### PR TITLE
Update VATNumberTaxManager.php

### DIFF
--- a/modules/vatnumber/VATNumberTaxManager.php
+++ b/modules/vatnumber/VATNumberTaxManager.php
@@ -36,10 +36,7 @@ class VATNumberTaxManager implements TaxManagerInterface
 	public function getTaxCalculator()
 	{
 		// If the address matches the european vat number criterias no taxes are applied
-		$tax = new Tax();
-		$tax->rate = 0;
-
-		return new TaxCalculator(array($tax));
+		return new TaxCalculator();
 	}
 }
 


### PR DESCRIPTION
Un bug est présent au niveau des webservices, une association inexistante (id = 0) se créé.
Exemple :

```
<prestashop xmlns:xlink="http://www.w3.org/1999/xlink">
<order_detail>
    <id><![CDATA[284]]></id>
    ...
<associations>
<taxes node_type="tax">
    <tax xlink:href="https://extranet.anevia.com/api/taxes/0">
    <id><![CDATA[0]]></id>
    </tax>
</taxes>
</associations>
</order_detail>
</prestashop>
```

Ce bug est présent sur la version 1.5 de prestashop avec le module vatnumber activé.

Ce bugfix permet d'éviter de sauvegarder inutilement la taxe avec un id_tax à 0 dans la table order_detail_tax lorsqu'il n'y a pas de taxe.

Lors d'une commande passée aux états-unis, aucun tuple n'est présent dans cette table.
Le cas particulier d'une commande intra-communautaire est le seul cas où un id_tax est à 0.
