### PR TITLE
[-] BO : Typo Remove erroneous parseFloat

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -767,7 +767,7 @@
 	function updateCartVouchers(vouchers)
 	{
 		var vouchers_html = '';
-		if (typeof(vouchers) == 'object')parseFloat
+		if (typeof(vouchers) == 'object')
 			$.each(vouchers, function(){
 				if (parseFloat(this.value_real) === 0 && parseInt(this.free_shipping) === 1)
 					var value = '{l s='Free shipping'}';


### PR DESCRIPTION
https://github.com/PrestaShop/PrestaShop/blob/1.6/admin-dev/themes/default/template/controllers/orders/form.tpl#L770

has parseFloat just hanging there... you sure this isn't a bug?
