### PR TITLE
UTF-8 encoding problem

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -50,7 +50,8 @@ class OrderDetailControllerCore extends FrontController
 		if (Tools::isSubmit('submitMessage'))
 		{
 			$idOrder = (int)(Tools::getValue('id_order'));
-			$msgText = Tools::getValue('msgText');
+			$msgText = utf8_encode(Tools::getValue('msgText'));
+
 
 			if (!$idOrder || !Validate::isUnsignedId($idOrder))
 				$this->errors[] = Tools::displayError('The order is no longer valid.');


### PR DESCRIPTION
When a message is sent from the order detail front controller, the
content is mis-encoded and the mail texts are truncated to the first
special character
