### PR TITLE
Update Cart.php

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -652,7 +652,7 @@ class CartCore extends ObjectModel
 					break;
 			}
 
-			$row['price_wt'] = $tax_calculator->addTaxes($row['price']);
+			$row['price_wt'] = Tools::ps_round($tax_calculator->addTaxes($row['price']), 6);
 
 			$ecotax_tax_amount = Tools::ps_round($row['ecotax'], 2);
 			if ($apply_eco_tax)


### PR DESCRIPTION
sometimes the var $row['price_wt'] have a price with more than 6 decimal and this provocate errors when saving the order_detail.
