### PR TITLE
[*] Mails : delete a hard-coded pink background

### DIFF
--- a/mails/en/order_conf.html
+++ b/mails/en/order_conf.html
@@ -72,8 +72,8 @@
 </tr>
 <tr style="text-align: right; font-weight: bold;">
 <td>&nbsp;</td>
-<td style="background-color: #f1aecf; padding: 0.6em 0.4em;" colspan="3">Total paid</td>
-<td style="background-color: #f1aecf; padding: 0.6em 0.4em;">{total_paid}</td>
+<td style="background-color: #ebecee; color: {color}; padding: 0.6em 0.4em;" colspan="3">Total paid</td>
+<td style="background-color: #ebecee; color: {color}; padding: 0.6em 0.4em;">{total_paid}</td>
 </tr>
 </tbody>
 </table>

--- a/mails/en/order_conf.html
+++ b/mails/en/order_conf.html
@@ -72,8 +72,8 @@
 </tr>
 <tr style="text-align: right; font-weight: bold;">
 <td>&nbsp;</td>
-<td style="background-color: #ebecee; color: {color}; padding: 0.6em 0.4em;" colspan="3">Total paid</td>
-<td style="background-color: #ebecee; color: {color}; padding: 0.6em 0.4em;">{total_paid}</td>
+<td style="background-color: {color}; padding: 0.6em 0.4em;" colspan="3">Total paid</td>
+<td style="background-color: {color}; padding: 0.6em 0.4em;">{total_paid}</td>
 </tr>
 </tbody>
 </table>

--- a/modules/mailalerts/mails/en/new_order.html
+++ b/modules/mailalerts/mails/en/new_order.html
@@ -43,8 +43,8 @@
 							<td style="background-color: #dde2e6; padding: 0.6em 0.4em;">{total_shipping}</td>
 						</tr>
 						<tr style="text-align: right; font-weight: bold;">
-							<td style="background-color: #f1aecf; padding: 0.6em 0.4em;" colspan="4">Total paid</td>
-							<td style="background-color: #f1aecf; padding: 0.6em 0.4em;">{total_paid}</td>
+							<td style="background-color: #ebecee; color: {color}; padding: 0.6em 0.4em;" colspan="4">Total paid</td>
+							<td style="background-color: #ebecee; color: {color}; padding: 0.6em 0.4em;">{total_paid}</td>
 						</tr>
 					</table>
 						

--- a/modules/mailalerts/mails/en/new_order.html
+++ b/modules/mailalerts/mails/en/new_order.html
@@ -43,8 +43,8 @@
 							<td style="background-color: #dde2e6; padding: 0.6em 0.4em;">{total_shipping}</td>
 						</tr>
 						<tr style="text-align: right; font-weight: bold;">
-							<td style="background-color: #ebecee; color: {color}; padding: 0.6em 0.4em;" colspan="4">Total paid</td>
-							<td style="background-color: #ebecee; color: {color}; padding: 0.6em 0.4em;">{total_paid}</td>
+							<td style="background-color: {color}; padding: 0.6em 0.4em;" colspan="4">Total paid</td>
+							<td style="background-color: {color}; padding: 0.6em 0.4em;">{total_paid}</td>
 						</tr>
 					</table>
 						


### PR DESCRIPTION
In the order_conf and new_order emails, a pinkish background remained for the total line.

Since we can now pick the email color in BO, there should not be a hard coded pink line in the emails. I just replaced it with a grey background and added a color: {color} to the total line to highlight it in a similar way.
