### PR TITLE
[-] BO : fixed bug loading wrong root category in AdminCategoriesController

### DIFF
--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -105,7 +105,7 @@ class AdminCategoriesControllerCore extends AdminController
 			$this->_category = new Category($id_category);
 		else
 		{
-			if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP)
+			if (Shop::getContext() == Shop::CONTEXT_SHOP)
 				$this->_category = new Category($this->context->shop->id_category);
 			elseif (count(Category::getCategoriesWithoutParent()) > 1 && Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && count(Shop::getShops(true, null, true)) != 1)
 				$this->_category = Category::getTopCategory();


### PR DESCRIPTION
Fix wrong root category being loaded.
There's an issue if you activate multishop and create a new root category which loads the wrong category and causes, at least, 'Add new Category' and 'Export' in AdminCategories to redirect back to the category list (e.g. impossible to add/remove categories).
