### PR TITLE
[-] BO : fix addFiltersToBreadcrumbs

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -489,7 +489,7 @@ class AdminControllerCore extends Controller
 	
 	public function addFiltersToBreadcrumbs()
 	{
-		if (Tools::isSubmit('submitFilter') && is_array($this->fields_list))
+		if ($this->filter && is_array($this->fields_list))
 		{
 			$filters = array();
 			foreach ($this->fields_list as $field => $t)


### PR DESCRIPTION
In initProcess(), $this->filter is set to true if filters are  used. it's better to used "$this->filter" than to check "submitFilter".

This fixes the following problem:

In Back office, creating a link to the list of orders filtered by customer (on the customer page) using AdminOrdersController.

Code for this link :

-form  method="post" action="{$link->getAdminLink('AdminOrders')|escape:'html':'UTF-8'}"-
   -input type="hidden" name="orderFilter_id_customer" value="{$customer->id|intval}" /-
   -input type="hidden" name="orderFilter_customer" value="{$customer->lastname|escape:'html':'UTF-8'} {$customer->firstname|escape:'html':'UTF-8'}" /-
   -input type="submit" name="submitFilterorder" value="{l s='All customer orders'}" /-
-/form-

"submitFilter" can't be used, because javascript function stops the form submit.
