### PR TITLE
Removed unused code in FrontOffice PDF Invoice

### DIFF
--- a/controllers/front/PdfInvoiceController.php
+++ b/controllers/front/PdfInvoiceController.php
@@ -63,23 +63,8 @@ class PdfInvoiceControllerCore extends FrontController
 		$order_invoice_list = $this->order->getInvoicesCollection();
 		Hook::exec('actionPDFInvoiceRender', array('order_invoice_list' => $order_invoice_list));
 
-		$pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty, $this->context->language->id);
+		$pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty);
 		$pdf->render();
 	}
 
-
-	/**
-	 * Returns the invoice template associated to the country iso_code
-	 * @param string $iso_user
-	 */
-	public function getTemplate($iso_country)
-	{
-		$template = _PS_THEME_PDF_DIR_.'/invoice.tpl';
-
-		$iso_template = _PS_THEME_PDF_DIR_.'/invoice.'.$iso_country.'.tpl';
-		if (file_exists($iso_template))
-			$template = $iso_template;
-
-		return $template;
-	}
 }


### PR DESCRIPTION
I looked through the code. And I can't see that, this code is used. Everything is handled in PDF class.
