### PR TITLE
[*] FO : Fix #PSCSX-4382:  Add hook to customize cart summary

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3038,7 +3038,7 @@ class CartCore extends ObjectModel
 			if ($cart_rule['value_real'] == 0)
 				unset($cart_rules[$key]);
 
-		return array(
+		$summary = array(
 			'delivery' => $delivery,
 			'delivery_state' => State::getNameById($delivery->id_state),
 			'invoice' => $invoice,
@@ -3063,6 +3063,12 @@ class CartCore extends ObjectModel
 			'free_ship' => $total_shipping ? 0 : 1,
 			'carrier' => new Carrier($this->id_carrier, $id_lang),
 		);
+
+		$hook = Hook::exec('displayCartSummary', $summary, null, true);
+		if ( is_array($hook) )
+			$summary = array_merge($summary, array_shift($hook));
+
+		return $summary;
 	}
 
 	public function checkQuantities($return_product = false)

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3065,8 +3065,8 @@ class CartCore extends ObjectModel
 		);
 
 		$hook = Hook::exec('actionCartSummary', $summary, null, true);
-		if ( is_array($hook) )
-			$summary = array_merge( $summary, array_shift($hook) );
+		if (is_array($hook))
+			$summary = array_merge($summary, array_shift($hook));
 
 		return $summary;
 	}

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3064,9 +3064,9 @@ class CartCore extends ObjectModel
 			'carrier' => new Carrier($this->id_carrier, $id_lang),
 		);
 
-		$hook = Hook::exec('displayCartSummary', $summary, null, true);
+		$hook = Hook::exec('actionCartSummary', $summary, null, true);
 		if ( is_array($hook) )
-			$summary = array_merge($summary, array_shift($hook));
+			$summary = array_merge( $summary, array_shift($hook) );
 
 		return $summary;
 	}


### PR DESCRIPTION
Actually, is not possible to customize cart summary without overriding Cart::getSummaryDetails()
An hook should be added to allow customization without the need to override the whole method.

Fix #PSCSX-4382
