### PR TITLE
6 decimals for shipping cost in admin tab 

### DIFF
--- a/admin-dev/themes/default/template/controllers/shipping/content.tpl
+++ b/admin-dev/themes/default/template/controllers/shipping/content.tpl
@@ -78,7 +78,7 @@
 										type="text" 
 										class="fees_{$range[$rangeIdentifier]}" 
 										onchange="this.value = this.value.replace(/,/g, \'.\');" name="fees_{$zone['id_zone']}_{$range[$rangeIdentifier]}" onkeyup="clearAllFees({$range[$rangeIdentifier]})" 
-										value="{$price|string_format:"%.2f"}"
+										value="{$price|string_format:"%.6f"}"
 										style="width: 45px;" 
 									/>
 									{$currency->getSign('right')} {l s='(tax excl.)'}


### PR DESCRIPTION
When you set the "Fees by carrier, geographical zone, and ranges" (in th...e "Shipping" tab), the prices are tax excluded and displayed with 2 decimals, but the price is saved with 6 decimals in the database.

So when you define a shipping fee with 6 decimals it is saved without problem, but when you come back to edit the values, they are rounded (2 decimals) so you are forced to edit the values again, or else saving will replace the previous 6-decimals values with the displayed 2-decimals values.

Having 6 decimals displayed in the BO (not rounded, raw value from the database) is necessary because these values are tax excluded and are displayed tax included on the FO.
