### PR TITLE
[-] Project : Fix #PSCFV-9181

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -344,7 +344,7 @@ class OrderCore extends ObjectModel
 	{
 		$product_price_tax_excl = $orderDetail->unit_price_tax_excl * $quantity;
 		$product_price_tax_incl = $orderDetail->unit_price_tax_incl * $quantity;
-		
+
 		/* Update cart */
 		$cart = new Cart($this->id_cart);
 		$cart->updateQty($quantity, $orderDetail->product_id, $orderDetail->product_attribute_id, false, 'down'); // customization are deleted in deleteCustomization
@@ -374,7 +374,7 @@ class OrderCore extends ObjectModel
 			'total_paid_tax_excl',
 			'total_paid_real'
 		);
-		
+
 		/* Prevent from floating precision issues (total_products has only 2 decimals) */
 		foreach ($fields as $field)
 			if ($this->{$field} < 0)
@@ -440,7 +440,7 @@ class OrderCore extends ObjectModel
 	{
 		if (!$id_order_state)
 			$id_order_state = 0;
-		
+
 		$logable = false;
 		$delivery = false;
 		$paid = false;
@@ -572,9 +572,9 @@ class OrderCore extends ObjectModel
 				// Get the display filename
 				$row['display_filename'] = ProductDownload::getFilenameFromFilename($row['filename']);
 			}
-			
+
 			$row['id_address_delivery'] = $this->id_address_delivery;
-			
+
 			/* Stock product */
 			$resultArray[(int)$row['id_order_detail']] = $row;
 		}
@@ -720,6 +720,29 @@ class OrderCore extends ObjectModel
 		WHERE ocr.`id_order` = '.(int)$this->id);
 	}
 
