### PR TITLE
[-] FO: Back button won't return to previous page

### DIFF
--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -1013,7 +1013,7 @@ function getProductAttribute()
 		$('#customizationForm').attr('action', customAction + request);
 	}
 
-	window.location = url + request;
+	window.location.replace(url + request);
 }
 
 function checkUrl()
@@ -1069,7 +1069,7 @@ function checkUrl()
 			}
 			// no combination found = removing attributes from url
 			else
-				window.location = url.substring(0, url.indexOf('#'));
+				window.location.replace(url.substring(0, url.indexOf('#')));
 		}
 	}
 	return false;


### PR DESCRIPTION
In some browsers (ie. Firefox, but not Chrome), selecting attributes will fill the browser history with new URLs and the back button won't return to the previous page, as example when the user came from the category page, unless he presses the back button as often as he selected attributes. The same occurs, when attributes in the URL would be removed because they couldn't be found. This fixes the back button in these browsers, to return to the previous page the user perceives as such, instead of just changing the attribute URL, which creates the wrong impression something would be broken as the user thinks nothing would be happening.
