### PR TITLE
[-] BO : Wrong cookie password verification

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -288,7 +288,7 @@ class EmployeeCore extends ObjectModel
 	  */
 	public static function checkPassword($id_employee, $passwd)
 	{
-	 	if (!Validate::isUnsignedId($id_employee) || !Validate::isPasswd($passwd, 8))
+	 	if (!Validate::isUnsignedId($id_employee) || !Validate::isMd5($passwd))
 	 		die (Tools::displayError());
 
 		return Db::getInstance()->getValue('


### PR DESCRIPTION
Here $passwd must be encrypted.
if this is not changed we can't change the behavior of the function Validate::isPasswd via override for exemple to force the usage of non alphanumeric chars for Customers/employees passwords.
(for exemple usnig a validation like :
if (!preg_match("/[a-zA-Z]/",$passwd) || !preg_match("/[0-9]/",$passwd) || !preg_match("/[^a-zA-Z0-9]/",$passwd))
return false; //paswsord must contains chars, numbers and specials
)
