### PR TITLE
[-] BO - AdminStoresController.php: wording

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -438,7 +438,7 @@ class AdminStoresControllerCore extends AdminController
 				'type' => 'text'
 			),
 			'PS_SHOP_DETAILS' => array(
-				'title' => $this->l('Registration'),
+				'title' => $this->l('Registration number'),
 				'hint' => $this->l('Shop registration information (e.g. SIRET or RCS).'),
 				'validation' => 'isGenericName',
 				'type' => 'textarea',


### PR DESCRIPTION
Registration > Registration number

For translation purposes, to have a different string from
https://github.com/PrestaShop/PrestaShop/blob/1.6/controllers/admin/AdminCustomersController.php#L149

where registration is "registration date" vs legal registration number here
