### PR TITLE
$id_shop_list filtering in addAttribute

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1448,6 +1448,7 @@ class ProductCore extends ObjectModel
 			$id_shop_list_array = Product::getShopsByProduct($this->id);
 			foreach ($id_shop_list_array as $array_shop)
 				$id_shop_list[] = $array_shop['id_shop'];
+			$id_shop_list = array_unique($id_shop_list);
 		}
 
 		if (count($id_shop_list))


### PR DESCRIPTION
When addAttribute is used with a not-empty $id_shop_list array argument,
the shop IDs are not filtered to be unique, so $combination->add()
fails.
