### PR TITLE
Update OrderInvoice.php

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -671,7 +671,7 @@ class OrderInvoiceCore extends ObjectModel
 	 */
 	public function getInvoiceNumberFormatted($id_lang, $id_shop = null)
 	{
-		return '#'.Configuration::get('PS_INVOICE_PREFIX', $id_lang, null, $id_shop).sprintf('%06d', $this->number);
+		return 'No. '.Configuration::get('PS_INVOICE_PREFIX', $id_lang, null, $id_shop).sprintf('%06d', $this->number);
 	}
 
 	public function saveCarrierTaxCalculator(array $taxes_amount)


### PR DESCRIPTION
I know that this hardcoded '#' is Prestashop standard for invoice numbers since 1.5.0, but I wouldn't agree that even in the USA this is a common abbreviation for purchase invoice numbers. Though the # is widely known for numbers,  in business the abbreviation No. or no. is preferred. Moreover, in European countries a '#' is totally unusual. In France and Spain it's 'N°', in GB 'No.', in Germany 'Nr.'. To avoid iritations for translators for the future I suggest to replace the '#' with the correct English 'No. ' - or just drop it and leave this to the translations section.
