### PR TITLE
Update ProductController.php

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -149,8 +149,12 @@ class ProductControllerCore extends FrontController
 					// If the previous page was a category and is a parent category of the product use this category as parent category
 					if (isset($regs[2]) && is_numeric($regs[2]))
 					{
-						if (Product::idIsOnCategoryId((int)$this->product->id, array('0' => array('id_category' => (int)$regs[2]))))
+						if (Product::idIsOnCategoryId((int)$this->product->id, array('0' => array('id_category' => (int)$regs[2])))){
 							$this->category = new Category($regs[2], (int)$this->context->cookie->id_lang);
+						}elseif(Product::idIsOnCategoryId((int)$this->product->id, array('0' => array('id_category' => (int)$this->product->id_category_default)))){
+							// fixed bug with url_rewrite is ON
+							$this->category = new Category($this->product->id_category_default, (int)$this->context->cookie->id_lang);
+						}
 					}
 					else if (isset($regs[5]) && is_numeric($regs[5]))
 					{


### PR DESCRIPTION
EN :

When the url rewrite is enabled, the preg match is true if you come from a product to another page product page. However, id recovered is that of a product category name. So the Breadcrumb is not built correctly. In fact, the last grade level is not formed as a link in assignCategory because it happens in the here and elseif construction Breadcrumb is the 3rd parameter to false.

---

FR :
Lorsque l'url rewrite est activé, le preg match est vrai si on vient d'une page produit sur une autre page produit. Cependant, l'id récupéré est celui d'un produit et nom d'une catégorie. Du coup le Breadcrumb ne se construit pas correctement. En effet le dernier niveau de catégorie n'est pas formé comme un lien car dans assignCategory, on passe dans le elseif et qu'ici la construction du Breadcrumb se fait avec le 3 ème paramètre à false.
