### PR TITLE
[-] MO: fix a problem with the wishlist_link

### DIFF
--- a/modules/blockwishlist/blockwishlist.php
+++ b/modules/blockwishlist/blockwishlist.php
@@ -170,6 +170,8 @@ class BlockWishList extends Module
 	{
 		$this->context->controller->addCSS(($this->_path).'blockwishlist.css', 'all');
 		$this->context->controller->addJS(($this->_path).'js/ajax-wishlist.js');
+		
+		$this->smarty->assign(array('wishlist_link' => $this->context->link->getModuleLink('blockwishlist', 'mywishlist')));
 	}
 
 	public function hookRightColumn($params)
@@ -202,8 +204,6 @@ class BlockWishList extends Module
 		}
 		else
 			$this->smarty->assign(array('wishlist_products' => false, 'wishlists' => false));
-		
-		$this->smarty->assign(array('wishlist_link' => $this->context->link->getModuleLink('blockwishlist', 'mywishlist')));
 		
 		return ($this->display(__FILE__, 'blockwishlist.tpl'));
 	}


### PR DESCRIPTION
With @Kreasite, we see that if you put the module "Block MyAccount" before the "Wishlist", the wishlist_link var is not declare yet, so the link is empty. If you put the var in the header, it can be accessed by the other tpl.

Or, we can put this in a {$link->getModuleLink(...)} in TPL


