### PR TITLE
[-] BO : changed price then setting Advanced Stock Management value

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -4141,7 +4141,7 @@ class AdminProductsControllerCore extends AdminController
 		if (!Tools::getValue('actionQty'))
 			return Tools::jsonEncode(array('error' => $this->l('Undefined action')));
 
-		$product = new Product((int)Tools::getValue('id_product'), true);
+		$product = new Product((int)Tools::getValue('id_product');
 		switch (Tools::getValue('actionQty'))
 		{
 			case 'depends_on_stock':


### PR DESCRIPTION
Bug description:

Product have specific price for all customers.

In Product edit page - Quantities tab.
Change "I want to use the advanced stock management system for this product." value.
Message "Data saved" appears. Refresh page, and product price is changed.
