### PR TITLE
[-] BO : Clear Tabs cache completely on tab deletion

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -152,7 +152,7 @@ class TabCore extends ObjectModel
 	 	if (Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'access WHERE `id_tab` = '.(int)$this->id) && parent::delete())
 		{
 			if (is_array(self::$_getIdFromClassName) && isset(self::$_getIdFromClassName[strtolower($this->class_name)]))
-				unset(self::$_getIdFromClassName[strtolower($this->class_name)]);
+				self::$_getIdFromClassName=null;
 			return $this->cleanPositions($this->id_parent);
 		}
 		return false;


### PR DESCRIPTION
In case a ClassName is existing twice, the previous approach fails.
I encountered this problem with an imcomplete module installation. Repeated installation resulted in multiple tabs added, but the uninstall only found the first tab to uninstall - after that getIdFromClassName() returns a wrong result.
