### PR TITLE
[*] CORE: PHPDoc types for class members that are classes

### DIFF
--- a/classes/FileUploader.php
+++ b/classes/FileUploader.php
@@ -27,6 +27,8 @@
 class FileUploaderCore
 {
 	protected $allowedExtensions = array();
+
+	/** @var QqUploadedFileXhr|QqUploadedFileForm|false */
 	protected $file;
 	protected $sizeLimit;
 

--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -71,7 +71,7 @@ class PrestaShopAutoload
 	/**
 	 * Get instance of autoload (singleton)
 	 *
-	 * @return Autoload
+	 * @return PrestaShopAutoload
 	 */
 	public static function getInstance()
 	{

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -236,7 +236,7 @@ class AdminControllerCore extends Controller
 	/** @var array Required_fields to display in the Required Fields form */
 	public $required_fields = array();
 
-	/** @var Helper */
+	/** @var HelperList */
 	protected $helper;
 
 	/**

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -84,8 +84,13 @@ class HelperListCore extends Helper
 	/** @var boolean Content line is clickable if true */
 	public $no_link = false;
 
+	/** @var Smarty_Internal_Template|string */
 	protected $header_tpl = 'list_header.tpl';
+
+	/** @var Smarty_Internal_Template|string */
 	protected $content_tpl = 'list_content.tpl';
+
+	/** @var Smarty_Internal_Template|string */
 	protected $footer_tpl = 'list_footer.tpl';
 
 	/** @var array list of required actions for each list row */

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2161,6 +2161,12 @@ abstract class ModuleCore
 		}
 	}
 
