### PR TITLE
[-] MO : Followup : Don't execute crontasks if the module is disabled

### DIFF
--- a/modules/followup/cron.php
+++ b/modules/followup/cron.php
@@ -33,7 +33,8 @@ if (isset($_GET['secure_key']))
 	if (!empty($secureKey) AND $secureKey === $_GET['secure_key'])
 	{
 		$followup = new Followup();
-		$followup->cronTask();
+		if ($followup->active)
+			$followup->cronTask();
 	}
 }
 


### PR DESCRIPTION
To reproduce the bug:
1. Enable Follow Up module with at least one type of emails activated (eg: "re-order")
2. Set up a cron task on you server, executing Followup's cron.php
3. Disable the module
4. The cron is still executed but it doesn't check wether the module is activated or not
