### PR TITLE
[-] CORE : Wrong method call for sql query in getDeliveryOptionList

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2173,7 +2173,7 @@ class CartCore extends ObjectModel
 		}
 
 		$cart_rules = CartRule::getCustomerCartRules(Context::getContext()->cookie->id_lang, Context::getContext()->cookie->id_customer, true, true, false, $this, true);
-		$result = Db::getInstance('SELECT * FROM '._DB_PREFIX_.'cart_cart_rule WHERE id_cart='.$this->id);
+		$result = Db::getInstance()->executeS('SELECT * FROM '._DB_PREFIX_.'cart_cart_rule WHERE id_cart='.$this->id);
 		$cart_rules_in_cart = array();
 
 		if (is_array($result) && count($result))


### PR DESCRIPTION
Returns the whole db instance object instead of a query result, because of a wrong method call
