### PR TITLE
[*] LO : Corrected units for weight/volume/distance

### DIFF
--- a/localization/gb.xml
+++ b/localization/gb.xml
@@ -74,10 +74,10 @@
 		</taxRulesGroup>
 	</taxes>
 	<units>
-		<unit type="weight" value="lb"/>
-		<unit type="volume" value="gal"/>
-		<unit type="short_distance" value="in"/>
-		<unit type="base_distance" value="ft"/>
+		<unit type="weight" value="Kg"/>
+		<unit type="volume" value="L"/>
+		<unit type="short_distance" value="cm"/>
+		<unit type="base_distance" value="m"/>
 		<unit type="long_distance" value="mi"/>
 	</units>
 </localizationPack>


### PR DESCRIPTION
UK uses Metric for weight, volume and short distances but uses Imperial  for long distances (i.e. Miles). Yes, it's a strange system here in the UK!
// I will add counties (states) with correct ISO codes when I get chance.
