### PR TITLE
[-] Installer : Fix require error on case sensitive file systems

### DIFF
--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -346,7 +346,7 @@ if (empty($fail_result))
 					if (strpos($phpString, '::') === false)
 					{
 						$func_name = str_replace($pattern[0], '', $php[0]);
-						require_once(_PS_INSTALLER_PHP_UPGRADE_DIR_.$func_name.'.php');
+						require_once(_PS_INSTALLER_PHP_UPGRADE_DIR_.strtolower($func_name).'.php');
 						$phpRes = call_user_func_array($func_name, $parameters);
 					}
 					/* Or an object method */


### PR DESCRIPTION
On case sensitive file systems, the `require_once` call will fail because functions names are camel cased but filenames in `install/upgrade/php/` are in lower case.

This patch avoid errors like this one:
`Warning: require_once(/var/www/example.com/install/upgrade/php/setAllGroupsOnHomeCategory.php) [function.require-once]: failed to open stream: No such file or directory in /var/www/example.com/install/upgrade/upgrade.php on line 349`
