### PR TITLE
[+] FO+BO Force customers to use strong password allowed

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -288,7 +288,7 @@ class EmployeeCore extends ObjectModel
 	  */
 	public static function checkPassword($id_employee, $passwd)
 	{
-	 	if (!Validate::isUnsignedId($id_employee) || !Validate::isPasswd($passwd, 8))
+	 	if (!Validate::isUnsignedId($id_employee) || Validate::isMd5($passwd))
 	 		die (Tools::displayError());
 
 		return Db::getInstance()->getValue('

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1041,7 +1041,11 @@ abstract class ObjectModelCore
 			// Hack for postcode required for country which does not have postcodes
 			if (!empty($value) || $value === '0' || ($field == 'postcode' && $value == '0'))
 			{
-				if (isset($data['validate']) && !Validate::$data['validate']($value) && (!empty($value) || $data['required']))
+				if ($field == 'passwd' && !Validate::isPasswdStrongEnough($value) && (!empty($value) || $data['required']))
+				{
+					$errors[$field] = '<b>'.Tools::displayError('is not strongh enough.').'</b> ';
+				}
+				else if (isset($data['validate']) && !Validate::$data['validate']($value) && (!empty($value) || $data['required']))
 					$errors[$field] = '<b>'.self::displayFieldName($field, get_class($this), $htmlentities).'</b> '.Tools::displayError('is invalid.');
 				else
 				{

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -39,8 +39,11 @@ class ToolsCore
 	* @param string $flag Output type (NUMERIC, ALPHANUMERIC, NO_NUMERIC)
 	* @return string Password
 	*/
-	public static function passwdGen($length = 8, $flag = 'ALPHANUMERIC')
+	public static function passwdGen($length = 8, $flag = 'ALPHANUMERIC', $customer_valid = false)
 	{
+		if ($customer_valid)
+			$length = max((int)Configuration::get('PS_CUSTOMER_PASSWORD_MIN_LENGTH'), $length);
+			
 		switch ($flag)
 		{
 			case 'NUMERIC':
@@ -49,6 +52,9 @@ class ToolsCore
 			case 'NO_NUMERIC':
 				$str = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 				break;
+			case 'SPECIALS':
+				$str = '?!%+$&()-_*';
+				break;
 			default:
 				$str = 'abcdefghijkmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 				break;
@@ -56,6 +62,23 @@ class ToolsCore
 
 		for ($i = 0, $passwd = ''; $i < $length; $i++)
 			$passwd .= Tools::substr($str, mt_rand(0, Tools::strlen($str) - 1), 1);
+		
+		
+		if ($customer_valid)
+		{
+			$rule = Configuration::get('PS_CUSTOMER_PASSWORD_CHARS');
+			if ($rule == PS_PASSWORD_ALPA_NUMBER)
+			{
+				$passwd  .=  Tools::passwdGen('1', 'NUMERIC');
+				$passwd  .=  Tools::passwdGen('1', 'NO_NUMERIC');
+			}
+			if ($rule == PS_PASSWORD_ALPA_NUMBER_SPECIAL)
+			{
+				$passwd  .=  Tools::passwdGen('1', 'SPECIALS');
+				$passwd  .=  Tools::passwdGen('1', 'NUMERIC');
+				$passwd  .=  Tools::passwdGen('1', 'NO_NUMERIC');
+			}
+		}
 		return $passwd;
 	}
 

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -433,6 +433,34 @@ class ValidateCore
 	{
 		return (Tools::strlen($passwd) >= $size && Tools::strlen($passwd) < 255);
 	}
+	
+	/**
+	 * Check for password force
+	 *
+	 * @param string $passwd Password to validate
+	 * @param int $min_size : to override config value
+	 * @param int $max_size : to override config value
+	 * @param int $rule : to override config value ( config/defines.inc.php )
+	 * @return boolean Validity is ok or not
+	 */	
+	public static function isPasswdStrongEnough($passwd, $min_size = Validate::PASSWORD_LENGTH,  $max_size = 255, $rule = 0)
+	{
+		$size = max((int)Configuration::get('PS_CUSTOMER_PASSWORD_MIN_LENGTH'), $min_size);
+		$max_size = min((int)Configuration::get('PS_CUSTOMER_PASSWORD_MAX_LENGTH'), $max_size);
+
+		if (!$rule)
+			$rule = Configuration::get('PS_CUSTOMER_PASSWORD_CHARS');
+	
+		if (Tools::strlen($passwd) < $size || Tools::strlen($passwd) > $max_size)
+			return false;
+		if ($rule == PS_PASSWORD_ALPA_NUMBER && (!preg_match("/[a-zA-Z]/",$passwd) || !preg_match("/[0-9]/",$passwd)))
+			return false;
+		if ($rule == PS_PASSWORD_ALPA_NUMBER_SPECIAL && (!preg_match("/[a-zA-Z]/",$passwd) || !preg_match("/[0-9]/",$passwd) || !preg_match("/[^a-zA-Z0-9]/",$passwd)))
+			return false;
+		
+		return true;
+	}
+	
 
 	public static function isPasswdAdmin($passwd)
 	{

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -159,6 +159,12 @@ define('PS_ROUND_HALF', PS_ROUND_HALF_UP);
 define('PS_REGISTRATION_PROCESS_STANDARD', 0);
 define('PS_REGISTRATION_PROCESS_AIO', 1);
 
+
+/* Passwords behavior */
+define('PS_PASSWORD_ALL', 0);
+define('PS_PASSWORD_ALPA_NUMBER', 1);
+define('PS_PASSWORD_ALPA_NUMBER_SPECIAL', 2);
+
 /* Carrier::getCarriers() filter */
 // these defines are DEPRECATED since 1.4.5 version
 define('PS_CARRIERS_ONLY', 1);

--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -44,6 +44,21 @@ class AdminCustomerPreferencesControllerCore extends AdminController
 				'name' => $this->l('Standard (account creation and address creation)')
 			)
 		);
+		
+		$customer_password_chars = array(
+			array(
+				'value' => PS_PASSWORD_ALL,
+				'name' => $this->l('Accept all')
+			),
+			array(
+				'value' => PS_PASSWORD_ALPA_NUMBER,
+				'name' => $this->l('Alpha and number required')
+			),
+			array(
+				'value' => PS_PASSWORD_ALPA_NUMBER_SPECIAL,
+				'name' => $this->l('Alpha, number and special required')
+			)
+		);
 
 		$this->fields_options = array(
 			'general' => array(
@@ -95,6 +110,38 @@ class AdminCustomerPreferencesControllerCore extends AdminController
 						'validation' => 'isBool',
 						'cast' => 'intval',
 						'type' => 'bool'
+					),
+				),
+				'submit' => array('title' => $this->l('Save')),
+			),
+			'passwords' => array(
+				'title' =>	$this->l('Password options'),
+				'icon' =>	'icon-cogs',
+				'fields' =>	array(
+					'PS_CUSTOMER_PASSWORD_MIN_LENGTH' => array(
+						'title' => $this->l('Password min lenght'),
+						'hint' => $this->l('Password minimum size.'),
+						'validation' => 'isUnsignedInt',
+						'cast' => 'intval',
+						'size' => 5,
+						'type' => 'text',
+					),
+					'PS_CUSTOMER_PASSWORD_MAX_LENGTH' => array(
+						'title' => $this->l('Password max lenght'),
+						'hint' => $this->l('Password maximum size.'),
+						'validation' => 'isUnsignedInt',
+						'cast' => 'intval',
+						'size' => 5,
+						'type' => 'text',
+					),
+					'PS_CUSTOMER_PASSWORD_CHARS' => array(
+						'title' => $this->l('Password rule'),
+						'hint' => $this->l('Chars needed for a valid password.'),
+						'validation' => 'isInt',
+						'cast' => 'intval',
+						'type' => 'select',
+						'list' => $customer_password_chars,
+						'identifier' => 'value'
 					),
 				),
 				'submit' => array('title' => $this->l('Save')),

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -79,7 +79,7 @@ class PasswordControllerCore extends FrontController
 					Tools::redirect('index.php?controller=authentication&error_regen_pwd');
 				else
 				{
-					$customer->passwd = Tools::encrypt($password = Tools::passwdGen(MIN_PASSWD_LENGTH));
+					$customer->passwd = Tools::encrypt($password = Tools::passwdGen(MIN_PASSWD_LENGTH, 'ALPHANUMERIC', true));
 					$customer->last_passwd_gen = date('Y-m-d H:i:s', time());
 					if ($customer->update())
 					{


### PR DESCRIPTION
In the admin>preferences>customer, new options are added for customer : Password min lenght , Password max lenght and Password rule.
Rules are |Accept all = same as now | , |Alpha and number required|, and |Alpha, number and special required|.
those options are considered in front on autentication and forgot password.
