### PR TITLE
Do not limit feature values on a list

### DIFF
--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -455,7 +455,7 @@ class AdminFeaturesControllerCore extends AdminController
 	 * AdminController::getList() override
 	 * @see AdminController::getList()
 	 */
-	public function getList($id_lang, $order_by = null, $order_way = null, $start = 0, $limit = null, $id_lang_shop = false)
+	public function getList($id_lang, $order_by = null, $order_way = null, $start = 0, $limit = false, $id_lang_shop = false)
 	{
 		if ($this->table == 'feature_value')
 			$this->_where .= ' AND a.custom = 0';


### PR DESCRIPTION
Controller use default method getList with pagination of 50 items. Argument $limit should be set to FALSE to disable limit, because if you have more than 50 values of one feature, then you can not access them in back office.

http://forge.prestashop.com/browse/PSCFV-5847
