### PR TITLE
Adding a position order by clause.

### DIFF
--- a/modules/homefeatured/homefeatured.php
+++ b/modules/homefeatured/homefeatured.php
@@ -120,7 +120,7 @@ class HomeFeatured extends Module
 		{
 			$category = new Category(Context::getContext()->shop->getCategory(), (int)Context::getContext()->language->id);
 			$nb = (int)Configuration::get('HOME_FEATURED_NBR');
-			$products = $category->getProducts((int)Context::getContext()->language->id, 1, ($nb ? $nb : 8));
+			$products = $category->getProducts((int)Context::getContext()->language->id, 1, ($nb ? $nb : 8), "position");
 
 			$this->smarty->assign(array(
 				'products' => $products,


### PR DESCRIPTION
Adding a position order by clause. This way you can manage how the featured products will display on home page. You can manage the order from the PrestaShop backend, and thus you have full control on the display in the frontend.
