### PR TITLE
 [-] FO : Fix problem with filtering by color on start

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -89,7 +89,7 @@ $(document).ready(function()
 	});
 
 	// Click on label
-	$('#layered_block_left label a').on({
+	$('#layered_block_left label:not(.layered_color) a').on({
 		click: function(e) {
 			e.preventDefault();
 			var disable = $(this).parent().parent().find('input').attr('disabled');


### PR DESCRIPTION
How to reproduce this bug?
1. Go to http://fo.demo.prestashop.com/pl/3-women on newest Chrome/Opera
2. Click on color name, for example Beige
3. Nothing happens, why? Because we use 2 functions on the same element.
4. 
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Sponsor company | impSolutions
