### PR TITLE
[-] Project : Fix newline trim

### DIFF
--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -379,7 +379,7 @@ class AddressFormatCore extends ObjectModel
 					$addressText .= (!empty($tmpText)) ? $tmpText.$newLine: '';
 				}
 
-		$addressText = rtrim($addressText, $newLine);
+		$addressText = preg_replace('/'.preg_quote($newLine,'/').'$/i', '', $addressText);
 		$addressText = rtrim($addressText, $separator);
 
 		return $addressText;


### PR DESCRIPTION
When used with `<br />` format it now allows for `b` and `r` chars at the end of last line. I think `rtrim` is not suitable when used with a word rather than a charlist.
