### PR TITLE
[*] FO : wording

### DIFF
--- a/themes/default-bootstrap/product.tpl
+++ b/themes/default-bootstrap/product.tpl
@@ -328,7 +328,7 @@
 						{/if}
 						<!-- minimal quantity wanted -->
 						<p id="minimal_quantity_wanted_p"{if $product->minimal_quantity <= 1 || !$product->available_for_order || $PS_CATALOG_MODE} style="display: none;"{/if}>
-							{l s='This product is not sold individually. You must select at least'} <b id="minimal_quantity_label">{$product->minimal_quantity}</b> {l s='quantity for this product.'}
+							{l s='The minimum purchase order quantity for the product is'} <b id="minimal_quantity_label">{$product->minimal_quantity}</b>
 						</p>
 						{if isset($groups)}
 							<!-- attributes -->


### PR DESCRIPTION
Help texts should be short and precisely verbalized and not this long-winded. Please don't split texts when you're not sure if this will cause problems for translations into other languages.
