### PR TITLE
[*]PDF: Update /PDFGenerator::render()

### DIFF
--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -132,7 +132,17 @@ class PDFGeneratorCore extends TCPDF
 
 		$this->lastPage();
 
-		$output = $display ? 'I' : 'S';
+		if ($display === true)
+			$output = 'D';
+		elseif ($display === false)
+			$output = 'S';
+		elseif (display == 'D')
+			$output = 'D';
+		elseif (display == 'S')
+			$output = 'S';
+		else 	
+			$output = 'I';
+			
 		return $this->output($filename, $output);
 	}
 

--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -122,7 +122,7 @@ class PDFGeneratorCore extends TCPDF
 	 * Render the pdf file
 	 *
 	 * @param string $filename
-     * @param boolean $inline
+         * @param  $display :  true:display to user, false:save, 'I','D','S' as fpdf display
 	 * @throws PrestaShopException
 	 */
 	public function render($filename, $display = true)


### PR DESCRIPTION
Proposal to enhance the $display parameter.

The proposal supports the true/false value, but also the 'D', 'I' and 'S' of fpdf.

The behavior of the true value is changed to 'D' instead of 'I'.
So, in front or back office, while clicking on a button to retrieve a PDF, the download windows of the navigator is proposed instead of displaying the PDF inside the navigator.
