### PR TITLE
Fix qtyToUse in getSpecificPrice

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -230,11 +230,11 @@ class SpecificPriceCore extends ObjectModel
 				)
 				AND id_cart IN (0, '.(int)$id_cart.') ';
 
+			$qty_to_use = $id_cart ? (int)$quantity : (int)$real_quantity;
 			if ($real_quantity != 0 && !Configuration::get('PS_QTY_DISCOUNT_ON_COMBINATION'))
-				$query .= ' AND IF(`from_quantity` > 1, `from_quantity`, 0) <= IF(id_product_attribute=0,'.(int)$quantity.' ,'.(int)$real_quantity.')';
+				$query .= ' AND IF(`from_quantity` > 1, `from_quantity`, 0) <= IF(id_product_attribute=0,'.(int)qty_to_use.' ,'.(int)$real_quantity.')';
 			else
 			{
-				$qty_to_use = $id_cart ? (int)$quantity : (int)$real_quantity;
 				$query .= 'AND `from_quantity` <= '.max(1, $qty_to_use);
 			}
 


### PR DESCRIPTION
I my FOQuantityAndDeclinaison Prices module, available on Addons store, I need to retrieve the price for a given quantity, either for simple products or for combinations of products, whatever the cart content.

I then call 
for combination price : Product::getPriceStatic($product->id, true, $id_product_attribute, 2, NULL, false, true, $qty, false, $customer->id, 0/_$id_cart_/, $id_address_vat)
for simple product : Product::getPriceStatic($product->id, $withTaxes, 0, 2, NULL, false, true, $qty, false, $customer->id, 0/_$id_cart_/, $id_address_vat)

The id_cart is set to 0, to be independant of the cart content.
The getPriceStatic must be modified to take care about the $qty given in parameter of the getPriceStatic rather than the $real_quantity.
