### PR TITLE
Delete tab_lang when delete a tab

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -150,7 +150,10 @@ class TabCore extends ObjectModel
 
 	public function delete()
 	{
-		if (Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'access WHERE `id_tab` = '.(int)$this->id) && parent::delete())
+	 	if (Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'access WHERE `id_tab` = '.(int)$this->id) &&
+			Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'tab_lang WHERE `id_tab` = '.(int)$this->id) &&
+			parent::delete())
+		{
 		{
 			if (is_array(self::$_getIdFromClassName) && isset(self::$_getIdFromClassName[strtolower($this->class_name)]))
 				self::$_getIdFromClassName = null;

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -154,7 +154,6 @@ class TabCore extends ObjectModel
 			Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'tab_lang WHERE `id_tab` = '.(int)$this->id) &&
 			parent::delete())
 		{
-		{
 			if (is_array(self::$_getIdFromClassName) && isset(self::$_getIdFromClassName[strtolower($this->class_name)]))
 				self::$_getIdFromClassName = null;
 			return $this->cleanPositions($this->id_parent);


### PR DESCRIPTION
I see no reasons to leave the tab_lang table records for some tab that does not exist anymore.
