### PR TITLE
[-] CORE : Added Validation rule to Specific price id_currency

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -56,7 +56,7 @@ class SpecificPriceCore extends ObjectModel
 			'id_cart' => 			array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
 			'id_product' => 			array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
 			'id_product_attribute' => 	array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId'),
-			'id_currency' => 			array('type' => self::TYPE_INT, 'required' => true),
+			'id_currency' => 			array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
 			'id_specific_price_rule' =>	array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId'),
 			'id_country' => 			array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
 			'id_group' => 				array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),

--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -51,7 +51,7 @@ class SpecificPriceRuleCore extends ObjectModel
 			'name' => 			array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true),
 			'id_shop' => 		array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
 			'id_country' => 	array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
-			'id_currency' => 	array('type' => self::TYPE_INT, 'required' => true),
+			'id_currency' => 	array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
 			'id_group' => 		array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
 			'from_quantity' => 	array('type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'required' => true),
 			'price' => 		array('type' => self::TYPE_FLOAT, 'validate' => 'isNegativePrice', 'required' => true),


### PR DESCRIPTION
Line 59: Changing the id_currency to validate as isUnsignedId prevents the id_currency being set as a negative number for a non existent Currency ID.

This change brings the validation for this file in line with the rest of PrestaShop core when it comes to handling ID numbers
