### PR TITLE
[*] CORE : Add new hook actionBeforeCartUpdateQty on Cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -831,6 +831,8 @@ class CartCore extends ObjectModel
 		if (isset(self::$_totalWeight[$this->id]))
 			unset(self::$_totalWeight[$this->id]);
 
+		Hook::exec('actionBeforeCartUpdateQty', array('cart' => $this, 'product' => $product, 'id_product' => $id_product, 'id_product_attribute' => $id_product_attribute, 'id_customization' => $id_customization, 'quantity' => $quantity, 'operator' => $operator, 'id_address_delivery' => $id_address_delivery, 'shop' => $shop, 'auto_add_cart_rule' => $auto_add_cart_rule));
+
 		if ((int)$quantity <= 0)
 			return $this->deleteProduct($id_product, $id_product_attribute, (int)$id_customization);
 		elseif (!$product->available_for_order || (Configuration::get('PS_CATALOG_MODE') && !defined('_PS_ADMIN_DIR_')))

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -834,7 +834,6 @@ class CartCore extends ObjectModel
 		Hook::exec('actionBeforeCartUpdateQty', array(
 			'cart' => $this,
 			'product' => $product,
-			'id_product' => $id_product,
 			'id_product_attribute' => $id_product_attribute,
 			'id_customization' => $id_customization,
 			'quantity' => $quantity,

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -831,7 +831,18 @@ class CartCore extends ObjectModel
 		if (isset(self::$_totalWeight[$this->id]))
 			unset(self::$_totalWeight[$this->id]);
 
-		Hook::exec('actionBeforeCartUpdateQty', array('cart' => $this, 'product' => $product, 'id_product' => $id_product, 'id_product_attribute' => $id_product_attribute, 'id_customization' => $id_customization, 'quantity' => $quantity, 'operator' => $operator, 'id_address_delivery' => $id_address_delivery, 'shop' => $shop, 'auto_add_cart_rule' => $auto_add_cart_rule));
+		Hook::exec('actionBeforeCartUpdateQty', array(
+			'cart' => $this,
+			'product' => $product,
+			'id_product' => $id_product,
+			'id_product_attribute' => $id_product_attribute,
+			'id_customization' => $id_customization,
+			'quantity' => $quantity,
+			'operator' => $operator,
+			'id_address_delivery' => $id_address_delivery,
+			'shop' => $shop,
+			'auto_add_cart_rule' => $auto_add_cart_rule,
+		));
 
 		if ((int)$quantity <= 0)
 			return $this->deleteProduct($id_product, $id_product_attribute, (int)$id_customization);


### PR DESCRIPTION
In order to block some cart actions, we must have an input before Cart::updateQty() is processed.
It's way better than doing the job after actionCartSave hook so the cart is only updated (or not) one time.
