### PR TITLE
[-] FO : show mobile theme if you have click "Broswe the mobile site" 

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -111,22 +111,27 @@ class ContextCore
 			$this->mobile_device = false;
 			if ($this->checkMobileContext())
 			{
-				require_once(_PS_TOOL_DIR_.'mobile_Detect/Mobile_Detect.php');
-				$this->mobile_detect = new Mobile_Detect();
-				switch ((int)Configuration::get('PS_ALLOW_MOBILE_DEVICE'))
+				if(Context::getContext()->cookie->no_mobile == false AND (int)Configuration::get('PS_ALLOW_MOBILE_DEVICE') != 0)
+					$this->mobile_device = true;
+				else
 				{
-					case 1: // Only for mobile device
-						if ($this->mobile_detect->isMobile() && !$this->mobile_detect->isTablet())
-							$this->mobile_device = true;
-						break;
-					case 2: // Only for touchpads
-						if ($this->mobile_detect->isTablet() && $this->mobile_detect->isMobile())
-							$this->mobile_device = true;
-						break;
-					case 3: // For touchpad or mobile devices
-						if ($this->mobile_detect->isMobile() || $this->mobile_detect->isTablet())
-							$this->mobile_device = true;
-						break;
+					require_once(_PS_TOOL_DIR_.'mobile_Detect/Mobile_Detect.php');
+					$this->mobile_detect = new Mobile_Detect();
+					switch ((int)Configuration::get('PS_ALLOW_MOBILE_DEVICE'))
+					{
+						case 1: // Only for mobile device
+							if ($this->mobile_detect->isMobile() && !$this->mobile_detect->isTablet())
+								$this->mobile_device = true;
+							break;
+						case 2: // Only for touchpads
+							if ($this->mobile_detect->isTablet() && $this->mobile_detect->isMobile())
+								$this->mobile_device = true;
+							break;
+						case 3: // For touchpad or mobile devices
+							if ($this->mobile_detect->isMobile() || $this->mobile_detect->isTablet())
+								$this->mobile_device = true;
+							break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
On a PC (not a mobile or tablet device), if you click the "Broswe the mobile site" link, nothing happen. With this commit, if you activate at least for a device type, you can have a look on to the mobile site
