### PR TITLE
[-] FO: re-open customer thread from history page

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -85,7 +85,12 @@ class OrderDetailControllerCore extends FrontController
 						$ct->add();
 					}
 					else
+					{
 						$ct = new CustomerThread((int)$id_customer_thread);
+						$ct->status = 'open';
+						$ct->update();
+					}
+					
 					$cm->id_customer_thread = $ct->id;
 					$cm->message = $msgText;
 					$cm->ip_address = (int)ip2long($_SERVER['REMOTE_ADDR']);


### PR DESCRIPTION
When a new message is sent from history page by a customer, existing customer thread has to be re-open as it is from the contact page.
