### PR TITLE
[*] MO : gsitemap - Do not include authentication in the sitemap as that...

### DIFF
--- a/modules/gsitemap/gsitemap.php
+++ b/modules/gsitemap/gsitemap.php
@@ -284,7 +284,7 @@ XML;
 			'new-products' => false,
 			'prices-drop' => false,
 			'stores' => false,
-			'authentication' => true,
+			'authentication' => false,
 			'best-sales' => false,
 			'contact-form' => true);
 


### PR DESCRIPTION
... controller is listed for search engine exclusion in the robots.txt file. Google Webmaster Tools will complain if a page is listed in both places.
