### PR TITLE
[-] CORE : Helper Category Tree categories selected

### DIFF
--- a/classes/helper/Helper.php
+++ b/classes/helper/Helper.php
@@ -212,9 +212,9 @@ class HelperCore
 		if (count($selected_cat) > 0)
 		{
 			if (isset($selected_cat[0]))
-				$html .= '			var selectedCat = '.(int)implode(',', $selected_cat).';'."\n";
+				$html .= '			var selectedCat = "'.implode(',', array_map('intval', $selected_cat)).'";'."\n";
 			else
-				$html .= '			var selectedCat = '.(int)implode(',', array_keys($selected_cat)).';'."\n";
+				$html .= '			var selectedCat = "'.implode(',', array_map('intval', array_keys($selected_cat))).'";'."\n";
 		}
 		else
 			$html .= '			var selectedCat = \'\';'."\n";


### PR DESCRIPTION
Removes the int cast of the categories ids list (the cast removes the values after to the comma). Use of array_map and intval instead.
With this fix, the subtotal of selected categories is now correct.
