### PR TITLE
fixes issues in getNestedCategories() where id of root_category is not 1

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -512,7 +512,7 @@ class CategoryCore extends ObjectModel
 			$buff = array();
 
 			if (!isset($root_category))
-				$root_category = 1;
+				$root_category = Category::getRootCategory()->id;
 
 			foreach ($result as $row)
 			{


### PR DESCRIPTION
This change fixes issues where `root_category` is not 1. The fix uses `Category::getRootCategory` to set the value to the correct one.
