### PR TITLE
Update controllers/admin/AdminTranslationsController.php

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1060,7 +1060,7 @@ class AdminTranslationsControllerCore extends AdminController
 					if ($type_file == 'php')
 						$regex = '/->l\(\''._PS_TRANS_PATTERN_.'\'(, ?\'(.+)\')?(, ?(.+))?\)/U';
 					else
-						$regex = '/\{l\s*s=\''._PS_TRANS_PATTERN_.'\'(\s*sprintf=.*)?(\s*mod=\'.+\')?(\s*js=1)?\s*\}/U';
+						$regex = '/\{l\s*s=[\'\"]'._PS_TRANS_PATTERN_.'[\'\"](\s*sprintf=.*)?(\s*mod=[\'\"].+[\'\"])?(\s*js=1)?\s*\}/U';
 				break;
 
 			case 'pdf':


### PR DESCRIPTION
For front tpl/js parse. You can translate those both technical declaration ' or " :

var test = "{l s='Test with this quote' mod='lambda'}";
var test = '{l s="Test with this doublequote" mod="lambda"}';

this way can be paste for all translation type :
front, back, errors, modules, pdf
