### PR TITLE
Shortened some code in config/defines.inc.php

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -62,13 +62,9 @@ if (!defined('_PS_ROOT_DIR_') && (getenv('_PS_ROOT_DIR_') || getenv('REDIRECT__P
 
 /* Directories */
 if (!defined('_PS_ROOT_DIR_'))
-{
 	define('_PS_ROOT_DIR_', realpath($currentDir.'/..'));
 
-	if (!defined('_PS_CORE_DIR_'))
-		define('_PS_CORE_DIR_', _PS_ROOT_DIR_);
-}
-elseif (!defined('_PS_CORE_DIR_'))
+if (!defined('_PS_CORE_DIR_'))
 	define('_PS_CORE_DIR_', realpath($currentDir.'/..'));
 
 define('_PS_ALL_THEMES_DIR_',        _PS_ROOT_DIR_.'/themes/');


### PR DESCRIPTION
Shorter (and more clear) code, does mean realpath($currentDir.'/..') is used instead of _PS_ROOT_DIR_ in the 1 out of 3 chance (when both _PS_ROOT_DIR_ and _PS_CORE_DIR_ aren't defined).
