### PR TITLE
Set the $default_routes with function

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -44,100 +44,7 @@ class DispatcherCore
 	/**
 	 * @var array List of default routes
 	 */
-	public $default_routes = array(
-		'category_rule' => array(
-			'controller' =>	'category',
-			'rule' =>		'{id}-{rewrite}',
-			'keywords' => array(
-				'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_category'),
-				'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-			),
-		),
-		'supplier_rule' => array(
-			'controller' =>	'supplier',
-			'rule' =>		'{id}__{rewrite}',
-			'keywords' => array(
-				'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_supplier'),
-				'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-			),
-		),
-		'manufacturer_rule' => array(
-			'controller' =>	'manufacturer',
-			'rule' =>		'{id}_{rewrite}',
-			'keywords' => array(
-				'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_manufacturer'),
-				'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-			),
-		),
-		'cms_rule' => array(
-			'controller' =>	'cms',
-			'rule' =>		'content/{id}-{rewrite}',
-			'keywords' => array(
-				'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_cms'),
-				'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-			),
-		),
-		'cms_category_rule' => array(
-			'controller' =>	'cms',
-			'rule' =>		'content/category/{id}-{rewrite}',
-			'keywords' => array(
-				'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_cms_category'),
-				'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-			),
-		),
-		'module' => array(
-			'controller' =>	null,
-			'rule' =>		'module/{module}{/:controller}',
-			'keywords' => array(
-				'module' =>			array('regexp' => '[_a-zA-Z0-9_-]+', 'param' => 'module'),
-				'controller' =>		array('regexp' => '[_a-zA-Z0-9_-]+', 'param' => 'controller'),
-			),
-			'params' => array(
-				'fc' => 'module',
-			),
-		),
-		'product_rule' => array(
-			'controller' =>	'product',
-			'rule' =>		'{category:/}{id}-{rewrite}{-:ean13}.html',
-			'keywords' => array(
-				'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_product'),
-				'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'ean13' =>			array('regexp' => '[0-9\pL]*'),
-				'category' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'categories' =>		array('regexp' => '[/_a-zA-Z0-9-\pL]*'),
-				'reference' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'manufacturer' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'supplier' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'price' =>			array('regexp' => '[0-9\.,]*'),
-				'tags' =>			array('regexp' => '[a-zA-Z0-9-\pL]*'),
-			),
-		),
-		// Must be after the product and category rules in order to avoid conflict
-		'layered_rule' => array(
-			'controller' =>	'category',
-			'rule' =>		'{id}-{rewrite}{/:selected_filters}',
-			'keywords' => array(
-				'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_category'),
-				/* Selected filters is used by the module blocklayered */
-				'selected_filters' =>		array('regexp' => '.*', 'param' => 'selected_filters'),
-				'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-				'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
-			),
-		),
-	);
+	public $default_routes = array();
 
 	/**
 	 * @var bool If true, use routes to build URL (mod rewrite must be activated)
@@ -199,6 +106,7 @@ class DispatcherCore
 	protected function __construct()
 	{
 		$this->use_routes = (bool)Configuration::get('PS_REWRITING_SETTINGS');
+		$this->default_routes = $this->getDefault_routes();
 
 		// Select right front controller
 		if (defined('_PS_ADMIN_DIR_'))
@@ -796,5 +704,103 @@ class DispatcherCore
 		}
 
 		return $controllers;
+	}
+
+	public function getDefault_routes()
+	{
+		return array(
+			'category_rule' => array(
+				'controller' =>	'category',
+				'rule' =>		'{id}-{rewrite}',
+				'keywords' => array(
+					'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_category'),
+					'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+				),
+			),
+			'supplier_rule' => array(
+				'controller' =>	'supplier',
+				'rule' =>		'{id}__{rewrite}',
+				'keywords' => array(
+					'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_supplier'),
+					'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+				),
+			),
+			'manufacturer_rule' => array(
+				'controller' =>	'manufacturer',
+				'rule' =>		'{id}_{rewrite}',
+				'keywords' => array(
+					'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_manufacturer'),
+					'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+				),
+			),
+			'cms_rule' => array(
+				'controller' =>	'cms',
+				'rule' =>		'content/{id}-{rewrite}',
+				'keywords' => array(
+					'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_cms'),
+					'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+				),
+			),
+			'cms_category_rule' => array(
+				'controller' =>	'cms',
+				'rule' =>		'content/category/{id}-{rewrite}',
+				'keywords' => array(
+					'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_cms_category'),
+					'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+				),
+			),
+			'module' => array(
+				'controller' =>	null,
+				'rule' =>		'module/{module}{/:controller}',
+				'keywords' => array(
+					'module' =>			array('regexp' => '[_a-zA-Z0-9_-]+', 'param' => 'module'),
+					'controller' =>		array('regexp' => '[_a-zA-Z0-9_-]+', 'param' => 'controller'),
+				),
+				'params' => array(
+					'fc' => 'module',
+				),
+			),
+			'product_rule' => array(
+				'controller' =>	'product',
+				'rule' =>		'{category:/}{id}-{rewrite}{-:ean13}.html',
+				'keywords' => array(
+					'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_product'),
+					'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'ean13' =>			array('regexp' => '[0-9\pL]*'),
+					'category' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'categories' =>		array('regexp' => '[/_a-zA-Z0-9-\pL]*'),
+					'reference' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'manufacturer' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'supplier' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'price' =>			array('regexp' => '[0-9\.,]*'),
+					'tags' =>			array('regexp' => '[a-zA-Z0-9-\pL]*'),
+				),
+			),
+			// Must be after the product and category rules in order to avoid conflict
+			'layered_rule' => array(
+				'controller' =>	'category',
+				'rule' =>		'{id}-{rewrite}{/:selected_filters}',
+				'keywords' => array(
+					'id' =>				array('regexp' => '[0-9]+', 'param' => 'id_category'),
+					/* Selected filters is used by the module blocklayered */
+					'selected_filters' =>		array('regexp' => '.*', 'param' => 'selected_filters'),
+					'rewrite' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_keywords' =>	array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+					'meta_title' =>		array('regexp' => '[_a-zA-Z0-9-\pL]*'),
+				),
+			),
+		);
 	}
 }


### PR DESCRIPTION
If the $default_routes needs to be overridden & it's done outside of an
function the uninstall of the module is corrupting the override file.

To test install than uninstall this module https://github.com/Ha99y/PrestaShop-modules-CleanURLs/

the file /override/classes/Dispatcher.php will get corrupted after uninstall.

File to look at:
https://github.com/Ha99y/PrestaShop-modules-CleanURLs/blob/master/cleanurls/override/classes/Dispatcher.php
