### PR TITLE
Prevent premature menu opening when interacted with via mobile device view.

### DIFF
--- a/themes/default-bootstrap/js/modules/blockcart/ajax-cart.js
+++ b/themes/default-bootstrap/js/modules/blockcart/ajax-cart.js
@@ -53,7 +53,7 @@ $(document).ready(function(){
 		});
 	}
 
-	$(document).on('touchstart', '#header .shopping_cart a:first', function(){
+	$(document).on('click', '#header .shopping_cart a:first', function(){
 		if ($(this).next('.cart_block:visible').length)
 			$("#header .cart_block").stop(true, true).slideUp(450);
 		else

--- a/themes/default-bootstrap/js/modules/blocktopmenu/js/blocktopmenu.js
+++ b/themes/default-bootstrap/js/modules/blocktopmenu/js/blocktopmenu.js
@@ -81,7 +81,7 @@ function mobileInit()
 	categoryMenu.superfish('destroy');
 	$('.sf-menu').removeAttr('style');
 
-	mCategoryGrover.on('click touchstart', function(e){
+	mCategoryGrover.on('click', function(e){
 		$(this).toggleClass('active').parent().find('ul.menu-content').stop().slideToggle('medium');
 		return false;
 	});


### PR DESCRIPTION
The top menu and cart block open prematurely making it extremely difficult to navigate (swipe scroll) down the page. This modification makes it so that you can touch-hold and scroll the page without having the cart or top menu blocks open.
