### PR TITLE
Deprecated Tools :: clearCache()

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2037,11 +2037,12 @@ FileETag INode MTime Size
 
 	/**
 	 * Clear cache for Smarty
-	 *
 	 * @param Smarty $smarty
+	 * @deprecated 1.5.2.0
 	 */
 	public static function clearCache($smarty, $tpl = false, $cache_id = null, $compile_id = null)
 	{
+		Tools::displayAsDeprecated();
 		return $smarty->clearAllCache();
 	}
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1617,7 +1617,7 @@ abstract class ModuleCore
 	protected function _clearCache($template, $cache_id = null, $compile_id = null)
 	{
 		Tools::enableCache();
-		Tools::clearCache(Context::getContext()->smarty, $template, $cache_id, $compile_id);
+		Context::getContext()->smarty->clearCache($template, $cache_id, $compile_id);
 		Tools::restoreCacheSettings();
 	}
 

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -462,7 +462,7 @@ class AdminMetaControllerCore extends AdminController
 		Tools::generateHtaccess($this->ht_file, null, null, '', Tools::getValue('PS_HTACCESS_DISABLE_MULTIVIEWS'));
 
 		Tools::enableCache();
-		Tools::clearCache($this->context->smarty);
+		$this->context->smarty->clearAllCache();
 		Tools::restoreCacheSettings();
 	}
 

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -527,7 +527,7 @@ class AdminThemesControllerCore extends AdminController
 		Configuration::updateValue('PS_IMG_UPDATE_TIME', time());
 		if (!empty($val) && !$this->_isThemeCompatible($val)) // don't submit if errors
 			unset($_POST['submitThemes'.$this->table]);
-		Tools::clearCache($this->context->smarty);
+		$this->context->smarty->clearAllCache();
 
 		parent::postProcess();
 	}


### PR DESCRIPTION
`Tools :: clearCache` doesn't really do what it should: it clears the whole Smarty cache and doesn't use the optional parameters. 

<pre>
public static function clearCache($smarty, $tpl = false, $cache_id = null, $compile_id = null) {
    return $smarty->clearAllCache();
}
</pre>


It is used in very few parts of the code, so I replaced call to `Tools :: clearCache` with direct calls to Smarty. 

Also now `Module :: _clearCache` works correctly, using all the optional parameters. 

The goal here is to reduce the dependency to the huge `Tools` class
