### PR TITLE
[-] FO : Fixed bug allowing large original store picture to be used

### DIFF
--- a/themes/default-bootstrap/stores.tpl
+++ b/themes/default-bootstrap/stores.tpl
@@ -50,7 +50,7 @@
 					<td class="logo">
 						{if $store.has_picture}
 							<div class="store-image">
-								<img src="{$img_store_dir}{$store.id_store}.jpg" alt="" />
+								<img src="{$img_store_dir}{$store.id_store}-medium_default.jpg" alt="" />
 							</div>
 						{/if}
 					</td>


### PR DESCRIPTION
When user uploads huge image for a store image, the same huge image is used and displayed in the store-list, instead of the already created "-medium_default.jpg" one from the img/st folder.
