### PR TITLE
[-] FO : In stock is now removed when Stock managment is disabled

### DIFF
--- a/themes/default/product-sort.tpl
+++ b/themes/default/product-sort.tpl
@@ -64,7 +64,7 @@ $(document).ready(function()
 			{/if}
 			<option value="name:asc" {if $orderby eq 'name' AND $orderway eq 'asc'}selected="selected"{/if}>{l s='Product Name: A to Z'}</option>
 			<option value="name:desc" {if $orderby eq 'name' AND $orderway eq 'desc'}selected="selected"{/if}>{l s='Product Name: Z to A'}</option>
-			{if !$PS_CATALOG_MODE}
+			{if $PS_STOCK_MANAGEMENT and !$PS_CATALOG_MODE}
 				<option value="quantity:desc" {if $orderby eq 'quantity' AND $orderway eq 'desc'}selected="selected"{/if}>{l s='In stock'}</option>
 			{/if}
 		</select>


### PR DESCRIPTION
Fixes the bug on 1.5.3.1 when Stock managment is disabled, it stil show "In Stock" in the sort by list.
Added $PS_STOCK_MANAGEMENT to line 67.
