### PR TITLE
[*] CORE : Get instance of current category in category controller

### DIFF
--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -205,5 +205,13 @@ class CategoryControllerCore extends FrontController
 
 		$this->context->smarty->assign('nb_products', $this->nbProducts);
 	}
+	
+	/**
+	 * Get instance of current category
+	 */
+	public function getCategory()
+	{
+		return $this->category;
+	}
 }
 


### PR DESCRIPTION
Get instance of category in for eg. module hook using:

$category = $this->context->controller->getCategory()

instead of

new Category(1,1);

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Sponsor company | impSolutions
