### PR TITLE
#PSCFV-10461

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2469,7 +2469,7 @@ class ProductCore extends ObjectModel
 		if (!Validate::isBool($usetax) || !Validate::isUnsignedId($id_product))
 			die(Tools::displayError());
 		// Initializations
-		$id_group = (isset($context->customer) ? $context->customer->id_default_group : (int)Configuration::get('PS_CUSTOMER_GROUP'));
+		$id_group = (isset($context->customer) && (int)$context->customer->id > 0 ? $context->customer->id_default_group : 1);
 
 		// If there is cart in context or if the specified id_cart is different from the context cart id
 		if (!is_object($cur_cart) || (Validate::isUnsignedInt($id_cart) && $id_cart && $cur_cart->id != $id_cart))


### PR DESCRIPTION
We always have access to $context->customer, there is always isset with return true and it's not good to have Customer Group ID by default even with not logged in user...

Related bug:
http://forge.prestashop.com/browse/PSCFV-10461
