### PR TITLE
Update WebserviceRequest.php

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -513,7 +513,6 @@ class WebserviceRequestCore
 						$this->setError(501, sprintf('The specific management class is not implemented for the "%s" entity.', $this->urlSegment[0]), 124);
 					else
 					{
-						$this->setFieldsToDisplay();
 						$this->objectSpecificManagement = new $specificObjectName();
 						$this->objectSpecificManagement->setObjectOutput($this->objOutput)
 													   ->setWsObject($this);


### PR DESCRIPTION
The deleted method calls $this->resourceConfiguration, which is never initialized in specific web services, so if we use the "display" parameter, the webservice returns an error
