### PR TITLE
Update Translate.php

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -180,7 +180,13 @@ class TranslateCore
 			if ($js)
 				$ret = addslashes($ret);
 
-			$lang_cache[$cache_key] = str_replace('"', '&quot;', $ret);
+                        $ret = str_replace('"', '&quot;', $ret);
+
+                        if ($sprintf === null)
+                                $lang_cache[$cache_key] = $ret; 
+                        else    
+                                return $ret;
+
 		}
 		return $lang_cache[$cache_key];
 	}


### PR DESCRIPTION
Translations shouldn't be cached if they contain dynamic vars (sprintf)

On productcomments, 
<li>{l s='%1$d out of %2$d people found this review useful.' sprintf=[$comment.total_useful, $comment.total_advice] mod='productcomments'}</li>
was always printing the same sentence
