### PR TITLE
[-] FO : Bug fixed #PSCFV-8497 Override of 'views' directory in theme.

### DIFF
--- a/classes/controller/ModuleFrontController.php
+++ b/classes/controller/ModuleFrontController.php
@@ -53,7 +53,9 @@ class ModuleFrontControllerCore extends FrontController
 	 */
 	public function setTemplate($template)
 	{
-		if (Tools::file_exists_cache(_PS_THEME_DIR_.'modules/'.$this->module->name.'/'.$template))
+		if (Tools::file_exists_cache(_PS_THEME_DIR_.'modules/'.$this->module->name.'/views/templates/front/'.$template))
+			$this->template = _PS_THEME_DIR_.'modules/'.$this->module->name.'/views/templates/front/'.$template;
+		elseif (Tools::file_exists_cache(_PS_THEME_DIR_.'modules/'.$this->module->name.'/'.$template))
 			$this->template = _PS_THEME_DIR_.'modules/'.$this->module->name.'/'.$template;
 		elseif (Tools::file_exists_cache($this->getTemplatePath().$template))
 			$this->template = $this->getTemplatePath().$template;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1641,6 +1641,8 @@ abstract class ModuleCore
 		$overloaded = $this->_isTemplateOverloaded($template);
 		if ($overloaded === null)
 			return null;
+		if(file_exists(_PS_THEME_DIR_.'modules/'.$this->name.'/views/templates/hook/'.$template))
+			return _PS_THEME_DIR_.'modules/'.$this->name.'/views/templates/hook/'.$template;
 		if ($overloaded)
 			return _PS_THEME_DIR_.'modules/'.$this->name.'/'.$template;
 		else if (file_exists(_PS_MODULE_DIR_.$this->name.'/views/templates/hook/'.$template))


### PR DESCRIPTION
This bug appeared in version 1.5.2.
It was annoying because we do not know if you had to use the "views" folder to store 'tpl' in modules such as the documentation indicates.
