### PR TITLE
filesize returns negavite int for realy large files

### DIFF
--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -276,7 +276,7 @@ class GetFileControllerCore extends FrontController
 		/* Set headers for download */
 		header('Content-Transfer-Encoding: binary');
 		header('Content-Type: '.$mimeType);
-		header('Content-Length: '.filesize($file));
+		header('Content-Length: '.sprintf('%u', filesize($file)));
 		header('Content-Disposition: attachment; filename="'.$filename.'"');
 		$fp = fopen($file, 'rb');
 		while (!feof($fp))


### PR DESCRIPTION
this will cast to unsigned int that will allow to display correct file size up about 4 gigabytes
