### PR TITLE
Fix css errors, clean up javascript

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1514,8 +1514,8 @@ html[xmlns] .clearfix {
 
 #table_customer{
 	border:1px solid #ccc;
-	cellpadding: 0;
-	cellspacing: 0;
+	padding: 0px;
+	border-spacing: 0px;
 	border-radius:3px;
 	background-color:#fff;
 }

--- a/themes/default/css/product.css
+++ b/themes/default/css/product.css
@@ -446,7 +446,7 @@ span.view_scroll_spacer {
 	width:260px;
 	border:1px solid #ccc;
 	font-size:12px;
-	color:#6666;
+	color:#666;
 }
 
 #send_friend_form .submit {

--- a/themes/default/js/cart-summary.js
+++ b/themes/default/js/cart-summary.js
@@ -31,7 +31,7 @@ $(document).ready(function()
 		$('.cart_quantity_up').unbind('click').live('click', function(){ upQuantity($(this).attr('id').replace('cart_quantity_up_', '')); return false;	});
 		$('.cart_quantity_down').unbind('click').live('click', function(){ downQuantity($(this).attr('id').replace('cart_quantity_down_', '')); return false; });
 		$('.cart_quantity_delete' ).unbind('click').live('click', function(){ deleteProductFromSummary($(this).attr('id')); return false; });
-		$('.cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 0, callback: function(val) { updateQty(val, true, this.el) } });
+		$('.cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 0, callback: function(val) { updateQty(val, true, this.el); } });
 	}
 	
 	$('.cart_address_delivery').live('change', function(){ changeAddressDelivery($(this)); });
@@ -56,16 +56,17 @@ function cleanSelectAddressDelivery()
 			
 			$.each(options, function(i) {
 				if ($(options[i]).val() > 0
-					&& ($('#product_' + id_product + '_' + id_product_attribute + '_0_' + $(options[i]).val()).length == 0 // Check the address is not already used for a similare products
-						|| id_address_delivery == $(options[i]).val()
+					&& ($('#product_' + id_product + '_' + id_product_attribute + '_0_' + $(options[i]).val()).length === 0 // Check the address is not already used for a similare products
+						|| id_address_delivery === $(options[i]).val()
 					)
 				)
 					address_count++;
 			});
 			
-			if (address_count < 2) // Need at least two address to allow skipping products to multiple address
+			// Need at least two address to allow skipping products to multiple address
+			if (address_count < 2)
 				$($(item).find('option[value=-2]')).remove();
-			else if($($(item).find('option[value=-2]')).length == 0)
+			else if($($(item).find('option[value=-2]')).length === 0)
 				$(item).append($('<option value="-2">' + ShipToAnOtherAddress + '</option>'));
 		});
 	}
@@ -79,7 +80,7 @@ function changeAddressDelivery(obj)
 	var old_id_address_delivery = ids[5];
 	var new_id_address_delivery = obj.val();
 	
-	if (new_id_address_delivery == old_id_address_delivery)
+	if (new_id_address_delivery === old_id_address_delivery)
 		return;
 	
 	if (new_id_address_delivery > 0) // Change the delivery address
@@ -98,7 +99,7 @@ function changeAddressDelivery(obj)
 				+'&allow_refresh=1',
 			success: function(jsonData)
 			{
-				if (typeof(jsonData.hasErrors) != 'undefined' && jsonData.hasErrors)
+				if (typeof(jsonData.hasErrors) !== 'undefined' && jsonData.hasErrors)
 				{
 					alert(jsonData.error);
 					// Reset the old address
@@ -113,7 +114,7 @@ function changeAddressDelivery(obj)
 						updateCustomizedDatas(jsonData.customizedDatas);
 						updateHookShoppingCart(jsonData.HOOK_SHOPPING_CART);
 						updateHookShoppingCartExtra(jsonData.HOOK_SHOPPING_CART_EXTRA);
-						if (typeof(getCarrierListAndUpdate) != 'undefined')
+						if (typeof(getCarrierListAndUpdate) !== 'undefined')
 							getCarrierListAndUpdate();
 	
 						// @todo reverse the remove order
@@ -132,12 +133,12 @@ function changeAddressDelivery(obj)
 			}
 		});
 	}
-	else if (new_id_address_delivery == -1) // Adding a new address
+	else if (new_id_address_delivery === -1) // Adding a new address
 			window.location = $($('.address_add a')[0]).attr('href');
