### PR TITLE
[-] BO : don't show translations for module overrides in admin modules translation page

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -858,7 +858,7 @@ class AdminTranslationsControllerCore extends AdminController
 	public function clearModuleFiles($files, $type_clear = 'file', $path = '')
 	{
 		// List of directory which not must be parsed
-		$arr_exclude = array('img', 'js', 'mails');
+		$arr_exclude = array('img', 'js', 'mails','override');
 
 		// List of good extention files
 		$arr_good_ext = array('.tpl', '.php');


### PR DESCRIPTION
According to the code, it looks like the translation of class/controller override in module is dealt directly in front/back office translation administration, but it also appears in module translation administration.

As using the modules translation admin page for changing those translations regarding override classes or controllers has no effect, whatever the sentence you try to change, I think the best is just not to show them. So it's not necessary to parse files in module_name/override. I hope my proposal is the best way to do it.
