### PR TITLE
[*] CORE: Fix undefined PHPDoc types of method and local variables + remove static tag

### DIFF
--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -364,10 +364,12 @@ class AddressFormatCore extends ObjectModel
 
 	/**
 	 * Generates the full address text
-	 * @param address is an instanciate object of Address class
-	 * @param patternrules is a defined rules array to avoid some pattern
-	 * @param newLine is a string containing the newLine format
-	 * @param separator is a string containing the separator format
+	 *
+	 * @param Address $address
+	 * @param array $patternRules A defined rules array to avoid some pattern
+	 * @param string $newLine A string containing the newLine format
+	 * @param string $separator A string containing the separator format
+	 * @param array $style
 	 * @return string
 	 */
 	public static function generateAddress(Address $address, $patternRules = array(), $newLine = "\r\n", $separator = ' ', $style = array())
@@ -470,7 +472,9 @@ class AddressFormatCore extends ObjectModel
 	/**
 	 * Returns address format fields in array by country
 	 *
-	 * @param Integer PS_COUNTRY.id if null using default country
+	 * @param int $id_country If null using PS_COUNTRY_DEFAULT
+	 * @param bool $split_all
+	 * @param bool $cleaned
 	 * @return Array String field address format
 	 */
 	public static function getOrderedAddressFields($id_country = 0, $split_all = false, $cleaned = false)
@@ -517,7 +521,7 @@ class AddressFormatCore extends ObjectModel
 	/**
 	 * Returns address format by country if not defined using default country
 	 *
-	 * @param Integer PS_COUNTRY.id
+	 * @param int $id_country
 	 * @return String field address format
 	 */
 	public static function getAddressCountryFormat($id_country = 0)
@@ -534,7 +538,7 @@ class AddressFormatCore extends ObjectModel
 	/**
 	 * Returns address format by country
 	 *
-	 * @param Integer PS_COUNTRY.id
+	 * @param int $id_country
 	 * @return String field address format
 	 */
 	public function getFormat($id_country)

--- a/classes/AdminTab.php
+++ b/classes/AdminTab.php
@@ -573,10 +573,12 @@ abstract class AdminTabCore
 		/* Delete object image */
 		if (isset($_GET['deleteImage']))
 		{
-			/** @var ObjectModel $object */
 			if (Validate::isLoadedObject($object = $this->loadObject()))
+			{
+				/** @var ObjectModel $object */
 				if (($object->deleteImage()))
 					Tools::redirectAdmin(self::$currentIndex.'&add'.$this->table.'&'.$this->identifier.'='.Tools::getValue($this->identifier).'&conf=7&token='.$token);
+			}
 			$this->_errors[] = Tools::displayError('An error occurred during image deletion (cannot load object).');
 		}
 
