### PR TITLE
[-] BO : Fix #PSCFV-10520

### DIFF
--- a/classes/Attribute.php
+++ b/classes/Attribute.php
@@ -139,7 +139,7 @@ class AttributeCore extends ObjectModel
 				ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = '.(int)$id_lang.')
 			'.Shop::addSqlAssociation('attribute_group', 'ag').'
 			'.Shop::addSqlAssociation('attribute', 'a').'
-			'.($not_null ? 'WHERE a.`id_attribute` IS NOT NULL AND al.`name` IS NOT NULL' : '').'
+			'.($not_null ? 'WHERE a.`id_attribute` IS NOT NULL AND al.`name` IS NOT NULL AND agl.`id_attribute_group` IS NOT NULL' : '').'
 			ORDER BY agl.`name` ASC, a.`position` ASC
 		');
 	}


### PR DESCRIPTION
`$attribute['id_attribute_group']` [here](https://github.com/PrestaShop/PrestaShop/blob/c2b9ff40ef4fe9d8d7da7e3cb3d9ccf19f2eb594/controllers/admin/AdminProductsController.php#L3648) was NULL in some cases which caused invalid JavaScript.
