### PR TITLE
Fix pagination incompatibility

### DIFF
--- a/modules/blocklayered/blocklayered.js
+++ b/modules/blocklayered/blocklayered.js
@@ -230,11 +230,11 @@ function initLayered()
 
 function paginationButton() {
 	$('#pagination a').not(':hidden').each(function () {
-		if ($(this).attr('href').search('&p=') == -1) {
+		if ($(this).attr('href').search(/&|\?p=/) == -1) {
 			var page = 1;
 		}
 		else {
-			var page = $(this).attr('href').replace(/^.*&p=(\d+).*$/, '$1');
+			var page = $(this).attr('href').replace(/^.*[&|\?]p=(\d+).*$/, '$1');
 		}
 		var location = window.location.href.replace(/#.*$/, '');
 		$(this).attr('href', location+current_friendly_url.replace(/\/page-(\d+)/, '')+'/page-'+page);


### PR DESCRIPTION
Javascript function paginateButton does not work with "p" GET parameter in first position, regex only takes &p and not ?p.
