### PR TITLE
[-] FO : Bad shop_url in the mails

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -233,7 +233,7 @@ class MailCore
 					$template_vars['{shop_logo}'] = '';
 
 			$template_vars['{shop_name}'] = Tools::safeOutput(Configuration::get('PS_SHOP_NAME'));
-			$template_vars['{shop_url}'] = Tools::getShopDomain(true, true).__PS_BASE_URI__.'index.php';
+			$template_vars['{shop_url}'] = Tools::getShopDomain(true, true).__PS_BASE_URI__;
 			$template_vars['{my_account_url}'] = Context::getContext()->link->getPageLink('my-account', true, Context::getContext()->language->id);
 			$template_vars['{guest_tracking_url}'] = Context::getContext()->link->getPageLink('guest-tracking', true, Context::getContext()->language->id);
 			$template_vars['{history_url}'] = Context::getContext()->link->getPageLink('history', true, Context::getContext()->language->id);


### PR DESCRIPTION
Most of the modules' mail are using something like {shop_url}{link} in the mail template.
{shop_url} now contains 'index.php', so a link like the one from the referralprogram will be : http://shopdomain/index.phpauthentication.php

Moreover, the homepage of the website is not necessary 'index.php'
