### PR TITLE
Update form.tpl

### DIFF
--- a/admin-dev/themes/default/template/controllers/products/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/products/helpers/form/form.tpl
@@ -106,7 +106,6 @@
 
 		$(document).ready(function()
 		{
-			$('#product-tab-content-wait').show();
 			//product_type = $("input[name=type_product]:checked").val();
 			if (product_type == product_type_pack)
 			{


### PR DESCRIPTION
I removed the line 109 because the price tab problem and because this line is redundant. The first show (line 95) always is executed.
If the price is saved twice, the second the div #product-tab-content-wait never is hided and show the loading forever.
It is because the line 109 show this tab again, in the sequence: show (line 95), hide (line 213), show (line 109).
This happening just for price tab.
