### PR TITLE
Tabs cache is reset on "add" function

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -97,9 +97,9 @@ class TabCore extends ObjectModel
 
 		// Add tab
 		if (parent::add($autodate, $null_values))
-		{
-			// refresh cache when adding new tab
-			self::$_getIdFromClassName[strtolower($this->class_name)] = $this->id;
+		{	
+                        //forces cache to be reloaded
+                        self::$_getIdFromClassName = null;
 			return Tab::initAccess($this->id);
 		}
 		return false;


### PR DESCRIPTION
$_getIdFromClassName is assigned "Null" to make it compatible with function "save". In P.S. 1.6.0.3 $_getIdFromClassName was assigned null after using "save function", but if a module is using "add" function new value is added to the array, but not reloaded. 

When a tab is created via "save" function $_getIdFromClassName is assigned "null", but if a module creates a tab using "add" function, newly added tab is assigned to $_getIdFromClassName (without reloading data from database), this causes $_getIdFromClassName to contain 1 value, and this prevents function "getIdFromClassName" to reload tabs data from database, and causes "getIdFromClassName" to return "false" in future calls.