+	/**
+	* Determine wether or not this order gets free shipping
+	*
+	* @return bool
+	*/
+	public function hasFreeShipping()
+	{
+		$cart_rules = $this->getCartRules();
+		if (count($cart_rules) === 0) {
+			$cart = new Cart($this->id_cart);
+			if (Validate::isLoadedObject($cart)) {
+				$cart_rules = $cart->getCartRules();
+			}
+		}
+
+		foreach($cart_rules as $cart_rule) {
+			if ($cart_rule['free_shipping'] === '1') {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public static function getDiscountsCustomer($id_customer, $id_cart_rule)
 	{
 		return Db::getInstance()->getValue('
@@ -757,7 +780,7 @@ class OrderCore extends ObjectModel
 	{
 		return count($this->getHistory((int)($this->id_lang), false, false, OrderState::FLAG_DELIVERY));
 	}
-	
+
 	/**
 	 * Has products returned by the merchant or by the customer?
 	 */
@@ -964,10 +987,10 @@ class OrderCore extends ObjectModel
 		}
 		return $return;
 	}
-	
+
 	/**
 	 * Get order customer
-	 * 
+	 *
 	 * @return Customer $customer
 	 */
 	public function getCustomer()
@@ -975,7 +998,7 @@ class OrderCore extends ObjectModel
 		static $customer = null;
 		if (is_null($customer))
 			$customer = new Customer((int)$this->id_customer);
-		
+
 		return $customer;
 	}
 
@@ -1130,7 +1153,7 @@ class OrderCore extends ObjectModel
 				FROM `'._DB_PREFIX_.'order_carrier`
 				WHERE `id_order` = '.(int)$order_invoice->id_order.'
 				AND (`id_order_invoice` IS NULL OR `id_order_invoice` = 0)');
-			
+
 			if ($id_order_carrier)
 			{
 				$order_carrier = new OrderCarrier($id_order_carrier);
@@ -1148,10 +1171,10 @@ class OrderCore extends ObjectModel
 			if ($use_existing_payment)
 			{
 				$id_order_payments = Db::getInstance()->executeS('
-					SELECT DISTINCT op.id_order_payment 
+					SELECT DISTINCT op.id_order_payment
 					FROM `'._DB_PREFIX_.'order_payment` op
 					INNER JOIN `'._DB_PREFIX_.'orders` o ON (o.reference = op.order_reference)
-					LEFT JOIN `'._DB_PREFIX_.'order_invoice_payment` oip ON (oip.id_order_payment = op.id_order_payment)					
+					LEFT JOIN `'._DB_PREFIX_.'order_invoice_payment` oip ON (oip.id_order_payment = op.id_order_payment)
 					WHERE (oip.id_order != '.(int)$order_invoice->id_order.' OR oip.id_order IS NULL) AND o.id_order = '.(int)$order_invoice->id_order);
 
 				if (count($id_order_payments))
@@ -1197,7 +1220,7 @@ class OrderCore extends ObjectModel
 				Configuration::updateValue('PS_DELIVERY_NUMBER', 1, false, null, $this->id_shop);
 				$number = 1;
 			}
-				
+
 			// Set delivery number on invoice
 			$order_invoice->delivery_number = $number;
 			$order_invoice->delivery_date = date('Y-m-d H:i:s');
@@ -1228,9 +1251,9 @@ class OrderCore extends ObjectModel
 
 	/**
 	 * Get a collection of orders using reference
-	 * 
+	 *
 	 * @since 1.5.0.14
-	 * 
+	 *
 	 * @param string $reference
 	 * @return Collection of Order
 	 */
@@ -1323,7 +1346,7 @@ class OrderCore extends ObjectModel
 		$this->delivery_number = $res['delivery_number'];
 		$this->update();
 
-		$history->addWithemail();		
+		$history->addWithemail();
 	}
 
 	public function addWs($autodate = true, $nullValues = false)
@@ -1462,10 +1485,10 @@ class OrderCore extends ObjectModel
 
 		// We put autodate parameter of add method to true if date_add field is null
 		$res = $order_payment->add(is_null($order_payment->date_add)) && $this->update();
-		
+
 		if (!$res)
 			return false;
-	
+
 		if (!is_null($order_invoice))
 		{
 			$res = Db::getInstance()->execute('
@@ -1475,7 +1498,7 @@ class OrderCore extends ObjectModel
 			// Clear cache
 			Cache::clean('order_invoice_paid_*');
 		}
-		
+
 		return $res;
 	}
 
@@ -1829,10 +1852,10 @@ class OrderCore extends ObjectModel
 		$sql_filter .= Shop::addSqlRestriction(Shop::SHARE_ORDER, 'main');
 		return parent::getWebserviceObjectList($sql_join, $sql_filter, $sql_sort, $sql_limit);
 	}
-	
+
 	/**
 	 * Get all other orders with the same reference
-	 * 
+	 *
 	 * @since 1.5.0.13
 	 */
 	public function getBrother()
@@ -1842,10 +1865,10 @@ class OrderCore extends ObjectModel
 		$collection->where('id_order', '<>', $this->id);
 		return $collection;
 	}
-	
+
 	/**
 	 * Get a collection of order payments
-	 * 
+	 *
 	 * @since 1.5.0.13
 	 */
 	public function getOrderPayments()
@@ -1855,10 +1878,10 @@ class OrderCore extends ObjectModel
 
 	/**
 	 * Return a unique reference like : GWJTHMZUN#2
-	 * 
+	 *
 	 * With multishipping, order reference are the same for all orders made with the same cart
 	 * in this case this method suffix the order reference by a # and the order number
-	 * 
+	 *
 	 * @since 1.5.0.14
 	 */
 	public function getUniqReference()
@@ -1867,21 +1890,21 @@ class OrderCore extends ObjectModel
 		$query->select('MIN(id_order) as min, MAX(id_order) as max');
 		$query->from('orders');
 		$query->where('id_cart = '.(int)$this->id_cart);
-		
+
 		$order = Db::getInstance()->getRow($query);
-		
+
 		if ($order['min'] == $order['max'])
 			return $this->reference;
 		else
 			return $this->reference.'#'.($this->id + 1 - $order['min']);
 	}
