### PR TITLE
[-] Fix: OrderHistory::changeIdOrderState

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -70,10 +70,10 @@ class OrderHistoryCore extends ObjectModel
 	 * Sets the new state of the given order
 	 *
 	 * @param int $new_order_state
-	 * @param int $id_order
+	 * @param int/object $id_order
 	 * @param bool $use_existing_payment
 	 */
-	public function changeIdOrderState($new_order_state, &$id_order, $use_existing_payment = false)
+	public function changeIdOrderState($new_order_state, $id_order, $use_existing_payment = false)
 	{
 		if (!$new_order_state || !$id_order)
 			return;


### PR DESCRIPTION
&$id_order breaks compatibility with existing codes :

1/ it's unnecessary : Objects are passed by references by default
2/ it causes fatal errors if you cast parameters: 

``` PHP
$foo->changeIdOrderState((int)$id_order_state, (int)$id_order);
```

Fatal error: Only variables can be passed by reference
