### PR TITLE
[*] Project: Avoid _PS_DEBUG_SQL_ notice

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -30,14 +30,18 @@ if (_PS_MODE_DEV_)
 {
 	@ini_set('display_errors', 'on');
 	@error_reporting(E_ALL | E_STRICT);
-	define('_PS_DEBUG_SQL_', true);
+	if (!defined('_PS_DEBUG_SQL_')) { // may be defined in Db::__construct()
+		define('_PS_DEBUG_SQL_', true);
+	}
 	/* Compatibility warning */
 	define('_PS_DISPLAY_COMPATIBILITY_WARNING_', true);
 }
 else
 {
 	@ini_set('display_errors', 'off');
-	define('_PS_DEBUG_SQL_', false);
+	if (!defined('_PS_DEBUG_SQL_')) { // may be defined in Db::__construct()
+		define('_PS_DEBUG_SQL_', false);
+	}
 	/* Compatibility warning */
 	define('_PS_DISPLAY_COMPATIBILITY_WARNING_', false);
 }


### PR DESCRIPTION
`_PS_DEBUG_SQL_` may be defined in defines.inc.php and in Db::__construct()
This avoid this notice :

```
Notice: Constant _PS_DEBUG_SQL_ already defined in \config\defines.inc.php on line 33
```
