### PR TITLE
[-] BO: Add overrides.css to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ config/xml/*
 
 # Themes, modules and overrides
 
+admin-dev/themes/default/css/overrides.css
 modules/*
 override/*
 


### PR DESCRIPTION
Add `overrides.css` to .gitignore. This file should not be managed by git
