### PR TITLE
[-] FO : Stores : warning thrown if hours is empty

### DIFF
--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -133,7 +133,15 @@ class StoresControllerCore extends FrontController
 		$days[7] = 'Sunday';
 		
 		$days_datas = array();
-		$hours = array_filter(unserialize($store['hours']));
+		$hours = array();
+		
+		if ($store['hours'])
+		{
+			$hours = unserialize($store['hours']);
+			if (is_array($hours))
+				$hours = array_filter($hours);
+		}
+		
 		if (!empty($hours))
 		{
 			for ($i = 1; $i < 8; $i++)


### PR DESCRIPTION
If the "hours" field is empty and you display errors (e.g. when developing), a warning is thrown because of array_filter used on a non-array value. The generated XML gets corrupted because of this error, so the JS parser fails and no store is shown on the FO.
