### PR TITLE
[*] FO : Search for Aliases that contain whitespaces

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -126,16 +126,25 @@ class SearchCore
 
 		if (!$indexation)
 		{
-			$words = explode(' ', $string);
 			$processed_words = array();
-			// search for aliases for each word of the query
-			foreach ($words as $word)
+			
+			// Attempt to find exact match with alias that contains whitespace.
+			$alias = new Alias(null, $string);
+			if (Validate::isLoadedObject($alias))
+				$processed_words[] = $alias->search;
+			else
 			{
-				$alias = new Alias(null, $word);
-				if (Validate::isLoadedObject($alias))
-					$processed_words[] = $alias->search;
-				else
-					$processed_words[] = $word;
+				$words = explode(' ', $string);
+			
+				// search for aliases for each word of the query
+				foreach ($words as $word)
+				{
+					$alias = new Alias(null, $word);
+					if (Validate::isLoadedObject($alias))
+						$processed_words[] = $alias->search;
+					else
+						$processed_words[] = $word;
+				}
 			}
 			$string = implode(' ', $processed_words);
 		}


### PR DESCRIPTION
It is possible to add Aliases that contain whitespace i.e. "Test product" "T product" etc. Now the search expression is first checked for aliases with an exact match including whitespaces. If that fails, it proceeds as before; word-by-word.
