### PR TITLE
Make the bank wire more useful in a multiple currencies shop

### DIFF
--- a/modules/bankwire/views/templates/front/payment_execution.tpl
+++ b/modules/bankwire/views/templates/front/payment_execution.tpl
@@ -38,42 +38,42 @@
 <h3>{l s='Bank-wire payment.' mod='bankwire'}</h3>
 <form action="{$link->getModuleLink('bankwire', 'validation', [], true)|escape:'html'}" method="post">
 <p>
-	<img src="{$this_path_bw}bankwire.jpg" alt="{l s='Bank wire' mod='bankwire'}" width="86" height="49" style="float:left; margin: 0px 10px 5px 0px;" />
+	<img src="{$this_path_bw}bankwire.jpg" alt="{l s='Bank wire' mod='bankwire'}" width="86" height="49" style="float:left; margin: 0px 10px 5px 0px;" /><br />
 	{l s='You have chosen to pay by bank wire.' mod='bankwire'}
 	<br/><br />
-	{l s='Here is a short summary of your order:' mod='bankwire'}
 </p>
-<p style="margin-top:20px;">
-	- {l s='The total amount of your order is' mod='bankwire'}
-	<span id="amount" class="price">{displayPrice price=$total}</span>
-	{if $use_taxes == 1}
-    	{l s='(tax incl.)' mod='bankwire'}
-    {/if}
-</p>
+<!-- if customer currency is that one I want -->
+{if ($cart->id_currency) == 1}
 <p>
-	-
-	{if $currencies|@count > 1}
-		{l s='We allow several currencies to be sent via bank wire.' mod='bankwire'}
-		<br /><br />
-		{l s='Choose one of the following:' mod='bankwire'}
-		<select id="currency_payement" name="currency_payement" onchange="setCurrency($('#currency_payement').val());">
-			{foreach from=$currencies item=currency}
-				<option value="{$currency.id_currency}" {if $currency.id_currency == $cust_currency}selected="selected"{/if}>{$currency.name}</option>
-			{/foreach}
-		</select>
-	{else}
-		{l s='We allow the following currency to be sent via bank wire:' mod='bankwire'}&nbsp;<b>{$currencies.0.name}</b>
-		<input type="hidden" name="currency_payement" value="{$currencies.0.id_currency}" />
-	{/if}
+	{l s='The total amount of your order is' mod='bankwire'}
+	<span id="amount" class="price" style="font-weight: bold">{displayPrice price=$total}</span>{if $priceDisplay == 1} {l s='(tax excl.)' mod='bankwire'}{else} {l s='(tax incl.)' mod='bankwire'}{/if}
 </p>
 <p>
 	{l s='Bank wire account information will be displayed on the next page.' mod='bankwire'}
-	<br /><br />
-	<b>{l s='Please confirm your order by clicking "Place my order."' mod='bankwire'}.</b>
+</p>
+<p>
+	<b>{l s='Please confirm your order by clicking \'Place my order\'' mod='bankwire'}.</b>
 </p>
 <p class="cart_navigation" id="cart_navigation">
 	<input type="submit" value="{l s='Place my order' mod='bankwire'}" class="exclusive_large" />
 	<a href="{$link->getPageLink('order', true, NULL, "step=3")|escape:'html'}" class="button_large">{l s='Other payment methods' mod='bankwire'}</a>
 </p>
 </form>
