### PR TITLE
[-] Wrong parameters for Memcache::addServer

### DIFF
--- a/classes/cache/CacheMemcache.php
+++ b/classes/cache/CacheMemcache.php
@@ -83,7 +83,7 @@ class CacheMemcacheCore extends Cache
 		if (!$servers)
 			return false;
 		foreach ($servers as $server)
-			$this->memcache->addServer($server['ip'], $server['port'], $server['weight']);
+			$this->memcache->addServer($server['ip'], $server['port'], true, (int) $server['weight']);
 
 		$this->is_connected = true;
 	}


### PR DESCRIPTION
 The 3th parameter is $persistent not $weight

http://php.net/manual/en/memcache.addserver.php
