### PR TITLE
[-] BO: Sorting category list tables brings back to root category

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -146,8 +146,8 @@
 									</span>
 									{if (!isset($params.orderby) || $params.orderby) && !$simple_header}
 										<br />
-										<a href="{$currentIndex}&{$table}Orderby={$key|urlencode}&{$table}Orderway=desc&token={$token}"><img border="0" src="../img/admin/down{if isset($order_by) && ($key == $order_by) && ($order_way == 'DESC')}_d{/if}.gif" /></a>
-										<a href="{$currentIndex}&{$table}Orderby={$key|urlencode}&{$table}Orderway=asc&token={$token}"><img border="0" src="../img/admin/up{if isset($order_by) && ($key == $order_by) && ($order_way == 'ASC')}_d{/if}.gif" /></a>
+										<a href="{$currentIndex}{if $table == 'category'}&id_category={$id_cat}{/if}&{$table}Orderby={$key|urlencode}&{$table}Orderway=desc&token={$token}"><img border="0" src="../img/admin/down{if isset($order_by) && ($key == $order_by) && ($order_way == 'DESC')}_d{/if}.gif" /></a>
+										<a href="{$currentIndex}{if $table == 'category'}&id_category={$id_cat}{/if}&{$table}Orderby={$key|urlencode}&{$table}Orderway=asc&token={$token}"><img border="0" src="../img/admin/up{if isset($order_by) && ($key == $order_by) && ($order_way == 'ASC')}_d{/if}.gif" /></a>
 									{elseif !$simple_header}
 										<br />&nbsp;
 									{/if}


### PR DESCRIPTION
In the BO, in Catalog > Categories, if you navigate into a nested category and try to sort by any of the available parameters, you will get redirected to the root category, where the sorting will be applied.
You could navigate back to the nested category, but this is not a good result.

This solution is not ideal, as it only deals with categories, and not with other potential nested lists.
