### PR TITLE
[-] FO : OrderConfirmationController is not kept on https

### DIFF
--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -26,6 +26,7 @@
 
 class OrderConfirmationControllerCore extends FrontController
 {
+	public $ssl = true;
 	public $php_self = 'order-confirmation';
 
 	public $id_cart;


### PR DESCRIPTION
[-] FO : OrderConfirmationController is not kept on https when the platform is set up to handle the order checkout process on https. Now, also the order confirmation page is on https if needed.
