### PR TITLE
[*] BO : Fixed regex typo

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -877,7 +877,7 @@ class AdminTranslationsControllerCore extends AdminController
 
 		foreach ($files as $file)
 		{
-			if (preg_match('/^(.*).(tpl|php)$/', $file) && Tools::file_exists_cache($dir.$file) && !in_array($file, self::$ignore_folder))
+			if (preg_match('/^(.*)\.(tpl|php)$/', $file) && Tools::file_exists_cache($dir.$file) && !in_array($file, self::$ignore_folder))
 			{
 				// Get content for this file
 				$content = file_get_contents($dir.$file);


### PR DESCRIPTION
Noticed a regex typo when reviewing the code. I'm guessing the regex should map (anything)(.)(tpl or php), not (anything)(anything)(tpl or php)