+<!-- if customer currency is different from what I want -->
+{else}
+<p>
+	{l s='We only accept payments in' mod='bankwire'} <b>{l s='Euros' mod='bankwire'}</b>. {l s='Your current currency is' mod='bankwire'} <b>{if ($cart->id_currency) == 2}{l s='Dollar' mod='bankwire'}{/if}</b><b>{if ($cart->id_currency) == 3}{l s='Pound' mod='bankwire'}{/if}</b>.<br /><br />
+	{l s='The total amount of your order is' mod='bankwire'}
+	<span id="amount" class="price"><b>{displayPrice price=$total}</b></span>{if $priceDisplay == 1} {l s='(tax excl.)' mod='bankwire'}{else} {l s='(tax incl.)' mod='bankwire'}{/if}
+	<br /><br />
+	<b>{l s='Please note' mod='bankwire'}</b>:<br />
+	{l s='The reference prices of the entire shop are in' mod='bankwire'} {l s='Euros' mod='bankwire'}. {l s='The conversion in' mod='bankwire'} {if ($cart->id_currency) == 2}{l s='Dollar' mod='bankwire'}{/if}{if ($cart->id_currency) == 3}{l s='Pound' mod='bankwire'}{/if} {l s='is automatically made using daily updated exchange rates, but keep in mind that exchange rates of your bank may be slightly different' mod='bankwire'}.<br /><br />
+	{l s='By clicking' mod='bankwire'} <b>OK</b> {l s='your order will be converted in' mod='bankwire'} {l s='Euros' mod='bankwire'} {l s='and you will be able to conclude the check out paying with bank wire' mod='bankwire'}.<br /><br />
+	{l s='Otherwise click' mod='bankwire'} <b>{l s='Other payment methods' mod='bankwire'}</b> {l s='and choose another kind of payment' mod='bankwire'}.
+</p>
+<p class="cart_navigation">
+	<input type="button" id="currency_payement" name="currency_payement" value="OK" onclick="setCurrency(1);" class="exclusive_large" />
+	<a href="{$link->getPageLink('order', true, NULL, "step=3")}" class="button_large">{l s='Other payment methods' mod='bankwire'}</a>
+</p>
+{/if}
 {/if}

--- a/modules/bankwire/views/templates/hook/payment_return.tpl
+++ b/modules/bankwire/views/templates/hook/payment_return.tpl
@@ -26,22 +26,29 @@
 {if $status == 'ok'}
 <p>{l s='Your order on %s is complete.' sprintf=$shop_name mod='bankwire'}
 		<br /><br />
-		{l s='Please send us a bank wire with' mod='bankwire'}
-		<br /><br />- {l s='Amount' mod='bankwire'} <span class="price"> <strong>{$total_to_pay}</strong></span>
-		<br /><br />- {l s='Name of account owner' mod='bankwire'}  <strong>{if $bankwireOwner}{$bankwireOwner}{else}___________{/if}</strong>
-		<br /><br />- {l s='Include these details' mod='bankwire'}  <strong>{if $bankwireDetails}{$bankwireDetails}{else}___________{/if}</strong>
-		<br /><br />- {l s='Bank name' mod='bankwire'}  <strong>{if $bankwireAddress}{$bankwireAddress}{else}___________{/if}</strong>
+		{l s='Please send us a bank wire with' mod='bankwire'}:<br /><br />
+		&bull; {l s='an amount of' mod='bankwire'}<span class="price">:<br />
+		<strong>{$total_to_pay}</strong></span><br /><br />
+		&bull; {l s='to the account owner' mod='bankwire'}:<br />
+		<strong>{if $bankwireOwner}{$bankwireOwner}{else}___________{/if}</strong><br /><br />
+		&bull; {l s='with these details' mod='bankwire'}:<br />
+		<strong>{if $bankwireDetails}{$bankwireDetails}{else}___________{/if}</strong><br /><br />
+		&bull; {l s='to this bank' mod='bankwire'}:<br />
+		<strong>{if $bankwireAddress}{$bankwireAddress}{else}___________{/if}</strong><br /><br />
 		{if !isset($reference)}
-			<br /><br />- {l s='Do not forget to insert your order number #%d in the subject of your bank wire' sprintf=$id_order mod='bankwire'}
+		&bull; {l s='Do not forget to insert your order number #%d in the subject of your bank wire' sprintf=$id_order mod='bankwire'}
 		{else}
