### PR TITLE
// do not use sprintf in installer when it is useless

### DIFF
--- a/install-dev/classes/languages.php
+++ b/install-dev/classes/languages.php
@@ -136,7 +136,9 @@ class InstallLanguages
 		}
 
 		$args[0] = $translation;
-		return call_user_func_array('sprintf', $args);
+		if(count($args) > 1)
+			return call_user_func_array('sprintf', $args);
+		else return $translation;
 	}
 
 	/**


### PR DESCRIPTION
In the installer we try to do "sprintf" on each translations, which results in an error when there is no sprintf to perform and unescaped percent (%) signs in the translation. This checks wheter additional arguments are passed to the l function before running sprintf. That way we do sprintf only when necessary.
