### PR TITLE
[-] BO : Fixed bug #PSCFV-12024, could not delete override files

### DIFF
--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -399,6 +399,8 @@ class AdminModulesControllerCore extends AdminController
 			return;
 		if (is_dir($dir))
 		{
+			if (strpos($dir, "override") !== false)
+				$hasOverrides = true;
 			$objects = scandir($dir);
 			foreach ($objects as $object)
 				if ($object != '.' && $object != '..')

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -394,6 +394,7 @@ class AdminModulesControllerCore extends AdminController
 
 	protected function recursiveDeleteOnDisk($dir)
 	{
+		$hasOverrides = false;
 		if (strpos(realpath($dir), realpath(_PS_MODULE_DIR_)) === false)
 			return;
 		if (is_dir($dir))
@@ -405,7 +406,17 @@ class AdminModulesControllerCore extends AdminController
 					if (filetype($dir.'/'.$object) == 'dir')
 						$this->recursiveDeleteOnDisk($dir.'/'.$object);
 					else
+					{
+						if ($hasOverrides === true)
+						{
+							if (file_exists(_PS_ROOT_DIR_ ."/cache/class_index.php") === true)
+								unlink(_PS_ROOT_DIR_ ."/cache/class_index.php");
+							$overrideDir = strstr($dir, "/override");
+							$overrideFileAbsPath = _PS_ROOT_DIR_ . $overrideDir . "/" . $object;
+							unlink($overrideFileAbsPath);
+						}
 						unlink($dir.'/'.$object);
+					}
 				}
 			reset($objects);
 			rmdir($dir);


### PR DESCRIPTION
Fixed bug #PSCFV-12024 where files copied into the override directories after a module install weren't delete appropriately after the module was uninstalled and deleted from prestashop
