### PR TITLE
[*] Core : fix escape quote in admin controller from module

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2088,6 +2088,11 @@ class CartCore extends ObjectModel
 		}
 
 		$cart_rules = CartRule::getCustomerCartRules(Context::getContext()->cookie->id_lang, Context::getContext()->cookie->id_customer, true);
+		$result = Db::getInstance('SELECT * FROM '._DB_PREFIX_.'cart_cart_rule WHERE id_cart=' . $this->id);
+                $cart_rules_in_cart = array();
+                foreach($result as $row) {
+                  $cart_rules_in_cart[] = $row['id_cart_rules'];
+                }
 
 		$free_carriers_rules = array();
 		foreach ($cart_rules as $cart_rule)
@@ -2095,7 +2100,7 @@ class CartCore extends ObjectModel
 			if ($cart_rule['free_shipping'] && $cart_rule['carrier_restriction'])
 			{
 				$cr = new CartRule((int)$cart_rule['id_cart_rule']);
-				if (Validate::isLoadedObject($cr))
+				if (Validate::isLoadedObject($cr) && $cr->checkValidity(Context::getContext(),in_array((int)$cart_rule['id_cart_rule'],$cart_rules_in_cart),false,false))
 				{
 					$carriers = $cr->getAssociatedRestrictions('carrier', true, false);
 					if (is_array($carriers) && count($carriers) && isset($carriers['selected']))

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -64,7 +64,7 @@ class TranslateCore
 			if (class_exists($class_name_controller) && Module::getModuleNameFromClass($class_name_controller))
 			{
 				$string = str_replace('\'', '\\\'', $string);
-				return Translate::getModuleTranslation(Module::$classInModule[$class_name_controller], $string, $class_name_controller);
+				return Translate::getModuleTranslation(Module::$classInModule[$class_name_controller], $string, $class_name_controller,$sprintf,$addslashes);
 			}
 		}
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -731,7 +731,7 @@ class AdminControllerCore extends Controller
 		// clean buffer
 		if (ob_get_level() && ob_get_length() > 0)
 			ob_clean();
-		$this->getList($this->context->language->id);
+		$this->getList($this->context->language->id,null,null,0,false);
 		if (!count($this->_list))
 			return;
 

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -182,9 +182,9 @@ class CartControllerCore extends FrontController
 		$mode = (Tools::getIsset('update') && $this->id_product) ? 'update' : 'add';
 
 		if ($this->qty == 0)
-			$this->errors[] = Tools::displayError('Null quantity.');
+			$this->errors[] = Tools::displayError('Null quantity.',false);
 		elseif (!$this->id_product)
-			$this->errors[] = Tools::displayError('Product not found');
+			$this->errors[] = Tools::displayError('Product not found',false);
 
 		$product = new Product($this->id_product, true, $this->context->language->id);
 		if (!$product->id || !$product->active)


### PR DESCRIPTION
Corrige le problème d'apostrophe avec un contrôleur d'administration créé dans un module avec un champs date dans le HelperForm
