### PR TITLE
[-] BO : Fix TinyMCE alignment buttons

### DIFF
--- a/js/tinymce.inc.js
+++ b/js/tinymce.inc.js
@@ -13,7 +13,7 @@ function tinySetup(config)
 	default_config = {
 		selector: ".rte" ,
 		plugins : "colorpicker link image paste pagebreak table contextmenu filemanager table code media autoresize textcolor",
-		toolbar1 : "code,|,bold,italic,underline,strikethrough,|,justifyleft,justifycenter,justifyright,justifyfull,formatselect,|,blockquote,colorpicker,pasteword,|,bullist,numlist,|,outdent,indent,|,link,unlink,|,cleanup,|,media,image",
+		toolbar1 : "code,|,bold,italic,underline,strikethrough,|,alignleft,aligncenter,alignright,alignfull,formatselect,|,blockquote,colorpicker,pasteword,|,bullist,numlist,|,outdent,indent,|,link,unlink,|,cleanup,|,media,image",
 		toolbar2: "",
 		external_filemanager_path: ad+"/filemanager/",
 		filemanager_title: "File manager" ,


### PR DESCRIPTION
Just a simple fix for incorrect alignment buttons in toolbar format. It currently doesn't cause any errors, TinyMCE just ignored the wrong name and the buttons are not there.

Reference about TinyMCE toolbar controls: http://www.tinymce.com/wiki.php/Controls.
