### PR TITLE
ParentOrderController->setMedia() proper order for typewatch and cart-su...

### DIFF
--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -153,8 +153,8 @@ class ParentOrderControllerCore extends FrontController
 		$this->addJqueryPlugin('fancybox');
 		if ((int)(Configuration::get('PS_BLOCK_CART_AJAX')) || Configuration::get('PS_ORDER_PROCESS_TYPE') == 1)
 		{
-			$this->addJS(_THEME_JS_DIR_.'cart-summary.js');
 			$this->addJqueryPlugin('typewatch');
+			$this->addJS(_THEME_JS_DIR_.'cart-summary.js');
 		}
 	}
 


### PR DESCRIPTION
In the original class, typewatch is inserted after cart-summary, but it is used for the quantity input in cart-summary.js, so we need to have typewatch first.
