### PR TITLE
[-] FO : Fix multiple "Add to cart" event when block layered is used

### DIFF
--- a/themes/default-bootstrap/js/modules/blockcart/ajax-cart.js
+++ b/themes/default-bootstrap/js/modules/blockcart/ajax-cart.js
@@ -131,7 +131,7 @@ var ajaxCart = {
 	//override every button in the page in relation to the cart
 	overrideButtonsInThePage : function(){
 		//for every 'add' buttons...
-		$(document).on('click', '.ajax_add_to_cart_button', function(e){
+		$(document).off('click', '.ajax_add_to_cart_button').on('click', '.ajax_add_to_cart_button', function(e){
 			e.preventDefault();
 			var idProduct =  parseInt($(this).data('id-product'));
 			var minimalQuantity =  parseInt($(this).data('minimal_quantity'));
@@ -141,13 +141,13 @@ var ajaxCart = {
 				ajaxCart.add(idProduct, null, false, this, minimalQuantity);
 		});
 		//for product page 'add' button...
-		$(document).on('click', '#add_to_cart button', function(e){
+		$(document).off('click', '#add_to_cart button').on('click', '#add_to_cart button', function(e){
 			e.preventDefault();
 			ajaxCart.add($('#product_page_product_id').val(), $('#idCombination').val(), true, null, $('#quantity_wanted').val(), null);
 		});
 
 		//for 'delete' buttons in the cart block...
-		$(document).on('click', '.cart_block_list .ajax_cart_block_remove_link', function(e){
+		$(document).off('click', '.cart_block_list .ajax_cart_block_remove_link').on('click', '.cart_block_list .ajax_cart_block_remove_link', function(e){
 			e.preventDefault();
 			// Customized product management
 			var customizationId = 0;


### PR DESCRIPTION
This issue was first discovered on IE, but we also noticed that the event is also fired on Firefox/Chrome but does fire add to cart process.
By adding off() to theses events, we prevent this behaviour to happen when using ajaxCart.overrideButtonsInThePage() method multiple time on a same page.
This is a simple inherit from the previous ajaxCart version (PS 1.5) that is using unbind() and already preventing this behaviour.
