### PR TITLE
Update AdminCustomerThreadsController.php

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -404,7 +404,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
 					$contact = new Contact((int)$ct->id_contact);
 					if (Validate::isLoadedObject($contact))
 					{
-						$from_name = $contact->name;
+						$from_name = $contact->name[(int)$ct->id_lang];
 						$from_email = $contact->email;
 					}
 					else


### PR DESCRIPTION
$contact->name can be an array throwing a warning Warning: preg_match() expects parameter 2 to be string when answering to a customer
