### PR TITLE
Update SpecificPrice.php

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -238,7 +238,7 @@ class SpecificPriceCore extends ObjectModel
 				$query .= 'AND `from_quantity` <= '.max(1, $qty_to_use);
 			}
 
-			$query .= ' ORDER BY `id_product_attribute` DESC, `from_quantity` DESC, `id_specific_price_rule` ASC, `score` DESC';
+			$query .= ' ORDER BY `id_product_attribute` DESC, `from_quantity` DESC, `id_specific_price_rule` DESC, `score` DESC';
 			
 			SpecificPrice::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
 				


### PR DESCRIPTION
L'ordre de tri de la requête fait que si deux règles sont applicables en même temps, c'est la plus ancienne qui est appliquée (la première qui a été créé).
Cela me parait illogique, car si on a des règles de prix pour son catalogue et que l'on en fait de nouvelles pour les soldes ce sont les dernières mise en place qui doivent être prises en compte.

L'idéal serai bien sur de pouvoir ordonner les règles
