### PR TITLE
Importer fixes

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1211,7 +1211,7 @@ class AdminImportControllerCore extends AdminController
 			//copying images of categories
 			if (isset($category->image) && !empty($category->image))
 				if (!(AdminImportController::copyImg($category->id, null, $category->image, 'categories', !Tools::getValue('regenerate'))))
-					$this->warnings[] = $category->image.' '.Tools::displayError('cannot be copied.');
+					$this->warnings[] = sprintf(Tools::displayError('"%1$s cannot be copied.'), $category->image);
 
 			// If both update and add above failed, report an error
 			if (!$res)


### PR DESCRIPTION
In the process of migrating our 250+ categories and 2600+ products to Prestashop, the importer gave me some work to do, so I fixed some stuff.

There is at least a functional change here (see the individual commit description for more info for what I considered "bugs"), but it won't overwrite categories anymore if they share the same ID in the DB and in the file unless you set "Force IDs".
