### PR TITLE
Make IMAP option "Create new threads"  work

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -814,24 +814,43 @@ class AdminCustomerThreadsControllerCore extends AdminController
 				 	//check if subject has id_order
 				 	preg_match('/\#ct([0-9]*)/', $subject, $matches1);
 				 	preg_match('/\#tc([0-9-a-z-A-Z]*)/', $subject, $matches2);
-					$new_ct = (Configuration::get('PS_SAV_IMAP_CREATE_THREADS') && !isset($matches1[1]) && !isset($matches2[1]) && !preg_match('/[no_sync]/', $subject));
-					if (isset($matches1[1]) && isset($matches2[1]) || $new_ct)
+					
+					$matchFound = false;
+					if (isset($matches1[1]) && isset($matches2[1]))
+						$matchFound = true;
+					
+					$new_ct = ( Configuration::get('PS_SAV_IMAP_CREATE_THREADS') && !$matchFound && (strpos($subject, '[no_sync]') == false));				
+					
+					if ( $matchFound || $new_ct)
 					{
 						if ($new_ct)
 						{
-							if (!preg_match('/<('.Tools::cleanNonUnicodeSupport('[a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+[._a-z\p{L}0-9-]*\.[a-z0-9]+').')>/', $overview->from, $result)
-								|| !Validate::isEmail($from = $result[1]))
-									continue;
-							
-							$contacts = Contact::getCategoriesContacts();
+							if (!preg_match('/<('.Tools::cleanNonUnicodeSupport('[a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+[._a-z\p{L}0-9-]*\.[a-z0-9]+').')>/', $overview->from, $result)|| !Validate::isEmail($from = $result[1]))
+								continue;
+									
+							$contacts = Contact::getContacts($this->context->language->id);
 							if (!$contacts)
 								continue;
-							$id_contact = $contacts[0]['id_contact'];
+								
+							foreach ($contacts as $contact) {
+								if (strpos($overview->to , $contact['email']) !== false)
+									$id_contact = $contact['id_contact'];
+							}
 							
+							if (!isset($id_contact))							
+								$id_contact = $contacts[0]['id_contact'];
+								
+							$customer = new Customer;
+								
+							$client = $customer->getByEmail($from);
+
 							$ct = new CustomerThread();
+							if (isset($client->id))
+								$ct->id_customer = $client->id;
 							$ct->email = $from;
 							$ct->id_contact = $id_contact;
 							$ct->id_lang = (int)Configuration::get('PS_LANG_DEFAULT');
+							$ct->id_shop = $this->context->shop->id;
 							$ct->status = 'open';
 							$ct->token = Tools::passwdGen(12);
 							$ct->add();	
@@ -841,9 +860,14 @@ class AdminCustomerThreadsControllerCore extends AdminController
 
 						if (Validate::isLoadedObject($ct) && ((isset($matches2[1]) && $ct->token == $matches2[1]) || $new_ct))
 						{
+							$message = imap_fetchbody($mbox, $overview->msgno, 1);
+							$message = quoted_printable_decode($message);
+							$message = utf8_encode($message);
+							$message = quoted_printable_decode($message);
+							$message = nl2br($message);
 							$cm = new CustomerMessage();
 							$cm->id_customer_thread = $ct->id;
-							$cm->message = imap_fetchbody($mbox, $overview->msgno, 1);
+							$cm->message = $message;
 							$cm->add();
 						}
 					}


### PR DESCRIPTION
"Create new threads" (Create new threads for unrecognized emails )

When you check that option the PS_SAV_IMAP_CREATE_THREADS variable is correctly set, and indeed messages are really scanned and imported and customer threads created in database for "unrecognized mails" but they never show on BO because the shop_id is 0 for those ct and some other bug inside the controller

This patch does 3 things:
1) show in backoffice message sent to customer service even if directly sent by mail without using the contact page

Than I added 2 new functionalities to that:

2) it is now able to insert the message in the right customer thread "category" (if you have more than one like support or suggestions etc..) depending on the mail the message is directed to.

3) it is now able to detect if the mail sending the message is owned by one of the registered customer and assign it to him showing customer details correctly (like customer name)
