### PR TITLE
[-] CORE : Undefined $id_address in OrderSlip.php

### DIFF
--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -310,6 +310,7 @@ class OrderSlipCore extends ObjectModel
 			$order_detail->save();
 
 			$address = Address::initialize($order->id_address_invoice, false);
+			$id_address = $address->id;
 			$id_tax_rules_group = Product::getIdTaxRulesGroupByIdProduct((int)$order_detail->product_id);
 			$tax_calculator = TaxManagerFactory::getManager($address, $id_tax_rules_group)->getTaxCalculator();
 


### PR DESCRIPTION
I really don't understand what that's for, but the $id_address variable was not defined, and this causes an error. So I assume it should be the id of the address...
