### PR TITLE
[~] BO : Fix search conf indexation amount (PSCSX-758)

### DIFF
--- a/controllers/admin/AdminSearchConfController.php
+++ b/controllers/admin/AdminSearchConfController.php
@@ -56,7 +56,7 @@ class AdminSearchConfControllerCore extends AdminController
 		$current_file_name = array_reverse(explode('/', $_SERVER['SCRIPT_NAME']));
 		$cron_url = Tools::getHttpHost(true, true).__PS_BASE_URI__.basename(_PS_ADMIN_DIR_).
 			'/searchcron.php?full=1&token='.substr(_COOKIE_KEY_, 34, 8);
-		list($total, $indexed) = Db::getInstance()->getRow('SELECT COUNT(*) as "0", SUM(product_shop.indexed) as "1" FROM '._DB_PREFIX_.'product p '.Shop::addSqlAssociation('product', 'p'));
+		list($total, $indexed) = Db::getInstance()->getRow('SELECT COUNT(*) as "0", SUM(product_shop.indexed) as "1" FROM '._DB_PREFIX_.'product p '.Shop::addSqlAssociation('product', 'p').' WHERE product_shop.`visibility` IN ("both", "search") AND product_shop.`active` = 1');
 
 		$this->fields_options = array(
 			'indexation' => array(


### PR DESCRIPTION
Fixes http://forge.prestashop.com/browse/PSCSX-758

The indexation values (amount / total) are wrong because the SQL query doesn't filter by product_shop "visibility" and "active" state (but the Search::indexation method does)
