### PR TITLE
translations - level 2 cache performance patch

### DIFF
--- a/admin-dev/functions.php
+++ b/admin-dev/functions.php
@@ -237,12 +237,7 @@ function translate($string)
 {
 	Tools::displayAsDeprecated();
 
-	global $_LANGADM;
-	if (!is_array($_LANGADM))
-		return str_replace('"', '&quot;', $string);
-	$key = md5(str_replace('\'', '\\\'', $string));
-	$str = (array_key_exists('index'.$key, $_LANGADM)) ? $_LANGADM['index'.$key] : ((array_key_exists('index'.$key, $_LANGADM)) ? $_LANGADM['index'.$key] : $string);
-	return str_replace('"', '&quot;', stripslashes($str));
+	return Translate::getTranslateFuncTranslation($string);
 }
 
 /**

--- a/admin-dev/init.php
+++ b/admin-dev/init.php
@@ -48,14 +48,6 @@ try
 		$currentIndex .= '&back='.urlencode($back);
 	AdminTab::$currentIndex = $currentIndex;
 
-	$iso = $context->language->iso_code;
-	if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/errors.php'))
-		include(_PS_TRANSLATIONS_DIR_.$iso.'/errors.php');
-	if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/fields.php'))
-		include(_PS_TRANSLATIONS_DIR_.$iso.'/fields.php');
-	if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php'))
-		include(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php');
-
 	/* Server Params */
 	$protocol_link = (Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';
 	$protocol_content = (isset($useSSL) AND $useSSL AND Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';
@@ -67,7 +59,7 @@ try
 		define('_PS_BASE_URL_SSL_', Tools::getShopDomainSsl(true));
 
 	$path = dirname(__FILE__).'/themes/';
-	// if the current employee theme is not valid (check layout.tpl presence), 
+	// if the current employee theme is not valid (check layout.tpl presence),
 	// reset to default theme
 	if (empty($context->employee->bo_theme) ||
 		!file_exists($path.$context->employee->bo_theme.'/template/layout.tpl'))

--- a/classes/AdminTab.php
+++ b/classes/AdminTab.php
@@ -248,15 +248,11 @@ abstract class AdminTabCore
 			$string = str_replace('\'', '\\\'', $string);
 			return Translate::getModuleTranslation(Module::$classInModule[$currentClass], $string, $currentClass);
 		}
-		global $_LANGADM;
 
         if ($class == __CLASS__)
                 $class = 'AdminTab';
 
-		$key = md5(str_replace('\'', '\\\'', $string));
-		$str = (array_key_exists(get_class($this).$key, $_LANGADM)) ? $_LANGADM[get_class($this).$key] : ((array_key_exists($class.$key, $_LANGADM)) ? $_LANGADM[$class.$key] : $string);
-		$str = $htmlentities ? htmlentities($str, ENT_QUOTES, 'utf-8') : $str;
-		return str_replace('"', '&quot;', ($addslashes ? addslashes($str) : stripslashes($str)));
+        return Translate::getAdminTabTranslation($string, $currentClass, $class, $addslashes, $htmlentities);
 	}
 
 	/**

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -105,7 +105,7 @@ class LanguageCore extends ObjectModel
 
 	/**
 	 * Generate translations files
-	 *
+	 * 
 	 */
 	protected function _generateFiles($newIso = null)
 	{
@@ -134,6 +134,9 @@ class LanguageCore extends ObjectModel
 
 			@chmod($path_file, 0777);
 		}
