### PR TITLE
[-] MO: Fix blocklayered select filter event

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -42,10 +42,14 @@ $(document).ready(function()
 		reloadContent(true);
 	});
 
-	$(document).on('click', '#layered_form .select, #layered_form input[type=checkbox], #layered_form input[type=radio]', function(e) {
+    $(document).on('click', '#layered_form input[type=checkbox], #layered_form input[type=radio]', function() {
+        reloadContent(true);
+    });
 
-		reloadContent(true);
-	});
+    // Doesn't work with document element
+    $('body').on('change', '#layered_form .select', function() {
+        reloadContent(true);
+    });
 
 	// Changing content of an input text
 	$(document).on('keyup', '#layered_form input.layered_input_range', function(e){


### PR DESCRIPTION
Click event for a select element is wrong, works only in chrome, on other browser sit's impossible to select an option (FF for example).

Also, I don't understand the state of dev branch of blocklayered module, it would be great to integrate this change to module file as well.
