### PR TITLE
[*] CORE: Add phone_mobile to address format

### DIFF
--- a/install-dev/data/xml/address_format.xml
+++ b/install-dev/data/xml/address_format.xml
@@ -13,7 +13,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_2" id_country="AT">
       <format>firstname lastname
@@ -23,7 +24,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_3" id_country="BE">
       <format>firstname lastname
@@ -33,7 +35,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_4" id_country="CA">
       <format>firstname lastname
@@ -42,7 +45,8 @@ address1
 address2
 city State:name postcode
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_5" id_country="CN">
       <format>firstname lastname
@@ -52,7 +56,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_6" id_country="ES">
       <format>firstname lastname
@@ -62,7 +67,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_7" id_country="FI">
       <format>firstname lastname
@@ -72,7 +78,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_8" id_country="FR">
       <format>firstname lastname
@@ -82,7 +89,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_9" id_country="GR">
       <format>firstname lastname
@@ -92,7 +100,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_10" id_country="IT">
       <format>firstname lastname
@@ -103,7 +112,8 @@ address2
 postcode city
 State:name
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_11" id_country="JP">
       <format>firstname lastname
@@ -114,7 +124,8 @@ address2
 postcode city
 State:name
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_12" id_country="LU">
       <format>firstname lastname
@@ -124,7 +135,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_13" id_country="NL">
       <format>firstname lastname
@@ -134,7 +146,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_14" id_country="PL">
       <format>firstname lastname
@@ -144,7 +157,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_15" id_country="PT">
       <format>firstname lastname
@@ -154,7 +168,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_16" id_country="CZ">
       <format>firstname lastname
@@ -164,7 +179,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_17" id_country="GB">
       <format>firstname lastname
@@ -174,7 +190,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_18" id_country="SE">
       <format>firstname lastname
@@ -184,7 +201,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_19" id_country="CH">
       <format>firstname lastname
@@ -194,7 +212,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_20" id_country="DK">
       <format>firstname lastname
@@ -204,7 +223,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_21" id_country="US">
       <format>firstname lastname
@@ -212,7 +232,8 @@ company
 address1 address2
 city, State:name postcode
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_22" id_country="HK">
       <format>firstname lastname
@@ -222,7 +243,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_23" id_country="NO">
       <format>firstname lastname
@@ -232,7 +254,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_24" id_country="AU">
       <format>firstname lastname
@@ -242,7 +265,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_25" id_country="SG">
       <format>firstname lastname
@@ -252,7 +276,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_26" id_country="IE">
       <format>firstname lastname
@@ -262,7 +287,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_27" id_country="NZ">
       <format>firstname lastname
@@ -272,7 +298,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_28" id_country="KR">
       <format>firstname lastname
@@ -282,7 +309,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_29" id_country="IL">
       <format>firstname lastname
@@ -292,7 +320,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_30" id_country="ZA">
       <format>firstname lastname
@@ -302,7 +331,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_31" id_country="NG">
       <format>firstname lastname
@@ -312,7 +342,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_32" id_country="CI">
       <format>firstname lastname
@@ -322,7 +353,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_33" id_country="TG">
       <format>firstname lastname
@@ -332,7 +364,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_34" id_country="BO">
       <format>firstname lastname
@@ -342,7 +375,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_35" id_country="MU">
       <format>firstname lastname
@@ -352,7 +386,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_36" id_country="RO">
       <format>firstname lastname
@@ -362,7 +397,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_37" id_country="SK">
       <format>firstname lastname
@@ -372,7 +408,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_38" id_country="DZ">
       <format>firstname lastname
@@ -382,7 +419,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_39" id_country="AS">
       <format>firstname lastname
@@ -392,7 +430,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_40" id_country="AD">
       <format>firstname lastname
@@ -402,7 +441,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_41" id_country="AO">
       <format>firstname lastname
@@ -412,7 +452,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_42" id_country="AI">
       <format>firstname lastname
@@ -422,7 +463,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_43" id_country="AG">
       <format>firstname lastname
@@ -432,7 +474,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_44" id_country="AR">
       <format>firstname lastname
@@ -443,7 +486,8 @@ address2
 postcode city
 State:name
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_45" id_country="AM">
       <format>firstname lastname
@@ -453,7 +497,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_46" id_country="AW">
       <format>firstname lastname
@@ -463,7 +508,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_47" id_country="AZ">
       <format>firstname lastname
@@ -473,7 +519,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_48" id_country="BS">
       <format>firstname lastname
