### PR TITLE
using filter_var for validate email instead of regex in Validate::isEmail()

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -47,7 +47,7 @@ class ValidateCore
 	 */
 	public static function isEmail($email)
 	{
-		return !empty($email) && preg_match(Tools::cleanNonUnicodeSupport('/^[a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+[._a-z\p{L}0-9-]*\.[a-z\p{L}0-9]+$/ui'), $email);
+		return !empty($email) && (filter_var($email, FILTER_VALIDATE_EMAIL) !== false);
 	}
 
 	/**


### PR DESCRIPTION
Currently, regex in Validate::isEmail() allows some emails which are violating the standard defined RFC 5322 (http://tools.ietf.org/html/rfc5322). (for example a.......@test.com). Using filter_var adresses such problems now and in the future
