### PR TITLE
Update FrontController.php

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -855,7 +855,7 @@ class FrontControllerCore extends Controller
 		elseif (!$this->context)
 			$this->context = Context::getContext();
 
-		$nArray = (int)Configuration::get('PS_PRODUCTS_PER_PAGE') != 10 ? array((int)Configuration::get('PS_PRODUCTS_PER_PAGE'), 10, 20, 50) : array(10, 20, 50);
+		$nArray = (int)Configuration::get('PS_PRODUCTS_PER_PAGE') != 10 ? array((int)Configuration::get('PS_PRODUCTS_PER_PAGE'), (int)Configuration::get('PS_PRODUCTS_PER_PAGE')*2, (int)Configuration::get('PS_PRODUCTS_PER_PAGE')*4) : array(10, 20, 50);
 		// Clean duplicate values
 		$nArray = array_unique($nArray);
 		asort($nArray);


### PR DESCRIPTION
Fixed the relation of Display products per page number when its modified on back office preferences>products>pagination: "Products displayed per page".

If you have 3 columns of products and 15 products per page, and you check the display list with 20 or 50 products, always we have a blank space at the end of the product list and you get the feeling of the list is finished. It's more easy get the var number and multiply with x pages, my recomendation 2, and 4, and then if you have and impar or par option you always have the list correctly filled
