### PR TITLE
[-] MO : Fix Bug #PSCSX-4554, bad price reset

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -87,22 +87,7 @@ $(document).ready(function()
 		});
 		return true;
 	});
-
-	// Click on label
-	$('#layered_block_left label:not(.layered_color) a').on({
-		click: function(e) {
-			e.preventDefault();
-			var disable = $(this).parent().parent().find('input').attr('disabled');
-			if (disable == ''
-			|| typeof(disable) == 'undefined'
-			|| disable == false)
-			{
-				$(this).parent().parent().find('input').click();
-				reloadContent();
-			}
-		}
-	});
-
+	
 	layered_hidden_list = {};
 	$('.hide-action').on('click', function(e){
 		if (typeof(layered_hidden_list[$(this).parent().find('ul').attr('id')]) == 'undefined' || layered_hidden_list[$(this).parent().find('ul').attr('id')] == false)

--- a/themes/default-bootstrap/modules/blocklayered/blocklayered.tpl
+++ b/themes/default-bootstrap/modules/blocklayered/blocklayered.tpl
@@ -94,11 +94,7 @@
 												<input type="checkbox" class="checkbox" name="layered_{$filter.type_lite}_{$id_value}" id="layered_{$filter.type_lite}{if $id_value || $filter.type == 'quantity'}_{$id_value}{/if}" value="{$id_value}{if $filter.id_key}_{$filter.id_key}{/if}"{if isset($value.checked)} checked="checked"{/if}{if !$value.nbr} disabled="disabled"{/if} /> 
 											{/if}
 											<label for="layered_{$filter.type_lite}_{$id_value}"{if !$value.nbr} class="disabled"{else}{if isset($filter.is_color_group) && $filter.is_color_group} name="layered_{$filter.type_lite}_{$id_value}" class="layered_color" data-rel="{$id_value}_{$filter.id_key}"{/if}{/if}>
-												{if !$value.nbr}
-												{$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}
-												{else}
-												<a href="{$value.link}"{if $value.rel|trim != ''} data-rel="{$value.rel}"{/if}>{$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}</a>
-												{/if}
+												<span>{$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<i>({$value.nbr})</i>{/if}</span>
 											</label>
 										</li>
 										{/if}


### PR DESCRIPTION
Block layered bug PSCSX-4554 fix. When blocklayered filters ON in the category and you have price SLIDER filter among other filters (ex. some features). After you have filtered products by price and then filter products by other features by pressing on LABEL (<label>name of the feature</label>) not checkbox itself, price filter resets, although it was active. However if you click on checkbox (enable or disable), with filter by price activated, it will stay active. and you will get products considering price too.
