### PR TITLE
PSCFV-10220

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -384,7 +384,7 @@ class DispatcherCore
 		$context = Context::getContext();
 		
 		// Load custom routes from modules
-		$modules_routes = Hook::exec('moduleRoutes', array('id_shop' => $id_shop), null, true, false);
+		$modules_routes = Hook::exec('ModuleRoutes', array('id_shop' => $id_shop), null, true, false);
 		if (is_array($modules_routes) && count($modules_routes))
 			foreach($modules_routes as $module_route)
 				foreach($module_route as $route => $route_details)


### PR DESCRIPTION
PSCFV-10220
http://forge.prestashop.com/browse/PSCFV-10220

With the change to Hook::getIdByName
The Dispatcher::loadRoutes don't match with :
$modules_routes = Hook::exec('moduleRoutes', array('id_shop' => $id_shop), null, true, false);

Replace in ./classes/Dispatcher.php line 387 :

$modules_routes = Hook::exec('moduleRoutes', array('id_shop' => $id_shop), null, true, false);

to

$modules_routes = Hook::exec('ModuleRoutes', array('id_shop' => $id_shop), null, true, false);

so 'm' to 'M'
