### PR TITLE
Better regexp to get country browser from HTTP_ACCEPT_LANGUAGE

### DIFF
--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -303,7 +303,9 @@ class AddressControllerCore extends FrontController
 			$selected_country = (int)$this->_address->id_country;
 		else if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE']))
 		{
-			$array = preg_split('/,|-/', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
+			// get all countries as language (xy) or language-country (wz-XY)
+			$array = array();
+			preg_match("#(?<=-)\w\w|\w\w(?!-)#",$_SERVER['HTTP_ACCEPT_LANGUAGE'],$array);
 			if (!Validate::isLanguageIsoCode($array[0]) || !($selected_country = Country::getByIso($array[0])))
 				$selected_country = (int)Configuration::get('PS_COUNTRY_DEFAULT');
 		}

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -107,7 +107,9 @@ class AuthControllerCore extends FrontController
 			
 			if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE']))
 			{
-				$array = preg_split('/,|-/', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
+				// get all countries as language (xy) or language-country (wz-XY)
+				$array = array();
+				preg_match("#(?<=-)\w\w|\w\w(?!-)#",$_SERVER['HTTP_ACCEPT_LANGUAGE'],$array);
 				if (!Validate::isLanguageIsoCode($array[0]) || !($sl_country = Country::getByIso($array[0])))
 					$sl_country = (int)Configuration::get('PS_COUNTRY_DEFAULT');
 			}


### PR DESCRIPTION
With HTTP_ACCEPT_LANGUAGE we have two choices :
- Country == language (displayed with two letter as fr,de,en,...)
- Country with multi language (displayes as fr-CH, de-CH, it-CH)

Previous regexp find only first case.

http://forge.prestashop.com/browse/PSCFV-8940
