### PR TITLE
Ability to show revocation page when checking out (ssl)

### DIFF
--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -53,7 +53,7 @@ class CmsControllerCore extends FrontController
 		else if ($id_cms_category = (int)Tools::getValue('id_cms_category'))
 			$this->cms_category = new CMSCategory($id_cms_category, $this->context->language->id);
 
-		if (Configuration::get('PS_SSL_ENABLED') && Tools::getValue('content_only') && Tools::getValue('id_cms') == (int)Configuration::get('PS_CONDITIONS_CMS_ID') && Validate::isLoadedObject($this->cms))
+		if (Configuration::get('PS_SSL_ENABLED') && Tools::getValue('content_only') && ( Tools::getValue('id_cms') == (int)Configuration::get('PS_CONDITIONS_CMS_ID') || Tools::getValue('id_cms') == (int)Configuration::get('LEGAL_CMS_ID_REVOCATION' ) ) && Validate::isLoadedObject($this->cms))
 			$this->ssl = true;
 		
 		parent::init();


### PR DESCRIPTION
When checking out the revocation page is not shown, because it will be redirected to non-ssl page.
There has already been a workaround for the "term & conditions", so this seems to be the right place to do.
(Required for eu_legal module!)
