### PR TITLE
[*] TR : Fixed wrong use of translation functions

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -761,7 +761,7 @@ class AdminTranslationsControllerCore extends AdminController
 							$this->errors[] = sprintf(Tools::displayError('Cannot delete the archive %s.'), $file);
 				}
 				else
-					$this->errors[] = Tools::displayError('The server does not have permissions for writing.'. ' '.sprintf(Tools::displayError('Please check rights for %s'), dirname($file)));
+					$this->errors[] = Tools::displayError('The server does not have permissions for writing.').' '.sprintf(Tools::displayError('Please check rights for %s'), dirname($file));
 			}
 			else
 				$this->errors[] = Tools::displayError('Language not found.');


### PR DESCRIPTION
In AdminTranslationController there was a problem with the use of Tools::displayError()

It led to the controller displaying the following error to be translated (which is nonsense):

The server does not have permissions for writing.'. ' '.sprintf(Tools::displayError('Please check rights for %s

Instead of:

The server does not have permissions for writing.

and

Please check rights for %s
