### PR TITLE
Fixed fieldset issue when customer is a guest

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -170,9 +170,9 @@
 					{l s='Account registered:'} <b>{dateFormat date=$customer->date_add full=true}</b><br />
 					{l s='Valid orders placed:'} <b>{$customerStats['nb_orders']}</b><br />
 					{l s='Total spent since registration:'} <b>{displayPrice price=Tools::ps_round(Tools::convertPrice($customerStats['total_orders'], $currency), 2) currency=$currency->id}</b><br />
-			</fieldset>
 				{/if}
 			{/if}
+			</fieldset>
 
 			<!-- Sources block -->
 			{if (sizeof($sources))}


### PR DESCRIPTION
When customer is a guest, the closing `fieldset` is not rendered, causing `displayAdminOrder` hooks to appear inside the customer information block instead of in their own block.
