### PR TITLE
Add multiple fields via $fields_form_override

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1922,7 +1922,7 @@ class AdminControllerCore extends Controller
 
 			// For add a fields via an override of $fields_form, use $fields_form_override
 			if (is_array($this->fields_form_override) && !empty($this->fields_form_override))
-				$this->fields_form[0]['form']['input'][] = $this->fields_form_override;
+				$this->fields_form[0]['form']['input'] = array_merge($this->fields_form[0]['form']['input'], $this->fields_form_override);
 
 			$fields_value = $this->getFieldsValue($this->object);
 


### PR DESCRIPTION
This patch allows multiple fields to be added using the "$fields_form_override" property. Currently, only one field can be added as the array is pushed to the "fields_form" list as a new single field. We have to merge it instead.
