### PR TITLE
[+] BO: Add hook actionGetBlogRss to customize dashboard news

### DIFF
--- a/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
@@ -98,7 +98,7 @@
 			<section class="dash_news panel">
 				<h3><i class="icon-rss"></i> {l s='PrestaShop News'}</h3>
 				<div class="dash_news_content"></div>
-				<div class="text-center"><h4><a href="http://www.prestashop.com/blog/" onclick="return !window.open(this.href);">{l s='Find more news'}</a></h4></div>
+				<div class="text-center"><h4><a class='find_more_news' href="#" onclick="return !window.open(this.href);">{l s='Find more news'}</a></h4></div>
 			</section>
 			<section id="dash_version" class="visible-lg">
 				<iframe style="overflow:hidden;border:none" src="{$new_version_url|escape:'html':'UTF-8'}" ></iframe>

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -341,7 +341,12 @@ class AdminDashboardControllerCore extends AdminController
 
 	public function ajaxProcessGetBlogRss()
 	{
-		$return = array('has_errors' => false, 'rss' => array());
+		// Call hook actionGetBlogRss
+		$return = Hook::exec('actionGetBlogRss');
+		if ( $return && isset($return['rss']) && is_array($return['rss']) )
+			die(Tools::jsonEncode($return));
+
+		$return = array('has_errors' => false, 'rss' => array(), 'moreLink' => 'http://www.prestashop.com/blog/');
 		if (!$this->isFresh('/config/xml/blog-'.$this->context->language->iso_code.'.xml', 86400))
 			if (!$this->refresh('/config/xml/blog-'.$this->context->language->iso_code.'.xml', _PS_API_URL_.'/rss/blog/blog-'.$this->context->language->iso_code.'.xml'))
 				$return['has_errors'] = true;

--- a/js/admin/dashboard.js
+++ b/js/admin/dashboard.js
@@ -200,6 +200,12 @@ function getBlogRss() {
 					var article_html = '<article><h4><a href="'+jsonData.rss[article].link+'" class="_blank" onclick="return !window.open(this.href);">'+jsonData.rss[article].title+'</a></h4><span class="dash-news-date text-muted">'+jsonData.rss[article].date+'</span><p>'+jsonData.rss[article].short_desc+' <a href="'+jsonData.rss[article].link+'">'+read_more+'</a><p></article><hr/>';
 					$('.dash_news .dash_news_content').append(article_html);
 				}
+
+				if (jsonData.moreLink !== undefined) {
+					$('.dash_news a.find_more_news').attr('href', jsonData.moreLink);
+				} else {
+					$('.dash_news a.find_more_news').hide();
+				}
 			}
 			else {
 				$('.dash_news').hide();


### PR DESCRIPTION
Add a new hook `actionGetBlogRss` to allow customization of dashboard news.
`actionGetBlogRss` should return a properly formatted JSON, something like this:

```
{
"moreLink": "http://www.prestashop.com/blog/",
"rss": [
  {"date": "", "title": "", "short_desc": "", "link": ""},
  {"date": "", "title": "", "short_desc": "", "link": ""},
  {"date": "", "title": "", "short_desc": "", "link": ""},
 ]
}
```

Additionally, is now possible to customize the "Find more news" link by returning a link `moreLink` in JSON property.
