### PR TITLE
PSCFV-12072 (slow product delete)

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -615,9 +615,7 @@ class ProductCore extends ObjectModel
 	 */
 	public static function cleanPositions($id_category,$position=0)
 	{
-		$return = true;
-
-		$return &= Db::getInstance()->update('category_product', array(
+		$return =  Db::getInstance()->update('category_product', array(
                         'position' => array('type' => 'sql', 'value' => '`position`-1')
                 ), '`id_category` = '.(int)$id_category.' AND `position` > '.(int)$position);
 


### PR DESCRIPTION
make only one update instead of one per product when deleting a product

there is also a wrong call to cleanPositions in delete method (it's parameter should be the category, not id_product and cleanPositions is called inside deleteCategories becaouse the parameter is set to true, so it was being called twice)
