### PR TITLE
[-] BO : MultiShop erase available_for_order

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1866,8 +1866,8 @@ class AdminProductsControllerCore extends AdminController
 				$this->copyFromPost($object, $this->table);
 				$object->indexed = 0;
 
-				if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP && Tools::getValue('multishop_check'))
-					$object->setFieldsToUpdate((array)Tools::getValue('multishop_check'));
+				if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP)
+					$object->setFieldsToUpdate((array)Tools::getValue('multishop_check',array()));
 
 				// Duplicate combinations if not associated to shop
 				if ($this->context->shop->getContext() == Shop::CONTEXT_SHOP && !$object->isAssociatedToShop())


### PR DESCRIPTION
With the condition on multishop_check that return false, update_fields was null so system take all fields.

11 days with this error in production, maybe tests have to be improve no ?
