### PR TITLE
[*] WS : order history add(POST) send customer email if sendemail=1 url ...

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -64,6 +64,9 @@ class OrderHistoryCore extends ObjectModel
 			'id_order_state' => array('required' => true, 'xlink_resource'=> 'order_states'),
 			'id_order' => array('xlink_resource' => 'orders'),
 		),
+		'objectMethods' => array(
+		    'add' => 'addWs',
+        ),
 	);
 
 	/**
@@ -393,6 +396,37 @@ class OrderHistoryCore extends ObjectModel
 
 		return true;
 	}
+
+    /**
+     * Add method for webservice create resource Order History      
+     * If sendemail=1 GET parameter is present sends email to customer otherwise does not
+     * @return bool
+     */
+    public function addWs()
+    {
+        $sendemail = false;
+        if (isset($_GET['sendemail']))
+        {
+            $sendemail = ($_GET['sendemail'] == '1');
+        }
+         
+        if ($sendemail)
+        {
+            //Mail::Send requires link object on context and is not set when getting here
+            $context = Context::getContext();
+            if ($context->link == null)
+            {
+                $protocol_link = (Tools::usingSecureMode() && Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';
+                $protocol_content = (Tools::usingSecureMode() && Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';
+                $context->link = new Link($protocol_link, $protocol_content);
+            }    
+        
+            return $this->addWithemail();            
+        }else{
+            return $this->add();
+        }
+        
+    }
 
 	public function add($autodate = true, $null_values = false)
 	{


### PR DESCRIPTION
Enhances order history to send email to customer when new entry is created.
It is opt-in by looking for a sendemail=1 GET parameter otherwise does not send email so it does not break existing behavior.
