### PR TITLE
[-] CORE : static cache bugfix on getCustomer()

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -993,17 +993,21 @@ class OrderCore extends ObjectModel
 	}
 	
 	/**
+	 * used to cache order customer
+	 */ 
+	protected $cacheCustomer = null;
+	
+	/**
 	 * Get order customer
 	 * 
 	 * @return Customer $customer
 	 */
 	public function getCustomer()
 	{
-		static $customer = null;
-		if (is_null($customer))
-			$customer = new Customer((int)$this->id_customer);
+		if (is_null($this->cacheCustomer))
+			$this->cacheCustomer = new Customer((int)$this->id_customer);
 		
-		return $customer;
+		return $this->cacheCustomer;
 	}
 
 	/**


### PR DESCRIPTION
This is **really a bad idea** to use a static variable here, because if you manipulate 2 order instance, and ask for the customer, the second will give you the first's customer...

ex :
$o1 = new Order(1);
var_dump($o1->getCustomer());

$o2 = new Order(2);
var_dump($o2->getCustomer());  // return $o1 customer...
