### PR TITLE
[-] Fix the PS_ALLOW_ACCENTED_CHARS_URL bug

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -454,6 +454,14 @@ class ProductCore extends ObjectModel
 
 			$this->loadStockData();
 		}
+		
+		// Fix the PS_ALLOW_ACCENTED_CHARS_URL bug of Prestashop 1.5.3.0
+		if (
+			$this->link_rewrite
+			&& !Validate::isLinkRewrite($this->link_rewrite)
+		) {
+			$this->link_rewrite = Tools::str2url($this->link_rewrite);
+		}
 
 		if ($this->id_category_default)
 			$this->category = Category::getLinkRewrite((int)$this->id_category_default, (int)$id_lang);
@@ -5171,3 +5179,5 @@ class ProductCore extends ObjectModel
 	}
 }
 
+= '.(int)$interval['nright']);
+		$sql-

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -456,12 +456,22 @@ class ProductCore extends ObjectModel
 		}
 		
 		// Fix the PS_ALLOW_ACCENTED_CHARS_URL bug of Prestashop 1.5.3.0
-		if (
+		if (is_array($this->link_rewrite)) {
+			foreach($this->link_rewrite as $id_lang => $link_rewrite) {
+				if (
+					$link_rewrite
+					&& !Validate::isLinkRewrite($link_rewrite)
+				) {
+					$this->link_rewrite[$id_lang] = Tools::str2url($link_rewrite);
+				}			
+			}
+		} elseif (
 			$this->link_rewrite
 			&& !Validate::isLinkRewrite($this->link_rewrite)
 		) {
 			$this->link_rewrite = Tools::str2url($this->link_rewrite);
 		}
+
 
 		if ($this->id_category_default)
 			$this->category = Category::getLinkRewrite((int)$this->id_category_default, (int)$id_lang);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5188,6 +5188,3 @@ class ProductCore extends ObjectModel
 		return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
 	}
 }
-
-= '.(int)$interval['nright']);
-		$sql-


### PR DESCRIPTION
In Prestashop < 1.5.3 utf8 chars was allowed in URL (it was a good thing btw)
In Prestashop >= 1.5.3 no more but rewrited URL are not modified 
so if you simply do

``` PHP
$p = new Product((int) $id_product, (int) $id_lang);
$p->save();
```

you can have an exception : "Property Product->link_rewrite is not valid"
