### PR TITLE
[*] CORE : Additional indexes added to cart_rule_combination table to improve performance

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -262,7 +262,9 @@ CREATE TABLE `PREFIX_cart_rule_carrier` (
 CREATE TABLE `PREFIX_cart_rule_combination` (
 	`id_cart_rule_1` int(10) unsigned NOT NULL,
 	`id_cart_rule_2` int(10) unsigned NOT NULL,
-	PRIMARY KEY (`id_cart_rule_1`, `id_cart_rule_2`)
+	PRIMARY KEY (`id_cart_rule_1`, `id_cart_rule_2`),
+	KEY `id_cart_rule_1` (`id_cart_rule_1`),
+	KEY `id_cart_rule_2` (`id_cart_rule_2`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
 CREATE TABLE `PREFIX_cart_rule_product_rule_group` (

--- a/install-dev/upgrade/sql/1.6.0.6.sql
+++ b/install-dev/upgrade/sql/1.6.0.6.sql
@@ -25,4 +25,7 @@ DELETE FROM `PREFIX_image_type` WHERE `name` = 'cart_default';
 INSERT INTO `PREFIX_image_type` (`id_image_type`,`name`,`width`,`height`,`products`,`categories`,`manufacturers`,`suppliers`,`scenes`,`stores`)
 VALUES (NULL, 'cart_default', '80', '80', '1', '0', '0', '0', '0', '0');
 
+ALTER TABLE `PREFIX_cart_rule_combination` ADD INDEX `id_cart_rule_1` (`id_cart_rule_1`);
+ALTER TABLE `PREFIX_cart_rule_combination` ADD INDEX `id_cart_rule_2` (`id_cart_rule_2`);
+
 /* PHP:p1606module_exceptions(); */;


### PR DESCRIPTION
With a siginificant quantity of cart rules (a few hundreds / thousands), cart_rule_combination table easily grows to few millions lines. Please note that primary index is set on both numerical columns, and in effect has a size of the table itself. So for table scanning (as in CartRule::getCartRuleCombinations ), it has to read a whole table as index can have a cardinality equal to the square of the size of cart_rule table.
Adding two separated indexes (each has cardinality <= size of cart_rule) can improve the performance of  such queries (even for small dataset of 140 cart rules and 16000 cart rule combinations difference is quite visible:
190 ms and 2270000 rows scanned before, 30 ms and 29800 rows scanned after; for bigger datasets the imporovement is even bigger)
