### PR TITLE
[*] CORE : Add semi-colon before and after packed js files

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -160,10 +160,10 @@ class MediaCore
 			} catch (Exception $e) {
 				if (_PS_MODE_DEV_)
 					echo $e->getMessage();
-				return ';'.$js_content.';';
+				return ';'.trim($js_content, ';').';';
 			}
 		}
-		return ';'.$js_content.';';
+		return ';'.trim($js_content, ';').';';
 	}
 
 	public static function minifyCSS($css_content, $fileuri = false, &$import_url = array())

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -146,7 +146,7 @@ class MediaCore
 		$preg_matches[count($preg_matches) - 1] = '/* ]]> */'.$preg_matches[count($preg_matches) - 1];
 		unset($preg_matches[0]);
 		$output = implode('', $preg_matches);
-		return ';'.$output.';';
+		return $output;
 	}
 
 

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -146,7 +146,7 @@ class MediaCore
 		$preg_matches[count($preg_matches) - 1] = '/* ]]> */'.$preg_matches[count($preg_matches) - 1];
 		unset($preg_matches[0]);
 		$output = implode('', $preg_matches);
-		return $output;
+		return ';'.$output.';';
 	}
 
 
@@ -160,10 +160,10 @@ class MediaCore
 			} catch (Exception $e) {
 				if (_PS_MODE_DEV_)
 					echo $e->getMessage();
-				return $js_content;
+				return ';'.$js_content.';';
 			}
 		}
-		return $js_content;
+		return ';'.$js_content.';';
 	}
 
 	public static function minifyCSS($css_content, $fileuri = false, &$import_url = array())


### PR DESCRIPTION
This prevents JavaScript error if combined packed files do not start or hand with an expression delimiter.
