### PR TITLE
[-] BO : fixed temp file getting lost in AdminImportController::split()

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -642,12 +642,11 @@ class AdminImportControllerCore extends AdminController
 		if (is_null($separator) || trim($separator) == '')
 			$separator = ',';
 
-		do $uniqid = uniqid(); while (file_exists(_PS_UPLOAD_DIR_.$uniqid));
-		$tmp_file = file_put_contents(_PS_UPLOAD_DIR_.$uniqid, $field);
-		$fd = fopen($temp, 'r');
+		$fd = fopen('php://memory', 'r+');
+		fwrite($fd, $field);
+		rewind($fd);
 		$tab = fgetcsv($fd, MAX_LINE_SIZE, $separator);
 		fclose($fd);
-		unlink($tmp_file);
 
 		if (empty($tab) || (!is_array($tab)))
 			return array();
@@ -1429,7 +1428,7 @@ class AdminImportControllerCore extends AdminController
 							$error = true;
 
 						if ($error)
-							$this->warnings[] = sprintf(Tools::displayError('Product n°%1$d: the picture cannot be saved: %2$s'), $image->id_product, $url);
+							$this->warnings[] = sprintf(Tools::displayError('Product n??%1$d: the picture cannot be saved: %2$s'), $image->id_product, $url);
 					}
 				}
 				if (isset($product->id_category))


### PR DESCRIPTION
This is similar in nature to the fix by @vAugagneur PrestaShop/PrestaShop@8d7196daf3b39d280c631882f0e3ebe473233d07 but instead of retaining the multiple open/close of the file and code that forces a bunch of (slow) disk I/O, it is all done in memory and the file descriptor is only opened and closed once (with no unlinking of the file required).
