### PR TITLE
[*] BO : Enables the browser built-in spellchecker in TinyMCE configuration

### DIFF
--- a/js/tinymce.inc.js
+++ b/js/tinymce.inc.js
@@ -12,7 +12,8 @@ function tinySetup(config)
 //    safari,pagebreak,style,table,advimage,advlink,inlinepopups,media,contextmenu,paste,fullscreen,xhtmlxtras,preview
 	default_config = {
 		selector: ".rte" ,
-		plugins : "colorpicker link image paste pagebreak table contextmenu filemanager table code media autoresize textcolor",
+		plugins : "colorpicker link image paste pagebreak table filemanager table code media autoresize textcolor",
+		browser_spellcheck : true,
 		toolbar1 : "code,|,bold,italic,underline,strikethrough,|,justifyleft,justifycenter,justifyright,justifyfull,formatselect,|,blockquote,colorpicker,pasteword,|,bullist,numlist,|,outdent,indent,|,link,unlink,|,cleanup,|,media,image",
 		toolbar2: "",
 		external_filemanager_path: ad+"/filemanager/",


### PR DESCRIPTION
Give me my spellchecker back ! 
The browser spellchecker is disabled by defaut by TinyMCE, which is kind of awkward + TinyMCE overrides the context menu with items that are redundant as they already are in the toolbar. 
This brings the browser spellchecker and context menu back.
