### PR TITLE
[*] CORE: Make all blocklayered fields available in products.tpl

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3254,10 +3254,34 @@ class ProductCore extends ObjectModel
 	{
 		if (!Combination::isFeatureActive())
 			return array();
+		if (Module::isInstalled('blocklayered') && Module::isEnabled('blocklayered'))
 		$sql = 'SELECT ag.`id_attribute_group`, ag.`is_color_group`, agl.`name` AS group_name, agl.`public_name` AS public_group_name,
 					a.`id_attribute`, al.`name` AS attribute_name, a.`color` AS attribute_color, product_attribute_shop.`id_product_attribute`,
-					IFNULL(stock.quantity, 0) as quantity, product_attribute_shop.`price`, product_attribute_shop.`ecotax`, product_attribute_shop.`weight`,
+						IFNULL(stock.quantity, 0) AS quantity, product_attribute_shop.`price`, product_attribute_shop.`ecotax`, product_attribute_shop.`weight`,
 					product_attribute_shop.`default_on`, pa.`reference`, product_attribute_shop.`unit_price_impact`,
+						product_attribute_shop.`minimal_quantity`, product_attribute_shop.`available_date`, ag.`group_type`,
+						lialv.`url_name`, lialv.`meta_title`, liaglv.`url_name` as group_url_name, liaglv.`meta_title` as group_meta_title
+					FROM `'._DB_PREFIX_.'product_attribute` pa
+					'.Shop::addSqlAssociation('product_attribute', 'pa').'
+					'.Product::sqlStock('pa', 'pa').'
+					LEFT JOIN `'._DB_PREFIX_.'product_attribute_combination` pac ON (pac.`id_product_attribute` = pa.`id_product_attribute`)
+					LEFT JOIN `'._DB_PREFIX_.'attribute` a ON (a.`id_attribute` = pac.`id_attribute`)
+					LEFT JOIN `'._DB_PREFIX_.'attribute_group` ag ON (ag.`id_attribute_group` = a.`id_attribute_group`)
+					LEFT JOIN `'._DB_PREFIX_.'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute`)
+					LEFT JOIN `'._DB_PREFIX_.'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group`)
+					LEFT JOIN `'._DB_PREFIX_.'layered_indexable_attribute_lang_value` lialv ON (a.`id_attribute` = lialv.`id_attribute` AND lialv.`id_lang` = '.(int)$id_lang.')
+					LEFT JOIN `'._DB_PREFIX_.'layered_indexable_attribute_group_lang_value` liaglv ON (ag.`id_attribute_group` = liaglv.`id_attribute_group` AND liaglv.`id_lang` = '.(int)$id_lang.')
+					'.Shop::addSqlAssociation('attribute', 'a').'
+					WHERE pa.`id_product` = '.(int)$this->id.'
+						AND al.`id_lang` = '.(int)$id_lang.'
+						AND agl.`id_lang` = '.(int)$id_lang.'
+					GROUP BY id_attribute_group, id_product_attribute
+					ORDER BY ag.`position` ASC, a.`position` ASC, agl.`name` ASC';
+		else
+			$sql = 'SELECT ag.`id_attribute_group`, ag.`is_color_group`, agl.`name` AS group_name, agl.`public_name` AS public_group_name,
+						a.`id_attribute`, al.`name` AS attribute_name, a.`color` AS attribute_color, product_attribute_shop.`id_product_attribute`,
+						IFNULL(stock.quantity, 0) AS quantity, product_attribute_shop.`price`, product_attribute_shop.`ecotax`, product_attribute_shop.`weight`,
+						product_attribute_shop.`default_on`, pa.`reference`, product_attribute_shop.`unit_price_impact`,
 					product_attribute_shop.`minimal_quantity`, product_attribute_shop.`available_date`, ag.`group_type`
 				FROM `'._DB_PREFIX_.'product_attribute` pa
 				'.Shop::addSqlAssociation('product_attribute', 'pa').'
