### PR TITLE
[+] Project: Add support for postcodes in zones

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -250,7 +250,7 @@ class AddressCore extends ObjectModel
 		FROM `'._DB_PREFIX_.'address` a
 		LEFT JOIN `'._DB_PREFIX_.'country` c ON c.`id_country` = a.`id_country`
 		LEFT JOIN `'._DB_PREFIX_.'state` s ON s.`id_state` = a.`id_state`
-		LEFT JOIN `'._DB_PREFIX_.'postcode` p ON a.postcode BETWEEN p.`min` AND p.`max`
+		LEFT JOIN `'._DB_PREFIX_.'postcode` p ON a.postcode = p.`postcode`
 		WHERE a.`id_address` = '.(int)$id_address);
 
 		if ((int)$result['id_zone_postcode'])

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -246,13 +246,20 @@ class AddressCore extends ObjectModel
 			return self::$_idZones[$id_address];
 
 		$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
-		SELECT s.`id_zone` AS id_zone_state, c.`id_zone`
+		SELECT z.`id_zone` AS id_zone_zip, s.`id_zone` AS id_zone_state, c.`id_zone`
 		FROM `'._DB_PREFIX_.'address` a
 		LEFT JOIN `'._DB_PREFIX_.'country` c ON c.`id_country` = a.`id_country`
 		LEFT JOIN `'._DB_PREFIX_.'state` s ON s.`id_state` = a.`id_state`
+		LEFT JOIN `'._DB_PREFIX_.'zip_zone` z ON a.postcode BETWEEN z.`min` AND z.`max`
 		WHERE a.`id_address` = '.(int)$id_address);
 
-		self::$_idZones[$id_address] = (int)((int)$result['id_zone_state'] ? $result['id_zone_state'] : $result['id_zone']);
+		if ((int)$result['id_zone_zip'])
+			self::$_idZones[$id_address] = (int)$result['id_zone_zip'];
+		elseif ((int)$result['id_zone_state'])
+			self::$_idZones[$id_address] = (int)$result['id_zone_state'];
+		else
+			self::$_idZones[$id_address] = $result['id_zone'];
+
 		return self::$_idZones[$id_address];
 	}
 

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -246,16 +246,16 @@ class AddressCore extends ObjectModel
 			return self::$_idZones[$id_address];
 
 		$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
-		SELECT z.`id_zone` AS id_zone_zip, s.`id_zone` AS id_zone_state, c.`id_zone`
+		SELECT p.`id_zone` AS id_zone_postcode, s.`id_zone` AS id_zone_state, c.`id_zone`
 		FROM `'._DB_PREFIX_.'address` a
 		LEFT JOIN `'._DB_PREFIX_.'country` c ON c.`id_country` = a.`id_country`
 		LEFT JOIN `'._DB_PREFIX_.'state` s ON s.`id_state` = a.`id_state`
-		LEFT JOIN `'._DB_PREFIX_.'zip_zone` z ON a.postcode BETWEEN z.`min` AND z.`max`
+		LEFT JOIN `'._DB_PREFIX_.'postcode` p ON a.postcode BETWEEN p.`min` AND p.`max`
 		WHERE a.`id_address` = '.(int)$id_address);
 
-		if ((int)$result['id_zone_zip'])
-			self::$_idZones[$id_address] = (int)$result['id_zone_zip'];
-		elseif ((int)$result['id_zone_state'])
+		if ((int)$result['id_zone_postcode'])
+			self::$_idZones[$id_address] = (int)$result['id_zone_postcode'];
+		else if ((int)$result['id_zone_state'])
 			self::$_idZones[$id_address] = (int)$result['id_zone_state'];
 		else
 			self::$_idZones[$id_address] = $result['id_zone'];

