### PR TITLE
Update admin.js

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -751,6 +751,7 @@ function doAdminAjax(data, success_func, error_func)
 	{
 		url : 'index.php',
 		data : data,
+		type : 'POST',
 		success : function(data){
 			if (success_func)
 				return success_func(data);


### PR DESCRIPTION
## Lorsqu'un produit possède trop d'images, il est impossible de réordonner celle-ci car la valeur JSON fourni en URL (GET) est beaucoup trop longue. Il faut envoyer les données JSON en POST pour solutionner le problème de longueur.

When a product has many pictures, we can't reorder them. The JSON value is too long in URL (GET). We need to send data with POST to avoid problem.
