### PR TITLE
[*] FO : Improve product.js attributes/combination selection

### DIFF
--- a/themes/default/js/product.js
+++ b/themes/default/js/product.js
@@ -126,7 +126,7 @@ function findCombination(firstTime)
 
 			//get available_date for combination product
 			selectedCombination['available_date'] = combinations[combination]['available_date'];
-			
+
 			//update the display
 			updateDisplay();
 
@@ -161,7 +161,7 @@ function updateDisplay()
 
 		//hide the hook out of stock
 		$('#oosHook').hide();
-		
+
 		$('#availability_date').fadeOut();
 
 		//availability value management
@@ -295,7 +295,7 @@ function updateDisplay()
 		var priceTaxExclWithoutGroupReduction = '';
 
 		// retrieve price without group_reduction in order to compute the group reduction after
-		// the specific price discount (done in the JS in order to keep backward compatibility)		
+		// the specific price discount (done in the JS in order to keep backward compatibility)
 		priceTaxExclWithoutGroupReduction = ps_round(productPriceTaxExcluded, 6) * (1 / group_reduction);
 
 		var tax = (taxRate / 100) + 1;
@@ -398,7 +398,7 @@ function updateDisplay()
 		else
 			productPricePretaxed = productPriceDisplay;
 		$('#pretaxe_price_display').text(formatCurrency(productPricePretaxed, currencyFormat, currencySign, currencyBlank));
-		// Unit price 
+		// Unit price
 		productUnitPriceRatio = parseFloat(productUnitPriceRatio);
 		if (productUnitPriceRatio > 0 )
 		{
@@ -425,7 +425,7 @@ function displayImage(domAAroundImgThumb, no_animation)
 			$('#bigpic').attr('src', newSrc).load(function() {
 				if (typeof(jqZoomEnabled) != 'undefined' && jqZoomEnabled)
 					$(this).attr('rel', domAAroundImgThumb.attr('href'));
-			}); 
+			});
 		}
 		$('#views_block li a').removeClass('shown');
 		$(domAAroundImgThumb).addClass('shown');
@@ -575,6 +575,33 @@ $(document).ready(function()
 		'transitionIn'	: 'elastic',
 		'transitionOut'	: 'elastic'
 	});
+
+	var attributes_container = $('.js-attributes');
+	var selectCombination = function() {
+		var elt = $(this);
+
+		if (elt.is('.js-attribute_color')) {
+			var id_attribute = parseInt(elt.attr('id').replace('color_', ''), 10);
+			attributes_container
+				.find('.js-attribute_color_hidden')
+					.val(id_attribute);
+			// Show color selection
+			$('.js-attribute_color').removeClass('selected');
+			elt.fadeTo('fast', 1, function(){
+				elt.fadeTo('fast', 0, function(){
+					elt.fadeTo('fast', 1, function(){
+						elt.addClass('selected');
+					});
+				});
+			});
+		}
+
+		findCombination();
+		getProductAttribute();
+	}
+	attributes_container
+		.on('change', '.js-attribute_select, .js-attribute_radio', selectCombination)
+		.on('click', '.js-attribute_color', selectCombination);
 });
 
 function saveCustomization()
@@ -595,8 +622,8 @@ function submitPublishProduct(url, redirect, token)
 	$.ajaxSetup({async: false});
 	$.post(url + '/index.php', {
 		action:'publishProduct',
-		id_product: id_product, 
-		status: 1, 
+		id_product: id_product,
+		status: 1,
 		redirect: redirect,
 		ajax: 1,
 		tab: 'AdminProducts',
@@ -623,21 +650,6 @@ function checkMinimalQuantity(minimal_quantity)
 		$('#quantity_wanted').css('border', '1px solid #BDC2C9');
 		$('#minimal_quantity_wanted_p').css('color', '#374853');
 	}
-}
-
-function colorPickerClick(elt)
-{
-	id_attribute = $(elt).attr('id').replace('color_', '');
-	$(elt).parent().parent().children().removeClass('selected');
-	$(elt).fadeTo('fast', 1, function(){
-								$(this).fadeTo('fast', 0, function(){
-									$(this).fadeTo('fast', 1, function(){
-										$(this).parent().addClass('selected');
-										});
-									});
-								});
-	$(elt).parent().parent().parent().children('.color_pick_hidden,#color_pick_hidden').val(id_attribute);
-	findCombination(false);
 }
 
 

--- a/themes/default/js/product.js
+++ b/themes/default/js/product.js
@@ -709,8 +709,7 @@ function checkUrl()
 				tabValues.push(tabParams[i].split('-'));
 			product_id = $('#product_page_product_id').val();
 			// fill html with values
