### PR TITLE
Excel CSV compatibility

### DIFF
--- a/admin-dev/themes/default/template/layout-export.tpl
+++ b/admin-dev/themes/default/template/layout-export.tpl
@@ -21,8 +21,7 @@
 *  @copyright  2007-2013 PrestaShop SA
 *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
-*}
-{foreach from=$export_headers item=header}{$header};{/foreach}
+*}{$export_precontent}{foreach from=$export_headers item=header}{$header};{/foreach}
 {foreach from=$export_content item=line}
 
 {foreach from=$line item=content}{$content};{/foreach}

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -583,7 +583,7 @@ class AdminControllerCore extends Controller
 
 		$headers = array();
 		foreach ($this->fields_list as $datas)
-			$headers[] = $datas['title'];
+			$headers[] = html_entity_decode($datas['title'], ENT_QUOTES, "UTF-8");
 
 		$content = array();
 		foreach ($this->_list as $i => $row)
@@ -595,6 +595,7 @@ class AdminControllerCore extends Controller
 				
 		}
 		$this->context->smarty->assign(array(
+			'export_precontent' => "\xEF\xBB\xBF",
 			'export_headers' => $headers,
 			'export_content' => $content
 			)


### PR DESCRIPTION
The CSV files generated by Prestashop need to have a BOM at the
beginning. If not, Excel throws an error about unrecognized format.

The HTML entites must be also converted : "&eacute;" (for example) is
not compatible with the usage of ";" as value separator
