### PR TITLE
ObjectModel::updateMultishopTable() where argument is not mandatory

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1284,7 +1284,7 @@ abstract class ObjectModelCore
 	 * @param string $specific_where Only executed for common table
 	 * @return bool
 	 */
-	public static function updateMultishopTable($classname, $data, $where, $specific_where = '')
+	public static function updateMultishopTable($classname, $data, $where = '', $specific_where = '')
 	{
 		$def = ObjectModel::getDefinition($classname);
 		$update_data = array();
@@ -1304,8 +1304,8 @@ abstract class ObjectModelCore
 
 		$sql = 'UPDATE '._DB_PREFIX_.$def['table'].' a
 				'.Shop::addSqlAssociation($def['table'], 'a', true, null, true).'
-				SET '.implode(', ', $update_data).'
-				WHERE '.$where;
+				SET '.implode(', ', $update_data).
+				(!empty($where) ? ' WHERE '.$where : '');
 		return Db::getInstance()->execute($sql);
 	}
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4609,7 +4609,7 @@ class ProductCore extends ObjectModel
 	{
 		return ObjectModel::updateMultishopTable('product', array(
 			'ecotax' => 0,
-		), '');
+		));
 	}
 
 	/**

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -413,7 +413,7 @@ class SearchCore
 		{
 			$db->execute('TRUNCATE '._DB_PREFIX_.'search_index');
 			$db->execute('TRUNCATE '._DB_PREFIX_.'search_word');
-			ObjectModel::updateMultishopTable('Product', array('indexed' => 0), '1');
+			ObjectModel::updateMultishopTable('Product', array('indexed' => 0));
 		}
 		else
 		{


### PR DESCRIPTION
ObjectModel::updateMultishopTable() $where argument is not mandatory.
Also this patch solves  Product::resetEcoTax() function bug (bacause this function calls updateMultishopTable with $where argument as empty string, formed SQL query is not valid).
