### PR TITLE
Check if search results were found before looping through them

### DIFF
--- a/controllers/front/SearchController.php
+++ b/controllers/front/SearchController.php
@@ -96,8 +96,9 @@ class SearchControllerCore extends FrontController
 			$original_query = $query;
 			$query = Tools::replaceAccentedChars(urldecode($query));
 			$search = Search::find($this->context->language->id, $query, $this->p, $this->n, $this->orderBy, $this->orderWay);
-			foreach ((array)$search['result'] as &$product)
-				$product['link'] .= (strpos($product['link'], '?') === false ? '?' : '&').'search_query='.urlencode($query).'&results='.(int)$search['total'];
+			if(is_array($search['result']))
+				foreach ($search['result'] as &$product)
+					$product['link'] .= (strpos($product['link'], '?') === false ? '?' : '&').'search_query='.urlencode($query).'&results='.(int)$search['total'];
 			Hook::exec('actionSearch', array('expr' => $query, 'total' => $search['total']));
 			$nbProducts = $search['total'];
 			$this->pagination($nbProducts);


### PR DESCRIPTION
This is following up from https://github.com/PrestaShop/PrestaShop/pull/2326 , which it turns out didn't actually resolve the issue. `$search['result']` can be false if nothing was found, and coercing it to an array will still cause warnings when you try to modify `$product['link']` in the line below.
