### PR TITLE
Fix PaymentModule::getInstalledModule() doublons in multishop

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -927,7 +927,7 @@ abstract class PaymentModuleCore extends Module
 		return Db::getInstance()->executeS('
 		SELECT DISTINCT m.`id_module`, h.`id_hook`, m.`name`, hm.`position`
 		FROM `'._DB_PREFIX_.'module` m
-		LEFT JOIN `'._DB_PREFIX_.'hook_module` hm ON hm.`id_module` = m.`id_module`
+		LEFT JOIN `'._DB_PREFIX_.'hook_module` hm ON hm.`id_module` = m.`id_module` AND hm.id_shop='.(int)Context::getContext()->shop->id.'
 		LEFT JOIN `'._DB_PREFIX_.'hook` h ON hm.`id_hook` = h.`id_hook`
 		INNER JOIN `'._DB_PREFIX_.'module_shop` ms ON (m.`id_module` = ms.`id_module` AND ms.id_shop='.(int)Context::getContext()->shop->id.')
 		WHERE h.`name` = \''.pSQL($hook_payment).'\'');


### PR DESCRIPTION
If a module was installed in several shops and if it was anchored at same hook but at different positions, the current query was returning multple rows with that plugin (with the hook position in the other shops).
