### PR TITLE
[*]FO: Add products check access in order process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .settings
 .idea
 .svn
+.DS_Store
 robots.txt
 sitemap.xml
 cache/smarty/cache/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+Contributing
+------------
+
+PrestaShop is an open-source e-commerce solution - To contribute to our project, you can make pull requests on the development branch.  
+If you need some help to make a [pull-request][1]  
+All contributions must respect [the coding norm][2] and [the commit norm][3] in your pull-request.  
+All core files you commit in your pull request must have Open Software License (OSL 3.0)  
+All modules files you commit in your pull request must have Academic Free License (AFL 3.0)  
+
+[1]: https://help.github.com/articles/using-pull-requests
+[2]: http://docs.prestashop.com/display/PS15/Coding+Standard
+[3]: http://docs.prestashop.com/display/PS15/Commit+norme

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,40 @@
+CONTRIBUTORS
+============
+
+- DamienMetzger 
+- François Gaillard 
+- Rémi Gaillard 
+- Vincent Augagneur 
+- aFolletete 
+- aKorczak 
+- aNiassy 
+- bLeveque 
+- bMancone 
+- dMetzger 
+- dSevere 
+- fBrignoli 
+- fSerny 
+- gBrunier 
+- gCharmes 
+- gPoulain 
+- hAitmansour 
+- jBreux 
+- jObregon 
+- jmCollin 
+- lBrieu 
+- lCherifi 
+- lLefevre 
+- mBertholino 
+- mDeflotte 
+- mMarinetti 
+- nPellicari 
+- rGaillard 
+- rMalie 
+- rMontagne 
+- sLorenzini 
+- sThiebaut 
+- tDidierjean 
+- vAugagneur 
+- vChabot 
+- vKham 
+- vSchoener 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+README
+======
+![PrestaShop](http://www.prestashop.com/images/banners/general/prestashop_728x90.png "PrestaShop")
+
+PREPARATION
+--------
+
+To install PrestaShop, you need a remote web server or on your computer (MAMP), with access to a database like MySQL.
+You'll need access to phpMyAdmin to create a database and to indicate the information in the database in the installer.
+
+If you do not host and unable to create your store, we offer a turnkey store, which lets you create your online store in less than 10 minutes without any technical knowledge.
+We invite you to visit: [http://www.prestabox.com][1]
+
+INSTALLATION
+--------
+
+Simply go to your PrestaShop web directory and use installer :-)
+
+If you have any PHP error, perhaps you don't have PHP5 or you need to activate it on your web host.
+Please go to our forum to find pre-installation settings (PHP 5, htaccess) for certain hosting services (1&1, Free, Lycos, OVH, Infomaniak, Amen, GoDaddy, etc).
+
+English webhost [specifics settings][2]
+
+
+If you don't find any solution to launch installer, please post on [our forum][3]
+
+
+There are always solutions for your issues ;-)
+
+DOCUMENTATION
+--------
+
+For any extra documentation (how-to), please read our [Online documentation][4]
+
+
+FORUMS
+--------
+
+You can also discuss, help and contribute with PrestaShop community on [our forums][5]
+
+
+Thanks for downloading and using PrestaShop e-commerce Open-source solution!
+
+[1]: http://www.prestabox.com
+[2]: http://www.prestashop.com/forums/topic/2946-pre-installation-settings-php-5-htaccess-for-certain-hosting-services/
+[3]: http://www.prestashop.com/forums/forum/7-installing-prestashop/
+[4]: http://doc.prestashop.com
+[5]: http://www.prestashop.com/forums/

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2933,6 +2933,18 @@ class CartCore extends ObjectModel
 		return true;
 	}
 
+	public function checkProductsAccess()
+	{
+		if (Configuration::get('PS_CATALOG_MODE'))
+			return false;
+
+		foreach ($this->getProducts() as $product)
+			if (! Product::checkAccess_static($product['id_product'], $this->id_customer))
+				return false;
+		
+		return true;
+	}
+	
 	public static function lastNoneOrderedCart($id_customer)
 	{
 		$sql = 'SELECT c.`id_cart`

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4133,7 +4133,11 @@ class ProductCore extends ObjectModel
 		return Pack::noPackPrice($this->id);
 	}
 
