### PR TITLE
[-] FO,BO,Project : Fixed and improved Tools::normalizeDirectory

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1457,15 +1457,7 @@ class ToolsCore
 
 	public static function normalizeDirectory($directory)
 	{
-		$last = $directory[strlen($directory) - 1];
-
-		if (in_array($last, array('/', '\\')))
-		{
-			$directory[strlen($directory) - 1] = DIRECTORY_SEPARATOR;
-			return $directory;
-		}
-
-		$directory .= DIRECTORY_SEPARATOR;
+		$directory = rtrim($directory, '/\\').DIRECTORY_SEPARATOR;
 		return $directory;
 	}
 


### PR DESCRIPTION
There are the following problems in the current version of the Tools::normalizeDirectory method that were addressed:

Incorrect behavior in case there are several slashes at the end: Tools::normalizeDirectory('/dir//') --> '/dir//'
Has been fixed to return '/dir/'

Not necessary calls to strlen (2 times) and in_array (rather slow function) were removed.
