### PR TITLE
[-] FO: BUG: Performance > NO COMBINATIONS = SQL Error

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2082,7 +2082,7 @@ class ProductCore extends ObjectModel
 		$sql->select(
 			'p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity, pl.`description`, pl.`description_short`, pl.`link_rewrite`, pl.`meta_description`,
 			pl.`meta_keywords`, pl.`meta_title`, pl.`name`, pl.`available_now`, pl.`available_later`, MAX(image_shop.`id_image`) id_image, il.`legend`, m.`name` AS manufacturer_name,
-			product_shop.`date_add` > "'.date('Y-m-d', strtotime('-'.(Configuration::get('PS_NB_DAYS_NEW_PRODUCT') ? (int)Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20).' DAY')).'" as new, product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity'
+			product_shop.`date_add` > "'.date('Y-m-d', strtotime('-'.(Configuration::get('PS_NB_DAYS_NEW_PRODUCT') ? (int)Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20).' DAY')).'" as new '.(Configuration::get('PS_COMBINATION_FEATURE_ACTIVE')==1 ? ", product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity" : "")
 		);
 
 		$sql->from('product', 'p');

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2082,7 +2082,7 @@ class ProductCore extends ObjectModel
 		$sql->select(
 			'p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity, pl.`description`, pl.`description_short`, pl.`link_rewrite`, pl.`meta_description`,
 			pl.`meta_keywords`, pl.`meta_title`, pl.`name`, pl.`available_now`, pl.`available_later`, MAX(image_shop.`id_image`) id_image, il.`legend`, m.`name` AS manufacturer_name,
-			product_shop.`date_add` > "'.date('Y-m-d', strtotime('-'.(Configuration::get('PS_NB_DAYS_NEW_PRODUCT') ? (int)Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20).' DAY')).'" as new '.(Configuration::get('PS_COMBINATION_FEATURE_ACTIVE')==1 ? ", product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity" : "")
+			product_shop.`date_add` > "'.date('Y-m-d', strtotime('-'.(Configuration::get('PS_NB_DAYS_NEW_PRODUCT') ? (int)Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20).' DAY')).'" as new '.(Configuration::get('PS_COMBINATION_FEATURE_ACTIVE')? ", product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity" : "")
 		);
 
 		$sql->from('product', 'p');


### PR DESCRIPTION
Solve the problem when using "Performance > OPTIONAL FEATURES > Combination" to "YES" and SQL states an alias for "product_attribute_shop.minimal_quantity" without checking if "Combinations" are enabled
