### PR TITLE
[*] BO: Show only the selected module in translate

### DIFF
--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -670,7 +670,7 @@ class AdminModulesControllerCore extends AdminController
 							
 							$backlink = self::$currentIndex.'&token='.$this->token.'&tab_module='.$module->tab.'&module_name='.$module->name;
 							$hooklink = 'index.php?tab=AdminModulesPositions&token='.Tools::getAdminTokenLite('AdminModulesPositions').'&show_modules='.(int)$module->id;
-							$tradlink = 'index.php?tab=AdminTranslations&token='.Tools::getAdminTokenLite('AdminTranslations').'&type=modules&lang=';
+							$tradlink = 'index.php?tab=AdminTranslations&token='.Tools::getAdminTokenLite('AdminTranslations').'&module='.$module->name.'&type=modules&lang=';
 
 							$toolbar = '<table class="table" cellpadding="0" cellspacing="0" style="margin:auto;text-align:center"><tr>
 									<th>'.$this->l('Module').' <span style="color: green;">'.$module->name.'</span></th>


### PR DESCRIPTION
When following the translation link from a module's configuration page only display the translation fields for that module. This speeds up the page load and also prevents the max_input_vars limits.
