### PR TITLE
[*] BO : improvement of multiple sql queries using order current states

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -408,13 +408,8 @@ class CartRuleCore extends ObjectModel
 			LEFT JOIN '._DB_PREFIX_.'order_cart_rule od ON o.id_order = od.id_order
 			WHERE o.id_customer = '.$context->cart->id_customer.'
 			AND od.id_cart_rule = '.(int)$this->id.'
-			AND '.(int)Configuration::get('PS_OS_ERROR').' != (
-				SELECT oh.id_order_state
-				FROM '._DB_PREFIX_.'order_history oh
-				WHERE oh.id_order = o.id_order
-				ORDER BY oh.date_add DESC
-				LIMIT 1
-			)');
+			AND '.(int)Configuration::get('PS_OS_ERROR').' != o.current_state
+			');
 			if ($quantityUsed + 1 > $this->quantity_per_user)
 				return (!$display_error) ? false : Tools::displayError('You cannot use this voucher anymore (usage limit reached)');
 		}

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -460,14 +460,8 @@ class OrderInvoiceCore extends ObjectModel
 			SELECT oi.*
 			FROM `'._DB_PREFIX_.'order_invoice` oi
 			LEFT JOIN `'._DB_PREFIX_.'orders` o ON (o.`id_order` = oi.`id_order`)
-			WHERE '.(int)$id_order_state.' = (
-				SELECT id_order_state
-				FROM '._DB_PREFIX_.'order_history oh
-				WHERE oh.id_order = o.id_order
-				ORDER BY date_add DESC, id_order_history DESC
-				LIMIT 1
-			)
-			'.Shop::addSqlRestriction(Shop::SHARE_ORDER, 'o').'
+			WHERE '.(int)$id_order_state.' = o.current_state 
+			'.Shop::addSqlRestriction(Shop::SHARE_ORDER, 'o').' 
 			ORDER BY oi.`date_add` ASC
 		');
 

--- a/controllers/admin/AdminInvoicesController.php
+++ b/controllers/admin/AdminInvoicesController.php
@@ -161,14 +161,12 @@ class AdminInvoicesControllerCore extends AdminController
 		);
 
 		$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-			SELECT COUNT( o.id_order ) AS nbOrders, oh.id_order_state 
-			FROM '._DB_PREFIX_ .'order_invoice oi 
-			LEFT JOIN '._DB_PREFIX_ .'orders o ON  oi.id_order = o.id_order 
-			JOIN '._DB_PREFIX_ .'order_history oh ON oh.id_order = o.id_order 
-			LEFT OUTER JOIN '._DB_PREFIX_ .'order_history oh2 ON oh2.id_order = oh.id_order AND oh2.id_order_history > oh.id_order_history 
-			WHERE o.id_shop IN('.implode(', ', Shop::getContextListShopID()).')	AND ISNULL(oh2.id_order_state) 
-			GROUP BY id_order_state
-		');
+			SELECT COUNT( o.id_order ) AS nbOrders, o.current_state as id_order_state
+			FROM `'._DB_PREFIX_.'order_invoice` oi
+			LEFT JOIN `'._DB_PREFIX_.'orders` o ON  oi.id_order = o.id_order 
+			WHERE o.id_shop IN('.implode(', ', Shop::getContextListShopID()).')
+			GROUP BY o.current_state
+		 ');
 
 		$status_stats = array();
 		foreach ($result as $row)


### PR DESCRIPTION
Since 1.5.x, there is this field : order => current_state.

But it's not really used in some request. With 140 000 orders and 278 000 order states, it takes a lot of time to process (~1mn to display one page), because for EACH order, it fetches every single state, and sorts it to extract the last one. I guess that's why "current_state" was created, but some 1.4 stuff is still hiding in the source code.

For the AdminInvoicesController, load time was at 5s, and now it's down to 0.5s. (10 times better !).

(I already did an optimization from 50s to 5s a few days ago, but this one is even better !)
