### PR TITLE
Import is very long ? Disable indexation on import

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1464,9 +1464,6 @@ class AdminImportControllerCore extends AdminController
 
 		}
 
-		if (Configuration::get('PS_SEARCH_INDEXATION'))
-			Search::indexation(true);
-
 		$this->closeCsvFile($handle);
 	}
 


### PR DESCRIPTION
The search indexation is very CPU intensive : it should be operated
using the indexation itself (not during the import).

On > 2000 products shop, indexation could take more than 5 minutes.

An option should be added on import if the user still wants to make indexation during import.
