### PR TITLE
[+] Smarty : PrestaShop caching system can be used instead smarty caching

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -28,8 +28,79 @@ define('_PS_SMARTY_DIR_', _PS_TOOL_DIR_.'smarty/');
 
 require_once(_PS_SMARTY_DIR_.'Smarty.class.php');
 
+class Smarty_CacheResource_Presta extends Smarty_CacheResource_KeyValueStore
+{
+	/**
+	 * memcache instance
+	 * @var Memcache
+	 */
+	protected $cache_instance = null;
+
+	public function __construct()
+	{
+		$this->cache_instance = Cache::getInstance();
+	}
+
+	/**
+	 * Read values for a set of keys from cache
+	 *
+	 * @param array $keys list of keys to fetch
+	 * @return array list of values with the given keys used as indexes
+	 * @return boolean true on success, false on failure
+	 */
+	protected function read(array $keys)
+	{
+		$res = array();
+		foreach ($keys as $key) {
+			$res[$key] = $this->cache_instance->get($key);
+		}
+		return $res;
+	}
+
+	/**
+	 * Save values for a set of keys to cache
+	 *
+	 * @param array $keys list of values to save
+	 * @param int $expire expiration time
+	 * @return boolean true on success, false on failure
+	 */
+	protected function write(array $keys, $expire=null)
+	{
+		foreach ($keys as $k => $v) {
+			$this->cache_instance->set($k, $v, $expire);
+		}
+		return true;
+	}
+
+	/**
+	 * Remove values from cache
+	 *
+	 * @param array $keys list of keys to delete
+	 * @return boolean true on success, false on failure
+	 */
+	protected function delete(array $keys)
+	{
+		foreach ($keys as $k) {
+			$this->cache_instance->delete($k);
+		}
+		return true;
+	}
+
+	/**
+	 * Remove *all* values from cache
+	 *
+	 * @return boolean true on success, false on failure
+	 */
+	protected function purge()
+	{
+		return $this->cache_instance->flush();
+	}
+}
+
 global $smarty;
 $smarty = new Smarty();
+if(_PS_CACHE_ENABLED_&&Configuration::get('PS_SMARTY_CACHE_REPLACE'))
+	$smarty->caching_type = 'presta';
 $smarty->setCompileDir(_PS_CACHE_DIR_.'smarty/compile');
 $smarty->setCacheDir(_PS_CACHE_DIR_.'smarty/cache');
 $smarty->setConfigDir(_PS_SMARTY_DIR_.'configs');

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -453,6 +453,26 @@ class AdminPerformanceControllerCore extends AdminController
 					'desc' => $this->l('Enable or disable caching system')
 				),
 				array(
+					'type' => 'radio',
+					'label' => $this->l('Cache for smarty'),
+					'name' => 'smarty_cache_replace',
+					'class' => 't',
+					'is_bool' => true,
+					'values' => array(
+						array(
+							'id' => 'smarty_cache_replace_on',
+							'value' => 1,
+							'label' => $this->l('Enabled')
+						),
+						array(
+							'id' => 'smarty_cache_replace_off',
+							'value' => 0,
+							'label' => $this->l('Disabled')
+						)
+					),
+					'desc' => $this->l('Selected caching system will be used instead default smarty caching')
+				),
+				array(
 					'type' => 'select',
 					'label' => $this->l('Caching system'),
 					'name' => 'caching_system',
@@ -478,6 +498,7 @@ class AdminPerformanceControllerCore extends AdminController
 
 		$depth = Configuration::get('PS_CACHEFS_DIRECTORY_DEPTH');
 		$this->fields_value['active'] = _PS_CACHE_ENABLED_;
+		$this->fields_value['smarty_cache_replace'] = Configuration::get('PS_SMARTY_CACHE_REPLACE');
 		$this->fields_value['caching_system'] = _PS_CACHING_SYSTEM_;
 		$this->fields_value['ps_cache_fs_directory_depth'] = $depth ? $depth : 1;
 
@@ -740,6 +761,7 @@ class AdminPerformanceControllerCore extends AdminController
 		{
 			if ($this->tabAccess['edit'] === '1')
 			{
+				Configuration::updateValue('PS_SMARTY_CACHE_REPLACE', Tools::getValue('smarty_cache_replace', 0));
 				$prev_settings = file_get_contents(dirname(__FILE__).'/../../config/settings.inc.php');
 				$new_settings = $prev_settings;
 				if (!Tools::getValue('active'))


### PR DESCRIPTION
Memcached, APC and other caching systems can be used instead default smarty caching in files. (If cachefs and memcache classes will be fixed in this pull request https://github.com/PrestaShop/PrestaShop/pull/61)
