### PR TITLE
[-] CORE : Removing PHP closing tag

### DIFF
--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -527,4 +527,3 @@ abstract class ControllerCore
 		die($value);
 	}
 }
-?>


### PR DESCRIPTION
This file is the only one in classes folder with a PHP closing tag. This is probably a mistake