@@ -483,7 +530,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_49" id_country="BH">
       <format>firstname lastname
@@ -493,7 +541,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_50" id_country="BD">
       <format>firstname lastname
@@ -503,7 +552,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_51" id_country="BB">
       <format>firstname lastname
@@ -513,7 +563,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_52" id_country="BY">
       <format>firstname lastname
@@ -523,7 +574,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_53" id_country="BZ">
       <format>firstname lastname
@@ -533,7 +585,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_54" id_country="BJ">
       <format>firstname lastname
@@ -543,7 +596,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_55" id_country="BM">
       <format>firstname lastname
@@ -553,7 +607,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_56" id_country="BT">
       <format>firstname lastname
@@ -563,7 +618,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_57" id_country="BW">
       <format>firstname lastname
@@ -573,7 +629,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_58" id_country="BR">
       <format>firstname lastname
@@ -583,7 +640,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_59" id_country="BN">
       <format>firstname lastname
@@ -593,7 +651,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_60" id_country="BF">
       <format>firstname lastname
@@ -603,7 +662,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_61" id_country="MM">
       <format>firstname lastname
@@ -613,7 +673,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_62" id_country="BI">
       <format>firstname lastname
@@ -623,7 +684,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_63" id_country="KH">
       <format>firstname lastname
@@ -633,7 +695,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_64" id_country="CM">
       <format>firstname lastname
@@ -643,7 +706,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_65" id_country="CV">
       <format>firstname lastname
@@ -653,7 +717,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_66" id_country="CF">
       <format>firstname lastname
@@ -663,7 +728,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_67" id_country="TD">
       <format>firstname lastname
@@ -673,7 +739,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_68" id_country="CL">
       <format>firstname lastname
@@ -683,7 +750,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_69" id_country="CO">
       <format>firstname lastname
@@ -693,7 +761,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_70" id_country="KM">
       <format>firstname lastname
@@ -703,7 +772,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_71" id_country="CD">
       <format>firstname lastname
@@ -713,7 +783,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_72" id_country="CG">
       <format>firstname lastname
@@ -723,7 +794,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_73" id_country="CR">
       <format>firstname lastname
@@ -733,7 +805,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_74" id_country="HR">
       <format>firstname lastname
@@ -743,7 +816,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_75" id_country="CU">
       <format>firstname lastname
@@ -753,7 +827,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_76" id_country="CY">
       <format>firstname lastname
@@ -763,7 +838,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_77" id_country="DJ">
       <format>firstname lastname
@@ -773,7 +849,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_78" id_country="DM">
       <format>firstname lastname
@@ -783,7 +860,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_79" id_country="DO">
       <format>firstname lastname
@@ -793,7 +871,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_80" id_country="TL">
       <format>firstname lastname
@@ -803,7 +882,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_81" id_country="EC">
       <format>firstname lastname
@@ -813,7 +893,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_82" id_country="EG">
       <format>firstname lastname
@@ -823,7 +904,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_83" id_country="SV">
       <format>firstname lastname
@@ -833,7 +915,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_84" id_country="GQ">
       <format>firstname lastname
@@ -843,7 +926,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_85" id_country="ER">
       <format>firstname lastname
@@ -853,7 +937,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_86" id_country="EE">
       <format>firstname lastname
@@ -863,7 +948,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_87" id_country="ET">
       <format>firstname lastname
@@ -873,7 +959,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_88" id_country="FK">
       <format>firstname lastname
@@ -883,7 +970,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_89" id_country="FO">
       <format>firstname lastname
@@ -893,7 +981,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_90" id_country="FJ">
       <format>firstname lastname
@@ -903,7 +992,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_91" id_country="GA">
       <format>firstname lastname
@@ -913,7 +1003,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_92" id_country="GM">
       <format>firstname lastname
@@ -923,7 +1014,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_93" id_country="GE">
       <format>firstname lastname
@@ -933,7 +1025,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_94" id_country="GH">
       <format>firstname lastname
@@ -943,7 +1036,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_95" id_country="GD">
       <format>firstname lastname
@@ -953,7 +1047,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_96" id_country="GL">
       <format>firstname lastname
@@ -963,7 +1058,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_97" id_country="GI">
       <format>firstname lastname
@@ -973,7 +1069,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_98" id_country="GP">
       <format>firstname lastname
@@ -983,7 +1080,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_99" id_country="GU">
       <format>firstname lastname
@@ -993,7 +1091,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_100" id_country="GT">
       <format>firstname lastname
@@ -1003,7 +1102,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_101" id_country="GG">
       <format>firstname lastname
