### PR TITLE
[-] MO: blockcart ajax cart product insert missing html class

### DIFF
--- a/modules/blockcart/ajax-cart.js
+++ b/modules/blockcart/ajax-cart.js
@@ -443,7 +443,7 @@ var ajaxCart = {
 					var content =  '<dt class="hidden" id="cart_block_product_' + domIdProduct + '">';
 					content += '<span class="quantity-formated"><span class="quantity">' + this.quantity + '</span>x</span>';
 					var name = (this.name.length > 12 ? this.name.substring(0, 10) + '...' : this.name);
-					content += '<a href="' + this.link + '" title="' + this.name + '">' + name + '</a>';
+					content += '<a href="' + this.link + '" title="' + this.name + '" class="cart_block_product_name">' + name + '</a>';
 					
 					if (parseFloat(this.price_float) > 0)
 						content += '<span class="remove_link"><a rel="nofollow" class="ajax_cart_block_remove_link" href="' + baseUri + '?controller=cart&amp;delete=1&amp;id_product=' + productId + '&amp;token=' + static_token + (this.hasAttributes ? '&amp;ipa=' + parseInt(this.idCombination) : '') + '"> </a></span>';


### PR DESCRIPTION
Added the same HTML class as the other product names have in the ajax cart. Perhaps it would be nice to add an added_from_ajax as well in case you would want to differ between the newly added items and previously added ones?
Another potential issue is on line 445 where there is no space after the insert. If Prestashop is set to minify the normal page, this is correct, otherwise there will be a space missing.
