### PR TITLE
Update themes/default/password.tpl

### DIFF
--- a/themes/default/password.tpl
+++ b/themes/default/password.tpl
@@ -23,7 +23,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 
-{capture name=path}{l s='Forgot your password?'}{/capture}
+{capture name=path}<a href="{$link->getPageLink('authentication', true)}" title="{l s='Authentication'}" rel="nofollow">{l s='Authentication'}</a><span class="navigation-pipe">{$navigationPipe}</span>{l s='Forgot your password'}{/capture}
 {include file="$tpl_dir./breadcrumb.tpl"}
 
 <h1>{l s='Forgot your password?'}</h1>
@@ -49,5 +49,5 @@
 </form>
 {/if}
 <p class="clear">
-	<a href="{$link->getPageLink('authentication', true)}" title="{l s='Return to Login'}"><img src="{$img_dir}icon/my-account.gif" alt="{l s='Return to Login'}" class="icon" /></a><a href="{$link->getPageLink('authentication')}" title="{l s='Back to Login'}">{l s='Back to Login'}</a>
+	<a href="{$link->getPageLink('authentication', true)}" title="{l s='Return to Login'}" rel="nofollow"><img src="{$img_dir}icon/my-account.gif" alt="{l s='Return to Login'}" class="icon" /></a><a href="{$link->getPageLink('authentication')}" title="{l s='Back to Login'}" rel="nofollow">{l s='Back to Login'}</a>
 </p>


### PR DESCRIPTION
- fix for properly displaying breadcrumb on password recovery page (Home > My Account > Forgot your password). Breadcrumb now displaying real user location.
- SEO improvement (added link rel="nofollow" parameters)
- just suggestion: rename customer entry page from "My Account" to "Authentication". "My Account" is good name for customer page where he can manage his account, not for multi-function entry page.