@@ -1013,7 +1113,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_102" id_country="GN">
       <format>firstname lastname
@@ -1023,7 +1124,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_103" id_country="GW">
       <format>firstname lastname
@@ -1033,7 +1135,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_104" id_country="GY">
       <format>firstname lastname
@@ -1043,7 +1146,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_105" id_country="HT">
       <format>firstname lastname
@@ -1053,7 +1157,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_106" id_country="HM">
       <format>firstname lastname
@@ -1063,7 +1168,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_107" id_country="VA">
       <format>firstname lastname
@@ -1073,7 +1179,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_108" id_country="HN">
       <format>firstname lastname
@@ -1083,7 +1190,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_109" id_country="IS">
       <format>firstname lastname
@@ -1093,7 +1201,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_110" id_country="IN">
       <format>firstname lastname
@@ -1103,7 +1212,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_111" id_country="ID">
       <format>firstname lastname
@@ -1114,7 +1224,8 @@ address2
 postcode city
 State:name
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_112" id_country="IR">
       <format>firstname lastname
@@ -1124,7 +1235,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_113" id_country="IQ">
       <format>firstname lastname
@@ -1134,7 +1246,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_114" id_country="IM">
       <format>firstname lastname
@@ -1144,7 +1257,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_115" id_country="JM">
       <format>firstname lastname
@@ -1154,7 +1268,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_116" id_country="JE">
       <format>firstname lastname
@@ -1164,7 +1279,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_117" id_country="JO">
       <format>firstname lastname
@@ -1174,7 +1290,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_118" id_country="KZ">
       <format>firstname lastname
@@ -1184,7 +1301,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_119" id_country="KE">
       <format>firstname lastname
@@ -1194,7 +1312,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_120" id_country="KI">
       <format>firstname lastname
@@ -1204,7 +1323,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_121" id_country="KP">
       <format>firstname lastname
@@ -1214,7 +1334,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_122" id_country="KW">
       <format>firstname lastname
@@ -1224,7 +1345,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_123" id_country="KG">
       <format>firstname lastname
@@ -1234,7 +1356,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_124" id_country="LA">
       <format>firstname lastname
@@ -1244,7 +1367,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_125" id_country="LV">
       <format>firstname lastname
@@ -1254,7 +1378,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_126" id_country="LB">
       <format>firstname lastname
@@ -1264,7 +1389,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_127" id_country="LS">
       <format>firstname lastname
@@ -1274,7 +1400,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_128" id_country="LR">
       <format>firstname lastname
@@ -1284,7 +1411,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_129" id_country="LY">
       <format>firstname lastname
@@ -1294,7 +1422,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_130" id_country="LI">
       <format>firstname lastname
@@ -1304,7 +1433,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_131" id_country="LT">
       <format>firstname lastname
@@ -1314,7 +1444,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_132" id_country="MO">
       <format>firstname lastname
@@ -1324,7 +1455,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_133" id_country="MK">
       <format>firstname lastname
@@ -1334,7 +1466,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_134" id_country="MG">
       <format>firstname lastname
@@ -1344,7 +1477,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_135" id_country="MW">
       <format>firstname lastname
@@ -1354,7 +1488,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_136" id_country="MY">
       <format>firstname lastname
@@ -1364,7 +1499,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_137" id_country="MV">
       <format>firstname lastname
@@ -1374,7 +1510,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_138" id_country="ML">
       <format>firstname lastname
@@ -1384,7 +1521,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_139" id_country="MT">
       <format>firstname lastname
@@ -1394,7 +1532,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_140" id_country="MH">
       <format>firstname lastname
@@ -1404,7 +1543,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_141" id_country="MQ">
       <format>firstname lastname
@@ -1414,7 +1554,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_142" id_country="MR">
       <format>firstname lastname
@@ -1424,7 +1565,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_143" id_country="HU">
       <format>firstname lastname
@@ -1434,7 +1576,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_144" id_country="YT">
       <format>firstname lastname
@@ -1444,7 +1587,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_145" id_country="MX">
       <format>firstname lastname
@@ -1455,7 +1599,8 @@ address2
 postcode city
 State:name
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_146" id_country="FM">
       <format>firstname lastname
@@ -1465,7 +1610,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_147" id_country="MD">
       <format>firstname lastname
@@ -1475,7 +1621,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_148" id_country="MC">
       <format>firstname lastname
@@ -1485,7 +1632,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_149" id_country="MN">
       <format>firstname lastname
