### PR TITLE
Order product of a cart is changing when update quantity  in an order on backoffice

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -877,7 +877,7 @@ class CartCore extends ObjectModel
 				else
 					Db::getInstance()->execute('
 						UPDATE `'._DB_PREFIX_.'cart_product`
-						SET `quantity` = `quantity` '.$qty.', `date_add` = NOW()
+						SET `quantity` = `quantity` '.$qty.'
 						WHERE `id_product` = '.(int)$id_product.
 						(!empty($id_product_attribute) ? ' AND `id_product_attribute` = '.(int)$id_product_attribute : '').'
 						AND `id_cart` = '.(int)$this->id.(Configuration::get('PS_ALLOW_MULTISHIPPING') && $this->isMultiAddressDelivery() ? ' AND `id_address_delivery` = '.(int)$id_address_delivery : '').'


### PR DESCRIPTION
On the back office, in an order made by an employee, when changing the quantity of a product line, the last modified product go to the bottom of the list. This is problematic.

The problem come from the order by the column date_add in database recently updated in the function getProducts of the same class (between 1.6.0.8->1.6.0.9, the order was from the product id and now it is from the creation date). 

Firstly it make a the previous problem that I said, and secondly its pretty weird to update the date of creation when updating a product cart
