### PR TITLE
Update order-confirmation.tpl

### DIFF
--- a/themes/default-bootstrap/order-confirmation.tpl
+++ b/themes/default-bootstrap/order-confirmation.tpl
@@ -41,6 +41,6 @@
     </p>
 {else}
 <p class="cart_navigation exclusive">
-	<a class="button-exclusive btn btn-default" href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='Back to orders'}"><i class="icon-chevron-left"></i>{l s='Back to orders'}</a>
+	<a class="button-exclusive btn btn-default" href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='Go to your order history page'}"><i class="icon-chevron-left"></i>{l s='View your order history'}</a>
 </p>
 {/if}


### PR DESCRIPTION
After creating a new order is under notification link "Back to orders". But it doesn't sense because "Back" means return to any previous page. The better meaning of this link is "View your order history" that after finishing an order can customer view his order history in you account.
