### PR TITLE
[+] BO: Allow override loadUpgradeVersionList() 

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -396,7 +396,7 @@ abstract class ModuleCore
 		self::$modules_cache[$module->name]['upgrade']['upgraded_from'] = $module->database_version;
 		// Check the version of the module with the registered one and look if any upgrade file exist
 		return Tools::version_compare($module->version, $module->database_version, '>')
-				&& Module::loadUpgradeVersionList($module->name, $module->version, $module->database_version);
+				&& $module->loadUpgradeVersionList($module->name, $module->version, $module->database_version);
 	}
 
 	/**


### PR DESCRIPTION
Sorry for this second time pull request for the reason I had to recreate my entire fork. (my bad)
The initial pull and comment are here: https://github.com/PrestaShop/PrestaShop/pull/33#issuecomment-10708105

I guess you have misunderstood the purpose of this change because you confuse the override world with the meaning it has in Prestashop.
Let rephrase that.

Allow a module to return a different upgradeVersionList than the base module implementation.

Does it make more sense?
