### PR TITLE
[-] BO: fixed lots of UI bugs in CMS:

### DIFF
--- a/controllers/admin/AdminCmsCategoriesController.php
+++ b/controllers/admin/AdminCmsCategoriesController.php
@@ -70,6 +70,7 @@ class AdminCmsCategoriesControllerCore extends AdminController
 	public function renderList()
 	{
 		$this->initToolbar();
+        $this->toolbar_btn['new']['href'] .= '&amp;id_parent='.(int)Tools::getValue('id_cms_category');
 		return parent::renderList();
 	}
 
@@ -101,6 +102,10 @@ class AdminCmsCategoriesControllerCore extends AdminController
 					return false;
 				}
 			}
+            $object = parent::postProcess();
+            if ($object !== false)
+                Tools::redirectAdmin(self::$currentIndex.'&conf=3&id_cms_category='.(int)$object->id.'&token='.Tools::getValue('token'));
+            return $object;
 		}
 		/* Change object statuts (active, inactive) */
 		elseif (Tools::isSubmit('statuscms_category') && Tools::getValue($this->identifier))
@@ -137,14 +142,15 @@ class AdminCmsCategoriesControllerCore extends AdminController
 							.' <b>'.$this->table.'</b><br />'.Tools::displayError('You cannot delete all of the items.');
 					else
 					{
+                        $identifier = ((int)$object->id_parent ? '&'.$this->identifier.'='.(int)$object->id_parent : '');
 						if ($this->deleted)
 						{
 							$object->deleted = 1;
 							if ($object->update())
-								Tools::redirectAdmin(self::$currentIndex.'&conf=1&token='.Tools::getValue('token'));
+								Tools::redirectAdmin(self::$currentIndex.'&conf=1&token='.Tools::getValue('token').$identifier);
 						}
 						elseif ($object->delete())
-							Tools::redirectAdmin(self::$currentIndex.'&conf=1&token='.Tools::getValue('token'));
+							Tools::redirectAdmin(self::$currentIndex.'&conf=1&token='.Tools::getValue('token').$identifier);
 						$this->errors[] = Tools::displayError('An error occurred during deletion.');
 					}
 				}
