### PR TITLE
[-] Project : Fixes PSCFV-11593. Added code to load the customer when a non-user calls the Product::getPriceStatic method

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2492,7 +2492,20 @@ class ProductCore extends ObjectModel
 			die(Tools::displayError());
 
 		// Initializations
-		$id_group = (int)Group::getCurrent()->id;
+		/* 
+		* When a non-user calls directly this method (e.g., payment module...) is on PrestaShop, 
+		* the context does not have customer but the customer ID is present so load the customer and assign the customer's default group
+		*/
+
+		if(isset($id_customer) && !Validate::isLoadedObject($context->customer))
+		{
+			$context->customer = new Customer($id_customer);
+            $id_group = (int)$context->customer->id_default_group;
+		}
+		else
+		{
+            $id_group = (int)Group::getCurrent()->id;
+        }
 
 		// If there is cart in context or if the specified id_cart is different from the context cart id
 		if (!is_object($cur_cart) || (Validate::isUnsignedInt($id_cart) && $id_cart && $cur_cart->id != $id_cart))


### PR DESCRIPTION
### The Bug - Product::getPriceStatic returns wrong price when called from Paypal

I have created an issue here : http://forge.prestashop.com/browse/PSCFV-11593
Reproducing from the bug tracker.
#### Steps to reproduce the bug
1. Login to the Administration Panel and go to Price Rules -> Catalog Price Rules.
2. Create a Catalog Price Rule which will offer all the customers (which means this discount is not applied for visitors or Guests) will get a discount of 6.25% (or any amount). (See : CatalogPriceRules.png)
3. Now add any product to the cart, register and login as a customer. Now the shopping cart summary will have the discount applied. (See : ShoppingCartSummary.png)
4. Now make a purchase using paypal.
5. No Order will be created.
#### The Cause

While validating the paypal order, paypal checks the cart total against the mc_gross (the total amount paid at paypal) value posted by paypal. Only when the two totals match an order is created. The static function Cart::getOrderTotal() returns without applying the Catalog price rule (In this case the Cart:getOrderTotal() method returns $66.05 instead of $61.03).
#### The Fix

On investigating further, this is what I found :

Cart::getOrderTotal() calls another static method Product::getPriceStatic(). This Product::getPriceStatic() method uses the group ID to calculate the catalog price rules. The group ID is determined like this in line 2514:

$id_group = (int)Group::getCurrent()->id;

The above line checks for the customer in the context. When Paypal posts the data, $id_group is returned as 1 which is the group of the visitor. Instead it should return the group of the customer ID. Since the group returned is visitor, no discount is applied and hence the difference in the cart totals.
