### PR TITLE
[-] CORE : fixing an error with non-multilang ObjectModel instance

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -204,7 +204,7 @@ abstract class ObjectModelCore
 				$sql->where('a.'.$this->def['primary'].' = '.(int)$id);
 
 				// Get lang informations
-				if ($id_lang)
+				if ($id_lang && isset($this->def['multilang']) && $this->def['multilang'])
 				{
 					$sql->leftJoin($this->def['table'].'_lang', 'b', 'a.'.$this->def['primary'].' = b.'.$this->def['primary'].' AND b.id_lang = '.(int)$id_lang);
 					if ($this->id_shop && !empty($this->def['multilang_shop']))


### PR DESCRIPTION
If you try to instanciate a non-multilang ObjectModel with an id_land in the construct, a mysql error is thrown because script tried to LEFT JOIN on an unknow table.

I added a check to assure that ObjectModel don't try to use a lang table, if definition doesnt allow it
