### PR TITLE
[-] Call Field Callback for CSV Export

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -778,6 +778,11 @@ class AdminControllerCore extends Controller
 					if ($path_to_image)
 						$field_value = $path_to_image;  
 				}
+				if (isset($params['callback']))
+                                {
+                                	$callback_obj = (isset($params['callback_object'])) ? $params['callback_object'] : $this->context->controller;
+                                	$field_value = call_user_func_array(array($callback_obj, $params['callback']), array($field_value, $row));
+                                }
 				$content[$i][] = $field_value;
 			}
 		}


### PR DESCRIPTION
Lorsque l'on exporte les paniers par le BO, la colonne "Total" retourne l'ID du panier. Cela est dû au fait qu'il manque l'appel à la callback permettant de calculer le total pour chaque ligne.

---

When we export carts by BO, the "Total" column returns the ID of the cart. This is because it lacks the call to callback to calculate the total for each row.
