### PR TITLE
[*] FO : adds tpl-uri smarty variable

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -335,6 +335,7 @@ class FrontControllerCore extends Controller
 			'content_dir' => $protocol_content.Tools::getHttpHost().__PS_BASE_URI__,
 			'base_uri' => $protocol_content.Tools::getHttpHost().__PS_BASE_URI__.(!Configuration::get('PS_REWRITING_SETTINGS') ? 'index.php' : ''),
 			'tpl_dir' => _PS_THEME_DIR_,
+			'tpl_uri' => _THEME_DIR_,
 			'modules_dir' => _MODULE_DIR_,
 			'mail_dir' => _MAIL_DIR_,
 			'lang_iso' => $this->context->language->iso_code,


### PR DESCRIPTION
I have added an helpful tpl_uri variable accessible in themes templates like this : `{$tpl_uri}`. We are using it to link to theme's assets.
