### PR TITLE
Disable search indexation

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1464,9 +1464,6 @@ class AdminImportControllerCore extends AdminController
 
 		}
 
-		if (Configuration::get('PS_SEARCH_INDEXATION'))
-			Search::indexation(true);
-
 		$this->closeCsvFile($handle);
 	}
 


### PR DESCRIPTION
The search indexation is very CPU intensive : it should not be launched here (or using a checkable option)
