### PR TITLE
"---<br />" string is now removed correctly from the end of customization data text

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -369,7 +369,9 @@ abstract class PaymentModuleCore extends Module
 									$customization_text .= sprintf(Tools::displayError('%d image(s)'), count($customization['datas'][Product::CUSTOMIZE_FILE])).'<br />';
 								$customization_text .= '---<br />';
 							}
-							$customization_text = rtrim($customization_text, '---<br />');
+							if(substr($customization_text, -9) == '---<br />'){
+								$customization_text = substr($customization_text, 0, -9);
+							}
 
 							$customization_quantity = (int)$product['customization_quantity'];
 							$products_list .=


### PR DESCRIPTION
rtrim was used before errorenously
