### PR TITLE
[*] FO: now you can download files >1G without running into max executio...

### DIFF
--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -279,7 +279,7 @@ class GetFileControllerCore extends FrontController
 		header('Content-Length: '.filesize($file));
 		header('Content-Disposition: attachment; filename="'.$filename.'"');
 		//prevents max execution timeout, when reading large files
-		set_time_limit(0);
+		@set_time_limit(0);
 		$fp = fopen($file, 'rb');
 		while (!feof($fp))
 			echo fgets($fp, 16384);

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -278,6 +278,8 @@ class GetFileControllerCore extends FrontController
 		header('Content-Type: '.$mimeType);
 		header('Content-Length: '.filesize($file));
 		header('Content-Disposition: attachment; filename="'.$filename.'"');
+		//prevents max execution timeout, when reading large files
+		set_time_limit(0);
 		$fp = fopen($file, 'rb');
 		while (!feof($fp))
 			echo fgets($fp, 16384);


### PR DESCRIPTION
...n limitation

when reading large files ( >1G ), you often get max execution timeout error, this fix will prevent this.