-			$('.color_pick').removeClass('selected');
-			$('.color_pick').parent().parent().children().removeClass('selected');
+			$('.js-attribute_color').removeClass('selected');
 			count = 0;
 			for (var z in tabValues)
 				for (var a in attributesCombinations)
@@ -720,7 +719,6 @@ function checkUrl()
 						count++;
 						// add class 'selected' to the selected color
 						$('#color_' + attributesCombinations[a]['id_attribute']).addClass('selected');
-						$('#color_' + attributesCombinations[a]['id_attribute']).parent().addClass('selected');
 						$('input:radio[value=' + attributesCombinations[a]['id_attribute'] + ']').attr('checked', true);
 						$('input:hidden[name=group_' + attributesCombinations[a]['id_attribute_group'] + ']').val(attributesCombinations[a]['id_attribute']);
 						$('select[name=group_' + attributesCombinations[a]['id_attribute_group'] + ']').val(attributesCombinations[a]['id_attribute']);

--- a/themes/default/product.tpl
+++ b/themes/default/product.tpl
@@ -279,7 +279,7 @@ var fieldRequired = '{l s='Please fill in all the required fields before saving 
 			<div class="product_attributes">
 				{if isset($groups)}
 				<!-- attributes -->
-				<div id="attributes">
+				<div id="attributes" class="js-attributes">
 				<div class="clear"></div>
 				{foreach from=$groups key=id_attribute_group item=group}
 					{if $group.attributes|@count}
@@ -288,7 +288,7 @@ var fieldRequired = '{l s='Please fill in all the required fields before saving 
 							{assign var="groupName" value="group_$id_attribute_group"}
 							<div class="attribute_list">
 							{if ($group.group_type == 'select')}
-								<select name="{$groupName}" id="group_{$id_attribute_group|intval}" class="attribute_select" onchange="findCombination();getProductAttribute();">
+								<select name="{$groupName}" id="group_{$id_attribute_group|intval}" class="attribute_select js-attribute_select">
 									{foreach from=$group.attributes key=id_attribute item=group_attribute}
 										<option value="{$id_attribute|intval}"{if (isset($smarty.get.$groupName) && $smarty.get.$groupName|intval == $id_attribute) || $group.default == $id_attribute} selected="selected"{/if} title="{$group_attribute|escape:'htmlall':'UTF-8'}">{$group_attribute|escape:'htmlall':'UTF-8'}</option>
 									{/foreach}
@@ -297,8 +297,8 @@ var fieldRequired = '{l s='Please fill in all the required fields before saving 
 								<ul id="color_to_pick_list" class="clearfix">
 									{assign var="default_colorpicker" value=""}
 									{foreach from=$group.attributes key=id_attribute item=group_attribute}
-									<li{if $group.default == $id_attribute} class="selected"{/if}>
-										<a id="color_{$id_attribute|intval}" class="color_pick{if ($group.default == $id_attribute)} selected{/if}" style="background: {$colors.$id_attribute.value};" title="{$colors.$id_attribute.name}" onclick="colorPickerClick(this);getProductAttribute();">
+									<li class="js-attribute_color {if $group.default == $id_attribute} selected{/if}">
+										<a id="color_{$id_attribute|intval}" class="color_pick" style="background: {$colors.$id_attribute.value};" title="{$colors.$id_attribute.name}">
 											{if file_exists($col_img_dir|cat:$id_attribute|cat:'.jpg')}
 												<img src="{$img_col_dir}{$id_attribute}.jpg" alt="{$colors.$id_attribute.name}" width="20" height="20" /><br />
 											{/if}
@@ -309,12 +309,12 @@ var fieldRequired = '{l s='Please fill in all the required fields before saving 
 									{/if}
 									{/foreach}
 								</ul>
-								<input type="hidden" class="color_pick_hidden" name="{$groupName}" value="{$default_colorpicker}" />
+								<input type="hidden" class="js-attribute_color_hidden" name="{$groupName}" value="{$default_colorpicker}" />
 							{elseif ($group.group_type == 'radio')}
 								<ul>
 									{foreach from=$group.attributes key=id_attribute item=group_attribute}
 										<li>
-											<input type="radio" class="attribute_radio" name="{$groupName}" value="{$id_attribute}" {if ($group.default == $id_attribute)} checked="checked"{/if} onclick="findCombination();getProductAttribute();" />
+											<input type="radio" class="attribute_radio js-attribute_radio" name="{$groupName}" value="{$id_attribute}" {if ($group.default == $id_attribute)} checked="checked"{/if} />
 											<span>{$group_attribute|escape:'htmlall':'UTF-8'}</span>
 										</li>
 									{/foreach}
