### PR TITLE
[-] BO : Fixes Syntax Error in Line 126 in AdminSearchConfController.php

### DIFF
--- a/controllers/admin/AdminSearchConfController.php
+++ b/controllers/admin/AdminSearchConfController.php
@@ -113,7 +113,7 @@ class AdminSearchConfControllerCore extends AdminController
 						'title' => $this->l('Blacklisted words'),
 						'size' => 35,
 						'validation' => 'isGenericName',
-						'desc' => $this->l('Please enter the index words separated by a "|".'|".'),
+						'desc' => $this->l('Please enter the index words separated by a "|".'),
 						'type' => 'textLang'
 					)
 				),


### PR DESCRIPTION
There was a Typo / Syntax Error in Line 116.
Issue #217
