### PR TITLE
update documents listing to display proper prefix

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/_documents.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_documents.tpl
@@ -68,9 +68,9 @@
 			{/if}
 			{if get_class($document) eq 'OrderInvoice'}
 				{if isset($document->is_delivery)}
-					#{Configuration::get('PS_DELIVERY_PREFIX', $current_id_lang)}{'%06d'|sprintf:$document->delivery_number}
+					#{Configuration::get('PS_DELIVERY_PREFIX', $current_id_lang, null, $order->id_shop)}{'%06d'|sprintf:$document->delivery_number}
 				{else}
-					{$document->getInvoiceNumberFormatted($current_id_lang)}
+					{$document->getInvoiceNumberFormatted($current_id_lang, $order->id_shop)}
 				{/if}
 			{elseif get_class($document) eq 'OrderSlip'}
 				#{Configuration::get('PS_CREDIT_SLIP_PREFIX', $current_id_lang)}{'%06d'|sprintf:$document->id}


### PR DESCRIPTION
In order details, generic prefix was displayed in right column instead of shop specific prefix