@@ -4137,16 +4161,30 @@ class ProductCore extends ObjectModel
 			return array();
 		if (!array_key_exists($id_product.'-'.$id_lang, self::$_frontFeaturesCache))
 		{
-			self::$_frontFeaturesCache[$id_product.'-'.$id_lang] = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-				SELECT name, value, pf.id_feature
-				FROM '._DB_PREFIX_.'feature_product pf
-				LEFT JOIN '._DB_PREFIX_.'feature_lang fl ON (fl.id_feature = pf.id_feature AND fl.id_lang = '.(int)$id_lang.')
-				LEFT JOIN '._DB_PREFIX_.'feature_value_lang fvl ON (fvl.id_feature_value = pf.id_feature_value AND fvl.id_lang = '.(int)$id_lang.')
-				LEFT JOIN '._DB_PREFIX_.'feature f ON (f.id_feature = pf.id_feature AND fl.id_lang = '.(int)$id_lang.')
-				'.Shop::addSqlAssociation('feature', 'f').'
-				WHERE pf.id_product = '.(int)$id_product.'
-				ORDER BY f.position ASC'
-			);
+			if (Module::isInstalled('blocklayered') && Module::isEnabled('blocklayered')) {
+				self::$_frontFeaturesCache[$id_product.'-'.$id_lang] = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+					SELECT `name`, `value`, pf.`id_feature`, liflv.`url_name`, liflv.`meta_title`
+					FROM `'._DB_PREFIX_.'feature_product` pf
+					LEFT JOIN `'._DB_PREFIX_.'feature_lang` fl ON (fl.`id_feature` = pf.`id_feature` AND fl.`id_lang` = '.(int)$id_lang.')
+					LEFT JOIN `'._DB_PREFIX_.'feature_value_lang` fvl ON (fvl.`id_feature_value` = pf.`id_feature_value` AND fvl.`id_lang` = '.(int)$id_lang.')
+					LEFT JOIN `'._DB_PREFIX_.'feature` f ON (f.id_feature = pf.id_feature AND fl.`id_lang` = '.(int)$id_lang.')
+					LEFT JOIN `'._DB_PREFIX_.'layered_indexable_feature_lang_value` liflv ON (f.`id_feature` = liflv.`id_feature` AND liflv.`id_lang` = '.(int)$id_lang.')
+					'.Shop::addSqlAssociation('feature', 'f').'
+					WHERE pf.`id_product` = '.(int)$id_product.'
+					ORDER BY f.`position` ASC'
+				);
+			} else {
+				self::$_frontFeaturesCache[$id_product.'-'.$id_lang] = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+					SELECT `name`, `value`, pf.`id_feature`
+					FROM `'._DB_PREFIX_.'feature_product` pf
+					LEFT JOIN `'._DB_PREFIX_.'feature_lang` fl ON (fl.`id_feature` = pf.`id_feature` AND fl.`id_lang` = '.(int)$id_lang.')
+					LEFT JOIN `'._DB_PREFIX_.'feature_value_lang` fvl ON (fvl.`id_feature_value` = pf.`id_feature_value` AND fvl.`id_lang` = '.(int)$id_lang.')
+					LEFT JOIN `'._DB_PREFIX_.'feature` f ON (f.id_feature = pf.id_feature AND fl.`id_lang` = '.(int)$id_lang.')
+					'.Shop::addSqlAssociation('feature', 'f').'
+					WHERE pf.`id_product` = '.(int)$id_product.'
+					ORDER BY f.`position` ASC'
+				);
+			}
 		}
 		return self::$_frontFeaturesCache[$id_product.'-'.$id_lang];
 	}

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3255,33 +3255,33 @@ class ProductCore extends ObjectModel
 		if (!Combination::isFeatureActive())
 			return array();
 		if (Module::isInstalled('blocklayered') && Module::isEnabled('blocklayered'))
-		$sql = 'SELECT ag.`id_attribute_group`, ag.`is_color_group`, agl.`name` AS group_name, agl.`public_name` AS public_group_name,
+			$sql = 'SELECT ag.`id_attribute_group`, ag.`is_color_group`, agl.`name` AS group_name, agl.`public_name` AS public_group_name,
 					a.`id_attribute`, al.`name` AS attribute_name, a.`color` AS attribute_color, product_attribute_shop.`id_product_attribute`,
