### PR TITLE
[-] BO : tagify call twice if field is not translatable

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -97,7 +97,6 @@
 											<script type="text/javascript">
 												$().ready(function () {
 													var input_id = '{/literal}{if isset($input.id)}{$input.id}{else}{$input.name}{/if}{literal}';
-													$('#'+input_id).tagify();
 													$('#'+input_id).tagify({delimiters: [13,44], addTagPrompt: '{/literal}{l s='Add tag'}{literal}'});
 													$({/literal}'#{$table}{literal}_form').submit( function() {
 														$(this).find('#'+input_id).val($('#'+input_id).tagify('serialize'));


### PR DESCRIPTION
Fields of type "tag" doesnt work if they are not translatable: tagify need an argument. I think the developer forget to remove this line.
