### PR TITLE
[*] FO : Disable display of delivery time for virtual products in products-comparison.tpl

### DIFF
--- a/themes/default-bootstrap/products-comparison.tpl
+++ b/themes/default-bootstrap/products-comparison.tpl
@@ -131,7 +131,7 @@
 									</span>
 								{/if}
 							</p>
-							{hook h="displayProductDeliveryTime" product=$product}
+							{if !$product->is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}
 							{hook h="displayProductPriceBlock" product=$product type="weight"}
 							<div class="clearfix">
 								<div class="button-container">


### PR DESCRIPTION
As downloadable products are instantly available, any display of delivery time is waste for those products and should be disabled.
