### PR TITLE
Update Cart.php

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3219,7 +3219,7 @@ class CartCore extends ObjectModel
 	public function getWsCartRows()
 	{
 		return Db::getInstance()->executeS('
-			SELECT id_product, id_product_attribute, quantity
+			SELECT id_product, id_product_attribute, quantity, id_address_delivery
 			FROM `'._DB_PREFIX_.'cart_product`
 			WHERE id_cart = '.(int)$this->id.' AND id_shop = '.(int)Context::getContext()->shop->id
 		);


### PR DESCRIPTION
The field "id_address_delivery" is missing in getWsCartRows.
Since id_address_delivery is required in the web service field definition.
The error will be shown below:
[PHP Notice _8] Undefined index: id_address_delivery (..\classes\webservice\WebserviceOutputBuilder.php, line 687)
