### PR TITLE
$smarty->compile_check is not set to false

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -37,7 +37,7 @@ if (!Tools::getSafeModeStatus())
 $smarty->setConfigDir(_PS_SMARTY_DIR_.'configs');
 $smarty->caching = false;
 $smarty->force_compile = (Configuration::get('PS_SMARTY_FORCE_COMPILE') == _PS_SMARTY_FORCE_COMPILE_) ? true : false;
-$smarty->compile_check = (Configuration::get('PS_SMARTY_FORCE_COMPILE') <= _PS_SMARTY_CHECK_COMPILE_) ? true : false;
+$smarty->compile_check = (Configuration::get('PS_SMARTY_FORCE_COMPILE') != _PS_SMARTY_NO_COMPILE_) ? true : false;
 
 // Production mode
 $smarty->debugging = false;


### PR DESCRIPTION
$smarty->compile_check should be set to false if we do not want to recompile template files
It does really improve disk I/O and PrestaShop speed !
