### PR TITLE
[-] Project : `ObjectModel::add()` does not handle `unset($this->id)` anymore

### DIFF
--- a/admin-dev/backup.php
+++ b/admin-dev/backup.php
@@ -52,11 +52,11 @@ if ($backupfile === false OR strncmp($backupdir, $backupfile, strlen($backupdir)
 	die (Tools::dieOrLog('The backup file does not exist.'));
 
 if (substr($backupfile, -4) == '.bz2')
-    $contentType = 'application/x-bzip2';
+	$contentType = 'application/x-bzip2';
 else if (substr($backupfile, -3) == '.gz')
-    $contentType = 'application/x-gzip';
+	$contentType = 'application/x-gzip';
 else
-    $contentType = 'text/x-sql';
+	$contentType = 'text/x-sql';
 $fp = @fopen($backupfile, 'r');
 
 if ($fp === false)

--- a/admin-dev/cron_currency_rates.php
+++ b/admin-dev/cron_currency_rates.php
@@ -32,5 +32,5 @@ if (isset($_GET['secure_key']))
 {
 	$secureKey = md5(_COOKIE_KEY_.Configuration::get('PS_SHOP_NAME'));
 	if (!empty($secureKey) AND $secureKey === $_GET['secure_key'])
-                Currency::refreshCurrencies();
+		Currency::refreshCurrencies();
 }

--- a/admin-dev/drawer.php
+++ b/admin-dev/drawer.php
@@ -39,8 +39,8 @@ $id_employee = Tools::getValue('id_employee');
 $id_lang = Tools::getValue('id_lang');
 
 if (!isset($cookie->id_employee) || !$cookie->id_employee  || $cookie->id_employee != $id_employee)
-    die(Tools::displayError());
-    
+	die(Tools::displayError());
+
 if (!Validate::isModuleName($module))
 	die(Tools::displayError());
 

--- a/admin-dev/functions.php
+++ b/admin-dev/functions.php
@@ -303,46 +303,46 @@ function checkTabRights($id_tab)
 
 
 /**
-     * Converts a simpleXML element into an array. Preserves attributes and everything.
-     * You can choose to get your elements either flattened, or stored in a custom index that
-     * you define.
-     * For example, for a given element
-     * <field name="someName" type="someType"/>
-     * if you choose to flatten attributes, you would get:
-     * $array['field']['name'] = 'someName';
-     * $array['field']['type'] = 'someType';
-     * If you choose not to flatten, you get:
-     * $array['field']['@attributes']['name'] = 'someName';
-     * _____________________________________
-     * Repeating fields are stored in indexed arrays. so for a markup such as:
-     * <parent>
-     * <child>a</child>
-     * <child>b</child>
-     * <child>c</child>
-     * </parent>
-     * you array would be:
-     * $array['parent']['child'][0] = 'a';
-     * $array['parent']['child'][1] = 'b';
-     * ...And so on.
-     * _____________________________________
-     * @param simpleXMLElement $xml the XML to convert
-     * @param boolean $flattenValues    Choose wether to flatten values
-     *                                    or to set them under a particular index.
-     *                                    defaults to true;
-     * @param boolean $flattenAttributes Choose wether to flatten attributes
-     *                                    or to set them under a particular index.
-     *                                    Defaults to true;
-     * @param boolean $flattenChildren    Choose wether to flatten children
-     *                                    or to set them under a particular index.
-     *                                    Defaults to true;
-     * @param string $valueKey            index for values, in case $flattenValues was set to
-            *                            false. Defaults to "@value"
-     * @param string $attributesKey        index for attributes, in case $flattenAttributes was set to
-            *                            false. Defaults to "@attributes"
-     * @param string $childrenKey        index for children, in case $flattenChildren was set to
-            *                            false. Defaults to "@children"
-     * @return array the resulting array.
-     */
+	 * Converts a simpleXML element into an array. Preserves attributes and everything.
+	 * You can choose to get your elements either flattened, or stored in a custom index that
+	 * you define.
+	 * For example, for a given element
+	 * <field name="someName" type="someType"/>
+	 * if you choose to flatten attributes, you would get:
+	 * $array['field']['name'] = 'someName';
+	 * $array['field']['type'] = 'someType';
+	 * If you choose not to flatten, you get:
+	 * $array['field']['@attributes']['name'] = 'someName';
+	 * _____________________________________
+	 * Repeating fields are stored in indexed arrays. so for a markup such as:
+	 * <parent>
+	 * <child>a</child>
+	 * <child>b</child>
+	 * <child>c</child>
+	 * </parent>
+	 * you array would be:
+	 * $array['parent']['child'][0] = 'a';
+	 * $array['parent']['child'][1] = 'b';
+	 * ...And so on.
+	 * _____________________________________
+	 * @param simpleXMLElement $xml the XML to convert
+	 * @param boolean $flattenValues     Choose wether to flatten values
+	 *                                    or to set them under a particular index.
+	 *                                    defaults to true;
+	 * @param boolean $flattenAttributes Choose wether to flatten attributes
+	 *                                    or to set them under a particular index.
+	 *                                    Defaults to true;
+	 * @param boolean $flattenChildren   Choose wether to flatten children
+	 *                                    or to set them under a particular index.
+	 *                                    Defaults to true;
+	 * @param string $valueKey           index for values, in case $flattenValues was set to
+	 *                                    false. Defaults to "@value"
+	 * @param string $attributesKey      index for attributes, in case $flattenAttributes was set to
+	 *                                    false. Defaults to "@attributes"
+	 * @param string $childrenKey        index for children, in case $flattenChildren was set to
+	 *                                    false. Defaults to "@children"
+	 * @return array the resulting array.
+	 */
 function simpleXMLToArray ($xml, $flattenValues = true, $flattenAttributes = true, $flattenChildren = true, $valueKey = '@value', $attributesKey = '@attributes', $childrenKey = '@children')
 {
 	$return = array();

--- a/admin-dev/grider.php
+++ b/admin-dev/grider.php
@@ -43,7 +43,7 @@ $id_lang = (int)(Tools::getValue('id_lang'));
 
 
 if (!isset($cookie->id_employee) || !$cookie->id_employee  || $cookie->id_employee != $id_employee)
-    die(Tools::displayError());
+	die(Tools::displayError());
 
 if (!Validate::isModuleName($module))
 	die(Tools::displayError());
@@ -96,8 +96,7 @@ if (!$shop_id)
 	Context::getContext()->shop = new Shop(Configuration::get('PS_SHOP_DEFAULT'));
 elseif (Context::getContext()->shop->id != $shop_id)
 	Context::getContext()->shop = new Shop($shop_id);
-	
-	
+
 require_once($module_path);
 
 $grid = new $module();
@@ -105,6 +104,6 @@ $grid->setEmployee($id_employee);
 $grid->setLang($id_lang);
 if ($option)
 	$grid->setOption($option);
-	
+
 $grid->create($render, $type, $width, $height, $start, $limit, $sort, $dir);
 $grid->render();

--- a/classes/AdminTab.php
+++ b/classes/AdminTab.php
@@ -250,8 +250,8 @@ abstract class AdminTabCore
 		}
 		global $_LANGADM;
 
-        if ($class == __CLASS__)
-                $class = 'AdminTab';
+		if ($class == __CLASS__)
+			$class = 'AdminTab';
 
 		$key = md5(str_replace('\'', '\\\'', $string));
 		$str = (array_key_exists(get_class($this).$key, $_LANGADM)) ? $_LANGADM[get_class($this).$key] : ((array_key_exists($class.$key, $_LANGADM)) ? $_LANGADM[$class.$key] : $string);
@@ -1671,7 +1671,7 @@ abstract class AdminTabCore
 					}
 					elseif (isset($params['icon']) && (isset($params['icon'][$tr[$key]]) || isset($params['icon']['default'])))
 						echo '<img src="../img/admin/'.(isset($params['icon'][$tr[$key]]) ? $params['icon'][$tr[$key]] : $params['icon']['default'].'" alt="'.$tr[$key]).'" title="'.$tr[$key].'" />';
-                    elseif (isset($params['price']))
+					elseif (isset($params['price']))
 						echo Tools::displayPrice($tr[$key], (isset($params['currency']) ? Currency::getCurrencyInstance($tr['id_currency']) : $this->context->currency), false);
 					elseif (isset($params['float']))
 						echo rtrim(rtrim($tr[$key], '0'), '.');
@@ -1707,13 +1707,13 @@ abstract class AdminTabCore
 				{
 					echo '<td class="center" style="white-space: nowrap;">';
 					if ($this->view)
-                        $this->_displayViewLink($token, $id);
+						$this->_displayViewLink($token, $id);
 					if ($this->edit)
-					    $this->_displayEditLink($token, $id);
+						$this->_displayEditLink($token, $id);
 					if ($this->delete && (!isset($this->_listSkipDelete) || !in_array($id, $this->_listSkipDelete)))
-					    $this->_displayDeleteLink($token, $id);
+						$this->_displayDeleteLink($token, $id);
 					if ($this->duplicate)
-                        $this->_displayDuplicate($token, $id);
+						$this->_displayDuplicate($token, $id);
 					echo '</td>';
 				}
 				echo '</tr>';
@@ -1728,29 +1728,29 @@ abstract class AdminTabCore
 
 	protected function _displayEnableLink($token, $id, $value, $active,  $id_category = NULL, $id_product = NULL)
 	{
-	    echo '<a href="'.self::$currentIndex.'&'.$this->identifier.'='.$id.'&'.$active.$this->table.
-	        ((int)$id_category && (int)$id_product ? '&id_category='.$id_category : '').'&token='.($token!=NULL ? $token : $this->token).'">
-	        <img src="../img/admin/'.($value ? 'enabled.gif' : 'disabled.gif').'"
-	        alt="'.($value ? $this->l('Enabled') : $this->l('Disabled')).'" title="'.($value ? $this->l('Enabled') : $this->l('Disabled')).'" /></a>';
+		echo '<a href="'.self::$currentIndex.'&'.$this->identifier.'='.$id.'&'.$active.$this->table.
+			((int)$id_category && (int)$id_product ? '&id_category='.$id_category : '').'&token='.($token!=NULL ? $token : $this->token).'">
+			<img src="../img/admin/'.($value ? 'enabled.gif' : 'disabled.gif').'"
+			alt="'.($value ? $this->l('Enabled') : $this->l('Disabled')).'" title="'.($value ? $this->l('Enabled') : $this->l('Disabled')).'" /></a>';
 	}
 
-    protected function _displayDuplicate($token = NULL, $id)
-    {
-        $_cacheLang['Duplicate'] = $this->l('Duplicate');
+	protected function _displayDuplicate($token = NULL, $id)
+	{
+		$_cacheLang['Duplicate'] = $this->l('Duplicate');
 		$_cacheLang['Copy images too?'] = $this->l('Would you like to copy the images too?', __CLASS__, TRUE, FALSE);
 
-    	$duplicate = self::$currentIndex.'&'.$this->identifier.'='.$id.'&duplicate'.$this->table;
+		$duplicate = self::$currentIndex.'&'.$this->identifier.'='.$id.'&duplicate'.$this->table;
 
 		echo '
 			<a class="pointer" onclick="if (confirm(\''.$_cacheLang['Copy images too?'].'\')) document.location = \''.$duplicate.'&token='.($token!=NULL ? $token : $this->token).'\'; else document.location = \''.$duplicate.'&noimage=1&token='.($token ? $token : $this->token).'\';">
-    		<img src="../img/admin/duplicate.png" alt="'.$_cacheLang['Duplicate'].'" title="'.$_cacheLang['Duplicate'].'" /></a>';
-    }
+			<img src="../img/admin/duplicate.png" alt="'.$_cacheLang['Duplicate'].'" title="'.$_cacheLang['Duplicate'].'" /></a>';
+	}
 
 	protected function _displayViewLink($token = NULL, $id)
 	{
 		$_cacheLang['View'] = $this->l('View');
 
-    	echo '
+		echo '
 			<a href="'.self::$currentIndex.'&'.$this->identifier.'='.$id.'&view'.$this->table.'&token='.($token!=NULL ? $token : $this->token).'">
 			<img src="../img/admin/details.gif" alt="'.$_cacheLang['View'].'" title="'.$_cacheLang['View'].'" /></a>';
 	}
@@ -1760,8 +1760,8 @@ abstract class AdminTabCore
 		$_cacheLang['Edit'] = $this->l('Edit');
 
 		echo '
-    		<a href="'.self::$currentIndex.'&'.$this->identifier.'='.$id.'&update'.$this->table.'&token='.($token!=NULL ? $token : $this->token).'">
-    		<img src="../img/admin/edit.gif" alt="" title="'.$_cacheLang['Edit'].'" /></a>';
+			<a href="'.self::$currentIndex.'&'.$this->identifier.'='.$id.'&update'.$this->table.'&token='.($token!=NULL ? $token : $this->token).'">
+			<img src="../img/admin/edit.gif" alt="" title="'.$_cacheLang['Edit'].'" /></a>';
 	}
 
 	protected function _displayDeleteLink($token = NULL, $id)
