### PR TITLE
[-] CORE : Classes Cart and Employee shouldn't pass id_lang to parent constructor

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -152,7 +152,11 @@ class CartCore extends ObjectModel
 
 	public function __construct($id = null, $id_lang = null)
 	{
-		parent::__construct($id, $id_lang);
+		parent::__construct($id);
+
+		if ($id_lang !== null)
+			$this->id_lang = (Language::getLanguage($id_lang) !== false) ? $id_lang : Configuration::get('PS_LANG_DEFAULT');
+		
 		if ($this->id_customer)
 		{
 			if (isset(Context::getContext()->customer) && Context::getContext()->customer->id == $this->id_customer)

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -110,8 +110,11 @@ class EmployeeCore extends ObjectModel
 
 	public function __construct($id = null, $id_lang = null, $id_shop = null)
 	{
-		parent::__construct($id, $id_lang, $id_shop);
-
+		parent::__construct($id, null, $id_shop);
+		
+		if ($id_lang !== null)
+			$this->id_lang = (Language::getLanguage($id_lang) !== false) ? $id_lang : Configuration::get('PS_LANG_DEFAULT');
+		
 		if ($this->id)
 			$this->associated_shops = $this->getAssociatedShops();
 	}


### PR DESCRIPTION
Classes Cart and Employee shouldn't pass id_lang to parent constructor because there is no associated *_lang table.
