### PR TITLE
[-] BO : fix parameters missing between AdminController and HelperList 2

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -39,10 +39,10 @@ class HelperListCore extends Helper
 	protected $_filter;
 
 	/** @var array Number of results in list per page (used in select field) */
-	protected $_pagination = array(20, 50, 100, 300, 1000);
+	public $_pagination = array(20, 50, 100, 300, 1000);
 	
 	/** @var integer Default number of results in list per page */
-	protected $_default_pagination = 50;
+	public $_default_pagination = 50;
 
 	/** @var string ORDER BY clause determined by field/arrows in list header */
 	public $orderBy;


### PR DESCRIPTION
[-] BO : fix parameters missing between AdminController and HelperList - part 2

Hi,
See pull request #2157

Some pagination parameters are not send from AdminController To HelperList.
With this modification, we can choose the default pagination for the list by controller.

These lines are missing in renderList():
$helper->_default_pagination = $this->_default_pagination;
$helper->_pagination = $this->_pagination;

_default_pagination and _pagination must be public.
