### PR TITLE
[-] Core: ProductSale no more takes products with no visibility

### DIFF
--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -98,6 +98,7 @@ class ProductSaleCore
 				LEFT JOIN `'._DB_PREFIX_.'tax` t ON (t.`id_tax` = tr.`id_tax`)
 				'.Product::sqlStock('p').'
 				WHERE product_shop.`active` = 1
+					AND p.`visibility` != \'none\'
 					AND p.`id_product` IN (
 						SELECT cp.`id_product`
 						FROM `'._DB_PREFIX_.'category_group` cg
@@ -150,6 +151,7 @@ class ProductSaleCore
 					ON cl.`id_category` = product_shop.`id_category_default`
 					AND cl.`id_lang` = '.(int)$id_lang.Shop::addSqlRestrictionOnLang('cl').'
 				WHERE product_shop.`active` = 1
+					AND p.`visibility` != \'none\'
 					AND p.`id_product` IN (
 						SELECT cp.`id_product`
 						FROM `'._DB_PREFIX_.'category_group` cg


### PR DESCRIPTION
Fixed bug that's ProductSale is taking products with no visibility, displaying them in module blockbestsellers. But as they have no visibility, we don't want to display them!
