### PR TITLE
Display of CMS from Checkout page is not working

### DIFF
--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -53,7 +53,8 @@ class CmsControllerCore extends FrontController
 		else if ($id_cms_category = (int)Tools::getValue('id_cms_category'))
 			$this->cms_category = new CMSCategory($id_cms_category, $this->context->language->id);
 
-		if (Configuration::get('PS_SSL_ENABLED') && Tools::getValue('content_only') && Tools::getValue('id_cms') == (int)Configuration::get('PS_CONDITIONS_CMS_ID') && Validate::isLoadedObject($this->cms))
+		if (Configuration::get('PS_SSL_ENABLED') && Tools::getValue('content_only'))
+
 			$this->ssl = true;
 		
 		parent::init();


### PR DESCRIPTION
When using ajax (fancybox for example) to display content pages on SSL secured checkout page, the page should NOT get redirected to non-ssl.
My suggestion is to either generally allow ssl for cms (why not ?) , or to include at least some content like revokation into the list of exceptions.
i.e.
        if (Configuration::get('PS_SSL_ENABLED') && Tools::getValue('content_only'))
or
        if (Configuration::get('PS_SSL_ENABLED') && Tools::getValue('content_only') && ( Tools::getValue('id_cms') == (int)Configuration::get('PS_CONDITIONS_CMS_ID') || Tools::getValue('id_cms') == (int)Configuration::get('LEGAL_CMS_ID_REVOCATION' ) ) && Validate::isLoadedObject($this->cms))

This is rather important, because it´s a legal requirement to show the revokation information in germany, and I think it is in the whole EU, too.
