### PR TITLE
Product comparison issue

### DIFF
--- a/themes/default-bootstrap/js/products-comparison.js
+++ b/themes/default-bootstrap/js/products-comparison.js
@@ -44,7 +44,7 @@ function addToCompare(productId)
 		action = 'remove';
 
 	$.ajax({
-		url: baseUri + '?controller=products-comparison&ajax=1&action=' + action + '&id_product=' + productId,
+		url: 'index.php?controller=products-comparison&ajax=1&action=' + action + '&id_product=' + productId,
 		async: true,
 		cache: false,
 		success: function(data) {
@@ -88,7 +88,7 @@ function reloadProductComparison()
 		e.preventDefault();
 		var idProduct = parseInt($(this).data('id-product'));
 		$.ajax({
-			url: baseUri + '?controller=products-comparison&ajax=1&action=remove&id_product=' + idProduct,
+			url: 'index.php??controller=products-comparison&ajax=1&action=remove&id_product=' + idProduct,
 			async: false,
 			cache: false
 		});


### PR DESCRIPTION
see: https://www.prestashop.com/forums/topic/398177-comparison-not-working-16011/#entry1941820.. has this been already fixed?

Is baseUri now defined? Why do we need to use baseUri here? shouldn't index.php be sufficient? It should start from wherever you currently are.
