### PR TITLE
[-] FO : Fix bug on invalid gift message

### DIFF
--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -314,8 +314,6 @@ class OrderControllerCore extends ParentOrderController
 			$this->_assignCarrier();
 			$this->step = 2;
 			$this->displayContent();
-			include(_PS_ROOT_DIR_.'/footer.php');
-			exit;
 		}
 		$orderTotal = $this->context->cart->getOrderTotal();
 	}


### PR DESCRIPTION
Bug not found in forge :
While submitting an invalide gift message (including per example "<" character), processCarrier function attempts to include footer.php (which does not exist anymore ?) and then exits script, instead of letting the classic validate system running and showing an error.
