### PR TITLE
[*] Class Tools: enhance fd method

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -730,11 +730,16 @@ class ToolsCore
 	*
 	* @param object $object Object to display
 	*/
-	public static function fd($object)
+	public static function fd($object, $type = 'log')
 	{
+		$types = array('log', 'debug', 'info', 'warn', 'error', 'assert');
+		
+		if(!in_array($type, $types))
+			$type = 'log';
+		
 		echo '
 			<script type="text/javascript">
-				console.log('.json_encode($object).');
+				console.'.$type.'('.json_encode($object).');
 			</script>
 		';
 	}


### PR DESCRIPTION
Add the posibilities to set an error, warning, info or assert.

Usage:
Tools::fd('test');
Tools::fd('test', 'debug');
Tools::fd('test', 'info');
Tools::fd('test', 'warn');
Tools::fd('test', 'error');
Tools::fd('test', 'assert');
