### PR TITLE
Update AdminThemesController.php

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -280,6 +280,16 @@ class AdminThemesControllerCore extends AdminController
 						'name' => 'PS_LOGO_INVOICE',
 						'tab' => 'logo2',
 						'thumb' => (Configuration::get('PS_LOGO_INVOICE') !== false && file_exists(_PS_IMG_DIR_.Configuration::get('PS_LOGO_INVOICE'))) ? _PS_IMG_.Configuration::get('PS_LOGO_INVOICE') : _PS_IMG_.Configuration::get('PS_LOGO')
+					),					
+					'PS_MAIL_COLOR' => array(
+						'title' => $this->l('Mail color'),
+						'desc' => $this->l('Your mail will be highlighted in this color. HTML colors only, please (e.g.').' "lightblue", "#CC6600")',
+						'type' => 'color',
+						'name' => 'PS_MAIL_COLOR',
+						'tab' => 'logo2',
+						'size' => 30,					
+						'value' => Configuration::get('PS_MAIL_COLOR')
+					
 					),
 					'PS_FAVICON' => array(
 						'title' => $this->l('Favicon'),


### PR DESCRIPTION
I really don't know why the color picker for mails was dropped. It's useful, so I added it again - and I hope the hard coded background-color #f8f8f8 in mails will be changed back to the variable {color} which is still active and usable. Back to the future of 1.5x. ;-)
