### PR TITLE
[-] BO : remove robots.txt rules preventing Google shopping indexing

### DIFF
--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -650,7 +650,7 @@ class AdminMetaControllerCore extends AdminController
 		}
 
 		$tab['GB'] = array(
-			'orderby=','orderway=','tag=','id_currency=','search_query=','back=','utm_source=','utm_medium=','utm_campaign=','n='
+			'orderby=','orderway=','tag=','id_currency=','search_query=','back=','n='
 		);
 
 		foreach ($disallow_controllers as $controller)


### PR DESCRIPTION
Google shopping refuses all products having their URL blocked by the robots.txt file (rules concerned: the ones starting with "utm_")
