### PR TITLE
[*] FO : Optimization of getDiscountsCustomer

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -360,16 +360,35 @@ class CartCore extends ObjectModel
 		return $result;
 	}
 
-	public function getDiscountsCustomer($id_cart_rule)
+	/* 
+	 * Oleacorner
+	 * manage a cache to have only one DB request per cart,
+	 * rather than one per id_cart_rule retrieved in the CartRule::getCustomerCartRules()
+	 * 
+	 */
+	public function getDiscountsCustomer($id_cart_rule, $refresh = null)
 	{
 		if (!CartRule::isFeatureActive())
 			return 0;
 
-		return Db::getInstance()->getValue('
-			SELECT COUNT(*)
-			FROM `'._DB_PREFIX_.'cart_cart_rule`
-			WHERE `id_cart_rule` = '.(int)$id_cart_rule.' AND `id_cart` = '.(int)$this->id
-		);
+		static $_cache = null;
+		
+		if ($refresh || !isset($_cache[$this->id])) {
+			$_cache[$this->id] = array();
+			$res = Db::getInstance()->executeS('
+				SELECT COUNT(*) as qty, id_cart_rule
+				FROM `'._DB_PREFIX_.'cart_cart_rule`
+				WHERE  `id_cart` = '.(int)$this->id.'
+				GROUP BY id_cart_rule'
+			);
+			foreach ((array)$res as $info) {
+				$_cache[$this->id][$info['id_cart_rule']] = $info['qty'];
+			}
+		}
+		
+		return isset($_cache[$this->id][$id_cart_rule])
+					? $_cache[$this->id][$id_cart_rule]
+					: 0; 
 	}
 
 	public function getLastProduct()

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -712,13 +712,30 @@ class OrderCore extends ObjectModel
 		WHERE ocr.`id_order` = '.(int)$this->id);
 	}
 
-	public static function getDiscountsCustomer($id_customer, $id_cart_rule)
+	/*
+	 * Oleacorner
+	* manage a cache to have only one DB request per customet,
+	* rather than one per id_cart_rule retrieved in the CartRule::getCustomerCartRules()
+	*
+	*/
+	
+	public static function getDiscountsCustomer($id_customer, $id_cart_rule, $refresh = null)
 	{
-		return Db::getInstance()->getValue('
-		SELECT COUNT(*) FROM `'._DB_PREFIX_.'orders` o
-		LEFT JOIN '._DB_PREFIX_.'order_cart_rule ocr ON (ocr.id_order = o.id_order)
-		WHERE o.id_customer = '.(int)$id_customer.'
-		AND ocr.id_cart_rule = '.(int)$id_cart_rule);
+		static $_cache = null;
+		
+		if ($refresh || ! isset($_cache[$id_customer])) {
+			$_cache[$id_customer] = array();
+			$res = Db::getInstance()->executeS('
+						SELECT COUNT(*) as qty, id_cart_rule
+						FROM `'._DB_PREFIX_.'orders` o
+						LEFT JOIN '._DB_PREFIX_.'order_cart_rule ocr ON (ocr.id_order = o.id_order)
+						WHERE o.id_customer = '.(int)$id_customer.'
+						GROUP BY ocr.id_cart_rule');
+			foreach((array)$res as $info)
+				$_cache[$id_customer][$info['id_cart_rule']] = $info['qty'];
+		}
+		
+		return isset($_cache[$id_customer][$id_cart_rule]) ?$_cache[$id_customer][$id_cart_rule] :0;
 	}
 
 	/**


### PR DESCRIPTION
When displaying the FO cart summary, Order::getDiscountsCustomer() and
Cart::getDiscountsCustomer() are called several time, one time per
id_cart_rule retrivied in the CartRule::getCustomerCartRules().
Theses 2 optimizations manage an internal cache to have only one request
per cart / per customer.
