### PR TITLE
[-] BO : fixed bug : it's not possible to override some AdminCartRulesCo...

### DIFF
--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -178,10 +178,9 @@ class PrestaShopAutoload
 				else if (substr($file, -4) == '.php')
 				{
 					$content = file_get_contents($root_dir.$path.$file);
-                    $namespacePattern='[\\a-z0-9_]*[\\]';
-                    $pattern = '#\W((abstract\s+)?class|interface)\s+(?P<classname>'.basename($file, '.php').'(?:Core)?)'
-                        .'(?:\s+extends\s+'.$namespacePattern.'[a-z][a-z0-9_]*)?(?:\s+implements\s+'.$namespacePattern.'[a-z][a-z0-9_]*(?:\s*,\s*'.$namespacePattern.'[a-z][a-z0-9_]*)*)?\s*\{#i';
-                    if (preg_match($pattern, $content, $m))
+			 		$pattern = '#\W((abstract\s+)?class|interface)\s+(?P<classname>'.basename($file, '.php').'(?:Core)?)'
+			 					.'(?:\s+extends\s+[a-z][a-z0-9_]*)?(?:\s+implements\s+[a-z][a-z0-9_]*(?:\s*,\s*[a-z][a-z0-9_]*)*)?\s*\{#i';
+			 		if (preg_match($pattern, $content, $m))
 			 		{
 			 			$classes[$m['classname']] = array(
 			 				'path' => $path.$file,

--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -178,9 +178,10 @@ class PrestaShopAutoload
 				else if (substr($file, -4) == '.php')
 				{
 					$content = file_get_contents($root_dir.$path.$file);
-			 		$pattern = '#\W((abstract\s+)?class|interface)\s+(?P<classname>'.basename($file, '.php').'(?:Core)?)'
-			 					.'(?:\s+extends\s+[a-z][a-z0-9_]*)?(?:\s+implements\s+[a-z][a-z0-9_]*(?:\s*,\s*[a-z][a-z0-9_]*)*)?\s*\{#i';
-			 		if (preg_match($pattern, $content, $m))
+                    $namespacePattern='[\\a-z0-9_]*[\\]';
+                    $pattern = '#\W((abstract\s+)?class|interface)\s+(?P<classname>'.basename($file, '.php').'(?:Core)?)'
+                        .'(?:\s+extends\s+'.$namespacePattern.'[a-z][a-z0-9_]*)?(?:\s+implements\s+'.$namespacePattern.'[a-z][a-z0-9_]*(?:\s*,\s*'.$namespacePattern.'[a-z][a-z0-9_]*)*)?\s*\{#i';
+                    if (preg_match($pattern, $content, $m))
 			 		{
 			 			$classes[$m['classname']] = array(
 			 				'path' => $path.$file,

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -305,7 +305,8 @@ class AdminCartRulesControllerCore extends AdminController
 		Context::getContext()->smarty->assign('product_rule_group_id', $product_rule_group_id);
 		Context::getContext()->smarty->assign('product_rule_group_quantity', $product_rule_group_quantity);
 		Context::getContext()->smarty->assign('product_rules', $product_rules);
-		return Context::getContext()->smarty->fetch('controllers/cart_rules/product_rule_group.tpl');
+
+		return $this -> createTemplate('product_rule_group.tpl')->fetch();
 	}
 
 	public function getProductRuleDisplay($product_rule_group_id, $product_rule_id, $product_rule_type, $selected = array())
@@ -349,7 +350,7 @@ class AdminCartRulesControllerCore extends AdminController
 				foreach ($results as $row)
 					$products[in_array($row['id'], $selected) ? 'selected' : 'unselected'][] = $row;
 				Context::getContext()->smarty->assign('product_rule_itemlist', $products);
-				$choose_content = $this->createTemplate('controllers/cart_rules/product_rule_itemlist.tpl')->fetch();
+				$choose_content = $this->createTemplate('product_rule_itemlist.tpl')->fetch();
 				Context::getContext()->smarty->assign('product_rule_choose_content', $choose_content);
 				break;
 			case 'manufacturers':
@@ -361,7 +362,7 @@ class AdminCartRulesControllerCore extends AdminController
 				foreach ($results as $row)
 					$products[in_array($row['id'], $selected) ? 'selected' : 'unselected'][] = $row;
 				Context::getContext()->smarty->assign('product_rule_itemlist', $products);
-				$choose_content = $this->createTemplate('controllers/cart_rules/product_rule_itemlist.tpl')->fetch();
+				$choose_content = $this->createTemplate('product_rule_itemlist.tpl')->fetch();
 				Context::getContext()->smarty->assign('product_rule_choose_content', $choose_content);
 				break;
 			case 'suppliers':
@@ -373,7 +374,7 @@ class AdminCartRulesControllerCore extends AdminController
 				foreach ($results as $row)
 					$products[in_array($row['id'], $selected) ? 'selected' : 'unselected'][] = $row;
 				Context::getContext()->smarty->assign('product_rule_itemlist', $products);
-				$choose_content = $this->createTemplate('controllers/cart_rules/product_rule_itemlist.tpl')->fetch();
+				$choose_content = $this->createTemplate('product_rule_itemlist.tpl')->fetch();
 				Context::getContext()->smarty->assign('product_rule_choose_content', $choose_content);
 				break;
 			case 'categories':
@@ -390,7 +391,7 @@ class AdminCartRulesControllerCore extends AdminController
 				foreach ($results as $row)
 					$categories[in_array($row['id'], $selected) ? 'selected' : 'unselected'][] = $row;
 				Context::getContext()->smarty->assign('product_rule_itemlist', $categories);
-				$choose_content = $this->createTemplate('controllers/cart_rules/product_rule_itemlist.tpl')->fetch();
+				$choose_content = $this->createTemplate('product_rule_itemlist.tpl')->fetch();
 				Context::getContext()->smarty->assign('product_rule_choose_content', $choose_content);
 				break;
 			default :
@@ -398,7 +399,7 @@ class AdminCartRulesControllerCore extends AdminController
 				Context::getContext()->smarty->assign('product_rule_choose_content', '');
 		}
 
-		return $this->createTemplate('controllers/cart_rules/product_rule.tpl')->fetch();
+		return $this->createTemplate('product_rule.tpl')->fetch();
 	}
 
 	public function ajaxProcess()


### PR DESCRIPTION
It was not possible to override "product_rule_group.tpl" because $this->createTemplate was not used to fetch the template.

It was not possible to override the other templates because template's full path was used and the computed template's override path was not good.
