### PR TITLE
[*] MO: blockcart animation optimization

### DIFF
--- a/modules/blockcart/ajax-cart.js
+++ b/modules/blockcart/ajax-cart.js
@@ -232,6 +232,7 @@ var ajaxCart = {
 					.animate({ 'width': $element.attr('width')*0.66, 'height': $element.attr('height')*0.66, 'opacity': 0.2, 'top': cartBlockOffset.top + 30, 'left': cartBlockOffset.left + 15 }, 1000)
 					.fadeOut(100, function() {
 						ajaxCart.updateCartInformation(jsonData, addedFromProductPage);
+						$(this).remove();
 					});
 				}
 				else


### PR DESCRIPTION
The animated element would not be removed upon the animation being finished. This made the site slow and unresponsive if the animated image was heavy (eg. a transparent png) and added to cart many times without reloading the page. This addition makes the animation behave as expected also when performing it multiple times.
