### PR TITLE
Override php module core file

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1027,6 +1027,19 @@ abstract class ModuleCore
 
 		if (!isset(self::$_INSTANCE[$module_name]))
 		{
+			if (Tools::file_exists_no_cache(_PS_OVERRIDE_DIR_ . 'modules/'.$module_name.'/'.$module_name.'.php'))
+			{
+				include_once(_PS_OVERRIDE_DIR_ . 'modules/'.$module_name.'/'.$module_name.'.php');
+				if (class_exists($module_name . 'Override', false))
+				{
+					include_once(_PS_MODULE_DIR_.$module_name.'/'.$module_name.'.php');
+					$c = $module_name . 'Override';
+					return self::$_INSTANCE[$module_name] = new $c;
+				}
+
+				if (class_exists($module_name, false))
+					return self::$_INSTANCE[$module_name] = new $module_name;
+			}
 			if (Tools::file_exists_no_cache(_PS_MODULE_DIR_.$module_name.'/'.$module_name.'.php'))
 			{
 				include_once(_PS_MODULE_DIR_.$module_name.'/'.$module_name.'.php');


### PR DESCRIPTION
With this code, you can create MODULE_NAME.php in override/modules/MODULE_NAME/ which will override the module core.

As example :
/override/modules/blocknewsletter/blocknewsletter.php :

```
<?php
class BlockNewsletterOverride extends BlockNewsletter
{
    protected function register($email, $register_status)
    {
            // do something
        return parent::register($email, $register_status);
    }
}
```
