### PR TITLE
Update AdminTranslationsController.php

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -952,7 +952,7 @@ class AdminTranslationsControllerCore extends AdminController
 						$pattern = '\'<{'.strtolower($module_name).'}prestashop>'.strtolower($template_name).'_'.md5($key).'\'';
 					}
 
-					if (array_key_exists($post_key, $_POST) && !in_array($pattern, $array_check_duplicate))
+					if (array_key_exists($post_key, $_POST) && !in_array($pattern, $array_check_duplicate) && !empty(pSQL(str_replace(array("\r\n", "\r", "\n"), ' ', $_POST[$post_key]))))
 					{
 						$array_check_duplicate[] = $pattern;
 						$str_write .= '$_MODULE['.$pattern.'] = \''.pSQL(str_replace(array("\r\n", "\r", "\n"), ' ', $_POST[$post_key])).'\';'."\n";


### PR DESCRIPTION
When validating, some of $_MODULE['whatever'] values are empties, which can cause lots of misunderstanding with empty fields.

Here is a tiny fix.
