### PR TITLE
[-] BO: Fix stock when combinations are removed.

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -108,6 +108,10 @@ class StockAvailableCore extends ObjectModel
 	
 	public static function getStockAvailableIdByProductId($id_product, $id_product_attribute = null, $id_shop = null)
 	{
+		// if null, it's a product without attributes
+		if ($id_product_attribute === null)
+			$id_product_attribute = 0;
+    
 		if (!Validate::isUnsignedId($id_product))
 			return false;
 
@@ -115,9 +119,7 @@ class StockAvailableCore extends ObjectModel
 		$query->select('id_stock_available');
 		$query->from('stock_available');
 		$query->where('id_product = '.(int)$id_product);
-
-		if ($id_product_attribute !== null)
-			$query->where('id_product_attribute = '.(int)$id_product_attribute);
+		$query->where('id_product_attribute = '.(int)$id_product_attribute);
 
 		$query = StockAvailable::addSqlShopRestriction($query, $id_shop);
 		return (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
@@ -172,7 +174,7 @@ class StockAvailableCore extends ObjectModel
 					if ($order_id_shop != null && !count(array_intersect($allowed_warehouse_for_product_clean, $order_warehouses)))
 						continue;
 
-					$product_quantity = $manager->getProductRealQuantities($id_product, null, $allowed_warehouse_for_product_clean, true);
+					$product_quantity = $manager->getProductRealQuantities($id_product, 0, $allowed_warehouse_for_product_clean, true);
 					
 					Hook::exec('actionUpdateQuantity',
 									array(

--- a/classes/stock/StockManager.php
+++ b/classes/stock/StockManager.php
@@ -423,6 +423,10 @@ class StockManagerCore implements StockManagerInterface
 	 */
 	public function getProductPhysicalQuantities($id_product, $id_product_attribute, $ids_warehouse = null, $usable = false)
 	{
+		// if null, it's a product without attributes
+		if ($id_product_attribute === null)
+			$id_product_attribute = 0;
+    
 		if (!is_null($ids_warehouse))
 		{
 			// in case $ids_warehouse is not an array
@@ -441,8 +445,7 @@ class StockManagerCore implements StockManagerInterface
 		$query->select('SUM('.($usable ? 's.usable_quantity' : 's.physical_quantity').')');
 		$query->from('stock', 's');
 		$query->where('s.id_product = '.(int)$id_product);
-		if (0 != $id_product_attribute)
-			$query->where('s.id_product_attribute = '.(int)$id_product_attribute);
+		$query->where('s.id_product_attribute = '.(int)$id_product_attribute);
 
 		if (count($ids_warehouse))
 			$query->where('s.id_warehouse IN('.implode(', ', $ids_warehouse).')');
@@ -455,6 +458,10 @@ class StockManagerCore implements StockManagerInterface
 	 */
 	public function getProductRealQuantities($id_product, $id_product_attribute, $ids_warehouse = null, $usable = false)
 	{
+		// if null, it's a product without attributes
+		if ($id_product_attribute === null)
+			$id_product_attribute = 0;
+    
 		if (!is_null($ids_warehouse))
 		{
 			// in case $ids_warehouse is not an array


### PR DESCRIPTION
The stock for a product currently gets messed up when you remove the combinations from it.
The steps to reproduce are:
1. Create a product with combinations
2. Use advanced stock management and add stock for the combinations
3. Remove all combinations

After that, the product is shown with the combined stock, but you are unable to manage it (because the stock is specific to an attribute).

As I see it there are at least three viable options to avoid the current behaviour:
1. Always specifying `id_product_attribute=0` when not given in the queries to `ps_stock` **(this is the approach I took in this PR)**
2. Removing stock together with the product combination (this might be the best option since you can't really recover the combination)
3. Change stock entries for a deleted combination to `id_product_attribute=0`

If you believe there's a better approach please share it.
