### PR TITLE
[-] FO : PS_SSL_ENABLED and mod_rewrite yields a 301 error (Too Many Red...

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -267,6 +267,9 @@ class ToolsCore
 		// $_SERVER['SSL'] exists only in some specific configuration
 		if (isset($_SERVER['SSL']))
 			return ($_SERVER['SSL'] == 1 || strtolower($_SERVER['SSL']) == 'on');
+		// $_SERVER['REDIRECT_HTTPS'] exists only in some specific configuration (e.g. Gandi's simple hosting)
+		if (isset($_SERVER['REDIRECT_HTTPS']))
+			return ($_SERVER['REDIRECT_HTTPS'] == 1 || strtolower($_SERVER['REDIRECT_HTTPS']) == 'on');
 
 		return false;
 	}


### PR DESCRIPTION
...irects) on pages served by https.

See http://www.prestashop.com/forums/topic/217724-activer-le-ssl-url-simplifiee-mod-rewrite-ne-marche-pas-erreur-301-sur-les-pages-commandes for more info.
