### PR TITLE
[*] FO : Unsets the etag for smaller request.

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2121,7 +2121,8 @@ class ToolsCore
 	ExpiresByType application/x-font-otf \"access plus 1 year\"
 </IfModule>
 
-FileETag INode MTime Size
+Header unset Etag
+FileETag none
 <IfModule mod_deflate.c>
 	<IfModule mod_filter.c>
 		AddOutputFilterByType DEFLATE text/html text/css text/javascript application/javascript application/x-javascript


### PR DESCRIPTION
Most PCI compliance companies recommend etags to be unset, but the information sent is redundant, it is already contained in the header. YSLOW also recommends unsetting it, it will make prestashop register faster on their tests. 
