### PR TITLE
Allow "=" sign in isGenericName()

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -383,7 +383,7 @@ class ValidateCore
 	 */
 	public static function isGenericName($name)
 	{
-		return empty($name) || preg_match('/^[^<>={}]*$/u', $name);
+		return empty($name) || preg_match('/^[^<>{}]*$/u', $name);
 	}
 
 	/**
@@ -704,7 +704,7 @@ class ValidateCore
 	public static function isLoadedObject($object)
 	{
 		return is_object($object) && $object->id;
-	}
+	}ge
 
 	/**
 	 * Check object validity

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -704,7 +704,7 @@ class ValidateCore
 	public static function isLoadedObject($object)
 	{
 		return is_object($object) && $object->id;
-	}ge
+	}
 
 	/**
 	 * Check object validity


### PR DESCRIPTION
Updated isGenericName() method to allow names with equality sign (=). I see no reason why it shouldn't be and it causes problems while importing such names from other ecommerce platforms.
