### PR TITLE
Fix minifyCSS() for Quoted URLs in Media.php

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -175,7 +175,7 @@ class MediaCore
 		{
 			$limit  = Media::getBackTrackLimit();
 			$css_content = preg_replace('#/\*.*?\*/#s', '', $css_content, $limit);
-			$css_content = preg_replace_callback('#(url\((?!data:)(?!http://)(?!https://)(?:\'|")?)([^\)\'"]*(?:\'|")?\))#s', array('Tools', 'replaceByAbsoluteURL'), $css_content, $limit); 
+			$css_content = preg_replace_callback('#(url\((?:\'|")?(?!data:)(?!http://)(?!https://))([^\)\'"]*(?:\'|")?\))#s', array('Tools', 'replaceByAbsoluteURL'), $css_content, $limit); 
 			$css_content = preg_replace('#\s+#', ' ', $css_content, $limit);		
 			$css_content = str_replace(array("\t", "\n", "\r"), '', $css_content);
 			$css_content = str_replace(array('; ', ': '), array(';', ':'), $css_content);


### PR DESCRIPTION
This fix allows for URLs to be enclosed in quotes. The existing code tests for the opening quote in the wrong place, it should be at the beginning of the URL.