-						IFNULL(stock.quantity, 0) AS quantity, product_attribute_shop.`price`, product_attribute_shop.`ecotax`, product_attribute_shop.`weight`,
+					IFNULL(stock.quantity, 0) AS quantity, product_attribute_shop.`price`, product_attribute_shop.`ecotax`, product_attribute_shop.`weight`,
 					product_attribute_shop.`default_on`, pa.`reference`, product_attribute_shop.`unit_price_impact`,
-						product_attribute_shop.`minimal_quantity`, product_attribute_shop.`available_date`, ag.`group_type`,
-						lialv.`url_name`, lialv.`meta_title`, liaglv.`url_name` as group_url_name, liaglv.`meta_title` as group_meta_title
-					FROM `'._DB_PREFIX_.'product_attribute` pa
-					'.Shop::addSqlAssociation('product_attribute', 'pa').'
-					'.Product::sqlStock('pa', 'pa').'
-					LEFT JOIN `'._DB_PREFIX_.'product_attribute_combination` pac ON (pac.`id_product_attribute` = pa.`id_product_attribute`)
-					LEFT JOIN `'._DB_PREFIX_.'attribute` a ON (a.`id_attribute` = pac.`id_attribute`)
-					LEFT JOIN `'._DB_PREFIX_.'attribute_group` ag ON (ag.`id_attribute_group` = a.`id_attribute_group`)
-					LEFT JOIN `'._DB_PREFIX_.'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute`)
-					LEFT JOIN `'._DB_PREFIX_.'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group`)
-					LEFT JOIN `'._DB_PREFIX_.'layered_indexable_attribute_lang_value` lialv ON (a.`id_attribute` = lialv.`id_attribute` AND lialv.`id_lang` = '.(int)$id_lang.')
-					LEFT JOIN `'._DB_PREFIX_.'layered_indexable_attribute_group_lang_value` liaglv ON (ag.`id_attribute_group` = liaglv.`id_attribute_group` AND liaglv.`id_lang` = '.(int)$id_lang.')
-					'.Shop::addSqlAssociation('attribute', 'a').'
-					WHERE pa.`id_product` = '.(int)$this->id.'
-						AND al.`id_lang` = '.(int)$id_lang.'
-						AND agl.`id_lang` = '.(int)$id_lang.'
-					GROUP BY id_attribute_group, id_product_attribute
-					ORDER BY ag.`position` ASC, a.`position` ASC, agl.`name` ASC';
+					product_attribute_shop.`minimal_quantity`, product_attribute_shop.`available_date`, ag.`group_type`,
+					lialv.`url_name`, lialv.`meta_title`, liaglv.`url_name` as group_url_name, liaglv.`meta_title` as group_meta_title
+				FROM `'._DB_PREFIX_.'product_attribute` pa
+				'.Shop::addSqlAssociation('product_attribute', 'pa').'
+				'.Product::sqlStock('pa', 'pa').'
+				LEFT JOIN `'._DB_PREFIX_.'product_attribute_combination` pac ON (pac.`id_product_attribute` = pa.`id_product_attribute`)
+				LEFT JOIN `'._DB_PREFIX_.'attribute` a ON (a.`id_attribute` = pac.`id_attribute`)
+				LEFT JOIN `'._DB_PREFIX_.'attribute_group` ag ON (ag.`id_attribute_group` = a.`id_attribute_group`)
+				LEFT JOIN `'._DB_PREFIX_.'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute`)
+				LEFT JOIN `'._DB_PREFIX_.'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group`)
+				LEFT JOIN `'._DB_PREFIX_.'layered_indexable_attribute_lang_value` lialv ON (a.`id_attribute` = lialv.`id_attribute` AND lialv.`id_lang` = '.(int)$id_lang.')
+				LEFT JOIN `'._DB_PREFIX_.'layered_indexable_attribute_group_lang_value` liaglv ON (ag.`id_attribute_group` = liaglv.`id_attribute_group` AND liaglv.`id_lang` = '.(int)$id_lang.')
+				'.Shop::addSqlAssociation('attribute', 'a').'
+				WHERE pa.`id_product` = '.(int)$this->id.'
+					AND al.`id_lang` = '.(int)$id_lang.'
+					AND agl.`id_lang` = '.(int)$id_lang.'
+				GROUP BY id_attribute_group, id_product_attribute
+				ORDER BY ag.`position` ASC, a.`position` ASC, agl.`name` ASC';
 		else
 			$sql = 'SELECT ag.`id_attribute_group`, ag.`is_color_group`, agl.`name` AS group_name, agl.`public_name` AS public_group_name,