@@ -1495,7 +1643,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_150" id_country="ME">
       <format>firstname lastname
@@ -1505,7 +1654,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_151" id_country="MS">
       <format>firstname lastname
@@ -1515,7 +1665,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_152" id_country="MA">
       <format>firstname lastname
@@ -1525,7 +1676,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_153" id_country="MZ">
       <format>firstname lastname
@@ -1535,7 +1687,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_154" id_country="NA">
       <format>firstname lastname
@@ -1545,7 +1698,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_155" id_country="NR">
       <format>firstname lastname
@@ -1555,7 +1709,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_156" id_country="NP">
       <format>firstname lastname
@@ -1565,7 +1720,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_157" id_country="AN">
       <format>firstname lastname
@@ -1575,7 +1731,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_158" id_country="NC">
       <format>firstname lastname
@@ -1585,7 +1742,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_159" id_country="NI">
       <format>firstname lastname
@@ -1595,7 +1753,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_160" id_country="NE">
       <format>firstname lastname
@@ -1605,7 +1764,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_161" id_country="NU">
       <format>firstname lastname
@@ -1615,7 +1775,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_162" id_country="NF">
       <format>firstname lastname
@@ -1625,7 +1786,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_163" id_country="MP">
       <format>firstname lastname
@@ -1635,7 +1797,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_164" id_country="OM">
       <format>firstname lastname
@@ -1645,7 +1808,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_165" id_country="PK">
       <format>firstname lastname
@@ -1655,7 +1819,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_166" id_country="PW">
       <format>firstname lastname
@@ -1665,7 +1830,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_167" id_country="PS">
       <format>firstname lastname
@@ -1675,7 +1841,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_168" id_country="PA">
       <format>firstname lastname
@@ -1685,7 +1852,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_169" id_country="PG">
       <format>firstname lastname
@@ -1695,7 +1863,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_170" id_country="PY">
       <format>firstname lastname
@@ -1705,7 +1874,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_171" id_country="PE">
       <format>firstname lastname
@@ -1715,7 +1885,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_172" id_country="PH">
       <format>firstname lastname
@@ -1725,7 +1896,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_173" id_country="PN">
       <format>firstname lastname
@@ -1735,7 +1907,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_174" id_country="PR">
       <format>firstname lastname
@@ -1745,7 +1918,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_175" id_country="QA">
       <format>firstname lastname
@@ -1755,7 +1929,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_176" id_country="RE">
       <format>firstname lastname
@@ -1765,7 +1940,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_177" id_country="RU">
       <format>firstname lastname
@@ -1775,7 +1951,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_178" id_country="RW">
       <format>firstname lastname
@@ -1785,7 +1962,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_179" id_country="BL">
       <format>firstname lastname
@@ -1795,7 +1973,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_180" id_country="KN">
       <format>firstname lastname
@@ -1805,7 +1984,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_181" id_country="LC">
       <format>firstname lastname
@@ -1815,7 +1995,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_182" id_country="MF">
       <format>firstname lastname
@@ -1825,7 +2006,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_183" id_country="PM">
       <format>firstname lastname
@@ -1835,7 +2017,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_184" id_country="VC">
       <format>firstname lastname
@@ -1845,7 +2028,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_185" id_country="WS">
       <format>firstname lastname
@@ -1855,7 +2039,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_186" id_country="SM">
       <format>firstname lastname
@@ -1865,7 +2050,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_187" id_country="ST">
       <format>firstname lastname
@@ -1875,7 +2061,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_188" id_country="SA">
       <format>firstname lastname
@@ -1885,7 +2072,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_189" id_country="SN">
       <format>firstname lastname
@@ -1895,7 +2083,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_190" id_country="RS">
       <format>firstname lastname
@@ -1905,7 +2094,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_191" id_country="SC">
       <format>firstname lastname
@@ -1915,7 +2105,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_192" id_country="SL">
       <format>firstname lastname
@@ -1925,7 +2116,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_193" id_country="SI">
       <format>firstname lastname
@@ -1935,7 +2127,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_194" id_country="SB">
       <format>firstname lastname
@@ -1945,7 +2138,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_195" id_country="SO">
       <format>firstname lastname
@@ -1955,7 +2149,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_196" id_country="GS">
       <format>firstname lastname
@@ -1965,7 +2160,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_197" id_country="LK">
       <format>firstname lastname
@@ -1975,7 +2171,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_198" id_country="SD">
       <format>firstname lastname
@@ -1985,7 +2182,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_199" id_country="SR">
       <format>firstname lastname
