### PR TITLE
[-] BO : pressing enter when filtering on first page won't change to page 2

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -28,7 +28,10 @@
 	<script type="text/javascript">
 		$(document).ready(function() {
 			$('table.{$list_id} .filter').keypress(function(event){
-				formSubmit(event, 'submitFilterButton{$list_id}')
+				if(formSubmit(event, 'submitFilterButton{$list_id}')){
+					event.preventDefault();
+					return false;
+				}
 			})
 		});
 	</script>

--- a/js/admin.js
+++ b/js/admin.js
@@ -348,7 +348,9 @@ function formSubmit(e, button)
 	{
 		getE(button).focus();
 		getE(button).click();
+		return true;
 	}
+	return false;
 }
 function noComma(elem)
 {


### PR DESCRIPTION
Bug : When trying to filter (products, customers, CMS...), if you type your filter then press enter, it redirects you to "page 2", and it seems like you don't have any results.

Fix : Now pressing enter redirects you to the first page (as it should), with your result.

Origin of the error : multiple javascript call and an event that should be "canceled" (the default ENTER event on forms was still fired instead of the "click" event expected on the filter button)

It's not a big bug, but we often had the question "why is there no result while I have this product ID ?", and we finally understand why.
