### PR TITLE
The email addresses update fails if accentuated

### DIFF
--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -856,7 +856,7 @@ class AdminCustomersControllerCore extends AdminController
 				$customer = new Customer();
 				if (Validate::isEmail($customer_email))
 					$customer->getByEmail($customer_email);
-				if ($customer->id)
+				if (($customer->id) && ($customer->id != (int)$this->object->id))
 					$this->errors[] = Tools::displayError('An account already exists for this email address:').' '.$customer_email;
 			}
 


### PR DESCRIPTION
If you try to update an accuentuated email address, it fails, since
MySQL (and the getByEmail method) isn't accentuated
characters-sensitive, but PHP is.

So we need to double-check if the new email address is really different
(and if it is really an already used one)
