### PR TITLE
[-] PSCFV-11441 : filter on current shop ID for price index

### DIFF
--- a/modules/blocklayered/blocklayered.php
+++ b/modules/blocklayered/blocklayered.php
@@ -2787,13 +2787,13 @@ class BlockLayered extends Module
 		{
 			$price_filter_query = '
 			INNER JOIN `'._DB_PREFIX_.'layered_price_index` psi ON (psi.id_product = p.id_product AND psi.id_currency = '.(int)$id_currency.'
-			AND psi.price_min <= '.(int)$filter_value[1].' AND psi.price_max >= '.(int)$filter_value[0].') ';
+			AND psi.price_min <= '.(int)$filter_value[1].' AND psi.price_max >= '.(int)$filter_value[0].' AND psi.id_shop='.(int)Context::getContext()->shop->id.') ';
 		}
 		else
 		{
 			$price_filter_query = '
 			INNER JOIN `'._DB_PREFIX_.'layered_price_index` psi 
-			ON (psi.id_product = p.id_product AND psi.id_currency = '.(int)$id_currency.') ';
+			ON (psi.id_product = p.id_product AND psi.id_currency = '.(int)$id_currency.' AND psi.id_shop='.(int)Context::getContext()->shop->id).') ';
 		}
 		
 		return array('join' => $price_filter_query, 'select' => ', psi.price_min, psi.price_max');


### PR DESCRIPTION
Requirements :
- Multishop instance
- Shop with prices and products (and not the one with the id_shop 1)
- Blocklayered with prices slider enabled

Symptom :
- The prices slider is not shown

Analysis :
The blocklayered->getPriceFilterSubQuery() method doesn't not filter on the id_shop, so it retrieves the other shops price indexes (which are null if you have only products on other shops than the first one).
So, the results filtered by getPriceFilterSubQuery() contain min_price/max_price at 0 values => the slider is not shown on the front-office
