### PR TITLE
Missing dollar sign on variable path

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2702,8 +2702,8 @@ class AdminTranslationsControllerCore extends AdminController
 	protected function writeSubjectTranslationFile($sub, $path)
 	{
 		if (!Tools::file_exists_cache(dirname($path)))
-			if (!mkdir(dirname(path), 0700))
-				throw new PrestaShopException('Directory '.dirname(path).' cannot be created.');
+			if (!mkdir(dirname($path), 0700))
+				throw new PrestaShopException('Directory '.dirname($path).' cannot be created.');
 		if ($fd = @fopen($path, 'w'))
 		{
 			$tab = 'LANGMAIL';


### PR DESCRIPTION
Missing dollar sign on variable path - method writeSubjectTranslationFile
