### PR TITLE
[-] CORE : CartRule::checkProductRestrictions : A gift product in the same category as its restrictions causes the gift to stay in the cart even if emptied

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -637,7 +637,8 @@ class CartRuleCore extends ObjectModel
 							FROM `'._DB_PREFIX_.'cart_product` cp
 							LEFT JOIN `'._DB_PREFIX_.'category_product` catp ON cp.id_product = catp.id_product
 							WHERE cp.`id_cart` = '.(int)$context->cart->id.'
-							AND cp.`id_product` IN ('.implode(array_map('intval', $eligibleProductsList), ',').')');
+							AND cp.`id_product` IN ('.implode(array_map('intval', $eligibleProductsList), ',').')
+							AND cp.`id_product` <> '.(int)$this->gift_product);
 							$countMatchingProducts = 0;
 							$matchingProductsList = array();
 							foreach ($cartCategories as $cartCategory)


### PR DESCRIPTION
To reproduce the bug:

BO:
- Create a category "Test category"
- Create 2 products "A" and "B" in this category
- Create a CartRule which sends "Product B" as a gift, and only applies to products in "Test category"

FO:
- Add "Product A" to the cart, then go to your cart
- You should see "Product A", and "Product B" as a gift
- Remove "Product A" from the cart: Product B should disappear but it stays in the cart and cannot be removed

The suggested fix adds an SQL condition to prevent this scenario.