-			<br /><br />- {l s='Do not forget to insert your order reference %s in the subject of your bank wire.' sprintf=$reference mod='bankwire'}
-		{/if}		<br /><br />{l s='An email has been sent with this information.' mod='bankwire'}
-		<br /><br /> <strong>{l s='Your order will be sent as soon as we receive payment.' mod='bankwire'}</strong>
-		<br /><br />{l s='If you have questions, comments or concerns, please contact our' mod='bankwire'} <a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='expert customer support team. ' mod='bankwire'}</a>.
+		&bull; {l s='Do not forget to insert your order reference %s in the subject of your bank wire.' sprintf=$reference mod='bankwire'}
+		{/if}<br /><br />
+		{l s='An email has been sent to you with this information.' mod='bankwire'}<br /><br />
+		{l s='Your order will be sent as soon as we receive your settlement' mod='bankwire'}.<br /><br />
+		<b>{l s='Please note' mod='bankwire'}</b>:<br />
+		{l s='Charges for bank transfer as well as any other cost for the transaction are fully charged to the buyer. During compilation of the bank transfer, please set the costs on \"OUR\"' mod='bankwire'}. <b>{l s='Only after receiving the full amount, we\'ll be able to submit your order.' mod='bankwire'}</b><br /><br />
+		{l s='For any questions or for further information, please contact our' mod='bankwire'} <a href="{$link->getPageLink('contact', true)}" style="color: #08c;">{l s='customer support' mod='bankwire'}</a>.
 	</p>
 {else}
 	<p class="warning">
-		{l s='We noticed a problem with your order. If you think this is an error, feel free to contact our' mod='bankwire'} 
-		<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='expert customer support team. ' mod='bankwire'}</a>.
+		{l s='We noticed a problem with your order. If you think this is an error, you can contact our' mod='bankwire'} 
+		<a href="{$link->getPageLink('contact', true)|escape:'html'}" style="color: #08c;">{l s='customer support' mod='bankwire'}</a>.
 	</p>
 {/if}

--- a/modules/bankwire/views/templates/hook/payment_return.tpl
+++ b/modules/bankwire/views/templates/hook/payment_return.tpl
@@ -36,9 +36,9 @@
 		&bull; {l s='to this bank' mod='bankwire'}:<br />
 		<strong>{if $bankwireAddress}{$bankwireAddress}{else}___________{/if}</strong><br /><br />
 		{if !isset($reference)}
-		&bull; {l s='Do not forget to insert your order number #%d in the subject of your bank wire' sprintf=$id_order mod='bankwire'}
+		&bull; {l s='Do not forget to insert your order number' mod='bankwire'} <b>{$id_order}</b> {l s='in the subject of your bank wire.' mod='bankwire'}
 		{else}
-		&bull; {l s='Do not forget to insert your order reference %s in the subject of your bank wire.' sprintf=$reference mod='bankwire'}
+		&bull; {l s='Do not forget to insert your order reference' mod='bankwire'} <b>{$reference}</b> {l s='in the subject of your bank wire.' mod='bankwire'}
 		{/if}<br /><br />
 		{l s='An email has been sent to you with this information.' mod='bankwire'}<br /><br />
 		{l s='Your order will be sent as soon as we receive your settlement' mod='bankwire'}.<br /><br />


### PR DESCRIPTION
With the default bank wire module, if the shop has multiple currencies, it is proposed to the customer only if the merchant accepts payments in all currency. If the merchant accepts payments just in its own currency, the bank wire will not be proposed to the customer that visit the shop with a different currency. That's wrong!

PayPal don't works in this way, the shop can have multiple currencies and it is proposed to everyone but the merchant can receive in its own only.

This mod permits to propose the bank wire in a multiple currencies shop, but it add a step that permit to the merchant to receive payment in its own only.
This is just a "front-end" mod, it needs some work to bring it totally configurable in the BO by adding variables, checkboxes, etc. All this is too much for me, I'm not a developer, unfortunately...

In the present mod I made changes directly in the code (so they are not OK for everyone):
- I use "Euros" as default currency (it should be choose in BO among all installed currencies of the shop, if any)
- It works with currencies ID (in this mod: euros=1, dollar=2, pound=3. Everything should follow the installed currencies, if any)

I added some message to help customer and the merchant in the payment process and I have made some changes to make the return page of the bank wire payment trying to have it more complete and readable. I added an important comment about receiving the full amount of money (bank charges should be charged to the customer). Everything following the default theme style and colour.

Sorry if I made something wrong, I'm a super-newbie, in the PS forge bugfix website I was advised to join here to propose my fixing and chages.
