### PR TITLE
[-] PDF : Save file when display is off in PDFGenerator.php

### DIFF
--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -165,7 +165,7 @@ class PDFGeneratorCore extends TCPDF
 		if ($display === true)
 			$output = 'D';
 		elseif ($display === false)
-			$output = 'S';
+			$output = 'F';
 		elseif ($display == 'D')
 			$output = 'D';
 		elseif ($display == 'S')


### PR DESCRIPTION
Change S to F when $display is false. Else, the F option is not settable.
Documentation:
S: return the document as a string (name is ignored).
F: save to a local server file with the name given by name.

Other solution is add : 
elseif ($display == 'F')
    $output = 'F';
