### PR TITLE
// clean up var initial_price declaration

### DIFF
--- a/themes/default-bootstrap/js/cart-summary.js
+++ b/themes/default-bootstrap/js/cart-summary.js
@@ -773,7 +773,7 @@ function updateCartSummary(json)
 		var reduction_type = product_list[i].reduction_type;
 		var reduction_symbol = '';
 		var initial_price_text = '';
-		initial_price = '';
+		var initial_price = '';
 
 		if (typeof(product_list[i].price_without_quantity_discount) !== 'undefined')
 			initial_price = formatCurrency(product_list[i].price_without_quantity_discount, currencyFormat, currencySign, currencyBlank);


### PR DESCRIPTION
The variable is only used in this for loop, not globally. Should then not be declared without var.

It was interfering with a global variable with the same name in custom JS code I created. Changed the name of my variable but figured this still might be an useful fix unless there is a specific reason I can't think of for "var" not being used.
