### PR TITLE
[-] FO : product.js : product with declinaisons without reductions : reduction price is showed anyway !

### DIFF
--- a/themes/default/js/product.js
+++ b/themes/default/js/product.js
@@ -312,7 +312,7 @@ function updateDisplay()
 			var taxExclPrice = (specific_currency ? product_specific_price.price : product_specific_price.price * currencyRate) + (selectedCombination['price'] * currencyRate);
 
 		if (!displayPrice && !noTaxForThisProduct)
-			productPriceDisplay = taxExclPrice * tax; // Need to be global => no var
+			productPriceDisplay = ps_round(taxExclPrice * tax, 2); // Need to be global => no var
 		else
 			productPriceDisplay = ps_round(taxExclPrice, 2); // Need to be global => no var
 
@@ -372,7 +372,6 @@ function updateDisplay()
 			$('#not_impacted_by_discount').hide();
 
 		productPriceDisplay -= reduction;
-		var tmp = productPriceDisplay * group_reduction;
 		productPriceDisplay = ps_round(productPriceDisplay * group_reduction, 2);
 
 		var ecotaxAmount = !displayPrice ? ps_round(selectedCombination['ecotax'] * (1 + ecotaxTax_rate / 100), 2) : selectedCombination['ecotax'];


### PR DESCRIPTION
on a product with declinaisons without reductions : reduction price is showed anyway !!

because of this comparison after (line ~400):

if (productPriceWithoutReductionDisplay > productPriceDisplay)

and :

var tmp = productPriceDisplay \* group_reduction;

is unused
