### PR TITLE
Fix variable name appearing in error message

### DIFF
--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -393,7 +393,7 @@ class AdminModulesControllerCore extends AdminController
 		foreach($zip_folders as $folder)
 			if (!in_array($folder, array('.', '..', '.svn', '.git', '__MACOSX')) && !Module::getInstanceByName($folder))
 			{
-				$this->errors[] = Tools::displayError('The \'.$folder.\' you uploaded is not a module');
+				$this->errors[] = Tools::displayError('The folder \''.$folder.'\' you uploaded is not a module.');
 				$this->recursiveDeleteOnDisk(_PS_MODULE_DIR_.$folder);
 			}
 			


### PR DESCRIPTION
Was having trouble installing the paypal module. This error kept appearing:

The '.$folder.' you uploaded is not a module

This was because of incorrect quotes where that error is reported. This small patch fixes the error.
