### PR TITLE
[*] WS : Dispatcher should handle XML POST same as PUT

### DIFF
--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -67,7 +67,7 @@ else
 	$input_xml = NULL;
 
 	// if a XML is in PUT
-	if ($_SERVER['REQUEST_METHOD'] == 'PUT')
+	if ($_SERVER['REQUEST_METHOD'] == 'PUT' OR $_SERVER['REQUEST_METHOD'] == 'POST')
 	{
 		$putresource = fopen("php://input", "r");
 		while ($putData = fread($putresource, 1024))


### PR DESCRIPTION
when POSTing xml to webservice the webservice dispatcher expects the xml to originate from a web form post with the xml in "xml" field. 
This usage is unnatural when calling webservice using method other than form post.

Currently if the XML is not in an "xml" field service gives non intuitive:
500 Internal Server Error (XML error : String could not be parsed as XML XML length : 0 Original XML : )

This change simply changes behavior to same used for PUT: assumes body of POST request is XML.
