### PR TITLE
Provide in any case category parent information

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -157,10 +157,11 @@ class ProductControllerCore extends FrontController
 							$this->category = new Category($regs[5], (int)$this->context->cookie->id_lang);
 					}
 				}
-				else
-					// Set default product category
-					$this->category = new Category($this->product->id_category_default, (int)$this->context->cookie->id_lang);
 			}
+			// If no category set, use the default product category
+			// Set default product category
+			if (!isset($this->category))
+				$this->category = new Category($this->product->id_category_default, (int)$this->context->cookie->id_lang);
 		}
 	}
 


### PR DESCRIPTION
When a product page is loaded and previous page check category test but is not a category (as product page with rewrite rule), category information is not set.
 A test is done to set at least default category information for any situation
