### PR TITLE
[-] CORE: Avoid double "?" into $link->getPaginationLink() when using Mo...

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -596,7 +596,7 @@ class LinkCore
 
 		if (!$array)
 			if (count($vars))
-				return $url.(($this->allow == 1 || $url == $this->url) ? '?' : '&').http_build_query($vars, '', '&');
+				return $url.(!strstr($url, '?') && ($this->allow == 1 || $url == $this->url) ? '?' : '&').http_build_query($vars, '', '&');
 			else
 				return $url;
 


### PR DESCRIPTION
...duleFrontController

When using native pagination.tpl with a ModuleFrontController, the URL contains "?" char two times if there are submitted parameters.

Example of an URL : http://domain.com/123456/my-custom-route
123456 => id
my-custom-route => rewrite

Pagination link will be :

http://domain.com?controller=<controller_name>?id=123456&rewrite=my-custom-route&fc=module&module=<module_name>&p=2

But it should be :

http://domain.com?controller=<controller_name>&id=123456&rewrite=my-custom-route&fc=module&module=<module_name>&p=2
