### PR TITLE
expose the variable shop_details to header.tpl when creating invoices

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -62,6 +62,7 @@ abstract class HTMLTemplateCore
 			'title' => $this->title,
 			'date' => $this->date,
 			'shop_name' => $shop_name,
+			'shop_details' => Configuration::get('PS_SHOP_DETAILS', null, null, (int)$id_shop),
 			'width_logo' => $width,
 			'height_logo' => $height
 		));


### PR DESCRIPTION
In Spain it is usual to put the Registration number (CIF) in the header of an invoice, but editing the template header.tpl will not do the trick: it is necessary to expose to smarty the variable shop_details, as done in HTMLTemplateCore.getFooter()
If there is other way, I'll be glad to know.
