### PR TITLE
[-] BO : bug in BO translations when Windows OS

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1773,12 +1773,14 @@ class AdminTranslationsControllerCore extends AdminController
 
 					if (preg_match('#controllers#', $tmp))
 					{
-						$parent_class = explode(DIRECTORY_SEPARATOR, $tmp);
+						$parent_class = explode(DIRECTORY_SEPARATOR, str_replace('/', DIRECTORY_SEPARATOR, $tmp));
 						$override = array_search('override', $parent_class);
 						if ($override !== false)
-							$prefix_key = 'Admin'.ucfirst($parent_class[count($parent_class) - 1]);
+							// case override/controllers/admin/templates/controller_name
+							$prefix_key = 'Admin'.ucfirst($parent_class[$override + 4]);
 						else
 						{
+							// case admin_name/themes/theme_name/template/controllers/controller_name
 							$key = array_search('controllers', $parent_class);
 							$prefix_key = 'Admin'.ucfirst($parent_class[$key + 1]);
 						}


### PR DESCRIPTION
[-] BO : bug in BO translations when Windows OS

Impossible to translate the strings of the back office in the directory override/controllers/admin/...
under windows environment.

The statement " $parent_class = explode(DIRECTORY_SEPARATOR,..) " returns wrong result under windows environment. because the path name has '/' and '\' chars.

$parent_class contains bad values and the string "override" is not found.

nota : use of "override" like currently can be problematic if the override folder name is changed
