### PR TITLE
search_query is lost when items per page are changed in some cases

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -565,7 +565,7 @@ class LinkCore
 		}
 
 		$vars = array();
-		$vars_nb = array('n', 'search_query');
+		$vars_nb = array('n');
 		$vars_sort = array('orderby', 'orderway');
 		$vars_pagination = array('p');
 


### PR DESCRIPTION
Steps to reproduce:
1. Perform a search that returns about 40 results, and view it at 12 results per page.
2. Go to the last page of results.
3. Change the number of items per page to 60.

Expected behaviour: user is redirected to the first page of search results.
Actual behaviour: search query is lost, and the user gets an error ("Please enter a search keyword").

This patch fixes the issue, but it is not clear to me why `search_query` was being excluded in `if_nb` in the first place, so there may be unintended consequences which the core developers can point out. In any case there is a bug here in how search result pagination is handled.
