### PR TITLE
[-] BO : Cannot access return array in AdminOrdersController.php

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -641,11 +641,12 @@ class AdminOrdersControllerCore extends AdminController
 					$order_detail_list = array();
 					foreach ($refunds as $id_order_detail => $amount_detail)
 					{
-						if (!Tools::getValue('partialRefundProductQuantity')[$id_order_detail])
+						$quantity = Tools::getValue('partialRefundProductQuantity');
+						if (!$quantity[$id_order_detail])
 							continue;
 
 						$order_detail_list[$id_order_detail] = array(
-							'quantity' => (int)Tools::getValue('partialRefundProductQuantity')[$id_order_detail],
+							'quantity' => (int)$quantity[$id_order_detail],
 							'id_order_detail' => (int)$id_order_detail
 						);
 


### PR DESCRIPTION
As seen in http://php.net/manual/en/language.types.array.php#example-102, is not possible to access the array key of the return of a function directly prior to PHP 5.4.

A temporary variable should be used to solve the problem for previous versions.
