### PR TITLE
[*] CORE : Additional index added to ps_orders on "references" to improve performance

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1112,6 +1112,7 @@ CREATE TABLE `PREFIX_orders` (
   `date_add` datetime NOT NULL,
   `date_upd` datetime NOT NULL,
   PRIMARY KEY (`id_order`),
+  KEY `reference` (`reference`),
   KEY `id_customer` (`id_customer`),
   KEY `id_cart` (`id_cart`),
   KEY `invoice_number` (`invoice_number`),

--- a/install-dev/upgrade/sql/1.6.0.10.sql
+++ b/install-dev/upgrade/sql/1.6.0.10.sql
@@ -56,3 +56,5 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 ALTER TABLE `PREFIX_employee` ADD `last_connection_date` date NOT NULL DEFAULT '0000-00-00';
 
 UPDATE `PREFIX_category` SET `is_root_category` = 0 WHERE `id_parent` != (SELECT `value` FROM `PREFIX_configuration` WHERE `name` = 'PS_ROOT_CATEGORY' LIMIT 1) AND `is_root_category` = 1;
+
+ALTER TABLE  `PREFIX_orders` ADD INDEX (`reference`);


### PR DESCRIPTION
Trying to find an order by reference will produce a full table scan because there is no index on the column.

This will improve performance during order creation, or during a search by reference in BO
