### PR TITLE
[-] BO : fixed bug : getNativeModule() always return $natives even if the list is empty

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -2064,7 +2064,7 @@ class AdminThemesControllerCore extends AdminController
 					break;
 			}
 
-			if (count($natives > 0))
+			if (count($natives) > 0)
 				return $natives;
 		}
 


### PR DESCRIPTION
This is due to a typo in the return condition.
