### PR TITLE
[-] WS: Sanity check before creating packs

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5377,7 +5377,8 @@ class ProductCore extends ObjectModel
 		Pack::deleteItems($this->id);
 		
 		foreach ($items as $item)
-			Pack::addItem($this->id, (int)$item['id'], (int)$item['quantity']);
+			if((int)$item['id'] > 0)
+				Pack::addItem($this->id, (int)$item['id'], (int)$item['quantity']);
 		return true;
 	}
 }


### PR DESCRIPTION
As it is before this commit, every product that is created from the schema without removing the empty pack item in the schema will become a pack containing one broken item.

Sorry, this bug was introduced by my previous pull request.