+	/**
+	 * @param string $template
+	 * @param string|null $cache_id
+	 * @param string|null $compile_id
+	 * @return Smarty_Internal_Template
+	 */
 	protected function getCurrentSubTemplate($template, $cache_id = null, $compile_id = null)
 	{
 		if (!isset($this->current_subtemplate[$template.'_'.$cache_id.'_'.$compile_id]))

--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -32,7 +32,11 @@ abstract class HTMLTemplateCore
 	public $title;
 	public $date;
 	public $available_in_your_account = true;
+
+	/** @var Smarty */
 	public $smarty;
+
+	/** @var Shop */
 	public $shop;
 
 	/**

--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -31,6 +31,11 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
 {
 	public $order;
 
+	/**
+	 * @param OrderInvoice $order_invoice
+	 * @param Smarty $smarty
+	 * @throws PrestaShopException
+	 */
 	public function __construct(OrderInvoice $order_invoice, $smarty)
 	{
 		$this->order_invoice = $order_invoice;

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -32,6 +32,11 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
 	public $order;
 	public $available_in_your_account = false;
 
+	/**
+	 * @param OrderInvoice $order_invoice
+	 * @param Smarty $smarty
+	 * @throws PrestaShopException
+	 */
 	public function __construct(OrderInvoice $order_invoice, $smarty)
 	{
 		$this->order_invoice = $order_invoice;

--- a/classes/pdf/HTMLTemplateOrderReturn.php
+++ b/classes/pdf/HTMLTemplateOrderReturn.php
@@ -32,6 +32,11 @@ class HTMLTemplateOrderReturnCore extends HTMLTemplate
 	public $order_return;
 	public $order;
 
+	/**
+	 * @param OrderReturn $order_return
+	 * @param Smarty $smarty
+	 * @throws PrestaShopException
+	 */
 	public function __construct(OrderReturn $order_return, $smarty)
 	{
 		$this->order_return = $order_return;

--- a/classes/pdf/HTMLTemplateSupplyOrderForm.php
+++ b/classes/pdf/HTMLTemplateSupplyOrderForm.php
@@ -35,6 +35,11 @@ class HTMLTemplateSupplyOrderFormCore extends HTMLTemplate
 	public $address_supplier;
 	public $context;
 
+	/**
+	 * @param SupplyOrder $supply_order
+	 * @param Smarty $smarty
+	 * @throws PrestaShopException
+	 */
 	public function __construct(SupplyOrder $supply_order, $smarty)
 	{
 		$this->supply_order = $supply_order;

--- a/classes/tree/Tree.php
+++ b/classes/tree/Tree.php
@@ -40,8 +40,13 @@ class TreeCore
 	protected $_node_folder_template;
 	protected $_node_item_template;
 	protected $_template;
+
+	/** @var string */
 	private   $_template_directory;
 	private   $_title;
+
+	/** @var TreeToolbar|ITreeToolbar */
+	private $_toolbar;
 
 	public function __construct($id, $data = null)
 	{
@@ -202,12 +207,19 @@ class TreeCore
 		return $this->_template;
 	}
 
+	/**
+	 * @param $value
+	 * @return $this
+	 */
 	public function setTemplateDirectory($value)
 	{
 		$this->_template_directory = $this->_normalizeDirectory($value);
 		return $this;
 	}
 
+	/**
+	 * @return string
+	 */
 	public function getTemplateDirectory()
 	{
 		if (!isset($this->_template_directory))

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -37,6 +37,8 @@ class WebserviceOutputBuilderCore
 
 	protected $wsUrl;
 	protected $output;
+
+	/** @var WebserviceOutputInterface|WebserviceOutputXML|WebserviceOutputJSON */
 	public $objectRender;
 	protected $wsResource;
 	protected $depth = 0;

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -45,7 +45,7 @@ class WebserviceRequestCore
 
 	/**
 	 * Set if the management is specific or if it is classic (entity management)
-	 * @var boolean
+	 * @var WebserviceSpecificManagementInterface|false
 	 */
 	protected $objectSpecificManagement = false;
 

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -26,8 +26,11 @@
 
 class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManagementInterface
 {
+	/** @var WebserviceOutputBuilder */
 	protected $objOutput;
 	protected $output;
+
+	/** @var WebserviceRequest */
 	protected $wsObject;
 
 	/**

--- a/classes/webservice/WebserviceSpecificManagementSearch.php
+++ b/classes/webservice/WebserviceSpecificManagementSearch.php
@@ -26,8 +26,11 @@
 
 class WebserviceSpecificManagementSearchCore implements WebserviceSpecificManagementInterface
 {
+	/** @var WebserviceOutputBuilder */
 	protected $objOutput;
 	protected $output;
+
+	/** @var WebserviceRequest */
 	protected $wsObject;
 
 	/* ------------------------------------------------

--- a/controllers/admin/AdminAttributeGeneratorController.php
+++ b/controllers/admin/AdminAttributeGeneratorController.php
@@ -29,6 +29,8 @@
 class AdminAttributeGeneratorControllerCore extends AdminController
 {
 	protected $combinations = array();
+
+	/** @var Product */
 	protected $product;
 
 	public function __construct()

--- a/controllers/admin/AdminCarriersController.php
+++ b/controllers/admin/AdminCarriersController.php
@@ -26,6 +26,9 @@
 
 class AdminCarriersControllerCore extends AdminController
 {
+	/** @var Carrier */
+	protected $object;
+
 	protected $position_identifier = 'id_carrier';
 
 	public function __construct()

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -26,6 +26,9 @@
 
 class AdminProductsControllerCore extends AdminController
 {
+	/** @var Product */
+	protected $object;
+
 	/** @var integer Max image size for upload
 	 * As of 1.5 it is recommended to not set a limit to max image size
 	 */

--- a/controllers/admin/AdminSearchConfController.php
+++ b/controllers/admin/AdminSearchConfController.php
@@ -26,6 +26,9 @@
 
 class AdminSearchConfControllerCore extends AdminController
 {
+	/** @var Alias */
+	protected $object;
+
 	protected $toolbar_scroll = false;
 
 	public function __construct()

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -26,6 +26,9 @@
 
 class AdminShopUrlControllerCore extends AdminController
 {
+	/** @var ShopUrl */
+	protected $object;
+
 	public function __construct()
 	{
 		$this->bootstrap = true;

--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -26,6 +26,9 @@
 
 class AdminSpecificPriceRuleControllerCore extends AdminController
 {
+	/** @var SpecificPriceRule */
+	protected $object;
+
 	public $list_reduction_type;
 
 	public function __construct()

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -26,6 +26,9 @@
 
 class AdminSuppliersControllerCore extends AdminController
 {
+	/** @var Supplier */
+	protected $object;
+
 	public $bootstrap = true ;
 
 	public function __construct()

--- a/controllers/admin/AdminTrackingController.php
+++ b/controllers/admin/AdminTrackingController.php
@@ -27,6 +27,8 @@
 class AdminTrackingControllerCore extends AdminController
 {
 	public $bootstrap = true;
+
+	/** @var HelperList */
 	protected $_helper_list;
 
 	public function postprocess()

--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -29,6 +29,8 @@ class CmsControllerCore extends FrontController
 	public $php_self = 'cms';
 	public $assignCase;
 	public $cms;
+
+	/** @var CMSCategory */
 	public $cms_category;
 	public $ssl = false;
 

--- a/controllers/front/IdentityController.php
+++ b/controllers/front/IdentityController.php
@@ -31,6 +31,9 @@ class IdentityControllerCore extends FrontController
 	public $authRedirection = 'identity';
 	public $ssl = true;
 
+	/** @var Customer */
+	protected $customer;
+
 	public function init()
 	{
 		parent::init();

--- a/controllers/front/ManufacturerController.php
+++ b/controllers/front/ManufacturerController.php
@@ -27,6 +27,8 @@
 class ManufacturerControllerCore extends FrontController
 {
 	public $php_self = 'manufacturer';
+
+	/** @var Manufacturer */
 	protected $manufacturer;
 
 	public function setMedia()

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -28,7 +28,10 @@ class ProductControllerCore extends FrontController
 {
 	public $php_self = 'product';
 
+	/** @var Product */
 	protected $product;
+
+	/** @var Category */
 	protected $category;
 
 	public function setMedia()

--- a/controllers/front/SupplierController.php
+++ b/controllers/front/SupplierController.php
@@ -28,6 +28,7 @@ class SupplierControllerCore extends FrontController
 {
 	public $php_self = 'supplier';
 
+	/** @var Supplier */
 	protected $supplier;
 
 	public function setMedia()


### PR DESCRIPTION
Please double check `protect $customer @ IdentintyController` and  `private $_toolbar @ Tree` member visibility scopes.

This patch solves autocomplete for properties that are clases. e.g. `$this->category->getProducts()`
