### PR TITLE
develivery slip should use prefix

### DIFF
--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -90,7 +90,7 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
 	 */
 	public function getFilename()
 	{
-		return Configuration::get('PS_DELIVERY_PREFIX').sprintf('%06d', $this->order->invoice_number).'.pdf';
+		return Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id, null, $this->order->id_shop).sprintf('%06d', $this->order->invoice_number).'.pdf';
 	}
 }
 


### PR DESCRIPTION
as develivery_prefix uses lang and shop id, those variables has to be passed as parameters
