### PR TITLE
[*] BO : Add block "close_td" in list_content.tpl

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_content.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_content.tpl
@@ -116,6 +116,8 @@
 				{if isset($params.color) && isset($tr.color)}
 					</span>
 				{/if}
+			{/block}
+			{block name="close_td"}
 				</td>
 			{/block}
 		{/foreach}


### PR DESCRIPTION
[*] BO : Add block "close_td" in list_content.tpl

{block name="td_content"}
.....
{/block}
{block name="close_td"}
"/td"
{/block}

So now we can override "td" and "/td" tags.
So we can create

"td" "a" ... content.... "/a" "/td"

when overriding the block open-td and close-td
and we can use "a" tag with "href" rather than "onclick" to create view links in the list.
And the user can choose to open the link in another tab or window.
