### PR TITLE
[-] MO : Greece could not be VAT applicable

### DIFF
--- a/modules/vatnumber/vatnumber.php
+++ b/modules/vatnumber/vatnumber.php
@@ -138,7 +138,7 @@ class VatNumber extends TaxManagerModule
 
 	public static function isApplicable($id_country)
 	{
-		return (((int)$id_country && in_array(Country::getIsoById($id_country), self::getPrefixIntracomVAT())) ? 1 : 0);
+		return (((int)$id_country && array_key_exists(Country::getIsoById($id_country), self::getPrefixIntracomVAT())) ? 1 : 0);
 	}
 
 	public static function WebServiceCheck($vat_number)


### PR DESCRIPTION
Il y a une recherche sur les valeurs du tableau de la fonction getPrefixIntracomVAT mais je pense qu'il faudrait rechercher sur les clés donc remplacer le "in_array" par "array_key_exists".
