### PR TITLE
SEO - make sure module and controller name are in lowercase

### DIFF
--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -85,11 +85,11 @@ class MetaCore extends ObjectModel
 		// Add modules controllers to list (this function is cool !)
 		foreach (glob(_PS_MODULE_DIR_.'*/controllers/front/*.php') as $file)
 		{
-			$filename = basename($file, '.php');
+			$filename = strtolower(basename($file, '.php'));
 			if ($filename == 'index')
 				continue;
 
-			$module = basename(dirname(dirname(dirname($file))));
+			$module = strtolower(basename(dirname(dirname(dirname($file)))));
 			$selected_pages[$module.' - '.$filename] = 'module-'.$module.'-'.$filename;
 		}
 

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -85,11 +85,11 @@ class MetaCore extends ObjectModel
 		// Add modules controllers to list (this function is cool !)
 		foreach (glob(_PS_MODULE_DIR_.'*/controllers/front/*.php') as $file)
 		{
-			$filename = strtolower(basename($file, '.php'));
+			$filename = Tools::strtolower(basename($file, '.php'));
 			if ($filename == 'index')
 				continue;
 
-			$module = strtolower(basename(dirname(dirname(dirname($file)))));
+			$module = Tools::strtolower(basename(dirname(dirname(dirname($file)))));
 			$selected_pages[$module.' - '.$filename] = 'module-'.$module.'-'.$filename;
 		}
 


### PR DESCRIPTION
For module controller, make sure that the name of the controller and the module are saved in lowercase. Otherwise the route will not be found in getModuleLink.
