### PR TITLE
[-] BO : Fix $gz usage in updateModulesTranslations

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -944,7 +944,8 @@ class LanguageCore extends ObjectModel
 					if (isset($file['filename']) && is_string($file['filename']))
 						$files_listing[] = $file['filename'];
 			}
-			$gz->extractList($files_listing, _PS_TRANSLATIONS_DIR_.'../', '');
+			if ($gz) // $gz is initialized inside th eforeach... it may not be initialized if no loop is done (case of not conencted to the internet)
+				$gz->extractList($files_listing, _PS_TRANSLATIONS_DIR_.'../', '');
 		}
 	}
 }


### PR DESCRIPTION
In the Language::updateModulesTranslation(), the $GZ is used after a froeach, but the init of this variable is done inside this foreach.
It may happen that the nit is not done, if no loop is done.

For exemple, when Prestashop is used on a local desktop, not conected to the internet, it's impossible to install a new module : the $gz is not initialised in this case
