### PR TITLE
[BO][-] Notice messages when accessing the BO translation page

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1221,6 +1221,8 @@ class AdminTranslationsControllerCore extends AdminController
 		// Set the path of selected theme
 		if ($this->theme_selected)
 			define('_PS_THEME_SELECTED_DIR_', _PS_ROOT_DIR_.'/themes/'.$this->theme_selected.'/');
+		else
+			define('_PS_THEME_SELECTED_DIR_', '');
 
 		// Get type of translation
 		if (($type = Tools::getValue('type')) && !is_array($type))


### PR DESCRIPTION
When accessing the translation part with "core translation" , you got 2 errors:
Notice: Use of undefined constant _PS_THEME_SELECTED_DIR_ - assumed '_PS_THEME_SELECTED_DIR_' in controllers\admin\AdminTranslationsController.php on line 1018

Notice: Use of undefined constant _PS_THEME_SELECTED_DIR_ - assumed '_PS_THEME_SELECTED_DIR_' in \controllers\admin\AdminTranslationsController.php on line 1026

It's because the variable $this->theme_selected is not set for that case.
