### PR TITLE
[-] FO: Fix Themeconfigurator's HTML field

### DIFF
--- a/modules/themeconfigurator/themeconfigurator.php
+++ b/modules/themeconfigurator/themeconfigurator.php
@@ -405,7 +405,7 @@ class ThemeConfigurator extends Module
 					image_w = '.(int)$image_w.',
 					image_h = '.(int)$image_h.',
 					active = '.(int)Tools::getValue('item_active').',
-					html = \''.pSQL($content).'\'
+					html = \''.pSQL($content, true).'\'
 			WHERE id_item = '.(int)Tools::getValue('item_id')
 		)
 		)

--- a/modules/themeconfigurator/views/templates/hook/hook.tpl
+++ b/modules/themeconfigurator/views/templates/hook/hook.tpl
@@ -40,7 +40,7 @@
 					{/if}
 					{if $hItem.html}
 						<div class="item-html">
-							{$hItem.html|escape:'htmlall':'UTF-8'} <i class="icon-double-angle-right"></i>
+							{$hItem.html|escape:'UTF-8'} <i class="icon-double-angle-right"></i>
 						</div>
 					{/if}
 				{if $hItem.url}


### PR DESCRIPTION
The field of Themeconfigurator's hook items labeled "HTML" was not stored
as HTML in the backend, as also it was not rendered as HTML
