### PR TITLE
[*] MO: Referral program: display currency in account page next to the voucher value

### DIFF
--- a/modules/referralprogram/controllers/front/program.php
+++ b/modules/referralprogram/controllers/front/program.php
@@ -29,31 +29,31 @@
  */
 include_once(dirname(__FILE__).'../../../ReferralProgramModule.php');
 include_once(dirname(__FILE__).'../../../referralprogram.php');
- 
+
 class ReferralprogramProgramModuleFrontController extends ModuleFrontController
 {
-	
+
 	public function init()
 	{
 		if (!$this->context->customer->isLogged())
 			Tools::redirect('index.php?controller=authentication&back=modules/referralprogram/referralprogram-program.php');
 		parent::init();
 	}
-	
+
 	public function setMedia()
 	{
 		parent::setMedia();
 		$this->addJqueryPlugin(array('thickbox', 'idTabs'));
 	}
 
-	
+
 	/**
 	 * @see FrontController::initContent()
 	 */
 	public function initContent()
 	{
 		parent::initContent();
-		
+
 		// get discount value (ready to display)
 		$discount_type = (int)(Configuration::get('REFERRAL_DISCOUNT_TYPE'));
 		if ($discount_type == 1)
@@ -63,7 +63,7 @@ class ReferralprogramProgramModuleFrontController extends ModuleFrontController
 
 		$activeTab = 'sponsor';
 		$error = false;
-		
+
 		// Mailing invitation to friend sponsor
 		$invitation_sent = false;
 		$nbInvitation = 0;
@@ -82,7 +82,7 @@ class ReferralprogramProgramModuleFrontController extends ModuleFrontController
 					$friendEmail = strval($friendEmail);
 					$friendLastName = strval($friendsLastName[$key]);
 					$friendFirstName = strval($friendsFirstName[$key]);
-		
+
 					if (empty($friendEmail) AND empty($friendLastName) AND empty($friendFirstName))
 						continue;
 					elseif (empty($friendEmail) OR !Validate::isEmail($friendEmail))
@@ -136,7 +136,7 @@ class ReferralprogramProgramModuleFrontController extends ModuleFrontController
 					$error = 'email exists';
 			}
 		}
-		
+
 		// Mailing revive
 		$revive_sent = false;
 		$nbRevive = 0;
@@ -174,16 +174,16 @@ class ReferralprogramProgramModuleFrontController extends ModuleFrontController
 			else
 				$error = 'no revive checked';
 		}
-		
+
 		$customer = new Customer((int)($this->context->customer->id));
 		$stats = $customer->getStats();
-		
+
 		$orderQuantity = (int)(Configuration::get('REFERRAL_ORDER_QUANTITY'));
 		$canSendInvitations = false;
 
 		if ((int)($stats['nb_orders']) >= $orderQuantity)
 			$canSendInvitations = true;
-		
+
 		// Smarty display
 		$this->context->smarty->assign(array(
 			'activeTab' => $activeTab,
@@ -198,7 +198,8 @@ class ReferralprogramProgramModuleFrontController extends ModuleFrontController
 			'revive_sent' => $revive_sent,
 			'nbRevive' => $nbRevive,
 			'subscribeFriends' => ReferralProgramModule::getSponsorFriend((int)($this->context->customer->id), 'subscribed'),
-			'mails_exists' => (isset($mails_exists) ? $mails_exists : array())
+			'mails_exists' => (isset($mails_exists) ? $mails_exists : array()),
+			'currencySign' => $this->context->currency->sign
 		));
 		$this->setTemplate('program.tpl');
 	}

--- a/modules/referralprogram/views/templates/front/program.tpl
+++ b/modules/referralprogram/views/templates/front/program.tpl
@@ -83,7 +83,7 @@
 
 	<div id="idTab1">
 		<p class="bold">
-			<strong>{l s='Get a discount of %d for you and your friends by recommending this Website.' sprintf=$discount mod='referralprogram'}</strong>
+			<strong>{l s='Get a discount of %1$d %2$s for you and your friends by recommending this Website.' sprintf=[$discount,$currencySign] mod='referralprogram'}</strong>
 		</p>
 		{if $canSendInvitations}
 			<p>
@@ -93,7 +93,7 @@
 				{else}
 					{l s='When one of them makes at least %d order' sprintf=$orderQuantity mod='referralprogram'}
 				{/if},
-				{l s='he or she will receive a %1$d voucher and you will receive your own voucher worth %2$d.' sprintf=[$discount,$discount] mod='referralprogram'}
+				{l s='he or she will receive a %1$d %2$s voucher and you will receive your own voucher worth %3$d %4$s.' sprintf=[$discount,$currencySign,$discount,$currencySign] mod='referralprogram'}
 			</p>
 			<form method="post" action="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html'}" class="std">
 				<table class="std">
@@ -125,7 +125,7 @@
 					<a href="{$link->getModuleLink('referralprogram', 'rules', ['height' => '500', 'width' => '400'], true)|escape:'html'}" class="thickbox" title="{l s='Conditions of the referral program' mod='referralprogram'}" rel="nofollow">{l s='Read conditions.' mod='referralprogram'}</a>
 				</p>
 				<p class="see_email">
-					{l s='Preview' mod='referralprogram'} 
+					{l s='Preview' mod='referralprogram'}
 					{assign var="file" value="{$lang_iso}/referralprogram-invitation.html"}
 					<a href="{$link->getModuleLink('referralprogram', 'email', ['height' => '500', 'width' => '600', 'mail' => {$file}], true)|escape:'html'}" class="thickbox" title="{l s='Invitation e-mail' mod='referralprogram'}" rel="nofollow">{l s='the default e-mail' mod='referralprogram'}</a> {l s='that will be sent to your friend(s).' mod='referralprogram'}
 				</p>


### PR DESCRIPTION
In the referral program account page the text was missing the currency sign. This commit fix it:
Before:
`...he or she will receive a 5 voucher and you will receive your own voucher worth 5`
After:
`...he or she will receive a 5 $ voucher and you will receive your own voucher worth 5 $.`
