### PR TITLE
[*] BO : product name with all shops in contex

### DIFF
--- a/admin-dev/themes/default/template/controllers/products/informations.tpl
+++ b/admin-dev/themes/default/template/controllers/products/informations.tpl
@@ -128,6 +128,7 @@
 
 	<div class="form-group">
 		<label class="control-label col-lg-3 required" for="name_{$id_lang}">
+			{include file="controllers/products/multishop/checkbox.tpl" field="name" type="default" multilang="true"}
 			<span class="label-tooltip" data-toggle="tooltip"
 				title="{l s='The public name for this product.'} {l s='Invalid characters:'} &lt;&gt;;=#{}">
 				{l s='Name'}


### PR DESCRIPTION
Need to add this line to support multishop.
Without this line you can't change the product name with all shops in context, and enabling the multishop button on top.
