### PR TITLE
[*] FO: Get instance of current product

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -158,8 +158,7 @@ class ProductControllerCore extends FrontController
 							$this->category = new Category($regs[5], (int)$this->context->cookie->id_lang);
 					}
 				}
-				if ( ! isset($this->category))
-					// Set default product category
+				if (!isset($this->category))
 					$this->category = new Category($this->product->id_category_default, (int)$this->context->cookie->id_lang);
 			}
 		}
@@ -658,5 +657,10 @@ class ProductControllerCore extends FrontController
 			$row['nextQuantity'] = (isset($specific_prices[$key + 1]) ? (int)$specific_prices[$key + 1]['from_quantity'] : -1);
 		}
 		return $specific_prices;
+	}
+	
+	public function getProduct()
+	{
+		return $this->product;
 	}
 }


### PR DESCRIPTION
Hello,

It's good to have possibility to get product object in for eg. module hooks without creating new Object and without additional queries, something like this:

$product_instance = $this->context->controller->getProduct()

IMO this could be applied in whole system to reduce queries number

What do you think about this?
