### PR TITLE
[-] Class: CartRule / If no currency set, use the default one.

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -123,7 +123,7 @@ class CartRuleCore extends ObjectModel
 	public function add($autodate = true, $null_values = false)
 	{
 		if (!$this->reduction_currency)
-			$this->reduction_currency = Configuration::get('PS_CURRENCY_DEFAULT'))->id;
+			$this->reduction_currency = Configuration::get('PS_CURRENCY_DEFAULT');
 		if (!parent::add($autodate, $null_values))
 			return false;
 
@@ -134,10 +134,10 @@ class CartRuleCore extends ObjectModel
 	public function update($null_values = false)
 	{
 		Cache::clean('getContextualValue_'.$this->id.'_*');
-		
+
 		if (!$this->reduction_currency)
-			$this->reduction_currency = Configuration::get('PS_CURRENCY_DEFAULT'))->id;
-		
+			$this->reduction_currency = Configuration::get('PS_CURRENCY_DEFAULT');
+
 		return parent::update($null_values);
 	}
 

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -122,6 +122,8 @@ class CartRuleCore extends ObjectModel
 	 */
 	public function add($autodate = true, $null_values = false)
 	{
+		if (!$this->reduction_currency)
+			$this->reduction_currency = Configuration::get('PS_CURRENCY_DEFAULT'))->id;
 		if (!parent::add($autodate, $null_values))
 			return false;
 
@@ -132,6 +134,10 @@ class CartRuleCore extends ObjectModel
 	public function update($null_values = false)
 	{
 		Cache::clean('getContextualValue_'.$this->id.'_*');
+		
+		if (!$this->reduction_currency)
+			$this->reduction_currency = Configuration::get('PS_CURRENCY_DEFAULT'))->id;
+		
 		return parent::update($null_values);
 	}
 


### PR DESCRIPTION
A CartRule with the reduction_currency set to 0 will never be used as we want. Let this parameter be the default one if we don't set it.