### PR TITLE
[-] FO : Update of product.js in theme

### DIFF
--- a/themes/default/js/product.js
+++ b/themes/default/js/product.js
@@ -438,7 +438,7 @@ function displayImage(domAAroundImgThumb, no_animation)
 				'title' : new_title
 			}).load(function(){
 				if (typeof(jqZoomEnabled) != 'undefined' && jqZoomEnabled)
-					$(this).prop('rel', new_href);
+					$(this).attr('rel', new_href);
 			}); 
 		}
 		$('#views_block li a').removeClass('shown');


### PR DESCRIPTION
Avoid bug with JQZoom on product page, remplace prop() with attr() : When we hover thumbnail on product page, "rel" attribute of #bigpic is not changed. So, the zoomed picture is never changed.

Permet d'éviter un bug avec JQZoom sur la page d'un produit, remplacer prop() avec attr() : Quand on passe la souris sur une thumbnail, l'attribut "rel" de #bigpic ne change pas. Ce qui fait que l'image s'affichant en zoom est toujours la même.
