### PR TITLE
[-] FO: products per page in category view

### DIFF
--- a/themes/default/nbr-product-page.tpl
+++ b/themes/default/nbr-product-page.tpl
@@ -39,7 +39,7 @@
 		{assign var='requestNb' value=$link->getPaginationLink(false, false, true, false, false, true)}
 	{/if}
 	<!-- nbr product/page -->
-	{if $nb_products > 10}
+	{if $nb_products > $add_prod_display}
 		<form action="{if !is_array($requestNb)}{$requestNb}{else}{$requestNb.requestUrl}{/if}" method="get" class="nbrItemPage pagination">
 			<p>
 				{if isset($search_query) AND $search_query}<input type="hidden" name="search_query" value="{$search_query|escape:'htmlall':'UTF-8'}" />{/if}


### PR DESCRIPTION
In category view the products per page selector should use the configuration setting:

PS_ATTRIBUTE_CATEGORY_DISPLAY

Reproduce the issue:

1.- In the backend Preferences > Products set products per page to 1
2.- In frontend load any category.
3.- You will not see the products per page selector because it's forced to be shown only when the number of items is > 10.
