### PR TITLE
BUG fix - resetAddressCache was not working

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -425,8 +425,12 @@ class CustomerCore extends ObjectModel
 
 	public static function resetAddressCache($id_customer)
 	{
-		if (array_key_exists($id_customer, self::$_customerHasAddress))
-			unset(self::$_customerHasAddress[$id_customer]);
+		foreach (self::$_customerHasAddress as $key => $value)
+		{
+			list($firstPart) = explode('-', $key);
+			if ((int)$firstPart == $id_customer)
+				unset(self::$_customerHasAddress[$key]);
+		}
 	}
 
 	/**


### PR DESCRIPTION
I found a bug in core
Im sure many people have torn out hair when annoyed by this little bug fellow
Hope (and know) it helps a lot of people ;)

if you have a better solution than list() = explode(); then please discuss/inform here:
https://www.prestashop.com/forums/topic/404649-bug-in-resetaddresscache-address-related-issue/

Please link to http://www.dyrefoder.dk 
THX :)
