### PR TITLE
[*] CORE : Add check cart rules validity when choosing carrier

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2074,14 +2074,17 @@ class CartCore extends ObjectModel
 		}
 
 		$cart_rules = CartRule::getCustomerCartRules(Context::getContext()->cookie->id_lang, Context::getContext()->cookie->id_customer, true, true, false, $this);
-
+		$result = Db::getInstance('SELECT * FROM '._DB_PREFIX_.'cart_cart_rule WHERE id_cart=' . $this->id);
+                $cart_rules_in_cart = array();
+                foreach($result as $row) 
+                  $cart_rules_in_cart[] = $row['id_cart_rules'];
 		$free_carriers_rules = array();
 		foreach ($cart_rules as $cart_rule)
 		{
 			if ($cart_rule['free_shipping'] && $cart_rule['carrier_restriction'])
 			{
 				$cr = new CartRule((int)$cart_rule['id_cart_rule']);
-				if (Validate::isLoadedObject($cr))
+				if (Validate::isLoadedObject($cr)  && $cr->checkValidity(Context::getContext(),in_array((int)$cart_rule['id_cart_rule'],$cart_rules_in_cart),false,false))
 				{
 					$carriers = $cr->getAssociatedRestrictions('carrier', true, false);
 					if (is_array($carriers) && count($carriers) && isset($carriers['selected']))

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -455,7 +455,7 @@ class CartRuleCore extends ObjectModel
 	 * @param bool $display_error Display error
 	 * @return bool|mixed|string
 	 */
-	public function checkValidity(Context $context, $alreadyInCart = false, $display_error = true)
+	public function checkValidity(Context $context, $alreadyInCart = false, $display_error = true, $check_carrier = true)
 	{
 		if (!CartRule::isFeatureActive())
 			return false;
@@ -510,7 +510,7 @@ class CartRuleCore extends ObjectModel
 		}
 
 		// Check if the carrier chosen by the customer is usable with the cart rule
-		if ($this->carrier_restriction)
+		if ($this->carrier_restriction && $check_carrier)
 		{
 			if (!$context->cart->id_carrier)
 				return (!$display_error) ? false : Tools::displayError('You must choose a carrier before applying this voucher to your order');


### PR DESCRIPTION
Permet de vérifier la validité d'une règle panier de gratuité des transports lors de la sélection des transporteurs dans le tunnel de commande
