### PR TITLE
Correct some "bad query" in the admin products getList

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2284,7 +2284,7 @@ class AdminControllerCore extends Controller
 		(isset($this->_filter) ? $this->_filter : '').$where_shop.'
 		'.(isset($this->_group) ? $this->_group.' ' : '').'
 		'.$having_clause.'
-		ORDER BY '.(($order_by == $this->identifier) ? 'a.' : '').pSQL($order_by).' '.pSQL($order_way).
+		ORDER BY '.(($order_by == $this->identifier || $order_by == 'quantity') ? 'a.' : '').pSQL($order_by).' '.pSQL($order_way).
 		($this->_tmpTableFilter ? ') tmpTable WHERE 1'.$this->_tmpTableFilter : '').
 		(($use_limit === true) ? ' LIMIT '.(int)$start.','.(int)$limit : '');
 


### PR DESCRIPTION
Here the wrong Sql generated :

SELECT SQL_CALC_FOUND_ROWS a.`id_product`,b.name as name,`reference`,a.price as price,a.active as active , MAX(i.id_image) id_image,cl.name `name_category` , a.`price`, 0 AS price_final, sav.`quantity` as sav_quantity, a.`active` FROM `ps_product` a LEFT JOIN `ps_product_lang` b ON (b.`id_product` = a.`id_product` AND b.`id_lang` = 2 AND b.`id_shop` = 1) LEFT JOIN `ps_image` i ON (i.`id_product` = a.`id_product` AND i.cover=1)LEFT JOIN `ps_category_lang` cl ON (a.`id_category_default` = cl.`id_category` AND b.`id_lang` = cl.`id_lang` AND cl.id_shop = 1) LEFT JOIN `ps_stock_available` sav ON (sav.`id_product` = a.`id_product` AND sav.`id_product_attribute` = 0 AND sav.id_shop = 1 ) WHERE 1 AND a.`active` = 0 GROUP BY a.id_product ORDER BY quantity desc LIMIT 0,50 

'quantity' is ambigus (for the ORDER BY)