--- a/classes/Postcode.php
+++ b/classes/Postcode.php
@@ -1,0 +1,173 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+class PostcodeCore extends ObjectModel
+{
+	/** @var integer Country id which state belongs */
+	public $id_country;
+
+	/** @var integer Zone id which state belongs */
+	public $id_zone;
+
+	/** @var string Postcode */
+	public $postcode;
+
+	/** @var boolean Status for delivery */
+	public $active = true;
+
+	/**
+	 * @see ObjectModel::$definition
+	 */
+	public static $definition = array(
+		'table' => 'postcode',
+		'primary' => 'id_postcode',
+		'fields' => array(
+			'id_country' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
+			'id_zone' => 	array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
+			'postcode' => 	array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 32),
+			'active' => 	array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),
+		),
+	);
+
+	protected $webserviceParameters = array(
+		'fields' => array(
+			'id_zone' => array('xlink_resource'=> 'zones'),
+			'id_country' => array('xlink_resource'=> 'countries')
+		),
+	);
+
+	public static function getPostcodes($id_lang = false, $active = false)
+	{
+		return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+		SELECT `id_postcode`, `id_country`, `id_zone`, `postcode`, `active`
+		FROM `'._DB_PREFIX_.'postcode`
+		'.($active ? 'WHERE active = 1' : '').'
+		ORDER BY `postcode` ASC');
+	}
+
+	/**
+	 * Get a postcode with its ID
+	 *
+	 * @param integer $id_postcode Postcode ID
+	 * @return string Postcode
+	 */
+	public static function getPostcodeById($id_postcode)
+	{
+		if (!$id_state)
+			return false;
+		$cache_id = 'Postcode::getPostcodeById_'.(int)$id_postcode;
+		if (!Cache::isStored($cache_id))
+		{
+			$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+				SELECT `postcode`
+				FROM `'._DB_PREFIX_.'postcode`
+				WHERE `id_postcode` = '.(int)$id_postcode
+			);
+			Cache::store($cache_id, $result);
+		}
+		return Cache::retrieve($cache_id);
+	}
+
+	/**
+	 * Get a postcode id with its postcode
+	 *
+	 * @param string $postcode Postcode
+	 * @return integer postcode id
+	 */
+	public static function getIdByPostcode($postcode)
+	{
+		if (empty($postcode))
+			return false;
+		$cache_id = 'Postcode::getIdByPostcode_'.pSQL($postcode);
+		if (!Cache::isStored($cache_id))
+		{
+			$result = (int)Db::getInstance()->getValue('
+				SELECT `id_postcode`
+				FROM `'._DB_PREFIX_.'postcode`
+				WHERE `postcode` LIKE \''.pSQL($postcode).'\'
+			');
+			Cache::store($cache_id, $result);
+		}
+		return Cache::retrieve($cache_id);
+	}
+
+	/**
+	* Delete a postcode
+	*
+	* @return boolean
+	*/
+	public function delete()
+	{
+		// Database deletion
+		$result = Db::getInstance()->delete($this->def['table'], '`'.$this->def['primary'].'` = '.(int)$this->id);
+		if (!$result)
+			return false;
+
+		// Database deletion for multilingual fields related to the object
+		if (!empty($this->def['multilang']))
+			Db::getInstance()->delete(bqSQL($this->def['table']).'_lang', '`'.$this->def['primary'].'` = '.(int)$this->id);
+		return $result;
+	}
+
+    public static function getPostcodesByIdCountry($id_country)
+    {
+        if (empty($id_country))
+            die(Tools::displayError());
+
+        return Db::getInstance()->executeS('
+        SELECT *
+        FROM `'._DB_PREFIX_.'postcode` p
+        WHERE p.`id_country` = '.(int)$id_country
+        );
+    }
+
+	public static function getIdZone($id_state)
+	{
+		if (!Validate::isUnsignedId($id_state))
+			die(Tools::displayError());
+
+		return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+			SELECT `id_zone`
+			FROM `'._DB_PREFIX_.'postcode`
+			WHERE `id_postcode` = '.(int)$id_postcode
+		);
+	}
+
+	/**
+	 * @param $ids_postcode
+	 * @param $id_zone
+	 * @return bool
+	 */
+	public function affectZoneToSelection($ids_postcode, $id_zone)
+	{
+		// cast every array values to int (security)
+		$ids_postcode = array_map('intval', $ids_postcode);
+		return Db::getInstance()->execute('
+		UPDATE `'._DB_PREFIX_.'postcode` SET `id_zone` = '.(int)$id_zone.' WHERE `id_postcode` IN ('.implode(',', $ids_postcode).')
+		');
+	}
+}
+

