### PR TITLE
// FIX: tags with UTF-8 chars

### DIFF
--- a/classes/Tag.php
+++ b/classes/Tag.php
@@ -105,7 +105,7 @@ class TagCore extends ObjectModel
 			{
 		 	 	if (!Validate::isGenericName($tag))
 		 	 		return false;
-				$tag = trim(substr($tag, 0, self::$definition['fields']['name']['size']));
+				$tag = trim(Tools::substr($tag, 0, self::$definition['fields']['name']['size']));
 				$tag_obj = new Tag(null, $tag, (int)$id_lang);
 	
 				/* Tag does not exist in database */


### PR DESCRIPTION
Fixed error Tag->Name is not valid if tag in non latin chars
