### PR TITLE
[*] CORE : bad redirection on history in order confirmation

### DIFF
--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -70,7 +70,7 @@ class OrderConfirmationControllerCore extends FrontController
 		if (!Validate::isLoadedObject($order) || $order->id_customer != $this->context->customer->id || $this->secure_key != $order->secure_key)
 			Tools::redirect($redirectLink);
 		$module = Module::getInstanceById((int)($this->id_module));
-		if ($order->payment != $module->displayName)
+		if ($order->module != $module->name)
 			Tools::redirect($redirectLink);
 	}
 


### PR DESCRIPTION
This change makes more sense to compare the orders module to the modules name.  Comparing the orders payment to the modules display name can result in executing the redirect and never hitting the order confirmation page.

For example, if I create a payment module that allows payment via Credit Card.
The module would have the following variables
name="my_great_module"
paymentMethod="Credit Card"
displayName="My Great Payment Module"

Now in the back office module listing, the merchant would see "My Great Payment Module".  This makes sense to the merchant who may have many payment modules.
But in the Order History page, the customer would see "Credit Card".  This makes much more sense to the customer who has no idea what "My Great Payment Module" is.

But in the order confirmation controller, since "My Great Payment Module" != "Credit Card", then the order confirmation page would never be displayed.  Instead you get redirected to the order history page.  This is not desirable

Instead we revise the order confirmation controller to compare the orders module name to the actual module name which both are "my_great_module".  This gives much greater flexibility
