### PR TITLE
[-] BO : fixed bug in require string

### DIFF
--- a/admin-dev/get-file-admin.php
+++ b/admin-dev/get-file-admin.php
@@ -25,5 +25,5 @@
 */
 
 define('_PS_ADMIN_DIR_', getcwd());
-require(_PS_ADMIN_DIR_.'/config/config.inc.php');
+require(_PS_ADMIN_DIR_.'/../config/config.inc.php');
 Controller::getController('GetFileController')->run();


### PR DESCRIPTION
In the last change made by vAugagneur (commit number: 5f47b81211ee1a434b7eef7939550118a2c64fcd) there was an error.
The config file is not in the _PS_ADMIN_DIR_/config/ path but in the parent folder: _PS_ADMIN_DIR_/../config/