@@ -1771,7 +1771,7 @@ abstract class AdminTabCore
 
 		echo '
 			<a href="'.self::$currentIndex.'&'.$this->identifier.'='.$id.'&delete'.$this->table.'&token='.($token!=NULL ? $token : $this->token).'" onclick="return confirm(\''.$_cacheLang['DeleteItem'].$id.' ?'.
-    				(!is_null($this->specificConfirmDelete) ? '\r'.$this->specificConfirmDelete : '').'\');">
+				(!is_null($this->specificConfirmDelete) ? '\r'.$this->specificConfirmDelete : '').'\');">
 			<img src="../img/admin/delete.gif" alt="'.$_cacheLang['Delete'].'" title="'.$_cacheLang['Delete'].'" /></a>';
 	}
 

--- a/classes/Blowfish.php
+++ b/classes/Blowfish.php
@@ -31,9 +31,9 @@ class BlowfishCore extends Crypt_Blowfish
 {
 	function encrypt($plaintext)
 	{
-        if (($length = strlen($plaintext)) >= 1048576)
+		if (($length = strlen($plaintext)) >= 1048576)
 			return false;
-			
+
 		$ciphertext = '';
 		$paddedtext = $this->maxi_pad($plaintext);
 		$strlen = strlen($paddedtext);

--- a/classes/CSV.php
+++ b/classes/CSV.php
@@ -32,15 +32,15 @@
 class CSVCore
 {
 	public $filename;
-    public $collection;
-    public $delimiter;
+	public $collection;
+	public $delimiter;
 
-    /**
-     * Loads objects, filename and optionnaly a delimiter.
-     * @param Collection $collection collection of objects / array (of non-objects)
-     * @param string $filename : used later to save the file
-     * @param string $delimiter Optional : delimiter used
-     */
+	/**
+	 * Loads objects, filename and optionnaly a delimiter.
+	 * @param Collection $collection collection of objects / array (of non-objects)
+	 * @param string $filename : used later to save the file
+	 * @param string $delimiter Optional : delimiter used
+	 */
 	public function __construct($collection, $filename, $delimiter = ';')
 	{
 		$this->filename = $filename;
@@ -80,8 +80,8 @@ class CSVCore
 	 */
 	public function output($data)
 	{
-    	$wraped_data = array_map(array('CSVCore', 'wrap'), $data);
-        echo sprintf("%s\n", implode($this->delimiter, $wraped_data));
+		$wraped_data = array_map(array('CSVCore', 'wrap'), $data);
+		echo sprintf("%s\n", implode($this->delimiter, $wraped_data));
 	}
 
 	/**
@@ -89,21 +89,20 @@ class CSVCore
 	 * @param string $data
 	 * @return string $data
 	 */
-    public static function wrap($data)
-    {
-    	$data = Tools::safeOutput($data, '";');
-        return sprintf('"%s"', $data);
-    }
+	public static function wrap($data)
+	{
+		$data = Tools::safeOutput($data, '";');
+		return sprintf('"%s"', $data);
+	}
 
-    /**
-     * Adds headers
-     */
-    public function headers()
-    {
-        header('Content-type: text/csv');
-        header('Content-Type: application/force-download; charset=UTF-8');
+	/**
+	 * Adds headers
+	 */
+	public function headers()
+	{
+		header('Content-type: text/csv');
+		header('Content-Type: application/force-download; charset=UTF-8');
 		header('Cache-Control: no-store, no-cache');
-        header('Content-disposition: attachment; filename="'.$this->filename.'.csv"');
-    }
+		header('Content-disposition: attachment; filename="'.$this->filename.'.csv"');
+	}
 }
-

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -306,12 +306,12 @@ class CurrencyCore extends ObjectModel
 		return Cache::retrieve($cache_id);
 	}
 
-    /**
-     * @static
-     * @param $iso_code
-     * @param int $id_shop
-     * @return int
-     */
+	/**
+	 * @static
+	 * @param $iso_code
+	 * @param int $id_shop
+	 * @return int
+	 */
 	public static function getIdByIsoCodeNum($iso_code_num, $id_shop = 0)
 	{
 		$query = Currency::getIdByQuery($id_shop);

--- a/classes/Discount.php
+++ b/classes/Discount.php
@@ -187,7 +187,7 @@ class DiscountCore extends CartRule
 		if (Validate::isLoadedObject($shop))
 			$context->shop = $shop;
 	 	return parent::getContextualValue($useTax, $context);
-    }
+	}
 
 	/**
 	  * @deprecated 1.5.0.1

--- a/classes/FileUploader.php
+++ b/classes/FileUploader.php
@@ -37,12 +37,12 @@ class FileUploaderCore
 		$this->allowedExtensions = $allowedExtensions;
 		$this->sizeLimit = $sizeLimit;
 
-        if (isset($_GET['qqfile']))
-            $this->file = new QqUploadedFileXhr();
-        elseif (isset($_FILES['qqfile']))
-            $this->file = new QqUploadedFileForm();
-        else
-            $this->file = false;
+		if (isset($_GET['qqfile']))
+			$this->file = new QqUploadedFileXhr();
+		elseif (isset($_FILES['qqfile']))
+			$this->file = new QqUploadedFileForm();
+		else
+			$this->file = false;
 	}
 
 	protected function toBytes($str)
@@ -88,10 +88,10 @@ class FileUploaderCore
 
 class QqUploadedFileForm
 {
-    /**
-     * Save the file to the specified path
-     * @return boolean TRUE on success
-     */
+	/**
+	 * Save the file to the specified path
+	 * @return boolean TRUE on success
+	 */
 	public function save()
 	{
 		$product = new Product($_GET['id_product']);
@@ -147,15 +147,15 @@ class QqUploadedFileForm
 		return array('success' => $img);
 	}
 
-    public function getName()
-    {
-        return $_FILES['qqfile']['name'];
-    }
+	public function getName()
+	{
+		return $_FILES['qqfile']['name'];
+	}
 
-    public function getSize()
-    {
-        return $_FILES['qqfile']['size'];
-    }
+	public function getSize()
+	{
+		return $_FILES['qqfile']['size'];
+	}
 }
 /**
  * Handle file uploads via XMLHttpRequest

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -289,9 +289,9 @@ class LocalizationPackCore
 					PaymentModule::addCurrencyPermissions($currency->id);
 				}
 			}
-            
+
 			if (($error = Currency::refreshCurrencies()) !== null)
-                $this->_errors[] = $error;
+				$this->_errors[] = $error;
 
 			if (!count($this->_errors) && $install_mode && isset($attributes['iso_code']) && count($xml->currencies->currency) == 1)
 				$this->iso_currency = $attributes['iso_code'];
@@ -431,4 +431,3 @@ class LocalizationPackCore
 		return $this->_errors;
 	}
 }
-

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -50,7 +50,7 @@ class MailCore
 	 * @param bool $modeSMTP
 	 * @param string $template_path
 	 * @param bool $die
-         * @param string $bcc Bcc recipient
+	 * @param string $bcc Bcc recipient
 	 */
 	public static function Send($id_lang, $template, $subject, $template_vars, $to,
 		$to_name = null, $from = null, $from_name = null, $file_attachment = null, $mode_smtp = null,

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -448,8 +448,6 @@ abstract class ObjectModelCore
 		}
 		
 		// Database insertion
