### PR TITLE
Wrong link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,5 +8,5 @@ All core files you commit in your pull request must have Open Software License (
 All modules files you commit in your pull request must have Academic Free License (AFL 3.0)  
 
 [1]: https://help.github.com/articles/using-pull-requests
-[2]: http://docs.prestashop.com/display/PS15/Coding+Standard
+[2]: http://docs.prestashop.com/display/PS15/Coding+Standards
 [3]: http://docs.prestashop.com/display/PS15/How+to+write+a+commit+message


### PR DESCRIPTION
Just noticed the "Coding standard" link had a small typo in CONTRIBUTING.md. A pull request might be overkill to report this ? Sorry if that's the case.

Anyway here you go
