### PR TITLE
[-] BO : Bug when adding a product on order

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2487,6 +2487,8 @@ class AdminOrdersControllerCore extends AdminController
 					$product['image_size'] = false;
 			}
 		}
+		
+		ksort($products);
 
 		return $products;
 	}


### PR DESCRIPTION
Sometimes, the $order->getProducts() method does not return the order_details in ascending order.
So when fetching de end() of the array, it wont always be the last product added, and the bag product was displayed.
This is why is force ordering by keys (containing the id_order_detail field value).