-		if (isset($this->id))
-			unset($this->id);
 		if (Shop::checkIdShopDefault($this->def['table']))
 			$this->id_shop_default = min($id_shop_list);
 		if (!$result = ObjectModel::$db->insert($this->def['table'], $this->getFields(), $null_values))

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3555,7 +3555,7 @@ class ProductCore extends ObjectModel
 			$return[$impact['id_attribute']]['weight'] = (float)$impact['weight'];
 		}
 		return $return;
-    }
+	}
 
 	/**
 	* Get product attribute image associations
@@ -3952,8 +3952,8 @@ class ProductCore extends ObjectModel
 		if ($row['id_product_attribute'])
 			$row['quantity'] = Product::getQuantity(
 				(int)$row['id_product'],
-    			$row['id_product_attribute'],
-			   isset($row['cache_is_pack']) ? $row['cache_is_pack'] : null
+				$row['id_product_attribute'],
+				isset($row['cache_is_pack']) ? $row['cache_is_pack'] : null
 			);
 
 		$row['id_image'] = Product::defineProductImage($row, $id_lang);

--- a/classes/Rijndael.php
+++ b/classes/Rijndael.php
@@ -45,7 +45,7 @@ class RijndaelCore
 	{
 		$length = (ini_get('mbstring.func_overload') & 2) ? mb_strlen($plaintext, ini_get('default_charset')) : strlen($plaintext);
 
-        if ($length >= 1048576)
+		if ($length >= 1048576)
 			return false;
 		return base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $this->_key, $plaintext, MCRYPT_MODE_ECB, $this->_iv)).sprintf('%06d', $length);
 	}
@@ -71,4 +71,3 @@ class RijndaelCore
 		}
 	}
 }
-

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -142,9 +142,9 @@ class SpecificPriceCore extends ObjectModel
 	public static function deleteByIdCart($id_cart, $id_product = false, $id_product_attribute = false)
 	{
 		return Db::getInstance()->execute('
-		    DELETE FROM `'._DB_PREFIX_.'specific_price`
-            WHERE id_cart='.(int)$id_cart.
-            ($id_product ? ' AND id_product='.(int)$id_product.' AND id_product_attribute='.(int)$id_product_attribute : ''));
+			DELETE FROM `'._DB_PREFIX_.'specific_price`
+			WHERE id_cart='.(int)$id_cart.
+			($id_product ? ' AND id_product='.(int)$id_product.' AND id_product_attribute='.(int)$id_product_attribute : ''));
 	}
 
 	public static function getIdsByProductId($id_product, $id_product_attribute = false, $id_cart = 0)
@@ -162,21 +162,21 @@ class SpecificPriceCore extends ObjectModel
 	 */
 	protected static function _getScoreQuery($id_product, $id_shop, $id_currency, $id_country, $id_group, $id_customer)
 	{
-	    $select = '(';
+		$select = '(';
 
-       $now = date('Y-m-d H:i:s');
-       $select .= ' IF (\''.$now.'\' >= `from` AND \''.$now.'\' <= `to`, '.pow(2, 0).', 0) + ';
+		$now = date('Y-m-d H:i:s');
+		$select .= ' IF (\''.$now.'\' >= `from` AND \''.$now.'\' <= `to`, '.pow(2, 0).', 0) + ';
 
-	    $priority = SpecificPrice::getPriority($id_product);
-	    foreach (array_reverse($priority) as $k => $field)
+		$priority = SpecificPrice::getPriority($id_product);
+		foreach (array_reverse($priority) as $k => $field)
 			if (!empty($field))
 				$select .= ' IF (`'.bqSQL($field).'` = '.(int)$$field.', '.pow(2, $k + 1).', 0) + ';
 
-	    return rtrim($select, ' +').') AS `score`';
+		return rtrim($select, ' +').') AS `score`';
 	}
 
