### PR TITLE
[-] Core : fixed bug with module mail_vars

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -391,9 +391,6 @@ class OrderHistoryCore extends ObjectModel
 				'{id_order}' => (int)$this->id_order,
 				'{order_name}' => $order->getUniqReference()
 			);
-			if ($template_vars)
-				$data = array_merge($data, $template_vars);
-
 			if ($result['module_name'])
 			{
 				$module = Module::getInstanceByName($result['module_name']);
@@ -401,6 +398,9 @@ class OrderHistoryCore extends ObjectModel
 					$data = array_merge($data, $module->extra_mail_vars);
 			}
 			
+			if ($template_vars)
+				$data = array_merge($data, $template_vars);
+
 			$data['{total_paid}'] = Tools::displayPrice((float)$order->total_paid, new Currency((int)$order->id_currency), false);
 			$data['{order_name}'] = $order->getUniqReference();
 


### PR DESCRIPTION
The bug is that, for example in bankwire moudle we send the mailvars as template_vars from the validation controller within the module. But order history first receives the template vars, and then overwrite them with the default ones in the modules $this->extra_mail_vars.
This makes it impossible to create code that extends the mail_vars with conditional  mail_vars from an module validation controller.
