### PR TITLE
Workaround for tax breakdown displayed wrong to customer. Invoices still need sorting.

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1395,17 +1395,17 @@ class CartCore extends ObjectModel
 				);
 
 				$total_ecotax = $product['ecotax'] * (int)$product['cart_quantity'];
-				$total_price = $price;
-    				if ($with_taxes)
-    				{
+			$total_price = Tools::ps_round($price * (int)$product['cart_quantity'],2);
+    if ($with_taxes)
+    {
          $product_tax_rate = (float)Tax::getProductTaxRate((int)$product['id_product'], (int)$address_id, $virtual_context);
          $product_eco_tax_rate = Tax::getProductEcotaxRate((int)$address_id);
-         $total_price = Tools::ps_round((($total_price - $total_ecotax) * (1 + $product_tax_rate / 100)),2);
+         $total_price = Tools::ps_round((($price - $total_ecotax) * (1 + $product_tax_rate / 100)),2);
          $total_price = $total_price * (int)$product['cart_quantity'];
          $total_ecotax = $total_ecotax * (1 + $product_eco_tax_rate / 100);
          $total_price = Tools::ps_round($total_price + $total_ecotax, 2);
-    				}
-			}
+    }
+			
 			else
 			{
 				if ($with_taxes)

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1395,17 +1395,16 @@ class CartCore extends ObjectModel
 				);
 
 				$total_ecotax = $product['ecotax'] * (int)$product['cart_quantity'];
-				$total_price = $price * (int)$product['cart_quantity'];
-
-				if ($with_taxes)
-				{
-					$product_tax_rate = (float)Tax::getProductTaxRate((int)$product['id_product'], (int)$address_id, $virtual_context);
-					$product_eco_tax_rate = Tax::getProductEcotaxRate((int)$address_id);
-
-					$total_price = ($total_price - $total_ecotax) * (1 + $product_tax_rate / 100);
-					$total_ecotax = $total_ecotax * (1 + $product_eco_tax_rate / 100);
-					$total_price = Tools::ps_round($total_price + $total_ecotax, 2);
-				}
+				$total_price = $price;
+    				if ($with_taxes)
+    				{
+         $product_tax_rate = (float)Tax::getProductTaxRate((int)$product['id_product'], (int)$address_id, $virtual_context);
+         $product_eco_tax_rate = Tax::getProductEcotaxRate((int)$address_id);
+         $total_price = Tools::ps_round((($total_price - $total_ecotax) * (1 + $product_tax_rate / 100)),2);
+         $total_price = $total_price * (int)$product['cart_quantity'];
+         $total_ecotax = $total_ecotax * (1 + $product_eco_tax_rate / 100);
+         $total_price = Tools::ps_round($total_price + $total_ecotax, 2);
+    				}
 			}
 			else
 			{


### PR DESCRIPTION
Rewrote tax calculation slightly to accurately calculate tax per product in the cart - not per group of products.
Tax is paid per Product, rounded (because you cannot pay a fraction of a penny / lowest currency denominator).

Because its per product, this must be worked out before the total for a group (\* quantity) is worked out. Otherwise it will definitely be wrong.

For Example:
(round(product \* (tax% + 1),2)\* quantity);
not
(round(product \* (tax% + 1) \* quantity,2);

Mrotacon on Forums.
Please see thread: http://www.prestashop.com/forums/topic/235504-tax-is-calculated-wrong-in-prestashop-it-has-to-be-not-just-me-but-everyone/page__p__1159913#entry1159913

Basically - the entire way tax is calculated in prestashop needs to be rewritten - but its very deeply seeded, across multiple classes.
