### PR TITLE
[-] BO : Fixing unique key blocking in some cases

### DIFF
--- a/install-dev/upgrade/sql/1.5.2.1.sql
+++ b/install-dev/upgrade/sql/1.5.2.1.sql
@@ -11,3 +11,6 @@ UPDATE `PREFIX_order_state` SET `delivery` = 0 WHERE `id_order_state` = 3;
 ALTER TABLE  `PREFIX_product_shop` ADD `id_product_redirected` int(10) unsigned NOT NULL default '0' AFTER `active` , ADD `available_for_order` tinyint(1) NOT NULL default '1' AFTER `id_product_redirected`;
 
 ALTER TABLE  `PREFIX_product` ADD `id_product_redirected` int(10) unsigned NOT NULL default '0' AFTER `active` , ADD `available_for_order` tinyint(1) NOT NULL default '1' AFTER `id_product_redirected`;
+
+ALTER TABLE  `prestashop15`.`ps_stock_available` DROP INDEX  `id_product_2` ,
+ADD UNIQUE  `id_product_2` (  `id_product` ,  `id_product_attribute` ,  `id_shop` ,  `id_shop_group` );

--- a/install-dev/upgrade/sql/1.5.2.1.sql
+++ b/install-dev/upgrade/sql/1.5.2.1.sql
@@ -11,3 +11,6 @@ UPDATE `PREFIX_order_state` SET `delivery` = 0 WHERE `id_order_state` = 3;
 ALTER TABLE  `PREFIX_product_shop` ADD `id_product_redirected` int(10) unsigned NOT NULL default '0' AFTER `active` , ADD `available_for_order` tinyint(1) NOT NULL default '1' AFTER `id_product_redirected`;
 
 ALTER TABLE  `PREFIX_product` ADD `id_product_redirected` int(10) unsigned NOT NULL default '0' AFTER `active` , ADD `available_for_order` tinyint(1) NOT NULL default '1' AFTER `id_product_redirected`;
+
+ALTER TABLE  `PREFIX_stock_available` DROP INDEX  `id_product_2` ,
+ADD UNIQUE  `id_product_2` (  `id_product` ,  `id_product_attribute` ,  `id_shop` ,  `id_shop_group` );

--- a/install-dev/upgrade/sql/1.5.2.1.sql
+++ b/install-dev/upgrade/sql/1.5.2.1.sql
@@ -12,5 +12,5 @@ ALTER TABLE  `PREFIX_product_shop` ADD `id_product_redirected` int(10) unsigned 
 
 ALTER TABLE  `PREFIX_product` ADD `id_product_redirected` int(10) unsigned NOT NULL default '0' AFTER `active` , ADD `available_for_order` tinyint(1) NOT NULL default '1' AFTER `id_product_redirected`;
 
-ALTER TABLE  `ps_stock_available` DROP INDEX  `id_product_2` ,
+ALTER TABLE  `prestashop15`.`ps_stock_available` DROP INDEX  `id_product_2` ,
 ADD UNIQUE  `id_product_2` (  `id_product` ,  `id_product_attribute` ,  `id_shop` ,  `id_shop_group` );

--- a/install-dev/upgrade/sql/1.5.2.1.sql
+++ b/install-dev/upgrade/sql/1.5.2.1.sql
@@ -11,6 +11,3 @@ UPDATE `PREFIX_order_state` SET `delivery` = 0 WHERE `id_order_state` = 3;
 ALTER TABLE  `PREFIX_product_shop` ADD `id_product_redirected` int(10) unsigned NOT NULL default '0' AFTER `active` , ADD `available_for_order` tinyint(1) NOT NULL default '1' AFTER `id_product_redirected`;
 
 ALTER TABLE  `PREFIX_product` ADD `id_product_redirected` int(10) unsigned NOT NULL default '0' AFTER `active` , ADD `available_for_order` tinyint(1) NOT NULL default '1' AFTER `id_product_redirected`;
-
-ALTER TABLE  `prestashop15`.`ps_stock_available` DROP INDEX  `id_product_2` ,
-ADD UNIQUE  `id_product_2` (  `id_product` ,  `id_product_attribute` ,  `id_shop` ,  `id_shop_group` );

--- a/install-dev/upgrade/sql/1.5.2.1.sql
+++ b/install-dev/upgrade/sql/1.5.2.1.sql
@@ -12,5 +12,5 @@ ALTER TABLE  `PREFIX_product_shop` ADD `id_product_redirected` int(10) unsigned 
 
 ALTER TABLE  `PREFIX_product` ADD `id_product_redirected` int(10) unsigned NOT NULL default '0' AFTER `active` , ADD `available_for_order` tinyint(1) NOT NULL default '1' AFTER `id_product_redirected`;
 
-ALTER TABLE  `prestashop15`.`ps_stock_available` DROP INDEX  `id_product_2` ,
+ALTER TABLE  `ps_stock_available` DROP INDEX  `id_product_2` ,
 ADD UNIQUE  `id_product_2` (  `id_product` ,  `id_product_attribute` ,  `id_shop` ,  `id_shop_group` );


### PR DESCRIPTION
If you have 2 groups sharing stock, then you can have this kind of line in ps_stock_available :
id_product=7, id_shop=0, id_shop_group=1
id_product=7, id_shop=0, id_shop_group=2
The actuel unique key don't permit these lines ! Isn't it a big bug ?
