### PR TITLE
[*] BO : Allow complex GROUP BY in SQL Manager

### DIFF
--- a/classes/RequestSql.php
+++ b/classes/RequestSql.php
@@ -245,9 +245,10 @@ class RequestSqlCore extends ObjectModel
 	 */
 	public function cutAttribute($attr, $from)
 	{
-		if (preg_match('#^((`(\()?([a-z0-9_])+`(\))?)|((\()?([a-z0-9_])+(\))?))\.((`(\()?([a-z0-9_])+`(\))?)|((\()?([a-z0-9_])+(\))?))$#i', $attr))
+		$matches = array();
+		if (preg_match('/((`(\()?([a-z0-9_])+`(\))?)|((\()?([a-z0-9_])+(\))?))\.((`(\()?([a-z0-9_])+`(\))?)|((\()?([a-z0-9_])+(\))?))$/i', $attr, $matches, PREG_OFFSET_CAPTURE))
 		{
-			$tab = explode('.', str_replace(array('`', '(', ')'), '', $attr));
+			$tab = explode('.', str_replace(array('`', '(', ')'), '', $matches[0][0]));
 			if (!$table = $this->returnNameTable($tab[0], $from))
 				return false;
 			else
@@ -256,9 +257,9 @@ class RequestSqlCore extends ObjectModel
 							'attribut' => $tab[1],
 							'string' => $attr);
 		}
-		elseif (preg_match('#^((`(\()?([a-z0-9_])+`(\))?)|((\()?([a-z0-9_])+(\))?))$#i', $attr))
+		elseif (preg_match('/((`(\()?([a-z0-9_])+`(\))?)|((\()?([a-z0-9_])+(\))?))$/i', $attr, $matches, PREG_OFFSET_CAPTURE))
 		{
-			$attribut = str_replace(array('`', '(', ')'), '', $attr);
+			$attribut = str_replace(array('`', '(', ')'), '', $matches[0][0]);
 			if (!$table = $this->returnNameTable(false, $from))
 				return false;
 			else


### PR DESCRIPTION
Improved slightly the RequestSql class to allow GROUP BY to use some functions.

For example, this would not work on the current version : 

``` sql
SELECT 
    DATE_FORMAT(`date_add`, '%m/%Y') as Mois, 
    SUM(shipping_cost_tax_excl) as `Frais de port HT`, 
    SUM(shipping_cost_tax_incl) as `Frais de port TTC` 
FROM ps_order_carrier 
GROUP BY MONTH(ps_order_carrier.date_add)
```

The GROUP BY MONTH(date_add) being the issue. This PR fixes it.
