### PR TITLE
[-] BO: Fix bug wrong Context mode name

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -402,7 +402,7 @@ class AdminControllerCore extends Controller
 				$this->context->mode = Context::MODE_HOST;
 		}
 		elseif (isset($this->context->cookie->is_contributor) && (int)$this->context->cookie->is_contributor === 1)
-			$this->context->mode = Context::MODE_CONTRIB;
+			$this->context->mode = Context::MODE_STD_CONTRIB;
 		else
 			$this->context->mode = Context::MODE_STD;
 


### PR DESCRIPTION
Critical bug, fatal error after sign in to addons account to back-office.
Fatal error: Undefined class constant 'MODE_CONTRIB' in classes\controller\AdminController.php on line 405

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Sponsor company | impSolutions
