### PR TITLE
[*] BO : FixBug JS French Calendar

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -952,7 +952,7 @@
 				pmNames: ['PM', 'P'],
 				timeFormat: 'hh:mm:ss tt',
 				timeSuffix: '',
-				timeOnlyTitle: '{l s='Choose Time'}',
+				timeOnlyTitle: "{l s='Choose Time'}",
 				timeText: '{l s='Time'}',
 				hourText: '{l s='Hour'}',
 				minuteText: '{l s='Minute'}',


### PR DESCRIPTION
This modification avoid error when we use calendar in French :

timeOnlyTitle: 'Choisir l'heure',
