### PR TITLE
[*] BO : Using "datetime" type in "from" and "to" in SpecificPriceRule

### DIFF
--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -117,12 +117,12 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
 			'from' => array(
 				'title' => $this->l('Beginning'),
 				'align' => 'right',
-				'type' => 'date',
+				'type' => 'datetime',
 			),
 			'to' => array(
 				'title' => $this->l('End'),
 				'align' => 'right',
-				'type' => 'date'
+				'type' => 'datetime'
 			),
 		);
 


### PR DESCRIPTION
Time is not visible in SpecificPriceRuleController helper list
