### PR TITLE
[*] BO: Allow stock transfer as soon as more than one warehouse exists

### DIFF
--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -99,7 +99,7 @@ class AdminStockManagementControllerCore extends AdminController
 		$this->addRowAction('addstock');
 		$this->addRowAction('removestock');
 
-		if (count(Warehouse::getWarehouses()) > 1)
+		if (count(Warehouse::getWarehouses(true)) > 1)
 			$this->addRowAction('transferstock');
 
 		// no link on list rows
@@ -817,7 +817,7 @@ class AdminStockManagementControllerCore extends AdminController
 			$this->addRowAction('addstock');
 			$this->addRowAction('removestock');
 
-			if (count(Warehouse::getWarehouses()) > 1)
+			if (count(Warehouse::getWarehouses(true)) > 1)
 				$this->addRowAction('transferstock');
 
 			// no link on list rows


### PR DESCRIPTION
[UP]

Stock transfer was allowed only if the context shop (not selectable from the page!) has more than one warehouse, but was allowed to any warehouse containing the product. This is inconsistent.

See also #2819 about stock management little upsetting defects
