### PR TITLE
[-] BO : fixed part of bug #PSCFV-8497 Override of 'views' directory

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1641,6 +1641,8 @@ abstract class ModuleCore
 		$overloaded = $this->_isTemplateOverloaded($template);
 		if ($overloaded === null)
 			return null;
+		if(file_exists(_PS_THEME_DIR_.'modules/'.$this->name.'/views/templates/hook/'.$template))
+			return _PS_THEME_DIR_.'modules/'.$this->name.'/views/templates/hook/'.$template;
 		if ($overloaded)
 			return _PS_THEME_DIR_.'modules/'.$this->name.'/'.$template;
 		else if (file_exists(_PS_MODULE_DIR_.$this->name.'/views/templates/hook/'.$template))


### PR DESCRIPTION
Fixed second part of bug #PSCFV-8497 Override of 'views' directory in /themes/theme/modules/
This correction is for /views/templates/hook/
See https://github.com/PrestaShop/PrestaShop/pull/426 for clause #PSCFV-8497
