### PR TITLE
[FIX] Presta breaks if you set modification date as default search order

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -279,8 +279,11 @@ class SearchCore
 			$order_by = pSQL($order_by[0]).'.`'.pSQL($order_by[1]).'`';
 		}
 		$alias = '';
-		if ($order_by == 'price')
+		if ($order_by == 'price') {
 			$alias = 'product_shop.';
+        } else if ($order_by == 'date_upd') {
+			$alias = 'p.';
+        }
 		$sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity, 
 				pl.`description_short`, pl.`available_now`, pl.`available_later`, pl.`link_rewrite`, pl.`name`,
 			 image_shop.`id_image`, il.`legend`, m.`name` manufacturer_name '.$score.', product_attribute_shop.`id_product_attribute`,


### PR DESCRIPTION
This fixes the following problem:
- set modification date as the default sort order in Preferences -> Products
- do a search
- change sorting to some non-default order
- change sorting to the default
- watch Presta break

The problem is because date_upd is ambiguous  in the search query. The problem is not apparent because the search has position hardcoded as the default order (which I think should be fixed as well).