-    public static function getPriority($id_product)
-    {
+	public static function getPriority($id_product)
+	{
 		if (!SpecificPrice::isFeatureActive())
 			return explode(';', Configuration::get('PS_SPECIFIC_PRICE_PRIORITIES'));
 
@@ -192,12 +192,12 @@ class SpecificPriceCore extends ObjectModel
 
 		$priority = SpecificPrice::$_cache_priorities[(int)$id_product];
 
-	    if (!$priority)
-	        $priority = Configuration::get('PS_SPECIFIC_PRICE_PRIORITIES');
+		if (!$priority)
+			$priority = Configuration::get('PS_SPECIFIC_PRICE_PRIORITIES');
 		$priority = 'id_customer;'.$priority;
 
-	    return preg_split('/;/', $priority);
-    }
+		return preg_split('/;/', $priority);
+	}
 
 	public static function getSpecificPrice($id_product, $id_shop, $id_currency, $id_country, $id_group, $quantity, $id_product_attribute = null, $id_customer = 0, $id_cart = 0, $real_quantity = 0)
 	{
@@ -247,7 +247,7 @@ class SpecificPriceCore extends ObjectModel
 			foreach ($priorities as $priority)
 				$value .= pSQL($priority).';';
 
-        SpecificPrice::deletePriorities();
+		SpecificPrice::deletePriorities();
 
 		return Configuration::updateValue('PS_SPECIFIC_PRICE_PRIORITIES', rtrim($value, ';'));
 	}
@@ -307,11 +307,11 @@ class SpecificPriceCore extends ObjectModel
 			if (!isset($last_quantity[(int)$specific_price['id_product_attribute']]))
 				 $last_quantity[(int)$specific_price['id_product_attribute']] = $specific_price['from_quantity'];
 			elseif ($last_quantity[(int)$specific_price['id_product_attribute']] == $specific_price['from_quantity'])
-		        continue;
+				continue;
 
 			$last_quantity[(int)$specific_price['id_product_attribute']] = $specific_price['from_quantity'];
-            if ($specific_price['from_quantity'] > 1)
-    		    $targeted_prices[] = $specific_price;
+			if ($specific_price['from_quantity'] > 1)
+				$targeted_prices[] = $specific_price;
 		}
 
 		return $targeted_prices;
@@ -424,4 +424,3 @@ class SpecificPriceCore extends ObjectModel
 																	 `to` <= \''.pSQL($to).'\''.$rule);
 	}
 }
-

--- a/classes/State.php
+++ b/classes/State.php
@@ -181,17 +181,17 @@ class StateCore extends ObjectModel
 		return $result;
 	}
 
-    public static function getStatesByIdCountry($id_country)
-    {
-        if (empty($id_country))
-            die(Tools::displayError());
+	public static function getStatesByIdCountry($id_country)
+	{
+		if (empty($id_country))
+			die(Tools::displayError());
 
-        return Db::getInstance()->executeS('
-        SELECT *
-        FROM `'._DB_PREFIX_.'state` s
-        WHERE s.`id_country` = '.(int)$id_country
-        );
-    }
+		return Db::getInstance()->executeS('
+			SELECT *
+			FROM `'._DB_PREFIX_.'state` s
+			WHERE s.`id_country` = '.(int)$id_country
+		);
+	}
 
 	public static function hasCounties($id_state)
 	{
@@ -224,4 +224,3 @@ class StateCore extends ObjectModel
 		');
 	}
 }
-

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -102,8 +102,8 @@ class TabCore extends ObjectModel
 		// Add tab
 		if (parent::add($autodate, $null_values))
 		{	
-            //forces cache to be reloaded
-            self::$_getIdFromClassName = null;
+			//forces cache to be reloaded
+			self::$_getIdFromClassName = null;
 			return Tab::initAccess($this->id);
 		}
 		return false;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -616,7 +616,7 @@ class ToolsCore
 			$amount *= $currency_to->conversion_rate;
 		else
 		{
-            $conversion_rate = ($currency_from->conversion_rate == 0 ? 1 : $currency_from->conversion_rate);
+			$conversion_rate = ($currency_from->conversion_rate == 0 ? 1 : $currency_from->conversion_rate);
 			// Convert amount to default currency (using the old currency rate)
 			$amount = Tools::ps_round($amount / $conversion_rate, 2);
 			// Convert to new currency
@@ -716,38 +716,42 @@ class ToolsCore
 	{
 		$dirname = rtrim($dirname, '/').'/';
 		if (file_exists($dirname))
+		{
 			if ($files = scandir($dirname))
 			{
 				foreach ($files as $file)
-    				if ($file != '.' && $file != '..' && $file != '.svn')
-    				{
-    					if (is_dir($dirname.$file))
-    						Tools::deleteDirectory($dirname.$file, true);
-    					elseif (file_exists($dirname.$file))
+					if ($file != '.' && $file != '..' && $file != '.svn')
+					{
+						if (is_dir($dirname.$file))
+							Tools::deleteDirectory($dirname.$file, true);
+						elseif (file_exists($dirname.$file))
 						{
 							@chmod($dirname.$file, 0777); // NT ?
 							unlink($dirname.$file);
 						}
-    				}
+					}
 				if ($delete_self && file_exists($dirname))
+				{
 					if (!rmdir($dirname))
 					{
 						@chmod($dirname, 0777); // NT ?
-                        return false;
+						return false;
 					}
-                return true;                    
+				}
+				return true;
 			}
-        return false;
-    }
+		}
+		return false;
+	}
 
-    /**
+	/**
 	* Delete file
 	*
 	* @param string File path
 	* @param array  Excluded files
 	*/
-    public static function deleteFile($file, $exclude_files = array())
-    {
+	public static function deleteFile($file, $exclude_files = array())
+	{
 		if (isset($exclude_files) && !is_array($exclude_files))
 			$exclude_files = array($exclude_files);
 
@@ -756,11 +760,11 @@ class ToolsCore
 			@chmod($dirname.$file, 0777); // NT ?
 			unlink($file);
 		}
-    }
-        
+	}
+
 	/**
 	* Clear XML cache folder
- 	*/
+	*/
 	public static function clearXMLCache()
 	{
 		$themes = array();
@@ -3118,4 +3122,3 @@ function cmpPriceDesc($a, $b)
 		return -1;
 	return 0;
 }
-

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -184,8 +184,8 @@ class TranslateCore
 
 			if ($sprintf === null)
 				$lang_cache[$cache_key] = $ret; 
-			else    
-         	return $ret;
+			else
+				return $ret;
 
 		}
 		return $lang_cache[$cache_key];
@@ -209,10 +209,10 @@ class TranslateCore
 		$override_i18n_file = _PS_THEME_DIR_.'pdf/lang/'.$iso.'.php';
 		$i18n_file = _PS_TRANSLATIONS_DIR_.$iso.'/pdf.php';
 		if (file_exists($override_i18n_file))
-            $i18n_file = $override_i18n_file;
+			$i18n_file = $override_i18n_file;
 
