### PR TITLE
[-] Project: use correct phpdoc return type PrestaShopCollection

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -764,7 +764,7 @@ class CategoryCore extends ObjectModel
 	 * Return an array of all children of the current category
 	 *
 	 * @param int $id_lang
-	 * @return Collection
+	 * @return PrestaShopCollection Collection of Category
 	 */
 	public function getAllChildren($id_lang = null)
 	{

--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -117,7 +117,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * @param $association Association name
 	 * @param string $on
 	 * @param int $type
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function join($association, $on = '', $type = null)
 	{
@@ -152,7 +152,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * @param string $operator List of operators : =, !=, <>, <, <=, >, >=, like, notlike, regexp, notregexp
 	 * @param mixed $value
 	 * @param string $type where|having
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function where($field, $operator, $value, $method = 'where')
 	{
@@ -216,7 +216,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * Add WHERE restriction on query using real SQL syntax
 	 *
 	 * @param string $sql
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function sqlWhere($sql)
 	{
@@ -230,7 +230,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * @param string $field Field name
 	 * @param string $operator List of operators : =, !=, <>, <, <=, >, >=, like, notlike, regexp, notregexp
 	 * @param mixed $value
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function having($field, $operator, $value)
 	{
@@ -241,7 +241,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * Add HAVING restriction on query using real SQL syntax
 	 *
 	 * @param string $sql
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function sqlHaving($sql)
 	{
@@ -254,7 +254,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 *
 	 * @param string $field Field name
 	 * @param string $order asc|desc
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function orderBy($field, $order = 'asc')
 	{
@@ -269,7 +269,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * Add ORDER BY restriction on query using real SQL syntax
 	 *
 	 * @param string $sql
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function sqlOrderBy($sql)
 	{
@@ -281,7 +281,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * Add GROUP BY restriction on query
 	 *
 	 * @param string $field Field name
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function groupBy($field)
 	{
@@ -293,7 +293,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * Add GROUP BY restriction on query using real SQL syntax
 	 *
 	 * @param string $sql
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function sqlGroupBy($sql)
 	{
@@ -305,7 +305,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * Launch sql query to create collection of objects
 	 *
 	 * @param bool $display_query If true, query will be displayed (for debug purpose)
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function getAll($display_query = false)
 	{
@@ -679,7 +679,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * Set the page number
 	 *
 	 * @param int $page_number
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function setPageNumber($page_number)
 	{
@@ -695,7 +695,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 	 * Set the nuber of item per page
 	 *
 	 * @param int $page_size
-	 * @return Collection
+	 * @return PrestaShopCollection
 	 */
 	public function setPageSize($page_size)
 	{

--- a/classes/ProductSupplier.php
+++ b/classes/ProductSupplier.php
@@ -190,7 +190,7 @@ class ProductSupplierCore extends ObjectModel
 	 *
 	 * @param int $id_product
 	 * @param int $group_by_supplier
-	 * @return Collection
+	 * @return PrestaShopCollection Collection of ProductSupplier
 	 */
 	public static function getSupplierCollection($id_product, $group_by_supplier = true)
 	{

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -291,7 +291,7 @@ class TabCore extends ObjectModel
 	 * @static
 	 * @param $module string Module name
 	 * @param null $id_lang integer Language ID
-	 * @return array|Collection Collection of tabs (or empty array)
+	 * @return array|PrestaShopCollection Collection of tabs (or empty array)
 	 */
 	public static function getCollectionFromModule($module, $id_lang = null)
 	{

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1295,7 +1295,7 @@ class OrderCore extends ObjectModel
 	 * @since 1.5.0.14
 	 * 
 	 * @param string $reference
-	 * @return Collection of Order
+	 * @return PrestaShopCollection Collection of Order
 	 */
 	public static function getByReference($reference)
 	{
@@ -1496,7 +1496,7 @@ class OrderCore extends ObjectModel
 	/**
 	 * This method allows to get all Order Payment for the current order
 	 * @since 1.5.0.1
-	 * @return Collection of Order Payment
+	 * @return PrestaShopCollection Collection of OrderPayment
 	 */
 	public function getOrderPaymentCollection()
 	{
@@ -1620,7 +1620,7 @@ class OrderCore extends ObjectModel
 	 *
 	 * Get all order_slips for the current order
 	 * @since 1.5.0.2
-	 * @return Collection of Order slip
+	 * @return PrestaShopCollection Collection of OrderSlip
 	 */
 	public function getOrderSlipsCollection()
 	{
@@ -1633,7 +1633,7 @@ class OrderCore extends ObjectModel
 	 *
 	 * Get all invoices for the current order
 	 * @since 1.5.0.1
-	 * @return Collection of Order invoice
+	 * @return PrestaShopCollection Collection of OrderInvoice
 	 */
 	public function getInvoicesCollection()
 	{
@@ -1646,7 +1646,7 @@ class OrderCore extends ObjectModel
 	 *
 	 * Get all delivery slips for the current order
 	 * @since 1.5.0.2
-	 * @return Collection of Order invoice
+	 * @return PrestaShopCollection Collection of OrderInvoice
 	 */
 	public function getDeliverySlipsCollection()
 	{
@@ -1659,7 +1659,7 @@ class OrderCore extends ObjectModel
 	/**
 	 * Get all not paid invoices for the current order
 	 * @since 1.5.0.2
-	 * @return Collection of Order invoice not paid
+	 * @return PrestaShopCollection Collection of Order invoice not paid
 	 */
 	public function getNotPaidInvoicesCollection()
 	{

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -565,6 +565,7 @@ class OrderInvoiceCore extends ObjectModel
 	 * Return collection of order invoice object linked to the payments of the current order invoice object
 	 * 
 	 * @since 1.5.0.14
+     * @return PrestaShopCollection|array Collection of OrderInvoice or empty array
 	 */
 	public function getSibling()
 	{
@@ -665,7 +666,7 @@ class OrderInvoiceCore extends ObjectModel
 
 	/**
 	 * @since 1.5.0.2
-	 * @return Collection of Order payment
+	 * @return PrestaShopCollection Collection of Order payment
 	 */
 	public function getOrderPaymentCollection()
 	{

--- a/classes/order/OrderPayment.php
+++ b/classes/order/OrderPayment.php
@@ -101,7 +101,7 @@ class OrderPaymentCore extends ObjectModel
 	 * Get Order Payments By Invoice ID
 	 * @static
 	 * @param $id_invoice Invoice ID
-	 * @return Collection Collection
+	 * @return PrestaShopCollection Collection of OrderPayment
 	 */
 	public static function getByInvoiceId($id_invoice)
 	{

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -703,7 +703,7 @@ class ShopCore extends ObjectModel
 	 *
 	 * @param bool $active
 	 * @param int $id_shop_group
-	 * @return Collection
+	 * @return PrestaShopCollection Collection of Shop
 	 */
 	public static function getShopsCollection($active = true, $id_shop_group = null)
 	{

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -91,7 +91,7 @@ class ShopUrlCore extends ObjectModel
 	 * Get list of shop urls
 	 *
 	 * @param bool $id_shop
-	 * @return Collection
+	 * @return PrestaShopCollection Collection of ShopUrl
 	 */
 	public static function getShopUrls($id_shop = false)
 	{

--- a/classes/stock/StockManager.php
+++ b/classes/stock/StockManager.php
@@ -643,7 +643,7 @@ class StockManagerCore implements StockManagerInterface
 	 * @param int $id_product_attribute
 	 * @param int $id_warehouse Optional
 	 * @param int $price_te Optional
-	 * @return Collection of Stock
+	 * @return PrestaShopCollection Collection of Stock
 	 */
 	protected function getStockCollection($id_product, $id_product_attribute, $id_warehouse = null, $price_te = null)
 	{

--- a/classes/stock/SupplyOrder.php
+++ b/classes/stock/SupplyOrder.php
@@ -279,7 +279,7 @@ class SupplyOrderCore extends ObjectModel
 	/**
 	 * Retrieves the details entries (i.e. products) collection for the current order
 	 *
-	 * @return Collection of SupplyOrderDetail
+	 * @return PrestaShopCollection Collection of SupplyOrderDetail
 	 */
 	public function getEntriesCollection()
 	{

--- a/classes/stock/WarehouseProductLocation.php
+++ b/classes/stock/WarehouseProductLocation.php
@@ -123,7 +123,7 @@ class WarehouseProductLocationCore extends ObjectModel
 	 * For a given product, gets its warehouses
 	 *
 	 * @param int $id_product
-	 * @return Collection The type of the collection is WarehouseProductLocation
+	 * @return PrestaShopCollection The type of the collection is WarehouseProductLocation
 	 */
 	public static function getCollection($id_product)
 	{


### PR DESCRIPTION
In 1.6.0.3 the class Collection was renamed to PrestaShopCollection. This fixes all phpdoc comments, as also adds missing @return's, to reference the correct return type PrestaShopCollection instead of Collection, where applicable. 