@@ -585,9 +587,9 @@ abstract class AdminTabCore
 		{
 			if ($this->tabAccess['delete'] === '1')
 			{
-				/** @var ObjectModel $object */
 				if (Validate::isLoadedObject($object = $this->loadObject()) && isset($this->fieldImageSettings))
 				{
+					/** @var ObjectModel $object */
 					// check if request at least one object with noZeroObject
 					if (isset($object->noZeroObject) && count(call_user_func(array($this->className, $object->noZeroObject))) <= 1)
 						$this->_errors[] = Tools::displayError('You need at least one object.').' <b>'.$this->table.'</b><br />'.Tools::displayError('You cannot delete all of the items.');
@@ -623,9 +625,9 @@ abstract class AdminTabCore
 		{
 			if ($this->tabAccess['edit'] === '1')
 			{
-				/** @var ObjectModel $object */
 				if (Validate::isLoadedObject($object = $this->loadObject()))
 				{
+					/** @var ObjectModel $object */
 					if ($object->toggleStatus())
 						Tools::redirectAdmin(self::$currentIndex.'&conf=5'.((($id_category = (int)(Tools::getValue('id_category'))) && Tools::getValue('id_product')) ? '&id_category='.$id_category : '').'&token='.$token);
 					else

--- a/classes/AdminTab.php
+++ b/classes/AdminTab.php
@@ -231,13 +231,13 @@ abstract class AdminTabCore
 
 
 	/**
-	 * use translations files to replace english expression.
+	 * Uses translations files to find a translation for a given string (string should be in english).
 	 *
-	 * @param mixed $string term or expression in english
+	 * @param string $string term or expression in english
 	 * @param string $class
-	 * @param boolan $addslashes if set to true, the return value will pass through addslashes(). Otherwise, stripslashes().
-	 * @param boolean $htmlentities if set to true(default), the return value will pass through htmlentities($string, ENT_QUOTES, 'utf-8')
-	 * @return string the translation if available, or the english default text.
+	 * @param bool $addslashes if set to true, the return value will pass through addslashes(). Otherwise, stripslashes().
+	 * @param bool $htmlentities if set to true(default), the return value will pass through htmlentities($string, ENT_QUOTES, 'utf-8')
+	 * @return string The translation if available, or the english default text.
 	 */
 	protected function l($string, $class = 'AdminTab', $addslashes = false, $htmlentities = true)
 	{

--- a/classes/AdminTab.php
+++ b/classes/AdminTab.php
@@ -333,6 +333,7 @@ abstract class AdminTabCore
 			<th>'.$this->l('Field Name').'</th>
 		</tr>';
 
+		/** @var ObjectModel $object */
 		$object = new $this->className();
 		$res = $object->getFieldsRequiredDatabase();
 
@@ -373,6 +374,8 @@ abstract class AdminTabCore
 				include_once('tabs/'.$classname.'.php');
 			if (!isset($this->_includeObj[$key]))
 				$this->_includeObj[$key] = new $classname;
+
+			/** @var AdminTab $adminTab */
 			$adminTab = $this->_includeObj[$key];
 			$adminTab->token = $this->token;
 
@@ -570,6 +573,7 @@ abstract class AdminTabCore
 		/* Delete object image */
 		if (isset($_GET['deleteImage']))
 		{
+			/** @var ObjectModel $object */
 			if (Validate::isLoadedObject($object = $this->loadObject()))
 				if (($object->deleteImage()))
 					Tools::redirectAdmin(self::$currentIndex.'&add'.$this->table.'&'.$this->identifier.'='.Tools::getValue($this->identifier).'&conf=7&token='.$token);
@@ -581,6 +585,7 @@ abstract class AdminTabCore
 		{
 			if ($this->tabAccess['delete'] === '1')
 			{
+				/** @var ObjectModel $object */
 				if (Validate::isLoadedObject($object = $this->loadObject()) && isset($this->fieldImageSettings))
 				{
 					// check if request at least one object with noZeroObject
@@ -618,6 +623,7 @@ abstract class AdminTabCore
 		{
 			if ($this->tabAccess['edit'] === '1')
 			{
+				/** @var ObjectModel $object */
 				if (Validate::isLoadedObject($object = $this->loadObject()))
 				{
 					if ($object->toggleStatus())
@@ -634,6 +640,7 @@ abstract class AdminTabCore
 		/* Move an object */
 		elseif (isset($_GET['position']))
 		{
+			/** @var ObjectModel $object */
 			if ($this->tabAccess['edit'] !== '1')
 				$this->_errors[] = Tools::displayError('You do not have permission to edit here.');
 			elseif (!Validate::isLoadedObject($object = $this->loadObject()))
@@ -650,6 +657,7 @@ abstract class AdminTabCore
 			{
 				if (isset($_POST[$this->table.'Box']))
 				{
+					/** @var ObjectModel $object */
 					$object = new $this->className();
 					if (isset($object->noZeroObject) &&
 						// Check if all object will be deleted
@@ -662,6 +670,7 @@ abstract class AdminTabCore
 						{
 							foreach (Tools::getValue($this->table.'Box') as $id)
 							{
+								/** @var ObjectModel $toDelete */
 								$toDelete = new $this->className($id);
 								$toDelete->deleted = 1;
 								$result = $result && $toDelete->update();
@@ -698,12 +707,14 @@ abstract class AdminTabCore
 				{
 					if ($this->tabAccess['edit'] === '1' || ($this->table == 'employee' && $this->context->employee->id == Tools::getValue('id_employee') && Tools::isSubmit('updateemployee')))
 					{
+						/** @var ObjectModel $object */
 						$object = new $this->className($id);
 						if (Validate::isLoadedObject($object))
 						{
 							/* Specific to objects which must not be deleted */
 							if ($this->deleted && $this->beforeDelete($object))
 							{
+								/** @var ObjectModel $objectNew */
 								// Create new one with old objet values
 								$objectNew = new $this->className($object->id);
 								$objectNew->id = null;
@@ -765,6 +776,7 @@ abstract class AdminTabCore
 				{
 					if ($this->tabAccess['add'] === '1')
 					{
+						/** @var ObjectModel $object */
 						$object = new $this->className();
 						$this->copyFromPost($object, $this->table);
 						if (!$object->add())
@@ -897,6 +909,7 @@ abstract class AdminTabCore
 			if (!is_array($fields = Tools::getValue('fieldsBox')))
 				$fields = array();
 
+			/** @var ObjectModel $object */
 			$object = new $this->className();
 			if (!$object->addFieldsRequiredDatabase($fields))
 				$this->_errors[] = Tools::displayError('Error in updating required fields');

--- a/classes/Attachment.php
+++ b/classes/Attachment.php
@@ -111,9 +111,8 @@ class AttachmentCore extends ObjectModel
 	}
 
 	/**
-	 * deassociate $id_product from the current object
+	 * Unassociate $id_product from the current object
 	 *
-	 * @static
 	 * @param $id_product int
 	 * @return bool
 	 */
@@ -147,10 +146,9 @@ class AttachmentCore extends ObjectModel
 	}
 
 	/**
-	 * associate an array of id_attachment $array to the product $id_product
+	 * Associate an array of id_attachment $array to the product $id_product
 	 * and remove eventual previous association
 	 *
-	 * @static
 	 * @param $id_product
 	 * @param $array
 	 * @return bool

--- a/classes/CSV.php
+++ b/classes/CSV.php
@@ -37,7 +37,7 @@ class CSVCore
 
 	/**
 	* Loads objects, filename and optionnaly a delimiter.
-	* @param Collection $collection collection of objects / array (of non-objects)
+	* @param array|Iterator $collection Collection of objects / arrays (of non-objects)
 	* @param string $filename : used later to save the file
 	* @param string $delimiter Optional : delimiter used
 	*/

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -230,8 +230,8 @@ class CarrierCore extends ObjectModel
 	/**
 	 * Get delivery prices for a given order
 	 *
-	 * @param floatval $totalWeight Order total weight
-	 * @param integer $id_zone Zone id (for customer delivery address)
+	 * @param float $total_weight Total order weight
+	 * @param int $id_zone Zone ID (for customer delivery address)
 	 * @return float Delivery price
 	 */
 	public function getDeliveryPriceByWeight($total_weight, $id_zone)
@@ -310,8 +310,9 @@ class CarrierCore extends ObjectModel
 	/**
 	 * Get delivery prices for a given order
 	 *
-	 * @param floatval $orderTotal Order total to pay
-	 * @param integer $id_zone Zone id (for customer delivery address)
+	 * @param float $order_total Order total to pay
+	 * @param int $id_zone Zone id (for customer delivery address)
+	 * @param int|null $id_currency
 	 * @return float Delivery price
 	 */
 	public function getDeliveryPriceByPrice($order_total, $id_zone, $id_currency = null)
@@ -349,10 +350,10 @@ class CarrierCore extends ObjectModel
 	/**
 	 * Check delivery prices for a given order
 	 *
-	 * @param id_carrier
-	 * @param floatval $orderTotal Order total to pay
-	 * @param integer $id_zone Zone id (for customer delivery address)
-	 * @param integer $id_currency
+	 * @param int $id_carrier
+	 * @param float $order_total Order total to pay
+	 * @param int $id_zone Zone id (for customer delivery address)
+	 * @param int|null $id_currency
 	 * @return float Delivery price
 	 */
 	public static function checkDeliveryPriceByPrice($id_carrier, $order_total, $id_zone, $id_currency = null)

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2711,6 +2711,7 @@ class CartCore extends ObjectModel
 				if (!isset(self::$_carriers[$row['id_carrier']]))
 					self::$_carriers[$row['id_carrier']] = new Carrier((int)$row['id_carrier']);
 
+				/** @var Carrier $carrier */
 				$carrier = self::$_carriers[$row['id_carrier']];
 
 				$shipping_method = $carrier->getShippingMethod();
@@ -2866,6 +2867,8 @@ class CartCore extends ObjectModel
 		if ($carrier->shipping_external)
 		{
 			$module_name = $carrier->external_module_name;
+
+			/** @var CarrierModule $module */
 			$module = Module::getInstanceByName($module_name);
 
 			if (Validate::isLoadedObject($module))
@@ -2951,6 +2954,8 @@ class CartCore extends ObjectModel
 
 	/**
 	 * @deprecated 1.5.0
+	 * @param CartRule $obj
+	 * @return bool|string
 	 */
 	public function checkDiscountValidity($obj, $discounts, $order_total, $products, $check_cart_discount = false)
 	{

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2534,9 +2534,9 @@ class CartCore extends ObjectModel
 	/**
 	* Return shipping total for the cart
 	*
-	* @param array $delivery_option Array of the delivery option for each address
-	* @param booleal $use_tax
-	* @param Country $default_country
+	* @param array|null $delivery_option Array of the delivery option for each address
+	* @param bool $use_tax
+	* @param Country|null $default_country
 	* @return float Shipping total
 	*/
 	public function getTotalShippingCost($delivery_option = null, $use_tax = true, Country $default_country = null)
@@ -2562,14 +2562,15 @@ class CartCore extends ObjectModel
 	}
 
 	/**
-	* Return shipping total of a specific carriers for the cart
-	*
-	* @param int $id_carrier
-	* @param array $delivery_option Array of the delivery option for each address
-	* @param booleal $useTax
-	* @param Country $default_country
-	* @return float Shipping total
-	*/
+	 * Return shipping total of a specific carriers for the cart
+	 *
+	 * @param int $id_carrier
+	 * @param array $delivery_option Array of the delivery option for each address
+	 * @param bool $useTax
+	 * @param Country|null $default_country
+	 * @param array|null $delivery_option
+	 * @return float Shipping total
+	 */
 	public function getCarrierCost($id_carrier, $useTax = true, Country $default_country = null, $delivery_option = null)
 	{
 		if (is_null($delivery_option))
@@ -2607,11 +2608,12 @@ class CartCore extends ObjectModel
 	/**
 	 * Return package shipping cost
 	 *
-	 * @param integer $id_carrier Carrier ID (default : current carrier)
-	 * @param booleal $use_tax
-	 * @param Country $default_country
-	 * @param Array $product_list
-	 * @param array $product_list List of product concerned by the shipping. If null, all the product of the cart are used to calculate the shipping cost
+	 * @param int          $id_carrier      Carrier ID (default : current carrier)
+	 * @param bool         $use_tax
+	 * @param Country|null $default_country
+	 * @param array|null   $product_list    List of product concerned by the shipping.
+	 *                                      If null, all the product of the cart are used to calculate the shipping cost
+	 * @param int|null $id_zone
 	 *
 	 * @return float Shipping total
 	 */

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -163,7 +163,6 @@ class CartRuleCore extends ObjectModel
 	/**
 	 * Copy conditions from one cart rule to an other
 	 *
-	 * @static
 	 * @param int $id_cart_rule_source
 	 * @param int $id_cart_rule_destination
 	 */
@@ -228,7 +227,6 @@ class CartRuleCore extends ObjectModel
 	/**
 	 * Retrieves the id associated to the given code
 	 *
-	 * @static
 	 * @param string $code
 	 * @return int|bool
 	 */
@@ -240,7 +238,6 @@ class CartRuleCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @param           $id_lang
 	 * @param           $id_customer
 	 * @param bool      $active
@@ -385,7 +382,6 @@ class CartRuleCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @param $name
 	 * @return bool
 	 */
@@ -401,7 +397,6 @@ class CartRuleCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @param $id_customer
 	 * @return bool
 	 */
@@ -1210,7 +1205,6 @@ class CartRuleCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @param Context|null $context
 	 * @return mixed
 	 */
@@ -1280,7 +1274,6 @@ class CartRuleCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @return bool
 	 */
 	public static function isFeatureActive()
@@ -1331,7 +1324,6 @@ class CartRuleCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @param $name
 	 * @param $id_lang
 	 * @return array

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1268,8 +1268,11 @@ class CartRuleCore extends ObjectModel
 			$cart_rules = ObjectModel::hydrateCollection('CartRule', $result);
 			if ($cart_rules)
 				foreach ($cart_rules as $cart_rule)
+				{
+					/** @var CartRule $cart_rule */
 					if ($cart_rule->checkValidity($context, false, false))
 						$context->cart->addCartRule($cart_rule->id);
+				}
 		}
 	}
 

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1569,7 +1569,6 @@ class CategoryCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @param null $id_lang
 	 * @return Category
 	 */

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -322,6 +322,7 @@ class CategoryCore extends ObjectModel
 		$all_cat[] = $this;
 		foreach ($all_cat as $cat)
 		{
+			/** @var Category $cat */
 			$cat->deleteLite();
 			if (!$this->hasMultishopEntries())
 			{
@@ -1691,7 +1692,10 @@ class CategoryCore extends ObjectModel
 		$return = Db::getInstance()->execute($sql);
 		// we have to update position for every new entries
 		foreach ($tab_categories as $category)
+		{
+			/** @var Category $category */
 			$category->addPosition(Category::getLastPosition($category->id_parent, $id_shop), $id_shop);
+		}
 
 		return $return;
 	}

--- a/classes/Chart.php
+++ b/classes/Chart.php
@@ -107,9 +107,12 @@ class ChartCore
 			$options = 'xaxis:{mode:"time",timeformat:\''.addslashes($this->format).'\',min:'.$this->from.'000,max:'.$this->to.'000}';
 			if ($this->granularity == 'd')
 				foreach ($this->curves as $curve)
+				{
+					/** @var Curve $curve */
 					for ($i = $this->from; $i <= $this->to; $i = strtotime('+1 day', $i))
 						if (!$curve->getPoint($i))
 							$curve->setPoint($i, 0);
+				}
 		}
 
 		$jsCurves = array();

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -156,10 +156,11 @@ class CookieCore
 	}
 
 	/**
-	 * Magic method wich add data into _content array
+	 * Magic method which adds data into _content array
 	 *
-	 * @param string $key key desired
-	 * @param $value value corresponding to the key
+	 * @param string $key Access key for the value
+	 * @param mixed $value Value corresponding to the key
+	 * @throws Exception
 	 */
 	public function __set($key, $value)
 	{

--- a/classes/Country.php
+++ b/classes/Country.php
@@ -231,9 +231,9 @@ class CountryCore extends ObjectModel
 	/**
 	 * Get a country id with its name
 	 *
-	 * @param integer $id_lang Language ID
+	 * @param int $id_lang Language ID
 	 * @param string $country Country Name
-	 * @return intval Country id
+	 * @return int Country ID
 	 */
 	public static function getIdByName($id_lang = null, $country)
 	{

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -410,8 +410,11 @@ class CurrencyCore extends ObjectModel
 
 		$currencies = Currency::getCurrencies(true, false, true);
 		foreach ($currencies as $currency)
+		{
+			/** @var Currency $currency */
 			if ($currency->id != $default_currency->id)
 				$currency->refreshCurrency($feed->list, $isoCodeSource, $default_currency);
+		}
 	}
 
 	/**

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -290,7 +290,6 @@ class CurrencyCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @param $iso_code
 	 * @param int $id_shop
 	 * @return int
@@ -310,8 +309,7 @@ class CurrencyCore extends ObjectModel
 	}
 
 	/**
-	 * @static
-	 * @param $iso_code
+	 * @param $iso_code_num
 	 * @param int $id_shop
 	 * @return int
 	 */
@@ -324,7 +322,6 @@ class CurrencyCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @param int $id_shop
 	 * @return DbQuery
 	 */

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -347,9 +347,9 @@ class CurrencyCore extends ObjectModel
 	 * Refresh the currency exchange rate
 	 * The XML file define exchange rate for each from a default currency ($isoCodeSource).
 	 *
-	 * @param $data XML content which contains all the exchange rates
-	 * @param $isoCodeSource The default currency used in the XML file
-	 * @param $defaultCurrency The default currency object
+	 * @param SimpleXMLElement $data XML content which contains all the exchange rates
+	 * @param string $isoCodeSource The default currency used in the XML file
+	 * @param Currency $defaultCurrency The default currency object
 	 */
 	public function refreshCurrency($data, $isoCodeSource, $defaultCurrency)
 	{

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -336,7 +336,6 @@ class CustomerCore extends ObjectModel
 	/**
 	 * Retrieve customers by email address
 	 *
-	 * @static
 	 * @param $email
 	 * @return array
 	 */

--- a/classes/Discount.php
+++ b/classes/Discount.php
@@ -199,6 +199,8 @@ class DiscountCore extends CartRule
 
 	/**
 	 * @deprecated 1.5.0.1
+	 * @param Order $order
+	 * @return Discount
 	 */
 	public static function createOrderDiscount($order, $productList, $qtyList, $name, $shipping_cost = false, $id_category = 0, $subcategory = 0)
 	{

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -848,7 +848,7 @@ class DispatcherCore
 	/**
 	 * Get list of available controllers from the specified dir
 	 *
-	 * @param string dir directory to scan (recursively)
+	 * @param string $dir Directory to scan (recursively)
 	 * @return array
 	 */
 	public static function getControllersInDirectory($dir)

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -230,8 +230,9 @@ class EmployeeCore extends ObjectModel
 
 	/**
 	 * Return list of employees
-	 * @param boolean $active_only Filter employee by active status
-	 * @return Employees array or false
+	 *
+	 * @param bool $active_only Filter employee by active status
+	 * @return array|false Employees or false
 	 */
 	public static function getEmployees($active_only = true)
 	{

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -58,7 +58,6 @@ class FeatureCore extends ObjectModel
 	 * @param integer $id_lang Language id
 	 * @param integer $id_feature Feature id
 	 * @return array Array with feature's data
-	 * @static
 	 */
 	public static function getFeature($id_lang, $id_feature)
 	{
@@ -76,7 +75,6 @@ class FeatureCore extends ObjectModel
 	 *
 	 * @param integer $id_lang Language id
 	 * @return array Multiple arrays with feature's data
-	 * @static
 	 */
 	public static function getFeatures($id_lang, $with_shop = true)
 	{
@@ -181,7 +179,6 @@ class FeatureCore extends ObjectModel
 	*
 	* @param integer $id_lang Language id
 	* @return int Number of feature
-	* @static
 	*/
 	public static function nbFeatures($id_lang)
 	{

--- a/classes/FeatureValue.php
+++ b/classes/FeatureValue.php
@@ -64,7 +64,6 @@ class FeatureValueCore extends ObjectModel
 	 *
 	 * @param boolean $id_feature Feature id
 	 * @return array Array with feature's values
-	 * @static
 	 */
 	public static function getFeatureValues($id_feature)
 	{
@@ -81,7 +80,6 @@ class FeatureValueCore extends ObjectModel
 	 * @param integer $id_lang Language id
 	 * @param boolean $id_feature Feature id
 	 * @return array Array with feature's values
-	 * @static
 	 */
 	public static function getFeatureValuesWithLang($id_lang, $id_feature, $custom = false)
 	{
@@ -101,7 +99,6 @@ class FeatureValueCore extends ObjectModel
 	 *
 	 * @param boolean $id_feature_value Feature value id
 	 * @return array Array with value's languages
-	 * @static
 	 */
 	public static function getFeatureValueLang($id_feature_value)
 	{
@@ -119,7 +116,6 @@ class FeatureValueCore extends ObjectModel
 	 * @param array $lang Array with all language
 	 * @param integer $id_lang Language id
 	 * @return string String value name selected
-	 * @static
 	 */
 	public static function selectLang($lang, $id_lang)
 	{

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -227,8 +227,9 @@ class GroupCore extends ObjectModel
 
 	/**
 	 * Truncate all modules restrictions for the group
-	 * @param integer id_group
-	 * @return boolean result
+	 *
+	 * @param int $id_group
+	 * @return bool
 	 */
 	public static function truncateModulesRestrictions($id_group)
 	{
@@ -239,8 +240,9 @@ class GroupCore extends ObjectModel
 
 	/**
 	 * Truncate all restrictions by module
-	 * @param integer id_module
-	 * @return boolean result
+	 *
+	 * @param int $id_module
+	 * @return bool
 	 */
 	public static function truncateRestrictionsByModule($id_module)
 	{
@@ -274,10 +276,12 @@ class GroupCore extends ObjectModel
 	}
 
 	/**
-	 * Add restrictions for a new module
+	 * Add restrictions for a new module.
 	 * We authorize every groups to the new module
-	 * @param integer id_module
+	 *
+	 * @param int $id_module
 	 * @param array $shops
+	 * @return bool
 	 */
 	public static function addRestrictionsForModule($id_module, $shops = array(1))
 	{

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -299,7 +299,7 @@ class GroupCore extends ObjectModel
 	/**
 	 * Return current group object
 	 * Use context
-	 * @static
+	 *
 	 * @return Group Group object
 	 */
 	public static function getCurrent()

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -667,7 +667,7 @@ class ImageCore extends ObjectModel
 	 * If max_execution_time is provided, stops before timeout and returns string "timeout".
 	 * If any image cannot be moved, stops and returns "false"
 	 *
-	 * @param int max_execution_time
+	 * @param int $max_execution_time
 	 * @return mixed success or timeout
 	 */
 	public static function moveToNewFileSystem($max_execution_time = 0)

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -302,9 +302,9 @@ class ImageManagerCore
 	/**
 	 * Check if image file extension is correct
 	 *
-	 * @static
-	 * @param $filename real filename
-	 * @return bool true if it's correct
+	 * @param string $filename Real filename
+	 * @param array|null $authorized_extensions
+	 * @return bool True if it's correct
 	 */
 	public static function isCorrectImageFileExt($filename, $authorized_extensions = null)
 	{

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -92,7 +92,6 @@ class ImageManagerCore
 	/**
 	 * Check if memory limit is too long or not
 	 *
-	 * @static
 	 * @param $image
 	 * @return bool
 	 */

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -90,11 +90,17 @@ class LocalizationPackCore
 		return $res;
 	}
 
+	/**
+	 * @param SimpleXMLElement $xml
+	 * @return bool
+	 * @throws PrestaShopException
+	 */
 	protected function _installStates($xml)
 	{
 		if (isset($xml->states->state))
 			foreach ($xml->states->state as $data)
 			{
+				/** @var SimpleXMLElement $data */
 				$attributes = $data->attributes();
 				$id_country = ($attributes['country']) ? (int)Country::getByIso(strval($attributes['country'])) : false;
 				$id_state = ($id_country) ? State::getIdByIso($attributes['iso_code'], $id_country) : State::getIdByName($attributes['name']);
@@ -158,6 +164,11 @@ class LocalizationPackCore
 		return true;
 	}
 
+	/**
+	 * @param SimpleXMLElement $xml
+	 * @return bool
+	 * @throws PrestaShopException
+	 */
 	protected function _installTaxes($xml)
 	{
 		if (isset($xml->taxes->tax))
@@ -165,6 +176,7 @@ class LocalizationPackCore
 			$assoc_taxes = array();
 			foreach ($xml->taxes->tax as $taxData)
 			{
+				/** @var SimpleXMLElement $taxData */
 				$attributes = $taxData->attributes();
 				if (($id_tax = Tax::getTaxIdByName($attributes['name'])))
 				{
@@ -193,6 +205,7 @@ class LocalizationPackCore
 
 			foreach ($xml->taxes->taxRulesGroup as $group)
 			{
+				/** @var SimpleXMLElement $group */
 				$group_attributes = $group->attributes();
 				if (!Validate::isGenericName($group_attributes['name']))
 					continue;
@@ -212,6 +225,7 @@ class LocalizationPackCore
 
 				foreach ($group->taxRule as $rule)
 				{
+					/** @var SimpleXMLElement $rule */
 					$rule_attributes = $rule->attributes();
 
 					// Validation
@@ -257,12 +271,19 @@ class LocalizationPackCore
 		return true;
 	}
 
+	/**
+	 * @param SimpleXMLElement $xml
+	 * @param bool $install_mode
+	 * @return bool
+	 * @throws PrestaShopException
+	 */
 	protected function _installCurrencies($xml, $install_mode = false)
 	{
 		if (isset($xml->currencies->currency))
 		{
 			foreach ($xml->currencies->currency as $data)
 			{
+				/** @var SimpleXMLElement $data */
 				$attributes = $data->attributes();
 				if (Currency::exists($attributes['iso_code'], (int)$attributes['iso_code_num']))
 					continue;
@@ -303,12 +324,18 @@ class LocalizationPackCore
 		return true;
 	}
 
+	/**
+	 * @param SimpleXMLElement $xml
+	 * @param bool $install_mode
+	 * @return bool
+	 */
 	protected function _installLanguages($xml, $install_mode = false)
 	{
 		$attributes = array();
 		if (isset($xml->languages->language))
 			foreach ($xml->languages->language as $data)
 			{
+				/** @var SimpleXMLElement $data */
 				$attributes = $data->attributes();
 				// if we are not in an installation context or if the pack is not available in the local directory
 				if (Language::getIdByIso($attributes['iso_code']) && !$install_mode)
@@ -326,12 +353,17 @@ class LocalizationPackCore
 		return !count($this->_errors);
 	}
 
+	/**
+	 * @param SimpleXMLElement $xml
+	 * @return bool
+	 */
 	protected function _installUnits($xml)
 	{
 		$varNames = array('weight' => 'PS_WEIGHT_UNIT', 'volume' => 'PS_VOLUME_UNIT', 'short_distance' => 'PS_DIMENSION_UNIT', 'base_distance' => 'PS_BASE_DISTANCE_UNIT', 'long_distance' => 'PS_DISTANCE_UNIT');
 		if (isset($xml->units->unit))
 			foreach ($xml->units->unit as $data)
 			{
+				/** @var SimpleXMLElement $data */
 				$attributes = $data->attributes();
 				if (!isset($varNames[strval($attributes['type'])]))
 				{
@@ -348,15 +380,19 @@ class LocalizationPackCore
 	}
 
 	/**
-	* Install/Uninstall a module from a localization file
-	* <modules>
-	*	<module name="module_name" [install="0|1"] />
-	*/
+	 * Install/Uninstall a module from a localization file
+	 * <modules>
+	 *	<module name="module_name" [install="0|1"] />
+	 *
+	 * @param SimpleXMLElement $xml
+	 * @return bool
+	 */
 	protected function installModules($xml)
 	{
 		if (isset($xml->modules))
 			foreach ($xml->modules->module as $data)
 			{
+				/** @var SimpleXMLElement $data */
 				$attributes = $data->attributes();
 				$name = (string)$attributes['name'];
 				if (isset($name) && $module = Module::getInstanceByName($name))
@@ -384,15 +420,19 @@ class LocalizationPackCore
 	}
 
 	/**
-	* Update a configuration variable from a localization file
-	* <configuration>
-	*	<configuration name="variable_name" value="variable_value" />
-	*/
+	 * Update a configuration variable from a localization file
+	 * <configuration>
+	 *	<configuration name="variable_name" value="variable_value" />
+	 *
+	 * @param SimpleXMLElement $xml
+	 * @return bool
+	 */
 	protected function installConfiguration($xml)
 	{
 		if (isset($xml->configurations))
 			foreach ($xml->configurations->configuration as $data)
 			{
+				/** @var SimpleXMLElement $data */
 				$attributes = $data->attributes();
 				$name = (string)$attributes['name'];
 
@@ -404,11 +444,19 @@ class LocalizationPackCore
 		return true;
 	}
 
+	/**
+	 * @param SimpleXMLElement $xml
+	 * @return bool
+	 */
 	protected function _installGroups($xml)
 	{
 		return $this->updateDefaultGroupDisplayMethod($xml);
 	}
 
+	/**
+	 * @param SimpleXMLElement $xml
+	 * @return bool
+	 */
 	protected function updateDefaultGroupDisplayMethod($xml)
 	{
 		if (isset($xml->group_default))

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -351,6 +351,7 @@ class MailCore extends ObjectModel
 				$mail->id_lang = (int)$id_lang;
 				foreach (array_merge($to_list->getTo(), $to_list->getCc(), $to_list->getBcc()) as $recipient)
 				{
+					/** @var Swift_Address $recipient */
 					$mail->id = null;
 					$mail->recipient = substr($recipient->getAddress(), 0, 126);
 					$mail->add();

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -42,10 +42,10 @@ class MailCore extends ObjectModel
 	/** @var string Subject */
 	public $subject;
 
-	/** @var unsigned integer Language ID */
+	/** @var int Language ID */
 	public $id_lang;
 
-	/** @var timestamp Date */
+	/** @var int Timestamp */
 	public $date_add;
 
 	/**

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -731,6 +731,8 @@ class MediaCore
 		$scripts = $dom->getElementsByTagName('script');
 		if (is_object($scripts) && $scripts->length)
 			foreach ($scripts as $script)
+			{
+				/** @var DOMElement $script */
 				if ($src = $script->getAttribute('src'))
 				{
 					if (substr($src, 0, 2) == '//')
@@ -766,6 +768,7 @@ class MediaCore
 					if (!in_array($src, Media::$inline_script_src))
 						Context::getContext()->controller->addJS($src);
 				}
+			}
 		$output = preg_replace_callback('/<script[^>]*>(.*)<\s*\/script\s*[^>]*>/Uims', array('Media', 'deferScript'), $output);
 		return $output;
 	}

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -447,7 +447,7 @@ class MediaCore
 	/**
 	* Combine Compress and Cache CSS (ccc) calls
 	*
-	* @param array css_files
+	* @param array $css_files
 	* @return array processed css_files
 	*/
 	public static function cccCss($css_files)
@@ -577,7 +577,7 @@ class MediaCore
 	/**
 	* Combine Compress and Cache (ccc) JS calls
 	*
-	* @param array js_files
+	* @param array $js_files
 	* @return array processed js_files
 	*/
 	public static function cccJS($js_files)

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -551,7 +551,7 @@ abstract class ObjectModelCore
 	/**
 	 * Duplicate current object to database
 	 *
-	 * @return new object
+	 * @return ObjectModel
 	 */
 	public function duplicateObject()
 	{

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -599,6 +599,7 @@ abstract class ObjectModelCore
 			}
 		}
 
+		/** @var ObjectModel $object_duplicated */
 		$object_duplicated = new $definition['classname']((int)$object_id);
 		$object_duplicated->duplicateShops((int)$this->id);
 
@@ -1568,6 +1569,7 @@ abstract class ObjectModelCore
 		// Hydrate objects
 		foreach ($rows as $row)
 		{
+			/** @var ObjectModel $obj */
 			$obj = new $class;
 			$obj->hydrate($row, $id_lang);
 			$collection[] = $obj;

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -33,7 +33,6 @@ class PackCore extends Product
 	/**
 	 * Is product a pack?
 	 *
-	 * @static
 	 * @param $id_product
 	 * @return bool
 	 */
@@ -56,7 +55,6 @@ class PackCore extends Product
 	/**
 	 * Is product in a pack?
 	 *
-	 * @static
 	 * @param $id_product
 	 * @return bool
 	 */

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -77,7 +77,11 @@ class PackCore extends Product
 		$price_display_method = !self::$_taxCalculationMethod;
 		$items = Pack::getItems($id_product, Configuration::get('PS_LANG_DEFAULT'));
 		foreach ($items as $item)
+		{
+			/** @var Product $item */
 			$sum += $item->getPrice($price_display_method) * $item->pack_quantity;
+		}
+
 		return $sum;
 	}
 
@@ -138,6 +142,7 @@ class PackCore extends Product
 
 		foreach ($items as $item)
 		{
+			/** @var Product $item */
 			// Updated for 1.5.0
 			if (Product::getQuantity($item->id) < $item->pack_quantity && !$item->isAvailableWhenOutOfStock((int)$item->out_of_stock))
 				return false;

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -256,6 +256,7 @@ abstract class PaymentModuleCore extends Module
 			foreach ($package_list as $id_address => $packageByAddress)
 				foreach ($packageByAddress as $id_package => $package)
 				{
+					/** @var Order $order */
 					$order = new Order();
 					$order->product_list = $package['product_list'];
 
@@ -414,6 +415,8 @@ abstract class PaymentModuleCore extends Module
 			CartRule::cleanCache();
 			foreach ($order_detail_list as $key => $order_detail)
 			{
+				/** @var OrderDetail $order_detail */
+
 				$order = $order_list[$key];
 				if (!$order_creation_failed && isset($order->id))
 				{

--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -35,7 +35,7 @@ class PrestaShopAutoload
 	const INDEX_FILE = 'cache/class_index.php';
 
 	/**
-	 * @var Autoload
+	 * @var PrestaShopAutoload
 	 */
 	protected static $instance;
 

--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -98,7 +98,7 @@ class PrestaShopBackupCore
 	 * Get the full path of the backup file
 	 *
 	 * @param string $filename prefix of the backup file (datetime will be the second part)
-	 * @return The full path of the backup file, or false if the backup file does not exists
+	 * @return string The full path of the backup file, or false if the backup file does not exists
 	 */
 	public static function getBackupPath($filename = '')
 	{

--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -135,9 +135,9 @@ class PrestaShopBackupCore
 		return @filemtime($backupdir.DIRECTORY_SEPARATOR.$filename);
 	}
 	/**
-	 * Get the URL used to retreive this backup file
+	 * Get the URL used to retrieve this backup file
 	 *
-	 * @return The url used to request the backup file
+	 * @return string The url used to request the backup file
 	 */
 	public function getBackupURL()
 	{

--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -77,7 +77,7 @@ class	PrestaShopLoggerCore extends ObjectModel
 	 * Send e-mail to the shop owner only if the minimal severity level has been reached
 	 *
 	 * @param Logger
-	 * @param unknown_type $log
+	 * @param PrestaShopLogger $log
 	 */
 	public static function sendByMail($log)
 	{

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5485,7 +5485,7 @@ class ProductCore extends ObjectModel
 
 	/**
 	 * This method allows to flush price cache
-	 * @static
+	 *
 	 * @since 1.5.0
 	 */
 	public static function flushPriceCache()

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5594,7 +5594,10 @@ class ProductCore extends ObjectModel
 		$collection_download = new PrestaShopCollection('ProductDownload');
 		$collection_download->where('id_product', '=', $this->id);
 		foreach ($collection_download as $product_download)
+		{
+			/** @var ProductDownload $product_download */
 			$result &= $product_download->delete($product_download->checkFile());
+		}
 		return $result;
 	}
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2725,7 +2725,7 @@ class ProductCore extends ObjectModel
 	 * @param int    $id_product_attribute Product attribute id
 	 * @param int    $id_country Country id
 	 * @param int    $id_state State id
-	 * @paran string $zipcode
+	 * @param string $zipcode
 	 * @param int    $id_currency Currency id
 	 * @param int    $id_group Group id
 	 * @param int    $quantity Quantity Required for Specific prices : quantity discount application

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -178,7 +178,7 @@ class ProductCore extends ObjectModel
 	/** @var string Object available order date */
 	public $available_date = '0000-00-00';
 
-	/** @var enum Product condition (new, used, refurbished) */
+	/** @var string Enumerated (enum) product condition (new, used, refurbished) */
 	public $condition;
 
 	/** @var boolean Show price of Product */
@@ -1663,10 +1663,10 @@ class ProductCore extends ObjectModel
 	}
 
 	/**
-	* Delete product attributes impacts
-	*
-	* @return Deletion result
-	*/
+	 * Delete product attributes impacts
+	 *
+	 * @return bool
+	 */
 	public function deleteAttributesImpacts()
 	{
 		return Db::getInstance()->execute(
@@ -2572,26 +2572,33 @@ class ProductCore extends ObjectModel
 	}
 
 	/**
-	* Get product price
-	*
-	* @param integer $id_product Product id
-	* @param boolean $usetax With taxes or not (optional)
-	* @param integer $id_product_attribute Product attribute id (optional).
-	* 	If set to false, do not apply the combination price impact. NULL does apply the default combination price impact.
-	* @param integer $decimals Number of decimals (optional)
-	* @param integer $divisor Useful when paying many time without fees (optional)
-	* @param boolean $only_reduc Returns only the reduction amount
-	* @param boolean $usereduc Set if the returned amount will include reduction
-	* @param integer $quantity Required for quantity discount application (default value: 1)
-	* @param boolean $forceAssociatedTax DEPRECATED - NOT USED Force to apply the associated tax. Only works when the parameter $usetax is true
-	* @param integer $id_customer Customer ID (for customer group reduction)
-	* @param integer $id_cart Cart ID. Required when the cookie is not accessible (e.g., inside a payment module, a cron task...)
-	* @param integer $id_address Customer address ID. Required for price (tax included) calculation regarding the guest localization
-	* @param variable_reference $specificPriceOutput.
-	* 	If a specific price applies regarding the previous parameters, this variable is filled with the corresponding SpecificPrice object
-	* @param boolean $with_ecotax insert ecotax in price output.
-	* @return float Product price
-	*/
+	 * Returns product price
+	 *
+	 * @param int      $id_product            Product id
+	 * @param bool     $usetax                With taxes or not (optional)
+	 * @param int|null $id_product_attribute  Product attribute id (optional).
+	 *                                        If set to false, do not apply the combination price impact.
+	 *                                        NULL does apply the default combination price impact.
+	 * @param int      $decimals              Number of decimals (optional)
+	 * @param int|null $divisor               Useful when paying many time without fees (optional)
+	 * @param bool     $only_reduc            Returns only the reduction amount
+	 * @param bool     $usereduc              Set if the returned amount will include reduction
+	 * @param int      $quantity              Required for quantity discount application (default value: 1)
+	 * @param bool     $force_associated_tax  DEPRECATED - NOT USED Force to apply the associated tax.
+	 *                                        Only works when the parameter $usetax is true
+	 * @param int|null $id_customer           Customer ID (for customer group reduction)
+	 * @param int|null $id_cart               Cart ID. Required when the cookie is not accessible
+	 *                                        (e.g., inside a payment module, a cron task...)
+	 * @param int|null $id_address            Customer address ID. Required for price (tax included)
+	 *                                        calculation regarding the guest localization
+	 * @param null     $specific_price_output If a specific price applies regarding the previous parameters,
+	 *                                        this variable is filled with the corresponding SpecificPrice object
+	 * @param bool     $with_ecotax           Insert ecotax in price output.
+	 * @param bool     $use_group_reduction
+	 * @param Context  $context
+	 * @param bool     $use_customer_price
+	 * @return float                          Product price
+	 */
 	public static function getPriceStatic($id_product, $usetax = true, $id_product_attribute = null, $decimals = 6, $divisor = null,
 		$only_reduc = false, $usereduc = true, $quantity = 1, $force_associated_tax = false, $id_customer = null, $id_cart = null,
 		$id_address = null, &$specific_price_output = null, $with_ecotax = true, $use_group_reduction = true, Context $context = null,
@@ -2711,25 +2718,31 @@ class ProductCore extends ObjectModel
 	}
 
 	/**
-	* Price calculation / Get product price
-	*
-	* @param integer $id_shop Shop id
-	* @param integer $id_product Product id
-	* @param integer $id_product_attribute Product attribute id
-	* @param integer $id_country Country id
-	* @param integer $id_state State id
-	* @param integer $id_currency Currency id
-	* @param integer $id_group Group id
-	* @param integer $quantity Quantity Required for Specific prices : quantity discount application
-	* @param boolean $use_tax with (1) or without (0) tax
-	* @param integer $decimals Number of decimals returned
-	* @param boolean $only_reduc Returns only the reduction amount
-	* @param boolean $use_reduc Set if the returned amount will include reduction
-	* @param boolean $with_ecotax insert ecotax in price output.
-	* @param variable_reference $specific_price_output
-	* 	If a specific price applies regarding the previous parameters, this variable is filled with the corresponding SpecificPrice object
-	* @return float Product price
-	**/
+	 * Price calculation / Get product price
+	 *
+	 * @param int    $id_shop Shop id
+	 * @param int    $id_product Product id
+	 * @param int    $id_product_attribute Product attribute id
+	 * @param int    $id_country Country id
+	 * @param int    $id_state State id
+	 * @paran string $zipcode
+	 * @param int    $id_currency Currency id
+	 * @param int    $id_group Group id
+	 * @param int    $quantity Quantity Required for Specific prices : quantity discount application
+	 * @param bool   $use_tax with (1) or without (0) tax
+	 * @param int    $decimals Number of decimals returned
+	 * @param bool   $only_reduc Returns only the reduction amount
+	 * @param bool   $use_reduc Set if the returned amount will include reduction
+	 * @param bool   $with_ecotax insert ecotax in price output.
+	 * @param null   $specific_price If a specific price applies regarding the previous parameters,
+	 *                               this variable is filled with the corresponding SpecificPrice object
+	 * @param bool   $use_group_reduction
+	 * @param int    $id_customer
+	 * @param bool   $use_customer_price
+	 * @param int    $id_cart
+	 * @param int    $real_quantity
+	 * @return float Product price
+	 **/
 	public static function priceCalculation($id_shop, $id_product, $id_product_attribute, $id_country, $id_state, $zipcode, $id_currency,
 		$id_group, $quantity, $use_tax, $decimals, $only_reduc, $use_reduc, $with_ecotax, &$specific_price, $use_group_reduction,
 		$id_customer = 0, $use_customer_price = true, $id_cart = 0, $real_quantity = 0)
@@ -3013,7 +3026,7 @@ class ProductCore extends ObjectModel
 	 *
 	 * @param array $params
 	 * @param object $smarty DEPRECATED
-	 * @return Ambigous <string, mixed, Ambigous <number, string>>
+	 * @return string Ambigous <string, mixed, Ambigous <number, string>>
 	 */
 	public static function convertPriceWithCurrency($params, &$smarty)
 	{
@@ -3029,8 +3042,8 @@ class ProductCore extends ObjectModel
 	 * Display WT price with currency
 	 *
 	 * @param array $params
-	 * @param object DEPRECATED $smarty
-	 * @return Ambigous <string, mixed, Ambigous <number, string>>
+	 * @param Smarty $smarty DEPRECATED
+	 * @return string Ambigous <string, mixed, Ambigous <number, string>>
 	 */
 	public static function displayWtPriceWithCurrency($params, &$smarty)
 	{
@@ -4685,8 +4698,11 @@ class ProductCore extends ObjectModel
 	}
 
 	/**
-	* @return the total taxes rate applied to the product
-	*/
+	 * Returns tax rate.
+	 *
+	 * @param Address|null $address
+	 * @return float The total taxes rate applied to the product
+	 */
 	public function getTaxesRate(Address $address = null)
 	{
 		if (!$address || !$address->id_country)
@@ -4724,11 +4740,11 @@ class ProductCore extends ObjectModel
 	}
 
 	/**
-	* Webservice setter : set product features association
-	*
-	* @param $productFeatures Product Feature ids
-	* @return boolean
-	*/
+	 * Webservice setter : set product features association
+	 *
+	 * @param $product_features Product Feature ids
+	 * @return bool
+	 */
 	public function setWsProductFeatures($product_features)
 	{
 		Db::getInstance()->execute('
@@ -4751,10 +4767,11 @@ class ProductCore extends ObjectModel
 	}
 
 	/**
-	* Webservice setter : set virtual field default combination
-	*
-	* @param $id_combination id default combination
-	*/
+	 * Webservice setter : set virtual field default combination
+	 *
+	 * @param int $id_combination id default combination
+	 * @return bool
+	 */
 	public function setWsDefaultCombination($id_combination)
 	{
 		$this->deleteDefaultAttributes();
@@ -4779,10 +4796,11 @@ class ProductCore extends ObjectModel
 	}
 
 	/**
-	* Webservice setter : set category ids of current product for association
-	*
-	* @param $category_ids category ids
-	*/
+	 * Webservice setter : set category ids of current product for association
+	 *
+	 * @param array $category_ids category ids
+	 * @return bool
+	 */
 	public function setWsCategories($category_ids)
 	{
 		$ids = array();

--- a/classes/RequestSql.php
+++ b/classes/RequestSql.php
@@ -76,7 +76,6 @@ class RequestSqlCore extends ObjectModel
 	/**
 	 * Get list of request SQL
 	 *
-	 * @static
 	 * @return array|bool
 	 */
 	public static function getRequestSql()
@@ -94,7 +93,6 @@ class RequestSqlCore extends ObjectModel
 	/**
 	 * Get list of request SQL by id request
 	 *
-	 * @static
 	 * @param $id
 	 * @return array
 	 */

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -353,6 +353,12 @@ class SearchCore
 		return array('total' => $total,'result' => $result_properties);
 	}
 
+	/**
+	 * @param Db $db
+	 * @param int $id_product
+	 * @param int $id_lang
+	 * @return string
+	 */
 	public static function getTags($db, $id_product, $id_lang)
 	{
 		$tags = '';
@@ -365,6 +371,12 @@ class SearchCore
 		return $tags;
 	}
 
+	/**
+	 * @param Db $db
+	 * @param int $id_product
+	 * @param int $id_lang
+	 * @return string
+	 */
 	public static function getAttributes($db, $id_product, $id_lang)
 	{
 		if (!Combination::isFeatureActive())
@@ -382,6 +394,12 @@ class SearchCore
 		return $attributes;
 	}
 
+	/**
+	 * @param Db $db
+	 * @param int $id_product
+	 * @param int $id_lang
+	 * @return string
+	 */
 	public static function getFeatures($db, $id_product, $id_lang)
 	{
 		if (!Feature::isFeatureActive())

--- a/classes/SmartyCustom.php
+++ b/classes/SmartyCustom.php
@@ -316,6 +316,10 @@ class SmartyCustomCore extends Smarty
 }
 
 class Smarty_Custom_Template extends Smarty_Internal_Template {
+
+	/** @var SmartyCustom|null */
+	public $smarty = null;
+
 	public function fetch($template = null, $cache_id = null, $compile_id = null, $parent = null, $display = false, $merge_tpl_vars = true, $no_output_filter = false)
 	{
 		if ($this->smarty->caching)

--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -148,7 +148,7 @@ class SpecificPriceRuleCore extends ObjectModel
 	}
 
 	/**
-	 * @param array $products
+	 * @param array|bool $products
 	 */
 	public static function applyAllRules($products = false)
 	{
@@ -157,7 +157,10 @@ class SpecificPriceRuleCore extends ObjectModel
 
 		$rules = new PrestaShopCollection('SpecificPriceRule');
 		foreach ($rules as $rule)
+		{
+			/** @var SpecificPriceRule $rule */
 			$rule->apply($products);
+		}
 	}
 
 	public function getConditions()

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -276,7 +276,7 @@ class TabCore extends ObjectModel
 	/**
 	 * Get tab id from name
 	 *
-	 * @param string class_name
+	 * @param string $class_name
 	 * @return int id_tab
 	 */
 	public static function getIdFromClassName($class_name)

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -220,7 +220,6 @@ class TabCore extends ObjectModel
 	/**
 	 * Return the list of tab used by a module
 	 *
-	 * @static
 	 * @return array
 	 */
 	public static function getModuleTabList()
@@ -294,7 +293,7 @@ class TabCore extends ObjectModel
 
 	/**
 	 * Get collection from module name
-	 * @static
+	 *
 	 * @param $module string Module name
 	 * @param null $id_lang integer Language ID
 	 * @return array|PrestaShopCollection Collection of tabs (or empty array)
@@ -314,7 +313,7 @@ class TabCore extends ObjectModel
 
 	/**
 	 * Enabling tabs for module
-	 * @static
+	 *
 	 * @param $module string Module Name
 	 * @return bool Status
 	 */
@@ -335,7 +334,7 @@ class TabCore extends ObjectModel
 
 	/**
 	 * Disabling tabs for module
-	 * @static
+	 *
 	 * @param $module string Module name
 	 * @return bool Status
 	 */

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -777,8 +777,8 @@ class ToolsCore
 	/**
 	* Delete file
 	*
-	* @param string File path
-	* @param array  Excluded files
+	* @param string $file File path
+	* @param array $exclude_files Excluded files
 	*/
 	public static function deleteFile($file, $exclude_files = array())
 	{
@@ -2489,9 +2489,9 @@ exit;
 	 * Function property_exists does not exist in PHP < 5.1
 	 *
 	 * @deprecated since 1.5.0 (PHP 5.1 required, so property_exists() is now natively supported)
-	 * @param object or class $class
+	 * @param object $class
 	 * @param string $property
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function property_exists($class, $property)
 	{
@@ -3041,7 +3041,7 @@ exit;
 	/**
 	 * Delete unicode class from regular expression patterns
 	 * @param string $pattern
-	 * @return pattern
+	 * @return string pattern
 	 */
 	public static function cleanNonUnicodeSupport($pattern)
 	{

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -456,6 +456,7 @@ class ToolsCore
 	{
 		if (Tools::isSubmit('SubmitCurrency') && ($id_currency = Tools::getValue('id_currency')))
 		{
+			/** @var Currency $currency */
 			$currency = Currency::getCurrencyInstance((int)$id_currency);
 			if (is_object($currency) && $currency->id && !$currency->deleted && $currency->isAssociatedToShop())
 				$cookie->id_currency = (int)$currency->id;
@@ -3300,6 +3301,7 @@ exit;
 					$config->set('URI.SafeIframeRegexp','/.*/');
 				}
 
+				/** @var HTMLPurifier_HTMLDefinition|HTMLPurifier_HTMLModule $def */
 				// http://developers.whatwg.org/the-video-element.html#the-video-element
 				if ($def = $config->maybeGetRawHTMLDefinition())
 				{

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -149,7 +149,7 @@ class ToolsCore
 	/**
 	 * getShopProtocol return the available protocol for the current shop in use
 	 * SSL if Configuration is set on and available for the server
-	 * @static
+	 *
 	 * @return String
 	 */
 	public static function getShopProtocol()
@@ -2966,7 +2966,6 @@ exit;
 	/**
 	 * Align version sent and use internal function
 	 *
-	 * @static
 	 * @param $v1
 	 * @param $v2
 	 * @param string $operator
@@ -2982,7 +2981,7 @@ exit;
 	 * Align 2 version with the same number of sub version
 	 * version_compare will work better for its comparison :)
 	 * (Means: '1.8' to '1.9.3' will change '1.8' to '1.8.0')
-	 * @static
+	 *
 	 * @param $v1
 	 * @param $v2
 	 */

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -88,7 +88,7 @@ class TranslateCore
 	 * @static
 	 * @param $string string to translate
 	 * @param null $key md5 key if already calculated (optional)
-	 * @param $lang_array global array of admin translations
+	 * @param array $lang_array Global array of admin translations
 	 * @return string translation
 	 */
 	public static function getGenericAdminTranslation($string, $key = null, &$lang_array)

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -85,7 +85,6 @@ class TranslateCore
 	/**
 	 * Return the translation for a string if it exists for the base AdminController or for helpers
 	 *
-	 * @static
 	 * @param $string string to translate
 	 * @param null $key md5 key if already calculated (optional)
 	 * @param array $lang_array Global array of admin translations

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -247,6 +247,7 @@ class UpgraderCore
 	{
 		foreach ($node as $key => $child)
 		{
+			/** @var SimpleXMLElement $child */
 			if (is_object($child) && $child->getName() == 'dir')
 			{
 				$current_path[$level] = (string)$child['name'];

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1033,9 +1033,9 @@ class ValidateCore
 
 	/**
 	 * Validate SIRET Code
-	 * @static
-	 * @param $siret SIRET Code
-	 * @return boolean Return true if is valid
+	 *
+	 * @param string $siret SIRET Code
+	 * @return bool Return true if is valid
 	 */
 	public static function isSiret($siret)
 	{
@@ -1054,8 +1054,8 @@ class ValidateCore
 
 	/**
 	 * Validate APE Code
-	 * @static
-	 * @param $ape APE Code
+	 *
+	 * @param string $ape APE Code
 	 * @return boolean Return true if is valid
 	 */
 	public static function isApe($ape)

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2234,7 +2234,11 @@ class AdminControllerCore extends Controller
 			$xml_modules = @simplexml_load_file(_PS_ROOT_DIR_.Module::CACHE_FILE_MODULES_LIST);
 		if ($xml_modules)
 			foreach ($xml_modules->children() as $xml_module)
+			{
+				/** @var SimpleXMLElement $xml_module */
 				foreach ($xml_module->children() as $module)
+				{
+					/** @var SimpleXMLElement $module */
 					foreach ($module->attributes() as $key => $value)
 					{
 						if ($xml_module->attributes() == 'native' && $key == 'name')
@@ -2242,6 +2246,8 @@ class AdminControllerCore extends Controller
 						if ($xml_module->attributes() == 'partner' && $key == 'name')
 							$this->list_partners_modules[] = (string)$value;
 					}
+				}
+			}
 
 		if ($this->getModulesList($this->filter_modules_list))
 		{

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3838,7 +3838,7 @@ class AdminControllerCore extends Controller
 	 * Create a template from the override file, else from the base file.
 	 *
 	 * @param string $tpl_name filename
-	 * @return Template|object
+	 * @return Smarty_Internal_Template
 	 */
 	public function createTemplate($tpl_name)
 	{

--- a/classes/controller/ModuleAdminController.php
+++ b/classes/controller/ModuleAdminController.php
@@ -53,8 +53,8 @@ abstract class ModuleAdminControllerCore extends AdminController
 	/**
 	 * Creates a template object
 	 *
-	 * @param string $tpl_name template filename
-	 * @return Template|object
+	 * @param string $tpl_name Template filename
+	 * @return Smarty_Internal_Template
 	 */
 	public function createTemplate($tpl_name)
 	{

--- a/classes/controller/ModuleFrontController.php
+++ b/classes/controller/ModuleFrontController.php
@@ -71,7 +71,7 @@ class ModuleFrontControllerCore extends FrontController
 	/**
 	 * Finds and returns module front template that take the highest precedence
 	 *
-	 * @param $template Template filename
+	 * @param string $template Template filename
 	 * @return string|false
 	 */
 	public function getTemplatePath($template)

--- a/classes/helper/Helper.php
+++ b/classes/helper/Helper.php
@@ -318,6 +318,7 @@ class HelperCore
 		foreach ($rules['required'] as $required)
 			$required_class_fields[] = $required;
 
+		/** @var ObjectModel $object */
 		$object = new $class_name();
 		$res = $object->getFieldsRequiredDatabase();
 

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -107,7 +107,7 @@ class HelperListCore extends Helper
 	/** @var bool If true, activates color on hover */
 	public $row_hover = true;
 
-	/** @var if not null, a title will be added on that list */
+	/** @var string|null If not null, a title will be added on that list */
 	public $title = null;
 
 	/** @var boolean ask for simple header : no filters, no paginations and no sorting */

--- a/classes/helper/HelperOptions.php
+++ b/classes/helper/HelperOptions.php
@@ -40,7 +40,7 @@ class HelperOptionsCore extends Helper
 
 	/**
 	 * Generate a form for options
-	 * @param array options
+	 * @param array $option_list
 	 * @return string html
 	 */
 	public function generateOptions($option_list)

--- a/classes/helper/HelperView.php
+++ b/classes/helper/HelperView.php
@@ -31,7 +31,7 @@ class HelperViewCore extends Helper
 	public $table;
 	public $token;
 
-	/** @var string|null Ff not null, a title will be added on that list */
+	/** @var string|null If not null, a title will be added on that list */
 	public $title = null;
 
 	public function __construct()

--- a/classes/helper/HelperView.php
+++ b/classes/helper/HelperView.php
@@ -31,7 +31,7 @@ class HelperViewCore extends Helper
 	public $table;
 	public $token;
 
-	/** @var if not null, a title will be added on that list */
+	/** @var string|null Ff not null, a title will be added on that list */
 	public $title = null;
 
 	public function __construct()

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -112,31 +112,31 @@ abstract class ModuleCore
 	 */
 	protected $local_path = null;
 
-	/** @var protected array filled with module errors */
+	/** @var array Array filled with module errors */
 	protected $_errors = array();
 
-	/** @var protected array filled with module success */
+	/** @var array Array  array filled with module success */
 	protected $_confirmations = array();
 
-	/** @var protected string main table used for modules installed */
+	/** @var string Main table used for modules installed */
 	protected $table = 'module';
 
-	/** @var protected string identifier of the main table */
+	/** @var string Identifier of the main table */
 	protected $identifier = 'id_module';
 
-	/** @var protected array cache filled with modules informations */
+	/** @var array Array cache filled with modules informations */
 	protected static $modules_cache;
 
-	/** @var protected array cache filled with modules instances */
+	/** @var array Array cache filled with modules instances */
 	protected static $_INSTANCE = array();
 
-	/** @var protected boolean filled with config xml generation mode */
+	/** @var bool Config xml generation mode */
 	protected static $_generate_config_xml_mode = false;
 
-	/** @var protected array filled with cache translations */
+	/** @var array Array filled with cache translations */
 	protected static $l_cache = array();
 
-	/** @var protected array filled with cache permissions (modules / employee profiles) */
+	/** @var array Array filled with cache permissions (modules / employee profiles) */
 	protected static $cache_permissions = array();
 
 	/** @var Context */
@@ -145,12 +145,12 @@ abstract class ModuleCore
 	/** @var Smarty_Data */
 	protected $smarty;
 
-	/** @var currentSmartySubTemplate */
+	/** @var Smarty_Internal_Template|null */
 	protected $current_subtemplate = null;
 
 	protected static $update_translations_after_install = true;
 
-	/** @var allow push */
+	/** @var bool If true, allow push */
 	public $allow_push;
 
 	public $push_time_limit = 180;
@@ -2343,7 +2343,9 @@ abstract class ModuleCore
 
 	/**
 	 * Get Unauthorized modules for a client group
-	 * @param integer group_id
+	 *
+	 * @param int $group_id
+	 * @return array|null
 	 */
 	public static function getAuthorizedModules($group_id)
 	{
@@ -2354,9 +2356,10 @@ abstract class ModuleCore
 	}
 
 	/**
-	 * Get id module by name
-	 * @param string name
-	 * @return integer id
+	 * Get ID module by name
+	 *
+	 * @param string $name
+	 * @return int Module ID
 	 */
 	public static function getModuleIdByName($name)
 	{

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -393,9 +393,7 @@ abstract class ModuleCore
 	/**
 	 * Init the upgrade module
 	 *
-	 * @static
-	 * @param $module_name
-	 * @param $module_version
+	 * @param $module
 	 * @return bool
 	 */
 	public static function initUpgradeModule($module)
@@ -476,7 +474,6 @@ abstract class ModuleCore
 	/**
 	 * Upgrade the registered version to a new one
 	 *
-	 * @static
 	 * @param $name
 	 * @param $version
 	 * @return bool
@@ -493,9 +490,7 @@ abstract class ModuleCore
 	 * Check if a module need to be upgraded.
 	 * This method modify the module_cache adding an upgrade list file
 	 *
-	 * @static
-	 * @param $module_name
-	 * @param $module_version
+	 * @param $module
 	 * @return bool
 	 */
 	public static function needUpgrade($module)
@@ -516,7 +511,6 @@ abstract class ModuleCore
 	 * Load the available list of upgrade of a specified module
 	 * with an associated version
 	 *
-	 * @static
 	 * @param $module_name
 	 * @param $module_version
 	 * @param $registered_version
@@ -572,7 +566,6 @@ abstract class ModuleCore
 	/**
 	 * Return the status of the upgraded module
 	 *
-	 * @static
 	 * @param $module_name
 	 * @return bool
 	 */

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1286,6 +1286,7 @@ abstract class ModuleCore
 				// If class exists, we just instanciate it
 				if (class_exists($module, false))
 				{
+					/** @var Module $tmp_module */
 					$tmp_module = new $module;
 
 					$item = new stdClass();

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -317,7 +317,15 @@ class OrderCore extends ObjectModel
 		return (int)$this->_taxCalculationMethod;
 	}
 
-	/* Does NOT delete a product but "cancel" it (which means return/refund/delete it depending of the case) */
+	/**
+	 * Does NOT delete a product but "cancel" it (which means return/refund/delete it depending of the case)
+	 *
+	 * @param $order
+	 * @param OrderDetail $order_detail
+	 * @param int $quantity
+	 * @return bool
+	 * @throws PrestaShopException
+	 */
 	public function deleteProduct($order, $order_detail, $quantity)
 	{
 		if (!(int)$this->getCurrentState() || !validate::isLoadedObject($order_detail))
@@ -373,7 +381,14 @@ class OrderCore extends ObjectModel
 		return $product_list;
 	}
 
-	/* DOES delete the product */
+	/**
+	 * DOES delete the product
+	 *
+	 * @param OrderDetail $order_detail
+	 * @param int $quantity
+	 * @return bool
+	 * @throws PrestaShopException
+	 */
 	protected function _deleteProduct($order_detail, $quantity)
 	{
 		$product_price_tax_excl = $order_detail->unit_price_tax_excl * $quantity;
@@ -1480,6 +1495,7 @@ class OrderCore extends ObjectModel
 
 	public function addWs($autodate = true, $null_values = false)
 	{
+		/** @var PaymentModule $payment_module */
 		$payment_module = Module::getInstanceByName($this->module);
 		$customer = new Customer($this->id_customer);
 		$payment_module->validateOrder($this->id_cart, Configuration::get('PS_OS_WS_PAYMENT'), $this->total_paid, $this->payment, null, array(), null, false, $customer->secure_key);
@@ -1744,8 +1760,12 @@ class OrderCore extends ObjectModel
 	{
 		$invoices = $this->getInvoicesCollection();
 		foreach ($invoices as $key => $invoice)
+		{
+			/** @var OrderInvoice $invoice */
 			if ($invoice->isPaid())
 				unset($invoices[$key]);
+		}
+
 		return $invoices;
 	}
 

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -919,7 +919,6 @@ class OrderCore extends ObjectModel
 	/**
 	 * @deprecated since 1.5.0.2
 	 *
-	 * @static
 	 * @param $date_from
 	 * @param $date_to
 	 * @param $id_customer
@@ -948,7 +947,6 @@ class OrderCore extends ObjectModel
 	/**
 	 * @deprecated 1.5.0.3
 	 *
-	 * @static
 	 * @param $id_order_state
 	 * @return array
 	 */

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -305,6 +305,7 @@ class OrderHistoryCore extends ObjectModel
 
 			foreach ($invoices as $invoice)
 			{
+				/** @var OrderInvoice $invoice */
 				$rest_paid = $invoice->getRestPaid();
 				if ($rest_paid > 0)
 				{

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -380,6 +380,7 @@ class OrderInvoiceCore extends ObjectModel
 	 * Returns the shipping taxes breakdown
 	 *
 	 * @since 1.5
+	 * @param Order $order
 	 * @return array
 	 */
 	public function getShippingTaxesBreakdown($order)

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -509,7 +509,6 @@ class OrderInvoiceCore extends ObjectModel
 	 * Returns all the order invoice that match the date interval
 	 *
 	 * @since 1.5
-	 * @static
 	 * @param $date_from
 	 * @param $date_to
 	 * @return array collection of OrderInvoice
@@ -532,7 +531,6 @@ class OrderInvoiceCore extends ObjectModel
 
 	/**
 	 * @since 1.5.0.3
-	 * @static
 	 * @param $id_order_state
 	 * @return array collection of OrderInvoice
 	 */
@@ -553,7 +551,6 @@ class OrderInvoiceCore extends ObjectModel
 
 	/**
 	 * @since 1.5.0.3
-	 * @static
 	 * @param $date_from
 	 * @param $date_to
 	 * @return array collection of invoice
@@ -575,7 +572,6 @@ class OrderInvoiceCore extends ObjectModel
 
 	/**
 	 * @since 1.5
-	 * @static
 	 * @param $id_order_invoice
 	 */
 	public static function getCarrier($id_order_invoice)
@@ -589,7 +585,6 @@ class OrderInvoiceCore extends ObjectModel
 
 	/**
 	 * @since 1.5
-	 * @static
 	 * @param $id_order_invoice
 	 */
 	public static function getCarrierId($id_order_invoice)
@@ -602,9 +597,9 @@ class OrderInvoiceCore extends ObjectModel
 	}
 
 	/**
-	 * @static
-	 * @param $id
+	 * @param int $id
 	 * @return OrderInvoice
+	 * @throws PrestaShopException
 	 */
 	public static function retrieveOneById($id)
 	{

--- a/classes/order/OrderPayment.php
+++ b/classes/order/OrderPayment.php
@@ -101,7 +101,7 @@ class OrderPaymentCore extends ObjectModel
 
 	/**
 	 * Get Order Payments By Invoice ID
-	 * @static
+	 *
 	 * @param int $id_invoice Invoice ID
 	 * @return PrestaShopCollection Collection of OrderPayment
 	 */

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -157,6 +157,11 @@ class OrderReturnCore extends ObjectModel
 		WHERE `id_order_return` = '.(int)$id_order_return);
 	}
 
+	/**
+	 * @param int $order_return_id
+	 * @param Order $order
+	 * @return array
+	 */
 	public static function getOrdersReturnProducts($order_return_id, $order)
 	{
 		$products_ret = OrderReturn::getOrdersReturnDetail($order_return_id);

--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -141,6 +141,11 @@ class OrderSlipCore extends ObjectModel
 		.($id_order_detail ? ' WHERE `id_order_detail` = '.(int)($id_order_detail) : ''));
 	}
 
+	/**
+	 * @param int $orderSlipId
+	 * @param Order $order
+	 * @return array
+	 */
 	public static function getOrdersSlipProducts($orderSlipId, $order)
 	{
 		$cart_rules = $order->getCartRules(true);

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -88,6 +88,11 @@ class PDFCore
 		}
 	}
 
+	/**
+	 * @param mixed $object
+	 * @return HTMLTemplate|false
+	 * @throws PrestaShopException
+	 */
 	public function getTemplateObject($object)
 	{
 		$class = false;

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1128,7 +1128,6 @@ class ShopCore extends ObjectModel
 	}
 
 	/**
-	 * @static
 	 * @param int $id
 	 * @return array
 	 */

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -744,7 +744,10 @@ class StockAvailableCore extends ObjectModel
 			$shop = $context->shop;
 		}
 		elseif (is_object($shop))
+		{
+			/** @var Shop $shop */
 			$shop_group = $shop->getGroup();
+		}
 		else
 		{
 			$shop = new Shop($shop);

--- a/classes/stock/SupplyOrder.php
+++ b/classes/stock/SupplyOrder.php
@@ -225,6 +225,7 @@ class SupplyOrderCore extends ObjectModel
 
 		foreach ($entries as $entry)
 		{
+			/** @var SupplyOrderDetail $entry */
 			// applys global discount rate on each product if possible
 			if ($is_discount)
 				$entry->applyGlobalDiscount((float)$this->discount_rate);

--- a/classes/tree/TreeToolbar.php
+++ b/classes/tree/TreeToolbar.php
@@ -140,6 +140,11 @@ class TreeToolbarCore implements ITreeToolbarCore
 			return $this->getTemplateDirectory().$template;
 	}
 
+	/**
+	 * @param ITreeToolbarButton $action
+	 * @return $this
+	 * @throws PrestaShopException
+	 */
 	public function addAction($action)
 	{
 		if (!is_object($action))
@@ -169,7 +174,10 @@ class TreeToolbarCore implements ITreeToolbarCore
 	public function render()
 	{
 		foreach ($this->getActions() as $action)
+		{
+			/** @var ITreeToolbarButton $action */
 			$action->setAttribute('data', $this->getData());
+		}
 
 		return $this->getContext()->smarty->createTemplate(
 			$this->getTemplateFile($this->getTemplate()),

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -45,7 +45,7 @@ class WebserviceRequestCore
 
 	/**
 	 * Set if the management is specific or if it is classic (entity management)
-	 * @var WebserviceSpecificManagementInterface|false
+	 * @var WebserviceSpecificManagementImages|WebserviceSpecificManagementSearch|false
 	 */
 	protected $objectSpecificManagement = false;
 
@@ -502,6 +502,7 @@ class WebserviceRequestCore
 					// load resource configuration
 					if ($this->urlSegment[0] != '')
 					{
+						/** @var ObjectModel $object */
 						$object = new $this->resourceList[$this->urlSegment[0]]['class']();
 						if (isset($this->resourceList[$this->urlSegment[0]]['parameters_attribute']))
 							$this->resourceConfiguration = $object->getWebserviceParameters($this->resourceList[$this->urlSegment[0]]['parameters_attribute']);
@@ -1191,6 +1192,7 @@ class WebserviceRequestCore
 				}
 				else
 				{
+					/** @var ObjectModel $object */
 					$object = new $this->resourceConfiguration['retrieveData']['className']();
 					$assoc = Shop::getAssoTable($this->resourceConfiguration['retrieveData']['table']);
 					if ($assoc !== false && $assoc['type'] == 'shop' && ($object->isMultiShopField($this->resourceConfiguration['fields'][$fieldName]['sqlId']) || $fieldName == 'id'))
@@ -1392,6 +1394,7 @@ class WebserviceRequestCore
 		{
 			foreach ($objects as $object)
 			{
+				/** @var ObjectModel $object */
 				if (isset($this->resourceConfiguration['objectMethods']) && isset($this->resourceConfiguration['objectMethods']['delete']))
 					$result = $object->{$this->resourceConfiguration['objectMethods']['delete']}();
 				else
@@ -1427,6 +1430,8 @@ class WebserviceRequestCore
 			$this->setError(500, 'XML error : '.$error->getMessage()."\n".'XML length : '.strlen($this->_inputXml)."\n".'Original XML : '.$this->_inputXml, 127);
 			return;
 		}
+
+		/** @var SimpleXMLElement|Countable $xmlEntities */
 		$xmlEntities = $xml->children();
 		$object = null;
 
@@ -1460,8 +1465,10 @@ class WebserviceRequestCore
 
 		foreach ($xmlEntities as $xmlEntity)
 		{
+			/** @var SimpleXMLElement $xmlEntity */
 			$attributes = $xmlEntity->children();
 
+			/** @var ObjectModel $object */
 			if ($this->method == 'POST')
 				$object = new $this->resourceConfiguration['retrieveData']['className']();
 			elseif ($this->method == 'PUT')
@@ -1514,7 +1521,10 @@ class WebserviceRequestCore
 					$i18n = true;
 					if (isset($attributes->$fieldName, $attributes->$fieldName->language))
 						foreach ($attributes->$fieldName->language as $lang)
+						{
+							/** @var SimpleXMLElement $lang */
 							$object->{$fieldName}[(int)$lang->attributes()->id] = (string)$lang;
+						}
 					else
 						$object->{$fieldName} = (string)$attributes->$fieldName;
 				}
@@ -1551,6 +1561,7 @@ class WebserviceRequestCore
 						if (isset($attributes->associations))
 							foreach ($attributes->associations->children() as $association)
 							{
+								/** @var SimpleXMLElement $association */
 								// associations
 								if (isset($this->resourceConfiguration['associations'][$association->getName()]))
 								{
@@ -1558,6 +1569,7 @@ class WebserviceRequestCore
 									$values = array();
 									foreach ($assocItems as $assocItem)
 									{
+										/** @var SimpleXMLElement $assocItem */
 										$fields = $assocItem->children();
 										$entry = array();
 										foreach ($fields as $fieldName => $fieldValue)

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -178,7 +178,7 @@ class WebserviceRequestCore
 
 	/**
 	 * Save the class name for override used in getInstance()
-	 * @var ws_current_classname
+	 * @var string
 	 */
 	public static $ws_current_classname;
 

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -91,6 +91,10 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 	 * GETTERS & SETTERS
 	 * ------------------------------------------------ */
 
+	/**
+	 * @param WebserviceOutputBuilderCore $obj
+	 * @return WebserviceSpecificManagementInterface
+	 */
 	public function setObjectOutput(WebserviceOutputBuilderCore $obj)
 	{
 		$this->objOutput = $obj;
@@ -818,6 +822,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 				{
 					if (in_array($this->imageType, array('categories', 'manufacturers', 'suppliers', 'stores')))
 					{
+						/** @var ObjectModel $object */
 						$object = new $this->wsObject->resourceList[$this->imageType]['class']((int)$this->wsObject->urlSegment[2]);
 						return $object->deleteImage(true);
 					}

--- a/classes/webservice/WebserviceSpecificManagementSearch.php
+++ b/classes/webservice/WebserviceSpecificManagementSearch.php
@@ -37,6 +37,10 @@ class WebserviceSpecificManagementSearchCore implements WebserviceSpecificManage
 	 * GETTERS & SETTERS
 	 * ------------------------------------------------ */
 
+	/**
+	 * @param WebserviceOutputBuilderCore $obj
+	 * @return WebserviceSpecificManagementInterface
+	 */
 	public function setObjectOutput(WebserviceOutputBuilderCore $obj)
 	{
 		$this->objOutput = $obj;

--- a/controllers/admin/AdminCarriersController.php
+++ b/controllers/admin/AdminCarriersController.php
@@ -428,7 +428,8 @@ class AdminCarriersControllerCore extends AdminController
 							$current_carrier = new Carrier($id);
 							if (!Validate::isLoadedObject($current_carrier))
 								throw new PrestaShopException('Cannot load Carrier object');
-							
+
+							/** @var Carrier $new_carrier */
 							// Duplicate current Carrier
 							$new_carrier = $current_carrier->duplicateObject();
 							if (Validate::isLoadedObject($new_carrier))
@@ -598,6 +599,10 @@ elseif ((isset($_GET['status'.$this->table]) || isset($_GET['status'])) && Tools
 		$this->fields_value['id_tax_rules_group'] = $this->object->getIdTaxRulesGroup($this->context);
 	}
 
+	/**
+	 * @param Carrier $object
+	 * @return int
+	 */
 	protected function beforeDelete($object)
 	{
 		return $object->isUsed();
@@ -618,6 +623,7 @@ elseif ((isset($_GET['status'.$this->table]) || isset($_GET['status'])) && Tools
 
 	public function changeZones($id)
 	{
+		/** @var Carrier $carrier */
 		$carrier = new $this->className($id);
 		if (!Validate::isLoadedObject($carrier))
 			die (Tools::displayError('The object cannot be loaded.'));

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -189,6 +189,7 @@ class AdminCartsControllerCore extends AdminController
 
 	public function renderView()
 	{
+		/** @var Cart $cart */
 		if (!($cart = $this->loadObject(true)))
 			return;
 		$customer = new Customer($cart->id_customer);

--- a/controllers/admin/AdminCmsController.php
+++ b/controllers/admin/AdminCmsController.php
@@ -351,6 +351,7 @@ class AdminCmsControllerCore extends AdminController
 		}
 		elseif (Tools::isSubmit('way') && Tools::isSubmit('id_cms') && (Tools::isSubmit('position')))
 		{
+			/** @var CMS $object */
 			if ($this->tabAccess['edit'] !== '1')
 				$this->errors[] = Tools::displayError('You do not have permission to edit this.');
 			elseif (!Validate::isLoadedObject($object = $this->loadObject()))

--- a/controllers/admin/AdminGendersController.php
+++ b/controllers/admin/AdminGendersController.php
@@ -171,6 +171,7 @@ class AdminGendersControllerCore extends AdminController
 			)
 		);
 
+		/** @var Gender $obj */
 		if (!($obj = $this->loadObject(true)))
 			return;
 

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -536,7 +536,7 @@ class AdminGroupsControllerCore extends AdminController
 
 	/**
 	 * Print enable / disable icon for show prices option
-	 * @static
+	 *
 	 * @param $id_group integer Group ID
 	 * @param $tr array Row data
 	 * @return string HTML link and icon

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1444,9 +1444,9 @@ class AdminModulesControllerCore extends AdminController
 					require_once(_PS_MODULE_DIR_.$module->name.'/'.$module->name.'.php');
 				}
 
-				/** @var Module $object */
 				if ($object = new $module->name())
 				{
+					/** @var Module $object */
 					$object->runUpgradeModule();
 					if ((count($errors_module_list = $object->getErrors())))
 						$module_errors[] = array('name' => $module->displayName, 'message' => $errors_module_list);

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -125,7 +125,11 @@ class AdminModulesControllerCore extends AdminController
 			$xml_modules = @simplexml_load_file(_PS_ROOT_DIR_.Module::CACHE_FILE_MODULES_LIST);
 		if ($xml_modules)
 			foreach ($xml_modules->children() as $xml_module)
+			{
+				/** @var SimpleXMLElement $xml_module */
 				foreach ($xml_module->children() as $module)
+				{
+					/** @var SimpleXMLElement $module */
 					foreach ($module->attributes() as $key => $value)
 					{
 						if ($xml_module->attributes() == 'native' && $key == 'name')
@@ -133,7 +137,8 @@ class AdminModulesControllerCore extends AdminController
 						if ($xml_module->attributes() == 'partner' && $key == 'name')
 							$this->list_partners_modules[] = (string)$value;
 					}
-
+				}
+			}
 	}
 
 	public function checkCategoriesNames($a, $b)
@@ -1438,6 +1443,8 @@ class AdminModulesControllerCore extends AdminController
 						continue;
 					require_once(_PS_MODULE_DIR_.$module->name.'/'.$module->name.'.php');
 				}
+
+				/** @var Module $object */
 				if ($object = new $module->name())
 				{
 					$object->runUpgradeModule();

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -268,6 +268,7 @@ class AdminOrdersControllerCore extends AdminController
 	{
 		if ($this->display == 'view')
 		{
+			/** @var Order $order */
 			$order = $this->loadObject();
 			$customer = $this->context->customer;
 
@@ -1394,6 +1395,7 @@ class AdminOrdersControllerCore extends AdminController
 								$order_invoices_collection = $order->getInvoicesCollection();
 								foreach ($order_invoices_collection as $order_invoice)
 								{
+									/** @var OrderInvoice $order_invoice */
 									if ($discount_value > $order_invoice->total_paid_tax_incl)
 										$this->errors[] = Tools::displayError('The discount value is greater than the order invoice total.').$order_invoice->getInvoiceNumberFormatted(Context::getContext()->language->id, (int)$order->id_shop).')';
 									else
@@ -2145,6 +2147,7 @@ class AdminOrdersControllerCore extends AdminController
 		$invoice_array = array();
 		foreach ($invoice_collection as $invoice)
 		{
+			/** @var OrderInvoice $invoice */
 			$invoice->name = $invoice->getInvoiceNumberFormatted(Context::getContext()->language->id, (int)$order->id_shop);
 			$invoice_array[] = $invoice;
 		}
@@ -2414,6 +2417,7 @@ class AdminOrdersControllerCore extends AdminController
 		$invoice_array = array();
 		foreach ($invoice_collection as $invoice)
 		{
+			/** @var OrderInvoice $invoice */
 			$invoice->name = $invoice->getInvoiceNumberFormatted(Context::getContext()->language->id, (int)$order->id_shop);
 			$invoice_array[] = $invoice;
 		}
@@ -2512,6 +2516,7 @@ class AdminOrdersControllerCore extends AdminController
 		$invoice_array = array();
 		foreach ($invoice_collection as $invoice)
 		{
+			/** @var OrderInvoice $invoice */
 			$invoice->name = $invoice->getInvoiceNumberFormatted(Context::getContext()->language->id, (int)$order->id_shop);
 			$invoice_array[] = $invoice;
 		}
@@ -2628,6 +2633,10 @@ class AdminOrdersControllerCore extends AdminController
 			)));
 	}
 
+	/**
+	 * @param Order $order
+	 * @return array
+	 */
 	protected function getProducts($order)
 	{
 		$products = $order->getProducts();
@@ -2651,6 +2660,11 @@ class AdminOrdersControllerCore extends AdminController
 		return $products;
 	}
 
+	/**
+	 * @param OrderDetail $order_detail
+	 * @param int $qty_cancel_product
+	 * @param bool $delete
+	 */
 	protected function reinjectQuantity($order_detail, $qty_cancel_product, $delete = false)
 	{
 		// Reinject product
@@ -2745,6 +2759,11 @@ class AdminOrdersControllerCore extends AdminController
 				$this->errors[] = Tools::displayError('This product cannot be re-stocked.');
 	}
 
+	/**
+	 * @param OrderInvoice $order_invoice
+	 * @param float $value_tax_incl
+	 * @param float $value_tax_excl
+	 */
 	protected function applyDiscountOnInvoice($order_invoice, $value_tax_incl, $value_tax_excl)
 	{
 		// Update OrderInvoice

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -3950,9 +3950,9 @@ class AdminProductsControllerCore extends AdminController
 	{
 		$carrier_list = Carrier::getCarriers($this->context->language->id, false, false, false, null, Carrier::ALL_CARRIERS);
 
-		/** @var Product $product */
 		if ($product = $this->loadObject(true))
 		{
+			/** @var Product $product */
 			$carrier_selected_list = $product->getCarriers();
 			foreach ($carrier_list as &$carrier)
 				foreach ($carrier_selected_list as $carrier_selected)

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1239,6 +1239,7 @@ class AdminProductsControllerCore extends AdminController
 	 */
 	public function processPosition()
 	{
+		/** @var Product $object */
 		if (!Validate::isLoadedObject($object = $this->loadObject()))
 		{
 			$this->errors[] = Tools::displayError('An error occurred while updating the status for an object.').
@@ -1944,6 +1945,7 @@ class AdminProductsControllerCore extends AdminController
 		/* Update an existing product */
 		if (isset($id) && !empty($id))
 		{
+			/** @var Product $object */
 			$object = new $this->className((int)$id);
 			$this->object = $object;
 
@@ -3080,6 +3082,12 @@ class AdminProductsControllerCore extends AdminController
 		}
 	}
 
+	/**
+	 * @param Product $obj
+	 * @throws Exception
+	 * @throws PrestaShopException
+	 * @throws SmartyException
+	 */
 	public function initFormAssociations($obj)
 	{
 		$product = $obj;
@@ -3146,6 +3154,11 @@ class AdminProductsControllerCore extends AdminController
 		$this->tpl_form_vars['custom_form'] = $data->fetch();
 	}
 
+	/**
+	 * @param Product $obj
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormPrices($obj)
 	{
 		$data = $this->createTemplate($this->tpl_form);
@@ -3342,6 +3355,11 @@ class AdminProductsControllerCore extends AdminController
 		return $pack_items;
 	}
 
+	/**
+	 * @param Product $product
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormPack($product)
 	{
 		$data = $this->createTemplate($this->tpl_form);
@@ -3719,6 +3737,11 @@ class AdminProductsControllerCore extends AdminController
 		return $content;
 	}
 
+	/**
+	 * @param Product $obj
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormCustomization($obj)
 	{
 		$data = $this->createTemplate($this->tpl_form);
@@ -3806,6 +3829,11 @@ class AdminProductsControllerCore extends AdminController
 		$this->tpl_form_vars['custom_form'] = $data->fetch();
 	}
 
+	/**
+	 * @param Product $product
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormInformations($product)
 	{
 		if (!$this->default_form_language)
@@ -3921,6 +3949,8 @@ class AdminProductsControllerCore extends AdminController
 	protected function getCarrierList()
 	{
 		$carrier_list = Carrier::getCarriers($this->context->language->id, false, false, false, null, Carrier::ALL_CARRIERS);
+
+		/** @var Product $product */
 		if ($product = $this->loadObject(true))
 		{
 			$carrier_selected_list = $product->getCarriers();
@@ -4073,6 +4103,11 @@ class AdminProductsControllerCore extends AdminController
 		die(Tools::jsonEncode(array($image_uploader->getName() => $files)));
 	}
 
+	/**
+	 * @param Product $obj
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormImages($obj)
 	{
 		$data = $this->createTemplate($this->tpl_form);
@@ -4154,6 +4189,11 @@ class AdminProductsControllerCore extends AdminController
 		return $this->initFormAttributes($obj);
 	}
 
+	/**
+	 * @param Product $product
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormAttributes($product)
 	{
 		$data = $this->createTemplate($this->tpl_form);
@@ -4235,6 +4275,11 @@ class AdminProductsControllerCore extends AdminController
 		$this->tpl_form_vars['custom_form'] = $data->fetch();
 	}
 
+	/**
+	 * @param Product $product
+	 * @param Currency|array|int $currency
+	 * @return string
+	 */
 	public function renderListAttributes($product, $currency)
 	{
 		$this->bulk_actions = array('delete' => array('text' => $this->l('Delete selected'), 'confirm' => $this->l('Delete selected items?')));
@@ -4331,6 +4376,11 @@ class AdminProductsControllerCore extends AdminController
 		return $helper->generateList($comb_array, $this->fields_list);
 	}
 
+	/**
+	 * @param Product $obj
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormQuantities($obj)
 	{
 		if (!$this->default_form_language)
@@ -4434,6 +4484,7 @@ class AdminProductsControllerCore extends AdminController
 					$pack_quantities = array();
 					foreach ($items as $item)
 					{
+						/** @var Product $item */
 						if (!$item->isAvailableWhenOutOfStock((int)$item->out_of_stock))
 						{
 							$pack_id_product_attribute = Product::getDefaultAttribute($item->id, 1);
@@ -4481,6 +4532,11 @@ class AdminProductsControllerCore extends AdminController
 		$this->tpl_form_vars['custom_form'] = $data->fetch();
 	}
 
+	/**
+	 * @param Product $obj
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormSuppliers($obj)
 	{
 		$data = $this->createTemplate($this->tpl_form);
@@ -4559,6 +4615,11 @@ class AdminProductsControllerCore extends AdminController
 		$this->tpl_form_vars['custom_form'] = $data->fetch();
 	}
 
+	/**
+	 * @param Product $obj
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormWarehouses($obj)
 	{
 		$data = $this->createTemplate($this->tpl_form);
@@ -4609,6 +4670,11 @@ class AdminProductsControllerCore extends AdminController
 		$this->tpl_form_vars['custom_form'] = $data->fetch();
 	}
 
+	/**
+	 * @param Product $obj
+	 * @throws Exception
+	 * @throws SmartyException
+	 */
 	public function initFormFeatures($obj)
 	{
 		if (!$this->default_form_language)
@@ -4748,6 +4814,7 @@ class AdminProductsControllerCore extends AdminController
 
 	public function getCombinationImagesJS()
 	{
+		/** @var Product $obj */
 		if (!($obj = $this->loadObject(true)))
 			return;
 

--- a/controllers/admin/AdminScenesController.php
+++ b/controllers/admin/AdminScenesController.php
@@ -106,6 +106,7 @@ class AdminScenesControllerCore extends AdminController
 	{
 		$this->initFieldsForm();
 
+		/** @var Scene $obj */
 		if (!($obj = $this->loadObject(true)))
 			return;
 

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -102,6 +102,7 @@ class AdminSearchControllerCore extends AdminController
 						$this->_list['orders'] = array();
 						foreach ($orders as $order)
 						{
+							/** @var Order $order */
 							$row = get_object_vars($order);
 							$row['id_order'] = $row['id'];
 							$customer = $order->getCustomer();

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -282,6 +282,10 @@ class AdminShopControllerCore extends AdminController
 		return false;
 	}
 
+	/**
+	 * @param Shop $new_shop
+	 * @return bool
+	 */
 	protected function afterAdd($new_shop)
 	{
 		$import_data = Tools::getValue('importData', array());
@@ -304,6 +308,10 @@ class AdminShopControllerCore extends AdminController
 		return parent::afterAdd($new_shop);
 	}
 
+	/**
+	 * @param Shop $new_shop
+	 * @return bool
+	 */
 	protected function afterUpdate($new_shop)
 	{
 		$categories = Tools::getValue('categoryBox');
@@ -630,6 +638,7 @@ class AdminShopControllerCore extends AdminController
 
 		if (!count($this->errors))
 		{
+			/** @var Shop $object */
 			$object = new $this->className();
 			$this->copyFromPost($object, $this->table);
 			$this->beforeAdd($object);

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -416,9 +416,9 @@ class AdminShopUrlControllerCore extends AdminController
 		{
 			if ($this->tabAccess['edit'] === '1')
 			{
-				/** @var ShopUrl $object */
 				if (Validate::isLoadedObject($object = $this->loadObject()))
 				{
+					/** @var ShopUrl $object */
 					if (!$object->main)
 					{
 						$result = $object->setMain();

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -416,6 +416,7 @@ class AdminShopUrlControllerCore extends AdminController
 		{
 			if ($this->tabAccess['edit'] === '1')
 			{
+				/** @var ShopUrl $object */
 				if (Validate::isLoadedObject($object = $this->loadObject()))
 				{
 					if (!$object->main)
@@ -443,6 +444,7 @@ class AdminShopUrlControllerCore extends AdminController
 
 	public function processSave()
 	{
+		/** @var ShopUrl $object */
 		$object = $this->loadObject(true);
 		if ($object->canAddThisUrl(Tools::getValue('domain'), Tools::getValue('domain_ssl'), Tools::getValue('physical_uri'), Tools::getValue('virtual_uri')))
 			$this->errors[] = Tools::displayError('A shop URL that uses this domain already exists.');
@@ -463,6 +465,7 @@ class AdminShopUrlControllerCore extends AdminController
 
 	public function processAdd()
 	{
+		/** @var ShopUrl $object */
 		$object = $this->loadObject(true);
 
 		if ($object->canAddThisUrl(Tools::getValue('domain'), Tools::getValue('domain_ssl'), Tools::getValue('physical_uri'), Tools::getValue('virtual_uri')))
@@ -492,6 +495,10 @@ class AdminShopUrlControllerCore extends AdminController
 		return parent::processUpdate();
 	}
 
+	/**
+	 * @param ShopUrl $object
+	 * @return void
+	 */
 	protected function afterUpdate($object)
 	{
 		if ($object->id && Tools::getValue('main'))

--- a/controllers/admin/AdminStatesController.php
+++ b/controllers/admin/AdminStatesController.php
@@ -221,6 +221,7 @@ class AdminStatesControllerCore extends AdminController
 		{
 			if ($this->tabAccess['delete'] === '1')
 			{
+				/** @var State $object */
 				if (Validate::isLoadedObject($object = $this->loadObject()))
 				{
 					if (!$object->isUsed())

--- a/controllers/admin/AdminStatesController.php
+++ b/controllers/admin/AdminStatesController.php
@@ -221,9 +221,9 @@ class AdminStatesControllerCore extends AdminController
 		{
 			if ($this->tabAccess['delete'] === '1')
 			{
-				/** @var State $object */
 				if (Validate::isLoadedObject($object = $this->loadObject()))
 				{
+					/** @var State $object */
 					if (!$object->isUsed())
 					{
 						if ($object->delete())

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -29,6 +29,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 	public static function getVisits($unique = false, $date_from, $date_to, $granularity = false)
 	{
 		$visits = ($granularity == false) ? 0 : array();
+		/** @var Gapi $gapi */
 		$gapi = Module::isInstalled('gapi') ? Module::getInstanceByName('gapi') : false;
 		if (Validate::isLoadedObject($gapi) && $gapi->isConfigured())
 		{

--- a/controllers/admin/AdminTagsController.php
+++ b/controllers/admin/AdminTagsController.php
@@ -98,6 +98,7 @@ class AdminTagsControllerCore extends AdminController
 	{
 		if ($this->tabAccess['edit'] === '1' && Tools::getValue('submitAdd'.$this->table))
 		{
+			/** @var Tag $obj */
 			if (($id = (int)Tools::getValue($this->identifier)) && ($obj = new $this->className($id)) && Validate::isLoadedObject($obj))
 			{
 				$previous_products = $obj->getProducts();
@@ -119,6 +120,7 @@ class AdminTagsControllerCore extends AdminController
 
 	public function renderForm()
 	{
+		/** @var Tag $obj */
 		if (!($obj = $this->loadObject(true)))
 			return;
 

--- a/controllers/admin/AdminTagsController.php
+++ b/controllers/admin/AdminTagsController.php
@@ -98,9 +98,9 @@ class AdminTagsControllerCore extends AdminController
 	{
 		if ($this->tabAccess['edit'] === '1' && Tools::getValue('submitAdd'.$this->table))
 		{
-			/** @var Tag $obj */
 			if (($id = (int)Tools::getValue($this->identifier)) && ($obj = new $this->className($id)) && Validate::isLoadedObject($obj))
 			{
+				/** @var Tag $obj */
 				$previous_products = $obj->getProducts();
 				$removed_products = array();
 

--- a/controllers/admin/AdminTaxesController.php
+++ b/controllers/admin/AdminTaxesController.php
@@ -234,6 +234,7 @@ class AdminTaxesControllerCore extends AdminController
 				/* Object update */
 				if (isset($id) && !empty($id))
 				{
+					/** @var Tax $object */
 					$object = new $this->className($id);
 					if (Validate::isLoadedObject($object))
 					{
@@ -252,6 +253,7 @@ class AdminTaxesControllerCore extends AdminController
 				/* Object creation */
 				else
 				{
+					/** @var Tax $object */
 					$object = new $this->className();
 					$this->copyFromPost($object, $this->table);
 					if (!$object->add())

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -598,6 +598,7 @@ class AdminThemesControllerCore extends AdminController
 			}
 		}
 
+		/** @var Theme $theme */
 		$theme = parent::processAdd();
 		if ((int)$theme->product_per_page == 0)
 		{
@@ -667,6 +668,7 @@ class AdminThemesControllerCore extends AdminController
 
 	public function processDelete()
 	{
+		/** @var Theme $obj */
 		$obj = $this->loadObject();
 		if ($obj)
 		{
@@ -831,6 +833,12 @@ class AdminThemesControllerCore extends AdminController
 		return false;
 	}
 
+	/**
+	 * @param ZipArchive $obj
+	 * @param string $file
+	 * @param string $server_path
+	 * @param string $archive_path
+	 */
 	private function archiveThisFile($obj, $file, $server_path, $archive_path)
 	{
 		if (is_dir($server_path.$file))
@@ -2811,6 +2819,7 @@ class AdminThemesControllerCore extends AdminController
 
 	public function processResponsive()
 	{
+		/** @var Theme $object */
 		if (Validate::isLoadedObject($object = $this->loadObject()))
 		{
 			if ($object->toggleResponsive())
@@ -2828,6 +2837,7 @@ class AdminThemesControllerCore extends AdminController
 
 	public function processDefaultLeftColumn()
 	{
+		/** @var Theme $object */
 		if (Validate::isLoadedObject($object = $this->loadObject()))
 		{
 			if ($object->toggleDefaultLeftColumn())
@@ -2845,6 +2855,7 @@ class AdminThemesControllerCore extends AdminController
 
 	public function processDefaultRightColumn()
 	{
+		/** @var Theme $object */
 		if (Validate::isLoadedObject($object = $this->loadObject()))
 		{
 			if ($object->toggleDefaultRightColumn())

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -2819,9 +2819,9 @@ class AdminThemesControllerCore extends AdminController
 
 	public function processResponsive()
 	{
-		/** @var Theme $object */
 		if (Validate::isLoadedObject($object = $this->loadObject()))
 		{
+			/** @var Theme $object */
 			if ($object->toggleResponsive())
 				$this->redirect_after = self::$currentIndex.'&conf=5&token='.$this->token;
 			else
@@ -2837,9 +2837,9 @@ class AdminThemesControllerCore extends AdminController
 
 	public function processDefaultLeftColumn()
 	{
-		/** @var Theme $object */
 		if (Validate::isLoadedObject($object = $this->loadObject()))
 		{
+			/** @var Theme $object */
 			if ($object->toggleDefaultLeftColumn())
 				$this->redirect_after = self::$currentIndex.'&conf=5&token='.$this->token;
 			else
@@ -2855,9 +2855,9 @@ class AdminThemesControllerCore extends AdminController
 
 	public function processDefaultRightColumn()
 	{
-		/** @var Theme $object */
 		if (Validate::isLoadedObject($object = $this->loadObject()))
 		{
+			/** @var Theme $object */
 			if ($object->toggleDefaultRightColumn())
 				$this->redirect_after = self::$currentIndex.'&conf=5&token='.$this->token;
 			else

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -35,16 +35,20 @@ class AdminThemesControllerCore extends AdminController
 		parent::__construct();
 	}
 
-	/** This value is used in isThemeCompatible method. only version node with an
+	/**
+	 * This value is used in isThemeCompatible method. only version node with an
 	 * higher version number will be used in [theme]/config.xml
+	 *
 	 * @since 1.4.0.11, check theme compatibility 1.4
-	 * @static
+	 * @var string
 	 */
 	public static $check_features_version = '1.4';
 
-	/** $check_features is a multidimensional array used to check [theme]/config.xml values,
+	/**
+	 * Multidimensional array used to check [theme]/config.xml values,
 	 * and also checks prestashop current configuration if not match.
-	 * @static
+	 *
+	 * @var array
 	 */
 	public static $check_features = array(
 		'ccc' => array(


### PR DESCRIPTION
- static tag is redundant, static methods and variables are detected without this tag;
- PHPDocs for local scope variables is very useful for programmers and for completing PHPDocs of functions;
