### PR TITLE
[-] PDF : Fixed unecessary slash in manufacturer image path test

### DIFF
--- a/controllers/front/ManufacturerController.php
+++ b/controllers/front/ManufacturerController.php
@@ -116,7 +116,7 @@ class ManufacturerControllerCore extends FrontController
 			$this->pagination($nbProducts);
 
 			foreach ($data as &$item)
-				$item['image'] = (!file_exists(_PS_MANU_IMG_DIR_.'/'.$item['id_manufacturer'].'-'.ImageType::getFormatedName('medium').'.jpg')) ? $this->context->language->iso_code.'-default' : $item['id_manufacturer'];
+				$item['image'] = (!file_exists(_PS_MANU_IMG_DIR_.$item['id_manufacturer'].'-'.ImageType::getFormatedName('medium').'.jpg')) ? $this->context->language->iso_code.'-default' : $item['id_manufacturer'];
 
 			$this->context->smarty->assign(array(
 				'pages_nb' => ceil($nbProducts / (int)($this->n)),


### PR DESCRIPTION
In the file_exists test of the manufacturer image path there is an unecessary slash after the constant _PS_MANU_IMG_DIR_, and then we can't display a specific manufacturer image.
