### PR TITLE
[-] BO: crash when missing qty in product import with advanced stock on

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1830,7 +1830,7 @@ class AdminImportControllerCore extends AdminController
 							StockAvailable::setQuantity((int)$product->id, 0, $product->quantity, $this->context->shop->id);
 					}
 					// elseif enable depends on stock and quantity, add quantity to stock
-					elseif (isset($product->quantity) && $product->depends_on_stock == 1)
+					elseif ((isset($product->quantity) && $product->quantity >= 1 ) && $product->depends_on_stock == 1)
 					{
 						// add stock
 						$stock_manager = StockManagerFactory::getManager();


### PR DESCRIPTION
If importing a product with Advanced Stock and Depends on Stock set to 1, and the product does not have quanity field or quantity is 0. 
Import would crash with and PrestaShop Fatal Error due to invaild Stock->physical_quantity
