### PR TITLE
Mistake in calcul of the price without taxe in product.js

### DIFF
--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -647,13 +647,17 @@ function updatePrice()
 			var reduction = parseFloat(combination.specific_price.reduction) / currencyRate;
 			priceWithDiscountsDisplay = priceWithDiscountsDisplay - reduction;
 			// We recalculate the price without tax in order to keep the data consistency
-			priceWithDiscountsWithoutTax = priceWithDiscountsDisplay * ( 1/(1+taxRate) / 100 );
+			 if(priceDisplayMethod == 0){
+			    priceWithDiscountsWithoutTax = priceWithDiscountsDisplay / ( 1+(taxRate/100) );
+            		 }
 		}
 		else if (combination.specific_price.reduction_type == 'percentage')
 		{
 			priceWithDiscountsDisplay = priceWithDiscountsDisplay * (1 - parseFloat(combination.specific_price.reduction));
 			// We recalculate the price without tax in order to keep the data consistency
-			priceWithDiscountsWithoutTax = priceWithDiscountsDisplay * ( 1/(1+taxRate) / 100 );
+			 if(priceDisplayMethod == 0){
+			    priceWithDiscountsWithoutTax = priceWithDiscountsDisplay / ( 1+(taxRate/100) );
+            	          }
 		}
 
 	// Compute discount value and percentage


### PR DESCRIPTION
The previous calcule was wrong : 
ex :
- TaxRate : 20
- Price : 120  tax inc.
  old : 120 \* ( 1/(1+20) / 100 ) = 0.05714
  new : 120 / ( 1+(20/100) ) = 100

For the if statement : when shop is B2B, the priceWithDiscountsWithoutTax is already in tax exclude.

thanks to @Jitrixis
