### PR TITLE
[*] BO : Option to always rewrite friendly url of product

### DIFF
--- a/admin-dev/themes/default/template/controllers/products/informations.tpl
+++ b/admin-dev/themes/default/template/controllers/products/informations.tpl
@@ -32,6 +32,11 @@
 	<input type="hidden" name="submitted_tabs[]" value="Informations" />
 	<h3 class="tab">{l s='Information'}</h3>
 	<script type="text/javascript">
+		{if isset($ps_force_friendly_product) && $ps_force_friendly_product}
+			var ps_force_friendly_product = 1;
+		{else}
+			var ps_force_friendly_product = 0;
+		{/if}
 		{if isset($PS_ALLOW_ACCENTED_CHARS_URL) && $PS_ALLOW_ACCENTED_CHARS_URL}
 			var PS_ALLOW_ACCENTED_CHARS_URL = 1;
 		{else}
@@ -131,7 +136,7 @@
 		<div class="col-lg-5">
 			{include file="controllers/products/input_text_lang.tpl"
 				languages=$languages
-				input_class="{$class_input_ajax}{if !$product->id}copy2friendlyUrl{/if} updateCurrentText"
+				input_class="{$class_input_ajax}{if !$product->id || Configuration::get('PS_FORCE_FRIENDLY_PRODUCT')}copy2friendlyUrl{/if} updateCurrentText"
 				input_value=$product->name
 				input_name="name"
 			}

--- a/controllers/admin/AdminPPreferencesController.php
+++ b/controllers/admin/AdminPPreferencesController.php
@@ -93,6 +93,14 @@ class AdminPPreferencesControllerCore extends AdminController
 							0 => $this->l('Products:'),
 							1 => $this->l('Combinations')
 						)
+					),
+					'PS_FORCE_FRIENDLY_PRODUCT' => array(
+						'title' => $this->l('Force update of friendly url'),
+						'hint' => $this->l('When active, friendly url will be updated on every save'),
+						'validation' => 'isBool',
+						'cast' => 'intval',
+						'required' => false,
+						'type' => 'bool'
 					)
 				),
 			),

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2577,6 +2577,8 @@ class AdminProductsControllerCore extends AdminController
 		$this->tpl_form_vars['post_data'] = Tools::jsonEncode($_POST);
 		$this->tpl_form_vars['save_error'] = !empty($this->errors);
 
+		$this->tpl_form_vars['ps_force_friendly_product'] = Configuration::get('PS_FORCE_FRIENDLY_PRODUCT');
+
 		// autoload rich text editor (tiny mce)
 		$this->tpl_form_vars['tinymce'] = true;
 		$iso = $this->context->language->iso_code;
@@ -3576,7 +3578,7 @@ class AdminProductsControllerCore extends AdminController
 			$product->$prop = $this->getFieldValue($product, $prop);
 
 		$product->name['class'] = 'updateCurrentText';
-		if (!$product->id)
+		if (!$product->id || Configuration::get('PS_FORCE_FRIENDLY_PRODUCT'))
 			$product->name['class'] .= ' copy2friendlyUrl';
 
 		$images = Image::getImages($this->context->language->id, $product->id);

--- a/js/admin.js
+++ b/js/admin.js
@@ -136,7 +136,7 @@ function copy2friendlyURL()
 	if (typeof(id_product) == 'undefined')
 		id_product = false;
 	
-	if (!$('#link_rewrite_' + id_language).val().length || !id_product)//check if user didn't type anything in rewrite field, to prevent overwriting
+	if (ps_force_friendly_product || !$('#link_rewrite_' + id_language).val().length || !id_product)//check if user didn't type anything in rewrite field, to prevent overwriting
 	{
 		$('#link_rewrite_' + id_language).val(str2url($('#name_' + id_language).val().replace(/^[0-9]+\./, ''), 'UTF-8').replace('%', ''));
 		if ($('#friendly-url'))


### PR DESCRIPTION
friendly url of the product will auto change every time name is changed.
Tested on multi language product.
Very useful for lazy ppl like my boss ;p

JavaScript and I have a mutual hate relationship, so if there is unnecessary code, or a better way to do this, let me know. This is how I finally got it working.
