### PR TITLE
Webservices not respect position, category_product

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4678,8 +4678,21 @@ class ProductCore extends ObjectModel
 	public function setWsCategories($category_ids)
 	{
 		$ids = array();
-		foreach ($category_ids as $value)
-			$ids[] = $value['id'];
+		foreach ($category_ids as $value) {
+            		$position_now = Db::getInstance()->getValue('SELECT position
+								FROM `'._DB_PREFIX_.'category_product`
+								WHERE id_category = '.(int)$value['id'].'
+								AND id_product = '.(int)$this->id);
+		       if($position_now)
+		                $ids[$position_now] = $value['id'];
+		       else 
+		                $idsWithoutPosition[] = $value['id'];
+        	}
+        
+        	foreach($idsWithoutPosition as $value)
+            		$ids[] = $value;
+		
+		
 		if ($this->deleteCategories())
 		{
 			if ($ids)

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4678,6 +4678,7 @@ class ProductCore extends ObjectModel
 	public function setWsCategories($category_ids)
 	{
 		$ids = array();
+		$idsWithoutPosition = array();
 		foreach ($category_ids as $value) {
             		$position_now = Db::getInstance()->getValue('SELECT position
 								FROM `'._DB_PREFIX_.'category_product`


### PR DESCRIPTION
I've detected that when you save a product with Webservices, the position of category_product is removed by $this->deleteCategories(). Furthermore if you use the setWsPositionInCategory, never save the value because the setWsCategories not save the positions before remove the category_product rows.