-      if (!include($i18n_file))
-            Tools::displayError(sprintf('Cannot include PDF translation language file : %s', $i18n_file));
+		if (!include($i18n_file))
+			Tools::displayError(sprintf('Cannot include PDF translation language file : %s', $i18n_file));
 
 		if (!isset($_LANGPDF) || !is_array($_LANGPDF))
 			return str_replace('"', '&quot;', $string);
@@ -272,4 +272,3 @@ class TranslateCore
 		return $string;
 	}
 }
-

--- a/classes/cache/CacheMemcache.php
+++ b/classes/cache/CacheMemcache.php
@@ -50,35 +50,33 @@ class CacheMemcacheCore extends Cache
 				$this->keys = array();
 		}
 
-       
-
-        /*
+		/*
 		// Get keys (this code comes from Doctrine 2 project)
 		if(is_array($servers) && count($servers) > 0 && method_exists('Memcache', 'getStats'))
-        	$all_slabs = $this->memcache->getStats('slabs');
-	    	        	
+			$all_slabs = $this->memcache->getStats('slabs');
+
 		if(isset($all_slabs) && is_array($all_slabs))
 			foreach ($all_slabs as $server => $slabs)
 			{
-			    if (is_array($slabs))
-			    {
+				if (is_array($slabs))
+				{
 					foreach (array_keys($slabs) as $i => $slab_id) // $slab_id is not an int but a string, using the key instead ?
 					{
 						if(is_int($i))
 						{		
-					        $dump = $this->memcache->getStats('cachedump', (int)$i);
-					        if ($dump)
-					        {
-					           foreach ($dump as $entries)
-					           {
+							$dump = $this->memcache->getStats('cachedump', (int)$i);
+							if ($dump)
+							{
+								foreach ($dump as $entries)
+								{
 									if($entries)
 										foreach ($entries as $key => $data)
 											$this->keys[$key] = $data[1];
-					           }
-					        }
-					    }
+								}
+							}
+						}
 					}
-			    }
+				}
 			}*/
 	}
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -474,7 +474,7 @@ class FrontControllerCore extends Controller
 		}
 
 		// Call hook before assign of css_files and js_files in order to include correctly all css and javascript files
