### PR TITLE
[-] FO : Fix bug #PSCSX-748

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -223,6 +223,9 @@ class MediaCore
 		if (is_array($media_uri) || $media_uri === null || empty($media_uri))
 			return false;
 
+        if (preg_match('#//.+#', $media_uri))
+            $media_uri = (Tools::usingSecureMode() ? 'https:' : 'http:').$media_uri;
+
 		$url_data = parse_url($media_uri);
 		$file_uri = '';
 		if (!array_key_exists('host', $url_data))


### PR DESCRIPTION
Fix for http://forge.prestashop.com/browse/PSCSX-74

Once again allows the use of URL's like this: 
//use.typekit.net/cak5ihv.js
after a recent commit https://github.com/PrestaShop/PrestaShop/commit/50ae04e019469d6d2928e27e454c777106b53c07 caused such URLs and their script-tags to be removed completely. 