@@ -350,7 +350,7 @@ var fieldRequired = '{l s='Please fill in all the required fields before saving 
 			<!-- availability -->
 			<p id="availability_statut"{if ($product->quantity <= 0 && !$product->available_later && $allow_oosp) OR ($product->quantity > 0 && !$product->available_now) OR !$product->available_for_order OR $PS_CATALOG_MODE} style="display: none;"{/if}>
 				<span id="availability_label">{l s='Availability:'}</span>
-				<span id="availability_value"{if $product->quantity <= 0} class="warning_inline"{/if}>{if $product->quantity <= 0}{if $allow_oosp}{$product->available_later}{else}{l s='This product is no longer in stock'}{/if}{else}{$product->available_now}{/if}</span>				
+				<span id="availability_value"{if $product->quantity <= 0} class="warning_inline"{/if}>{if $product->quantity <= 0}{if $allow_oosp}{$product->available_later}{else}{l s='This product is no longer in stock'}{/if}{else}{$product->available_now}{/if}</span>
 			</p>
 			<p id="availability_date"{if ($product->quantity > 0) OR !$product->available_for_order OR $PS_CATALOG_MODE OR !isset($product->available_date) OR $product->available_date < $smarty.now|date_format:'%Y-%m-%d'} style="display: none;"{/if}>
 				<span id="availability_date_label">{l s='Availability date:'}</span>
@@ -555,14 +555,14 @@ var fieldRequired = '{l s='Please fill in all the required fields before saving 
 									</div>
 									<div class="clear_product_desc">&nbsp;</div>
 								</div>
-								
+
 								<p class="clearfix" style="margin-top:5px">
 									<a class="button" href="{$accessoryLink|escape:'htmlall':'UTF-8'}" title="{l s='View'}">{l s='View'}</a>
 									{if !$PS_CATALOG_MODE && ($accessory.allow_oosp || $accessory.quantity > 0)}
 									<a class="exclusive button ajax_add_to_cart_button" href="{$link->getPageLink('cart', true, NULL, "qty=1&amp;id_product={$accessory.id_product|intval}&amp;token={$static_token}&amp;add")}" rel="ajax_id_product_{$accessory.id_product|intval}" title="{l s='Add to cart'}">{l s='Add to cart'}</a>
 									{/if}
 								</p>
-								
+
 							</li>
 						{/if}
 					{/foreach}

--- a/themes/default/product.tpl
+++ b/themes/default/product.tpl
@@ -297,8 +297,8 @@ var fieldRequired = '{l s='Please fill in all the required fields before saving 
 								<ul id="color_to_pick_list" class="clearfix">
 									{assign var="default_colorpicker" value=""}
 									{foreach from=$group.attributes key=id_attribute item=group_attribute}
-									<li class="js-attribute_color {if $group.default == $id_attribute} selected{/if}">
-										<a id="color_{$id_attribute|intval}" class="color_pick" style="background: {$colors.$id_attribute.value};" title="{$colors.$id_attribute.name}">
+									<li class="js-attribute_color {if $group.default == $id_attribute} selected{/if}" id="color_{$id_attribute|intval}">
+										<a class="color_pick" style="background: {$colors.$id_attribute.value};" title="{$colors.$id_attribute.name}">
 											{if file_exists($col_img_dir|cat:$id_attribute|cat:'.jpg')}
 												<img src="{$img_col_dir}{$id_attribute}.jpg" alt="{$colors.$id_attribute.name}" width="20" height="20" /><br />
 											{/if}


### PR DESCRIPTION
A few changes to the way event listening was handled on attributes : 
## Events listeners for combinations

Removed the DOM0 listeners from the template, and switched to Jquery "on" event handler instead.
## Explicit classes for JS purpose

Prefixing classes which are required by JS code makes it easier for everyone to work with the templates. Here are the classes I added : 

```
.js-attributes // The container for all attributes selectors
.js-attribute_select // Attribute <select> tag
.js-attribute_color // Color picker
.js-attribute_color_hidden // The hidden color picker field
.js-attribute_radio // Atrribute <input type="radio" /> tag
```
## Less DOM traversing

`$(elt).parent().parent().parent().children('.color_pick_hidden,#color_pick_hidden')` and similar selectors break easily if any changes are made to the HTML code. I cleaned up some of them.

If you are OK with those changes, I'll be more than happy to push further on simplifying product.js !
Regards,
