### PR TITLE
Suppress Error at rename

### DIFF
--- a/classes/Autoload.php
+++ b/classes/Autoload.php
@@ -139,7 +139,7 @@ class Autoload
 			$filename_tmp = tempnam(dirname($filename), basename($filename.'.'));
 			if($filename_tmp !== FALSE and file_put_contents($filename_tmp, $content, LOCK_EX) !== FALSE)
             {
-				rename($filename_tmp, $filename);
+				@rename($filename_tmp, $filename);
                 @chmod($filename, 0664);
 			}
             else


### PR DESCRIPTION
If debugging is on (_PS_MODE_DEV_ set to TRUE)
there is a warning on line 142 in /classes/Autoload.php at function rename()