--- a/controllers/admin/AdminPostcodesController.php
+++ b/controllers/admin/AdminPostcodesController.php
@@ -1,0 +1,250 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+class AdminPostcodesControllerCore extends AdminController
+{
+	public function __construct()
+	{
+		$this->bootstrap = true;
+		$this->table = 'postcode';
+		$this->className = 'Postcode';
+		$this->lang = false;
+		$this->requiredDatabase = true;
+
+		$this->context = Context::getContext();
+
+		if (!Tools::getValue('realedit'))
+			$this->deleted = false;
+
+		$this->_select = 'z.`name` AS zone, cl.`name` AS country';
+		$this->_join = '
+		LEFT JOIN `'._DB_PREFIX_.'zone` z ON (z.`id_zone` = a.`id_zone`)
+		LEFT JOIN `'._DB_PREFIX_.'country_lang` cl ON (cl.`id_country` = a.`id_country` AND cl.id_lang = '.(int)$this->context->language->id.')';
+		
+		$countries_array = $zones_array = array();
+		$this->zones = Zone::getZones();
+		$this->countries = Country::getCountries($this->context->language->id, false, true, false);
+		foreach ($this->zones as $zone)
+			$zones_array[$zone['id_zone']] = $zone['name'];
+		foreach ($this->countries as $country)
+			$countries_array[$country['id_country']] = $country['name'];
+
+		$this->fields_list = array(
+			'id_postcode' => array(
+				'title' => $this->l('ID'),
+				'align' => 'center',
+				'class' => 'fixed-width-xs'
+			),
+			'postcode' => array(
+				'title' => $this->l('Postcode'),
+				'filter_key' => 'a!postcode'
+			),
+			'zone' => array(
+				'title' => $this->l('Zone'),
+				'type' => 'select',
+				'list' => $zones_array,
+				'filter_key' => 'z!id_zone',
+				'filter_type' => 'int',
+				'order_key' => 'zone'
+			),
+			'country' => array(
+				'title' => $this->l('Country'),
+				'type' => 'select',
+				'list' => $countries_array,
+				'filter_key' => 'cl!id_country',
+				'filter_type' => 'int',
+				'order_key' => 'country'
+			),
+			'active' => array(
+				'title' => $this->l('Enabled'),
+				'align' => 'center',
+				'active' => 'status',
+				'type' => 'bool',
+				'orderby' => false,
+				'class' => 'fixed-width-sm'
+			)
+		);
+
+		$this->bulk_actions = array(
+			'delete' => array(
+				'text' => $this->l('Delete selected'),
+				'confirm' => $this->l('Delete selected items?'),
+				'icon' => 'icon-trash'
+			)
+		);
+
+		parent::__construct();
+	}
+
+	public function initPageHeaderToolbar()
+	{
+		if (empty($this->display))
+			$this->page_header_toolbar_btn['new_postcode'] = array(
+				'href' => self::$currentIndex.'&addpostcode&token='.$this->token,
+				'desc' => $this->l('Add new postcode', null, null, false),
+				'icon' => 'process-icon-new'
+			);
+
+		parent::initPageHeaderToolbar();
+	}
+
+	public function renderList()
+	{
+		$this->addRowAction('edit');
+		$this->addRowAction('delete');
+
+		return parent::renderList();
+	}
+
+	public function renderForm()
+	{
+		$this->fields_form = array(
+			'legend' => array(
+				'title' => $this->l('Postcodes'),
+				'icon' => 'icon-globe'
+			),
+			'input' => array(
+				array(
+					'type' => 'text',
+					'label' => $this->l('Postcode'),
+					'name' => 'postcode',
+					'maxlength' => 32,
+					'required' => true,
+					'hint' => $this->l('Provide the postcode to add to a zone.')
+				),
+				array(
+					'type' => 'select',
+					'label' => $this->l('Country'),
+					'name' => 'id_country',
+					'required' => true,
+					'default_value' => (int)$this->context->country->id,
+					'options' => array(
+						'query' => Country::getCountries($this->context->language->id, false, true),
+						'id' => 'id_country',
+						'name' => 'name',
+					),
+					'hint' => $this->l('Country where the postcode is located.')
+				),
+				array(
+					'type' => 'select',
+					'label' => $this->l('Zone'),
+					'name' => 'id_zone',
+					'required' => true,
+					'options' => array(
+						'query' => Zone::getZones(),
+						'id' => 'id_zone',
+						'name' => 'name'
+					),
+					'hint' => array(
+						$this->l('Geographical region where this postcode is located.'),
+						$this->l('Used for shipping')
+					)
+				),
+				array(
+					'type' => 'switch',
+					'label' => $this->l('Status'),
+					'name' => 'active',
+					'required' => true,
+					'values' => array(
+						array(
+							'id' => 'active_on',
+							'value' => 1,
+							'label' => '<img src="../img/admin/enabled.gif" alt="'.$this->l('Enabled').'" title="'.$this->l('Enabled').'" />'
+						),
+						array(
+							'id' => 'active_off',
+							'value' => 0,
+							'label' => '<img src="../img/admin/disabled.gif" alt="'.$this->l('Disabled').'" title="'.$this->l('Disabled').'" />'
+						)
+					)
+				)
+			),
+			'submit' => array(
+				'title' => $this->l('Save'),
+			)
+		);
+
+		return parent::renderForm();
+	}
+
+	public function postProcess()
+	{
+		if (Tools::isSubmit($this->table.'Orderby') || Tools::isSubmit($this->table.'Orderway'))
+			$this->filter = true;
+
+		/* Delete postcode */
+		if (Tools::isSubmit('delete'.$this->table))
+		{
+			if ($this->tabAccess['delete'] === '1')
+			{
+				if (Validate::isLoadedObject($object = $this->loadObject()))
+				{
+					if ($object->delete())
+						Tools::redirectAdmin(self::$currentIndex.'&conf=1&token='.(Tools::getValue('token') ? Tools::getValue('token') : $this->token));
+					$this->errors[] = Tools::displayError('An error occurred during deletion.');
+				}
+				else
+					$this->errors[] = Tools::displayError('An error occurred while deleting the object.').' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+			}
+			else
+				$this->errors[] = Tools::displayError('You do not have permission to delete this.');
+		}
+
+		if (!count($this->errors))
+			parent::postProcess();
+	}
+
+	protected function displayAjaxPostcodes()
+	{
+		if ($this->tabAccess['view'] === '1')
+		{
+			$postcodes = Db::getInstance()->executeS('
+			SELECT p.id_postcode, p.postcode
+			FROM '._DB_PREFIX_.'postcode p
+			LEFT JOIN '._DB_PREFIX_.'country c ON (p.`id_country` = c.`id_country`)
+			WHERE p.id_country = '.(int)(Tools::getValue('id_country')).' AND p.active = 1
+			ORDER BY p.`postcode` ASC');
+
+			if (is_array($postcodes) AND !empty($postcodes))
+			{
+				$list = '';
+				if ((bool)Tools::getValue('no_empty') != true)
+				{
+					$empty_value = (Tools::isSubmit('empty_value')) ? Tools::getValue('empty_value') : '-';
+					$list = '<option value="0">'.Tools::htmlentitiesUTF8($empty_value).'</option>'."\n";
+				}
+
+				foreach ($postcodes AS $postcode)
+					$list .= '<option value="'.(int)($postcode['id_postcode']).'"'.((isset($_GET['id_postcode']) AND $_GET['id_postcode'] == $state['id_postcode']) ? ' selected="selected"' : '').'>'.$postcode['postcode'].'</option>'."\n";
+			}
+			else
+				$list = 'false';
+
+			die($list);
+		}
+	}
+
+}

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2579,17 +2579,14 @@ CREATE TABLE IF NOT EXISTS `PREFIX_mail` (
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 
 CREATE TABLE IF NOT EXISTS `PREFIX_postcode` (
-	`id` INT(10) NOT NULL AUTO_INCREMENT,
+	`id_postcode` INT(10) NOT NULL AUTO_INCREMENT,
 	`id_country` INT(10) NULL DEFAULT NULL,
 	`id_zone` INT(10) NULL DEFAULT NULL,
-	`min` INT(10) NULL DEFAULT NULL,
-	`max` INT(10) NULL DEFAULT NULL,
-	PRIMARY KEY (`id`),
-	INDEX `ZCZCountryIndex` (`id_country`),
-	INDEX `ZCZZoneIndex` (`id_zone`)
-)
-COLLATE='utf8_general_ci'
-ENGINE=InnoDB
-AUTO_INCREMENT=148
-;
-
+	`postcode` VARCHAR(32) NOT NULL,
+	`active` tinyint(1) NOT NULL DEFAULT '0',
+	PRIMARY KEY (`id_postcode`),
+	KEY `id_country` (`id_country`),
+	KEY `id_zone` (`id_zone`),
+	KEY `active` (`active`),
+	UNIQUE KEY `postcode` (`postcode`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2577,3 +2577,19 @@ CREATE TABLE IF NOT EXISTS `PREFIX_mail` (
   PRIMARY KEY (`id_mail`),
   KEY `recipient` (`recipient`(10))
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+
+CREATE TABLE IF NOT EXISTS `PREFIX_postcode` (
+	`id` INT(10) NOT NULL AUTO_INCREMENT,
+	`id_country` INT(10) NULL DEFAULT NULL,
+	`id_zone` INT(10) NULL DEFAULT NULL,
+	`min` INT(10) NULL DEFAULT NULL,
+	`max` INT(10) NULL DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	INDEX `ZCZCountryIndex` (`id_country`),
+	INDEX `ZCZZoneIndex` (`id_zone`)
+)
+COLLATE='utf8_general_ci'
+ENGINE=InnoDB
+AUTO_INCREMENT=148
+;
+

--- a/install-dev/langs/en/data/tab.xml
+++ b/install-dev/langs/en/data/tab.xml
@@ -100,4 +100,5 @@
   <tab id="Supply_orders" name="Supply orders"/>
   <tab id="Configuration" name="Configuration"/>
   <tab id="CarrierWizard" name="Carrier"/>
+  <tab id="Postcodes" name="Postcodes"/>
 </entity_tab>

--- a/install-dev/langs/it/data/tab.xml
+++ b/install-dev/langs/it/data/tab.xml
@@ -100,4 +100,5 @@
   <tab id="Webservice" name="Webservice"/>
   <tab id="Zones" name="Zone"/>
   <tab id="CarrierWizard" name="Carrier"/>
+  <tab id="Postcodes" name="CAP"/>
 </entity_tab>

--- a/install-dev/upgrade/sql/1.6.0.13.sql
+++ b/install-dev/upgrade/sql/1.6.0.13.sql
@@ -1,0 +1,19 @@
+SET NAMES 'utf8';
+
+CREATE TABLE IF NOT EXISTS `PREFIX_postcode` (
+	`id_postcode` INT(10) NOT NULL AUTO_INCREMENT,
+	`id_country` INT(10) NULL DEFAULT NULL,
+	`id_zone` INT(10) NULL DEFAULT NULL,
+	`postcode` VARCHAR(32) NOT NULL,
+	`active` tinyint(1) NOT NULL DEFAULT '0',
+	PRIMARY KEY (`id_postcode`),
+	KEY `id_country` (`id_country`),
+	KEY `id_zone` (`id_zone`),
+	KEY `active` (`active`),
+	UNIQUE KEY `postcode` (`postcode`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+
+SET @id_parent = (SELECT `id_parent` FROM `PREFIX_tab` WHERE `class_name` = 'AdminStates' LIMIT 1);
+SET @position = (SELECT `position`+1 FROM `PREFIX_tab` WHERE `id_parent` = @id_parent ORDER BY position DESC LIMIT 1);
+/* PHP:add_new_tab(AdminPostcodes, en:Postcodes|it:CAP,  1); */;
+UPDATE `PREFIX_tab` SET `id_parent` = @id_parent, `position` = @position WHERE `class_name` = 'AdminPostcodes' LIMIT 1;


### PR DESCRIPTION
A must have feature for all Italian customers, where many postcodes are subject to specific prices by carriers.
This add support to postcodes grouped by zones. In this way will be possible to create a carrier bound to a specific zone with "special" postcodes with surchange (island, special destination, and so on...)

Missing translations, i don't know how to add default translation in this PR. Let me know and I'll fix ASAP.
Install/upgrade should be tested.

Let me know If this could be improved in any way.
