### PR TITLE
BO: Modules - show update button even if module is not installed but don...

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/list.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/list.tpl
@@ -101,7 +101,7 @@
 								<a href="{$module->addons_buy_url}" target="_blank" class="button updated"><span><img src="../img/admin/cart_addons.png">&nbsp;&nbsp;{if isset($module->id_currency) && isset($module->price)}{displayPrice price=$module->price currency=$module->id_currency}{/if}</span></a>
 							</li>
 						{else}
-							{if $module->id && isset($module->version_addons) && $module->version_addons}
+							{if isset($module->version_addons) && $module->version_addons}
 								<li><a href="{$module->options.update_url}" class="button updated"><span>{l s='Update it!'}</span></a></li>
 							{/if}
 								<li>

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1108,8 +1108,8 @@ class AdminModulesControllerCore extends AdminController
 					$modules[$km]->preferences = $modules_preferences[$modules[$km]->name];
 			}
 			unset($object);
-			if (isset($module->version_addons))
-				$upgrade_available[] = array('anchor' => ucfirst($module->name), 'name' => $module->displayName);;
+			if ($module->installed && isset($module->version_addons) && $module->version_addons)
+				$upgrade_available[] = array('anchor' => ucfirst($module->name), 'name' => $module->displayName);
 		}
 
 		// Don't display categories without modules


### PR DESCRIPTION
BO: Modules - show update button even if module is not installed but don't warn for modules with updates available but not installed.

From the idea brought by @PrestaEdit, in pull request #724, here's my proposal to allow modules that are not installed (but present on disk) to be automatically updated before being installed.

I too (like @PrestaEdit) believe it doesn't make sense to warn users for an available update for a module they're not using.
