### PR TITLE
BO: Update Admin translations controller

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1208,7 +1208,7 @@ class AdminTranslationsControllerCore extends AdminController
 						$regex = '/->l\((\')'._PS_TRANS_PATTERN_.'\'(, ?\'(.+)\')?(, ?(.+))?\)/U';
 					else
 						// In tpl file look for something that should contain mod='module_name' according to the documentation
-						$regex = '/\{l\s*s=([\'\"])'._PS_TRANS_PATTERN_.'\1.*\s+mod=\''.$module_name.'\'.*\}/U';
+						$regex = '/\{l\s*s=([\'\"])'._PS_TRANS_PATTERN_.'\1.*\s+mod=([\'\"])'.$module_name.'([\'\"]).*\}/U';
 				break;
 
 			case 'pdf':


### PR DESCRIPTION
Update module tpl translation regexp.

Now part of the `mod='mymodule'` does not depend on the type of quotes, and expressing 
`{l s='Hello world!' mod='mymodule'}`
and 
`{l s='Hello world!' mod="mymodule"}`
behave similarly
