### PR TITLE
[-] FO : Fix invalid argument warning in SearchController.php

### DIFF
--- a/controllers/front/SearchController.php
+++ b/controllers/front/SearchController.php
@@ -96,7 +96,7 @@ class SearchControllerCore extends FrontController
 			$original_query = $query;
 			$query = Tools::replaceAccentedChars(urldecode($query));
 			$search = Search::find($this->context->language->id, $query, $this->p, $this->n, $this->orderBy, $this->orderWay);
-			foreach ($search['result'] as &$product)
+			foreach ((array)$search['result'] as &$product)
 				$product['link'] .= (strpos($product['link'], '?') === false ? '?' : '&').'search_query='.urlencode($query).'&results='.(int)$search['total'];
 			Hook::exec('actionSearch', array('expr' => $query, 'total' => $search['total']));
 			$nbProducts = $search['total'];


### PR DESCRIPTION
`$search['result']` (populated from `Search::find()`) be `false` instead of an array, if the SQL query failed for any reason. This causes an invalid argument error when the code in `SearchController` tries to iterate over that.
