### PR TITLE
[-] CORE : $link_conditions with SSL

### DIFF
--- a/controllers/front/OrderOpcController.php
+++ b/controllers/front/OrderOpcController.php
@@ -562,7 +562,7 @@ class OrderOpcControllerCore extends ParentOrderController
 		$address_delivery = new Address($this->context->cart->id_address_delivery);
 		
 		$cms = new CMS(Configuration::get('PS_CONDITIONS_CMS_ID'), $this->context->language->id);
-		$link_conditions = $this->context->link->getCMSLink($cms, $cms->link_rewrite);
+		$link_conditions = $this->context->link->getCMSLink($cms, $cms->link_rewrite, Configuration::get('PS_SSL_ENABLED'));
 		if (!strpos($link_conditions, '?'))
 			$link_conditions .= '?content_only=1';
 		else


### PR DESCRIPTION
SSL parameter added to add https to the terms of services link for fancy fancy box on OPC page.
Found this bug in this configuration : 
1.6 store + 1.6 PS bootstrap theme + SSL + account created + disconnected
1- add a product to the cart
2- Go to OPC 
3- Check that the link to terms of services (fancy box) has HTTPS
4- login on the OPC page (already has an account click here)

> > The terms of services does NOT have the HTTPS. So the cms page won't load there is this error message in the debug console : 

[blocked] The page at 'https://www.______________.com/fr/commande-rapide' was loaded over HTTPS, but ran insecure content from 'http://www.______________.com/fr/content/conditions-d-utilisation-3?content_only=1': this content should also be loaded over HTTPS.
