### PR TITLE
Add some hooks to allow invoice customizations

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1251,7 +1251,7 @@ class OrderCore extends ObjectModel
 			if (Configuration::get('PS_INVOICE')) {
 				$invoice_number = Hook::exec('actionSetInvoice', array(get_class($this) => $this, get_class($order_invoice) => $order_invoice, 'use_existing_payment' => $use_existing_payment));
 				if (is_numeric($invoice_number))
-					$this->invoice_number = $invoice_number;
+					$this->invoice_number = (int)$invoice_number;
 				else
 					$this->invoice_number = $this->getInvoiceNumber($order_invoice->id);
 			}

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1248,10 +1248,17 @@ class OrderCore extends ObjectModel
 
 			// Keep it for backward compatibility, to remove on 1.6 version
 			$this->invoice_date = $order_invoice->date_add;
-			if (Configuration::get('PS_INVOICE'))
-				$this->invoice_number = $this->getInvoiceNumber($order_invoice->id);
+			if (Configuration::get('PS_INVOICE')) {
+				$invoice_number = Hook::exec('actionSetInvoice', array(get_class($this) => $this, get_class($order_invoice) => $order_invoice, 'use_existing_payment' => $use_existing_payment));
+				if (is_numeric($invoice_number)) {
+					$this->invoice_number = $invoice_number;
+				} else {
+					$this->invoice_number = $this->getInvoiceNumber($order_invoice->id);
+				}
+			}
 			$this->update();
 		}
+
 	}
 
 	/**

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1250,11 +1250,10 @@ class OrderCore extends ObjectModel
 			$this->invoice_date = $order_invoice->date_add;
 			if (Configuration::get('PS_INVOICE')) {
 				$invoice_number = Hook::exec('actionSetInvoice', array(get_class($this) => $this, get_class($order_invoice) => $order_invoice, 'use_existing_payment' => $use_existing_payment));
-				if (is_numeric($invoice_number)) {
+				if (is_numeric($invoice_number))
 					$this->invoice_number = $invoice_number;
-				} else {
+				else
 					$this->invoice_number = $this->getInvoiceNumber($order_invoice->id);
-				}
 			}
 			$this->update();
 		}

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -670,7 +670,11 @@ class OrderInvoiceCore extends ObjectModel
 	 * @return string
 	 */
 	public function getInvoiceNumberFormatted($id_lang, $id_shop = null)
-	{
+	{	
+		$invoice_formatted_number = Hook::exec('actionInvoiceNumberFormatted', array(get_class($this) => $this, 'id_lang' => $id_lang, 'id_shop' => $id_shop));
+		if (!empty($invoice_formatted_number))
+			return $invoice_formatted_number;
+
 		return '#'.Configuration::get('PS_INVOICE_PREFIX', $id_lang, null, $id_shop).sprintf('%06d', $this->number);
 	}
 


### PR DESCRIPTION
These hooks allows a better invoice customizations without using php overrides.
`actionSetInvoice` is called when setting a new invoice for an order. Modules would be able to replace the `invoice_number` bound to an order and take some actions (for example, by replacing the invoice progressive number based on some criteria, like new year reset and so on)
`actionInvoiceNumberFormatted` is called when displaying the invoice number. With this hook will be possible to customize the formatted number. (in example: `INVOICE-0000123/2015`)
