### PR TITLE
Update classes/module/Module.php

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -400,9 +400,10 @@ abstract class ModuleCore
 		// Check the version of the module with the registered one and look if any upgrade file exist
 		if (Tools::version_compare($module->version, $module->database_version, '>'))
 		{
+			$oldVersion = $module->database_version;
 			$module = Module::getInstanceByName($module->name);
 			if ($module instanceof Module)
-				return $module->loadUpgradeVersionList($module->name, $module->version, $module->database_version);
+				return $module->loadUpgradeVersionList($module->name, $module->version, $oldVersion);
 		}
 		return null;
 	}

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -400,10 +400,10 @@ abstract class ModuleCore
 		// Check the version of the module with the registered one and look if any upgrade file exist
 		if (Tools::version_compare($module->version, $module->database_version, '>'))
 		{
-			$oldVersion = $module->database_version;
+			$old_version = $module->database_version;
 			$module = Module::getInstanceByName($module->name);
 			if ($module instanceof Module)
-				return $module->loadUpgradeVersionList($module->name, $module->version, $oldVersion);
+				return $module->loadUpgradeVersionList($module->name, $module->version, $old_version);
 		}
 		return null;
 	}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | [-] FO : Fix for automatic modules upgrades
| Sponsor company   | Prestaplugins

Automatic upgrade of modules doesn't work anymore in 1.5.3.1 because $module->database_version is now set in __construct, so when the new module to upgrade is instanciated, it overwrites the old version, and versions which are comparated are now the same... So no upgrade is launched...
