### PR TITLE
Warning in AdminController.php

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1544,10 +1544,13 @@ class AdminControllerCore extends Controller
 			file_put_contents(_PS_ROOT_DIR_.Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, Tools::addonsRequest('native'));
 		
 		$country_module_list_xml = simplexml_load_file(_PS_ROOT_DIR_.Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST);
+		if($country_module_list_xml === TRUE)
+		{
 			$country_module_list = array();
 			foreach ($country_module_list_xml->module as $k => $m)
 				$country_module_list[] = (string)$m->name;
-		$this->tab_modules_list['slider_list'] = array_intersect($this->tab_modules_list['slider_list'], $country_module_list);
+			$this->tab_modules_list['slider_list'] = array_intersect($this->tab_modules_list['slider_list'], $country_module_list);
+		}
 		
 		if (is_array($this->tab_modules_list['slider_list']) && count($this->tab_modules_list['slider_list']))
 			$this->toolbar_btn['modules-list'] = array(


### PR DESCRIPTION
If debugging is on (_PS_MODE_DEV_ set to TRUE)

On a fresh install there is a warning on admin home page (/admin/index.php?controller=AdminHome) 
on line 1542 in /classes/controller/AdminController.php at function addToolBarModulesListButton().

Because of the warning xml files are not populated with data.

Warning: simplexml_load_file()
1: parser error : Document is empty
