### PR TITLE
[-] [BO] The div for colorAttributeProperties is not closed

### DIFF
--- a/admin-dev/themes/default/template/controllers/attributes/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/attributes/helpers/form/form.tpl
@@ -29,6 +29,9 @@
 	{if $input.type == 'color'}
 		<div id="colorAttributeProperties" style="display:{if $colorAttributeProperties}block{else}none{/if};">
 	{/if}
+	{if $input.type == 'closediv'}
+		</div>
+	{/if}
 	{$smarty.block.parent}
 {/block}
 

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -328,6 +328,10 @@ class AdminAttributesGroupsControllerCore extends AdminController
 			'label' => $this->l('Current texture:'),
 			'name' => 'current_texture'
 		);
+		
+		$this->fields_form['input'][] = array(
+			'type' => 'closediv'
+		);
 
 		$this->fields_form['submit'] = array(
 			'title' => $this->l('Save   '),


### PR DESCRIPTION
In form.tpl for attributes controller, a div with id = colorAttributeProperties is added for the color picker. This div is not closed.

The solution consists in adding a new field with type 'closediv'. This one is translated by form.tpl to "</div>"
