### PR TITLE
Update FrontController.php

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -312,8 +312,6 @@ class FrontControllerCore extends Controller
 			'currency' => $currency,
 			'cookie' => $this->context->cookie,
 			'page_name' => $page_name,
-			'hide_left_column' => !$this->display_column_left,
-			'hide_right_column' => !$this->display_column_right,
 			'base_dir' => _PS_BASE_URL_.__PS_BASE_URI__,
 			'base_dir_ssl' => $protocol_link.Tools::getShopDomainSsl().__PS_BASE_URI__,
 			'content_dir' => $protocol_content.Tools::getHttpHost().__PS_BASE_URI__,
@@ -437,6 +435,12 @@ class FrontControllerCore extends Controller
 				'HOOK_MOBILE_HEADER' => Hook::exec('displayMobileHeader'),
 			));
 		}
+		
+		$this->context->smarty->assign(array(
+			// Usefull for layout.tpl
+			'hide_left_column' => !$this->display_column_left,
+			'hide_right_column' => !$this->display_column_right,
+		));
 	}
 
 	/**


### PR DESCRIPTION
When you set hide_left_column or hide_right_column from a Module Controller:

[code]
class \* extends ModuleFrontController
{
    public function initContent()
    {
        $this->display_column_left = false;
        $this->display_column_right = false;

```
    parent::initcontent();

    $this->setTemplate('*.tpl');
}
```

}
[/code]

these values are not passed to smarty, so you don't know in a TPL if columns are hidden. These values should be set at initContent function.
