### PR TITLE
[-] FO : Fix versatile jQuery selector

### DIFF
--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -730,7 +730,7 @@ function checkUrl()
 						$('#color_' + attributesCombinations[a]['id_attribute']).addClass('selected');
 						$('#color_' + attributesCombinations[a]['id_attribute']).parent().addClass('selected');
 						$('input:radio[value=' + attributesCombinations[a]['id_attribute'] + ']').attr('checked', true);
-						$('input:hidden[name=group_' + attributesCombinations[a]['id_attribute_group'] + ']').val(attributesCombinations[a]['id_attribute']);
+						$('input[type=hidden][name=group_' + attributesCombinations[a]['id_attribute_group'] + ']').val(attributesCombinations[a]['id_attribute']);
 						$('select[name=group_' + attributesCombinations[a]['id_attribute_group'] + ']').val(attributesCombinations[a]['id_attribute']);
 					}
 			// find combination


### PR DESCRIPTION
`:hidden` selects form elements with `type="hidden"` but also : elements with `display:none`, elements with their width/height equal to zero and which the ancestor element is hidden.
`input[type=hidden]` is more appropriate for those reasons.
