### PR TITLE
[-] FO : addCustomizationPrice retrocompat

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4142,8 +4142,9 @@ class ProductCore extends ObjectModel
 				else
 					$price_wt = $price * (1 + ((isset($product_update['tax_rate']) ? $product_update['tax_rate'] : $product_update['rate']) * 0.01));
 
-				if (isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery])) {
-					if(!isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
+				if (isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
+				{
+					if (!isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
                                             $id_address_delivery = 0;
 					foreach ($customized_datas[$product_id][$product_attribute_id][$id_address_delivery] as $customization)
 					{

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4142,13 +4142,16 @@ class ProductCore extends ObjectModel
 				else
 					$price_wt = $price * (1 + ((isset($product_update['tax_rate']) ? $product_update['tax_rate'] : $product_update['rate']) * 0.01));
 
-				if (isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
+				if (isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery])) {
+					if(!isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
+                                            $id_address_delivery = 0;
 					foreach ($customized_datas[$product_id][$product_attribute_id][$id_address_delivery] as $customization)
 					{
 						$customization_quantity += (int)$customization['quantity'];
 						$customization_quantity_refunded += (int)$customization['quantity_refunded'];
 						$customization_quantity_returned += (int)$customization['quantity_returned'];
 					}
+				}
 
 				$product_update['customizationQuantityTotal'] = $customization_quantity;
 				$product_update['customizationQuantityRefunded'] = $customization_quantity_refunded;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4142,7 +4142,7 @@ class ProductCore extends ObjectModel
 				else
 					$price_wt = $price * (1 + ((isset($product_update['tax_rate']) ? $product_update['tax_rate'] : $product_update['rate']) * 0.01));
 
-				if (isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
+				if (isset($customized_datas[$product_id][$product_attribute_id]))
 				{
 					if (!isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
                                             $id_address_delivery = 0;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4142,10 +4142,10 @@ class ProductCore extends ObjectModel
 				else
 					$price_wt = $price * (1 + ((isset($product_update['tax_rate']) ? $product_update['tax_rate'] : $product_update['rate']) * 0.01));
 
-				if (isset($customized_datas[$product_id][$product_attribute_id]))
+				if (!isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
+                                        $id_address_delivery = 0;
+				if (isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
 				{
-					if (!isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery]))
-                                            $id_address_delivery = 0;
 					foreach ($customized_datas[$product_id][$product_attribute_id][$id_address_delivery] as $customization)
 					{
 						$customization_quantity += (int)$customization['quantity'];


### PR DESCRIPTION
When a customization was done on a lower PS version, $id_address_delivery is set to 0 for the customization.
