### PR TITLE
[-] CORE : Fix different hook parameters for a same hook name

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -531,7 +531,7 @@ class ProductCore extends ObjectModel
 		$return = parent::update($null_values);
 		$this->setGroupReduction();
 		Hook::exec('actionProductSave', array('id_product' => $this->id));
-		Hook::exec('actionProductUpdate', array('id_product' => $this->id));
+		Hook::exec('actionProductUpdate', array('id_product' => $this->id, 'product' => $this));
 		if ($this->getType() == Product::PTYPE_VIRTUAL && $this->active && !Configuration::get('PS_VIRTUAL_PROD_FEATURE_ACTIVE'))
 			Configuration::updateGlobalValue('PS_VIRTUAL_PROD_FEATURE_ACTIVE', '1');
 

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -4528,7 +4528,7 @@ class AdminProductsControllerCore extends AdminController
 					die (Tools::jsonEncode(array('error' =>  $this->l('Undefined id product attribute'))));
 
 				StockAvailable::setQuantity($product->id, (int)Tools::getValue('id_product_attribute'), (int)Tools::getValue('value'));
-				Hook::exec('actionProductUpdate', array('product' => $this->object));
+				Hook::exec('actionProductUpdate', array('id_product' => $this->object->id, 'product' => $this->object));
 				
 				// Catch potential echo from modules
 				$error = ob_get_contents();


### PR DESCRIPTION
actionProductUpdate has only "product" into AdminProductsController while Product has only id_product. That is confusing.
Let's use both id_product & product so we keep retro-compatibility
