### PR TITLE
[-] PDF : Fixed unecessary slash in overriden template path

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -163,7 +163,7 @@ abstract class HTMLTemplateCore
 	{
 		$template = false;
 		$default_template = _PS_PDF_DIR_.'/'.$template_name.'.tpl';
-		$overriden_template = _PS_THEME_DIR_.'/pdf/'.$template_name.'.tpl';
+		$overriden_template = _PS_THEME_DIR_.'pdf/'.$template_name.'.tpl';
 
 		if (file_exists($overriden_template))
 			$template = $overriden_template;


### PR DESCRIPTION
The overriden template path is using an unecessary slash before the "pdf" directory, and we can't use an overriden template for PDF, it always take the default template.
