### PR TITLE
[*] FO : Enhance products check access in order process

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3004,7 +3004,19 @@ class CartCore extends ObjectModel
 
 		return true;
 	}
+	
+	public function checkProductsAccess()
+	{
+		if (Configuration::get('PS_CATALOG_MODE'))
+			return false;
 
+		foreach ($this->getProducts() as $product)
+			if (! Product::checkAccess_static($product['id_product'], $this->id_customer))
+				return false;
+
+		return true;
+	}
+	
 	public static function lastNoneOrderedCart($id_customer)
 	{
 		$sql = 'SELECT c.`id_cart`

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4407,10 +4407,15 @@ class ProductCore extends ObjectModel
 
 	public function checkAccess($id_customer)
 	{
+		self::checkAccess_static ($this->id, $id_customer);
+	}
+
+	public function checkAccess_static($id_product, $id_customer)
+	{
 		if (!Group::isFeatureActive())
 			return true;
 
-		$cache_id = 'Product::checkAccess_'.(int)$this->id.'-'.(int)$id_customer.(!$id_customer ? '-'.(int)Group::getCurrent()->id : '');
+		$cache_id = 'Product::checkAccess_'.(int)$id_product.'-'.(int)$id_customer.(!$id_customer ? '-'.(int)Group::getCurrent()->id : '');
 		if (!Cache::isStored($cache_id))
 		{
 			if (!$id_customer)
@@ -4418,14 +4423,14 @@ class ProductCore extends ObjectModel
 				SELECT ctg.`id_group`
 				FROM `'._DB_PREFIX_.'category_product` cp
 				INNER JOIN `'._DB_PREFIX_.'category_group` ctg ON (ctg.`id_category` = cp.`id_category`)
-				WHERE cp.`id_product` = '.(int)$this->id.' AND ctg.`id_group` = '.(int)Group::getCurrent()->id);
+				WHERE cp.`id_product` = '.(int)$id_product.' AND ctg.`id_group` = '.(int)Group::getCurrent()->id);
 			else
 				$result = (bool)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 				SELECT cg.`id_group`
 				FROM `'._DB_PREFIX_.'category_product` cp
 				INNER JOIN `'._DB_PREFIX_.'category_group` ctg ON (ctg.`id_category` = cp.`id_category`)
 				INNER JOIN `'._DB_PREFIX_.'customer_group` cg ON (cg.`id_group` = ctg.`id_group`)
-				WHERE cp.`id_product` = '.(int)$this->id.' AND cg.`id_customer` = '.(int)$id_customer);
+				WHERE cp.`id_product` = '.(int)$id_product.' AND cg.`id_customer` = '.(int)$id_customer);
 			Cache::store($cache_id, $result);
 		}
 		return Cache::retrieve($cache_id);

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -187,7 +187,7 @@ class CartControllerCore extends FrontController
 			$this->errors[] = Tools::displayError('Product not found', !Tools::getValue('ajax'));
 
 		$product = new Product($this->id_product, true, $this->context->language->id);
-		if (!$product->id || !$product->active)
+		if (!$product->id || !$product->active || !Product::checkAccess_static($this->id_product, $this->context->cart->id_customer))
 		{
 			$this->errors[] = Tools::displayError('This product is no longer available.', !Tools::getValue('ajax'));
 			return;

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -43,7 +43,7 @@ class OrderControllerCore extends ParentOrderController
 			$this->step = -1;		
 
 		// If some products have disappear
-		if (!$this->context->cart->checkQuantities())
+		if (!$this->context->cart->checkQuantities() || !$this->context->cart->checkProductsAccess())
 		{
 			$this->step = 0;
 			$this->errors[] = Tools::displayError('An item in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.');

--- a/controllers/front/OrderOpcController.php
+++ b/controllers/front/OrderOpcController.php
@@ -534,7 +534,7 @@ class OrderOpcControllerCore extends ParentOrderController
 			return '<p class="warning">'.Tools::displayError('Please accept the Terms of Service.').'</p>';
 		
 		/* If some products have disappear */
-		if (!$this->context->cart->checkQuantities())
+		if (!$this->context->cart->checkQuantities() || !$this->context->cart->checkProductsAccess())
 			return '<p class="warning">'.Tools::displayError('An item in your cart is no longer available. You cannot proceed with your order.').'</p>';
 
 		/* Check minimal amount */


### PR DESCRIPTION
The order process checks the products quantity availability of the cart to go futher.

This pull request is a proposal for an enhancement also checking the Access right of the products.

It may happen that a customer was in a customer group in which he had access to some restricted products and have perheaps already bought them in an order or already just placed them in a cart.

If the customer is no more in this group or if the products are moved to another category not accessible to this customer, the product must not be accessible in the cart/order
