### PR TITLE
[-] FO : Fixed products without images

### DIFF
--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -372,6 +372,7 @@ class ParentOrderControllerCore extends FrontController
 			'currencyFormat' => $this->context->currency->format,
 			'currencyBlank' => $this->context->currency->blank,
 			'show_option_allow_separate_package' => $show_option_allow_separate_package,
+			'smallSize' => Image::getSize(ImageType::getFormatedName('small')),
 				
 		));
 


### PR DESCRIPTION
On cart page products without images have no set size for the default image which is too large. See 
https://github.com/PrestaShop/PrestaShop/blob/development/themes/default/shopping-cart-product-line.tpl#L28.
