### PR TITLE
changed non-secured connection to secured

### DIFF
--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -279,6 +279,6 @@ class StoresControllerCore extends FrontController
 		if (!Configuration::get('PS_STORES_SIMPLIFIED'))
 			$this->addJS(_THEME_JS_DIR_.'stores.js');
         $default_country = new Country((int)Configuration::get('PS_COUNTRY_DEFAULT'));
-		$this->addJS('http://maps.google.com/maps/api/js?sensor=true&amp;region='.substr($default_country->iso_code, 0, 2));
+		$this->addJS('https://maps.google.com/maps/api/js?sensor=true&amp;region='.substr($default_country->iso_code, 0, 2));
 	}
 }


### PR DESCRIPTION
Added https protocol to google maps library. Without ssl map in store locator doesn't work when someone viewing website with secured connection (ssl turned on, forced ssl on all pages).
