### PR TITLE
[MO] Fix reduction_tax default value

### DIFF
--- a/modules/loyalty/loyalty-program.php
+++ b/modules/loyalty/loyalty-program.php
@@ -61,6 +61,7 @@ if (Tools::getValue('transform-points') == 'true' AND $customerPoints > 0)
 	$cartRule->reduction_amount = LoyaltyModule::getVoucherValue((int)$customerPoints);
 	$cartRule->quantity = 1;
 	$cartRule->quantity_per_user = 1;
+	$cartRule->reduction_tax = 1;
 
 	/* If merchandise returns are allowed, the voucher musn't be usable before this max return date */
 	$dateFrom = Db::getInstance()->getValue('


### PR DESCRIPTION
This correction is made to avoid the problem that display different amounts on cart and discount code listing page. Taxes are now included when inserting the cart rule in database (as mentioned in the discount code listing page).
