### PR TITLE
[ - ] TR :  wrong translation, Ireland is the english name, it should be...

### DIFF
--- a/install-dev/langs/fr/data/country.xml
+++ b/install-dev/langs/fr/data/country.xml
@@ -76,7 +76,7 @@
     <name>Singapour</name>
   </country>
   <country id="IE">
-    <name>Ireland</name>
+    <name>Irlande</name>
   </country>
   <country id="NZ">
     <name>Nouvelle-Z&#xE9;lande</name>


### PR DESCRIPTION
... Irlande in french.
