### PR TITLE
Payment currency restriction incorret type of input for radio

### DIFF
--- a/admin-dev/themes/default/template/controllers/payment/restrictions.tpl
+++ b/admin-dev/themes/default/template/controllers/payment/restrictions.tpl
@@ -64,7 +64,7 @@
 								{$type = 'checkbox'}
 							{/if}
 							{if $type != 'null'}
-								<input type="checkbox" name="{$module->name}_{$list['name_id']}[]" value="{$item[$list['identifier']]}" {if $item['check_list'][$key_module] == 'checked'}checked="checked"{/if}/>
+								<input type="{$type}" name="{$module->name}_{$list['name_id']}[]" value="{$item[$list['identifier']]}" {if $item['check_list'][$key_module] == 'checked'}checked="checked"{/if}/>
 							{else}
                                 <input type="hidden" name="{$module->name}_{$list['name_id']}[]" value="{$item[$list['identifier']]}"/>--
 							{/if}


### PR DESCRIPTION
When payment module has currencies restrictions set to radio it still displays as checkbox because in TPL file type of input is not being changed

http://forge.prestashop.com/browse/PSCFV-9310
