### PR TITLE
[-] FO : use $left_column_size for left_column

### DIFF
--- a/themes/default-bootstrap/header.tpl
+++ b/themes/default-bootstrap/header.tpl
@@ -105,7 +105,7 @@
 					</div>
 					<div class="row">
 						{if isset($left_column_size) && !empty($left_column_size)}
-						<div id="left_column" class="column col-xs-12 col-sm-3">
+						<div id="left_column" class="column col-xs-12 col-sm-{$left_column_size}">
 							{$HOOK_LEFT_COLUMN}
 						</div>
 						{/if}


### PR DESCRIPTION
A static value was used, where the variable should be used to keep formatting bootstrap columns correct, when $left_column_size is changed. 
