### PR TITLE
Update GuestTrackingController.php

### DIFF
--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -58,7 +58,7 @@ class GuestTrackingControllerCore extends FrontController
 				{
 					$order = new Order((int)$id_order);
 					if (Validate::isLoadedObject($order))
-						$order_collection[] = $order;
+						$order_collection = Order::getByReference($order->reference);
 				}
 				else
 					$order_collection = Order::getByReference($id_order);


### PR DESCRIPTION
Fixed issue with retrocompatibility where the ->getFirst() caused a 505 error on the order_collection when a collection class was not loaded.
