### PR TITLE
Update of Category scene block

### DIFF
--- a/themes/default-bootstrap/category.tpl
+++ b/themes/default-bootstrap/category.tpl
@@ -47,9 +47,6 @@
                         </div>
                     {else}
                     <!-- Category image -->
-                    <div class="content_scene_cat_bg" {if $category->id_image}style="background:url({$link->getCatImageLink($category->link_rewrite, $category->id_image, 'category_default')|escape:'html'}) 0 bottom no-repeat; background-size:contain; min-height:{$categorySize.height}px;" {/if}>
-                        {if $category->description}
-                            <div class="cat_desc">
                             <h1 class="category-name">
                                 {strip}
                                     {$category->name|escape:'html':'UTF-8'}
@@ -58,17 +55,20 @@
                                     {/if}
                                 {/strip}
                             </h1>
+                    <div class="content_scene_cat_bg" {if $category->id_image}style="background:url({$link->getCatImageLink($category->link_rewrite, $category->id_image, 'category_default')|escape:'html'}) 0 bottom no-repeat; background-size:contain; min-height:{$categorySize.height}px;   background-position: center;" {/if}>
+                    </div>
+                        {if $category->description}
+                            <div class="cat_desc">
                             {if strlen($category->description) > 350}
                                 <div id="category_description_short">{$category->description|truncate:350}</div>
                                 <div id="category_description_full" style="display:none">{$category->description}</div>
                                 <a href="#" onclick="$('#category_description_short').hide(); $('#category_description_full').show(); $(this).hide(); return false;" class="lnk_more">{l s='More'}</a>
                             {else}
-                                <div>{$category->description}</div>
+                                {$category->description}
                             {/if}
                             </div>
                         {/if}
                      
-                     </div>
                   {/if}
             </div>
 		{/if}

--- a/themes/default-bootstrap/css/category.css
+++ b/themes/default-bootstrap/css/category.css
@@ -17,9 +17,10 @@
   }
 }
 .content_scene_cat h1.category-name {
+	background: #464646;
   font: 600 42px/51px "Open Sans", sans-serif;
   color: white;
-  margin-bottom: 12px;
+  padding-left: 10px;
 }
 @media (max-width: 1199px) {
   .content_scene_cat h1.category-name {
@@ -39,13 +40,14 @@
 .content_scene_cat .content_scene {
   color: #777777;
 }
-.content_scene_cat .content_scene .cat_desc {
-  padding-top: 20px;
+.content_scene_cat .cat_desc {
+  padding: 5px;
+  background: #464646;
 }
-.content_scene_cat .content_scene .cat_desc a {
+.content_scene_cat .cat_desc a {
   color: #777777;
 }
-.content_scene_cat .content_scene .cat_desc a:hover {
+.content_scene_cat .cat_desc a:hover {
   color: #515151;
 }
 

--- a/themes/default-bootstrap/css/category.css
+++ b/themes/default-bootstrap/css/category.css
@@ -6,10 +6,10 @@
   color: #d7d7d7;
   line-height: 19px;
   margin-bottom: 26px;
+	background-color: #464646 !important;
 }
 .content_scene_cat .content_scene_cat_bg {
   padding: 18px 10px 10px 42px;
-  background-color: #464646 !important;
 }
 @media (max-width: 1199px) {
   .content_scene_cat .content_scene_cat_bg {
@@ -17,7 +17,6 @@
   }
 }
 .content_scene_cat h1.category-name {
-	background: #464646;
   font: 600 42px/51px "Open Sans", sans-serif;
   color: white;
   padding-left: 10px;
@@ -42,7 +41,6 @@
 }
 .content_scene_cat .cat_desc {
   padding: 5px;
-  background: #464646;
 }
 .content_scene_cat .cat_desc a {
   color: #777777;


### PR DESCRIPTION
Centered category image
Placed text above and bellow image.

![screenshot from 2013-11-26 15 04 15](https://f.cloud.github.com/assets/4573767/1622538/87b88a66-56a7-11e3-80fa-20d1e200af86.png)
![screenshot from 2013-11-26 15 05 08](https://f.cloud.github.com/assets/4573767/1622539/87ee8684-56a7-11e3-9f6e-ffe5baa2876b.png)

I think this is better. Before the text overlapped the image, and image was aligned to left.
