### PR TITLE
[-] FO: Show free shipping if json.free_ship = 1

### DIFF
--- a/themes/default-bootstrap/js/cart-summary.js
+++ b/themes/default-bootstrap/js/cart-summary.js
@@ -934,7 +934,7 @@ function updateCartSummary(json)
 	}
 	else
 	{
-		if (json.carrier.id != null)
+		if (json.carrier.id != null || json.free_ship == 1)
 			$('#total_shipping').html(freeShippingTranslation);
 		else if (!hasDeliveryAddress)
 			$('.cart_total_delivery').hide();


### PR DESCRIPTION
Show free shipping if JSON has `free_ship` set to `1`

Why not removing all code that checks for `total_shipping` and just use `free_ship` value? Seems to be duplicate code or should `free_ship` be renamed to `free_shipping` in Cart.php ?