-	else if (new_id_address_delivery == -2) // Add a new line for this product
+	else if (new_id_address_delivery === -2) // Add a new line for this product
 	{
 		// This test is will not usefull in the future
-		if (old_id_address_delivery == 0)
+		if (old_id_address_delivery === 0)
 		{
 			alert(txtSelectAnAddressFirst);
 			return false;
@@ -147,8 +148,8 @@ function changeAddressDelivery(obj)
 		var id_address_delivery = 0;
 		var options = $('#select_address_delivery_'+id_product+'_'+id_product_attribute+'_'+old_id_address_delivery+' option');
 		$.each(options, function(i) {
-			if ($(options[i]).val() > 0 && $(options[i]).val() != old_id_address_delivery
-				&& $('#product_' + id_product + '_' + id_product_attribute + '_0_' + $(options[i]).val()).length == 0 // Check the address is not already used for a similare products
+			if ($(options[i]).val() > 0 && $(options[i]).val() !== old_id_address_delivery
+				&& $('#product_' + id_product + '_' + id_product_attribute + '_0_' + $(options[i]).val()).length === 0 // Check the address is not already used for a similare products
 			)
 			{
 				id_address_delivery = $(options[i]).val();
@@ -205,8 +206,8 @@ function changeAddressDelivery(obj)
 
 function updateAddressId(id_product, id_product_attribute, old_id_address_delivery, id_address_delivery, line)
 {
-	if (typeof(line) == 'undefined')
-		var line = $('#product_' + id_product+'_' + id_product_attribute + '_0_' + old_id_address_delivery);
+	if (typeof(line) === 'undefined')
+		line = $('#product_' + id_product+'_' + id_product_attribute + '_0_' + old_id_address_delivery);
 	
 	line.attr('id', 'product_' + id_product+'_' + id_product_attribute + '_0_' + id_address_delivery);
 	line.find('.cart_quantity_input')
@@ -225,15 +226,17 @@ function updateAddressId(id_product, id_product_attribute, old_id_address_delive
 
 function updateQty(val, cart, el)
 {
-	if (typeof(cart) == 'undefined' || cart)
-		var prefix = '#order-detail-content ';
+	var prefix = "";
+
+	if (typeof(cart) === 'undefined' || cart)
+		prefix = '#order-detail-content ';
 	else
-		var prefix = '#fancybox-content ';
+		prefix = '#fancybox-content ';
 
 	var id = $(el).attr('name');
 	var exp = new RegExp("^[0-9]+$");
 
-	if (exp.test(val) == true)
+	if (exp.test(val) === true)
 	{
 		var hidden = $(prefix+'input[name='+ id +'_hidden]').val();
 		var input = $(prefix+'input[name='+ id +']').val();
@@ -247,7 +250,7 @@ function updateQty(val, cart, el)
 	else
 		$(prefix+'input[name='+ id +']').val($(prefix+'input[name='+ id +'_hidden]').val());
 	
-	if (typeof(getCarrierListAndUpdate) != 'undefined')
+	if (typeof(getCarrierListAndUpdate) !== 'undefined')
 		getCarrierListAndUpdate();
 }
 
@@ -260,11 +263,11 @@ function deleteProductFromSummary(id)
 	var ids = 0;
 	ids = id.split('_');
 	productId = parseInt(ids[0]);
-	if (typeof(ids[1]) != 'undefined')
+	if (typeof(ids[1]) !== 'undefined')
 		productAttributeId = parseInt(ids[1]);
-	if (typeof(ids[2]) != 'undefined')
+	if (typeof(ids[2]) !== 'undefined')
 		customizationId = parseInt(ids[2]);
-	if (typeof(ids[3]) != 'undefined')
+	if (typeof(ids[3]) !== 'undefined')
 		id_address_delivery = parseInt(ids[3]);
 	$.ajax({
 		type: 'GET',
@@ -276,7 +279,7 @@ function deleteProductFromSummary(id)
 			+'&ajax=true&delete&summary'
 			+'&id_product='+productId
 			+'&ipa='+productAttributeId
-			+'&id_address_delivery='+id_address_delivery+ ( (customizationId != 0) ? '&id_customization='+customizationId : '')
+			+'&id_address_delivery='+id_address_delivery+ ( (customizationId !== 0) ? '&id_customization='+customizationId : '')
 			+'&token=' + static_token
 			+'&allow_refresh=1',
 		success: function(jsonData)
@@ -284,23 +287,23 @@ function deleteProductFromSummary(id)
 			if (jsonData.hasError)
 			{
 				var errors = '';
-				for(error in jsonData.errors)
+				for(var error in jsonData.errors)
 				//IE6 bug fix
-				if (error != 'indexOf')
+				if (error !== 'indexOf')
 					errors += jsonData.errors[error] + "\n";
 			}
 			else
 			{
 				if (jsonData.refresh)
 					location.reload();
-				if (parseInt(jsonData.summary.products.length) == 0)
+				if (parseInt(jsonData.summary.products.length) === 0)
 				{
-					if (typeof(orderProcess) == 'undefined' || orderProcess != 'order-opc')
+					if (typeof(orderProcess) === 'undefined' || orderProcess !== 'order-opc')
 						document.location.href = document.location.href; // redirection
 					else
 					{
 						$('#center_column').children().each(function() {
-							if ($(this).attr('id') != 'emptyCartWarning' && $(this).attr('class') != 'breadcrumb' && $(this).attr('id') != 'cart_title')
+							if ($(this).attr('id') !== 'emptyCartWarning' && $(this).attr('class') !== 'breadcrumb' && $(this).attr('id') !== 'cart_title')
 							{
 								$(this).fadeOut('slow', function () {
 									$(this).remove();
@@ -322,9 +325,9 @@ function deleteProductFromSummary(id)
 
 					var exist = false;
 					for (i=0;i<jsonData.summary.products.length;i++)
-						if (jsonData.summary.products[i].id_product == productId
-							&& jsonData.summary.products[i].id_product_attribute == productAttributeId
-							&& jsonData.summary.products[i].id_address_delivery == id_address_delivery)
+						if (jsonData.summary.products[i].id_product === productId
+							&& jsonData.summary.products[i].id_product_attribute === productAttributeId
+							&& jsonData.summary.products[i].id_address_delivery === id_address_delivery)
 							exist = true;
 
 					// if all customization removed => delete product line
@@ -338,12 +341,12 @@ function deleteProductFromSummary(id)
 				updateCustomizedDatas(jsonData.customizedDatas);
 				updateHookShoppingCart(jsonData.HOOK_SHOPPING_CART);
 				updateHookShoppingCartExtra(jsonData.HOOK_SHOPPING_CART_EXTRA);
-				if (typeof(getCarrierListAndUpdate) != 'undefined')
+				if (typeof(getCarrierListAndUpdate) !== 'undefined')
 					getCarrierListAndUpdate();
 			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus != 'abort')
+			if (textStatus !== 'abort')
 				alert("TECHNICAL ERROR: unable to save update quantity \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 		}
 	});
@@ -355,7 +358,7 @@ function refreshOddRow()
 	var even_class = 'even';
 	$.each($('.cart_item'), function(i, it)
 	{
-		if (i == 0) // First item
+		if (i === 0) // First item
 		{
 			if ($(this).hasClass('even'))
 			{
@@ -374,7 +377,7 @@ function refreshOddRow()
 
 function upQuantity(id, qty)
 {
-	if (typeof(qty) == 'undefined' || !qty)
+	if (typeof(qty) === 'undefined' || !qty)
 		qty = 1;
 	var customizationId = 0;
 	var productId = 0;
@@ -383,11 +386,11 @@ function upQuantity(id, qty)
 	var ids = 0;
 	ids = id.split('_');
 	productId = parseInt(ids[0]);
-	if (typeof(ids[1]) != 'undefined')
+	if (typeof(ids[1]) !== 'undefined')
 		productAttributeId = parseInt(ids[1]);
-	if (typeof(ids[2]) != 'undefined')
+	if (typeof(ids[2]) !== 'undefined')
 		customizationId = parseInt(ids[2]);
-	if (typeof(ids[3]) != 'undefined')
+	if (typeof(ids[3]) !== 'undefined')
 		id_address_delivery = parseInt(ids[3]);
 	$.ajax({
 		type: 'GET',
@@ -403,7 +406,7 @@ function upQuantity(id, qty)
 			+'&id_product='+productId
 			+'&ipa='+productAttributeId
 			+'&id_address_delivery='+id_address_delivery
-			+ ( (customizationId != 0) ? '&id_customization='+customizationId : '')
+			+ ( (customizationId !== 0) ? '&id_customization='+customizationId : '')
 			+'&qty='+qty
 			+'&token='+static_token
 			+'&allow_refresh=1',
@@ -412,9 +415,9 @@ function upQuantity(id, qty)
 			if (jsonData.hasError)
 			{
 				var errors = '';
-				for(error in jsonData.errors)
+				for(var error in jsonData.errors)
 					//IE6 bug fix
-					if(error != 'indexOf')
+					if(error !== 'indexOf')
 						errors += jsonData.errors[error] + "\n";
 				alert(errors);
 				$('input[name=quantity_'+ id +']').val($('input[name=quantity_'+ id +'_hidden]').val());
@@ -427,12 +430,12 @@ function upQuantity(id, qty)
 				updateCustomizedDatas(jsonData.customizedDatas);
 				updateHookShoppingCart(jsonData.HOOK_SHOPPING_CART);
 				updateHookShoppingCartExtra(jsonData.HOOK_SHOPPING_CART_EXTRA);
-				if (typeof(getCarrierListAndUpdate) != 'undefined')
+				if (typeof(getCarrierListAndUpdate) !== 'undefined')
 					getCarrierListAndUpdate();
 			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus != 'abort')
+			if (textStatus !== 'abort')
 				alert("TECHNICAL ERROR: unable to save update quantity \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 		}
 	});
@@ -442,7 +445,7 @@ function downQuantity(id, qty)
 {
 	var val = $('input[name=quantity_'+id+']').val();
 	var newVal = val;
-	if(typeof(qty)=='undefined' || !qty)
+	if(typeof(qty) === 'undefined' || !qty)
 	{
 		qty = 1;
 		newVal = val - 1;
@@ -458,11 +461,11 @@ function downQuantity(id, qty)
 	
 	ids = id.split('_');
 	productId = parseInt(ids[0]);
-	if (typeof(ids[1]) != 'undefined')
+	if (typeof(ids[1]) !== 'undefined')
 		productAttributeId = parseInt(ids[1]);
-	if (typeof(ids[2]) != 'undefined')
+	if (typeof(ids[2]) !== 'undefined')
 		customizationId = parseInt(ids[2]);
-	if (typeof(ids[3]) != 'undefined')
+	if (typeof(ids[3]) !== 'undefined')
 		id_address_delivery = parseInt(ids[3]);
 
 	if (newVal > 0 || $('#product_'+id+'_gift').length)
@@ -482,7 +485,7 @@ function downQuantity(id, qty)
 				+'&ipa='+productAttributeId
 				+'&id_address_delivery='+id_address_delivery
 				+'&op=down'
-				+ ((customizationId != 0) ? '&id_customization='+customizationId : '')
+				+ ((customizationId !== 0) ? '&id_customization='+customizationId : '')
 				+'&qty='+qty
 				+'&token='+static_token
 				+'&allow_refresh=1',
@@ -491,9 +494,9 @@ function downQuantity(id, qty)
 				if (jsonData.hasError)
 				{
 					var errors = '';
-					for(error in jsonData.errors)
+					for(var error in jsonData.errors)
 						//IE6 bug fix
-						if(error != 'indexOf')
+						if(error !== 'indexOf')
 							errors += jsonData.errors[error] + "\n";
 					alert(errors);
 					$('input[name=quantity_'+ id +']').val($('input[name=quantity_'+ id +'_hidden]').val());
@@ -507,15 +510,15 @@ function downQuantity(id, qty)
 					updateHookShoppingCart(jsonData.HOOK_SHOPPING_CART);
 					updateHookShoppingCartExtra(jsonData.HOOK_SHOPPING_CART_EXTRA);
 					
-					if (newVal == 0)
+					if (newVal === 0)
 						$('#product_'+id).hide();
 					
-					if (typeof(getCarrierListAndUpdate) != 'undefined')
+					if (typeof(getCarrierListAndUpdate) !== 'undefined')
 						getCarrierListAndUpdate();
 				}
 			},
 			error: function(XMLHttpRequest, textStatus, errorThrown) {
-				if (textStatus != 'abort')
+				if (textStatus !== 'abort')
 					alert("TECHNICAL ERROR: unable to save update quantity \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 			}
 		});
@@ -533,7 +536,7 @@ function updateCartSummary(json)
 	var i;
 	var nbrProducts = 0;
 
-	if (typeof json == 'undefined')
+	if (typeof json === 'undefined')
 		return;
 
 	$('.cart_quantity_input').val(0);
@@ -546,7 +549,7 @@ function updateCartSummary(json)
 	{
 		for (i=0;i<json.gift_products.length;i++)
 		{
-			if (typeof(product_list[json.gift_products[i].id_product+'_'+json.gift_products[i].id_product_attribute+'_'+json.gift_products[i].id_address_delivery]) != 'undefined')
+			if (typeof(product_list[json.gift_products[i].id_product+'_'+json.gift_products[i].id_product_attribute+'_'+json.gift_products[i].id_address_delivery]) !== 'undefined')
 				product_list[json.gift_products[i].id_product+'_'+json.gift_products[i].id_product_attribute+'_'+json.gift_products[i].id_address_delivery].quantity -= json.gift_products[i].cart_quantity;
 		}
 	}
@@ -554,7 +557,7 @@ function updateCartSummary(json)
 	{
 		for (i=0;i<json.gift_products.length;i++)
 		{
-			if (typeof(product_list[json.gift_products[i].id_product+'_'+json.gift_products[i].id_product_attribute+'_'+json.gift_products[i].id_address_delivery]) == 'undefined')
+			if (typeof(product_list[json.gift_products[i].id_product+'_'+json.gift_products[i].id_product_attribute+'_'+json.gift_products[i].id_address_delivery]) === 'undefined')
 				product_list[json.gift_products[i].id_product+'_'+json.gift_products[i].id_product_attribute+'_'+json.gift_products[i].id_address_delivery] = json.gift_products[i];
 		}
 	}
@@ -565,16 +568,16 @@ function updateCartSummary(json)
 		var reduction = product_list[i].reduction_applies;
 		var initial_price_text = '';
 		initial_price = '';
-		if (typeof(product_list[i].price_without_quantity_discount) != 'undefined')
+		if (typeof(product_list[i].price_without_quantity_discount) !== 'undefined')
 			initial_price = formatCurrency(product_list[i].price_without_quantity_discount, currencyFormat, currencySign, currencyBlank);
 		var current_price = '';
-		if (priceDisplayMethod != 0)
+		if (priceDisplayMethod !== 0)
 			current_price = formatCurrency(product_list[i].price, currencyFormat, currencySign, currencyBlank);
 		else
 			current_price = formatCurrency(product_list[i].price_wt, currencyFormat, currencySign, currencyBlank);
-		if (reduction && typeof(initial_price) != 'undefined')
+		if (reduction && typeof(initial_price) !== 'undefined')
 		{
-			if (initial_price != '' && initial_price > current_price)
+			if (initial_price !== '' && initial_price > current_price)
 				initial_price_text = '<span style="text-decoration:line-through;">'+initial_price+'</span><br />';
 		}
 
@@ -582,7 +585,7 @@ function updateCartSummary(json)
 
 		$('#cart_block_product_'+key_for_blockcart+' span.quantity').html(product_list[i].quantity);
 
-		if (priceDisplayMethod != 0)
+		if (priceDisplayMethod !== 0)
 		{
 			$('#cart_block_product_'+key_for_blockcart+' span.price').html(formatCurrency(product_list[i].total, currencyFormat, currencySign, currencyBlank));
 			$('#product_price_'+product_list[i].id_product+'_'+product_list[i].id_product_attribute+'_'+product_list[i].id_address_delivery).html(initial_price_text+current_price);
@@ -599,7 +602,7 @@ function updateCartSummary(json)
 		$('input[name=quantity_'+product_list[i].id_product+'_'+product_list[i].id_product_attribute+'_0_'+product_list[i].id_address_delivery+']').val(product_list[i].quantity_without_customization);
 		$('input[name=quantity_'+product_list[i].id_product+'_'+product_list[i].id_product_attribute+'_0_'+product_list[i].id_address_delivery+'_hidden]').val(product_list[i].quantity_without_customization);
 		
-		if (typeof(product_list[i].customizationQuantityTotal) != 'undefined')
+		if (typeof(product_list[i].customizationQuantityTotal) !== 'undefined')
 		{
 			$('#cart_quantity_custom_'+product_list[i].id_product+'_'+product_list[i].id_product_attribute+'_'+product_list[i].id_address_delivery)
 					.html(product_list[i].customizationQuantityTotal);
@@ -607,24 +610,24 @@ function updateCartSummary(json)
 					.val(product_list[i].customizationQuantityTotal);
 		}
 		// Show / hide quantity button if minimal quantity
-		if (parseInt(product_list[i].minimal_quantity) == parseInt(product_list[i].quantity) && product_list[i].minimal_quantity != 1)
+		if (parseInt(product_list[i].minimal_quantity) === parseInt(product_list[i].quantity) && product_list[i].minimal_quantity !== 1)
 			$('#cart_quantity_down_'+product_list[i].id_product+'_'+product_list[i].id_product_attribute+'_'+Number(product_list[i].id_customization)+'_'+product_list[i].id_address_delivery).fadeTo('slow',0.3);
 		else
 			$('#cart_quantity_down_'+product_list[i].id_product+'_'+product_list[i].id_product_attribute+'_'+Number(product_list[i].id_customization)+'_'+product_list[i].id_address_delivery).fadeTo('slow',1);
 	}
 
 	// Update discounts
-	if (json.discounts.length == 0)
+	if (json.discounts.length === 0)
 	{
-		$('.cart_discount').each(function(){$(this).remove()});
+		$('.cart_discount').each(function(){$(this).remove();});
 		$('.cart_total_voucher').remove();
 	}
 	else
 	{
-		if ($('.cart_discount').length == 0)
+		if ($('.cart_discount').length === 0)
 			location.reload();
 
-		if (priceDisplayMethod != 0)
+		if (priceDisplayMethod !== 0)
 			$('#total_discount').html(formatCurrency(json.total_discounts_tax_exc, currencyFormat, currencySign, currencyBlank));
 		else
 			$('#total_discount').html(formatCurrency(json.total_discounts, currencyFormat, currencySign, currencyBlank));
@@ -635,11 +638,11 @@ function updateCartSummary(json)
 
 			for (i=0;i<json.discounts.length;i++)
 			{
-				if (json.discounts[i].id_discount == idElmt)
+				if (json.discounts[i].id_discount === idElmt)
 				{
-					if (json.discounts[i].value_real != '!')
+					if (json.discounts[i].value_real !== '!')
 					{
-						if (priceDisplayMethod != 0)
+						if (priceDisplayMethod !== 0)
 							$('#cart_discount_' + idElmt + ' td.cart_discount_price span.price-discount').html(formatCurrency(json.discounts[i].value_tax_exc * -1, currencyFormat, currencySign, currencyBlank));
 						else
 							$('#cart_discount_' + idElmt + ' td.cart_discount_price span.price-discount').html(formatCurrency(json.discounts[i].value_real * -1, currencyFormat, currencySign, currencyBlank));
@@ -654,7 +657,7 @@ function updateCartSummary(json)
 	}
 
 	// Block cart
-	if (priceDisplayMethod != 0)
+	if (priceDisplayMethod !== 0)
 	{
 		$('#cart_block_shipping_cost').html(formatCurrency(json.total_shipping_tax_exc, currencyFormat, currencySign, currencyBlank));
 		$('#cart_block_wrapping_cost').html(formatCurrency(json.total_wrapping_tax_exc, currencyFormat, currencySign, currencyBlank));
@@ -670,7 +673,7 @@ function updateCartSummary(json)
 
 	// Cart summary
 	$('#summary_products_quantity').html(nbrProducts+' '+(nbrProducts > 1 ? txtProducts : txtProduct));
-	if (priceDisplayMethod != 0)
+	if (priceDisplayMethod !== 0)
 		$('#total_product').html(formatCurrency(json.total_products, currencyFormat, currencySign, currencyBlank));
 	else
 		$('#total_product').html(formatCurrency(json.total_products_wt, currencyFormat, currencySign, currencyBlank));
@@ -680,7 +683,7 @@ function updateCartSummary(json)
 
 	if (json.total_shipping > 0)
 	{
-		if (priceDisplayMethod != 0)
+		if (priceDisplayMethod !== 0)
 		{
 			$('#total_shipping').html(formatCurrency(json.total_shipping_tax_exc, currencyFormat, currencySign, currencyBlank));
 		}
@@ -718,10 +721,10 @@ function updateCartSummary(json)
 
 function updateCustomizedDatas(json)
 {
-	for(i in json)
-		for(j in json[i])
-			for(k in json[i][j])
-				for(l in json[i][j][k])
+	for(var i in json)
+		for(var j in json[i])
+			for(var k in json[i][j])
+				for(var l in json[i][j][k])
 				{
 					var quantity = json[i][j][k][l]['quantity'];
 					$('input[name=quantity_'+i+'_'+j+'_'+l+'_'+k+'_hidden]').val(quantity);
@@ -744,7 +747,7 @@ function refreshDeliveryOptions()
 	$.each($('.delivery_option_radio'), function() {
 		if ($(this).prop('checked'))
 		{
-			if ($(this).parent().find('.delivery_option_carrier.not-displayable').length == 0)
+			if ($(this).parent().find('.delivery_option_carrier.not-displayable').length === 0)
 				$(this).parent().find('.delivery_option_carrier').show();
 			var carrier_id_list = $(this).val().split(',');
 			carrier_id_list.pop();
@@ -777,7 +780,7 @@ $(document).ready(function() {
 				+'&allow_refresh=1',
 			success: function(jsonData)
 			{
-				if (typeof(getCarrierListAndUpdate) != 'undefined')
+				if (typeof(getCarrierListAndUpdate) !== 'undefined')
 					getCarrierListAndUpdate();
 			}
 		});
@@ -799,10 +802,12 @@ $(document).ready(function() {
 
 function updateExtraCarrier(id_delivery_option, id_address)
 {
-	if(typeof(orderOpcUrl) != 'undefined')
-		var url = orderOpcUrl;
+	var url = "";
+
+	if(typeof(orderOpcUrl) !== 'undefined')
+		url = orderOpcUrl;
 	else
-		var url = orderUrl;
+		url = orderUrl;
 	
 	$.ajax({
 		type: 'POST',

--- a/themes/default/js/history.js
+++ b/themes/default/js/history.js
@@ -28,7 +28,7 @@ function showOrder(mode, var_content, file)
 {
 	$.get(
 		file,
-		((mode == 1) ? {'id_order': var_content, 'ajax': true} : {'id_order_return': var_content, 'ajax': true}),
+		((mode === 1) ? {'id_order': var_content, 'ajax': true} : {'id_order_return': var_content, 'ajax': true}),
 		function(data)
 		{
 			$('#block-order-detail').fadeOut('slow', function()
@@ -56,7 +56,7 @@ function showOrder(mode, var_content, file)
 					{
 						var maxQuantity = parseInt($(this).parent().find('.order_qte_span').text());
 						var quantity = parseInt($(this).val());
-						if (isNaN($(this).val()) && $(this).val() != '')
+						if (isNaN($(this).val()) && $(this).val() !== '')
 						{
 							$(this).val(maxQuantity);
 						}

--- a/themes/default/js/order-address.js
+++ b/themes/default/js/order-address.js
@@ -25,7 +25,7 @@
 
 $(document).ready(function()
 {
-	if (typeof(formatedAddressFieldsValuesList) != 'undefined')
+	if (typeof(formatedAddressFieldsValuesList) !== 'undefined')
 		updateAddressesDisplay(true);
 	resizeAddressesBox();
 });
@@ -49,9 +49,9 @@ function updateAddressesDisplay(first_view)
 
 	// update content of invoice address
 	//if addresses have to be equals...
-	if ($('input[type=checkbox]#addressesAreEquals:checked').length == 1 && ($('#multishipping_mode_checkbox:checked').length == 0))
+	if ($('input[type=checkbox]#addressesAreEquals:checked').length === 1 && ($('#multishipping_mode_checkbox:checked').length === 0))
 	{
-		if ($('#multishipping_mode_checkbox:checked').length == 0) {
+		if ($('#multishipping_mode_checkbox:checked').length === 0) {
 			$('#address_invoice_form:visible').hide('fast');
 		}
 		$('ul#address_invoice').html($('ul#address_delivery').html());
@@ -71,7 +71,7 @@ function updateAddressesDisplay(first_view)
 
 	if(!first_view)
 	{
-		if (orderProcess == 'order')
+		if (orderProcess === 'order')
 			updateAddresses();
 	}
 	return true;
@@ -99,7 +99,7 @@ function updateAddressDisplay(addressType)
 function updateAddresses()
 {
 	var idAddress_delivery = $('#id_address_delivery').val();
-	var idAddress_invoice = $('input[type=checkbox]#addressesAreEquals:checked').length == 1 ? idAddress_delivery : $('#id_address_invoice').val();
+	var idAddress_invoice = $('input[type=checkbox]#addressesAreEquals:checked').length === 1 ? idAddress_delivery : $('#id_address_invoice').val();
 	$.ajax({
 		type: 'POST',
 		url: baseUri,
@@ -121,15 +121,15 @@ function updateAddresses()
 			if (jsonData.hasError)
 			{
 				var errors = '';
-				for(error in jsonData.errors)
+				for(var error in jsonData.errors)
 					//IE6 bug fix
-					if(error != 'indexOf')
+					if(error !== 'indexOf')
 						errors += jsonData.errors[error] + "\n";
 				alert(errors);
 			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus != 'abort')
+			if (textStatus !== 'abort')
 				alert("TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 		}
 	});

--- a/themes/default/js/order-opc.js
+++ b/themes/default/js/order-opc.js
@@ -45,8 +45,8 @@ function updatePaymentMethods(json)
 
 function updateAddressSelection()
 {
-	var idAddress_delivery = ($('#opc_id_address_delivery').length == 1 ? $('#opc_id_address_delivery').val() : $('#id_address_delivery').val());
-	var idAddress_invoice = ($('#opc_id_address_invoice').length == 1 ? $('#opc_id_address_invoice').val() : ($('#addressesAreEquals:checked').length == 1 ? idAddress_delivery : ($('#id_address_invoice').length == 1 ? $('#id_address_invoice').val() : idAddress_delivery)));
+	var idAddress_delivery = ($('#opc_id_address_delivery').length === 1 ? $('#opc_id_address_delivery').val() : $('#id_address_delivery').val());
+	var idAddress_invoice = ($('#opc_id_address_invoice').length === 1 ? $('#opc_id_address_invoice').val() : ($('#addressesAreEquals:checked').length === 1 ? idAddress_delivery : ($('#id_address_invoice').length === 1 ? $('#id_address_invoice').val() : idAddress_delivery)));
 
 	$('#opc_account-overlay').fadeIn('slow');
 	$('#opc_delivery_methods-overlay').fadeIn('slow');
@@ -64,9 +64,9 @@ function updateAddressSelection()
 			if (jsonData.hasError)
 			{
 				var errors = '';
-				for(error in jsonData.errors)
+				for(var error in jsonData.errors)
 					//IE6 bug fix
-					if(error != 'indexOf')
+					if(error !== 'indexOf')
 						errors += jsonData.errors[error] + "\n";
 				alert(errors);
 			}
@@ -86,7 +86,7 @@ function updateAddressSelection()
 
 					if ($(this).find('.cart_quantity_input').length > 0 && $(this).find('.cart_quantity_input').attr('name').length > 0)
 					{
-						name = $(this).find('.cart_quantity_input').attr('name')+'_hidden';
+						var name = $(this).find('.cart_quantity_input').attr('name')+'_hidden';
 						$(this).find('.cart_quantity_input').attr('name', $(this).find('.cart_quantity_input').attr('name').replace(/_\d+$/, '_'+idAddress_delivery));
 						if ($(this).find('[name='+name+']').length > 0)
 							$(this).find('[name='+name+']').attr('name', name.replace(/_\d+_hidden$/, '_'+idAddress_delivery+'_hidden'));
@@ -95,19 +95,19 @@ function updateAddressSelection()
 					if ($(this).find('.cart_quantity_delete').length > 0 && $(this).find('.cart_quantity_delete').attr('id').length > 0) {
 						$(this).find('.cart_quantity_delete')
 							.attr('id', $(this).find('.cart_quantity_delete').attr('id').replace(/_\d+$/, '_'+idAddress_delivery))
-							.attr('href', $(this).find('.cart_quantity_delete').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'))
+							.attr('href', $(this).find('.cart_quantity_delete').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'));
 					}
 					
 					if ($(this).find('.cart_quantity_down').length > 0 && $(this).find('.cart_quantity_down').attr('id').length > 0) {
 						$(this).find('.cart_quantity_down')
 							.attr('id', $(this).find('.cart_quantity_down').attr('id').replace(/_\d+$/, '_'+idAddress_delivery))
-							.attr('href', $(this).find('.cart_quantity_down').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'))
+							.attr('href', $(this).find('.cart_quantity_down').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'));
 					}
 
 					if ($(this).find('.cart_quantity_up').length > 0 && $(this).find('.cart_quantity_up').attr('id').length > 0) {
 						$(this).find('.cart_quantity_up')
 							.attr('id', $(this).find('.cart_quantity_up').attr('id').replace(/_\d+$/, '_'+idAddress_delivery))
-							.attr('href', $(this).find('.cart_quantity_up').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'))
+							.attr('href', $(this).find('.cart_quantity_up').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'));
 					}
 					
 				});
@@ -120,7 +120,7 @@ function updateAddressSelection()
 				updateCartSummary(jsonData.summary);
 				updateHookShoppingCart(jsonData.HOOK_SHOPPING_CART);
 				updateHookShoppingCartExtra(jsonData.HOOK_SHOPPING_CART_EXTRA);
-				if ($('#gift-price').length == 1)
+				if ($('#gift-price').length === 1)
 					$('#gift-price').html(jsonData.gift_price);
 				$('#opc_account-overlay').fadeOut('slow');
 				$('#opc_delivery_methods-overlay').fadeOut('slow');
@@ -128,7 +128,7 @@ function updateAddressSelection()
 			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus != 'abort')
+			if (textStatus !== 'abort')
 				alert("TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 			$('#opc_account-overlay').fadeOut('slow');
 			$('#opc_delivery_methods-overlay').fadeOut('slow');
@@ -152,9 +152,9 @@ function getCarrierListAndUpdate()
 				if (jsonData.hasError)
 				{
 					var errors = '';
-					for(error in jsonData.errors)
+					for(var error in jsonData.errors)
 						//IE6 bug fix
-						if(error != 'indexOf')
+						if(error !== 'indexOf')
 							errors += jsonData.errors[error] + "\n";
 					alert(errors);
 				}
@@ -177,8 +177,8 @@ function updateCarrierSelectionAndGift()
 		if ($(this).prop('checked'))
 			delivery_option_params += $(delivery_option_radio[i]).attr('name') + '=' + $(delivery_option_radio[i]).val() + '&';
 	});
-	if (delivery_option_params == '&')
-		delivery_option_params = '&delivery_option=&'
+	if (delivery_option_params === '&')
+		delivery_option_params = '&delivery_option=&';
 
 	if ($('input#recyclable:checked').length)
 		recyclablePackage = 1;
@@ -202,9 +202,9 @@ function updateCarrierSelectionAndGift()
 			if (jsonData.hasError)
 			{
 				var errors = '';
-				for(error in jsonData.errors)
+				for(var error in jsonData.errors)
 					//IE6 bug fix
-					if(error != 'indexOf')
+					if(error !== 'indexOf')
 						errors += jsonData.errors[error] + "\n";
 				alert(errors);
 			}
@@ -221,7 +221,7 @@ function updateCarrierSelectionAndGift()
 			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus != 'abort')
+			if (textStatus !== 'abort')
 				alert("TECHNICAL ERROR: unable to save carrier \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 			$('#opc_payment_methods-overlay').fadeOut('slow');
 			$('#opc_delivery_methods-overlay').fadeOut('slow');
@@ -231,7 +231,7 @@ function updateCarrierSelectionAndGift()
 
 function confirmFreeOrder()
 {
-	if ($('#opc_new_account-overlay').length != 0)
+	if ($('#opc_new_account-overlay').length !== 0)
 		$('#opc_new_account-overlay').fadeIn('slow');
 	else
 		$('#opc_account-overlay').fadeIn('slow');
@@ -256,7 +256,7 @@ function confirmFreeOrder()
 			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus != 'abort')
+			if (textStatus !== 'abort')
 				alert("TECHNICAL ERROR: unable to confirm the order \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 		}
 	});
@@ -264,26 +264,26 @@ function confirmFreeOrder()
 
 function saveAddress(type)
 {
-	if (type != 'delivery' && type != 'invoice')
+	if (type !== 'delivery' && type !== 'invoice')
 		return false;
 	
-	var params = 'firstname='+encodeURIComponent($('#firstname'+(type == 'invoice' ? '_invoice' : '')).val())+'&lastname='+encodeURIComponent($('#lastname'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'company='+encodeURIComponent($('#company'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'vat_number='+encodeURIComponent($('#vat_number'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'dni='+encodeURIComponent($('#dni'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'address1='+encodeURIComponent($('#address1'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'address2='+encodeURIComponent($('#address2'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'postcode='+encodeURIComponent($('#postcode'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'city='+encodeURIComponent($('#city'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
+	var params = 'firstname='+encodeURIComponent($('#firstname'+(type === 'invoice' ? '_invoice' : '')).val())+'&lastname='+encodeURIComponent($('#lastname'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'company='+encodeURIComponent($('#company'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'vat_number='+encodeURIComponent($('#vat_number'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'dni='+encodeURIComponent($('#dni'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'address1='+encodeURIComponent($('#address1'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'address2='+encodeURIComponent($('#address2'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'postcode='+encodeURIComponent($('#postcode'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'city='+encodeURIComponent($('#city'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
 	params += 'id_country='+encodeURIComponent($('#id_country').val())+'&';
-	if ($('#id_state'+(type == 'invoice' ? '_invoice' : '')).val())
+	if ($('#id_state'+(type === 'invoice' ? '_invoice' : '')).val())
 	{
-	params += 'id_state='+encodeURIComponent($('#id_state'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'id_state='+encodeURIComponent($('#id_state'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
 	}
-	params += 'other='+encodeURIComponent($('#other'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'phone='+encodeURIComponent($('#phone'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'phone_mobile='+encodeURIComponent($('#phone_mobile'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
-	params += 'alias='+encodeURIComponent($('#alias'+(type == 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'other='+encodeURIComponent($('#other'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'phone='+encodeURIComponent($('#phone'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'phone_mobile='+encodeURIComponent($('#phone_mobile'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
+	params += 'alias='+encodeURIComponent($('#alias'+(type === 'invoice' ? '_invoice' : '')).val())+'&';
 	// Clean the last &
 	params = params.substr(0, params.length-1);
 
@@ -302,9 +302,9 @@ function saveAddress(type)
 			{
 				var tmp = '';
 				var i = 0;
-				for(error in jsonData.errors)
+				for(var error in jsonData.errors)
 					//IE6 bug fix
-					if(error != 'indexOf')
+					if(error !== 'indexOf')
 					{
 						i = i+1;
 						tmp += '<li>'+jsonData.errors[error]+'</li>';
@@ -327,7 +327,7 @@ function saveAddress(type)
 			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus != 'abort')
+			if (textStatus !== 'abort')
 				alert("TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 			$('#opc_new_account-overlay').fadeOut('slow');
 			$('#opc_delivery_methods-overlay').fadeOut('slow');
@@ -353,13 +353,13 @@ function updateNewAccountToAddressBlock()
 		success: function(json)
 		{
 			isLogged = 1;
-			if (json.no_address == 1)
+			if (json.no_address === 1)
 				document.location.href = addressUrl;
 			
 			$('#opc_new_account').fadeOut('fast', function() {
 				$('#opc_new_account').html(json.order_opc_adress);
 				// update block user info
-				if (json.block_user_info != '' && $('#header_user').length == 1)
+				if (json.block_user_info !== '' && $('#header_user').length === 1)
 				{
 					$('#header_user').fadeOut('slow', function() {
 						$(this).attr('id', 'header_user_old').after(json.block_user_info).fadeIn('slow');
@@ -377,7 +377,7 @@ function updateNewAccountToAddressBlock()
 					updateAddressesDisplay(true);
 					updateCarrierList(json.carrier_data);
 					updatePaymentMethods(json);
-					if ($('#gift-price').length == 1)
+					if ($('#gift-price').length === 1)
 						$('#gift-price').html(json.gift_price);
 					$('#opc_delivery_methods-overlay').fadeOut('slow');
 					$('#opc_payment_methods-overlay').fadeOut('slow');
@@ -385,7 +385,7 @@ function updateNewAccountToAddressBlock()
 			});
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus != 'abort')
+			if (textStatus !== 'abort')
 				alert("TECHNICAL ERROR: unable to send login informations \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 			$('#opc_delivery_methods-overlay').fadeOut('slow');
 			$('#opc_payment_methods-overlay').fadeOut('slow');
@@ -471,9 +471,9 @@ $(function() {
 					if (jsonData.hasError)
 					{
 						var errors = '<b>'+txtThereis+' '+jsonData.errors.length+' '+txtErrors+':</b><ol>';
-						for(error in jsonData.errors)
+						for(var error in jsonData.errors)
 							//IE6 bug fix
-							if(error != 'indexOf')
+							if(error !== 'indexOf')
 								errors += '<li>'+jsonData.errors[error]+'</li>';
 						errors += '</ol>';
 						$('#opc_login_errors').html(errors).slideDown('slow');
@@ -486,7 +486,7 @@ $(function() {
 					}
 				},
 				error: function(XMLHttpRequest, textStatus, errorThrown) {
-					if (textStatus != 'abort')
+					if (textStatus !== 'abort')
 						alert("TECHNICAL ERROR: unable to send login informations \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 				}
 			});
@@ -498,7 +498,7 @@ $(function() {
 			if ($('#invoice_address:checked').length > 0)
 			{
 				$('#opc_invoice_address').slideDown('slow');
-				if ($('#company_invoice').val() == '')
+				if ($('#company_invoice').val() === '')
 					$('#vat_number_block_invoice').hide();
 				updateState('invoice');
 				updateNeedIDNumber('invoice');
@@ -517,15 +517,18 @@ $(function() {
 			// RESET ERROR(S) MESSAGE(S)
 			$('#opc_account_errors').html('').slideUp('slow');
 			
-			if ($('#opc_id_customer').val() == 0)
+			var callingFile = '';
+			var params = '';
+
+			if ($('#opc_id_customer').val() === 0)
 			{
-				var callingFile = authenticationUrl;
-				var params = 'submitAccount=true&';
+				callingFile = authenticationUrl;
+				params = 'submitAccount=true&';
 			}
 			else
 			{
-				var callingFile = orderOpcUrl;
-				var params = 'method=editCustomer&';
+				callingFile = orderOpcUrl;
+				params = 'method=editCustomer&';
 			}
 
 			$('#opc_account_form input:visible, #opc_account_form input[type=hidden]').each(function() {
@@ -566,9 +569,9 @@ $(function() {
 					{
 						var tmp = '';
 						var i = 0;
-						for(error in jsonData.errors)
+						for(var error in jsonData.errors)
 							//IE6 bug fix
-							if(error != 'indexOf')
+							if(error !== 'indexOf')
 							{
 								i = i+1;
 								tmp += '<li>'+jsonData.errors[error]+'</li>';
@@ -579,9 +582,9 @@ $(function() {
 						$.scrollTo('#opc_account_errors', 800);
 					}
 
-					isGuest = ($('#is_new_customer').val() == 1 ? 0 : 1);
+					isGuest = ($('#is_new_customer').val() === 1 ? 0 : 1);
 					
-					if (jsonData.id_customer != undefined && jsonData.id_customer != 0 && jsonData.isSaved)
+					if (jsonData.id_customer !== undefined && jsonData.id_customer !== 0 && jsonData.isSaved)
 					{
 						// update token
 						static_token = jsonData.token;
@@ -591,7 +594,7 @@ $(function() {
 						$('#opc_id_address_invoice').val(jsonData.id_address_invoice);
 						
 						// It's not a new customer
-						if ($('#opc_id_customer').val() != '0')
+						if ($('#opc_id_customer').val() !== '0')
 						{
 							if (!saveAddress('delivery'))
 								return false;
@@ -600,7 +603,7 @@ $(function() {
 						// update id_customer
 						$('#opc_id_customer').val(jsonData.id_customer);
 						
-						if ($('#invoice_address:checked').length != 0)
+						if ($('#invoice_address:checked').length !== 0)
 						{
 							if (!saveAddress('invoice'))
 								return false;
@@ -625,7 +628,7 @@ $(function() {
 					$('#opc_payment_methods-overlay').fadeOut('slow');
 				},
 				error: function(XMLHttpRequest, textStatus, errorThrown) {
-					if (textStatus != 'abort')
+					if (textStatus !== 'abort')
 						alert("TECHNICAL ERROR: unable to save account \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 					$('#opc_new_account-overlay').fadeOut('slow');
 					$('#opc_delivery_methods-overlay').fadeOut('slow');
@@ -665,9 +668,9 @@ function bindInputs()
 				if (jsonData.hasError)
 				{
 					var errors = '';
-					for(error in jsonData.errors)
+					for(var error in jsonData.errors)
 						//IE6 bug fix
-						if(error != 'indexOf')
+						if(error !== 'indexOf')
 							errors += jsonData.errors[error] + "\n";
 					alert(errors);
 				}
@@ -675,7 +678,7 @@ function bindInputs()
 				$('#opc_delivery_methods-overlay').fadeOut('slow');
 			},
 			error: function(XMLHttpRequest, textStatus, errorThrown) {
-				if (textStatus != 'abort')
+				if (textStatus !== 'abort')
 					alert("TECHNICAL ERROR: unable to save message \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
 				$('#opc_delivery_methods-overlay').fadeOut('slow');
 			}
@@ -708,10 +711,12 @@ function bindInputs()
 	
 	// Term Of Service (TOS)
 	$('#cgv').click(function() {
-		if ($('#cgv:checked').length != 0)
-			var checked = 1;
+		var checked = '';
+
+		if ($('#cgv:checked').length !== 0)
+			checked = 1;
 		else
-			var checked = 0;
+			checked = 0;
 		
 		$('#opc_payment_methods-overlay').fadeIn('slow');
 		$.ajax({
@@ -758,7 +763,7 @@ function multishippingMode(it)
 					cache: false,
 					success: function(data) {
 						$('#cart_summary').replaceWith($(data).find('#cart_summary'));
-						$('.cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 0, callback: function(val) { updateQty(val, true, this.el) } });
+						$('.cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 0, callback: function(val) { updateQty(val, true, this.el); } });
 					}
 				});
 				updateCarrierSelectionAndGift();
@@ -773,7 +778,7 @@ function multishippingMode(it)
 			},
 			'onComplete': function()
 			{
-				$('#fancybox-content .cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 0, callback: function(val) { updateQty(val, false, this.el)} });
+				$('#fancybox-content .cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 0, callback: function(val) { updateQty(val, false, this.el);} });
 				cleanSelectAddressDelivery();
 				$('#fancybox-content').append($('<div class="multishipping_close_container"><a id="multishipping-close" class="button_large" href="#">' + CloseTxt + '</a></div>'));
 				$('#multishipping-close').click(function() {
@@ -781,7 +786,7 @@ function multishippingMode(it)
 					$('#fancybox-content .cart_quantity_input').each(function(){
 						newTotalQty += parseInt($(this).val());
 					});
-					if (newTotalQty != totalQty) {
+					if (newTotalQty !== totalQty) {
 						if(!confirm(QtyChanged)) {
 							return false;
 						}
@@ -835,12 +840,12 @@ $(document).ready(function() {
 	// If the multishipping mode is off assure us the checkbox "I want to specify a delivery address for each products I order." is unchecked.
 	$('#multishipping_mode_checkbox').attr('checked', false);
 	// If the multishipping mode is on, check the box "I want to specify a delivery address for each products I order.".
-	if (typeof(multishipping_mode) != 'undefined' && multishipping_mode) {
+	if (typeof(multishipping_mode) !== 'undefined' && multishipping_mode) {
 		$('#multishipping_mode_checkbox').click();
 		$('.addressesAreEquals').hide();
 		$('.addressesAreEquals').find('input').attr('checked', false);
 	}
 	
-	if (typeof(open_multishipping_fancybox) != 'undefined' && open_multishipping_fancybox)
+	if (typeof(open_multishipping_fancybox) !== 'undefined' && open_multishipping_fancybox)
 		$('#link_multishipping_form').click();
 });

--- a/themes/default/js/product.js
+++ b/themes/default/js/product.js
@@ -25,16 +25,16 @@
 
 
 //global variables
-var combinations = new Array();
-var selectedCombination = new Array();
-var globalQuantity = new Number;
-var colors = new Array();
+var combinations = [];
+var selectedCombination = [];
+var globalQuantity = 0;
+var colors = [];
 
 //check if a function exists
 function function_exists(function_name)
 {
-	if (typeof function_name == 'string')
-		return (typeof window[function_name] == 'function');
+	if (typeof function_name === 'string')
+		return (typeof window[function_name] === 'function');
 	return (function_name instanceof Function);
 }
 
@@ -53,7 +53,7 @@ function addCombination(idCombination, arrayOfIdAttributes, quantity, price, eco
 {
 	globalQuantity += quantity;
 
-	var combination = new Array();
+	var combination = [];
 	combination['idCombination'] = idCombination;
 	combination['quantity'] = quantity;
 	combination['idsAttributes'] = arrayOfIdAttributes;
@@ -64,7 +64,7 @@ function addCombination(idCombination, arrayOfIdAttributes, quantity, price, eco
 	combination['unit_price'] = unit_price;
 	combination['minimal_quantity'] = minimal_quantity;
 	combination['available_date'] = available_date;
-	combination['specific_price'] = new Array();
+	combination['specific_price'] = [];
 	combination['specific_price'] = combination_specific_price;
 	combinations.push(combination);
 }
@@ -75,7 +75,7 @@ function findCombination(firstTime)
 	$('#minimal_quantity_wanted_p').fadeOut();
 	$('#quantity_wanted').val(1);
 	//create a temporary 'choice' array containing the choices of the customer
-	var choice = new Array();
+	var choice = [];
 	$('#attributes select, #attributes input[type=hidden], #attributes input[type=radio]:checked').each(function(){
 		choice.push($(this).val());
 	});
@@ -91,7 +91,7 @@ function findCombination(firstTime)
 			{
 				combinationMatchForm = false;
 			}
-		})
+		});
 
 		if (combinationMatchForm)
 		{
@@ -100,7 +100,7 @@ function findCombination(firstTime)
 				$('#minimal_quantity_label').html(combinations[combination]['minimal_quantity']);
 				$('#minimal_quantity_wanted_p').fadeIn();
 				$('#quantity_wanted').val(combinations[combination]['minimal_quantity']);
-				$('#quantity_wanted').bind('keyup', function() {checkMinimalQuantity(combinations[combination]['minimal_quantity'])});
+				$('#quantity_wanted').bind('keyup', function() {checkMinimalQuantity(combinations[combination]['minimal_quantity']);});
 			}
 			//combination of the user has been found in our specifications of combinations (created in back office)
 			selectedCombination['unavailable'] = false;
@@ -118,7 +118,7 @@ function findCombination(firstTime)
 				selectedCombination['ecotax'] = default_eco_tax;
 
 			//show the large image in relation to the selected combination
-			if (combinations[combination]['image'] && combinations[combination]['image'] != -1)
+			if (combinations[combination]['image'] && combinations[combination]['image'] !== -1)
 				displayImage( $('#thumb_'+combinations[combination]['image']).parent() );
 
 			//show discounts values according to the selected combination
@@ -131,7 +131,7 @@ function findCombination(firstTime)
 			//update the display
 			updateDisplay();
 
-			if(typeof(firstTime) != 'undefined' && firstTime)
+			if(typeof(firstTime) !== 'undefined' && firstTime)
 				refreshProductImages(0);
 			else
 				refreshProductImages(combinations[combination]['idCombination']);
@@ -147,7 +147,7 @@ function findCombination(firstTime)
 //update display of the availability of the product AND the prices of the product
 function updateDisplay()
 {
-	if (!selectedCombination['unavailable'] && quantityAvailable > 0 && productAvailableForOrder == 1)
+	if (!selectedCombination['unavailable'] && quantityAvailable > 0 && productAvailableForOrder === 1)
 	{
 		//show the choice of quantities
 		$('#quantity_wanted_p:hidden').show('slow');
@@ -163,12 +163,12 @@ function updateDisplay()
 		$('#availability_date_value').hide();
 
 		//availability value management
-		if (availableNowValue != '')
+		if (availableNowValue !== '')
 		{
 			//update the availability statut of the product
 			$('#availability_value').removeClass('warning_inline');
 			$('#availability_value').text(availableNowValue);
-			if(stock_management == 1)
+			if(stock_management === 1)
 				$('#availability_statut:hidden').show();
 		}
 		else
@@ -206,7 +206,7 @@ function updateDisplay()
 	else
 	{
 		//show the hook out of stock
-		if (productAvailableForOrder == 1)
+		if (productAvailableForOrder === 1)
 		{
 			$('#oosHook').show();
 			if ($('#oosHook').length > 0 && function_exists('oosHookJsCode'))
@@ -231,7 +231,7 @@ function updateDisplay()
 			$('#availability_value').text(doesntExist).addClass('warning_inline');
 			$('#oosHook').hide();
 		}
-		if(stock_management == 1)
+		if(stock_management === 1)
 			$('#availability_statut:hidden').show();
 		
 		//display availability date
@@ -256,14 +256,14 @@ function updateDisplay()
 			}
 		}
 		//show the 'add to cart' button ONLY IF it's possible to buy when out of stock AND if it was previously invisible
-		if (allowBuyWhenOutOfStock && !selectedCombination['unavailable'] && productAvailableForOrder == 1)
+		if (allowBuyWhenOutOfStock && !selectedCombination['unavailable'] && productAvailableForOrder === 1)
 		{
 			$('#add_to_cart:hidden').fadeIn(600);
 
-			if (availableLaterValue != '')
+			if (availableLaterValue !== '')
 			{
 				$('#availability_value').text(availableLaterValue);
-				if(stock_management == 1)
+				if(stock_management === 1)
 					$('#availability_statut:hidden').show('slow');
 			}
 			else
@@ -272,11 +272,11 @@ function updateDisplay()
 		else
 		{
 			$('#add_to_cart:visible').fadeOut(600);
-			if(stock_management == 1)
+			if(stock_management === 1)
 				$('#availability_statut:hidden').show('slow');
 		}
 
-		if (productAvailableForOrder == 0)
+		if (productAvailableForOrder === 0)
 			$('#availability_statut:visible').hide();
 	}
 
@@ -292,15 +292,17 @@ function updateDisplay()
 		$('#product_reference:visible').hide('slow');
 
 	//update display of the the prices in relation to tax, discount, ecotax, and currency criteria
-	if (!selectedCombination['unavailable'] && productShowPrice == 1)
+	if (!selectedCombination['unavailable'] && productShowPrice === 1)
 	{
+		var priceTaxExclWithoutGroupReduction = '';
+
 		// retrieve price without group_reduction in order to compute the group reduction after
 		// the specific price discount (done in the JS in order to keep backward compatibility)
 		if (!displayPrice && !noTaxForThisProduct)
 		{
-			var priceTaxExclWithoutGroupReduction = ps_round(productPriceTaxExcluded, 6) * (1 / group_reduction);
+			priceTaxExclWithoutGroupReduction = ps_round(productPriceTaxExcluded, 6) * (1 / group_reduction);
 		} else {
-			var priceTaxExclWithoutGroupReduction = ps_round(productPriceTaxExcluded, 6) * (1 / group_reduction);
+			priceTaxExclWithoutGroupReduction = ps_round(productPriceTaxExcluded, 6) * (1 / group_reduction);
 		}
 		var combination_add_price = selectedCombination['price'] * group_reduction;
 
@@ -310,12 +312,12 @@ function updateDisplay()
 		if (selectedCombination.specific_price)
 		{
 			display_specific_price = selectedCombination.specific_price['price'];
-			if (selectedCombination['specific_price'].reduction_type == 'percentage')
+			if (selectedCombination['specific_price'].reduction_type === 'percentage')
 			{
 				$('#reduction_amount').hide();
 				$('#reduction_percent_display').html('-' + parseFloat(selectedCombination['specific_price'].reduction_percent) + '%');
 				$('#reduction_percent').show();
-			} else if (selectedCombination['specific_price'].reduction_type == 'amount' && selectedCombination['specific_price'].reduction_price != 0) {
+			} else if (selectedCombination['specific_price'].reduction_type === 'amount' && selectedCombination['specific_price'].reduction_price !== 0) {
 				$('#reduction_amount_display').html('-' + formatCurrency(selectedCombination['specific_price'].reduction_price, currencyFormat, currencySign, currencyBlank));
 				$('#reduction_percent').hide();
 				$('#reduction_amount').show();
@@ -327,16 +329,16 @@ function updateDisplay()
 		else
 		{
 			display_specific_price = product_specific_price['price'];
-			if (product_specific_price['reduction_type'] == 'percentage')
+			if (product_specific_price['reduction_type'] === 'percentage')
 				$('#reduction_percent_display').html(product_specific_price['specific_price'].reduction_percent);
 		}
 		
-		if (product_specific_price['reduction_type'] != '' || selectedCombination['specific_price'].reduction_type != '')
+		if (product_specific_price['reduction_type'] !== '' || selectedCombination['specific_price'].reduction_type !== '')
 			$('#discount_reduced_price,#old_price').show();
 		else
 			$('#discount_reduced_price,#old_price').hide();
 		
-		if (product_specific_price['reduction_type'] == 'percentage' || selectedCombination['specific_price'].reduction_type == 'percentage')
+		if (product_specific_price['reduction_type'] === 'percentage' || selectedCombination['specific_price'].reduction_type === 'percentage')
 			$('#reduction_percent').show();
 		else
 			$('#reduction_percent').hide();
@@ -401,11 +403,13 @@ function updateDisplay()
 			$('#old_price,#old_price_display,#old_price_display_taxes').show();
 		else
 			$('#old_price,#old_price_display,#old_price_display_taxes').hide();
+
 		// Special feature: "Display product price tax excluded on product page"
+		var productPricePretaxed = '';
 		if (!noTaxForThisProduct)
-			var productPricePretaxed = productPrice / tax;
+			productPricePretaxed = productPrice / tax;
 		else
-			var productPricePretaxed = productPrice;
+			productPricePretaxed = productPrice;
 		$('#pretaxe_price_display').text(formatCurrency(productPricePretaxed, currencyFormat, currencySign, currencyBlank));
 		// Unit price 
 		productUnitPriceRatio = parseFloat(productUnitPriceRatio);
@@ -416,7 +420,7 @@ function updateDisplay()
 		}
 
 		// Ecotax
-		var ecotaxAmount = !displayPrice ? ps_round(selectedCombination['ecotax'] * (1 + ecotaxTax_rate / 100), 2) : selectedCombination['ecotax'];
+		ecotaxAmount = !displayPrice ? ps_round(selectedCombination['ecotax'] * (1 + ecotaxTax_rate / 100), 2) : selectedCombination['ecotax'];
 		$('#ecotax_price_display').text(formatCurrency(ecotaxAmount, currencyFormat, currencySign, currencyBlank));
 	}
 }
@@ -424,17 +428,17 @@ function updateDisplay()
 //update display of the large image
 function displayImage(domAAroundImgThumb, no_animation)
 {
-	if (typeof(no_animation) == 'undefined')
+	if (typeof(no_animation) === 'undefined')
 		no_animation = false;
 	
 	if (domAAroundImgThumb.attr('href'))
 	{
 		var newSrc = domAAroundImgThumb.attr('href').replace('thickbox','large');
-		if ($('#bigpic').attr('src') != newSrc)
+		if ($('#bigpic').attr('src') !== newSrc)
 		{
 			$('#bigpic').fadeOut((no_animation ? 0 : 'fast'), function(){
 				$(this).attr('src', newSrc).show();
-				if (typeof(jqZoomEnabled) != 'undefined' && jqZoomEnabled)
+				if (typeof(jqZoomEnabled) !== 'undefined' && jqZoomEnabled)
 					$(this).attr('alt', domAAroundImgThumb.attr('href'));
 			});
 		}
@@ -447,13 +451,13 @@ function displayImage(domAAroundImgThumb, no_animation)
 function displayDiscounts(combination)
 {
 	$('#quantityDiscount tbody tr').each(function() {
-		if (($(this).attr('id') != 'quantityDiscount_0') &&
-			($(this).attr('id') != 'quantityDiscount_'+combination) &&
-			($(this).attr('id') != 'noQuantityDiscount'))
+		if (($(this).attr('id') !== 'quantityDiscount_0') &&
+			($(this).attr('id') !== 'quantityDiscount_'+combination) &&
+			($(this).attr('id') !== 'noQuantityDiscount'))
 			$(this).fadeOut('slow');
 	 });
 
-	if ($('#quantityDiscount_'+combination).length != 0) {
+	if ($('#quantityDiscount_'+combination).length !== 0) {
 		$('#quantityDiscount_'+combination).show();
 		$('#noQuantityDiscount').hide();
 	} else
@@ -466,7 +470,7 @@ function serialScrollFixLock(event, targeted, scrolled, items, position)
 	serialScrollNbImages = $('#thumbs_list li:visible').length;
 	serialScrollNbImagesDisplayed = 3;
 
-	var leftArrow = position == 0 ? true : false;
+	var leftArrow = position === 0 ? true : false;
 	var rightArrow = position + serialScrollNbImagesDisplayed >= serialScrollNbImages ? true : false;
 
 	$('#view_scroll_left').css('cursor', leftArrow ? 'default' : 'pointer').css('display', leftArrow ? 'none' : 'block').fadeTo(0, leftArrow ? 0 : 1);
@@ -481,7 +485,7 @@ function refreshProductImages(id_product_attribute)
 	$('#thumbs_list li').hide();
 	id_product_attribute = parseInt(id_product_attribute);
 
-	if (typeof(combinationImages) != 'undefined' && typeof(combinationImages[id_product_attribute]) != 'undefined')
+	if (typeof(combinationImages) !== 'undefined' && typeof(combinationImages[id_product_attribute]) !== 'undefined')
 	{
 		for (var i = 0; i < combinationImages[id_product_attribute].length; i++)
 			$('#thumbnail_' + parseInt(combinationImages[id_product_attribute][i])).show();
@@ -531,7 +535,7 @@ $(document).ready(function()
 	);
 
 	//set jqZoom parameters if needed
-	if (typeof(jqZoomEnabled) != 'undefined' && jqZoomEnabled)
+	if (typeof(jqZoomEnabled) !== 'undefined' && jqZoomEnabled)
 	{
 		$('img.jqzoom').jqueryzoom({
 			xzoom: 200, //zooming div default width(default width value is 200)
@@ -559,9 +563,9 @@ $(document).ready(function()
 	});
 
 	//init the price in relation of the selected attributes
-	if (typeof productHasAttributes != 'undefined' && productHasAttributes)
+	if (typeof productHasAttributes !== 'undefined' && productHasAttributes)
 		findCombination(true);
-	else if (typeof productHasAttributes != 'undefined' && !productHasAttributes)
+	else if (typeof productHasAttributes !== 'undefined' && !productHasAttributes)
 		refreshProductImages(0);
 
 	$('#resetImages').click(function() {
@@ -655,25 +659,25 @@ function getProductAttribute()
 	// get every attributes values
 	request = '';
 	//create a temporary 'tab_attributes' array containing the choices of the customer
-	var tab_attributes = new Array();
+	var tab_attributes = [];
 	$('#attributes select, #attributes input[type=hidden], #attributes input[type=radio]:checked').each(function(){
 		tab_attributes.push($(this).val());
 	});
 
 	// build new request
-	for (i in attributesCombinations)
-		for (a in tab_attributes)
-			if (attributesCombinations[i]['id_attribute'] == tab_attributes[a])
+	for (var i in attributesCombinations)
+		for (var a in tab_attributes)
+			if (attributesCombinations[i]['id_attribute'] === tab_attributes[a])
 				request += '/'+attributesCombinations[i]['group']+'-'+attributesCombinations[i]['attribute'];
 	request = request.replace(request.substring(0, 1), '#/');
 	url = window.location+'';
 
 	// redirection
-	if (url.indexOf('#') != -1)
+	if (url.indexOf('#') !== -1)
 		url = url.substring(0, url.indexOf('#'));
 
 	// set ipa to the customization form
-	$('#customizationForm').attr('action', $('#customizationForm').attr('action')+request)
+	$('#customizationForm').attr('action', $('#customizationForm').attr('action')+request);
 	window.location = url+request;
 }
 
@@ -685,30 +689,30 @@ function initLocationChange(time)
 
 function checkUrl()
 {
-	if (original_url != window.location || first_url_check)
+	if (original_url !== window.location || first_url_check)
 	{
 		first_url_check = false;
 		url = window.location+'';
 		// if we need to load a specific combination
-		if (url.indexOf('#/') != -1)
+		if (url.indexOf('#/') !== -1)
 		{
 			// get the params to fill from a "normal" url
 			params = url.substring(url.indexOf('#') + 1, url.length);
 			tabParams = params.split('/');
-			tabValues = new Array();
-			if (tabParams[0] == '')
+			tabValues = [];
+			if (tabParams[0] === '')
 				tabParams.shift();
-			for (i in tabParams)
+			for (var i in tabParams)
 				tabValues.push(tabParams[i].split('-'));
 			product_id = $('#product_page_product_id').val();
 			// fill html with values
 			$('.color_pick').removeClass('selected');
 			$('.color_pick').parent().parent().children().removeClass('selected');
 			count = 0;
-			for (z in tabValues)
-				for (a in attributesCombinations)
-					if (attributesCombinations[a]['group'] == decodeURIComponent(tabValues[z][0])
-						&& attributesCombinations[a]['attribute'] == tabValues[z][1])
+			for (var z in tabValues)
+				for (var a in attributesCombinations)
+					if (attributesCombinations[a]['group'] === decodeURIComponent(tabValues[z][0])
+						&& attributesCombinations[a]['attribute'] === tabValues[z][1])
 					{
 						count++;
 						// add class 'selected' to the selected color

--- a/themes/default/js/products-comparison.js
+++ b/themes/default/js/products-comparison.js
@@ -52,7 +52,7 @@ reloadProductComparison = function() {
 	  			url: 'index.php?controller=products-comparison&ajax=1&action=add&id_product=' + idProduct,
 	 			async: true,
 	  			success: function(data){
-	  				if (data == '0')
+	  				if (data === '0')
 	  				{
 	  					checkbox.attr('checked', false);
 		alert(max_item);
@@ -69,7 +69,7 @@ reloadProductComparison = function() {
 	  			url: 'index.php?controller=products-comparison&ajax=1&action=remove&id_product=' + idProduct,
 	 			async: true,
 	  			success: function(data){
-	  				if (data == '0')
+	  				if (data === '0')
 	  					checkbox.attr('checked', true);
 	    		},
 	    		error: function(){

--- a/themes/default/js/scenes.js
+++ b/themes/default/js/scenes.js
@@ -38,9 +38,9 @@ function loadScene(id_scene){
 function onSceneMove(){
 	if (next_scene_is_at_right) current_move++;
 	else current_move--;
-	if (current_move == nb_move_available - 1)	$('#scenes .next').fadeOut();
+	if (current_move === nb_move_available - 1)	$('#scenes .next').fadeOut();
 	else $('#scenes .next:hidden').fadeIn().css('display','block');
-	if (current_move == 0) $('#scenes .prev').fadeOut().css('display','block');
+	if (current_move === 0) $('#scenes .prev').fadeOut().css('display','block');
 	else $('#scenes .prev').fadeIn().css('display','block');
 	return true;
 }

--- a/themes/default/js/stores.js
+++ b/themes/default/js/stores.js
@@ -53,7 +53,7 @@ function searchLocations()
 	var address = document.getElementById('addressInput').value;
 	var geocoder = new google.maps.Geocoder();
 	geocoder.geocode({address: address}, function(results, status) {
-		if (status == google.maps.GeocoderStatus.OK)
+		if (status === google.maps.GeocoderStatus.OK)
 			searchLocationsNear(results[0].geometry.location);
 		else
 			alert(address+' '+translation_6);
@@ -76,7 +76,7 @@ function clearLocations(n)
 		option.innerHTML = translation_1;
 	else
 	{
-		if (n == 1)
+		if (n === 1)
 			option.innerHTML = '1'+' '+translation_2;
 		else
 			option.innerHTML = n+' '+translation_3;
@@ -113,7 +113,7 @@ function searchLocationsNear(center)
 			createMarker(latlng, name, address, other, id_store, has_store_picture);
 			bounds.extend(latlng);
 
-			$('#stores-table tr:last').after('<tr class="node"><td class="num">'+parseInt(i + 1)+'</td><td><b>'+name+'</b>'+(has_store_picture == 1 ? '<br /><img src="'+img_store_dir+parseInt(id_store)+'-medium.jpg" alt="" />' : '')+'</td><td>'+address+(phone != '' ? '<br /><br />'+translation_4+' '+phone : '')+'</td><td class="distance">'+distance+' '+distance_unit+'</td></tr>');
+			$('#stores-table tr:last').after('<tr class="node"><td class="num">'+parseInt(i + 1)+'</td><td><b>'+name+'</b>'+(has_store_picture === 1 ? '<br /><img src="'+img_store_dir+parseInt(id_store)+'-medium.jpg" alt="" />' : '')+'</td><td>'+address+(phone !== '' ? '<br /><br />'+translation_4+' '+phone : '')+'</td><td class="distance">'+distance+' '+distance_unit+'</td></tr>');
 			$('#stores-table').show();
 		}
 
@@ -135,12 +135,14 @@ function searchLocationsNear(center)
 
 function createMarker(latlng, name, address, other, id_store, has_store_picture)
 {
-	var html = '<b>'+name+'</b><br/>'+address+(has_store_picture == 1 ? '<br /><br /><img src="'+img_store_dir+parseInt(id_store)+'-medium.jpg" alt="" />' : '')+other+'<br /><a href="http://maps.google.com/maps?saddr=&daddr='+latlng+'" target="_blank">'+translation_5+'<\/a>';
+	var html = '<b>'+name+'</b><br/>'+address+(has_store_picture === 1 ? '<br /><br /><img src="'+img_store_dir+parseInt(id_store)+'-medium.jpg" alt="" />' : '')+other+'<br /><a href="http://maps.google.com/maps?saddr=&daddr='+latlng+'" target="_blank">'+translation_5+'<\/a>';
 	var image = new google.maps.MarkerImage(img_ps_dir+logo_store);
+	var marker = '';
+
 	if (hasStoreIcon)
-		var marker = new google.maps.Marker({ map: map, icon: image, position: latlng });
+		marker = new google.maps.Marker({ map: map, icon: image, position: latlng });
 	else
-		var marker = new google.maps.Marker({ map: map, position: latlng });
+		marker = new google.maps.Marker({ map: map, position: latlng });
 	google.maps.event.addListener(marker, 'click', function() {
 		infoWindow.setContent(html);
 		infoWindow.open(map, marker);
@@ -160,10 +162,10 @@ function downloadUrl(url, callback)
 {
 	var request = window.ActiveXObject ?
 	new ActiveXObject('Microsoft.XMLHTTP') :
-	new XMLHttpRequest;
+	new XMLHttpRequest();
 
 	request.onreadystatechange = function() {
-		if (request.readyState == 4) {
+		if (request.readyState === 4) {
 			request.onreadystatechange = doNothing;
 			callback(request.responseText, request.status);
 		}
@@ -181,7 +183,7 @@ function parseXml(str)
 		return doc;
 	}
 	else if (window.DOMParser) {
-		return (new DOMParser).parseFromString(str, 'text/xml');
+		return (new DOMParser()).parseFromString(str, 'text/xml');
 	}
 }
 
@@ -200,13 +202,13 @@ $(document).ready(function()
 	locationSelect = document.getElementById('locationSelect');
 		locationSelect.onchange = function() {
 		var markerNum = locationSelect.options[locationSelect.selectedIndex].value;
-		if (markerNum != 'none')
+		if (markerNum !== 'none')
 		google.maps.event.trigger(markers[markerNum], 'click');
 	};
 	
 	$('#addressInput').keypress(function(e) {
 		code = e.keyCode ? e.keyCode : e.which;
-		if(code.toString() == 13)
+		if(code.toString() === 13)
 			searchLocations();
 	});
 

--- a/themes/default/js/tools.js
+++ b/themes/default/js/tools.js
@@ -25,40 +25,40 @@
 
 function ps_round(value, precision)
 {
-	if (typeof(roundMode) == 'undefined')
+	if (typeof(roundMode) === 'undefined')
 		roundMode = 2;
-	if (typeof(precision) == 'undefined')
+	if (typeof(precision) === 'undefined')
 		precision = 2;
 	
 	method = roundMode;
-	if (method == 0)
+	if (method === 0)
 		return ceilf(value, precision);
-	else if (method == 1)
+	else if (method === 1)
 		return floorf(value, precision);
-	precisionFactor = precision == 0 ? 1 : Math.pow(10, precision);
+	precisionFactor = precision === 0 ? 1 : Math.pow(10, precision);
 	return Math.round(value * precisionFactor) / precisionFactor;
 }
 
 function ceilf(value, precision)
 {
-	if (typeof(precision) == 'undefined')
+	if (typeof(precision) === 'undefined')
 		precision = 0;
-	precisionFactor = precision == 0 ? 1 : Math.pow(10, precision);
+	precisionFactor = precision === 0 ? 1 : Math.pow(10, precision);
 	tmp = value * precisionFactor;
 	tmp2 = tmp.toString();
-	if (tmp2[tmp2.length - 1] == 0)
+	if (tmp2[tmp2.length - 1] === 0)
 		return value;
 	return Math.ceil(value * precisionFactor) / precisionFactor;
 }
 
 function floorf(value, precision)
 {
-	if (typeof(precision) == 'undefined')
+	if (typeof(precision) === 'undefined')
 		precision = 0;
-	precisionFactor = precision == 0 ? 1 : Math.pow(10, precision);
+	precisionFactor = precision === 0 ? 1 : Math.pow(10, precision);
 	tmp = value * precisionFactor;
 	tmp2 = tmp.toString();
-	if (tmp2[tmp2.length - 1] == 0)
+	if (tmp2[tmp2.length - 1] === 0)
 		return value;
 	return Math.floor(value * precisionFactor) / precisionFactor;
 }
@@ -66,13 +66,13 @@ function floorf(value, precision)
 function formatedNumberToFloat(price, currencyFormat, currencySign)
 {
 	price = price.replace(currencySign, '');
-	if (currencyFormat == 1)
+	if (currencyFormat === 1)
 		return parseFloat(price.replace(',', '').replace(' ', ''));
-	else if (currencyFormat == 2)
+	else if (currencyFormat === 2)
 		return parseFloat(price.replace(' ', '').replace(',', '.'));
-	else if (currencyFormat == 3)
+	else if (currencyFormat === 3)
 		return parseFloat(price.replace('.', '').replace(' ', '').replace(',', '.'));
-	else if (currencyFormat == 4)
+	else if (currencyFormat === 4)
 		return parseFloat(price.replace(',', '').replace(' ', ''));
 	return price;
 }
@@ -86,15 +86,15 @@ function formatCurrency(price, currencyFormat, currencySign, currencyBlank)
 	price = ps_round(price, priceDisplayPrecision);
 	if (currencyBlank > 0)
 		blank = ' ';
-	if (currencyFormat == 1)
+	if (currencyFormat === 1)
 		return currencySign + blank + formatNumber(price, priceDisplayPrecision, ',', '.');
-	if (currencyFormat == 2)
+	if (currencyFormat === 2)
 		return (formatNumber(price, priceDisplayPrecision, ' ', ',') + blank + currencySign);
-	if (currencyFormat == 3)
+	if (currencyFormat === 3)
 		return (currencySign + blank + formatNumber(price, priceDisplayPrecision, '.', ','));
-	if (currencyFormat == 4)
+	if (currencyFormat === 4)
 		return (formatNumber(price, priceDisplayPrecision, ',', '.') + blank + currencySign);
-	if (currencyFormat == 5)
+	if (currencyFormat === 5)
 		return (formatNumber(price, priceDisplayPrecision, ' ', '.') + blank + currencySign);
 	return price;
 }
@@ -105,15 +105,15 @@ function formatNumber(value, numberOfDecimal, thousenSeparator, virgule)
 	value = value.toFixed(numberOfDecimal);
 	var val_string = value+'';
 	var tmp = val_string.split('.');
-	var abs_val_string = (tmp.length == 2) ? tmp[0] : val_string;
-	var deci_string = ('0.' + (tmp.length == 2 ? tmp[1] : 0)).substr(2);
+	var abs_val_string = (tmp.length === 2) ? tmp[0] : val_string;
+	var deci_string = ('0.' + (tmp.length === 2 ? tmp[1] : 0)).substr(2);
 	var nb = abs_val_string.length;
 
 	for (var i = 1 ; i < 4; i++)
 		if (value >= Math.pow(10, (3 * i)))
 			abs_val_string = abs_val_string.substring(0, nb - (3 * i)) + thousenSeparator + abs_val_string.substring(nb - (3 * i));
 
-	if (parseInt(numberOfDecimal) == 0)
+	if (parseInt(numberOfDecimal) === 0)
 		return abs_val_string;
 	return abs_val_string + virgule + (deci_string > 0 ? deci_string : '00');
 }
@@ -121,27 +121,27 @@ function formatNumber(value, numberOfDecimal, thousenSeparator, virgule)
 //change the text of a jQuery element with a sliding effect (velocity could be a number in ms, 'slow' or 'fast', effect1 and effect2 could be slide, fade, hide, show)
 function updateTextWithEffect(jQueryElement, text, velocity, effect1, effect2, newClass)
 {
-	if(jQueryElement.text() != text)
-		if(effect1 == 'fade')
+	if(jQueryElement.text() !== text)
+		if(effect1 === 'fade')
 			jQueryElement.fadeOut(velocity, function(){
 				$(this).addClass(newClass);
-				if(effect2 == 'fade') $(this).text(text).fadeIn(velocity);
-				else if(effect2 == 'slide') $(this).text(text).slideDown(velocity);
-					else if(effect2 == 'show')	$(this).text(text).show(velocity, function(){});
+				if(effect2 === 'fade') $(this).text(text).fadeIn(velocity);
+				else if(effect2 === 'slide') $(this).text(text).slideDown(velocity);
+					else if(effect2 === 'show')	$(this).text(text).show(velocity, function(){});
 			});
-		else if(effect1 == 'slide')
+		else if(effect1 === 'slide')
 			jQueryElement.slideUp(velocity, function(){
 				$(this).addClass(newClass);
-				if(effect2 == 'fade') $(this).text(text).fadeIn(velocity);
-				else if(effect2 == 'slide') $(this).text(text).slideDown(velocity);
-					else if(effect2 == 'show')	$(this).text(text).show(velocity);
+				if(effect2 === 'fade') $(this).text(text).fadeIn(velocity);
+				else if(effect2 === 'slide') $(this).text(text).slideDown(velocity);
+					else if(effect2 === 'show')	$(this).text(text).show(velocity);
 			});
-			else if(effect1 == 'hide')
+			else if(effect1 === 'hide')
 				jQueryElement.hide(velocity, function(){
 					$(this).addClass(newClass);
-					if(effect2 == 'fade') $(this).text(text).fadeIn(velocity);
-					else if(effect2 == 'slide') $(this).text(text).slideDown(velocity);
-						else if(effect2 == 'show')	$(this).text(text).show(velocity);
+					if(effect2 === 'fade') $(this).text(text).fadeIn(velocity);
+					else if(effect2 === 'slide') $(this).text(text).slideDown(velocity);
+						else if(effect2 === 'show')	$(this).text(text).show(velocity);
 				});
 }
 
@@ -179,12 +179,12 @@ function print_r(arr, level)
 	for (var j = 0 ; j < level + 1; j++)
 		level_padding += "    ";
 
-	if (typeof(arr) == 'object')
+	if (typeof(arr) === 'object')
 	{ //Array/Hashes/Objects 
 		for (var item in arr)
 		{
 			var value = arr[item];
-			if (typeof(value) == 'object') { //If it is an array,
+			if (typeof(value) === 'object') { //If it is an array,
 				dumped_text += level_padding + "'" + item + "' ...\n";
 				dumped_text += dump(value,level+1);
 			}
@@ -205,7 +205,7 @@ function print_r(arr, level)
 function in_array(value, array)
 {
 	for (var i in array)
-		if (array[i] == value)
+		if (array[i] === value)
 			return true;
 	return false;
 }
@@ -214,7 +214,7 @@ function resizeAddressesBox(nameBox)
 {
 	maxHeight = 0;
 
-	if (typeof(nameBox) == 'undefined')
+	if (typeof(nameBox) === 'undefined')
 		nameBox = '.address';
 	$(nameBox).each(function()
 	{
@@ -235,10 +235,10 @@ $(document).ready(function() {
 		
 		if (!$(this).attr('eventCheckboxChange'))
 		{
-			$(this).live('change', function() { $(this).checkboxChange(fnChecked, fnUnchecked) });
+			$(this).live('change', function() { $(this).checkboxChange(fnChecked, fnUnchecked); });
 			$(this).attr('eventCheckboxChange', true);
 		}
-	}
+	};
 });
 
 

--- a/themes/default/js/tools/statesManagement.js
+++ b/themes/default/js/tools/statesManagement.js
@@ -11,14 +11,14 @@ function bindStateInputAndUpdate()
 		updateZipCode();
 	});
 	
-	if ($('select#id_country_invoice').length != 0)
+	if ($('select#id_country_invoice').length !== 0)
 	{
 		$('select#id_country_invoice').change(function(){
 			updateState('invoice');
 			updateNeedIDNumber('invoice');
 			updateZipCode();
 		});
-		if ($('select#id_country_invoice:visible').length != 0)
+		if ($('select#id_country_invoice:visible').length !== 0)
 		{
 			updateState('invoice');
 			updateNeedIDNumber('invoice');
@@ -35,10 +35,10 @@ function updateState(suffix)
 {
 	$('select#id_state'+(suffix !== undefined ? '_'+suffix : '')+' option:not(:first-child)').remove();
 	var states = countries[$('select#id_country'+(suffix !== undefined ? '_'+suffix : '')).val()];
-	if(typeof(states) != 'undefined')
+	if(typeof(states) !== 'undefined')
 	{
 		$(states).each(function (key, item){
-			$('select#id_state'+(suffix !== undefined ? '_'+suffix : '')).append('<option value="'+item.id+'"'+ (idSelectedCountry == item.id ? ' selected="selected"' : '') + '>'+item.name+'</option>');
+			$('select#id_state'+(suffix !== undefined ? '_'+suffix : '')).append('<option value="'+item.id+'"'+ (idSelectedCountry === item.id ? ' selected="selected"' : '') + '>'+item.name+'</option>');
 		});
 		
 		$('p.id_state'+(suffix !== undefined ? '_'+suffix : '')+':hidden').slideDown('slow');
@@ -62,7 +62,7 @@ function updateZipCode(suffix)
 {
 	var idCountry = parseInt($('select#id_country'+(suffix !== undefined ? '_'+suffix : '')).val());
 	
-	if (countriesNeedZipCode[idCountry] != 0)
+	if (countriesNeedZipCode[idCountry] !== 0)
 		$('.postcode'+(suffix !== undefined ? '_'+suffix : '')).slideDown('slow');
 	else
 		$('.postcode'+(suffix !== undefined ? '_'+suffix : '')).slideUp('fast');


### PR DESCRIPTION
In css/admin.css, cellpadding and cellspacing are not valid css, so
replace them with the correct css equivalent.

In css/product.css, simply remove an extra 6 on color.

The rest are all javascript changes. Mainly minor fixups, a lot of it is simply changing == to === and != to !==. Some other minor improvements made to arrays and variable scope, but nothing that should break anything.
