### PR TITLE
[-] Class: Tax / exlude taxes if group without

### DIFF
--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -165,6 +165,13 @@ class TaxCore extends ObjectModel
 		static $ps_tax = null;
 		if ($ps_tax === null)
 			$ps_tax = Configuration::get('PS_TAX');
+		
+		if($ps_tax)
+		{
+			$id_group = Group::getCurrent();
+			$group = new Group($id_group);
+			$ps_tax = $group->price_display_method;
+		}
 
 		return !$ps_tax;
 	}


### PR DESCRIPTION
Maybe we need to exlude tax if the customer group is without taxe. I think it's a problem, because sometimes this kind of group see taxes,...

Isn't it ?
