### PR TITLE
[-] BO : Permit "product_rule_group.tpl" override

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -290,7 +290,7 @@ class AdminCartRulesControllerCore extends AdminController
 		Context::getContext()->smarty->assign('product_rule_group_id', $product_rule_group_id);
 		Context::getContext()->smarty->assign('product_rule_group_quantity', $product_rule_group_quantity);
 		Context::getContext()->smarty->assign('product_rules', $product_rules);
-		return Context::getContext()->smarty->fetch('controllers/cart_rules/product_rule_group.tpl');
+		return $this->createTemplate('product_rule_group.tpl')->fetch();
 	}
 
 	public function getProductRuleDisplay($product_rule_group_id, $product_rule_id, $product_rule_type, $selected = array())


### PR DESCRIPTION
We need to use createTemplate() instead of getContext()->smarty->fetch(), like other call of tpl in this file, if we want override "product_rule_group.tpl".

Il est nécessaire d'utiliser la fonction createTemplate() au lieu de getContext()->smarty->fetch(), comme utilisé pour les autres appels dans ce fichier, si l'on veut surcharger le fichier "product_rule_group.tpl".
