### PR TITLE
Update product-list.tpl

### DIFF
--- a/themes/default-bootstrap/product-list.tpl
+++ b/themes/default-bootstrap/product-list.tpl
@@ -105,7 +105,7 @@
 							</a>
 						{/if}
 					</div>
-					{hook h="displayProductDeliveryTime" product=$product}
+					{if !$product.is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}
 					{hook h="displayProductPriceBlock" product=$product type="weight"}
 				</div>
 				<div class="right-block">


### PR DESCRIPTION
As downloadable products are instantly available, any display of delivery time is waste for those products and should be disabled.
