### PR TITLE
[-] CORE : actionUpdateQuantity should be called after cache is cleared

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -464,6 +464,8 @@ class StockAvailableCore extends ObjectModel
 		$stock_available->quantity = $stock_available->quantity + $delta_quantity;
 		$stock_available->update();
 
+		Cache::clean('StockAvailable::getQuantityAvailableByProduct_'.(int)$id_product.'*');
+
 		Hook::exec('actionUpdateQuantity',
 				   array(
 				   	'id_product' => $id_product,
@@ -471,8 +473,6 @@ class StockAvailableCore extends ObjectModel
 				   	'quantity' => $stock_available->quantity
 				   )
 				  );
-
-		Cache::clean('StockAvailable::getQuantityAvailableByProduct_'.(int)$id_product.'*');
 
 		return true;
 	}


### PR DESCRIPTION
If you are using StockAvailable::getQuantityAvailableByProduct into actionUpdateQuantity hook, results are not "fresh" for the current edited product.
Even if the quantity is real into hook parameters, it may be nice that StockAvailable::getQuantityAvailableByProduct return the fresh result into this hook.
There may be others methods into StockAvailable class that should also work like this
