### PR TITLE
Update update_order_detail_taxes.php

### DIFF
--- a/install-dev/upgrade/php/update_order_detail_taxes.php
+++ b/install-dev/upgrade/php/update_order_detail_taxes.php
@@ -49,11 +49,10 @@ function update_order_detail_taxes()
 			
 		if ( $id_tax || $id_tax_alt)
 		{
-			$create_tax = !(bool)Db::getInstance()->getValue('SELECT count(*) 
-				FROM `'._DB_PREFIX_.'tax` 
-				WHERE id_tax = '. (int)$id_tax .' 
-					AND rate = "'.pSql($order_detail_tax['tax_rate']).'"
-			');
+			if(!$id_tax){
+				$id_tax=$id_tax_alt;
+			}
+			$create_tax=false;
 		}
 
 		if ($create_tax)


### PR DESCRIPTION
When I tried to upgrade my prestashop 1.4.6.2 with the "upgrade.php" script, this file "update_order_detail_taxes.php" took about 2 or 3 hours. For each "order_detail" in the database, it create a new "tax" even if its "tax" already exist.
I think the query in the "if($id_tax || $id_tax_alt)" is useless and its result is always false.
