### PR TITLE
[-] BO : Allow the use of routes in back-office

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -409,7 +409,7 @@ class DispatcherCore
 				);
 		
 		// Load the custom routes prior the defaults to avoid infinite loops
-		if ($this->use_routes)
+		if ($this->use_routes || defined('_PS_ADMIN_DIR_'))
 		{
 			// Get iso lang
 			$iso_lang = Tools::getValue('isolang');


### PR DESCRIPTION
Bug appearing when using:
- Sitemap generation in "gsitemap" module through the back-office with custom routes
- Preview action in product page in back-office
