### PR TITLE
[FO] "Combination unavailable" and hide "add to cart" button in mobile theme

### DIFF
--- a/themes/default/mobile/js/product.js
+++ b/themes/default/mobile/js/product.js
@@ -439,7 +439,7 @@ var ProductDisplay = (function()
 				$('#availability_value').text(ProductFn.doesntExistNoMore + (ProductFn.globalQuantity > 0 ? ' ' + ProductFn.doesntExistNoMoreBut : '')).addClass('warning_inline');
 			else
 			{
-				$('#availability_value').text(doesntExist).addClass('warning_inline');
+				$('#availability_value').text(ProductFn.doesntExist).addClass('warning_inline');
 				$('#oosHook').hide();
 			}
 			$('#availability_statut:hidden').show();


### PR DESCRIPTION
When an unavailable product combination was selected in the default mobile theme, the JS console reveals an unhandled exception (where the script incorrectly refers to ProductFn.doesntExist as just doesntExist (line 442 in product.js)). This halted the JS execution, preventing the message from being shown, and prevented the "add to cart" button from being correctly hidden.
