### PR TITLE
Fix cookie handling for pagination

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -892,12 +892,15 @@ class FrontControllerCore extends Controller
 		if ((int)Tools::getValue('n') && (int)$total_products > 0)
 			$nArray[] = $total_products;
 		// Retrieve the current number of products per page (either the default, the GET parameter or the one in the cookie)
+		// If a GET parameter exists, then update the cookie.
 		$this->n = $default_products_per_page;
+		if (isset($this->context->cookie->nb_item_per_page) && in_array($this->context->cookie->nb_item_per_page, $nArray))
+			$this->n = (int)$this->context->cookie->nb_item_per_page;
+
 		if ((int)Tools::getValue('n') && in_array((int)Tools::getValue('n'), $nArray))
 		{
 			$this->n = (int)Tools::getValue('n');
-			if (isset($this->context->cookie->nb_item_per_page) && in_array($this->context->cookie->nb_item_per_page, $nArray))
-				$this->n = (int)$this->context->cookie->nb_item_per_page;
+			$this->context->cookie->nb_item_per_page = $this->n;
 		}
 
 		// Retrieve the page number (either the GET parameter or the first page)
@@ -908,9 +911,6 @@ class FrontControllerCore extends Controller
 
 		// Remove the page parameter in order to get a clean URL for the pagination template
 		$current_url = preg_replace('/(\?)?(&amp;)?p=\d+/', '$1', Tools::htmlentitiesUTF8($_SERVER['REQUEST_URI']));
-
-		if ($this->n != $default_products_per_page)
-			$this->context->cookie->nb_item_per_page = $this->n;
 
 		$pages_nb = ceil($total_products / (int)$this->n);
 		if ($this->p > $pages_nb && $total_products != 0)


### PR DESCRIPTION
The current way in which PrestaShop handles pagination cookies is badly broken. If a cookie is set, then the value in the cookie overrides everything (including GET params). That means that once you set the cookie the first time, there is no way to change your preference. Even if you change the `nb_item` selector, the cookie overrides it.

You can test this on a default prestashop install by doing the following:
1. Change a product list to show 24 items per page.
2. Now change it to show 12 items per page. You can't, because the cookie that was set in step 1 overrides the GET request, and you still get 24 items per page.

This patch fixes that behaviour so that:
- Cookie value is used **only if no GET param is present**.
- If a get param is present, then it takes precedence and the cookie is updated accordingly.
- Instead of updating the cookie on every request (which is unnecessary), the cookie is only updated when the GET param signals a change.
