### PR TITLE
Minor fix for field validation in ObjectModel::validateFieldsLang()

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -865,8 +865,13 @@ abstract class ObjectModelCore
 
 			$values = $this->$field;
 			if (!is_array($values))
-				$values = array($this->id_lang => $values);
-			if (!isset($values[Configuration::get('PS_LANG_DEFAULT')]))
+			{
+				$value = $values;
+				$values = array();
+				$values[$this->id_lang] = $value;
+				$values[Configuration::get('PS_LANG_DEFAULT')] = $value;
+			}
+			else if (!isset($values[Configuration::get('PS_LANG_DEFAULT')]))
 				$values[Configuration::get('PS_LANG_DEFAULT')] = '';
 
 			foreach ($values as $id_lang => $value)

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1325,7 +1325,7 @@ class ProductCore extends ObjectModel
 				$product_supplier_entity->id_product_attribute = (int)$id_product_attribute;
 				$product_supplier_entity->id_supplier = (int)$id_supplier;
 				$product_supplier_entity->product_supplier_reference = pSQL($supplier_reference);
-				$product_supplier_entity->product_supplier_price_te = (int)$price;
+				$product_supplier_entity->product_supplier_price_te = (float)$price;
 				$product_supplier_entity->id_currency = (int)$id_currency;
 				$product_supplier_entity->save();
 			}


### PR DESCRIPTION
In ObjectModel::validateFieldsLang(), required field validation should not fail just because $this->id_lang != Configuration::get('PS_LANG_DEFAULT') and supplied field value is not an array.
