### PR TITLE
[-] BO : hitting enter to filter BO lists in Chrome 31+

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -346,6 +346,7 @@ function formSubmit(e, button)
 	key = window.event ? window.event.keyCode : e.which;
 	if (key == 13)
 	{
+		e.preventDefault();
 		getE(button).focus();
 		getE(button).click();
 	}


### PR DESCRIPTION
Since the Chrome update v31, shop owners using Chrome can't use the automatic filtering of helperLists by hitting Enter.
Typical example: The user wants to filter products by name on the products BO page. He writes a product name at the top of the name column in the dedicated field and hits Enter. The form does submit and the page reloads but shows "page 2/1" and no product.
Cause: when the user hits Enter, the formSubmit function in admin.js simulate a click on the Filter button but does not prevent the action of the actual keypress. In former versions of Chrome and in other browsers, this wouldn't cause a bug as the filter button would submit its form before any other action would be considered. It doesn't seem to be the case in the recent Chrome update.
Solution: prevent the keypress action if the key pressed is Enter (while still clicking the Filter button). Quick fix allowing the regular behaviour to return.
