### PR TITLE
[*] FO: More visible confirmations and errors in blocknewsletter

### DIFF
--- a/themes/default-bootstrap/modules/blocknewsletter/blocknewsletter.tpl
+++ b/themes/default-bootstrap/modules/blocknewsletter/blocknewsletter.tpl
@@ -26,19 +26,19 @@
 <!-- Block Newsletter module-->
 
 <div id="newsletter_block_left" class="block">
-	<h4>{l s='Newsletter' mod='blocknewsletter'}</h4>
-	<div class="block_content">
-		<form action="{$link->getPageLink('index')|escape:'html'}" method="post">
-			<div class="form-group">
-				<input class="inputNew form-control grey" id="newsletter-input" type="text" name="email" size="18" value="{if isset($value) && $value}{$value}{else}{l s='Enter your e-mail' mod='blocknewsletter'}{/if}" />
+    <h4>{l s='Newsletter' mod='blocknewsletter'}</h4>
+    <div class="block_content">
+        <form action="{$link->getPageLink('index')|escape:'html'}" method="post">
+            <div class="form-group">
+                <input class="inputNew form-control grey" id="newsletter-input" type="text" name="email" size="18" value="{if isset($value) && $value}{$value}{else}{l s='Enter your e-mail' mod='blocknewsletter'}{/if}" />
                 <button type="submit" name="submitNewsletter" class="btn btn-default button button-small"><span>{l s='Ok' mod='blocknewsletter'}</span></button>
-				<input type="hidden" name="action" value="0" />
-			</div>
-		</form>
+                <input type="hidden" name="action" value="0" />
+            </div>
+        </form>
         {if isset($msg) && $msg}
             <div class="{if $nw_error}warning_inline{else}success_inline{/if}">{$msg}</div>
         {/if}
-	</div>
+    </div>
 </div>
 <!-- /Block Newsletter module-->
 
@@ -60,6 +60,7 @@
 
             {if isset($msg)}
                 $('#columns > .row').before('<div class="clearfix"></div><p class="alert {if $nw_error}alert-danger{else}alert-success{/if}">{l s="Newsletter:" js=1 mod="blocknewsletter"} {$msg}</p>');
+                $('html,body').animate({ldelim}scrollTop: $('#columns > .row').offset().top{rdelim},'slow');
             {/if}
         });
 </script>


### PR DESCRIPTION
Now we didn't see any errors and confirmations on first look at the page, with those modifications whole site is animated to the .error or .success container.

Any other changes are only different identations caused by SublimeText
