### PR TITLE
[-] FO : fix contact-form id_order input when customer is not logged

### DIFF
--- a/themes/default/contact-form.tpl
+++ b/themes/default/contact-form.tpl
@@ -88,7 +88,7 @@
 							<option value="{$order.value|intval}" {if $order.selected|intval}selected="selected"{/if}>{$order.label|escape:'htmlall':'UTF-8'}</option>
 						{/foreach}
 					</select>
-				{elseif !isset($customerThread.id_order) && !isset($isLogged)}
+				{elseif !isset($customerThread.id_order) && empty($isLogged)}
 					<input type="text" name="id_order" id="id_order" value="{if isset($customerThread.id_order) && $customerThread.id_order|intval > 0}{$customerThread.id_order|intval}{else}{if isset($smarty.post.id_order) && !empty($smarty.post.id_order)}{$smarty.post.id_order|intval}{/if}{/if}" />
 				{elseif $customerThread.id_order|intval > 0}
 					<input type="text" name="id_order" id="id_order" value="{$customerThread.id_order|intval}" readonly="readonly" />


### PR DESCRIPTION
Some popular modules always set the isLogged variable in smarty (pm_advancedtopmenu, pm_adsandslideshow, favourite...), and it can be set to false, or 0. When the customer is not logged, the contact form doesn't render properly, since there is no "input" that shows. 
That's why instead of "!isset", putting "empty" gives the expected output. (it checks for both isset and false !).
