### PR TITLE
[*]MO: Blockcategories changed title to use name

### DIFF
--- a/modules/blockcategories/category-tree-branch.tpl
+++ b/modules/blockcategories/category-tree-branch.tpl
@@ -25,7 +25,7 @@
 
 <li class="category_{$node.id}{if isset($last) && $last == 'true'} last{/if}">
 	<a href="{$node.link|escape:'html':'UTF-8'}" {if isset($currentCategoryId) && $node.id == $currentCategoryId}class="selected"{/if}
-		title="{$node.desc|strip_tags|trim|escape:'html':'UTF-8'}">{$node.name|escape:'html':'UTF-8'}</a>
+		title="{$node.name|escape:'html':'UTF-8'}">{$node.name|escape:'html':'UTF-8'}</a>
 	{if $node.children|@count > 0}
 		<ul>
 		{foreach from=$node.children item=child name=categoryTreeBranch}


### PR DESCRIPTION
Changed the title tag to use the name of the link not the description. Using the description will get sites with a lot of content keyword stuffing penalties. See screenshot http://screencast.com/t/SXY93Ax7Sm
