### PR TITLE
[+] FO: Add hooks to intercept itentity submit

### DIFF
--- a/controllers/front/IdentityController.php
+++ b/controllers/front/IdentityController.php
@@ -47,6 +47,11 @@ class IdentityControllerCore extends FrontController
 
 		if (Tools::isSubmit('submitIdentity'))
 		{
+			Hook::exec('actionBeforeSubmitIdentity', array(
+				'post' => $_POST,
+				'controller' => $this,
+			));
+
 			$email = trim(Tools::getValue('email'));
 
 			if (Tools::getValue('months') != '' && Tools::getValue('days') != '' && Tools::getValue('years') != '')
@@ -109,6 +114,11 @@ class IdentityControllerCore extends FrontController
 		}
 		else
 			$_POST = array_map('stripslashes', $this->customer->getFields());
+
+		Hook::exec('actionAfterSubmitIdentity', array(
+			'post' => $_POST,
+			'controller' => $this,
+		));
 
 		return $this->customer;
 	}


### PR DESCRIPTION
Add two hooks to intercept identity submit:
`actionBeforeSubmitIdentity` and `actionAfterSubmitIdentity`

this allows to customize the customer identity, for example, by adding custom field in customer form and saving fields to DB when submitting (`actionBeforeSubmitIdentity`) or replacing saved values after identity is submitted and saved (`actionAfterSubmitIdentity`)
