### PR TITLE
[-] FO: toFixed() causes price calculation error

### DIFF
--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -666,7 +666,7 @@ function updatePrice()
 
 	// If the calculated price (after all discounts) is different than the base price
 	// we show the old price striked through
-	if (priceWithDiscountsDisplay.toFixed(2) != basePriceDisplay.toFixed(2))
+	if (parseInt(priceWithDiscountsDisplay * 100) != parseInt(basePriceDisplay * 100))
 	{
 		$('#old_price_display').text(formatCurrency(basePriceDisplay * currencyRate, currencyFormat, currencySign, currencyBlank));
 		$('#old_price,#old_price_display,#old_price_display_taxes').show();


### PR DESCRIPTION
Variable "priceWithDiscountsDisplay" comes with a precision of 3 as the variable "basePriceDisplay" comes with a precision of 2. It results in a comparison error as the Number.toFixed() method rounds value to the superior decimal (ie: 1.116 becomes 1.12 but 1.114 returns 1.11). In our case, a discount price is then displayed (which is wrong) as the converted value is higher than the real price.
