### PR TITLE
Conditions to hide VAT fields fail if there are no company fields

### DIFF
--- a/themes/default/order-opc-new-account.tpl
+++ b/themes/default/order-opc-new-account.tpl
@@ -74,14 +74,14 @@
 				{literal}
 				function vat_number()
 				{
-					if ($('#company').val() != '')
+					if (($('#company').length) && ($('#company').val() != ''))
 						$('#vat_number_block').show();
 					else
 						$('#vat_number_block').hide();
 				}
 				function vat_number_invoice()
 				{
-					if ($('#company_invoice').val() != '')
+					if (($('#company_invoice').length) && ($('#company_invoice').val() != ''))
 						$('#vat_number_block_invoice').show();
 					else
 						$('#vat_number_block_invoice').hide();


### PR DESCRIPTION
"Company" fields may or may not be rendered on this form, whereas "VAT" fields are always rendered and depend on the former ones to be shown (or hidden) with CSS.

This fixes an edge case where there are no "Company" fields rendered and "VAT" fields still wrongly appear, which was caused by the fact that `$('#field').val() != ''` is truthy when `$('#field').length` is zero (since `'' != undefined`).
