### PR TITLE
"---<br />" string is now removed correctly from the end of customization data text

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -369,7 +369,9 @@ abstract class PaymentModuleCore extends Module
 									$customization_text .= sprintf(Tools::displayError('%d image(s)'), count($customization['datas'][Product::CUSTOMIZE_FILE])).'<br />';
 								$customization_text .= '---<br />';
 							}
-							$customization_text = rtrim($customization_text, '---<br />');
+							if(substr($customization_text, -9) == '---<br />'){
+								$customization_text = substr($customization_text, 0, -9);
+							}
 
 							$customization_quantity = (int)$product['customization_quantity'];
 							$products_list .=

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -369,9 +369,8 @@ abstract class PaymentModuleCore extends Module
 									$customization_text .= sprintf(Tools::displayError('%d image(s)'), count($customization['datas'][Product::CUSTOMIZE_FILE])).'<br />';
 								$customization_text .= '---<br />';
 							}
-							if(substr($customization_text, -9) == '---<br />'){
-								$customization_text = substr($customization_text, 0, -9);
-							}
+
+							$customization_text = Tools::rtrimString($customization_text, '---<br />');
 
 							$customization_quantity = (int)$product['customization_quantity'];
 							$products_list .=

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2739,6 +2739,20 @@ exit;
 		}
 		return $fileAttachment;
 	}
+
+	/**
+	 * Delete a substring from another one starting from the right
+	 * @param string $str
+	 * @param string $str_search
+	 * @return string
+	 */
+	public static function rtrimString($str, $str_search)
+	{
+		$length_str = strlen($str_search);
+		if (strlen($str) >= $length_str && substr($str, -$length_str) == $str_search)
+			$str = substr($str, 0, -$length_str);
+		return $str;
+	}
 }
 
 /**

--- a/modules/mailalerts/mailalerts.php
+++ b/modules/mailalerts/mailalerts.php
@@ -318,7 +318,7 @@ class MailAlerts extends Module
 					$customization_text .= '---<br />';
 				}
 
-				$customization_text = rtrim($customization_text, '---<br />');
+				$customization_text = Tools::rtrimString($customization_text, '---<br />');
 			}
 
 			$items_table .=


### PR DESCRIPTION
rtrim was used before errorenously

Full explanation with example about the problem here : https://github.com/PrestaShop/PrestaShop/pull/999#issuecomment-28884513
