### PR TITLE
Fix mail error, make a little more robust

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -212,7 +212,7 @@ class MailCore
 			else if (!file_exists($template_path.$template.'.html') && ($configuration['PS_MAIL_TYPE'] == Mail::TYPE_BOTH || $configuration['PS_MAIL_TYPE'] == Mail::TYPE_HTML))
 			{
 				Tools::dieOrLog(Tools::displayError('Error - The following e-mail template is missing:').' '.$template_path.$template.'.html', $die);
-				reutrn false;
+				return false;
 			}
 			$template_html = file_get_contents($template_path.$template.'.html');
 			$template_txt = strip_tags(html_entity_decode(file_get_contents($template_path.$template.'.txt'), null, 'utf-8'));

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -204,10 +204,15 @@ class MailCore
 				$template_path = $theme_path.'mails/';
 				$override_mail  = true;
 			}
-			else if (!file_exists($template_path.$template.'.txt') || !file_exists($template_path.$template.'.html'))
+			else if (!file_exists($template_path.$template.'.txt') && ($configuration['PS_MAIL_TYPE'] == Mail::TYPE_BOTH || $configuration['PS_MAIL_TYPE'] == Mail::TYPE_TEXT))
 			{
 				Tools::dieOrLog(Tools::displayError('Error - The following e-mail template is missing:').' '.$template_path.$template.'.txt', $die);
 				return false;
+			}
+			else if (!file_exists($template_path.$template.'.html') && ($configuration['PS_MAIL_TYPE'] == Mail::TYPE_BOTH || $configuration['PS_MAIL_TYPE'] == Mail::TYPE_HTML))
+			{
+				Tools::dieOrLog(Tools::displayError('Error - The following e-mail template is missing:').' '.$template_path.$template.'.html', $die);
+				reutrn false;
 			}
 			$template_html = file_get_contents($template_path.$template.'.html');
 			$template_txt = strip_tags(html_entity_decode(file_get_contents($template_path.$template.'.txt'), null, 'utf-8'));


### PR DESCRIPTION
This changes two things in the mail class.
1. If the html template was missing, it would tell you the txt template
   was missing. It now tells you that the html template is missing.
2. If the type is set to only text or html, don't fail if the other
   template is missing. Example, if set to only use text templates, don't
   fail if the html template does not exist. If the type is set to both,
   or if the specific type of template is missing, it will still complain.
