### PR TITLE
Suppress notice when reduction_tax is undefined

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2769,7 +2769,7 @@ class ProductCore extends ObjectModel
 				if (!$specific_price['id_currency'])
 					$reduction_amount = Tools::convertPrice($reduction_amount, $id_currency);
 
-				if ($specific_price['reduction_tax'] )
+				if (@$specific_price['reduction_tax'] )
 					$specific_price_reduction = !$use_tax ? $product_tax_calculator->removeTaxes($reduction_amount) : $reduction_amount;
 				else
 					$specific_price_reduction = $reduction_amount;


### PR DESCRIPTION
Or alternatively check if isset($specific_price['reduction_tax']) prior...
