### PR TITLE
Use substr to extract the checksum

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -270,9 +270,7 @@ class CookieCore
 			//printf("\$content = %s<br />", $content);
 			
 			/* Get cookie checksum */
-			$tmpTab = explode('¤', $content);
-			array_pop($tmpTab);
-			$content_for_checksum = implode('¤', $tmpTab).'¤';
+			$content_for_checksum = substr($content, 0, strrpos($content, '¤')) . '¤';
 			$checksum = crc32($this->_salt.$content_for_checksum);
 			//printf("\$checksum = %s<br />", $checksum);
 			


### PR DESCRIPTION
To avoid create a temporary array (which stay in memory), and string manipulation is a bit faster than explode/array_pop/implode array.

BTW, why not use json or PHP serializer instead home made pattern?