-	
+
 	/**
 	 * Return a unique reference like : GWJTHMZUN#2
-	 * 
+	 *
 	 * With multishipping, order reference are the same for all orders made with the same cart
 	 * in this case this method suffix the order reference by a # and the order number
-	 * 
+	 *
 	 * @since 1.5.0.14
 	 */
 	public static function getUniqReferenceOf($id_order)
@@ -1889,21 +1912,21 @@ class OrderCore extends ObjectModel
 		$order = new Order($id_order);
 		return $order->getUniqReference();
 	}
-	
+
 	/**
 	 * Return a unique reference like : GWJTHMZUN#2
-	 * 
+	 *
 	 * With multishipping, order reference are the same for all orders made with the same cart
 	 * in this case this method suffix the order reference by a # and the order number
-	 * 
+	 *
 	 * @since 1.5.5.0
-	 */	
-	public function getIdOrderCarrier()	
+	 */
+	public function getIdOrderCarrier()
 	{
 		return (int)Db::getInstance()->getValue('
 				SELECT `id_order_carrier`
 				FROM `'._DB_PREFIX_.'order_carrier`
 				WHERE `id_order` = '.(int)$this->id);
-	}		
+	}
 }
 

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -29,7 +29,7 @@ class OrderInvoiceCore extends ObjectModel
 	const TAX_EXCL = 0;
 	const TAX_INCL = 1;
 	const DETAIL = 2;
-	
+
 	/** @var integer */
 	public $id_order;
 
@@ -161,9 +161,9 @@ class OrderInvoiceCore extends ObjectModel
 				// Get the display filename
 				$row['display_filename'] = ProductDownload::getFilenameFromFilename($row['filename']);
 			}
-			
+
 			$row['id_address_delivery'] = $order->id_address_delivery;
-			
+
 			/* Stock product */
 			$resultArray[(int)$row['id_order_detail']] = $row;
 		}
@@ -312,8 +312,15 @@ class OrderInvoiceCore extends ObjectModel
 
 			// sum by taxes
 			$tmp_tax_infos = array();
+			// We need to calc a total_discounts without shipping discounts
+			$products_discounts_tax_excl = $this->total_discount_tax_excl;
+			$order = new Order((int)$this->id_order);
+			if (Validate::isLoadedObject($order) && $order->hasFreeShipping()) {
+				$products_discounts_tax_excl -= $this->total_shipping_tax_excl;
+			}
 			foreach ($taxes_infos as $tax_infos)
 			{
+
 				if (!isset($tmp_tax_infos[$tax_infos['rate']]))
 					$tmp_tax_infos[$tax_infos['rate']] = array(
 						'total_amount' => 0,
@@ -322,7 +329,7 @@ class OrderInvoiceCore extends ObjectModel
 					);
 
 				$ratio = $tax_infos['total_price_tax_excl'] / $this->total_products;
-				$order_reduction_amount = $this->total_discount_tax_excl * $ratio;
+				$order_reduction_amount = $products_discounts_tax_excl * $ratio;
 				$tmp_tax_infos[$tax_infos['rate']]['total_amount'] += ($tax_infos['total_amount'] - Tools::ps_round($tax_infos['ecotax'] * $tax_infos['product_quantity'] * $tax_infos['ecotax_tax_rate'] / 100, 2));
 				$tmp_tax_infos[$tax_infos['rate']]['name'] = $tax_infos['name'];
 				$tmp_tax_infos[$tax_infos['rate']]['total_price_tax_excl'] += $tax_infos['total_price_tax_excl'] - $order_reduction_amount - Tools::ps_round($tax_infos['ecotax'] * $tax_infos['product_quantity'], 2);
@@ -345,7 +352,7 @@ class OrderInvoiceCore extends ObjectModel
 		// shipping cost are added in the product taxes breakdown
 		if ($this->useOneAfterAnotherTaxComputationMethod())
 			return $taxes_breakdown;
-		
+
 		// No shipping breakdown if it's free!
 		foreach ($order->getCartRules() as $cart_rule)
 			if ($cart_rule['free_shipping'])
@@ -543,11 +550,11 @@ class OrderInvoiceCore extends ObjectModel
 	{
 		return round($this->total_paid_tax_incl + $this->getSiblingTotal() - $this->getTotalPaid(), 2);
 	}
-	
+
 
 	/**
 	 * Return collection of order invoice object linked to the payments of the current order invoice object
-	 * 
+	 *
 	 * @since 1.5.0.14
 	 */
 	public function getSibling()
@@ -558,27 +565,27 @@ class OrderInvoiceCore extends ObjectModel
 		$query->innerJoin('order_invoice_payment', 'oip2',
 			'oip2.id_order_payment = oip1.id_order_payment AND oip2.id_order_invoice <> oip1.id_order_invoice');
 		$query->where('oip1.id_order_invoice = '.$this->id);
-		
+
 		$invoices = Db::getInstance()->executeS($query);
 		if (!$invoices)
 			return array();
-		
+
 		$invoice_list = array();
 		foreach ($invoices as $invoice)
 			$invoice_list[] = $invoice['id_order_invoice'];
-		
+
 		$payments = new Collection('OrderInvoice');
 		$payments->where('id_order_invoice', 'IN', $invoice_list);
-		
+
 		return $payments;
 	}
