### PR TITLE
[-] BO : fixed bug while use filter with enter key

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -340,6 +340,7 @@ function formSubmit(e, button)
 	{
 		getE(button).focus();
 		getE(button).click();
+		e.preventDefault();
 	}
 }
 function noComma(elem)


### PR DESCRIPTION
If you use filter with enter key in customer or some admin pages.
And there is first img tag has onclick event like this getE('submitFiltercustomer').value=2 in form tag, that onclick event is fired. Because of that you will move 2nd page with blank result.
This is bug with some browser. It can be prevented with e.preventDefault() function.
