### PR TITLE
[*] BO : Wording in translation form templates.

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
@@ -47,9 +47,6 @@
 		{l s='%s at least, or you will have to edit the translation files manually.' sprintf=$limit_warning['needed_limit']}
 	</div>
 	{else}
-		<div class="alert alert-info">
-			{l s='Some sentences to translate use this syntax: "Word %s word". These "%s" are variables, and PrestaShop takes care of replacing them before displaying your translation. You must leave these in your translations, and place them appropriately in your sentence.' sprintf='%d, %s, %1$s, %2$d'}
-		</div>
 		<div class="panel">
 			<p>{l s='Expressions to translate:'} <span class="badge">{l s='%d' sprintf=$count}</span></p>
 			<p>{l s='Total missing expressions:'} <span class="badge">{l s='%d' sprintf=$missing_translations|array_sum}</p>
@@ -67,13 +64,14 @@
 		<div id="BoxUseSpecialSyntax">
 			<div class="alert alert-warning">
 				<p>
-					{l s='Some of these expressions use this special syntax:'} <span>%d.</span><br />
-					{l s='You MUST use this syntax in your translations. Here are several examples:'}
+					{l s='Some of these expressions use this special syntax: %s.' sprintf='%d'}
+					<br />
+					{l s='You MUST use this syntax in your translations. Here are a few examples:'}
 				</p>
 				<ul>
-					<li>"There are <strong>%d</strong> products": "<strong>%d</strong>" {l s='will be replaced by a number.'}).</li>
-					<li>"List of pages in <strong>%s</strong>": "<strong>%s</strong>" {l s='will be replaced by a string.'}).</li>
-					<li>"Feature: <strong>%1$s</strong> (<strong>%2$d</strong> values)": "<strong>n$</strong>" {l s='helps you reorder the arguments when necessary.'}).</li>
+					<li>"There are <strong>%d</strong> products": {l s='"%s" will be replaced by a number.' sprintf='%d'}</li>
+					<li>"List of pages in <strong>%s</strong>": {l s='"%s" will be replaced by a string.' sprintf='%s'}</li>
+					<li>"Feature: <strong>%1$s</strong> (<strong>%2$d</strong> values)": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
 				</ul>
 			</div>
 		</div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
@@ -49,10 +49,9 @@
 	{else}
 
 		<div class="alert alert-info">
-			<ul>
-				<li>{l s='Click on titles to open fieldsets'}.</li>
-				<li>{l s='Some sentences to translate use this syntax: "Word %%s word". These "%%s" are variables, and PrestaShop takes care of replacing them before displaying your translation. You must leave these in your translations, and place them appropriately in your sentence.'}</li>
-			</ul>
+			<p>
+				{l s='Click on the title of a section to open its fieldsets.'}
+			</p>
 		</div>
 		<div class="panel">
 			<p>{l s='Expressions to translate:'} <span class="badge">{l s='%d' sprintf=$count}</span></p>
@@ -77,13 +76,14 @@
 				<div id="BoxUseSpecialSyntax">
 					<div class="alert alert-warning">
 						<p>
-							{l s='Some of these expressions use this special syntax:'} <strong>%d.</strong>
+							{l s='Some of these expressions use this special syntax: %s.' sprintf='%d'}
+							<br />
 							{l s='You MUST use this syntax in your translations. Here are several examples:'}
 						</p>
 						<ul>
-							<li>"There are <strong>%d</strong> products": "<strong>%d</strong>" {l s='will be replaced by a number.'}).</li>
-							<li>"List of pages in <strong>%s</strong>": "<strong>%s</strong>" {l s='will be replaced by a string.'}).</li>
-							<li>"Feature: <strong>%1$s</strong> (<strong>%2$d</strong> values)": "<strong>n$</strong>" {l s='helps you reorder the arguments when necessary.'}).</li>
+							<li>"There are <strong>%d</strong> products": {l s='"%s" will be replaced by a number.' sprintf='%d'}</li>
+							<li>"List of pages in <strong>%s</strong>": {l s='"%s" will be replaced by a string.' sprintf='%s'}</li>
+							<li>"Feature: <strong>%1$s</strong> (<strong>%2$d</strong> values)": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
 						</ul>
 					</div>
 				</div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -65,13 +65,14 @@
 				<div id="BoxUseSpecialSyntax">
 					<div class="alert alert-warning">
 						<p>
-							{l s='Some of these expressions use this special syntax:'} <strong>%d</strong><br><br>
+							{l s='Some of these expressions use this special syntax: %s.' sprintf='%d'}
+							<br />
 							{l s='You MUST use this syntax in your translations. Here are several examples:'}
 						</p>
 						<ul>
-							<li>"There are <strong>%d</strong> products": "<strong>%d</strong>" {l s='will be replaced by a number.'}).</li>
-							<li>"List of pages in <strong>%s</strong>": "<strong>%s</strong>" {l s='will be replaced by a string.'}).</li>
-							<li>"Feature: <strong>%1$s</strong> (<strong>%2$d</strong> values)": "<strong>n$</strong>" {l s='helps you reorder the arguments when necessary.'}).</li>
+							<li>"There are <strong>%d</strong> products": {l s='"%s" will be replaced by a number.' sprintf='%d'}</li>
+							<li>"List of pages in <strong>%s</strong>": {l s='"%s" will be replaced by a string.' sprintf='%s'}</li>
+							<li>"Feature: <strong>%1$s</strong> (<strong>%2$d</strong> values)": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
 						</ul>
 					</div>
 				</div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
@@ -49,11 +49,7 @@
 	{else}
 		<div class="alert alert-info">
 			<p>
-				{l s='Some sentences to translate use this syntax: "You have %%s items...". These "%s" are variables, and PrestaShop takes care of replacing them before displaying your translation.' sprintf='%d, %s, %1$s, %2$d'}<br>
-				<strong>{l s='You must leave these in your translations, and place them appropriately in your sentence.'}</strong>
-			</p>
-			<p>
-				{l s='Click on titles to open fieldsets'}.
+				{l s='Click on the title of a section to open its fieldsets.'}
 			</p>
 		</div>
 		<div class="panel">
@@ -69,13 +65,14 @@
 				<div id="BoxUseSpecialSyntax">
 					<div class="alert alert-warning">
 						<p>
-							{l s='Some of these expressions use this special syntax:'} <span>%d.</span><br />
+							{l s='Some of these expressions use this special syntax: %s.' sprintf='%d'}
+							<br />
 							{l s='You MUST use this syntax in your translations. Here are several examples:'}
 						</p>
 						<ul>
-							<li>"There are <strong>%d</strong> products": "<strong>%d</strong>" {l s='will be replaced by a number.'}).</li>
-							<li>"List of pages in <strong>%s</strong>": "<strong>%s</strong>" {l s='will be replaced by a string.'}).</li>
-							<li>"Feature: <strong>%1$s</strong> (<strong>%2$d</strong> values)": "<strong>n$</strong>" {l s='helps you reorder the arguments when necessary.'}).</li>
+							<li>"There are <strong>%d</strong> products": {l s='"%s" will be replaced by a number.' sprintf='%d'}</li>
+							<li>"List of pages in <strong>%s</strong>": {l s='"%s" will be replaced by a string.' sprintf='%s'}</li>
+							<li>"Feature: <strong>%1$s</strong> (<strong>%2$d</strong> values)": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
 						</ul>
 					</div>
 				</div>				


### PR DESCRIPTION
Removed duplicate information and simplified strings in order to make life easier for translators.
