### PR TITLE
[-] CORE : Module controller named with a "_" not routed

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -759,7 +759,7 @@ class DispatcherCore
 									$_GET[$k] = $v;
 		
 							// A patch for module friendly urls
-							if (preg_match('#module-([a-z0-9_-]+)-([a-z0-9]+)$#i', $controller, $m))
+							if (preg_match('#module-([a-z0-9_-]+)-([a-z0-9_]+)$#i', $controller, $m))
 							{
 								$_GET['module'] = $m[1];
 								$_GET['fc'] = 'module';


### PR DESCRIPTION
If a module controller is named with an underscore (ex: "my_controller.php"), then the Dispatcher won't be able to match it. This patch just adds the "_" character in the regexp.
