### PR TITLE
[*] BO : performance improvement on AdminInvoices loading time

### DIFF
--- a/controllers/admin/AdminInvoicesController.php
+++ b/controllers/admin/AdminInvoicesController.php
@@ -159,16 +159,12 @@ class AdminInvoicesControllerCore extends AdminController
 		);
 
 		$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-			SELECT COUNT(o.id_order) as nbOrders, (
-				SELECT oh.id_order_state
-				FROM '._DB_PREFIX_.'order_history oh
-				WHERE oh.id_order = oi.id_order
-				ORDER BY oh.date_add DESC, oh.id_order_history DESC
-				LIMIT 1
-			) id_order_state
-			FROM '._DB_PREFIX_.'order_invoice oi
-			LEFT JOIN '._DB_PREFIX_.'orders o ON (oi.id_order = o.id_order)
-			WHERE o.id_shop IN('.implode(', ', Shop::getContextListShopID()).')
+			SELECT COUNT( o.id_order ) AS nbOrders, oh.id_order_state 
+			FROM ps_order_invoice oi 
+			LEFT JOIN ps_orders o ON  oi.id_order = o.id_order 
+			JOIN ps_order_history oh ON oh.id_order = o.id_order 
+			LEFT OUTER JOIN ps_order_history oh2 ON oh2.id_order = oh.id_order AND oh2.id_order_history > oh.id_order_history 
+			WHERE o.id_shop IN('.implode(', ', Shop::getContextListShopID()).') AND ISNULL(oh2.id_order_state) 
 			GROUP BY id_order_state
 		');
 

--- a/controllers/admin/AdminInvoicesController.php
+++ b/controllers/admin/AdminInvoicesController.php
@@ -160,10 +160,10 @@ class AdminInvoicesControllerCore extends AdminController
 
 		$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 			SELECT COUNT( o.id_order ) AS nbOrders, oh.id_order_state 
-			FROM ps_order_invoice oi 
-			LEFT JOIN ps_orders o ON  oi.id_order = o.id_order 
-			JOIN ps_order_history oh ON oh.id_order = o.id_order 
-			LEFT OUTER JOIN ps_order_history oh2 ON oh2.id_order = oh.id_order AND oh2.id_order_history > oh.id_order_history 
+			FROM '._DB_PREFIX_.'order_invoice oi 
+			LEFT JOIN '._DB_PREFIX_.'orders o ON  oi.id_order = o.id_order 
+			JOIN '._DB_PREFIX_.'order_history oh ON oh.id_order = o.id_order 
+			LEFT OUTER JOIN '._DB_PREFIX_.'order_history oh2 ON oh2.id_order = oh.id_order AND oh2.id_order_history > oh.id_order_history 
 			WHERE o.id_shop IN('.implode(', ', Shop::getContextListShopID()).') AND ISNULL(oh2.id_order_state) 
 			GROUP BY id_order_state
 		');


### PR DESCRIPTION
On a shop with lots of orders, this page takes forever to load. Why ? Because this request is really slow, just to show "how many orders are with this status".

Datas :
On a shop (1.5.6.0) with 150 000 orders
Request used to take up to ~50s
Time cut down to 5s for the same results on the same page after optimization
