### PR TITLE
[-] MO : Followup : don't send emails for empty carts

### DIFF
--- a/modules/followup/followup.php
+++ b/modules/followup/followup.php
@@ -280,8 +280,9 @@ class Followup extends Module
 		SELECT c.id_cart, c.id_lang, cu.id_customer, cu.firstname, cu.lastname, cu.email
 		FROM '._DB_PREFIX_.'cart c
 		LEFT JOIN '._DB_PREFIX_.'orders o ON (o.id_cart = c.id_cart)
-		LEFT JOIN '._DB_PREFIX_.'customer cu ON (cu.id_customer = c.id_customer)
-			WHERE DATE_SUB(CURDATE(),INTERVAL 7 DAY) <= c.date_add AND cu.id_customer IS NOT NULL AND o.id_order IS NULL';
+		RIGHT JOIN '._DB_PREFIX_.'customer cu ON (cu.id_customer = c.id_customer)
+		RIGHT JOIN '._DB_PREFIX_.'cart_product cp ON (cp.id_cart = c.id_cart)
+			WHERE DATE_SUB(CURDATE(),INTERVAL 7 DAY) <= c.date_add AND o.id_order IS NULL';
 		
 		if(!empty($emailLogs))
 			$sql .= ' AND c.id_cart NOT IN ('.join(',', $emailLogs).')';


### PR DESCRIPTION
"Cancelled cart" must only apply to carts which are not empty.

We have also changed the "ps_customer" table join to simplify the SQL request (RIGHT JOIN instead of LEFT JOIN + WHERE condition)

This Pull Request completes these ones:
- https://github.com/PrestaShop/PrestaShop/pull/482
- https://github.com/PrestaShop/PrestaShop/pull/484
