### PR TITLE
[-] BO : don't show unecessary tpl module translations - complience with documentation

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -815,7 +815,7 @@ class AdminTranslationsControllerCore extends AdminController
 				$type_file = substr($file, -4) == '.tpl' ? 'tpl' : 'php';
 
 				// Parse this content
-				$matches = $this->userParseFile($content, $this->type_selected, $type_file);
+				$matches = $this->userParseFile($content, $this->type_selected, $type_file, $module_name);
 
 				// Write each translation on its module file
 				$template_name = substr(basename($file), 0, -4);
@@ -914,7 +914,7 @@ class AdminTranslationsControllerCore extends AdminController
 				$type_file = substr($file, -4) == '.tpl' ? 'tpl' : 'php';
 
 				// Parse this content
-				$matches = $this->userParseFile($content, $this->type_selected, $type_file);
+				$matches = $this->userParseFile($content, $this->type_selected, $type_file, $module_name);
 
 				// Write each translation on its module file
 				$template_name = substr(basename($file), 0, -4);
@@ -1057,9 +1057,10 @@ class AdminTranslationsControllerCore extends AdminController
 	 * @param $content
 	 * @param $type_translation : front, back, errors, modules...
 	 * @param string|bool $type_file : (tpl|php)
+	 * @param string $module_name : name of the module
 	 * @return return $matches
 	 */
-	protected function userParseFile($content, $type_translation, $type_file = false)
+	protected function userParseFile($content, $type_translation, $type_file = false, $module_name = '')
 	{
 		switch ($type_translation)
 		{
@@ -1088,7 +1089,8 @@ class AdminTranslationsControllerCore extends AdminController
 					if ($type_file == 'php')
 						$regex = '/->l\(\''._PS_TRANS_PATTERN_.'\'(, ?\'(.+)\')?(, ?(.+))?\)/U';
 					else
-						$regex = '/\{l\s*s=[\'\"]'._PS_TRANS_PATTERN_.'[\'\"](\s*sprintf=.*)?(\s*mod=\'.+\')?(\s*js=1)?\s*\}/U';
+						// In tpl file look for something that should contain mod='module_name' according to the documentation
+						$regex = '/\{l\s*s=[\'\"]'._PS_TRANS_PATTERN_.'[\'\"].*\s+mod=\''.$module_name.'\'.*\}/U';
 				break;
 
 			case 'pdf':


### PR DESCRIPTION
# About the patch

When overriding controllers you may have to also override associated tpl. If you put a copy of it in your module, the translation tool will propose you to modify all sentences of that file whereas you may just need to change or add few of them.

Moreover according to the PrestaShop documentation [here](http://doc.prestashop.com/display/PS15/Creating+a+PrestaShop+module#CreatingaPrestaShopmodule-Moduletranslation), you should always add mod='my_module' in your tpl files translations request:

```
<li><a href="{$my_module_link}" title="Click this link">Click me!</a></li>
```

becomes

```
<li><a href="{$my_module_link}"  title="{l s='Click this link' mod='my_module'}">{l s='Click me!' mod='my_module'}</a></li>
```

So this patch look only for {l s='whatever' whatever mod='my_module' whatever} string in the tpl files of module my_module.
# Arround the patch

Looking deeply in the regular expression in function userParseFile:

```
$regex = '/\{l\s*s=[\'\"]'._PS_TRANS_PATTERN_.'[\'\"](\s*sprintf=.*)?(\s*mod=\'.+\')?(\s*js=1)?\s*\}/U';
```

I would say:
1. no need to look for sprintf or mod or js if it's not used after
2. if you really want to look at it. Be careful, because with this code, you must have written sprintf then mod then js in this order, either it doesn't work.

I say that because it appears several times in AdminTranslationsController.php. I didn't change them as I needn't it (until now).
