### PR TITLE
[-] CORE : Fix #PSCSX-4935

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -354,20 +354,21 @@ abstract class DbCore
 	 * Execute a query and get result resource
 	 *
 	 * @param string|DbQuery $sql
+	 * @param boolean $use_query
 	 * @return bool|mysqli_result|PDOStatement|resource
 	 * @throws PrestaShopDatabaseException
 	 */
-	public function query($sql)
+	public function query($sql, $use_query = true)
 	{
 		if ($sql instanceof DbQuery)
 			$sql = $sql->build();
 
-		$this->result = $this->_query($sql);
+		$this->result = $this->_query($sql, $use_query);
 
 		if (!$this->result && $this->getNumberError() == 2006)
 		{
 			if ($this->connect())
-				$this->result = $this->_query($sql);
+				$this->result = $this->_query($sql, $use_query);
 		}
 
 		if (_PS_DEBUG_SQL_)
@@ -560,7 +561,7 @@ abstract class DbCore
 			return $this->execute($sql, $use_cache);
 		}
 
-		$this->result = $this->query($sql);
+		$this->result = $this->query($sql, $array);
 
 		if (!$this->result)
 			$result = false;

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -121,11 +121,22 @@ class DbPDOCore extends Db
 	 *
 	 * @see DbCore::_query()
 	 * @param string $sql
+	 * @param boolean $use_query
 	 * @return PDOStatement
 	 */
-	protected function _query($sql)
+	protected function _query($sql, $use_query = true)
 	{
-		return $this->link->query($sql);
+		if ($use_query)
+			return $this->link->query($sql);
+		else
+		{
+			$stmt = $this->link->prepare($sql, array(
+				PDO::ATTR_EMULATE_PREPARES => false,
+				PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false,
+				PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY,
+			));
+			return ($stmt->execute()?$stmt:false);
+		}
 	}
 
 	/**


### PR DESCRIPTION
When a cursor is created using Db::executeS($sql, true),
should the abstraction uses DbPDO, 
the query is run thru prepare() and execute() to avoid multi query() collision on multiple cursors
