### PR TITLE
[-] MO : fix statslive empty result when using maintenance ips ending with a comma

### DIFF
--- a/modules/statslive/statslive.php
+++ b/modules/statslive/statslive.php
@@ -100,7 +100,7 @@ class StatsLive extends Module
 	private function getVisitorsOnline()
 	{
 		if ($maintenance_ips = Configuration::get('PS_MAINTENANCE_IP'))
-			$maintenance_ips = implode(',', array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))));
+			$maintenance_ips = implode(',', array_map('ip2long', array_filter(array_map('trim', explode(',', $maintenance_ips)))));
 
 		if (Configuration::get('PS_STATSDATA_CUSTOMER_PAGESVIEWS'))
 		{


### PR DESCRIPTION
When adding an IP with the button "add my ip to maintenance ips", it adds a comma in this format : "127.0.0.1,"

But when statslive reads this value, it creates a request like this : [...] NOT IN (2130706433,) [...] which obvisouly returns FALSE because there is a syntax error.

Using "array_filter" after the "trim" will fix this issue by removing "empty" ips. Making live stats working again !
