### PR TITLE
[-] FO : Fix bug in order-opc.js blocking account creation

### DIFF
--- a/themes/default/js/order-opc.js
+++ b/themes/default/js/order-opc.js
@@ -520,7 +520,7 @@ $(function() {
 			var callingFile = '';
 			var params = '';
 
-			if ($('#opc_id_customer').val() === 0)
+			if ($('#opc_id_customer').val() === '0')
 			{
 				callingFile = authenticationUrl;
 				params = 'submitAccount=true&';


### PR DESCRIPTION
jQuery val() method return a string, not an integer. So check for a string.

This bug is blocking the order when creating a new account.
