### PR TITLE
[-] FO : OrderConfirmationController is not kept on https

### DIFF
--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -27,6 +27,7 @@
 class OrderConfirmationControllerCore extends FrontController
 {
 	public $php_self = 'order-confirmation';
+        public $ssl = true;
 
 	public $id_cart;
 	public $id_module;


### PR DESCRIPTION
[-] FO : OrderConfirmationController is not kept on https when the platform is set up to handle the order checkout process on https. Now, also the order confirmation page is on https if needed.
