### PR TITLE
[-] Installer : fixed bug while inserting product suppliers to new table

### DIFF
--- a/install-dev/upgrade/php/set_product_suppliers.php
+++ b/install-dev/upgrade/php/set_product_suppliers.php
@@ -46,8 +46,8 @@ function set_product_suppliers()
 				`id_currency`)
 			VALUES
 			("'.(int)$row['id_product'].'", "0", "'.(int)$row['id_supplier'].'", 
-			"'.(int)$row['supplier_reference'].'", "'.(int)$row['wholesale_price'].'", 
-				"'.(int)$ps_currency_default.'"
+			"'.$row['supplier_reference'].'", "'.(int)$row['wholesale_price'].'", 
+				"'.(int)$ps_currency_default.'")
 		');
 
 		//Try to get product attribues
@@ -68,7 +68,7 @@ function set_product_suppliers()
 				`product_supplier_price_te`, `id_currency`)
 				VALUES
 				("'.(int)$row['id_product'].'", "'.(int)$attribute['id_product_attribute'].'", 
-				"'.(int)$row['id_supplier'].'", "'.(int)$attribute['supplier_reference'].'", 
+				"'.(int)$row['id_supplier'].'", "'.$attribute['supplier_reference'].'", 
 				"'.(int)$attribute['wholesale_price'].'", "'.(int)$ps_currency_default.'")
 			');
 		}


### PR DESCRIPTION
Fix SQL query for insert product supplier reference to new tables.
'supplier_reference' can have letters, not only numbers.
