### PR TITLE
[-] BO: Fix function return value in write context in AdminWarehousesController.php

### DIFF
--- a/controllers/admin/AdminWarehousesController.php
+++ b/controllers/admin/AdminWarehousesController.php
@@ -461,8 +461,9 @@ class AdminWarehousesControllerCore extends AdminController
 		}
 
 		// handles carriers associations
-		if (!empty(Tools::isSubmit('ids_carriers_selected')))
-			$object->setCarriers(Tools::getValue('ids_carriers_selected'));
+		$ids_carriers_selected = Tools::getValue('ids_carriers_selected');
+		if (Tools::isSubmit('ids_carriers_selected') && !empty($ids_carriers_selected))
+			$object->setCarriers($ids_carriers_selected);
 		else
 			$object->setCarriers(Tools::getValue('ids_carriers_available'));
 


### PR DESCRIPTION
As subject, fix Fatal error: Can't use function return value in write context in /controllers/admin/AdminWarehousesController.php on line 464
