### PR TITLE
[*] CORE : Bug in Configuration::updateValue()

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -351,8 +351,11 @@ class ConfigurationCore extends ObjectModel
 			$values = array($values);
 
 		if ($html)
+		{
 			foreach ($values as &$value)
 				$value = Tools::purifyHTML($value);
+			unset($value);
+		}
 
 		$result = true;
 		foreach ($values as $lang => $value)


### PR DESCRIPTION
Should 'unset' the $value reference at the end of the first foreach, before start the second one.
This may cause value mistake.
