### PR TITLE
Add support for blacklisting modules.

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1405,7 +1405,7 @@ abstract class ModuleCore
 			}
 
 		foreach ($module_list as $key => &$module)
-			if ((defined('_PS_HOST_MODE_') && in_array($module->name, self::$hosted_modules_blacklist)) || (defined('_PS_MODULES_BLACKLIST_') && _PS_MODULES_BLACKLIST_ && in_array($module->name, explode(',', _PS_MODULES_BLACKLIST_))))
+			if ((defined('_PS_HOST_MODE_') && in_array($module->name, self::$hosted_modules_blacklist)) || (_PS_MODULES_BLACKLIST_ && in_array($module->name, explode(',', _PS_MODULES_BLACKLIST_))))
 				unset($module_list[$key]);
 			elseif (isset($modules_installed[$module->name]))
 			{

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1405,7 +1405,7 @@ abstract class ModuleCore
 			}
 
 		foreach ($module_list as $key => &$module)
-			if (defined('_PS_HOST_MODE_') && in_array($module->name, self::$hosted_modules_blacklist))
+			if ((defined('_PS_HOST_MODE_') && in_array($module->name, self::$hosted_modules_blacklist)) || (defined('_PS_MODULES_BLACKLIST_') && _PS_MODULES_BLACKLIST_ && in_array($module->name, explode(',', _PS_MODULES_BLACKLIST_))))
 				unset($module_list[$key]);
 			elseif (isset($modules_installed[$module->name]))
 			{

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -245,6 +245,9 @@ if (!defined('_MEDIA_SERVER_2_'))
 if (!defined('_MEDIA_SERVER_3_'))
 	define('_MEDIA_SERVER_3_', Configuration::get('PS_MEDIA_SERVER_3'));
 
+/* _PS_MODULES_BLACKLIST_ must be defined (empty or not) to avoid modules blacklisting other modules */
+Tools::safeDefine('_PS_MODULES_BLACKLIST_', '');
+
 /* Get smarty */
 require_once(dirname(__FILE__).'/smarty.config.inc.php');
 $context->smarty = $smarty;

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -806,7 +806,7 @@ class AdminModulesControllerCore extends AdminController
 					// Check potential error
 					if (!($module = Module::getInstanceByName(urldecode($name))))
 						$this->errors[] = $this->l('Module not found');
-					elseif ((($this->context->mode >= Context::MODE_HOST_CONTRIB) && in_array($module->name, Module::$hosted_modules_blacklist)) || (defined('_PS_MODULES_BLACKLIST_') && _PS_MODULES_BLACKLIST_ && in_array($module->name, explode(',', _PS_MODULES_BLACKLIST_))))
+					elseif ((($this->context->mode >= Context::MODE_HOST_CONTRIB) && in_array($module->name, Module::$hosted_modules_blacklist)) || (_PS_MODULES_BLACKLIST_ && in_array($module->name, explode(',', _PS_MODULES_BLACKLIST_))))
 						$this->errors[] = Tools::displayError('You do not have permission to access this module.');
 					elseif ($key == 'install' && $this->tabAccess['add'] !== '1')
 						$this->errors[] = Tools::displayError('You do not have permission to install this module.');

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -806,7 +806,7 @@ class AdminModulesControllerCore extends AdminController
 					// Check potential error
 					if (!($module = Module::getInstanceByName(urldecode($name))))
 						$this->errors[] = $this->l('Module not found');
-					elseif (($this->context->mode >= Context::MODE_HOST_CONTRIB) && in_array($module->name, Module::$hosted_modules_blacklist))
+					elseif ((($this->context->mode >= Context::MODE_HOST_CONTRIB) && in_array($module->name, Module::$hosted_modules_blacklist)) || (defined('_PS_MODULES_BLACKLIST_') && _PS_MODULES_BLACKLIST_ && in_array($module->name, explode(',', _PS_MODULES_BLACKLIST_))))
 						$this->errors[] = Tools::displayError('You do not have permission to access this module.');
 					elseif ($key == 'install' && $this->tabAccess['add'] !== '1')
 						$this->errors[] = Tools::displayError('You do not have permission to install this module.');


### PR DESCRIPTION
In some environments some modules must be blacklisted for security reasons.
This PR add the modules blacklist feature.

Not directly using an array because constants only support scalar values, thus, a CSV constant is required, for example: `define('_PS_MODULES_BLACKLIST_', 'module1, module2, module3');` in `settings.inc.php`

I'm open to suggestions or make improvements.
