### PR TITLE
Mail translation methods fix & template translation fix 

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -372,11 +372,11 @@ class MailCore
 
 		$file_core = _PS_ROOT_DIR_.'/mails/'.$iso_code.'/lang.php';
 		if (Tools::file_exists_cache($file_core) && empty($_LANGMAIL))
-			include_once($file_core);
+			include($file_core);
 
 		$file_theme = _PS_THEME_DIR_.'mails/'.$iso_code.'/lang.php';
 		if (Tools::file_exists_cache($file_theme))
-			include_once($file_theme);
+			include($file_theme);
 
 		if (!is_array($_LANGMAIL))
 			return (str_replace('"', '&quot;', $string));

--- a/mails/en/backoffice_order.html
+++ b/mails/en/backoffice_order.html
@@ -20,7 +20,7 @@
 <td>&nbsp;</td>
 </tr>
 <tr>
-<td style="background-color: {color}; color: #fff; font-size: 12px; font-weight: bold; padding: 0.5em 1em;" align="left">A new command has been generated to you.</td>
+<td style="background-color: {color}; color: #fff; font-size: 12px; font-weight: bold; padding: 0.5em 1em;" align="left">A new order has been generated to you.</td>
 </tr>
 <tr>
 <td>&nbsp;</td>

--- a/mails/en/backoffice_order.txt
+++ b/mails/en/backoffice_order.txt
@@ -1,6 +1,6 @@
 Hi {firstname} {lastname},
 
-A new command has been generated to you.
+A new order has been generated to you.
 
 Go on {order_link} to finalize the payment.
 


### PR DESCRIPTION
Mail class and l method :

If id_lang are mixed (1, 2, 3, 1, 4, 2...) the translations aren't correctly populated from the theme lang.php override if include_once is used. include must be used in order to handle mixed id_lang in a same process.