-	
+
 
 	/**
 	 * Return total to paid of sibling invoices
-	 * 
+	 *
 	 * @param int $mod TAX_EXCL, TAX_INCL, DETAIL
-	 * 
+	 *
 	 * @since 1.5.0.14
 	 */
 	public function getSiblingTotal($mod = OrderInvoice::TAX_INCL)
@@ -591,9 +598,9 @@ class OrderInvoiceCore extends ObjectModel
 		$query->leftJoin('order_invoice', 'oi',
 			'oi.id_order_invoice = oip2.id_order_invoice');
 		$query->where('oip1.id_order_invoice = '.$this->id);
-		
+
 		$row = Db::getInstance()->getRow($query);
-		
+
 		switch ($mod)
 		{
 			case OrderInvoice::TAX_EXCL:
@@ -614,7 +621,7 @@ class OrderInvoiceCore extends ObjectModel
 	public function getGlobalRestPaid()
 	{
 		static $cache;
-		
+
 		if (!isset($cache[$this->id]))
 		{
 			$res = Db::getInstance()->getRow('
@@ -634,7 +641,7 @@ class OrderInvoiceCore extends ObjectModel
 			) sub');
 			$cache[$this->id] = round($res['to_paid'] - $res['paid'], 2);
 		}
-		
+
 		return $cache[$this->id];
 	}
 


### PR DESCRIPTION
# Reminder

The issue was a wrong tax break-down on orders using cart rules with free shipping (see http://forge.prestashop.com/browse/PSCFV-9181)
# Analysis

Basically, the total_discounts_tax_excl was substracted from the total_products, without taking into account that part of the discount was not applying to products at all, but to the shipping fee. For example, worst case scenario : a cart rule with two actions :
- -10€ tax incl on the whole order
- Free shipping

Let's assume our shipping fee was 2,39€ tax incl.
The tax breakdown was substracting 12.39€ tax incl (french tax excl : 10.35€) to the total_products instead of 12.39 - 2.39 (free shipping discount) = 10€ tax incl (french tax excl : 8.36€).
This made the entire breakdown go wrong.

The issue was actually happening at two different steps : 
- The wrong total products tax excl in the breakdown was calculated in OrderInvoice, when generating the invoice
- The wrong tax detail was calculated and stored in ps_order_detail_tax at the Order valdiation step for later use
# Solution

In order to fix the two failure points, we had to determine if the order had free shipping, and if it was the case, substract total_shipping_tax_excl from total_discounts_tax_excl. To ease the process, we added a new method on Order : hasFreeShipping. It relies on Order::getCartRules but has a fallback on Cart::getCartRules (at the time it's called in OrderDetail, ps_order_cart_rule is not populated yet, so Order::getCartRules() returns an empty array).

Regards,

PS : My editor automagically removed a lot of extra white spaces, sorry about that ! It may be cleaner this way though :)
