### PR TITLE
[*] [BO] Don't update link_rewrite by default

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -135,10 +135,7 @@ function str2url(str, encoding, ucfirst)
 
 function copy2friendlyURL()
 {
-	if (typeof(id_product) == 'undefined')
-		id_product = false;
-
-	if (ps_force_friendly_product || !$('#link_rewrite_' + id_language).val().length || !id_product)//check if user didn't type anything in rewrite field, to prevent overwriting
+	if (ps_force_friendly_product || !$('#link_rewrite_' + id_language).val().length)//check if user didn't type anything in rewrite field, to prevent overwriting
 	{
 		$('#link_rewrite_' + id_language).val(str2url($('#name_' + id_language).val().replace(/^[0-9]+\./, ''), 'UTF-8').replace('%', ''));
 		if ($('#friendly-url'))


### PR DESCRIPTION
Except for products, "link_rewrite" field is always updated when you edit the corresponding "name" field, even if the link is already defined. 
Maybe that this is not the expected behavior and that is probably a bad idea for SEO...
