### PR TITLE
[+] CORE: Debug tools for printing into PHP error logs

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -918,6 +918,21 @@ class ToolsCore
 	}
 
 	/**
+	 * Prints object information into error log
+	 *
+	 * @see error_log()
+	 * @param mixed $object
+	 * @param int|null    $message_type
+	 * @param string|null $destination
+	 * @param string|null $extra_headers
+	 * @return bool
+	 */
+	public static function epr($object, $message_type = null, $destination = null, $extra_headers = null)
+	{
+		return error_log(print_r($object, true), $message_type, $destination, $extra_headers);
+	}
+
+	/**
 	* Check if submit has been posted
 	*
 	* @param string $submit submit name

--- a/config/alias.php
+++ b/config/alias.php
@@ -49,6 +49,11 @@ function ddd($var)
 	Tools::d($var);
 }
 
+function epr($var, $message_type = null, $destination = null, $extra_headers = null)
+{
+	return Tools::epr($var, $message_type, $destination, $extra_headers);
+}
+
 /**
  * Sanitize data which will be injected into SQL query
  *


### PR DESCRIPTION
I believe this could be a very useful tools for everyone. It's also very flexible:
- doesn't kill the process
- can print an object of any type
- can print to default php eror log or a custom file
- can send an email with the message (could be useful when on working on client's server)
- has all the parameters of `error_log`

I get tired of writing `error_log(print_r($var ,1))` every day :)
