### PR TITLE
[-] FO : Could not translate New for product condition

### DIFF
--- a/themes/default-bootstrap/product.tpl
+++ b/themes/default-bootstrap/product.tpl
@@ -160,7 +160,7 @@
 				<label>{l s='Condition:'} </label>
 				{if $product->condition == 'new'}
 					<link itemprop="itemCondition" href="http://schema.org/NewCondition"/>
-					<span class="editable">{l s='New'}</span>
+					<span class="editable">{l s='New product'}</span>
 				{elseif $product->condition == 'used'}
 					<link itemprop="itemCondition" href="http://schema.org/UsedCondition"/>
 					<span class="editable">{l s='Used'}</span>


### PR DESCRIPTION
Needs to be different from line 65 : {l s='New'}
Because in French the translations are different : 
line 65 = Nouveau (=Nouveau produit)
line 163 = Neuf (=Produit neuf)
