### PR TITLE
Update AdminCustomerThreadsController.php

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -401,7 +401,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
 						),
 					);
 					//#ct == id_customer_thread    #tc == token of thread   <== used in the synchronization imap
-					$contact = new Contact((int)$ct->id_contact);
+					$contact = new Contact((int)$ct->id_contact, (int)$ct->id_lang);
 					if (Validate::isLoadedObject($contact))
 					{
 						$from_name = $contact->name[(int)$ct->id_lang];


### PR DESCRIPTION
If language is not defined returns an array instead of a string which makes function Mail::Send to throw a warning.
