### PR TITLE
Needs to be a non followed url

### DIFF
--- a/themes/default-bootstrap/order-carrier.tpl
+++ b/themes/default-bootstrap/order-carrier.tpl
@@ -266,7 +266,7 @@
 	<p class="carrier_title">{l s='Terms of service'}</p>
 	<p class="checkbox">
 		<input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} autocomplete="off"/>
-		<label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label> <a href="{$link_conditions}" class="iframe">{l s='(Read the Terms of Service)'}</a>
+		<label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label> <a href="{$link_conditions}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
 	</p>
 	<script type="text/javascript">
 		$(document).ready(function() {


### PR DESCRIPTION
Is an ajax type link, needs to be no followed for duplicate content reasons.
