### PR TITLE
[*] TEST : Add tool to easily init unit testing inside a module

### DIFF
--- a/tests/module_testing/DummyTest.php
+++ b/tests/module_testing/DummyTest.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace PrestaShop\PrestaShop\Tests\Unit;
+
+
+use PHPUnit_Framework_TestCase;
+
+class DummyTest extends PHPUnit_Framework_TestCase
+{
+
+    public function test_Dummy()
+    {
+        $this->assertTrue(true, "Everything works fine");
+    }
+}

--- a/tests/module_testing/bootstrap.php
+++ b/tests/module_testing/bootstrap.php
@@ -24,7 +24,7 @@
 *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 */
-$mainDir = dirname(__FILE__).'/../../../';
+$mainDir = dirname(__DIR__).DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR;
 require_once($mainDir.'config/defines.inc.php');
 require_once(_PS_CONFIG_DIR_.'autoload.php');
 require($mainDir.'tests/vendor/autoload.php');

--- a/tests/module_testing/bootstrap.php
+++ b/tests/module_testing/bootstrap.php
@@ -1,0 +1,30 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @version  Release: $Revision$
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+$mainDir = dirname(__FILE__).'/../../../';
+require_once($mainDir.'config/defines.inc.php');
+require_once(_PS_CONFIG_DIR_.'autoload.php');
+require($mainDir.'tests/vendor/autoload.php');

--- a/tests/module_testing/init_module_unit_testing.sh
+++ b/tests/module_testing/init_module_unit_testing.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+
+function help
+{
+	echo "
+	Usage: init_module_unit_testing.sh -m <module_directory>
+
+	-m <module_directory>    The module name, corresponding to the directory where you need to init testing tools
+	-h                       This help message. Exits after printing...
+
+	Init testing tools on module :
+	==============================
+	* This script creates automatically the structure of unit tests in the desired module directory.
+	* This script is supposed to be executed while inside module_testing folder.
+	"
+}
+
+declare module_name
+
+if [ $# -eq 0 ]
+  then
+    echo "No arguments supplied"
+    help "$@"
+    exit 1
+fi
+
+while [ $# -gt 0 ]
+do
+	case $1 in
+		-h|-help)
+			help "$@"
+			exit 0
+			;;
+		-m)
+			shift
+            module_name=$1
+		    if [ -z "$module_name" ]; then
+                echo "Module name is empty"
+                help "$@"
+                exit 1
+            fi
+			;;
+		*)
+			echo "Unknown argument specified: $1"
+			help "$@"
+			exit 1
+			;;
+	esac
+	shift
+done
+
+
+modulepath=../../modules/${module_name}
+
+# Create test folders
+mkdir ${modulepath}/tests
+mkdir ${modulepath}/tests/Unit
+mkdir ${modulepath}/tests/Integration
+
+# Copy settings files
+cp ../phpunit.xml ${modulepath}/tests
+cp ./bootstrap.php ${modulepath}/tests
+cp ./phpunit ${modulepath}/tests
+cp ./DummyTest.php ${modulepath}/tests/Unit
+
+echo "You should now be able to create tests in your module $module_name :
+    Just go to your module tests directory (cd $modulepath/tests) and run ./phpunit.
+    We added a DummyTest.php file in order to check that everything works fine.
+"

--- a/tests/module_testing/phpunit
+++ b/tests/module_testing/phpunit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+main_test_path=../../../tests
+${main_test_path}/vendor/bin/phpunit -c .


### PR DESCRIPTION
The script init_module_unit_testing.sh automatically creates folders and settings to run unit tests inside a module.

Run the script from its directory, by example : 

``` bash
    $ ./init_module_unit_testing.sh -m example_module
    $ cd ../../modules/example_module/tests
    $ ./phpunit
    PHPUnit 4.5.0 by Sebastian Bergmann and contributors.

    Configuration read from /PrestaShop/modules/example_module/tests/phpunit.xml
    .
    Time: 599 ms, Memory: 2.75Mb
    OK (1 test, 1 assertion)
```

The script initiates a DummyTest.php file, so you should immediatly validate that PHPUnit works.
