### PR TITLE
Update PaymentModule.php

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -297,7 +297,7 @@ abstract class PaymentModuleCore extends Module
 				$this->context->country = $context_country;
 
 			// Register Payment only if the order status validate the order
-			if ($order_status->logable)
+			if ($order_status->logable && $id_order_state == Configuration::get('PS_OS_ERROR'))
 			{
 				// $order is the last order loop in the foreach
 				// The method addOrderPayment of the class Order make a create a paymentOrder


### PR DESCRIPTION
Hi, I altered the line 300 because a error message in order payment. This happens when the cart generate more than one order (more than one package). So, it generate a amount for the entire cart, but not for individual orders.
At this point, the order view show the message, "Warning: xxx.xx paid instead of xxx.xx / This warning also concerns the order xxx".
But the order is correct! The invoice is correct too. The generated payment from the first order not. Are two orders from one cart. So I altered the line to generate payment just in case of error in amount sent in function is different from amount from the total cart.
I tested and worked, but I would like of your revision!
