### PR TITLE
Update AdminSpecificPriceRuleController.php

### DIFF
--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -268,14 +268,14 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
 			),
 		);
 		if (($value = $this->getFieldValue($this->object, 'price')) != -1)	
-			$price = number_format($value, 2);
+			$price = number_format($value, 6);
 		else
 			$price = '';
 
 		$this->fields_value = array(
 										'price' => $price,
 										'from_quantity' => (($value = $this->getFieldValue($this->object, 'from_quantity')) ? $value : 1),
-										'reduction' => number_format((($value = $this->getFieldValue($this->object, 'reduction')) ? $value : 0), 2),
+										'reduction' => number_format((($value = $this->getFieldValue($this->object, 'reduction')) ? $value : 0), 6),
 										'leave_bprice_on' => $price ? 0 : 1
 									);
 


### PR DESCRIPTION
Lors du ré affichage de la page de prix spécifique, le prix est coupé à 2 chiffres après la virgule, si notre ancien prix a plus de 2 chiffres il est tronqué et le prix change