@@ -167,11 +173,8 @@ class AdminCmsCategoriesControllerCore extends AdminController
 				$this->errors[] = Tools::displayError('Failed to update the position.');
 			else
 			{
-				$identifier = '';
-				if ($id_category = (int)Tools::getValue($this->identifier, Tools::getValue('id_cms_category_parent', 1)))
-					$identifier = '&'.$this->identifier.'='.$id_category;
+				$identifier = ((int)$object->id_parent ? '&'.$this->identifier.'='.(int)$object->id_parent : '');
 				$token = Tools::getAdminTokenLite('AdminCmsContent');
-
 				Tools::redirectAdmin(
 					self::$currentIndex.'&'.$this->table.'Orderby=position&'.$this->table.'Orderway=asc&conf=5'.$identifier.'&token='.$token
 				);
@@ -191,7 +194,7 @@ class AdminCmsCategoriesControllerCore extends AdminController
 					{
 						$cms_category->cleanPositions((int)Tools::getValue('id_cms_category'));
 						$token = Tools::getAdminTokenLite('AdminCmsContent');
-						Tools::redirectAdmin(self::$currentIndex.'&conf=2&token='.$token.'&id_category='.(int)Tools::getValue('id_cms_category'));
+						Tools::redirectAdmin(self::$currentIndex.'&conf=2&token='.$token.'&id_cms_category='.(int)Tools::getValue('id_cms_category'));
 					}
 					$this->errors[] = Tools::displayError('An error occurred while deleting selection.');
 

--- a/controllers/admin/AdminCmsContentController.php
+++ b/controllers/admin/AdminCmsContentController.php
@@ -113,6 +113,7 @@ class AdminCmsContentControllerCore extends AdminController
 		if (Tools::isSubmit('submitDelcms')
 			|| Tools::isSubmit('previewSubmitAddcmsAndPreview')
 			|| Tools::isSubmit('submitAddcms')
+            || Tools::isSubmit('submitBulkdeletecms')
 			|| Tools::isSubmit('deletecms')
 			|| Tools::isSubmit('viewcms')
 			|| (Tools::isSubmit('statuscms') && Tools::isSubmit('id_cms'))
@@ -126,6 +127,8 @@ class AdminCmsContentControllerCore extends AdminController
 			|| (Tools::isSubmit('statuscms_category') && Tools::isSubmit('id_cms_category'))
 			|| (Tools::isSubmit('position') && Tools::isSubmit('id_cms_category_to_move')))
 				$this->admin_cms_categories->postProcess();
+        else
+            parent::postProcess();
 
 		if (((Tools::isSubmit('submitAddcms_category') || Tools::isSubmit('submitAddcms_categoryAndStay')) && count($this->admin_cms_categories->errors))
 			|| Tools::isSubmit('updatecms_category')
@@ -146,8 +149,6 @@ class AdminCmsContentControllerCore extends AdminController
 
 		if (isset($this->admin_cms_categories->errors))
 			$this->errors = array_merge($this->errors, $this->admin_cms_categories->errors);
-
-		parent::postProcess();
 	}
 
 	public function setMedia()

--- a/controllers/admin/AdminCmsController.php
+++ b/controllers/admin/AdminCmsController.php
@@ -269,7 +269,7 @@ class AdminCmsControllerCore extends AdminController
 					{
 						$cms->cleanPositions((int)Tools::getValue('id_cms_category'));
 						$token = Tools::getAdminTokenLite('AdminCmsContent');
-						Tools::redirectAdmin(self::$currentIndex.'&conf=2&token='.$token.'&id_category='.(int)Tools::getValue('id_cms_category'));
+						Tools::redirectAdmin(self::$currentIndex.'&conf=2&token='.$token.'&id_cms_category='.(int)Tools::getValue('id_cms_category'));
 					}
 					$this->errors[] = Tools::displayError('An error occurred while deleting selection.');
 
@@ -283,60 +283,56 @@ class AdminCmsControllerCore extends AdminController
 		elseif (Tools::isSubmit('submitAddcms') || Tools::isSubmit('submitAddcmsAndPreview'))
 		{
 			parent::validateRules();
-			if (!count($this->errors))
-			{
-				if (!$id_cms = (int)Tools::getValue('id_cms'))
-				{
-					$cms = new CMS();
-					$this->copyFromPost($cms, 'cms');
-					if (!$cms->add())
-						$this->errors[] = Tools::displayError('An error occurred while creating object.')
-							.' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
-					else
-						$this->updateAssoShop($cms->id);
-				}
-				else
-				{
-					$cms = new CMS($id_cms);
-					$this->copyFromPost($cms, 'cms');
-					if (!$cms->update())
-						$this->errors[] = Tools::displayError('An error occurred while updating object.')
-							.' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
-					else
-						$this->updateAssoShop($cms->id);
-
-				}
-                if (Tools::isSubmit('submitAddcmsAndPreview'))
-                {
-                    $alias = $this->getFieldValue($cms, 'link_rewrite', $this->context->language->id);
-                    $preview_url = $this->context->link->getCMSLink($cms, $alias, $this->context->language->id);
-
-                    if (!$cms->active)
-                    {
-                    	$admin_dir = dirname($_SERVER['PHP_SELF']);
-                        $admin_dir = substr($admin_dir, strrpos($admin_dir, '/') + 1);
-                    	
-                    	$params = http_build_query(array(
-                    		'adtoken' => Tools::getAdminTokenLite('AdminCmsContent'),
-                    		'ad' => $admin_dir,
-                    		'id_employee' => (int)$this->context->employee->id)
-                    		);
-                    	if (Configuration::get('PS_REWRITING_SETTINGS'))
-                    		$params = '?'.$params;
-                    	else
-                    		$params = '&'.$params;
-                    	
-                    	$preview_url .= $cms->active ? '' : $params;
-                    }
-                    Tools::redirectAdmin($preview_url);
-                }
-                elseif (Tools::isSubmit('submitAdd'.$this->table.'AndStay'))
-                    $this->redirect_after = self::$currentIndex.'&'.$this->identifier.'='.$object->id.'&conf=4&update'.$this->table.'&token='.$this->token;
+			if (count($this->errors))
+                return false;
+            if (!$id_cms = (int)Tools::getValue('id_cms'))
+            {
+                $cms = new CMS();
+                $this->copyFromPost($cms, 'cms');
+                if (!$cms->add())
+                    $this->errors[] = Tools::displayError('An error occurred while creating object.')
+                        .' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
                 else
-					Tools::redirectAdmin(self::$currentIndex.'&id_cms_category='.$cms->id_cms_category.'&conf=4&token='.Tools::getAdminTokenLite('AdminCmsContent'));
-			}
+                    $this->updateAssoShop($cms->id);
+            }
+            else
+            {
+                $cms = new CMS($id_cms);
+                $this->copyFromPost($cms, 'cms');
+                if (!$cms->update())
+                    $this->errors[] = Tools::displayError('An error occurred while updating object.')
+                        .' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
+                else
+                    $this->updateAssoShop($cms->id);
+            }
+            if (Tools::isSubmit('submitAddcmsAndPreview'))
+            {
+                $alias = $this->getFieldValue($cms, 'link_rewrite', $this->context->language->id);
+                $preview_url = $this->context->link->getCMSLink($cms, $alias, $this->context->language->id);
+
+                if (!$cms->active)
+                {
+                    $admin_dir = dirname($_SERVER['PHP_SELF']);
+                    $admin_dir = substr($admin_dir, strrpos($admin_dir, '/') + 1);
+                    $params = http_build_query(array(
+                        'adtoken' => Tools::getAdminTokenLite('AdminCmsContent'),
+                        'ad' => $admin_dir,
+                        'id_employee' => (int)$this->context->employee->id)
+                        );
+                    if (Configuration::get('PS_REWRITING_SETTINGS'))
+                        $params = '?'.$params;
+                    else
+                        $params = '&'.$params;
+                    $preview_url .= $cms->active ? '' : $params;
+                }
+                Tools::redirectAdmin($preview_url);
+            }
+            elseif (Tools::isSubmit('submitAdd'.$this->table.'AndStay'))
+                Tools::redirectAdmin(self::$currentIndex.'&'.$this->identifier.'='.$cms->id.'&conf=4&update'.$this->table.'&token='.Tools::getAdminTokenLite('AdminCmsContent'));
+            else
+                Tools::redirectAdmin(self::$currentIndex.'&id_cms_category='.$cms->id_cms_category.'&conf=4&token='.Tools::getAdminTokenLite('AdminCmsContent'));
 		}
-		elseif (Tools::getValue('position'))
+		elseif (Tools::isSubmit('way') && Tools::isSubmit('id_cms') && (Tools::isSubmit('position')))
 		{
 			if ($this->tabAccess['edit'] !== '1')
 				$this->errors[] = Tools::displayError('You do not have permission to edit here.');
@@ -346,7 +342,7 @@ class AdminCmsControllerCore extends AdminController
 			elseif (!$object->updatePosition((int)Tools::getValue('way'), (int)Tools::getValue('position')))
 				$this->errors[] = Tools::displayError('Failed to update the position.');
 			else
-				Tools::redirectAdmin(self::$currentIndex.'&'.$this->table.'Orderby=position&'.$this->table.'Orderway=asc&conf=4'.(($id_category = (int)Tools::getValue('id_cms_category')) ? ('&id_cms_category='.$id_category) : '').'&token='.Tools::getAdminTokenLite('AdminCmsContent'));
+				Tools::redirectAdmin(self::$currentIndex.'&'.$this->table.'Orderby=position&'.$this->table.'Orderway=asc&conf=4&id_cms_category='.(int)$object->id_cms_category.'&token='.Tools::getAdminTokenLite('AdminCmsContent'));
 		}
 		/* Change object statuts (active, inactive) */
 		elseif (Tools::isSubmit('statuscms') && Tools::isSubmit($this->identifier))
@@ -356,7 +352,7 @@ class AdminCmsControllerCore extends AdminController
 				if (Validate::isLoadedObject($object = $this->loadObject()))
 				{
 					if ($object->toggleStatus())
-						Tools::redirectAdmin(self::$currentIndex.'&conf=5'.((int)Tools::getValue('id_cms_category') ? '&id_cms_category='.(int)Tools::getValue('id_cms_category') : '').'&token='.Tools::getValue('token'));
+						Tools::redirectAdmin(self::$currentIndex.'&conf=5&id_cms_category='.(int)$object->id_cms_category.'&token='.Tools::getValue('token'));
 					else
 						$this->errors[] = Tools::displayError('An error occurred while updating status.');
 				}
@@ -366,6 +362,25 @@ class AdminCmsControllerCore extends AdminController
 			}
 			else
 				$this->errors[] = Tools::displayError('You do not have permission to edit here.');
