### PR TITLE
[*] BO : moved display*ListAfter inside form

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_footer.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_footer.tpl
@@ -153,9 +153,6 @@
 {else}
 	</div>
 {/if}
-{block name="endForm"}
-</form>
-{/block}
 
 {hook h='displayAdminListAfter'}
 {if isset($name_controller)}
@@ -166,5 +163,8 @@
 	{hook h=$hookName}
 {/if}
 
+{block name="endForm"}
+</form>
+{/block}
 
 {block name="after"}{/block}


### PR DESCRIPTION
the display*ListAfter is more usefull inside the form, beacuse we can then make a list that has save buttons and so on.
