### PR TITLE
Bug causing the loss of customization fields when editing all shops

### DIFF
--- a/js/admin-products.js
+++ b/js/admin-products.js
@@ -1851,8 +1851,8 @@ var ProductMultishop = new function()
 
 	this.checkAllCustomization = function()
 	{
-		ProductMultishop.checkField($('input[name=\'multishop_check[uploadable_files]\']').prop('checked'), 'uploadable_files');
-		ProductMultishop.checkField($('input[name=\'multishop_check[text_fields]\']').prop('checked'), 'text_fields');
+		/*ProductMultishop.checkField($('input[name=\'multishop_check[uploadable_files]\']').prop('checked'), 'uploadable_files');
+		ProductMultishop.checkField($('input[name=\'multishop_check[text_fields]\']').prop('checked'), 'text_fields');*/
 	};
 
 	this.checkAllCombinations = function()


### PR DESCRIPTION
The uploadable_files and text_fields are common fields, so we don't need to have any checkbox handling...
The problem was that when editing all the shops those two fields were disabled and thus not send per post, and so the customization fields were deleted by _deleteOldLabels().
