### PR TITLE
[+] BO : Override of list, form or view fields

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2036,7 +2036,7 @@ class AdminControllerCore extends Controller
 		}
 
 		$this->setHelperDisplay($helper);
-		$helper->tpl_vars = $this->tpl_list_vars;
+		$helper->tpl_vars = $this->getTemplateListVars();
 		$helper->tpl_delete_link_vars = $this->tpl_delete_link_vars;
 
 		// For compatibility reasons, we have to check standard actions in class attributes
@@ -2050,6 +2050,12 @@ class AdminControllerCore extends Controller
 
 		return $list;
 	}
+	
+	public function getTemplateListVars()
+	{
+		return $this->tpl_list_vars;
+	}
+
 
 	/**
 	 * Override to render the view page
@@ -2058,12 +2064,17 @@ class AdminControllerCore extends Controller
 	{
 		$helper = new HelperView($this);
 		$this->setHelperDisplay($helper);
-		$helper->tpl_vars = $this->tpl_view_vars;
+		$helper->tpl_vars = $this->getTemplateViewVars();
 		if (!is_null($this->base_tpl_view))
 			$helper->base_tpl = $this->base_tpl_view;
 		$view = $helper->generateView();
 
 		return $view;
+	}
+	
+	public function getTemplateViewVars()
+	{
+		return $this->tpl_View_vars;
 	}
 
 	/**
@@ -2106,7 +2117,7 @@ class AdminControllerCore extends Controller
 			$this->setHelperDisplay($helper);
 			$helper->fields_value = $fields_value;
 			$helper->submit_action = $this->submit_action;
-			$helper->tpl_vars = $this->tpl_form_vars;
+			$helper->tpl_vars = $this->getTemplateFormVars();
 			$helper->show_cancel_button = (isset($this->show_form_cancel_button)) ? $this->show_form_cancel_button : ($this->display == 'add' || $this->display == 'edit');
 
 			$back = Tools::safeOutput(Tools::getValue('back', ''));
@@ -2128,6 +2139,11 @@ class AdminControllerCore extends Controller
 
 			return $form;
 		}
+	}
+	
+	public function getTemplateFormVars()
+	{
+		return $this->tpl_form_vars;
 	}
 
 	public function renderKpis()


### PR DESCRIPTION
This is a method to allow to add new fields in admin controllers.

In adminController.php, i add new functions to override in AdminController--- : 

getTemplateListVars()
getTemplateViewVars()
getTemplateFormVars()

Now i can easily add some new fields, by override these functions, and not the all functions renderView(), or renderList(),...

Like:
In Override/.../adminControllerCustomer:
public function getTemplateViewVars()
{
     $myVars = array('var1'=>value, .......);
     return array_merge($myVars, $this->tpl_view_vars);
}
