### PR TITLE
module ajax position capability

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -51,16 +51,17 @@
 		});
 	</script>
 {/if}
+{* Display column names and arrows for ordering (ASC, DESC) *}
+{if $is_order_position}
+	<script type="text/javascript" src="../js/jquery/plugins/jquery.tablednd.js"></script>
+	<script type="text/javascript">
+		var come_from = '{$list_id|addslashes}';
+		var module_configure = '{$module_configure|addslashes}'; // used for ./js/admin-dnd.js
+		var alternate = {if $order_way == 'DESC'}'1'{else}'0'{/if};
+	</script>
+	<script type="text/javascript" src="../js/admin-dnd.js"></script>
+{/if}
 {if !$simple_header}
-	{* Display column names and arrows for ordering (ASC, DESC) *}
-	{if $is_order_position}
-		<script type="text/javascript" src="../js/jquery/plugins/jquery.tablednd.js"></script>
-		<script type="text/javascript">
-			var come_from = '{$list_id|addslashes}';
-			var alternate = {if $order_way == 'DESC'}'1'{else}'0'{/if};
-		</script>
-		<script type="text/javascript" src="../js/admin-dnd.js"></script>
-	{/if}
 	<script type="text/javascript">
 		$(function() {
 			$('table.{$list_id} .filter').keypress(function(event){

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -338,6 +338,7 @@ class HelperListCore extends Helper
 			'has_actions' => !empty($this->actions),
 			'list_skip_actions' => $this->list_skip_actions,
 			'row_hover' => $this->row_hover,
+			'module_configure' => isset($this->module_configure) ? $this->module_configure : null,
 			'list_id' => isset($this->list_id) ? $this->list_id : $this->table,
 			'checked_boxes' => Tools::getValue((isset($this->list_id) ? $this->list_id : $this->table).'Box')
 		)));
@@ -649,6 +650,7 @@ class HelperListCore extends Helper
 			'name' => isset($name) ? $name : null,
 			'name_id' => isset($name_id) ? $name_id : null,
 			'row_hover' => $this->row_hover,
+			'module_configure' => isset($this->module_configure) ? $this->module_configure : null,
 			'list_id' => isset($this->list_id) ? $this->list_id : $this->table
 		), $this->tpl_vars));
 

--- a/js/admin-dnd.js
+++ b/js/admin-dnd.js
@@ -115,6 +115,16 @@ function initTableDnD(table)
 						way: way
 					};
 				}
+				// from module with $HelperList->module_configure = 'modulename'
+				else if(module_configure != '')
+				{
+					params = {
+						action : 'updatePositions',
+						configure : module_configure,
+						id : ids[2],
+						way: way
+					}
+				}
 				// default
 				else
 				{


### PR DESCRIPTION
Fix to module ajax position capability

Currently, it's not possible to dispatch the ajaxProcess linked to change list positions since HelperList and from the Module class.

This patch allows you to easily make it possible to access ajaxProcessUpdatePositions since our modules.
