### PR TITLE
Update Cart.php

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3030,8 +3030,10 @@ class CartCore extends ObjectModel
 	public function addTextFieldToProduct($id_product, $index, $type, $text_value)
 	{
 		$text_value = str_replace(array("\n", "\r"), '', nl2br($text_value));
-		$text_value = str_replace('\\', '\\\\', $text_value);
-		$text_value = str_replace('\'', '\\\'', $text_value);
+		if (!_PS_MAGIC_QUOTES_GPC_){
+			$text_value = str_replace('\\', '\\\\', $text_value);
+			$text_value = str_replace('\'', '\\\'', $text_value);
+		}
 		return $this->_addCustomization($id_product, 0, $index, $type, $text_value, 0);
 	}
 


### PR DESCRIPTION
If magic_quotes_gpc is enabled, there is no need to escape the characters from $ _POST as they already are.
