### PR TITLE
[*] - FO - pagination - nbr products/page

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -828,7 +828,12 @@ class FrontControllerCore extends Controller
 		elseif (!$this->context)
 			$this->context = Context::getContext();
 
-		$nArray = (int)Configuration::get('PS_PRODUCTS_PER_PAGE') != 10 ? array((int)Configuration::get('PS_PRODUCTS_PER_PAGE'), 10, 20, 50) : array(10, 20, 50);
+	        if ((int)Configuration::get('PS_PRODUCTS_PER_PAGE') != 10) {
+	            $prodPerPage =   (int)Configuration::get('PS_PRODUCTS_PER_PAGE');
+	            $nArray =   array($prodPerPage,$prodPerPage*2,$prodPerPage*3);
+	        } else {
+	            $nArray =   array(array(10, 20, 50));
+	        }
 		// Clean duplicate values
 		$nArray = array_unique($nArray);
 		asort($nArray);


### PR DESCRIPTION
It allows to keep a number of 'products per page' related' to original value (PS_PRODUCTS_PER_PAGE).
ex:
Set product per page to '12' (in BO), it display '12','24','36' in the pagination's combo-box, and not '10','12','20','50'

I make this edit in most of my project, it's important in advanced layout (products display by col and not by row like in default template)

(I prefer check if PS_PRODUCT_PER_PAGE is != 0, but with !=10 it keeps original setting (10,20,50))
