### PR TITLE
[-] Installer: console / install theme before modules

### DIFF
--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -104,13 +104,12 @@ class InstallControllerConsoleProcess extends InstallControllerConsole
 			$this->printErrors();
 		if (!$this->processInstallFixtures())
 			$this->printErrors();
+		if (!$this->processInstallTheme())
+			$this->printErrors();
 		if (!$this->processInstallModules())
 			$this->printErrors();
 		if (!$this->processInstallAddonsModules())
 			$this->printErrors();
-		if (!$this->processInstallTheme())
-			$this->printErrors();
-
 		if ($this->datas->newsletter)
 		{
 			$params = http_build_query(array(


### PR DESCRIPTION
We need to install the theme before the module cause they need a theme with a active column to be install. If not, the installation will return false and somes erros will come in console.

If we install the modules before, we will have one errors with the theme.sql process cause table "PREFIX_linksmenutop" doesn't exist at this time.
