### PR TITLE
[-] BO: Fix undefined feature value when importing products with inactiv...

### DIFF
--- a/classes/FeatureValue.php
+++ b/classes/FeatureValue.php
@@ -167,7 +167,7 @@ class FeatureValueCore extends ObjectModel
 		$feature_value = new FeatureValue();
 		$feature_value->id_feature = (int)$id_feature;
 		$feature_value->custom = (bool)$custom;
-		foreach (Language::getLanguages() as $language)
+		foreach (Language::getLanguages(false) as $language)
 			$feature_value->value[$language['id_lang']] = $value;
 		$feature_value->add();
 


### PR DESCRIPTION
...e lang

Feature value should inherit from the imported value for any languages, even if they are disabled.
Example: if default language is disabled and you try to import a product with a feature, import will fail because value is empty.

Anyway, excluding this case, we really think that value should always be filled even if the lang is inactive at this time.
