### PR TITLE
[-] BO : Speed up search indexing, reduce memory usage and fix attribute indexing (PSCSX-5039, PSCSX-5028)

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -441,11 +441,8 @@ class SearchCore
 
 
 			$res = Db::getInstance()->executeS($sql, false);
-			while($row = Db::getInstance()->nextRow($res))
-			{
+			while ($row = Db::getInstance()->nextRow($res))
 				$ids[] = $row['id_product'];
-			}
-
 		}
 
 		// Now get every attribute in every language

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -590,7 +590,7 @@ class SearchCore
 						FROM '._DB_PREFIX_.'search_word sw
 						WHERE sw.word IN ('.implode(',', $query_array2).')
 						AND sw.id_lang = '.(int)$product['id_lang'].'
-						AND sw.id_shop = '.(int)$product['id_shop']);
+						AND sw.id_shop = '.(int)$product['id_shop'], true, false);
 						foreach ($added_words as $word_id)
 							$word_ids_by_word['_'.$word_id['word']] = (int)$word_id['id_word'];
 					}

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -495,8 +495,7 @@ class SearchCore
 				AND product_shop.`active` = 1
 				AND '.($id_product ? 'p.`id_product` = '.(int)$id_product : 'product_shop.`indexed` = 0'));
 
-			$db->execute('UPDATE `'._DB_PREFIX_.'search_index` si
-				INNER JOIN `'._DB_PREFIX_.'product` p ON (p.id_product = si.id_product)
+			$db->execute('UPDATE `'._DB_PREFIX_.'product` p
 				'.Shop::addSqlAssociation('product', 'p').'
 				SET p.`indexed` = 0, product_shop.`indexed` = 0
 				WHERE product_shop.`visibility` IN ("both", "search")

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1512,7 +1512,8 @@ CREATE TABLE IF NOT EXISTS `PREFIX_product_shop` (
   `pack_stock_type` int(11) unsigned DEFAULT '3' NOT NULL,
   PRIMARY KEY (`id_product`, `id_shop`),
   KEY `id_category_default` (`id_category_default`),
-  KEY `date_add` (`date_add` , `active` , `visibility`)
+  KEY `date_add` (`date_add` , `active` , `visibility`),
+  KEY `indexed` (`indexed`, `active`, `id_product`)
 ) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8 COLLATION;
 
 CREATE TABLE `PREFIX_product_attribute` (

--- a/install-dev/upgrade/sql/1.6.1.0.sql
+++ b/install-dev/upgrade/sql/1.6.1.0.sql
@@ -163,3 +163,5 @@ ALTER TABLE `PREFIX_customer` ADD KEY `id_shop` (`id_shop`, `date_add`);
 
 ALTER TABLE `PREFIX_cart` DROP KEY `id_shop`;
 ALTER TABLE `PREFIX_cart` ADD KEY `id_shop_2` (`id_shop`,`date_upd`), ADD KEY `id_shop` (`id_shop`,`date_add`);
+
+ALTER TABLE `PREFIX_product_shop` ADD KEY `indexed` (`indexed`, `active`, `id_product`);


### PR DESCRIPTION
On a DB with 1925 products, for a full reindex :

Before this fix : 
- 12.8 Mo peak memory consumption
- 101s to index the products

After this fix :
- 8.1 Mo peak memory consumption
- 56s to index the products
