### PR TITLE
[-] BO : fix parameters missing between AdminController and HelperList

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2074,6 +2074,8 @@ class AdminControllerCore extends Controller
 		}
 
 		$this->setHelperDisplay($helper);
+		$helper->_default_pagination = $this->_default_pagination;
+		$helper->_pagination = $this->_pagination;
 		$helper->tpl_vars = $this->tpl_list_vars;
 		$helper->tpl_delete_link_vars = $this->tpl_delete_link_vars;
 


### PR DESCRIPTION
Hi,

Some pagination parameters are not send from AdminController To HelperList.
With this modification, we can choose the default pagination for the list by controller.

These lines are missing in renderList():
$helper->_default_pagination = $this->_default_pagination;
$helper->_pagination = $this->_pagination;
