### PR TITLE
make use of PS_TAX variable

### DIFF
--- a/modules/bankwire/controllers/front/payment.php
+++ b/modules/bankwire/controllers/front/payment.php
@@ -47,7 +47,7 @@ class BankwirePaymentModuleFrontController extends ModuleFrontController
 			'nbProducts' => $cart->nbProducts(),
 			'cust_currency' => $cart->id_currency,
 			'currencies' => $this->module->getCurrency((int)$cart->id_currency),
-			'total' => $cart->getOrderTotal(true, Cart::BOTH),
+			'total' => ((int)Configuration::get('PS_TAX') == 1 ? $cart->getOrderTotal(true, Cart::BOTH) : $cart->getOrderTotal(false, Cart::BOTH)),
 			'this_path' => $this->module->getPathUri(),
 			'this_path_bw' => $this->module->getPathUri(),
 			'this_path_ssl' => Tools::getShopDomainSsl(true, true).__PS_BASE_URI__.'modules/'.$this->module->name.'/'


### PR DESCRIPTION
Bankwire module does not take into account the value of variable PS_TAX. If you disable taxes, it does continue to display the tax included price in payment confirmation page.
