### PR TITLE
Update FrontController.php

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -117,17 +117,7 @@ class FrontControllerCore extends Controller
 		$css_files = $this->css_files;
 		$js_files = $this->js_files;
 
-		// If we call a SSL controller without SSL or a non SSL controller with SSL, we redirect with the right protocol
-		if (Configuration::get('PS_SSL_ENABLED') && ($_SERVER['REQUEST_METHOD'] != 'POST') && $this->ssl != Tools::usingSecureMode())
-		{	
-			header('HTTP/1.1 301 Moved Permanently');
-			header('Cache-Control: no-cache');
-			if ($this->ssl)					
-				header('Location: '.Tools::getShopDomainSsl(true).$_SERVER['REQUEST_URI']);
-			else						
-				header('Location: '.Tools::getShopDomain(true).$_SERVER['REQUEST_URI']);
-			exit();
-		}
+
 		
 		if ($this->ajax)
 		{


### PR DESCRIPTION
when you're on secured order page (with ssl) and when you're trying to read TOS - in all modern browsers you see this: [blocked] The page at https://localhost/1560a/index.php?controller=order ran insecure content from http://localhost/1560a/index.php?id_cms=3&controller=cms&id_lang=1&content_only=1.

It appears even if I change http:// to https:// in {$link_conditions} variable. Prestashop automatically change the secured url to unsecured, this is the most annoying thing so in my opinion this code should be removed!

more about mixed content filtering: https://blog.mozilla.org/tanvi/2013/04/10/mixed-content-blocking-enabled-in-firefox-23/
for now all modern browsers use the same filtering method.
