### PR TITLE
[*] BO : add two image generation methods, crop and adjust #PSCSX-4894

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -201,7 +201,22 @@ class ImageManagerCore
 		$width_diff = $dst_width / $src_width;
 		$height_diff = $dst_height / $src_height;
 
-		if ($width_diff > 1 && $height_diff > 1)
+		if ((int)Configuration::get('PS_IMAGE_GENERATION_METHOD') > 2)
+		{
+			// crop method (3) and adjust method (4)
+ 			$next_height = $dst_height;
+			$next_width = $dst_width;
+
+			if (((int)Configuration::get('PS_IMAGE_GENERATION_METHOD') == 3) == ($width_diff > $height_diff))
+			{
+				$next_height = round($src_height * $width_diff);
+			}
+			else
+			{
+				$next_width = round($src_width * $height_diff);
+			}
+		}
+		else if ($width_diff > 1 && $height_diff > 1)
 		{
 			$next_width = $src_width;
 			$next_height = $src_height;

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -126,6 +126,14 @@ class AdminImagesControllerCore extends AdminController
 							array(
 								'id' => '2',
 								'name' => $this->l('Height')
+							),
+							array(
+								'id' => '3',
+								'name' => $this->l('Crop')
+							),
+							array(
+								'id' => '4',
+								'name' => $this->l('Adjust (might produce stripes)')
 							)
 						),
 						'identifier' => 'id',


### PR DESCRIPTION
Add two image generation methods, **crop** and **adjust**.
See Issue I've create [#PSCSX-4894](http://forge.prestashop.com/browse/PSCSX-4894)

I add two new values the configuration option `PS_IMAGE_GENERATION_METHOD` : 
- Crop (id 3)
- Adjust (id 4)

Both methods will adapt your source ratio to your destination ratio, the **Crop** method may crop your source, the **Adjust** method may show some stripes.

Maybe the BO `PS_IMAGE_GENERATION_METHOD` field title should be more exhaustive. _I've not edit this part._

This is my first PR. Thanks. 
