### PR TITLE
[.] FO : expiration date not displayed in email for downloadable product

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -122,8 +122,8 @@ class OrderHistoryCore extends ObjectModel
 							.'&id_order='.(int)$order->id
 							.'&secure_key='.$order->secure_key;
 						$assign[$key]['link'] = $dl_link;
-						if (isset($virtual_product['date_expiration']) && $virtual_product['date_expiration'] != '0000-00-00 00:00:00')
-							$assign[$key]['deadline'] = Tools::displayDate($virtual_product['date_expiration ']);
+						if (isset($virtual_product['download_deadline']) && $virtual_product['download_deadline'] != '0000-00-00 00:00:00')
+							$assign[$key]['deadline'] = Tools::displayDate($virtual_product['download_deadline']);
 						if ($product_download->nb_downloadable != 0)
 							$assign[$key]['downloadable'] = (int)$product_download->nb_downloadable;
 					}


### PR DESCRIPTION
Replaced $virtual_product['date_expiration'] by
$virtual_product['download_deadline'].

Order::getVirtualProducts() doesn't return `date_expiration` field (doesn't exists) but `download_deadline`.
