### PR TITLE
[*] BO : Firstname before Lastname in customerlist

### DIFF
--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -93,11 +93,11 @@ class AdminCustomersControllerCore extends AdminController
 				'filter_type' => 'int',
 				'order_key' => 'gl!name'
 			),
-			'lastname' => array(
-				'title' => $this->l('Last name')
-			),
 			'firstname' => array(
 				'title' => $this->l('First name')
+			),
+			'lastname' => array(
+				'title' => $this->l('Last name')
 			),
 			'email' => array(
 				'title' => $this->l('Email address')


### PR DESCRIPTION
It's for consistency. Address and order have it this way
If accepted Employee list can be changed to.