-	public function checkAccess($id_customer)
+	public function checkAccess($id_customer) {
+		self::checkAccess_static ($this->id, $id_customer);
+	}
+	
+	{public function checkAccess_static($id_customer)
 	{
 		if (!$id_customer)
 			return (bool)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4137,21 +4137,21 @@ class ProductCore extends ObjectModel
 		self::checkAccess_static ($this->id, $id_customer);
 	}
 	
-	{public function checkAccess_static($id_customer)
+	{public function checkAccess_static($id_cart, $id_customer)
 	{
 		if (!$id_customer)
 			return (bool)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 			SELECT ctg.`id_group`
 			FROM `'._DB_PREFIX_.'category_product` cp
 			INNER JOIN `'._DB_PREFIX_.'category_group` ctg ON (ctg.`id_category` = cp.`id_category`)
-			WHERE cp.`id_product` = '.(int)$this->id.' AND ctg.`id_group` = 1');
+			WHERE cp.`id_product` = '.(int)$id_cart.' AND ctg.`id_group` = 1');
 		else
 			return (bool)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 			SELECT cg.`id_group`
 			FROM `'._DB_PREFIX_.'category_product` cp
 			INNER JOIN `'._DB_PREFIX_.'category_group` ctg ON (ctg.`id_category` = cp.`id_category`)
 			INNER JOIN `'._DB_PREFIX_.'customer_group` cg ON (cg.`id_group` = ctg.`id_group`)
-			WHERE cp.`id_product` = '.(int)$this->id.' AND cg.`id_customer` = '.(int)$id_customer);
+			WHERE cp.`id_product` = '.(int)$id_cart.' AND cg.`id_customer` = '.(int)$id_customer);
 	}
 
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4137,21 +4137,21 @@ class ProductCore extends ObjectModel
 		self::checkAccess_static ($this->id, $id_customer);
 	}
 	
-	{public function checkAccess_static($id_cart, $id_customer)
+	{public function checkAccess_static($id_product, $id_customer)
 	{
 		if (!$id_customer)
 			return (bool)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 			SELECT ctg.`id_group`
 			FROM `'._DB_PREFIX_.'category_product` cp
 			INNER JOIN `'._DB_PREFIX_.'category_group` ctg ON (ctg.`id_category` = cp.`id_category`)
-			WHERE cp.`id_product` = '.(int)$id_cart.' AND ctg.`id_group` = 1');
+			WHERE cp.`id_product` = '.(int)$id_product.' AND ctg.`id_group` = 1');
 		else
 			return (bool)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 			SELECT cg.`id_group`
 			FROM `'._DB_PREFIX_.'category_product` cp
 			INNER JOIN `'._DB_PREFIX_.'category_group` ctg ON (ctg.`id_category` = cp.`id_category`)
 			INNER JOIN `'._DB_PREFIX_.'customer_group` cg ON (cg.`id_group` = ctg.`id_group`)
-			WHERE cp.`id_product` = '.(int)$id_cart.' AND cg.`id_customer` = '.(int)$id_customer);
+			WHERE cp.`id_product` = '.(int)$id_product.' AND cg.`id_customer` = '.(int)$id_customer);
 	}
 
 

--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -133,7 +133,17 @@ class PDFGeneratorCore extends TCPDF
 
 		$this->lastPage();
 
-		$output = $display ? 'I' : 'S';
+		if ($display === true)
+			$output = 'D';
+		elseif ($display === false)
+			$output = 'S';
+		elseif (display == 'D')
+			$output = 'D';
+		elseif (display == 'S')
+			$output = 'S';
+		else 	
+			$output = 'I';
+			
 		return $this->output($filename, $output);
 	}
 

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -183,7 +183,7 @@ class CartControllerCore extends FrontController
 			$this->errors[] = Tools::displayError('Product not found');
 
 		$product = new Product($this->id_product, true, $this->context->language->id);
-		if (!$product->id || !$product->active)
+		if (!$product->id || !$product->active || ! Product::checkAccess_static($this->id_product, $this->context->cart->id_customer))
 		{
 			$this->errors[] = Tools::displayError('Product is no longer available.', false);
 			return;

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -44,7 +44,7 @@ class OrderControllerCore extends ParentOrderController
 			$this->step = -1;
 
 		// If some products have disappear
-		if (!$this->context->cart->checkQuantities())
+		if (!$this->context->cart->checkQuantities() || !$this->context->cart->checkProductsAccess())
 		{
 			$this->step = 0;
 			$this->errors[] = Tools::displayError('An item in your cart is no longer available in this quantity, you cannot proceed with your order.');

--- a/controllers/front/OrderOpcController.php
+++ b/controllers/front/OrderOpcController.php
@@ -449,7 +449,7 @@ class OrderOpcControllerCore extends ParentOrderController
 			return '<p class="warning">'.Tools::displayError('Please accept the Terms of Service').'</p>';
 		
 		/* If some products have disappear */
-		if (!$this->context->cart->checkQuantities())
+		if (!$this->context->cart->checkQuantities()  || !$this->context->cart->checkProductsAccess())
 			return '<p class="warning">'.Tools::displayError('An item in your cart is no longer available, you cannot proceed with your order.').'</p>';
 
 		/* Check minimal amount */


### PR DESCRIPTION
The order process must check that all products of the cart are accessible by the customer.

Suppose a customer has placed an order several weeks ago. Since this order, the product could have been placed in a category nor more accessible to the customer.
In case of order re-order, the order must not be finalized as the product us not accessible.
In the same idea, the checkAccess() controls are done only on CategoryController and ProductController. It could happen that the product is added to the cart through another way (like the order duplication). In that case, the order should not be finalized.

Thanks to ignore the following files of this PR : CONTRIBUTING.md CONTRIBUTORS.md README.md  .gitignore classes/pdf/PDFGenerator.php
I don't understand why there are on my branch and don't know how to remove them
