### PR TITLE
[-] FO Fix sort with layered and no pagination in result

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -478,6 +478,8 @@ function reloadContent(params_plus)
 				n = '&n=' + option.value;
 		});
 	}
+	if (params_plus === true)
+		params_plus ='';
 	ajaxQuery = $.ajax(
 	{
 		type: 'GET',


### PR DESCRIPTION
If the page displays only few products (no pagination and no nbr Item Page), sort bug with blocklayered because ajax request send something like this : http://fo.demo.prestashop.com/modules/blocklayered/blocklayered-ajax.php?id_category_layered=11&layered_price_slider=16_32&orderby=price&orderway=asctrue&_=1423216373140

=> orderway=asctrue
