### PR TITLE
[*] BO : Correct the getList() request for quantity and id_product

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -201,7 +201,8 @@ class AdminProductsControllerCore extends AdminController
 		$this->fields_list['id_product'] = array(
 			'title' => $this->l('ID'),
 			'align' => 'center',
-			'width' => 20
+			'type' => 'int',
+			'width' => 40
 		);
 		$this->fields_list['image'] = array(
 			'title' => $this->l('Photo'),
@@ -253,6 +254,7 @@ class AdminProductsControllerCore extends AdminController
 			$this->fields_list['sav_quantity'] = array(
 				'title' => $this->l('Quantity'),
 				'width' => 90,
+				'type' => 'int',
 				'align' => 'right',
 				'filter_key' => 'sav!quantity',
 				'orderby' => true,


### PR DESCRIPTION
Quantity and Id_product should be fixe as Int, else the Mysql request do something like : quantity LIKE "%0%"

When an admin key-in quantity as 0, he want product with quantity as 0, not as 0 / 10 /20 / 30... ect (The same for id_product)
