### PR TITLE
[*] MO : Order return states (like order messages) should be kept after ...

### DIFF
--- a/modules/pscleaner/pscleaner.php
+++ b/modules/pscleaner/pscleaner.php
@@ -475,8 +475,6 @@ class PSCleaner extends Module
 					'order_payment',
 					'order_return',
 					'order_return_detail',
-					'order_return_state',
-					'order_return_state_lang',
 					'order_slip',
 					'order_slip_detail',
 					'page',


### PR DESCRIPTION
...a call to truncate('sales') in pscleaner module.