-						a.`id_attribute`, al.`name` AS attribute_name, a.`color` AS attribute_color, product_attribute_shop.`id_product_attribute`,
-						IFNULL(stock.quantity, 0) AS quantity, product_attribute_shop.`price`, product_attribute_shop.`ecotax`, product_attribute_shop.`weight`,
-						product_attribute_shop.`default_on`, pa.`reference`, product_attribute_shop.`unit_price_impact`,
+					a.`id_attribute`, al.`name` AS attribute_name, a.`color` AS attribute_color, product_attribute_shop.`id_product_attribute`,
+					IFNULL(stock.quantity, 0) AS quantity, product_attribute_shop.`price`, product_attribute_shop.`ecotax`, product_attribute_shop.`weight`,
+					product_attribute_shop.`default_on`, pa.`reference`, product_attribute_shop.`unit_price_impact`,
 					product_attribute_shop.`minimal_quantity`, product_attribute_shop.`available_date`, ag.`group_type`
 				FROM `'._DB_PREFIX_.'product_attribute` pa
 				'.Shop::addSqlAssociation('product_attribute', 'pa').'

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -436,16 +436,16 @@ class ProductControllerCore extends FrontController
 				}
 				if (!isset($groups[$row['id_attribute_group']])) {
 					if (Module::isInstalled('blocklayered') && Module::isEnabled('blocklayered'))
-					$groups[$row['id_attribute_group']] = array(
-						'group_name' => $row['group_name'],
+						$groups[$row['id_attribute_group']] = array(
+							'group_name' => $row['group_name'],
 							'group_url_name' => $row['group_url_name'],
 							'group_meta_title' => $row['group_meta_title'],
-						'name' => $row['public_group_name'],
+							'name' => $row['public_group_name'],
 							'url_name' => $row['url_name'],
 							'meta_title' => $row['meta_title'],
-						'group_type' => $row['group_type'],
-						'default' => -1,
-					);
+							'group_type' => $row['group_type'],
+							'default' => -1,
+						);
 					else
 						$groups[$row['id_attribute_group']] = array(
 							'group_name' => $row['group_name'],

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -434,13 +434,26 @@ class ProductControllerCore extends FrontController
 						$colors[$row['id_attribute']]['attributes_quantity'] = 0;
 					$colors[$row['id_attribute']]['attributes_quantity'] += (int)$row['quantity'];
 				}
-				if (!isset($groups[$row['id_attribute_group']]))
+				if (!isset($groups[$row['id_attribute_group']])) {
+					if (Module::isInstalled('blocklayered') && Module::isEnabled('blocklayered'))
 					$groups[$row['id_attribute_group']] = array(
 						'group_name' => $row['group_name'],
+							'group_url_name' => $row['group_url_name'],
+							'group_meta_title' => $row['group_meta_title'],
 						'name' => $row['public_group_name'],
+							'url_name' => $row['url_name'],
+							'meta_title' => $row['meta_title'],
 						'group_type' => $row['group_type'],
 						'default' => -1,
 					);
+					else
+						$groups[$row['id_attribute_group']] = array(
+							'group_name' => $row['group_name'],
+							'name' => $row['public_group_name'],
+							'group_type' => $row['group_type'],
+							'default' => -1,
+						);
+				}
 
 				$groups[$row['id_attribute_group']]['attributes'][$row['id_attribute']] = $row['attribute_name'];
 				if ($row['default_on'] && $groups[$row['id_attribute_group']]['default'] == -1)


### PR DESCRIPTION
The module blocklayered introduces new fields for attributes. While partially there has been support for them, not all these fields were everywhere available, though fields especially like the group meta title might be wanted for modifications in products.tpl. This improvement enhances the existing data structure to make all fields available, when blocklayered is used.
