### PR TITLE
[-]BO: Fixes issue with logo name.

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -614,7 +614,7 @@ class AdminThemesControllerCore extends AdminController
 
 			$ext = ($field_name == 'PS_STORES_ICON') ? '.gif' : '.jpg';
 			$logo_name = $logo_prefix.'-'.(int)$id_shop.$ext;
-			if (Context::getContext()->shop->getContext() == Shop::CONTEXT_ALL || $id_shop == 0 || (bool)Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE')==false)
+			if (Context::getContext()->shop->getContext() == Shop::CONTEXT_ALL || $id_shop == 0 || Shop::isFeatureActive()==false)
 				$logo_name = $logo_prefix.$ext;
 
 			if ($field_name == 'PS_STORES_ICON')

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -614,7 +614,7 @@ class AdminThemesControllerCore extends AdminController
 
 			$ext = ($field_name == 'PS_STORES_ICON') ? '.gif' : '.jpg';
 			$logo_name = $logo_prefix.'-'.(int)$id_shop.$ext;
-			if (Context::getContext()->shop->getContext() == Shop::CONTEXT_ALL || $id_shop == 0)
+			if (Context::getContext()->shop->getContext() == Shop::CONTEXT_ALL || $id_shop == 0 || (bool)Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE')==false)
 				$logo_name = $logo_prefix.$ext;
 
 			if ($field_name == 'PS_STORES_ICON')


### PR DESCRIPTION
Upgraded shops sometimes gets a -1 on the logo filename even if the multishop feature is turned off. Causing the BO and FO to link to the wrong file.
