### PR TITLE
[*] CORE: change clearSmartyCache to use native clear

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -749,15 +749,13 @@ class ToolsCore
     }
     
 	/**
-	* Clear smarty cache folders
+	* Clear smarty cache
  	*/
 	public static function clearSmartyCache()
 	{
-		foreach (array(_PS_CACHE_DIR_.'smarty/cache', _PS_CACHE_DIR_.'smarty/compile') as $dir)
-			if (file_exists($dir))
-				foreach (scandir($dir) as $file)
-					if ($file[0] != '.' && $file != 'index.php')
-						self::deleteDirectory($dir.DIRECTORY_SEPARATOR.$file);
+        	$smarty = Context::getContext()->smarty;
+        	$smarty->clearAllCache();
+        	$smarty->clearCompiledTemplate();
 	}
     
 	/**


### PR DESCRIPTION
When using not file based cache the function is not working.

reported in tracker as http://forge.prestashop.com/browse/PSCSX-1139
