### PR TITLE
[-] WS: do not escape shop name overzealously

### DIFF
--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -285,7 +285,7 @@ class WebserviceOutputBuilderCore
 		if (is_null($this->wsResource))
 			throw new WebserviceException ('You must set web service resource for get the resources list.', array(82, 500));
 		$output = '';
-		$more_attr = array('shop_name' => htmlentities(Configuration::get('PS_SHOP_NAME')));
+		$more_attr = array('shop_name' => htmlspecialchars(Configuration::get('PS_SHOP_NAME')));
 		$output .= $this->objectRender->renderNodeHeader('api', array(), $more_attr);
 		foreach ($this->wsResource as $resourceName => $resource)
 		{


### PR DESCRIPTION
The shop name is likely to contain accented characters and, as it is, it is encoded into a latin-1 representation of UTF-8 input and breaks some XML parsers, like Firefox's:
![pic](https://f.cloud.github.com/assets/315139/773504/1fc2c518-e93b-11e2-8e63-d4d978605d3d.png)
(should say PrestaDév)
Only quotes need to be escaped, so we might as well not worry with the rest.