@@ -1995,7 +2193,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_200" id_country="SJ">
       <format>firstname lastname
@@ -2005,7 +2204,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_201" id_country="SZ">
       <format>firstname lastname
@@ -2015,7 +2215,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_202" id_country="SY">
       <format>firstname lastname
@@ -2025,7 +2226,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_203" id_country="TW">
       <format>firstname lastname
@@ -2035,7 +2237,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_204" id_country="TJ">
       <format>firstname lastname
@@ -2045,7 +2248,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_205" id_country="TZ">
       <format>firstname lastname
@@ -2055,7 +2259,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_206" id_country="TH">
       <format>firstname lastname
@@ -2065,7 +2270,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_207" id_country="TK">
       <format>firstname lastname
@@ -2075,7 +2281,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_208" id_country="TO">
       <format>firstname lastname
@@ -2085,7 +2292,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_209" id_country="TT">
       <format>firstname lastname
@@ -2095,7 +2303,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_210" id_country="TN">
       <format>firstname lastname
@@ -2105,7 +2314,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_211" id_country="TR">
       <format>firstname lastname
@@ -2115,7 +2325,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_212" id_country="TM">
       <format>firstname lastname
@@ -2125,7 +2336,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_213" id_country="TC">
       <format>firstname lastname
@@ -2135,7 +2347,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_214" id_country="TV">
       <format>firstname lastname
@@ -2145,7 +2358,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_215" id_country="UG">
       <format>firstname lastname
@@ -2155,7 +2369,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_216" id_country="UA">
       <format>firstname lastname
@@ -2165,7 +2380,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_217" id_country="AE">
       <format>firstname lastname
@@ -2175,7 +2391,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_218" id_country="UY">
       <format>firstname lastname
@@ -2185,7 +2402,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_219" id_country="UZ">
       <format>firstname lastname
@@ -2195,7 +2413,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_220" id_country="VU">
       <format>firstname lastname
@@ -2205,7 +2424,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_221" id_country="VE">
       <format>firstname lastname
@@ -2215,7 +2435,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_222" id_country="VN">
       <format>firstname lastname
@@ -2225,7 +2446,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_223" id_country="VG">
       <format>firstname lastname
@@ -2235,7 +2457,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_224" id_country="VI">
       <format>firstname lastname
@@ -2245,7 +2468,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_225" id_country="WF">
       <format>firstname lastname
@@ -2255,7 +2479,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_226" id_country="EH">
       <format>firstname lastname
@@ -2265,7 +2490,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_227" id_country="YE">
       <format>firstname lastname
@@ -2275,7 +2501,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_228" id_country="ZM">
       <format>firstname lastname
@@ -2285,7 +2512,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_229" id_country="ZW">
       <format>firstname lastname
@@ -2295,7 +2523,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_230" id_country="AL">
       <format>firstname lastname
@@ -2305,7 +2534,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_231" id_country="AF">
       <format>firstname lastname
@@ -2315,7 +2545,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_232" id_country="AQ">
       <format>firstname lastname
@@ -2325,7 +2556,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_233" id_country="BA">
       <format>firstname lastname
@@ -2335,7 +2567,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_234" id_country="BV">
       <format>firstname lastname
@@ -2345,7 +2578,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_235" id_country="IO">
       <format>firstname lastname
@@ -2355,7 +2589,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_236" id_country="BG">
       <format>firstname lastname
@@ -2365,7 +2600,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_237" id_country="KY">
       <format>firstname lastname
@@ -2375,7 +2611,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_238" id_country="CX">
       <format>firstname lastname
@@ -2385,7 +2622,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_239" id_country="CC">
       <format>firstname lastname
@@ -2395,7 +2633,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_240" id_country="CK">
       <format>firstname lastname
@@ -2405,7 +2644,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_241" id_country="GF">
       <format>firstname lastname
@@ -2415,7 +2655,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_242" id_country="PF">
       <format>firstname lastname
@@ -2425,7 +2666,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_243" id_country="TF">
       <format>firstname lastname
@@ -2435,7 +2677,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
     <address_format id="address_format_244" id_country="AX">
       <format>firstname lastname
@@ -2445,7 +2688,8 @@ address1
 address2
 postcode city
 Country:name
-phone</format>
+phone
+phone_mobile</format>
     </address_format>
   </entities>
 </entity_address_format>


### PR DESCRIPTION
I honestly do not know why you decided by default to show only the first field of the phone :)

Users often ask me why they don't see their mobile phone on orders in BO.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Sponsor company | impSolutions
