### PR TITLE
restricted-country.css removed because it's empty

### DIFF
--- a/themes/default/restricted-country.tpl
+++ b/themes/default/restricted-country.tpl
@@ -36,7 +36,6 @@
 {/if}
 		<meta name="robots" content="{if isset($nobots)}no{/if}index,follow" />
 		<link rel="shortcut icon" href="{$favicon_url}" />
-		<link href="{$css_dir}restricted-country.css" rel="stylesheet" type="text/css" />
 	</head>
 	<body>
 		<div id="restricted-country">


### PR DESCRIPTION
Well, this one can be disputable. From our experience restricted-country.css is never used and is emty, so it can be deleted, but maybe there are sites which are using that? 
