### PR TITLE
[*] Class: Mail / hook "actionGetExtraMailTemplateVars"

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -322,6 +322,15 @@ class MailCore extends ObjectModel
 			$template_vars['{guest_tracking_url}'] = Context::getContext()->link->getPageLink('guest-tracking', true, Context::getContext()->language->id, null, false, $id_shop);
 			$template_vars['{history_url}'] = Context::getContext()->link->getPageLink('history', true, Context::getContext()->language->id, null, false, $id_shop);
 			$template_vars['{color}'] = Tools::safeOutput(Configuration::get('PS_MAIL_COLOR', null, null, $id_shop));
+			// Get extra template_vars
+			$extra_template_vars = array();
+			Hook::exec('actionGetExtraMailTemplateVars', array(
+				'template' => $template,
+				'template_vars' => $template_vars,
+				'extra_template_vars' => &$extra_template_vars,
+				'id_lang' => (int)$id_lang
+			), null, true);
+			$template_vars = array_merge($template_vars, $extra_template_vars);
 			$swift->attachPlugin(new Swift_Plugin_Decorator(array($to_plugin => $template_vars)), 'decorator');
 			if ($configuration['PS_MAIL_TYPE'] == Mail::TYPE_BOTH || $configuration['PS_MAIL_TYPE'] == Mail::TYPE_TEXT)
 				$message->attach(new Swift_Message_Part($template_txt, 'text/plain', '8bit', 'utf-8'));


### PR DESCRIPTION
# Example of use:

public function hookActionGetExtraMailTemplateVars($params)
    {
        $template = $params['template'];
        $template_vars = $params['template_vars'];
        $extra_template_vars = $params['extra_template_vars'];

```
    if ($template == 'password_query')
        $params['extra_template_vars']['{test}'] = $this->l('Extra var for test');
}
```
