### PR TITLE
[-] BO : hide stmp options when selecting never send emails

### DIFF
--- a/controllers/admin/AdminEmailsController.php
+++ b/controllers/admin/AdminEmailsController.php
@@ -62,7 +62,7 @@ class AdminEmailsControllerCore extends AdminController
 						),
 						'js' => array(
 							1 => 'onclick="$(\'#smtp\').slideUp();"', 
-							2 => 'onclick="$(\'#smtp\').slideDown();"'
+							2 => 'onclick="$(\'#smtp\').slideDown();"',
 							3 => 'onclick="$(\'#smtp\').slideUp();"'
 						),
 						'visibility' => Shop::CONTEXT_ALL

--- a/controllers/admin/AdminEmailsController.php
+++ b/controllers/admin/AdminEmailsController.php
@@ -63,6 +63,7 @@ class AdminEmailsControllerCore extends AdminController
 						'js' => array(
 							1 => 'onclick="$(\'#smtp\').slideUp();"', 
 							2 => 'onclick="$(\'#smtp\').slideDown();"'
+							3 => 'onclick="$(\'#smtp\').slideUp();"'
 						),
 						'visibility' => Shop::CONTEXT_ALL
 					),


### PR DESCRIPTION
If first selecting
Set my own SMTP parameters. For advanced users ONLY
and then 
Never send emails (may be useful for test purpose)

The Email / SMTP configuration did not hide.
