### PR TITLE
[*] FO/BO: Added Cart Rule Action: Apply a discount to the cheapest selected products

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
@@ -101,6 +101,13 @@
 				{l s='Selected product(s)'}{if $product_rule_groups|@count == 0}&nbsp;<span id="apply_discount_to_selection_warning" class="text-muted clearfix"><i class="icon-warning-sign"></i> <a href="#" id="apply_discount_to_selection_shortcut">{l s='You must select some products before'}</a></span>{/if}
 			</label>
 		</p>
+                <p class="radio">
+                        <label for="apply_discount_to_cheapest_selection">
+                                <input type="radio" name="apply_discount_to" id="apply_discount_to_cheapest_selection" value="cheapest_selection"{if $currentTab->getFieldValue($currentObject, 'reduction_product')|intval == -3} checked="checked"{/if}{if $product_rule_groups|@count == 0}disabled="disabled"{/if} />
+                                {l s='Cheapest selected product(s)'}{if $product_rule_groups|@count == 0}&nbsp;<span id="apply_discount_to_selection_warning" class="text-muted clearfix"><i class="icon-warning-sign"></i> <a href="#" id="apply_discount_to_selection_shortcut">{l s='You must select some products before'}</a></span>{/if}
+                        </label>
+                </p>
+
 	</div>
 </div>
 

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -144,6 +144,8 @@ function toggleApplyDiscount(percent, amount, apply_to)
 		$('*[for=apply_discount_to_cheapest]').show();
 		$('#apply_discount_to_selection').show();
 		$('*[for=apply_discount_to_selection]').show();
+                $('#apply_discount_to_cheapest_selection').show();
+                $('*[for=apply_discount_to_cheapest_selection]').show();
 	}
 	else
 	{
@@ -162,6 +164,9 @@ function toggleApplyDiscount(percent, amount, apply_to)
 		$('#apply_discount_to_selection').hide();
 		$('*[for=apply_discount_to_selection]').hide();
 		$('#apply_discount_to_selection').removeAttr('checked');
+                $('#apply_discount_to_cheapest_selection').hide();
+                $('*[for=apply_discount_to_cheapest_selection]').hide();
+                $('#apply_discount_to_cheapest_selection').removeAttr('checked');
 	}
 	else
 	{
@@ -198,6 +203,9 @@ function toggleApplyDiscountTo()
 			$('#reduction_product').val('-1');
 		if ($('#apply_discount_to_selection').prop('checked'))
 			$('#reduction_product').val('-2');
+                if ($('#apply_discount_to_cheapest_selection').prop('checked'))
+                        $('#reduction_product').val('-3');
+
 	}
 }
 
@@ -241,6 +249,10 @@ $('#apply_discount_to_selection').click(function() {toggleApplyDiscountTo();});
 if ($('#apply_discount_to_selection').prop('checked'))
 	toggleApplyDiscountTo();
 	
+$('#apply_discount_to_cheapest_selection').click(function() {toggleApplyDiscountTo();});
+if ($('#apply_discount_to_cheapest_selection').prop('checked'))
+        toggleApplyDiscountTo();
+
 $('#free_gift_on').click(function() {toggleGiftProduct();});
 $('#free_gift_off').click(function() {toggleGiftProduct();});
 toggleGiftProduct();

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -832,20 +832,36 @@ class CartRuleCore extends ObjectModel
 						$reduction_value += ($use_tax ? $product['total_wt'] : $product['total']) * $this->reduction_percent / 100;
 			}
 
-			// Discount (%) on the cheapest product
-			if ($this->reduction_percent && $this->reduction_product == -1)
-			{
-				$minPrice = false;
-				$cheapest_product = null;
-				foreach ($all_products as $product)
-				{
-					$price = ($use_tax ? $product['price_wt'] : $product['price']);
-					if ($price > 0 && ($minPrice === false || $minPrice > $price))
-					{
-						$minPrice = $price;
-						$cheapest_product = $product['id_product'].'-'.$product['id_product_attribute'];
-					}
-				}
+			// Discount (%) on the cheapest product (-1) or cheapest from selected product (-3)
+                        if ($this->reduction_percent && ($this->reduction_product == -1 || $this->reduction_product == -3))
+                        {
+                                $minPrice = false;
+                                $cheapest_product = null;
+
+                                $selected_products = null;
+                                if ($this->reduction_product == -3)
+                                {
+                                        $selected_products = $this->checkProductRestrictions($context, true);
+                                }
+
+
+                                foreach ($all_products as $product)
+                                {
+                                        // if we have selected products and our cart product is not one we skip it
+                                        if ($selected_products && is_array($selected_products)
+                                              && ! (in_array($product['id_product'].'-'.$product['id_product_attribute'], $selected_products)
+                                                    || in_array($product['id_product'].'-0', $selected_products)) )
+                                        {
+                                                continue;
+                                        }
+
+                                        $price = ($use_tax ? $product['price_wt'] : $product['price']);
+                                        if ($price > 0 && ($minPrice === false || $minPrice > $price))
+                                        {
+                                                $minPrice = $price;
+                                                $cheapest_product = $product['id_product'].'-'.$product['id_product_attribute'];
+                                        }
+                                }
 				
 				// Check if the cheapest product is in the package
 				$in_package = false;


### PR DESCRIPTION
This is needed (and useful) when you want to discount the cheapest product of a category (eg: Ties). Currently the cheapest option applies to the entire cart.

One request for the feature is in this forum thread: http://www.prestashop.com/forums/topic/325571-problem-with-cart-rules

Implementation:

I've added a new action "Cheapest selected product(s)" to the admin screen. If selected it sets reduction_product to a new id of -3 (-1 is "selected" product(s) and -2 is "cheapest" product).

I updated the logic in CartRules.php which is handling the cheapest product logic to also check for "cheapest selected" in which case it ignores any products not in the selected group.

How Tested:
- Verified the admin screen stores the value when "cheapest selected" is picked and saved.
- Verified that the "cheapest seleted" option hides/shows if the percentage option is on/off.
- Verified that the option is disabled if the user has not made a product selection (and a helper link is displayed to prompt them to make a selection)
- Created a cart rules with cheapest selection of a single category:
  - item in cart not from category - discount is not applied
  - item in cart of category - discount is applied
  - item in cart of category - qty 2 - discount is applied to only 1
  - items 2 in cart: 1 of category, 1 of other - discount is applied to 1 of category
  - items 3 in cart: 2 of cateory different prices, 1 of other - discount is applied to cheapest of the category
