### PR TITLE
FO : id_country to configuration PS_COUNTRY_DEFAULT in assignAddressFormat

### DIFF
--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -333,7 +333,7 @@ class AddressControllerCore extends FrontController
 	 */
 	protected function assignAddressFormat()
 	{
-		$id_country = is_null($this->_address)? 0 : (int)$this->_address->id_country;
+		$id_country = is_null($this->_address) ? Configuration::get('PS_COUNTRY_DEFAULT') : (int)$this->_address->id_country;
 		$ordered_adr_fields = AddressFormat::getOrderedAddressFields($id_country, true, true);
 		$this->context->smarty->assign('ordered_adr_fields', $ordered_adr_fields);
 	}


### PR DESCRIPTION
Now when i configure my first address on FO, I have the format address configuration of the default country
