### PR TITLE
Avoid using stream_context_get_options when $stream_context is null

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1291,14 +1291,16 @@ class ToolsCore
 			curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
 			curl_setopt($curl, CURLOPT_TIMEOUT, $curl_timeout);
 			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
-			$opts = stream_context_get_options($stream_context);
-			if (isset($opts['http']['method']) && Tools::strtolower($opts['http']['method']) == 'post')
-			{
-				curl_setopt($curl, CURLOPT_POST, true);
-				if (isset($opts['http']['content']))
+			if ($stream_context != null) {
+				$opts = stream_context_get_options($stream_context);
+				if (isset($opts['http']['method']) && Tools::strtolower($opts['http']['method']) == 'post')
 				{
-					parse_str($opts['http']['content'], $datas);
-					curl_setopt($curl, CURLOPT_POSTFIELDS, $datas);
+					curl_setopt($curl, CURLOPT_POST, true);
+					if (isset($opts['http']['content']))
+					{
+						parse_str($opts['http']['content'], $datas);
+						curl_setopt($curl, CURLOPT_POSTFIELDS, $datas);
+					}
 				}
 			}
 			$content = curl_exec($curl);


### PR DESCRIPTION
Otherwise it will error (when using curl and a http url) with this message:

```[Tue Jun 18 10:30:29 2013] [error] [client 123.123.123.123] PHP Warning:  stream_context_get_options() expects parameter 1 to be resource, null
 given in /var/www/example/classes/Tools.php on line 1290, referer: http://example.com/adminareia/index.php?controller=A
dminModules&token=6cb1f7b4ea8f1091840128401928010918249

```
```
