### PR TITLE
[-] Fix multilingual field bad value retrieval

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2828,14 +2828,18 @@ class AdminControllerCore extends Controller
 			}
 
 		/* Multilingual fields */
-		$rules = call_user_func(array(get_class($object), 'getValidationRules'), get_class($object));
-		if (count($rules['validateLang']))
-		{
-			$languages = Language::getLanguages(false);
-			foreach ($languages as $language)
-				foreach (array_keys($rules['validateLang']) as $field)
-					if (isset($_POST[$field.'_'.(int)$language['id_lang']]))
+		$languages = Language::getLanguages(false);
+		$class = get_class($object);
+		$fields = $class::$definition['fields'];
+
+		foreach ($fields as $field => $params) {
+			if (array_key_exists('lang', $params) && $params['lang']) {
+				foreach ($languages as $language) {
+					if (isset($_POST[$field.'_'.(int)$language['id_lang']])) {
 						$object->{$field}[(int)$language['id_lang']] = $_POST[$field.'_'.(int)$language['id_lang']];
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
The original way of finding multilingual fields in objects (`ObjectModel` child classes) only worked for fields defined with a `validate` field. This means that when writing this :

``` php
public static $definition = array(
    'multilang' => true,

    'fields' => array(
        'myfield' => array(
            'type' => ObjectModel::TYPE_STRING,
            'required' => true
        ),
        'mylangfield' => array(
            'type' => ObjectModel::TYPE_STRING,
            'required' => true,
            'lang' => true
        )
    )
);
```

...`mylangfield` wasn't found, which means no update of the field in the database upon `update` for example. In order to make it work, you had to add a `validate` key to the field's definition array, and if you had no particular validation rule to apply to the field, you just ended up setting `isAnything` as a value. Not really useful.

The way I changed it into directly checks the class's `$definition` static variable to find multilingual fields, regardless of the fact they need to be validated or not, just to trigger the value retrieval, and therefore eliminates the need for said `validate` key.

PS : I didn't specify a "category" in my commit message as this issue is directly core-related (neither front-office-, back-office- nor module- specifically related).

PPS : This is a repost of https://github.com/PrestaShop/PrestaShop/pull/1052 on the `bootstrap` branch, as requested. FMI, am I supposed to direct future PRs to this branch as well ?
