### PR TITLE
[+] BO: Fix Bug Progress Bar Upload Image Product

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1872,6 +1872,7 @@ div.progressBarImage
 	height: 15px;
 	margin-left: 3px;
 	width: 233px;
+	position:relative;
 }
 #showCounter
 {


### PR DESCRIPTION
Lorsque l'on ajoute des images a des produits, la barre de progression s'affiche en dehors de son cadre. "position:relative" n'est pas présent pour "div.progressBarImage" dans le fichier admin.css .

When we add pictures to products, the progress bar is out of his wrapper. "position:relative" is missing for "div.progressBarImage" in admin.css file.
