### PR TITLE
Fix getTables() in Cache.php

### DIFF
--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -255,8 +255,13 @@ abstract class CacheCore
 
 	protected function getTables($string)
 	{
-		if (preg_match_all('/(?:from|join|update|into)\s+`?('._DB_PREFIX_.'[a-z_-]+)`?(?:,\s{0,}`?('._DB_PREFIX_.'[a-z_-]+)`?)?\s.*/Umsi', $string, $res))
-			return array_merge($res[1], $res[2]);
+		if (preg_match_all('/(?:from|join|update|into)\s+`?('._DB_PREFIX_.'[0-9a-z_-]+)(?:`?\s{0,},\s{0,}`?('._DB_PREFIX_.'[0-9a-z_-]+)`?)?(?:`|\s+|\Z)(?!\s*,)/Umsi', $string, $res))
+		{
+			foreach ($res[2] as $table)
+				if ($table != '')
+					$res[1][] = $table;
+			return array_unique($res[1]);
+		}
 		else
 			return false;
 	}


### PR DESCRIPTION
This fix provides a modified Regex to better capture table names from queries. Previous Regex did not retrieve table names from queries like SELECT \* FROM `ps_hook_alias`

More importantly it strips NULL table names from the returned array. The majority of queries will generate a NULL table name because $res[2] will normally contain NULL.

The consequence of the NULL table name is that setQuery() will record a large number of queries in $sql_tables_cached as belonging to table NULL.

A subsequent call to deleteQuery() will result in all the queries listed under table NULL being deleted because more than likely the call to getTables() in deleteQuery() will show that the query contains table NULL, so all Table NULL queries will be deleted.

This results in queries being created and deleted in the cache without every being re-used and is a major factor in disc thrashing and rendering the cache worse than useless.
