### PR TITLE
[-] BO : FixBug #PSCFV-10325 - No field to translate in translations>front office

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1069,7 +1069,7 @@ class AdminTranslationsControllerCore extends AdminController
 		{
 			case 'front':
 					// Parsing file in Front office
-					$regex = '/\{l\s*s=(?|\'('._PS_TRANS_PATTERN_.')\'|"('._PS_TRANS_PATTERN_.')")(\s*sprintf=.*)?(\s*js=1)?\s*\}/U';
+					$regex = '/\{l\s*s=[\'\"]'._PS_TRANS_PATTERN_.'[\'\"](\s*sprintf=.*)?(\s*js=1)?\}/U';
 				break;
 
 			case 'back':
@@ -1079,7 +1079,7 @@ class AdminTranslationsControllerCore extends AdminController
 					else if ($type_file == 'specific')
 						$regex = '/Translate::getAdminTranslation\(\''._PS_TRANS_PATTERN_.'\'\)/U';
 					else
-						$regex = '/\{l\s*s\s*=(?|\''._PS_TRANS_PATTERN_.'\'|"'._PS_TRANS_PATTERN_.'")(\s*sprintf=.*)?(\s*js=1)?(\s*slashes=1)?\s*\}/U';
+						$regex = '/\{l\s*s\s*=[\'\"]'._PS_TRANS_PATTERN_.'[\'\"](\s*sprintf=.*)?(\s*js=1)?(\s*slashes=1)?\s*\}/U';
 				break;
 
 			case 'errors':
@@ -1093,7 +1093,7 @@ class AdminTranslationsControllerCore extends AdminController
 						$regex = '/->l\(\''._PS_TRANS_PATTERN_.'\'(, ?\'(.+)\')?(, ?(.+))?\)/U';
 					else
 						// In tpl file look for something that should contain mod='module_name' according to the documentation
-						$regex = '/\{l\s*s=(?|\''._PS_TRANS_PATTERN_.'\'|"'._PS_TRANS_PATTERN_.'").*\s+mod=\''.$module_name.'\'.*\}/U';
+						$regex = '/\{l\s*s=[\'\"]'.PS_TRANS_PATTERN_.'[\'\"].*\s+mod=\''.$module_name.'\'.*\}/U';
 				break;
 
 			case 'pdf':
@@ -1101,7 +1101,7 @@ class AdminTranslationsControllerCore extends AdminController
 					if ($type_file == 'php')
 						$regex = '/HTMLTemplate.*::l\(\''._PS_TRANS_PATTERN_.'\'[\)|\,]/U';
 					else
-						$regex = '/\{l\s*s=(?|\''._PS_TRANS_PATTERN_.'\'|"'._PS_TRANS_PATTERN_.'")(\s*sprintf=.*)?(\s*js=1)?(\s*pdf=\'true\')?\s*\}/U';
+						$regex = '/\{l\s*s=[\'\"]'._PS_TRANS_PATTERN_.'[\'\"](\s*sprintf=.*)?(\s*js=1)?(\s*pdf=\'true\')?\s*\}/U';
 				break;
 		}
 


### PR DESCRIPTION
Replace "?|" syntax for preg_match_all because on some server (PHPv5.3.3) this syntax is unknow and we got this error :

[error] PHP Warning:  preg_match_all() [<a href='function.preg-match-all'>function.preg-match-all</a>]: Compilation failed: unrecognized character after (? at offset 10 in /htdocs/controllers/admin/AdminTranslationsController.php on line 1104
