### PR TITLE
[-] CORE: Replace LIKE with "=" in some SQL Queries

### DIFF
--- a/classes/Country.php
+++ b/classes/Country.php
@@ -240,7 +240,7 @@ class CountryCore extends ObjectModel
 		$sql = '
 		SELECT `id_country`
 		FROM `'._DB_PREFIX_.'country_lang`
-		WHERE `name` LIKE \''.pSQL($country).'\'';
+		WHERE `name` = \''.pSQL($country).'\'';
 		if ($id_lang)
 			$sql .= ' AND `id_lang` = '.(int)$id_lang;
 

--- a/classes/State.php
+++ b/classes/State.php
@@ -111,7 +111,7 @@ class StateCore extends ObjectModel
 			$result = (int)Db::getInstance()->getValue('
 				SELECT `id_state`
 				FROM `'._DB_PREFIX_.'state`
-				WHERE `name` LIKE \''.pSQL($state).'\'
+				WHERE `name` = \''.pSQL($state).'\'
 			');
 			Cache::store($cache_id, $result);
 		}

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1010,7 +1010,7 @@ class ShopCore extends ObjectModel
 		static $feature_active = null;
 
 		if ($feature_active === null)
-			$feature_active = (bool)Db::getInstance()->getValue('SELECT value FROM `'._DB_PREFIX_.'configuration` WHERE `name` LIKE "PS_MULTISHOP_FEATURE_ACTIVE"')
+			$feature_active = (bool)Db::getInstance()->getValue('SELECT value FROM `'._DB_PREFIX_.'configuration` WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"')
 				&& (Db::getInstance()->getValue('SELECT COUNT(*) FROM '._DB_PREFIX_.'shop') > 1);
 
 		return $feature_active;


### PR DESCRIPTION
By replacing unneeded LIKE with "=" in some SQL query we improve performance by using `const` tables.
See http://dev.mysql.com/doc/refman/5.0/en/explain-output.html#jointype_const

More replace could be done, for example in `Category::searchByName` what do you think ?
