### PR TITLE
[-] FO/MO : Fixed typo

### DIFF
--- a/modules/blocklayered/blocklayered.js
+++ b/modules/blocklayered/blocklayered.js
@@ -123,19 +123,19 @@ $(document).ready(function()
 		hideFilterValueAction(this);
 	});
 
-	// To be sure there is no other events attached to the selectPrductSort, change the ID
+	// To be sure there is no other events attached to the selectProductSort, change the ID
 	var id = 1;
-	while ($('#selectPrductSort').length) { // Because ids are duplicated
-		// Unbind event change on #selectPrductSort
-		$('#selectPrductSort').unbind('change');
-		$('#selectPrductSort').attr('onchange', '');
-		$('#selectPrductSort').addClass('selectProductSort');
-		$('#selectPrductSort').attr('id', 'selectPrductSort'+id);
-		$('label[for=selectPrductSort]').attr('for', 'selectPrductSort'+id);
+	while ($('#selectProductSort').length) { // Because ids are duplicated
+		// Unbind event change on #selectProductSort
+		$('#selectProductSort').unbind('change');
+		$('#selectProductSort').attr('onchange', '');
+		$('#selectProductSort').addClass('selectProductSort');
+		$('#selectProductSort').attr('id', 'selectProductSort'+id);
+		$('label[for=selectProductSort]').attr('for', 'selectProductSort'+id);
 		id++;
 	}
 	
-	// Since 1.5, event is add to .selectProductSort and not to #selectPrductSort
+	// Since 1.5, event is add to .selectProductSort and not to #selectProductSort
 	setTimeout(function() {
 		$('.selectProductSort').unbind('change');
 	}, 100);

--- a/modules/blocklayered/blocklayered.php
+++ b/modules/blocklayered/blocklayered.php
@@ -1274,7 +1274,7 @@ class BlockLayered extends Module
 				//<![CDATA[
 				$(document).ready(function()
 				{
-					$(\'#selectPrductSort\').unbind(\'change\').bind(\'change\', function()
+					$(\'#selectProductSort\').unbind(\'change\').bind(\'change\', function()
 					{
 						reloadContent();
 					})

--- a/themes/default/css/global.css
+++ b/themes/default/css/global.css
@@ -349,7 +349,7 @@ ul.footer_links li .icon {
 .ie7 #center_column .sortPagiBar form {display:inline;}
 
 .sortPagiBar #productsSortForm {float:right;}
-	.sortPagiBar select#selectPrductSort {
+	.sortPagiBar select#selectProductSort {
 		margin:0 0 0 10px;
 		color:#000;
 		border:1px solid #ccc

--- a/themes/default/js/modules/blocklayered/blocklayered.js
+++ b/themes/default/js/modules/blocklayered/blocklayered.js
@@ -123,19 +123,19 @@ $(document).ready(function()
 		hideFilterValueAction(this);
 	});
 
-	// To be sure there is no other events attached to the selectPrductSort, change the ID
+	// To be sure there is no other events attached to the selectProductSort, change the ID
 	var id = 1;
-	while ($('#selectPrductSort').length) { // Because ids are duplicated
-		// Unbind event change on #selectPrductSort
-		$('#selectPrductSort').unbind('change');
-		$('#selectPrductSort').attr('onchange', '');
-		$('#selectPrductSort').addClass('selectProductSort');
-		$('#selectPrductSort').attr('id', 'selectPrductSort'+id);
-		$('label[for=selectPrductSort]').attr('for', 'selectPrductSort'+id);
+	while ($('#selectProductSort').length) { // Because ids are duplicated
+		// Unbind event change on #selectProductSort
+		$('#selectProductSort').unbind('change');
+		$('#selectProductSort').attr('onchange', '');
+		$('#selectProductSort').addClass('selectProductSort');
+		$('#selectProductSort').attr('id', 'selectProductSort'+id);
+		$('label[for=selectProductSort]').attr('for', 'selectProductSort'+id);
 		id++;
 	}
 	
-	// Since 1.5, event is add to .selectProductSort and not to #selectPrductSort
+	// Since 1.5, event is add to .selectProductSort and not to #selectProductSort
 	setTimeout(function() {
 		$('.selectProductSort').unbind('change');
 	}, 100);

--- a/themes/default/mobile/category-product-sort.tpl
+++ b/themes/default/mobile/category-product-sort.tpl
@@ -40,7 +40,7 @@
 		//<![CDATA[
 		$(document).ready(function()
 		{
-			$('.selectPrductSort').change(function()
+			$('.selectProductSort').change(function()
 			{
 				var requestSortProducts = '{$request}';
 				var splitData = $(this).val().split(':');
@@ -53,7 +53,7 @@
 
 	<div class="{$container_class}">
 		<form id="productsSortForm" action="{$request|escape:'htmlall':'UTF-8'}">
-			<select class="selectPrductSort">
+			<select class="selectProductSort">
 				<option value="{$orderbydefault|escape:'htmlall':'UTF-8'}:{$orderwaydefault|escape:'htmlall':'UTF-8'}" {if $orderby eq $orderbydefault}selected="selected"{/if}>{l s='Sort by'}</option>
 				{if !$PS_CATALOG_MODE}
 					<option value="price:asc" {if $orderby eq 'price' AND $orderway eq 'asc'}selected="selected"{/if}>{l s='Price: Lowest first'}</option>

--- a/themes/default/product-sort.tpl
+++ b/themes/default/product-sort.tpl
@@ -56,8 +56,8 @@ $(document).ready(function(){
 {/if}
 <form id="productsSortForm{if isset($paginationId)}_{$paginationId}{/if}" action="{$request|escape:'htmlall':'UTF-8'}" class="productsSortForm">
 	<p class="select">
-		<label for="selectPrductSort{if isset($paginationId)}_{$paginationId}{/if}">{l s='Sort by'}</label>
-		<select id="selectPrductSort{if isset($paginationId)}_{$paginationId}{/if}" class="selectProductSort">
+		<label for="selectProductSort{if isset($paginationId)}_{$paginationId}{/if}">{l s='Sort by'}</label>
+		<select id="selectProductSort{if isset($paginationId)}_{$paginationId}{/if}" class="selectProductSort">
 			<option value="{$orderbydefault|escape:'htmlall':'UTF-8'}:{$orderwaydefault|escape:'htmlall':'UTF-8'}" {if $orderby eq $orderbydefault}selected="selected"{/if}>{l s='--'}</option>
 			{if !$PS_CATALOG_MODE}
 				<option value="price:asc" {if $orderby eq 'price' AND $orderway eq 'asc'}selected="selected"{/if}>{l s='Price: Lowest first'}</option>


### PR DESCRIPTION
This fixes the typo on "selectPrductSort" classes and IDs, adding the missing "o".
Related files are both from the default theme and the blocklayered module.
