### PR TITLE
[BO] set id_category for HelperList

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -154,8 +154,10 @@ class AdminProductsControllerCore extends AdminController
 				$this->id_current_category = $id_category;
 				$this->context->cookie->id_category_products_filter = $id_category;
 			}
-			elseif ($id_category = $this->context->cookie->id_category_products_filter)
+			elseif ($id_category = $this->context->cookie->id_category_products_filter) {
 				$this->id_current_category = $id_category;
+				$_GET['id_category'] = $id_category; //set for HelperList
+			}
 			if ($this->id_current_category)
 				$this->_category = new Category((int)$this->id_current_category);
 			else


### PR DESCRIPTION
else the product sorting doesnt work when coming back from other page

to reproduce: 

1) open products and filter category, then change positon of product in category - it works
2) now go to other page and then come back here (or remove id_category from url) and try sorting - it says ok, but sorting is not applied (look on FO)
