### PR TITLE
[+] Permit to get order information for contact

### DIFF
--- a/controllers/front/ContactController.php
+++ b/controllers/front/ContactController.php
@@ -175,8 +175,12 @@ class ContactControllerCore extends FrontController
 					$id_product = (int)Tools::getValue('id_product');
 
 					if (isset($ct) && Validate::isLoadedObject($ct) && $ct->id_order)
-					{
 						$order = new Order((int)$ct->id_order);
+					elseif($id_order)
+						$order = new Order((int)$id_order);
+					
+					if ((isset($ct) && Validate::isLoadedObject($ct) && $ct->id_order) || $id_order)
+					{
 						$var_list['{order_name}'] = $order->getUniqReference();
 						$var_list['{id_order}'] = (int)$order->id;
 					}


### PR DESCRIPTION
Permet de récupérer les informations de la commande (choisi via le select du formulaire de contact) dans les emails, même lorsque l'on utilise pas le système de thread/sujet entre administrateur/client via l'historique de commande.
