### PR TITLE
[*] Core: Missing attributes field for templates

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -422,6 +422,7 @@ class ProductControllerCore extends FrontController
 				}
 				if (!isset($groups[$row['id_attribute_group']]))
 					$groups[$row['id_attribute_group']] = array(
+						'group_name' => $row['group_name'],
 						'name' => $row['public_group_name'],
 						'group_type' => $row['group_type'],
 						'default' => -1,


### PR DESCRIPTION
The field 'group_name' (on backend just "Name" in the Product Attributes) isn't available in the product template. All product fields should be available in templates. I came across one situation, where a design couldn't be implemented without the use of this additional field, unless "public_group_name" would be compared with endless strings (because of localization). 
