### PR TITLE
[*] BO : Add block "override_form_extra"

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -80,6 +80,9 @@
 
 {if !$simple_header}
 <form method="post" action="{$action}" class="form">
+
+	{block name="override_form_extra"}{/block}
+
 	<input type="hidden" id="submitFilter{$table}" name="submitFilter{$table}" value="0"/>
 {/if}
 	<table class="table_grid" name="list_table">


### PR DESCRIPTION
Add block "override_form_extra" in list_header.tpl

{if !$simple_header}

<form method="post" action="{$action}" class="form">

```
{block name="override_form_extra"}{/block}
```

In AdminXxxxController, If we display list which are filtered by "variable" like

index.php?controller=AdminXxxx&variable=val&token=...

When using pagination or columns filters, the controller is called without our variable.

There are two methods to retrieve our variable: cookie or form Post.

To use the second opportunity, we need to put hidden input "variable" in the form.

So we need à block in the form to override.
