### PR TITLE
[*] Project : Add paging to Collections

### DIFF
--- a/classes/Collection.php
+++ b/classes/Collection.php
@@ -83,7 +83,7 @@ class CollectionCore implements Iterator, ArrayAccess, Countable
 	/**
 	 * @var int Size of a page
 	 */
-	protected $page_size = 10;
+	protected $page_size = 0;
 
 	protected $fields = array();
 	protected $alias = array();

--- a/classes/Collection.php
+++ b/classes/Collection.php
@@ -684,9 +684,8 @@ class CollectionCore implements Iterator, ArrayAccess, Countable
 	public function setPageNumber($page_number)
 	{
 		$page_number = (int)$page_number;
-		if ($page_number > 0) {
+		if ($page_number > 0)
 			$page_number--;
-		}
 		
 		$this->page_number = $page_number;
 		return $this;

--- a/classes/Collection.php
+++ b/classes/Collection.php
@@ -74,6 +74,16 @@ class CollectionCore implements Iterator, ArrayAccess, Countable
 	 * @var int Total of elements for iteration
 	 */
 	protected $total;
+	
+	/**
+	 * @var int Page number
+	 */
+	protected $page_number = 0;
+	
+	/**
+	 * @var int Size of a page
+	 */
+	protected $page_size = 10;
 
 	protected $fields = array();
 	protected $alias = array();
@@ -334,6 +344,11 @@ class CollectionCore implements Iterator, ArrayAccess, Countable
 				break;
 			}
 		}
+		
+		// All limit clause
+		if ($this->page_size)
+			$this->query->limit($this->page_size, $this->page_number * $this->page_size);
+		
 
 		// Shall we display query for debug ?
 		if ($display_query)
@@ -658,6 +673,35 @@ class CollectionCore implements Iterator, ArrayAccess, Countable
 			);
 		}
 		return $this->fields[$field];
+	}
+	
+	/**
+	 * Set the page number
+	 *
+	 * @param int $page_number
+	 * @return Collection
+	 */
+	public function setPageNumber($page_number)
+	{
+		$page_number = (int)$page_number;
+		if ($page_number > 0) {
+			$page_number--;
+		}
+		
+		$this->page_number = $page_number;
+		return $this;
+	}
+	
+	/**
+	 * Set the nuber of item per page
+	 *
+	 * @param int $page_size
+	 * @return Collection
+	 */
+	public function setPageSize($page_size)
+	{
+		$this->page_size = (int)$page_size;
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
I do not see any way to limit the number of objects in a Collection. Collection::setPageSize() and Collection::setPageNumber() add a limit clause to the query.
For example:
$collection = new Collection('Customer');
$collection->setPageSize(10); // Get ten customers
$collection->setPageNumber(2); // Start with the eleventh
$collection->getResults();
