### PR TITLE
Small fix of the admin controller error handler

### DIFF
--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -91,7 +91,7 @@ abstract class ControllerCore
 	public function init()
 	{
 		if (_PS_MODE_DEV_ && $this->controller_type == 'admin')
-			set_error_handler(array(__CLASS__, 'myErrorHandler'));
+			set_error_handler(array(__CLASS__, 'myErrorHandler')); // Happy debugging, bitches!
 
 		if (!defined('_PS_BASE_URL_'))
 			define('_PS_BASE_URL_', Tools::getShopDomain(true));


### PR DESCRIPTION
Try to create some function with object type hint in AdminController
For example:

``` PHP
    public function test(Product $product)
    {
        die(get_class($product));
    }
```

And try to call it like: 

``` PHP
    $this->test(new Customer());
```

See this commit.