-        $this->context->smarty->assign(array(
+		$this->context->smarty->assign(array(
 			'HOOK_HEADER' => $hook_header,
 			'HOOK_TOP' => Hook::exec('displayTop'),
 			'HOOK_LEFT_COLUMN' => ($this->display_column_left ? Hook::exec('displayLeftColumn') : ''),
@@ -1002,7 +1002,7 @@ class FrontControllerCore extends Controller
 			if (!preg_match('/^http(s?):\/\//i', $media))
 			{
 				$different = 0;
-                $different_css = 0;
+				$different_css = 0;
 				$type = 'css';
 				if (!$css_media_type)
 				{
@@ -1011,12 +1011,12 @@ class FrontControllerCore extends Controller
 				}
 				$override_path = str_replace(__PS_BASE_URI__.'modules/', _PS_ROOT_DIR_.'/themes/'._THEME_NAME_.'/'.$type.'/modules/', $file, $different);
 
-                $override_path_css = str_replace(basename ($file), $type.'/'.basename ($file), str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_.'/', $file), $different_css );
+				$override_path_css = str_replace(basename ($file), $type.'/'.basename ($file), str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_.'/', $file), $different_css );
 
 				if ($different && file_exists($override_path))
 					$file = str_replace(__PS_BASE_URI__.'modules/', __PS_BASE_URI__.'themes/'._THEME_NAME_.'/'.$type.'/modules/', $file, $different);
-                elseif ($different_css && file_exists($override_path_css))
-                    $file = $override_path_css;
+				elseif ($different_css && file_exists($override_path_css))
+					$file = $override_path_css;
 
 				if ($css_media_type)
 					$list_uri[$file] = $media;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -322,17 +322,17 @@ class OrderCore extends ObjectModel
 	public function getCartProducts()
 	{
 		$product_id_list = array();
-        	$products = $this->getProducts();
+		$products = $this->getProducts();
 		foreach ($products as &$product)
-        	{
+		{
 			$product['id_product_attribute'] = $product['product_attribute_id'];
 			$product['cart_quantity'] = $product['product_quantity'];
 			$product_id_list[] = $this->id_address_delivery.'_'
 				.$product['product_id'].'_'
 				.$product['product_attribute_id'].'_'
 				.(isset($product['id_customization']) ? $product['id_customization'] : '0');
-	        }
-	        unset($product);
+		}
+		unset($product);
 
 		$product_list = array();
 		foreach ($products as $product)
@@ -472,20 +472,21 @@ class OrderCore extends ObjectModel
 		{
 			$id_lang = $id_lang ? (int)($id_lang) : 'o.`id_lang`';
 			$result = Db::getInstance()->executeS('
-			SELECT os.*, oh.*, e.`firstname` as employee_firstname, e.`lastname` as employee_lastname, osl.`name` as ostate_name
-			FROM `'._DB_PREFIX_.'orders` o
-			LEFT JOIN `'._DB_PREFIX_.'order_history` oh ON o.`id_order` = oh.`id_order`
-			LEFT JOIN `'._DB_PREFIX_.'order_state` os ON os.`id_order_state` = oh.`id_order_state`
-			LEFT JOIN `'._DB_PREFIX_.'order_state_lang` osl ON (os.`id_order_state` = osl.`id_order_state` AND osl.`id_lang` = '.(int)($id_lang).')
-			LEFT JOIN `'._DB_PREFIX_.'employee` e ON e.`id_employee` = oh.`id_employee`
-			WHERE oh.id_order = '.(int)($this->id).'
-			'.($no_hidden ? ' AND os.hidden = 0' : '').'
-			'.($logable ? ' AND os.logable = 1' : '').'
-			'.($delivery ? ' AND os.delivery = 1' : '').'
-			'.($paid ? ' AND os.paid = 1' : '').'
-			'.($shipped ? ' AND os.shipped = 1' : '').'
-			'.((int)($id_order_state) ? ' AND oh.`id_order_state` = '.(int)($id_order_state) : '').'
-			ORDER BY oh.date_add DESC, oh.id_order_history DESC');
+				SELECT os.*, oh.*, e.`firstname` as employee_firstname, e.`lastname` as employee_lastname, osl.`name` as ostate_name
+				FROM `'._DB_PREFIX_.'orders` o
+				LEFT JOIN `'._DB_PREFIX_.'order_history` oh ON o.`id_order` = oh.`id_order`
+				LEFT JOIN `'._DB_PREFIX_.'order_state` os ON os.`id_order_state` = oh.`id_order_state`
+				LEFT JOIN `'._DB_PREFIX_.'order_state_lang` osl ON (os.`id_order_state` = osl.`id_order_state` AND osl.`id_lang` = '.(int)($id_lang).')
+				LEFT JOIN `'._DB_PREFIX_.'employee` e ON e.`id_employee` = oh.`id_employee`
+				WHERE oh.id_order = '.(int)($this->id).'
+				'.($no_hidden ? ' AND os.hidden = 0' : '').'
+				'.($logable ? ' AND os.logable = 1' : '').'
+				'.($delivery ? ' AND os.delivery = 1' : '').'
+				'.($paid ? ' AND os.paid = 1' : '').'
+				'.($shipped ? ' AND os.shipped = 1' : '').'
+				'.((int)($id_order_state) ? ' AND oh.`id_order_state` = '.(int)($id_order_state) : '').'
+				ORDER BY oh.date_add DESC, oh.id_order_history DESC
+			');
 			if ($no_hidden)
 				return $result;
 			self::$_historyCache[$this->id.'_'.$id_order_state.'_'.$filters] = $result;
@@ -496,11 +497,12 @@ class OrderCore extends ObjectModel
 	public function getProductsDetail()
 	{
 		return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-		SELECT *
-		FROM `'._DB_PREFIX_.'order_detail` od
-		LEFT JOIN `'._DB_PREFIX_.'product` p ON (p.id_product = od.product_id)
-		LEFT JOIN `'._DB_PREFIX_.'product_shop` ps ON (ps.id_product = p.id_product AND ps.id_shop = od.id_shop)
-		WHERE od.`id_order` = '.(int)($this->id));
+			SELECT *
+			FROM `'._DB_PREFIX_.'order_detail` od
+			LEFT JOIN `'._DB_PREFIX_.'product` p ON (p.id_product = od.product_id)
+			LEFT JOIN `'._DB_PREFIX_.'product_shop` ps ON (ps.id_product = p.id_product AND ps.id_shop = od.id_shop)
+			WHERE od.`id_order` = '.(int)($this->id)
+		);
 	}
 
 	public function getFirstMessage()

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -86,11 +86,11 @@ class OrderDetailCore extends ObjectModel
 	/** @var float */
 	public $reduction_amount;
 
-    /** @var float */
-    public $reduction_amount_tax_excl;
+	/** @var float */
+	public $reduction_amount_tax_excl;
 
-    /** @var float */
-    public $reduction_amount_tax_incl;
+	/** @var float */
+	public $reduction_amount_tax_incl;
 
 	/** @var float */
 	public $group_reduction;
@@ -143,11 +143,11 @@ class OrderDetailCore extends ObjectModel
 	/** @var int Id warehouse */
 	public $id_warehouse;
 
-    /** @var float additional shipping price tax excl */
-    public $total_shipping_price_tax_excl;
+	/** @var float additional shipping price tax excl */
+	public $total_shipping_price_tax_excl;
 
-    /** @var float additional shipping price tax incl */
-    public $total_shipping_price_tax_incl;
+	/** @var float additional shipping price tax incl */
+	public $total_shipping_price_tax_incl;
 
 	/** @var float */
 	public $purchase_supplier_price;
@@ -174,8 +174,8 @@ class OrderDetailCore extends ObjectModel
 			'product_price' => 				array('type' => self::TYPE_FLOAT, 'validate' => 'isPrice', 'required' => true),
 			'reduction_percent' => 			array('type' => self::TYPE_FLOAT, 'validate' => 'isFloat'),
 			'reduction_amount' =>			array('type' => self::TYPE_FLOAT, 'validate' => 'isPrice'),
-            'reduction_amount_tax_incl' =>  array('type' => self::TYPE_FLOAT, 'validate' => 'isPrice'),
-            'reduction_amount_tax_excl' =>  array('type' => self::TYPE_FLOAT, 'validate' => 'isPrice'),
+			'reduction_amount_tax_incl' =>  array('type' => self::TYPE_FLOAT, 'validate' => 'isPrice'),
+			'reduction_amount_tax_excl' =>  array('type' => self::TYPE_FLOAT, 'validate' => 'isPrice'),
 			'group_reduction' => 			array('type' => self::TYPE_FLOAT, 'validate' => 'isFloat'),
 			'product_quantity_discount' => 	array('type' => self::TYPE_FLOAT, 'validate' => 'isFloat'),
 			'product_ean13' => 				array('type' => self::TYPE_STRING, 'validate' => 'isEan13'),
@@ -506,9 +506,9 @@ class OrderDetailCore extends ObjectModel
 		$this->total_price_tax_incl = (float)$product['total_wt'];
 		$this->total_price_tax_excl = (float)$product['total'];
 
-        $this->purchase_supplier_price = (float)$product['wholesale_price'];
-        if ($product['id_supplier'] > 0)
-            $this->purchase_supplier_price = (float)ProductSupplier::getProductPrice((int)$product['id_supplier'], $product['id_product'], $product['id_product_attribute'], true);
+		$this->purchase_supplier_price = (float)$product['wholesale_price'];
+		if ($product['id_supplier'] > 0)
+			$this->purchase_supplier_price = (float)ProductSupplier::getProductPrice((int)$product['id_supplier'], $product['id_product'], $product['id_product_attribute'], true);
 
 		$this->setSpecificPrice($order, $product);
 
@@ -626,34 +626,34 @@ class OrderDetailCore extends ObjectModel
 		return $this->outOfStock;
 	}
 
-    /**
-     * Set the additional shipping information
-     *
-     * @param Order $order
-     * @param $product
-     */
-    public function setShippingCost(Order $order, $product)
-    {
-        $tax_rate = 0;
+	/**
+	 * Set the additional shipping information
+	 *
+	 * @param Order $order
+	 * @param $product
+	 */
+	public function setShippingCost(Order $order, $product)
+	{
+		$tax_rate = 0;
 
-        $carrier = OrderInvoice::getCarrier((int)$this->id_order_invoice);
-        if (isset($carrier) && Validate::isLoadedObject($carrier))
-            $tax_rate = $carrier->getTaxesRate(new Address((int)$order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}));
+		$carrier = OrderInvoice::getCarrier((int)$this->id_order_invoice);
+		if (isset($carrier) && Validate::isLoadedObject($carrier))
+			$tax_rate = $carrier->getTaxesRate(new Address((int)$order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}));
 
-        $this->total_shipping_price_tax_excl = (float)$product['additional_shipping_cost'];
-        $this->total_shipping_price_tax_incl = (float)($this->total_shipping_price_tax_excl * (1 + ($tax_rate / 100)));
-        $this->total_shipping_price_tax_incl = Tools::ps_round($this->total_shipping_price_tax_incl, 2);
-    }
+		$this->total_shipping_price_tax_excl = (float)$product['additional_shipping_cost'];
+		$this->total_shipping_price_tax_incl = (float)($this->total_shipping_price_tax_excl * (1 + ($tax_rate / 100)));
+		$this->total_shipping_price_tax_incl = Tools::ps_round($this->total_shipping_price_tax_incl, 2);
+	}
 
-    public function getWsTaxes()
-    {
-    	$query = new DbQuery();
-    	$query->select('id_tax as id');
-    	$query->from('order_detail_tax', 'tax');
-    	$query->join('LEFT JOIN `'._DB_PREFIX_.'order_detail` od ON (tax.`id_order_detail` = od.`id_order_detail`)');
-    	$query->where('od.`id_order_detail` = '.(int)$this->id_order_detail);
-    	return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
-    }
+	public function getWsTaxes()
+	{
+		$query = new DbQuery();
+		$query->select('id_tax as id');
+		$query->from('order_detail_tax', 'tax');
+		$query->join('LEFT JOIN `'._DB_PREFIX_.'order_detail` od ON (tax.`id_order_detail` = od.`id_order_detail`)');
+		$query->where('od.`id_order_detail` = '.(int)$this->id_order_detail);
+		return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+	}
 
 	public static function getCrossSells($id_product, $id_lang, $limit = 12)
 	{

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -458,29 +458,29 @@ class OrderHistoryCore extends ObjectModel
 		AND os.`logable` = 1');
 	}
 
-    /**
-     * Add method for webservice create resource Order History      
-     * If sendemail=1 GET parameter is present sends email to customer otherwise does not
-     * @return bool
-     */
+	/**
+	 * Add method for webservice create resource Order History      
+	 * If sendemail=1 GET parameter is present sends email to customer otherwise does not
+	 * @return bool
+	 */
 	public function addWs()
 	{
-	    $sendemail = (bool)Tools::getValue('sendemail', false);
-	    $this->changeIdOrderState($this->id_order_state, $this->id_order);
-	    
-	    if ($sendemail)
-	    {
-	        //Mail::Send requires link object on context and is not set when getting here
-	        $context = Context::getContext();
-	        if ($context->link == null)
-	        {
-	            $protocol_link = (Tools::usingSecureMode() && Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';
-	            $protocol_content = (Tools::usingSecureMode() && Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';
-	            $context->link = new Link($protocol_link, $protocol_content);
-	        }
-	        return $this->addWithemail();            
-	    }
+		$sendemail = (bool)Tools::getValue('sendemail', false);
+		$this->changeIdOrderState($this->id_order_state, $this->id_order);
+
+		if ($sendemail)
+		{
+			//Mail::Send requires link object on context and is not set when getting here
+			$context = Context::getContext();
+			if ($context->link == null)
+			{
+				$protocol_link = (Tools::usingSecureMode() && Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';
+				$protocol_content = (Tools::usingSecureMode() && Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';
+				$context->link = new Link($protocol_link, $protocol_content);
+			}
+			return $this->addWithemail();            
+		}
 		else
-	        return $this->add();
+			return $this->add();
 	}
 }

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -567,7 +567,7 @@ class OrderInvoiceCore extends ObjectModel
 	 * Return collection of order invoice object linked to the payments of the current order invoice object
 	 * 
 	 * @since 1.5.0.14
-     * @return PrestaShopCollection|array Collection of OrderInvoice or empty array
+	 * @return PrestaShopCollection|array Collection of OrderInvoice or empty array
 	 */
 	public function getSibling()
 	{

--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -153,7 +153,7 @@ class PDFGeneratorCore extends TCPDF
 	 * Render the pdf file
 	 *
 	 * @param string $filename
-         * @param  $display :  true:display to user, false:save, 'I','D','S' as fpdf display
+	 * @param  $display :  true:display to user, false:save, 'I','D','S' as fpdf display
 	 * @throws PrestaShopException
 	 */
 	public function render($filename, $display = true)

--- a/classes/stock/StockMvtWS.php
+++ b/classes/stock/StockMvtWS.php
@@ -171,7 +171,7 @@ class StockMvtWSCore extends ObjectModelCore
 		),
 	);
 
-    /**
+	/**
 	 * @see ObjectModel::$webserviceParameters
 	 */
  	protected $webserviceParameters = array(

--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -88,10 +88,10 @@ class TaxCore extends ObjectModel
 
 	public function toggleStatus()
 	{
-	    if (parent::toggleStatus())
-            return $this->_onStatusChange();
+		if (parent::toggleStatus())
+			return $this->_onStatusChange();
 
-        return false;
+		return false;
 	}
 
 	public function update($nullValues = false)
@@ -117,10 +117,10 @@ class TaxCore extends ObjectModel
 
 	protected function _onStatusChange()
 	{
-        if (!$this->active)
-            return TaxRule::deleteTaxRuleByIdTax($this->id);
+		if (!$this->active)
+			return TaxRule::deleteTaxRuleByIdTax($this->id);
 
-        return true;
+		return true;
 	}
 
 	/**
@@ -265,4 +265,3 @@ class TaxCore extends ObjectModel
 		return $tax_calculator->getTotalRate();
 	}
 }
-

--- a/classes/tax/TaxRule.php
+++ b/classes/tax/TaxRule.php
@@ -53,31 +53,31 @@ class TaxRuleCore extends ObjectModel
 		),
 	);
 
-    protected $webserviceParameters = array(
-        'fields' => array(
-            'id_tax_rules_group' => array('xlink_resource'=> 'tax_rule_groups'),
-            'id_state' => array('xlink_resource'=> 'states'),
-            'id_country' => array('xlink_resource'=> 'countries')
-        ),
-    );
+	protected $webserviceParameters = array(
+		'fields' => array(
+			'id_tax_rules_group' => array('xlink_resource'=> 'tax_rule_groups'),
+			'id_state' => array('xlink_resource'=> 'states'),
+			'id_country' => array('xlink_resource'=> 'countries')
+		),
+	);
 
-    public static function deleteByGroupId($id_group)
-    {
-        if (empty($id_group))
-            die(Tools::displayError());
+	public static function deleteByGroupId($id_group)
+	{
+		if (empty($id_group))
+			die(Tools::displayError());
 
-        return Db::getInstance()->execute('
-        DELETE FROM `'._DB_PREFIX_.'tax_rule`
-        WHERE `id_tax_rules_group` = '.(int)$id_group
-        );
-    }
+		return Db::getInstance()->execute('
+			DELETE FROM `'._DB_PREFIX_.'tax_rule`
+			WHERE `id_tax_rules_group` = '.(int)$id_group
+		);
+	}
 
-    public static function retrieveById($id_tax_rule)
-    {
-    	return Db::getInstance()->getRow('
-    	SELECT * FROM `'._DB_PREFIX_.'tax_rule`
-    	WHERE `id_tax_rule` = '.(int)$id_tax_rule);
-    }
+	public static function retrieveById($id_tax_rule)
+	{
+		return Db::getInstance()->getRow('
+		SELECT * FROM `'._DB_PREFIX_.'tax_rule`
+		WHERE `id_tax_rule` = '.(int)$id_tax_rule);
+	}
 
 	public static function getTaxRulesByGroupId($id_lang, $id_group)
 	{
@@ -100,13 +100,13 @@ class TaxRuleCore extends ObjectModel
 		);
 	}
 
-    public static function deleteTaxRuleByIdTax($id_tax)
-    {
-        return Db::getInstance()->execute('
-        DELETE FROM `'._DB_PREFIX_.'tax_rule`
-        WHERE `id_tax` = '.(int)$id_tax
-        );
-    }
+	public static function deleteTaxRuleByIdTax($id_tax)
+	{
+		return Db::getInstance()->execute('
+			DELETE FROM `'._DB_PREFIX_.'tax_rule`
+			WHERE `id_tax` = '.(int)$id_tax
+		);
+	}
 
 
 	/**
@@ -122,8 +122,8 @@ class TaxRuleCore extends ObjectModel
 	* @param int $id_tax
 	* @return boolean
 	*/
-    public static function isTaxInUse($id_tax)
-    {
+	public static function isTaxInUse($id_tax)
+	{
 		$cache_id = 'TaxRule::isTaxInUse_'.(int)$id_tax;
 		if (!Cache::isStored($cache_id))
 		{
@@ -131,7 +131,7 @@ class TaxRuleCore extends ObjectModel
 			Cache::store($cache_id, $result);
 		}
 		return Cache::retrieve($cache_id);
-    }
+	}
 
 
 	 /**
@@ -183,4 +183,3 @@ class TaxRuleCore extends ObjectModel
 		);
 	}
 }
-

--- a/classes/tax/TaxRulesGroup.php
+++ b/classes/tax/TaxRulesGroup.php
@@ -27,10 +27,10 @@
 
 class TaxRulesGroupCore extends ObjectModel
 {
-    public $name;
+	public $name;
 
-    /** @var bool active state */
-    public $active;
+	/** @var bool active state */
+	public $active;
 
 	/**
 	 * @see ObjectModel::$definition
@@ -45,8 +45,8 @@ class TaxRulesGroupCore extends ObjectModel
 	);
 
 	protected $webserviceParameters = array(
-	'objectsNodeName' => 'tax_rule_groups',
-	'objectNodeName' => 'tax_rule_group',
+		'objectsNodeName' => 'tax_rule_groups',
+		'objectNodeName' => 'tax_rule_group',
 		'fields' => array(
 		),
 	);
@@ -149,4 +149,3 @@ class TaxRulesGroupCore extends ObjectModel
 	}
 
 }
-

--- a/classes/tree/Tree.php
+++ b/classes/tree/Tree.php
@@ -392,13 +392,13 @@ class TreeCore
 	private function _normalizeDirectory($directory)
 	{
 		$last = $directory[strlen($directory) - 1];
-        
-        if (in_array($last, array('/', '\\'))) {
-            $directory[strlen($directory) - 1] = DIRECTORY_SEPARATOR;
-            return $directory;
-        }
-        
-        $directory .= DIRECTORY_SEPARATOR;
-        return $directory;
+
+		if (in_array($last, array('/', '\\'))) {
+			$directory[strlen($directory) - 1] = DIRECTORY_SEPARATOR;
+			return $directory;
+		}
+
+		$directory .= DIRECTORY_SEPARATOR;
+		return $directory;
 	}
 }

--- a/classes/tree/TreeToolbar.php
+++ b/classes/tree/TreeToolbar.php
@@ -180,13 +180,13 @@ class TreeToolbarCore implements ITreeToolbarCore
 	private function _normalizeDirectory($directory)
 	{
 		$last = $directory[strlen($directory) - 1];
-        
-        if (in_array($last, array('/', '\\'))) {
-            $directory[strlen($directory) - 1] = DIRECTORY_SEPARATOR;
-            return $directory;
-        }
-        
-        $directory .= DIRECTORY_SEPARATOR;
-        return $directory;
+
+		if (in_array($last, array('/', '\\'))) {
+			$directory[strlen($directory) - 1] = DIRECTORY_SEPARATOR;
+			return $directory;
+		}
+
+		$directory .= DIRECTORY_SEPARATOR;
+		return $directory;
 	}
 }

--- a/classes/tree/TreeToolbarButton.php
+++ b/classes/tree/TreeToolbarButton.php
@@ -203,13 +203,13 @@ abstract class TreeToolbarButtonCore
 	private function _normalizeDirectory($directory)
 	{
 		$last = $directory[strlen($directory) - 1];
-        
-        if (in_array($last, array('/', '\\'))) {
-            $directory[strlen($directory) - 1] = DIRECTORY_SEPARATOR;
-            return $directory;
-        }
-        
-        $directory .= DIRECTORY_SEPARATOR;
-        return $directory;
+
+		if (in_array($last, array('/', '\\'))) {
+			$directory[strlen($directory) - 1] = DIRECTORY_SEPARATOR;
+			return $directory;
+		}
+
+		$directory .= DIRECTORY_SEPARATOR;
+		return $directory;
 	}
 }

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -620,20 +620,20 @@ class WebserviceRequestCore
 			return;
 			
 		$errortype = array (
-                E_ERROR              => 'Error',
-                E_WARNING            => 'Warning',
-                E_PARSE              => 'Parse',
-                E_NOTICE             => 'Notice',
-                E_CORE_ERROR         => 'Core Error',
-                E_CORE_WARNING       => 'Core Warning',
-                E_COMPILE_ERROR      => 'Compile Error',
-                E_COMPILE_WARNING    => 'Compile Warning',
-                E_USER_ERROR         => 'Error',
-                E_USER_WARNING       => 'User warning',
-                E_USER_NOTICE        => 'User notice',
-                E_STRICT             => 'Runtime Notice',
-                E_RECOVERABLE_ERROR => 'Recoverable error'
-                );
+			E_ERROR              => 'Error',
+			E_WARNING            => 'Warning',
+			E_PARSE              => 'Parse',
+			E_NOTICE             => 'Notice',
+			E_CORE_ERROR         => 'Core Error',
+			E_CORE_WARNING       => 'Core Warning',
+			E_COMPILE_ERROR      => 'Compile Error',
+			E_COMPILE_WARNING    => 'Compile Warning',
+			E_USER_ERROR         => 'Error',
+			E_USER_WARNING       => 'User warning',
+			E_USER_NOTICE        => 'User notice',
+			E_STRICT             => 'Runtime Notice',
+			E_RECOVERABLE_ERROR => 'Recoverable error'
+		);
 		$type = (isset($errortype[$errno]) ? $errortype[$errno] : 'Unknown error');
 		error_log('[PHP '.$type.' #'.$errno.'] '.$errstr.' ('.$errfile.', line '.$errline.')');
 

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -47,8 +47,8 @@ $currentDir = dirname(__FILE__);
 
 if (!defined('PHP_VERSION_ID'))
 {
-    $version = explode('.', PHP_VERSION);
-    define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
+	$version = explode('.', PHP_VERSION);
+	define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
 }
 
 if (!defined('_PS_VERSION_') && (getenv('_PS_VERSION_') || getenv('REDIRECT__PS_VERSION_')))
@@ -75,18 +75,18 @@ define('_PS_ALL_THEMES_DIR_',        _PS_ROOT_DIR_.'/themes/');
 /* BO THEMES */
 if (defined('_PS_ADMIN_DIR_'))
 	define('_PS_BO_ALL_THEMES_DIR_', _PS_ADMIN_DIR_.'/themes/');
-define('_PS_CACHE_DIR_',			 _PS_ROOT_DIR_.'/cache/');
-define('_PS_CONFIG_DIR_',			 _PS_CORE_DIR_.'/config/');
+define('_PS_CACHE_DIR_',             _PS_ROOT_DIR_.'/cache/');
+define('_PS_CONFIG_DIR_',            _PS_CORE_DIR_.'/config/');
 define('_PS_CLASS_DIR_',             _PS_CORE_DIR_.'/classes/');
 define('_PS_DOWNLOAD_DIR_',          _PS_ROOT_DIR_.'/download/');
 define('_PS_MAIL_DIR_',              _PS_CORE_DIR_.'/mails/');
 if (!defined('_PS_MODULE_DIR_'))
 	define('_PS_MODULE_DIR_',        _PS_ROOT_DIR_.'/modules/');
 if (!defined('_PS_OVERRIDE_DIR_'))
-    define('_PS_OVERRIDE_DIR_',          _PS_ROOT_DIR_.'/override/');
+	define('_PS_OVERRIDE_DIR_',      _PS_ROOT_DIR_.'/override/');
 define('_PS_PDF_DIR_',               _PS_CORE_DIR_.'/pdf/');
 define('_PS_TRANSLATIONS_DIR_',      _PS_ROOT_DIR_.'/translations/');
-define('_PS_UPLOAD_DIR_',			 _PS_ROOT_DIR_.'/upload/');
+define('_PS_UPLOAD_DIR_',            _PS_ROOT_DIR_.'/upload/');
 
 define('_PS_CONTROLLER_DIR_',        _PS_CORE_DIR_.'/controllers/');
 define('_PS_ADMIN_CONTROLLER_DIR_',  _PS_CORE_DIR_.'/controllers/admin/');
@@ -107,7 +107,7 @@ else
 	define('_PS_CORE_IMG_DIR_',      _PS_ROOT_DIR_.'/img/');
 
 define('_PS_CAT_IMG_DIR_',           _PS_IMG_DIR_.'c/');
-define('_PS_COL_IMG_DIR_',			 _PS_IMG_DIR_.'co/');
+define('_PS_COL_IMG_DIR_',           _PS_IMG_DIR_.'co/');
 define('_PS_EMPLOYEE_IMG_DIR_',      _PS_IMG_DIR_.'e/');
 define('_PS_GENDERS_DIR_',           _PS_IMG_DIR_.'genders/');
 define('_PS_LANG_IMG_DIR_',          _PS_IMG_DIR_.'l/');
@@ -117,7 +117,7 @@ define('_PS_PROD_IMG_DIR_',          _PS_IMG_DIR_.'p/');
 define('_PS_SCENE_IMG_DIR_',         _PS_IMG_DIR_.'scenes/');
 define('_PS_SCENE_THUMB_IMG_DIR_',   _PS_IMG_DIR_.'scenes/thumbs/');
 define('_PS_SHIP_IMG_DIR_',          _PS_IMG_DIR_.'s/');
-define('_PS_STORE_IMG_DIR_',		 _PS_IMG_DIR_.'st/');
+define('_PS_STORE_IMG_DIR_',         _PS_IMG_DIR_.'st/');
 define('_PS_SUPP_IMG_DIR_',          _PS_IMG_DIR_.'su/');
 define('_PS_TMP_IMG_DIR_',           _PS_IMG_DIR_.'tmp/');
 


### PR DESCRIPTION
Unsetting models ID should be done prior to calling this method.
This allows inserting an entity with a previously set ID, which may come in handy when regularely syncing PrestaShop with an external system (an AS400 database for exemple), avoiding in some case the need for an extra column storage to keep the external ID.
