### PR TITLE
[FIX] http://forge.prestashop.com/browse/PSCFV-7821

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1962,7 +1962,7 @@ class AdminProductsControllerCore extends AdminController
 	public function updateDownloadProduct($product, $edit = 0)
 	{
 		$is_virtual_file = (int)Tools::getValue('is_virtual_file');
-		$product_type = (int)Tools::getValue('product_type');
+		$type_product = (int)Tools::getValue('type_product');
 		// add or update a virtual product
 		if (Tools::getValue('is_virtual_good') == 'true')
 		{
@@ -2024,7 +2024,7 @@ class AdminProductsControllerCore extends AdminController
 			else
 				$id_product_download = ProductDownload::getIdFromIdProduct($product->id);
 
-			if (!empty($id_product_download) && $product_type != 2)
+			if (!empty($id_product_download) && $type_product != 2)
 			{
 				$product_download = new ProductDownload((int)$id_product_download);
 				$product_download->date_expiration = date('Y-m-d H:i:s', time() - 1);

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1962,6 +1962,7 @@ class AdminProductsControllerCore extends AdminController
 	public function updateDownloadProduct($product, $edit = 0)
 	{
 		$is_virtual_file = (int)Tools::getValue('is_virtual_file');
+		$product_type = (int)Tools::getValue('product_type');
 		// add or update a virtual product
 		if (Tools::getValue('is_virtual_good') == 'true')
 		{
@@ -2023,7 +2024,7 @@ class AdminProductsControllerCore extends AdminController
 			else
 				$id_product_download = ProductDownload::getIdFromIdProduct($product->id);
 
-			if (!empty($id_product_download))
+			if (!empty($id_product_download) && $product_type != 2)
 			{
 				$product_download = new ProductDownload((int)$id_product_download);
 				$product_download->date_expiration = date('Y-m-d H:i:s', time() - 1);


### PR DESCRIPTION
If you have a virtual product and you modify it not entering the "virtual product" tab, the download is set to inactive.

The problem is that the form fields related to the download are not loaded unless you enter in the virtual product tab. For example if you enter a previously created virtual product, and change just the name and save it, parameters like is_virtual_good are not send in the $_POST and the code in tej AdminProductsCo0ntroller -> updateDownloadProduct deactivates it automatically.
