### PR TITLE
Update order-address.tpl

### DIFF
--- a/themes/default-bootstrap/order-address.tpl
+++ b/themes/default-bootstrap/order-address.tpl
@@ -91,12 +91,12 @@
 			<span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span>
 		</a>
 	</p>
-	{if !$opc}
+
 		<div id="ordermsg" class="form-group">
 			<label>{l s='If you would like to add a comment about your order, please write it in the field below.'}</label>
-			<textarea class="form-control" cols="60" rows="6" name="message">{if isset($oldMessage)}{$oldMessage}{/if}</textarea>
+			<textarea class="form-control" cols="60" rows="6" name="message" id="message">{if isset($oldMessage)}{$oldMessage}{/if}</textarea>
 		</div>
-	{/if}
+
 </div> <!-- end addresses -->
 {if !$opc}
 			<p class="cart_navigation clearfix">


### PR DESCRIPTION
Allow the order message textarea to appear during one page checkout, there is no reason it should only appear during 5 page.

Also fixed a bug due to the missing id attribute
