### PR TITLE
Update login.js

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -173,6 +173,7 @@ function doAjaxForgot() {
 				} else {
 					alert(jsonData.confirm);
 					$('#forgot_password_form').hide();
+					$('a.show-forgot-password').hide();
 					displayLogin();
 				}
 			},


### PR DESCRIPTION
Hide the forgot password link after a successful password reset. Right now only the form is hide, the link for password reset remains in the login form.
