### PR TITLE
[*] BO: Modules to export checked by default

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -1280,6 +1280,9 @@ class AdminThemesControllerCore extends AdminController
 
 		if (count($to_install) > 0)
 		{
+			foreach ($to_install as $module)
+				$fields_value['modulesToExport_module'.$module] = true;
+				
 			$fields_form['form']['input'][] = array(
 				'type' => 'checkbox',
 				'label' => $this->l('Select the theme\'s modules that you wish to export'),


### PR DESCRIPTION
We export themes (for eg. for Addons Marketplace) very often and it's annoying to check all modules every time, more easily is to uncheck not used modules :)

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Sponsor company | impSolutions
