### PR TITLE
[-] BO : id_order in where clause is ambiguous on AdminReturn

### DIFF
--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -39,9 +39,9 @@ class AdminReturnControllerCore extends AdminController
 
  		$this->fields_list = array(
 			'id_order_return' => array('title' => $this->l('ID'), 'align' => 'center', 'width' => 25),
-			'id_order' => array('title' => $this->l('Order ID'), 'width' => 100, 'align' => 'center'),
+			'a!id_order' => array('title' => $this->l('Order ID'), 'width' => 100, 'align' => 'center'),
 			'name' => array('title' => $this->l('Status'), 'width' => 'auto', 'align' => 'left'),
-			'date_add' => array('title' => $this->l('Date issued'), 'width' => 150, 'type' => 'date', 'align' => 'right'),
+			'a!date_add' => array('title' => $this->l('Date issued'), 'width' => 150, 'type' => 'date', 'align' => 'right'),
  		);
 
 		$this->fields_options = array(


### PR DESCRIPTION
When filtering return product, Prestashop show "colomun xxx is ambiguous'
