### PR TITLE
Improve SEO by adding the H1 tags missing in the index

### DIFF
--- a/themes/default/header.tpl
+++ b/themes/default/header.tpl
@@ -76,7 +76,9 @@
 			<!-- Header -->
 			<div id="header" class="grid_9 alpha omega">
 				<a id="header_logo" href="{$base_dir}" title="{$shop_name|escape:'htmlall':'UTF-8'}">
-					<img class="logo" src="{$logo_url}" alt="{$shop_name|escape:'htmlall':'UTF-8'}" {if $logo_image_width}width="{$logo_image_width}"{/if} {if $logo_image_height}height="{$logo_image_height}" {/if}/>
+					{if $page_name=='index'}<h1>{/if}
+					<img class="logo" src="{$logo_url}" alt="{$shop_name|escape:'htmlall':'UTF-8'}" {if $logo_image_width}width="{$logo_image_width}"{/if} {if $logo_image_height}height="{$logo_image_height}" {/if} />
+					{if $page_name=='index'}</h1>{/if}
 				</a>
 				<div id="header_right" class="grid_9 omega">
 					{$HOOK_TOP}


### PR DESCRIPTION
The main page of prestashop with the default theme didn't have any H1 tags, by surrounding the logo (+ alt text) with h1 we should get better positioning.
With the conditional in the templates it doesn't affect to the rest of the shop where the h1 tags are properly applied.
More discussion on this at:  http://www.prestashop.com/forums/topic/257033-adding-h1-tags-in-the-home-page/page__p__1280108
