### PR TITLE
[*] Project : Orders should rely only on ps_order_cart_rule

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -712,11 +712,10 @@ class OrderCore extends ObjectModel
 	}
 
 	public function getCartRules()
-	{
+	{	
 		return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 		SELECT *
 		FROM `'._DB_PREFIX_.'order_cart_rule` ocr
-		LEFT JOIN `'._DB_PREFIX_.'cart_rule` cr ON cr.`id_cart_rule` = ocr.`id_cart_rule`
 		WHERE ocr.`id_order` = '.(int)$this->id);
 	}
 

--- a/classes/order/OrderCartRule.php
+++ b/classes/order/OrderCartRule.php
@@ -46,6 +46,9 @@ class OrderCartRuleCore extends ObjectModel
 
 	/** @var float value (tax excl.) of voucher */
 	public $value_tax_excl;
+	
+	/** @var boolean value : voucher gives free shipping or not */
+	public $free_shipping;
 
 	/**
 	 * @see ObjectModel::$definition
@@ -59,7 +62,8 @@ class OrderCartRuleCore extends ObjectModel
 			'id_order_invoice' =>	array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId'),
 			'name' => 				array('type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'required' => true),
 			'value' => 				array('type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'required' => true),
-			'value_tax_excl' => 	array('type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'required' => true)
+			'value_tax_excl' => 	array('type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'required' => true),
+			'free_shipping' => 		array('type' => self::TYPE_BOOL, 'validate' => 'isBool')
 		)
 	);
 

--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -129,19 +129,6 @@ class OrderSlipCore extends ObjectModel
 			{
 				$products[$key] = $product;
 				$products[$key]['product_quantity'] = $slip_quantity[$product['id_order_detail']];
-				if (count($cart_rules))
-				{
-					$order->setProductPrices($product);
-					$realProductPrice = $products[$key]['product_price'];
-					// Todo : must be updated to use the cart rules
-					foreach ($cart_rules as $cart_rule)
-					{
-						if ($cart_rule['reduction_percent'])
-							$products[$key]['product_price'] -= $realProductPrice * ($cart_rule['reduction_percent'] / 100);
-						elseif ($cart_rule['reduction_amount'])
-							$products[$key]['product_price'] -= (($cart_rule['reduction_amount'] * ($product['product_price_wt'] / $order->total_products_wt)) / (1.00 + ($product['tax_rate'] / 100)));
-					}
-				}
 			}
 		return $order->getProducts($products);
 	}


### PR DESCRIPTION
The goal of this PR is to ensure that we only rely on ps_order_cart_rule to generate Invoices, OrderSlip and every Order related PDF documents.
**Thoses changes have absolutely no impact on the PDFs generated. This is just some code cleanup and minor refactoring.**

We carefully looked out for any code part where the LEFT JOIN on ps_cart_rule would be needed, and the only place where that was the case is OrderSlip. OrderSlip used data from ps_cart_rule (reduction_percent and reduction_amount) to build a $products array with a 'product_price' index. However, this particular index is never used in the OderSlip so we're better off without it.

Last, but not least, ps_order_cart_rule has a free_shipping column, but it was never correctly filled because the free_shipping attribute wasn't declared in OrderCartRule.php. This is fixed as well.

Regards,
