### PR TITLE
HookActionAdminOrdersTrackingNumberUpdate execution

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -303,13 +303,11 @@ class AdminOrdersControllerCore extends AdminController
 							'{id_order}' => $order->id,
 							'{order_name}' => $order->getUniqReference()
 						);
+						Hook::exec('actionAdminOrdersTrackingNumberUpdate', array('order' => $order));
 						if (@Mail::Send((int)$order->id_lang, 'in_transit', Mail::l('Package in transit', (int)$order->id_lang), $templateVars,
 							$customer->email, $customer->firstname.' '.$customer->lastname, null, null, null, null,
 							_PS_MAIL_DIR_, true, (int)$order->id_shop))
-						{
-							Hook::exec('actionAdminOrdersTrackingNumberUpdate', array('order' => $order));
 							Tools::redirectAdmin(self::$currentIndex.'&id_order='.$order->id.'&vieworder&conf=4&token='.$this->token);
-						}
 						else
 							$this->errors[] = Tools::displayError('An error occurred while sending e-mail to the customer.');
 					}


### PR DESCRIPTION
HookActionAdminOrdersTrackingNumberUpdate should be executed even if mail is not sent

Many situations would make this mandatory. We already now that this
number is valid, and don't want to rely on whether the mail has been
sent or not as the tracking number is pushed in the database right
before
