### PR TITLE
// take smarty config options into account even in Back-Office

### DIFF
--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -28,9 +28,8 @@ global $smarty;
 $smarty->debugging = false;
 $smarty->debugging_ctrl = 'NONE';
 
-/* Smarty should be in compile check mode in the BackOffice */
-$smarty->force_compile = false;
-$smarty->compile_check = true;
+$smarty->force_compile = (Configuration::get('PS_SMARTY_FORCE_COMPILE') == _PS_SMARTY_FORCE_COMPILE_) ? true : false;
+$smarty->compile_check = (Configuration::get('PS_SMARTY_FORCE_COMPILE') >= _PS_SMARTY_CHECK_COMPILE_) ? true : false;
 
 function smartyTranslate($params, &$smarty)
 {


### PR DESCRIPTION
The compile check mode is not working for me, so when developing I always set force_compile to true. Problem is: this setting was ignored by PrestaShop in the Back-Office. There's no point in forcing a choice here since if a merchant sets his production store to force_compile then a slow Back-Office is the least of their problems.
