### PR TITLE
[*] Calculate carrier price on the real order price

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2585,7 +2585,7 @@ class CartCore extends ObjectModel
 			return Cache::retrieve($cache_id);
 
 		// Order total in default currency without fees
-		$order_total = $this->getOrderTotal(true, Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING, $product_list);
+		$order_total = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $product_list);
 
 		// Start with shipping cost at 0
 		$shipping_cost = 0;


### PR DESCRIPTION
Calculate the carrier price with the REAL price customer is gonna pay, so have to use the BOTH_WITHOUT_SHIPPING const.

By now the Discount is not use in the calculation.
For exemple if you have a specific carrier price range for order > 50€ => free shipping. If the customer buy an 60€ item and use a -20% discount, customer gonna pay 48€ AND have the free shipping.

I think it's not the expected functionment
