### PR TITLE
[+] BO :Display admin tabs translations in override admin tabs

### DIFF
--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -66,7 +66,14 @@ function smartyTranslate($params, &$smarty)
 		{
 	// Split by \ and / to get the folder tree for the file
 		$folder_tree = preg_split('#[/\\\]#', $filename);
-		$key = array_search('controllers', $folder_tree);
+				
+		// If we use a TPL override, we must go farther in the folder tree
+		if (strpos($filename,'override')) {
+			$key = 3 + array_search('controllers', $folder_tree);
+		} else {
+			$key = array_search('controllers', $folder_tree);
+		}
+
 
 		// If there was a match, construct the class name using the child folder name
 		// Eg. xxx/controllers/customers/xxx => AdminCustomers

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -67,6 +67,13 @@ function smartyTranslate($params, &$smarty)
 	// Split by \ and / to get the folder tree for the file
 		$folder_tree = preg_split('#[/\\\]#', $filename);
 		$key = array_search('controllers', $folder_tree);
+		
+		// If we use a TPL override, we must go farther in the folder tree
+		if (strpos($filename,'override')) {
+			$key = 3 + array_search('controllers', $folder_tree);
+		} else {
+			$key = array_search('controllers', $folder_tree);
+		}
 
 		// If there was a match, construct the class name using the child folder name
 		// Eg. xxx/controllers/customers/xxx => AdminCustomers

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -67,13 +67,6 @@ function smartyTranslate($params, &$smarty)
 	// Split by \ and / to get the folder tree for the file
 		$folder_tree = preg_split('#[/\\\]#', $filename);
 		$key = array_search('controllers', $folder_tree);
-		
-		// If we use a TPL override, we must go farther in the folder tree
-		if (strpos($filename,'override')) {
-			$key = 3 + array_search('controllers', $folder_tree);
-		} else {
-			$key = array_search('controllers', $folder_tree);
-		}
 
 		// If there was a match, construct the class name using the child folder name
 		// Eg. xxx/controllers/customers/xxx => AdminCustomers

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -67,11 +67,9 @@ function smartyTranslate($params, &$smarty)
 	// Split by \ and / to get the folder tree for the file
 		$folder_tree = preg_split('#[/\\\]#', $filename);
 				
-		// If we use a TPL override, we must go farther in the folder tree
-		if (strpos($filename,'override')) {
-			$key = 3 + array_search('controllers', $folder_tree);
-		} else {
-			$key = array_search('controllers', $folder_tree);
+		$key = array_search('controllers', $folder_tree);
+		if (strpos($filename,'override')&&($key!==false)) {
+			$key += 3;
 		}
 
 


### PR DESCRIPTION
The present patch permits to use the native admin tabs translations in
the overrided tabs (actually, we need to retranslate the overrided tabs)
