### PR TITLE
[-] CORE : Clean cache when uninstalling module

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -626,6 +626,7 @@ abstract class ModuleCore
 		if (Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'module` WHERE `id_module` = '.(int)$this->id))
 		{
 			Cache::clean('Module::isInstalled'.$this->name);
+			Cache::clean('Module::getModuleIdByName_'.pSQL($this->name));
 			return true;
 		}
 		


### PR DESCRIPTION
When resetting a module the installation fails because isInstalled() still return true because of the 'getModuleIdByName_' cache.
