### PR TITLE
[*] FO : Changed the method, that gets the search block text input field width.

### DIFF
--- a/themes/default-bootstrap/js/modules/blocksearch/blocksearch.js
+++ b/themes/default-bootstrap/js/modules/blocksearch/blocksearch.js
@@ -31,7 +31,7 @@ $(document).ready(function()
 
 	var $input = $("#search_query_" + blocksearch_type);
 
-	var width_ac_results = 	$input.parent('form').width();
+	var width_ac_results = 	$input.parent('form').outerWidth();
 	if (typeof ajaxsearch != 'undefined' && ajaxsearch) {
 		$input.autocomplete(
 			search_url,


### PR DESCRIPTION
Hi there,

I've recently moved the autocomplete input field, that we see in blocksearch in default-bootstrap theme and I've noticed, that with certain styling it doesn't work correctly (when we set position: absolute in CSS in example it gives us like 1px wide suggest box). With this change, the width of a parent object is calculated properly.
