### PR TITLE
[*] BO : Force integer value for the default form language

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -890,7 +890,7 @@
 {if $firstCall}
 	<script type="text/javascript">
 		var module_dir = '{$smarty.const._MODULE_DIR_}';
-		var id_language = {$defaultFormLanguage};
+		var id_language = {$defaultFormLanguage|intval};
 		var languages = new Array();
 		var vat_number = {if $vat_number}1{else}0{/if};
 		// Multilang field setup must happen before document is ready so that calls to displayFlags() to avoid


### PR DESCRIPTION
This prevents a JavaScript error if the variable is empty.