+
+		Translate::clearL2Cache();
+		Translate::setL2CacheDoNotSaveFlag();
 	}
 
 	/**
@@ -173,10 +176,14 @@ class LanguageCore extends ObjectModel
 				if (file_exists(_PS_ALL_THEMES_DIR_.$theme_dir.'/modules/'.$module.'/'.$this->iso_code.'.php'))
 					rename(_PS_ALL_THEMES_DIR_.$theme_dir.'/modules/'.$module.'/'.$this->iso_code.'.php', _PS_ALL_THEMES_DIR_.$theme_dir.'/modules/'.$module.'/'.$newIso.'.php');
 		}
+
+		Translate::clearL2Cache();
+		Translate::setL2CacheDoNotSaveFlag();
+
 	}
 
 	/**
-	  * Return an array of theme 
+	  * Return an array of theme
 	  *
 	  * @return array([theme dir] => array('name' => [theme name]))
 	  * @deprecated
@@ -430,7 +437,7 @@ class LanguageCore extends ObjectModel
 						$primary_key_exists = true;
 				}
 				$fields = rtrim($fields, ', ');
-				
+
 				if (!$primary_key_exists)
 					continue;
 
@@ -487,21 +494,21 @@ class LanguageCore extends ObjectModel
 		{
 			if (empty($this->iso_code))
 				$this->iso_code = Language::getIsoById($this->id);
-	
+
 			// Database translations deletion
 			$result = Db::getInstance()->executeS('SHOW TABLES FROM `'._DB_NAME_.'`');
 			foreach ($result as $row)
 				if (isset($row['Tables_in_'._DB_NAME_]) && !empty($row['Tables_in_'._DB_NAME_]) && preg_match('/'.preg_quote(_DB_PREFIX_).'_lang/', $row['Tables_in_'._DB_NAME_]))
 					if (!Db::getInstance()->execute('DELETE FROM `'.$row['Tables_in_'._DB_NAME_].'` WHERE `id_lang` = '.(int)$this->id))
 						return false;
-	
-	
+
+
 			// Delete tags
 			Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'tag WHERE id_lang = '.(int)$this->id);
-	
+
 			// Delete search words
 			Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'search_word WHERE id_lang = '.(int)$this->id);
-	
+
 			// Files deletion
 			foreach (Language::getFilesList($this->iso_code, _THEME_NAME_, false, false, false, true, true) as $key => $file)
 				if (file_exists($key))
@@ -514,7 +521,7 @@ class LanguageCore extends ObjectModel
 				$files = @scandir(_PS_MODULE_DIR_.$mod.'/mails/');
 				if (count($files) <= 2)
 					Language::recurseDeleteDir(_PS_MODULE_DIR_.$mod.'/mails/');
-	
+
 				if (file_exists(_PS_MODULE_DIR_.$mod.'/'.$this->iso_code.'.php'))
 				{
 					unlink(_PS_MODULE_DIR_.$mod.'/'.$this->iso_code.'.php');
@@ -523,7 +530,7 @@ class LanguageCore extends ObjectModel
 						Language::recurseDeleteDir(_PS_MODULE_DIR_.$mod);
 				}
 			}
-	
+
 			if (file_exists(_PS_MAIL_DIR_.$this->iso_code))
 				Language::recurseDeleteDir(_PS_MAIL_DIR_.$this->iso_code);
 			if (file_exists(_PS_TRANSLATIONS_DIR_.$this->iso_code))
@@ -547,6 +554,9 @@ class LanguageCore extends ObjectModel
 						unlink(_PS_ROOT_DIR_.'/img/l/'.$this->id.'.jpg');
 				}
 		}
+
+		Translate::clearL2Cache($this->id);
+		Translate::setL2CacheDoNotSaveFlag();
 
 		if (!parent::delete())
 			return false;
@@ -650,7 +660,7 @@ class LanguageCore extends ObjectModel
 		// or a close match.
 		$id_lang = Db::getInstance()->getValue(
 			'SELECT `id_lang`, IF(language_code = \''.pSQL($code).'\', 0, LENGTH(language_code)) as found
-			FROM `'._DB_PREFIX_.'lang` 
+			FROM `'._DB_PREFIX_.'lang`
 			WHERE LEFT(`language_code`,2) = \''.pSQL($lang).'\'
 			ORDER BY found ASC'
 		);
@@ -854,7 +864,7 @@ class LanguageCore extends ObjectModel
 				elseif (!is_writable($file))
 					$errors[] = Tools::displayError('Server does not have permissions for writing.').' ('.$file.')';
 			}
-		
+
 		if (!file_exists($file))
 			$errors[] = Tools::displayError('No language pack is available for your version.');
 		elseif ($install)
@@ -899,11 +909,15 @@ class LanguageCore extends ObjectModel
 				$errors[] = Tools::displayError('Cannot decompress the translation file for the following language:').' '.(string)$iso;
 			// Clear smarty modules cache
 			Tools::clearCache();
+
+			Translate::clearL2Cache();
+			Translate::setL2CacheDoNotSaveFlag();
+
 			if (!Language::checkAndAddLanguage((string)$iso, $lang_pack, false, $params))
 				$errors[] = Tools::displayError('An error occurred while creating the language: ').(string)$iso;
 			else
 			{
-				// Reset cache 
+				// Reset cache
 				Language::loadLanguages();
 
 				AdminTranslationsController::checkAndAddMailsFiles($iso, $files_list);
@@ -968,5 +982,8 @@ class LanguageCore extends ObjectModel
 			if ($gz)
 				$gz->extractList($files_listing, _PS_TRANSLATIONS_DIR_.'../', '');
 		}
+
+		Translate::clearL2Cache();
+		Translate::setL2CacheDoNotSaveFlag();
 	}
 }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1005,18 +1005,9 @@ abstract class ObjectModelCore
 		return true;
 	}
 
-	public static function displayFieldName($field, $class = __CLASS__, $htmlentities = true, Context $context = null)
+	public static function displayFieldName($field, $class = __CLASS__, $htmlentities = true, Context $htmlentities = null)
 	{
-		global $_FIELDS;
-
-		if(!isset($context))
-			$context = Context::getContext();
-
-		if ($_FIELDS === null && file_exists(_PS_TRANSLATIONS_DIR_.$context->language->iso_code.'/fields.php'))
-			include_once(_PS_TRANSLATIONS_DIR_.$context->language->iso_code.'/fields.php');
-
-		$key = $class.'_'.md5($field);
-		return ((is_array($_FIELDS) && array_key_exists($key, $_FIELDS)) ? ($htmlentities ? htmlentities($_FIELDS[$key], ENT_QUOTES, 'utf-8') : $_FIELDS[$key]) : $field);
+		return Translate::getTranslateDisplayFieldName($field, $class, $htmlentities, $htmlentities);
 	}
 
 	/**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -809,20 +809,12 @@ class ToolsCore
 	*/
 	public static function displayError($string = 'Fatal error', $htmlentities = true, Context $context = null)
 	{
-		global $_ERRORS;
-
-		if (is_null($context))
-			$context = Context::getContext();
-
-		@include_once(_PS_TRANSLATIONS_DIR_.$context->language->iso_code.'/errors.php');
 
 		if (defined('_PS_MODE_DEV_') && _PS_MODE_DEV_ && $string == 'Fatal error')
 			return ('<pre>'.print_r(debug_backtrace(), true).'</pre>');
-		if (!is_array($_ERRORS))
-			return $htmlentities ? Tools::htmlentitiesUTF8($string) : $string;
-		$key = md5(str_replace('\'', '\\\'', $string));
-		$str = (isset($_ERRORS) && is_array($_ERRORS) && array_key_exists($key, $_ERRORS)) ? $_ERRORS[$key] : $string;
-		return $htmlentities ? Tools::htmlentitiesUTF8(stripslashes($str)) : $str;
+
+		return Translate::displayErrorTranslate($string, $htmlentities, $context);
+
 	}
 
 	/**

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -25,10 +25,63 @@
 */
 
 /**
+ * Small parasite class initialised by Translate
+ * It's only purpose is to call Translate::saveTranslationToL2Cache
+ * at the script end. As Translate is not instatiated, we cannot do
+ * it directly there
+ */
+class TranslateSaveGuard
+{
+	/**
+	 * Calls Translate::saveTranslationToL2Cache
+	 */
+	public function __destruct(){
+		Translate::saveTranslationToL2Cache();
+	}
+}
+
+/**
+ *
  * @since 1.5.0
  */
 class TranslateCore
 {
+
+	/**
+	 * @var TranslateSaveGuard
+	 */
+	protected static $l2_save_guard = null;
+
+	/**
+	 * Md5-hashed context bound identifier
+	 * @var string
+	 */
+	protected static $l2_context_identifier = null;
+
+	/**
+	 * Current cache
+	 * @var array
+	 */
+	protected static $l2_cache = array();
+
+	/**
+	 * List of cache miss
+	 * @var array
+	*/
+	protected static $l2_miss = array();
+
+	/**
+	 * Flag for marking tainted execution - when we do not want to recreate files (after removal generally)
+	 * @var boolean
+	 */
+	protected static $l2_do_not_save = false;
+
+	/**
+	 * Flag which marks if 3 main translation files for admin were included
+	 * @var boolean
+	 */
+	protected static $l2_admin_translations_loaded = false;
+
 	/**
 	 * Get a translation for an admin controller
 	 *
@@ -40,46 +93,57 @@ class TranslateCore
 	 */
 	public static function getAdminTranslation($string, $class = 'AdminTab', $addslashes = false, $htmlentities = true, $sprintf = null)
 	{
-		static $modules_tabs = null;
+		if (!self::$l2_save_guard)
+			self::initL2Cache();
+		$l2_cache_key = md5(sprintf('at|%s|%s|%s|%s|%d', $string, $class, (int)$addslashes, (int)$htmlentities, $sprintf ? json_encode($sprintf) : ''));
+		if (!isset(self::$l2_cache[$l2_cache_key]) && !isset(self::$l2_miss[$l2_cache_key])){
+			self::$l2_miss[$l2_cache_key] = true;
 
-		// @todo remove global keyword in translations files and use static
-		global $_LANGADM;
+			static $modules_tabs = null;
 
-		if ($modules_tabs === null)
-			$modules_tabs = Tab::getModuleTabList();
+			// @todo remove global keyword in translations files and use static
+			global $_LANGADM;
 
-		if ($_LANGADM == null)
-		{
-			$iso = Context::getContext()->language->iso_code;
-			if (empty($iso))
-				$iso = Language::getIsoById((int)(Configuration::get('PS_LANG_DEFAULT')));
-			if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php'))
-				include_once(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php');
+			if ($modules_tabs === null)
+				$modules_tabs = Tab::getModuleTabList();
+
+			if ($_LANGADM == null)
+			{
+				$iso = Context::getContext()->language->iso_code;
+				if (empty($iso))
+					$iso = Language::getIsoById((int)(Configuration::get('PS_LANG_DEFAULT')));
+				if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php'))
+					include_once(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php');
+			}
+
+			if (isset($modules_tabs[strtolower($class)]))
+			{
+				$class_name_controller = $class.'controller';
+				// if the class is extended by a module, use modules/[module_name]/xx.php lang file
+				if (class_exists($class_name_controller) && Module::getModuleNameFromClass($class_name_controller)){
+					self::$l2_cache[$l2_cache_key] = Translate::getModuleTranslation(Module::$classInModule[$class_name_controller], $string, $class_name_controller, $sprintf, $addslashes);
+					return self::$l2_cache[$l2_cache_key];
+				}
+			}
+
+			$string = preg_replace("/\\*'/", "\'", $string);
+			$key = md5($string);
+			if (isset($_LANGADM[$class.$key]))
+				$str = $_LANGADM[$class.$key];
+			else
+				$str = Translate::getGenericAdminTranslation($string, $key, $_LANGADM);
+
+			if ($htmlentities)
+				$str = htmlspecialchars($str, ENT_QUOTES, 'utf-8');
+			$str = str_replace('"', '&quot;', $str);
+
+			if ($sprintf !== null)
+				$str = Translate::checkAndReplaceArgs($str, $sprintf);
+
+			self::$l2_cache[$l2_cache_key] = ($addslashes ? addslashes($str) : stripslashes($str));
 		}
 
-		if (isset($modules_tabs[strtolower($class)]))
-		{
-			$class_name_controller = $class.'controller';
-			// if the class is extended by a module, use modules/[module_name]/xx.php lang file
-			if (class_exists($class_name_controller) && Module::getModuleNameFromClass($class_name_controller))
-				return Translate::getModuleTranslation(Module::$classInModule[$class_name_controller], $string, $class_name_controller, $sprintf, $addslashes);
-		}
-
-		$string = preg_replace("/\\*'/", "\'", $string);
-		$key = md5($string);
-		if (isset($_LANGADM[$class.$key]))
-			$str = $_LANGADM[$class.$key];
-		else
-			$str = Translate::getGenericAdminTranslation($string, $key, $_LANGADM);
-
-		if ($htmlentities)
-			$str = htmlspecialchars($str, ENT_QUOTES, 'utf-8');
-		$str = str_replace('"', '&quot;', $str);
-
-		if ($sprintf !== null)
-			$str = Translate::checkAndReplaceArgs($str, $sprintf);
-
-		return ($addslashes ? addslashes($str) : stripslashes($str));
+		return self::$l2_cache[$l2_cache_key];
 	}
 
 	/**
@@ -122,85 +186,98 @@ class TranslateCore
 	{
 		global $_MODULES, $_MODULE, $_LANGADM;
 
-		static $lang_cache = array();
-		// $_MODULES is a cache of translations for all module.
-		// $translations_merged is a cache of wether a specific module's translations have already been added to $_MODULES
-		static $translations_merged = array();
+		if (!self::$l2_save_guard)
+			self::initL2Cache();
 
-		$name = $module instanceof Module ? $module->name : $module;
-		$language = Context::getContext()->language;
+		$l2_cache_key = md5(sprintf('mt|%s|%s|%s|%s|%d', $module instanceof Module ? $module->name : (string)$module, $string, $source, $sprintf ? json_encode($sprintf) : '', (int)$js));
 
-		if (!isset($translations_merged[$name]) && isset(Context::getContext()->language))
+		if (!isset(self::$l2_cache[$l2_cache_key]) && !isset(self::$l2_miss[$l2_cache_key]))
 		{
-			$files_by_priority = array(
-				// Translations in theme
-				_PS_THEME_DIR_.'modules/'.$name.'/translations/'.$language->iso_code.'.php',
-				_PS_THEME_DIR_.'modules/'.$name.'/'.$language->iso_code.'.php',
-				// PrestaShop 1.5 translations
-				_PS_MODULE_DIR_.$name.'/translations/'.$language->iso_code.'.php',
-				// PrestaShop 1.4 translations
-				_PS_MODULE_DIR_.$name.'/'.$language->iso_code.'.php'
-			);
-			foreach ($files_by_priority as $file)
-				if (file_exists($file))
+			self::$l2_miss[$l2_cache_key] = true;
+
+			static $lang_cache = array();
+			// $_MODULES is a cache of translations for all module.
+			// $translations_merged is a cache of wether a specific module's translations have already been added to $_MODULES
+			static $translations_merged = array();
+
+			$name = $module instanceof Module ? $module->name : $module;
+			$language = Context::getContext()->language;
+
+			if (!isset($translations_merged[$name]) && isset(Context::getContext()->language))
+			{
+				$files_by_priority = array(
+					// Translations in theme
+					_PS_THEME_DIR_.'modules/'.$name.'/translations/'.$language->iso_code.'.php',
+					_PS_THEME_DIR_.'modules/'.$name.'/'.$language->iso_code.'.php',
+					// PrestaShop 1.5 translations
+					_PS_MODULE_DIR_.$name.'/translations/'.$language->iso_code.'.php',
+					// PrestaShop 1.4 translations
+					_PS_MODULE_DIR_.$name.'/'.$language->iso_code.'.php'
+				);
+				foreach ($files_by_priority as $file)
+					if (file_exists($file))
+					{
+						include_once($file);
+						$_MODULES = !empty($_MODULES) ? $_MODULES + $_MODULE : $_MODULE; //we use "+" instead of array_merge() because array merge erase existing values.
+						$translations_merged[$name] = true;
+					}
+			}
+			$string = preg_replace("/\\*'/", "\'", $string);
+			$key = md5($string);
+
+			$cache_key = $name.'|'.$string.'|'.$source.'|'.(int)$js;
+
+			if (!isset($lang_cache[$cache_key]))
+			{
+				if ($_MODULES == null)
 				{
-					include_once($file);
-					$_MODULES = !empty($_MODULES) ? $_MODULES + $_MODULE : $_MODULE; //we use "+" instead of array_merge() because array merge erase existing values.
-					$translations_merged[$name] = true;
+					if ($sprintf !== null)
+						$string = Translate::checkAndReplaceArgs($string, $sprintf);
+					self::$l2_cache[$l2_cache_key] = str_replace('"', '&quot;', $string);
+				} else {
+					$current_key = strtolower('<{'.$name.'}'._THEME_NAME_.'>'.$source).'_'.$key;
+					$default_key = strtolower('<{'.$name.'}prestashop>'.$source).'_'.$key;
+					if ('controller' == ($file = substr($source, 0, - 10)))
+					{
+						$current_key_file = strtolower('<{'.$name.'}'._THEME_NAME_.'>'.$file).'_'.$key;
+						$default_key_file = strtolower('<{'.$name.'}prestashop>'.$file).'_'.$key;
+					}
+
+					if (isset($current_key_file) && isset($_MODULES[$current_key_file]))
+						$ret = stripslashes($_MODULES[$current_key_file]);
+					elseif (isset($default_key_file) && isset($_MODULES[$default_key_file]))
+						$ret = stripslashes($_MODULES[$default_key_file]);
+					elseif (isset($_MODULES[$current_key]))
+						$ret = stripslashes($_MODULES[$current_key]);
+					elseif (isset($_MODULES[$default_key]))
+						$ret = stripslashes($_MODULES[$default_key]);
+					// if translation was not found in module, look for it in AdminController or Helpers
+					elseif (self::loadInitTranslations() && !empty($_LANGADM))
+						$ret = Translate::getGenericAdminTranslation($string, $key, $_LANGADM);
+					else
+						$ret = stripslashes($string);
+
+					if ($sprintf !== null)
+						$ret = Translate::checkAndReplaceArgs($ret, $sprintf);
+
+					if ($js)
+						$ret = addslashes($ret);
+					else
+						$ret = htmlspecialchars($ret, ENT_COMPAT, 'UTF-8');
+
+					if ($sprintf === null)
+						$lang_cache[$cache_key] = $ret;
+					else {
+						self::$l2_cache[$l2_cache_key] = $ret;
+						return self::$l2_cache[$l2_cache_key];
+					}
 				}
-		}
-		$string = preg_replace("/\\*'/", "\'", $string);
-		$key = md5($string);
-
-		$cache_key = $name.'|'.$string.'|'.$source.'|'.(int)$js;
-
-		if (!isset($lang_cache[$cache_key]))
-		{
-			if ($_MODULES == null)
-			{
-				if ($sprintf !== null)
-					$string = Translate::checkAndReplaceArgs($string, $sprintf);
-				return str_replace('"', '&quot;', $string);
 			}
-
-			$current_key = strtolower('<{'.$name.'}'._THEME_NAME_.'>'.$source).'_'.$key;
-			$default_key = strtolower('<{'.$name.'}prestashop>'.$source).'_'.$key;
-
-			if ('controller' == ($file = substr($source, 0, - 10)))
-			{
-				$current_key_file = strtolower('<{'.$name.'}'._THEME_NAME_.'>'.$file).'_'.$key;
-				$default_key_file = strtolower('<{'.$name.'}prestashop>'.$file).'_'.$key;
-			}
-
-			if (isset($current_key_file) && isset($_MODULES[$current_key_file]))
-				$ret = stripslashes($_MODULES[$current_key_file]);
-			elseif (isset($default_key_file) && isset($_MODULES[$default_key_file]))
-				$ret = stripslashes($_MODULES[$default_key_file]);
-			elseif (isset($_MODULES[$current_key]))
-				$ret = stripslashes($_MODULES[$current_key]);
-			elseif (isset($_MODULES[$default_key]))
-				$ret = stripslashes($_MODULES[$default_key]);
-			// if translation was not found in module, look for it in AdminController or Helpers
-			elseif (!empty($_LANGADM))
-				$ret = Translate::getGenericAdminTranslation($string, $key, $_LANGADM);
-			else
-				$ret = stripslashes($string);
-
-			if ($sprintf !== null)
-				$ret = Translate::checkAndReplaceArgs($ret, $sprintf);
-
-			if ($js)
-				$ret = addslashes($ret);
-			else
-				$ret = htmlspecialchars($ret, ENT_COMPAT, 'UTF-8');
-
-			if ($sprintf === null)
-				$lang_cache[$cache_key] = $ret;
-			else
-				return $ret;
-
+			self::$l2_cache[$l2_cache_key] = $lang_cache[$cache_key];
 		}
-		return $lang_cache[$cache_key];
+
+		return self::$l2_cache[$l2_cache_key];
+
 	}
 
 	/**
@@ -213,28 +290,39 @@ class TranslateCore
 	{
 		global $_LANGPDF;
 
-		$iso = Context::getContext()->language->iso_code;
+		if (!self::$l2_save_guard)
+			self::initL2Cache();
 
-		if (!Validate::isLangIsoCode($iso))
-			Tools::displayError(sprintf('Invalid iso lang (%s)', Tools::safeOutput($iso)));
+		$l2_cache_key = md5(sprintf('pdf|%s', $string));
 
-		$override_i18n_file = _PS_THEME_DIR_.'pdf/lang/'.$iso.'.php';
-		$i18n_file = _PS_TRANSLATIONS_DIR_.$iso.'/pdf.php';
-		if (file_exists($override_i18n_file))
-            $i18n_file = $override_i18n_file;
+		if (!isset(self::$l2_cache[$l2_cache_key]) && !isset(self::$l2_miss[$l2_cache_key]))
+		{
+			self::$l2_miss[$l2_cache_key] = true;
 
-      if (!include($i18n_file))
-            Tools::displayError(sprintf('Cannot include PDF translation language file : %s', $i18n_file));
+			$iso = Context::getContext()->language->iso_code;
 
-		if (!isset($_LANGPDF) || !is_array($_LANGPDF))
-			return str_replace('"', '&quot;', $string);
+			if (!Validate::isLangIsoCode($iso))
+				Tools::displayError(sprintf('Invalid iso lang (%s)', Tools::safeOutput($iso)));
 
-		$string = preg_replace("/\\*'/", "\'", $string);
-		$key = md5($string);
+			$override_i18n_file = _PS_THEME_DIR_.'pdf/lang/'.$iso.'.php';
+			$i18n_file = _PS_TRANSLATIONS_DIR_.$iso.'/pdf.php';
+			if (file_exists($override_i18n_file))
+       	    	$i18n_file = $override_i18n_file;
 
-		$str = (array_key_exists('PDF'.$key, $_LANGPDF) ? $_LANGPDF['PDF'.$key] : $string);
+			if (!include($i18n_file))
+				Tools::displayError(sprintf('Cannot include PDF translation language file : %s', $i18n_file));
 
-		return $str;
+			if (!isset($_LANGPDF) || !is_array($_LANGPDF))
+				self::$l2_cache[$l2_cache_key] =  str_replace('"', '&quot;', $string);
+			else {
+
+				$string = preg_replace("/\\*'/", "\'", $string);
+				$key = md5($string);
+
+				self::$l2_cache[$l2_cache_key] = (array_key_exists('PDF'.$key, $_LANGPDF) ? $_LANGPDF['PDF'.$key] : $string);
+			}
+		}
+		return self::$l2_cache[$l2_cache_key];
 	}
 
 	/**
@@ -301,4 +389,266 @@ class TranslateCore
 	{
 		return Translate::postProcessTranslation($string, array('tags' => $tags));
 	}
+
+	public static function setL2CacheDoNotSaveFlag()
+	{
+		self::$l2_do_not_save = true;
+	}
+
+
+	/**
+	 * Deletes all L2 cache files
+	 * @return array
+	 */
+	public static function clearL2Cache($prefix = null){
+		return array_map('unlink', glob(self::getTranslationL2CacheDir().($prefix !==null && trim($prefix, 'a..zA..Z0..9') =='' ? (string)$prefix : ''). '*'));
+	}
+
+	/**
+	 * Saves translation to cache file if necessary.
+	 * @return boolean True if file created succesfully or false otherwise
+	 */
+	public static function saveTranslationToL2Cache(){
+		if (!self::$l2_do_not_save && !empty(self::$l2_cache) && (!empty(self::$l2_miss) || !file_exists(self::getTranslationL2CacheFileName())))
+		{
+			if (!file_exists(self::getTranslationL2CacheDir()))
+			{
+				mkdir(self::getTranslationL2CacheDir(), 0777, true);
+			}
+			$tmpfile  = tempnam(self::getTranslationL2CacheDir(), '_tm');
+			if ($tmpfile && file_put_contents($tmpfile, json_encode(self::$l2_cache)))
+			{
+				return (rename($tmpfile, self::getTranslationL2CacheFileName()) || (unlink($tmpfile) && false));
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Inits save guard object and loads cache if disponible
+	 */
+	protected static function initL2Cache(){
+		if (self::$l2_save_guard === null)
+		{
+			self::$l2_save_guard = new TranslateSaveGuard();
+			self::$l2_cache = self::loadTranslationFromL2Cache();
+		}
+	}
+
+	/**
+	 * Returns translation cache from file defined by context
+	 * @return array
+	 */
+	protected static function loadTranslationFromL2Cache()
+	{
+		$result = array();
+		$filename = self::getTranslationL2CacheFileName();
+		if (file_exists($filename)) {
+			$result = json_decode((string)file_get_contents($filename), true);
+		}
+		return is_array($result) ? $result : array();
+	}
+
+	/**
+	 * Returns actual cache file name, based on context
+	 * @return string Full file path
+	 */
+	protected static function getTranslationL2CacheFileName()
+	{
+		return self::getTranslationL2CacheDir().self::getContextIdentifier(). '.json';
+	}
+
+	/**
+	 * Returns L2 cache directory (which not necessary exists), which is a subdir of cache dir
+	 * @return string Directory path with directory separator at end
+	 */
+	protected static function getTranslationL2CacheDir()
+	{
+		return _PS_CACHE_DIR_.DIRECTORY_SEPARATOR.'tl2c'.DIRECTORY_SEPARATOR;
+	}
+
+	/**
+	 * Returns unique context identifier. It's calculated at first call, to avoid problems with some
+	 * context elements changing during the script execution.
+	 * Currently elements of context identifier are : language id,shop id, controller name, theme name, bo flag
+	 * @return string Context identifier in format <id_lang>-<md5 of rest of params>
+	 */
+	protected static function getContextIdentifier()
+	{
+		if (self::$l2_context_identifier === null)
+		{
+			$result = array();
+			$context = Context::getContext();
+
+			if (isset($context) && isset($context->language) && isset($context->language->id))
+				$lang = $context->language->id;
+			else
+				$lang = (int)Configuration::get('PS_LANG_DEFAULT');
+
+			if (isset($context) && isset($context->shop) && isset($context->shop->id))
+				$result[] = $context->shop->id;
+
+			if (isset($context) && isset($context->controller) && isset($context->controller->php_self))
+				$result[] = $context->controller->php_self;
+
+			if (isset($context) && isset($context->theme) && isset($context->theme->name))
+				$result[] = $context->theme->name;
+
+			if (isset($context) && isset($context->employee) && isset($context->employee->id))
+				$result[] = 'bo';
+
+			self::$l2_context_identifier = (string)$lang.'-'.md5(implode('-', array_map('strval', $result)));
+		}
+		return self::$l2_context_identifier;
+	}
+
+	/**
+	 * Loads 3 main admin translation files
+	 * @return boolean
+	 */
+	public static function loadInitTranslations(){
+		
+		if (!self::$l2_admin_translations_loaded){
+			self::$l2_admin_translations_loaded = true;
+			$context = Context::getContext();
+			$iso = $context->language->iso_code;
+			if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/errors.php'))
+				include_once(_PS_TRANSLATIONS_DIR_.$iso.'/errors.php');
+			if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/fields.php'))
+				include_once(_PS_TRANSLATIONS_DIR_.$iso.'/fields.php');
+			if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php'))
+				include_once(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php');
+		}
+		
+		return self::$l2_admin_translations_loaded;
+	}
+
+	/**
+	 * for AdminTab::l
+	 * @param unknown_type $string
+	 * @param unknown_type $currentClass
+	 * @param unknown_type $class
+	 * @param unknown_type $addslashes
+	 * @param unknown_type $htmlentities
+	 * @return multitype:
+	 */
+	public function getAdminTabTranslation($string,  $currentClass = 'AdminTab', $class = 'AdminTab', $addslashes = false, $htmlentities = true)
+	{
+		if (!self::$l2_save_guard)
+			self::initL2Cache();
+
+		$l2_cache_key = md5(sprintf('atl|%s|%s|%s|%d|%d', $string, $currentClass, $class, (int)$addslashes, (int)$htmlentities));
+
+		if (!isset(self::$l2_cache[$l2_cache_key]) && !isset(self::$l2_miss[$l2_cache_key]))
+		{
+			self::$l2_miss[$l2_cache_key] = true;
+			self::loadInitTranslations();
+			global $_LANGADM;
+			$key = md5(str_replace('\'', '\\\'', $string));
+			$str = (array_key_exists($currentClass.$key, $_LANGADM)) ? $_LANGADM[$currentClass.$key] : ((array_key_exists($class.$key, $_LANGADM)) ? $_LANGADM[$class.$key] : $string);
+			$str = $htmlentities ? htmlentities($str, ENT_QUOTES, 'utf-8') : $str;
+			self::$l2_cache[$l2_cache_key] = str_replace('"', '&quot;', ($addslashes ? addslashes($str) : stripslashes($str)));
+		}
+		
+		return self::$l2_cache[$l2_cache_key];
+	}
+
+	/**
+	 * For translate() from functions.php
+	 * @param string $string
+	 * @return multitype:
+	 */
+	public function getTranslateFuncTranslation($string)
+	{
+		if (!self::$l2_save_guard)
+			self::initL2Cache();
+
+		$l2_cache_key = md5(sprintf('tft|%s', $string));
+		
+		if (!isset(self::$l2_cache[$l2_cache_key]) && !isset(self::$l2_miss[$l2_cache_key]))
+		{
+			self::$l2_miss[$l2_cache_key] = true;
+			self::loadInitTranslations();
+			global $_LANGADM;
+			if (!is_array($_LANGADM))
+				self::$l2_cache[$l2_cache_key] = str_replace('"', '&quot;', $string);
+			else {
+				$key = md5(str_replace('\'', '\\\'', $string));
+				$str = (array_key_exists('index'.$key, $_LANGADM)) ? $_LANGADM['index'.$key] : ((array_key_exists('index'.$key, $_LANGADM)) ? $_LANGADM['index'.$key] : $string);
+				self::$l2_cache[$l2_cache_key] = str_replace('"', '&quot;', stripslashes($str));
+			}
+		}
+
+		return self::$l2_cache[$l2_cache_key];
+
+	}
+
+	/**
+	 * For Tools::displayError
+	 * @param unknown_type $string
+	 * @param unknown_type $htmlentities
+	 * @param Context $context
+	 * @return multitype:
+	 */
+	public static function getTranslateDisplayError($string, $htmlentities, Context $context = null)
+	{
+		if (!self::$l2_save_guard)
+			self::initL2Cache();
+
+		if ($context === null)
+			$context = Context::getContext();
+
+		$l2_cache_key = md5(sprintf('tde|%s|%d|%s', $string, (int)$htmlentities, $context->language->iso_code));
+
+		if (!isset(self::$l2_cache[$l2_cache_key]) && !isset(self::$l2_miss[$l2_cache_key]))
+		{
+			self::$l2_miss[$l2_cache_key] = true;
+			global $_ERRORS;
+			@include_once(_PS_TRANSLATIONS_DIR_.$context->language->iso_code.'/errors.php');
+
+			if (!is_array($_ERRORS))
+				self::$l2_cache[$l2_cache_key] = $htmlentities ? Tools::htmlentitiesUTF8($string) : $string;
+			else {
+				$key = md5(str_replace('\'', '\\\'', $string));
+				$str = (isset($_ERRORS) && is_array($_ERRORS) && array_key_exists($key, $_ERRORS)) ? $_ERRORS[$key] : $string;
+				self::$l2_cache[$l2_cache_key] =  $htmlentities ? Tools::htmlentitiesUTF8(stripslashes($str)) : $str;
+			}
+		}
+		
+		return self::$l2_cache[$l2_cache_key];
+	}
+
+	/**
+	 * For ObjectModel::displayFieldName
+	 * @param unknown_type $field
+	 * @param unknown_type $class
+	 * @param unknown_type $htmlentities
+	 * @param Context $context
+	 * @return Ambigous <unknown, string>
+	 */
+	public static function getTranslateDisplayFieldName($field, $class, $htmlentities = true, Context $context = null)
+	{
+		if (!self::$l2_save_guard)
+			self::initL2Cache();
+
+		if ($context === null)
+			$context = Context::getContext();
+
+		$l2_cache_key = md5(sprintf('om|%s|%s|%d|%s', $field, $class, (int)$htmlentities, $context->language->iso_code));
+
+		if (!isset(self::$l2_cache[$l2_cache_key]) && !isset(self::$l2_miss[$l2_cache_key]))
+		{
+			self::$l2_miss[$l2_cache_key] = true;
+			global $_FIELDS;
+
+			if ($_FIELDS === null && file_exists(_PS_TRANSLATIONS_DIR_.$context->language->iso_code.'/fields.php'))
+				include_once(_PS_TRANSLATIONS_DIR_.$context->language->iso_code.'/fields.php');
+
+			$key = $class.'_'.md5($field);
+			self::$l2_cache[$l2_cache_key] = ((is_array($_FIELDS) && array_key_exists($key, $_FIELDS)) ? ($htmlentities ? htmlentities($_FIELDS[$key], ENT_QUOTES, 'utf-8') : $_FIELDS[$key]) : $field);
+		}
+		
+		return self::$l2_cache[$l2_cache_key];
+	}
+
 }

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -217,6 +217,7 @@ class AdminSearchControllerCore extends AdminController
 		$this->_list['features'] = array();
 
 		global $_LANGADM;
+		Translate::loadInitTranslations();
 		if ($_LANGADM === null)
 			return;
 

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -329,6 +329,9 @@ class AdminTranslationsControllerCore extends AdminController
 			fwrite($fd, "\n?>");
 			fclose($fd);
 
+			Translate::clearL2Cache();
+			Translate::setL2CacheDoNotSaveFlag();
+
 			// Redirect
 			if ($save_and_stay)
 				$this->redirect(true);


### PR DESCRIPTION
This is a performance patch for Prestashop 1.6.x (although it should work also for 1.5.x)

Idea is quite simple: to cache translated strings depending on the current context. Every context (defined loosely as language / shop / theme / controller / frontend vs backend combination) uses only small subset of translations. Instead of loading every time all translations availables, we are using only those which applies to current context. If a translation is not
in the cache, we are launching a full procedure (including and parsing translation files, calculating keys etc) . Once all actions for given context are executed, cache is saturated and there is
no longer need to use base system (apart of modyfing new translations; in such case cache is purged and regenerates anew during subsequent calls)

Additionally, level 2 cache is in json format, which is parsed faster than php. 

Performance analysis: 
We've observed gain of about 4-5% (~20ms from 400 - 500ms on our test infrastructure) when cache is saturated. There is 20% less files included (148 vs 187 on homepage). Potential gains can be  even bigger when there is more traductions or I/O system is less performant (separated or networking file servers etc.).
When cache is cold, which occurs only one or few times depending on complexity of context, performance loss is negligeable ( 1 file read, 1 file write and possibly 1 mkdir, less than 2 ms for the script with 100% miss ratio on homepage)

There is certainly room for improvement (better context segmentation, include mail translations, use this possibilty for make cleanup of translation system etc ), but I hope that's a good start yet. 
