### PR TITLE
[+] FO : add getManufacturer() to ManufacturerControllerCore

### DIFF
--- a/controllers/front/ManufacturerController.php
+++ b/controllers/front/ManufacturerController.php
@@ -134,4 +134,12 @@ class ManufacturerControllerCore extends FrontController
 		else
 			$this->context->smarty->assign('nbManufacturers', 0);
 	}
+	
+	/**
+	 * Get instance of current manufacturer
+	 */
+	public function getManufacturer()
+	{
+		return $this->manufacturer;
+	}
 }


### PR DESCRIPTION
Add getManufacturer() to ManufacturerControllerCore to access the protected manufacturer instance of the controller.