+		}
+        /* Delete multiple CMS content */
+		elseif (Tools::isSubmit('submitBulkdeletecms'))
+		{
+			if ($this->tabAccess['delete'] === '1')
+			{
+                $this->action = 'bulkdelete';
+                $this->boxes = Tools::getValue($this->table.'Box');
+                if (is_array($this->boxes) && array_key_exists(0, $this->boxes))
+                {
+                    $firstCms = new CMS((int)$this->boxes[0]);
+                    $id_cms_category = (int)$firstCms->id_cms_category;
+                    if (!$res = parent::postProcess(true))
+                        return $res;
+                    Tools::redirectAdmin(self::$currentIndex.'&conf=2&token='.Tools::getAdminTokenLite('AdminCmsContent').'&id_cms_category='.$id_cms_category);
+                }
+			}
+			else
+				$this->errors[] = Tools::displayError('You do not have permission to delete here.');
 		}
 		else
 			parent::postProcess(true);


### PR DESCRIPTION
- no more id_category (doesn't exists, it's id_cms_category)
- change category position now redirects in parent category (not at root category)
- change category status now redirects in parent category (not at root category)
- delete category now redirects in parent category (not at root category)
- add a new category now redirects in parent category (not at root category)
- delete multiple categories now redirects in parent category (not at root category)
- now execute parent::postProcess() only if none action found (duplicate postProcess was done)
- now redirects to CMS form if found errors (not at root category)
- fixed unexists $object variable (was $cms) for saveAndStay
- delete multiple cms content now redirects in parent category (not at root category)
- change cms content position now redirects in parent category (not at root category)
- change cms content status now redirects in parent category (not at root category)
