### PR TITLE
[-] WS : Fix bug #PSCFV-11328 : Don't insert attribute image(s) id if no...

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -206,15 +206,18 @@ class CombinationCore extends ObjectModel
 			WHERE `id_product_attribute` = '.(int)$this->id) === false)
 		return false;
 
-		$sql_values = array();
+		if (!empty($ids_image))
+		{
+			$sql_values = array();
 
-		foreach ($ids_image as $value)
-			$sql_values[] = '('.(int)$this->id.', '.(int)$value.')';
+			foreach ($ids_image as $value)
+				$sql_values[] = '('.(int)$this->id.', '.(int)$value.')';
 
-		Db::getInstance()->execute('
-			INSERT INTO `'._DB_PREFIX_.'product_attribute_image` (`id_product_attribute`, `id_image`)
-			VALUES '.implode(',', $sql_values)
-		);
+			Db::getInstance()->execute('
+				INSERT INTO `'._DB_PREFIX_.'product_attribute_image` (`id_product_attribute`, `id_image`)
+				VALUES '.implode(',', $sql_values)
+			);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
... id to insert

There was an issue with the webservice where inserting an empty <images node_type="image"></images> tag would result in an error 500 when it was not needed.
