### PR TITLE
[-] FO : moved default language detection from Tools::setCookieLanguage to Cookie::update

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -296,10 +296,28 @@ class CookieCore
 		else
 			$this->_content['date_add'] = date('Y-m-d H:i:s');
 
+		/* Automatically detect language if not already defined */
+		if (!$this->id_lang && isset($_SERVER['HTTP_ACCEPT_LANGUAGE']))
+		{
+			$array = explode(',', Tools::strtolower($_SERVER['HTTP_ACCEPT_LANGUAGE']));
+			if (Tools::strlen($array[0]) > 2)
+			{
+				$tab = explode('-', $array[0]);
+				$string = $tab[0];
+			}
+			else
+				$string = $array[0];
+			if (Validate::isLanguageIsoCode($string))
+			{
+				$lang = new Language(Language::getIdByIso($string));
+				if (Validate::isLoadedObject($lang) && $lang->active)
+					$this->id_lang = (int)$lang->id;
+			}
+		}
+
 		//checks if the language exists, if not choose the default language
 		if (!Language::getLanguage((int)$this->id_lang))
 			$this->id_lang = Configuration::get('PS_LANG_DEFAULT');
-
 	}
 
 	/**


### PR DESCRIPTION
The default language detection from Tools::setCookieLanguage is never processed because Cookie::$id_lang is populated before this method is called.

To allow automatic language detection base on the client HTTP headers, I moved the language detection code from Tools::setCookieLanguage to Cookie::update.

To test this feature : access the base URL of a multilingual PrestaShop 1.5.3.1 ; without language suffix, and let the default language redirection happen: without this fix, PS_LANG_DEFAULT is always used. With this fix, the browser language is used (fallback = default language).
