### PR TITLE
[-] BO : fix left and right column display

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -76,8 +76,12 @@ class FrontControllerCore extends Controller
 		if (isset($this->php_self)  && is_object(Context::getContext()->theme))
 		{
 			$colums = Context::getContext()->theme->hasColumns($this->php_self);
-			$this->display_column_left = $colums['left_column'];
-			$this->display_column_right = $colums['right_column'];
+			// don't use theme tables if not configurated in DB
+			if ($colums)
+			{
+				$this->display_column_left = $colums['left_column'];
+				$this->display_column_right = $colums['right_column'];
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi,
The problem is :
For pages that doesn't exists in 'ps_theme_meta' tables ( like front controller in new module, or add in override/controllers ),
$colums['left_column'] and $colums['right_column'] value is null, so the columns aren't displayed even if $this->display_column_left or $this->display_column_right is set to true.

$column test resolve this problem.
Thanks
