### PR TITLE
[-] CORE : Language deletion not complete

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -489,7 +489,7 @@ class LanguageCore extends ObjectModel
 				$this->iso_code = Language::getIsoById($this->id);
 
 			// Database translations deletion
-			$regexp = '/^'.preg_quote(_DB_PREFIX_).'.*_lang$/';
+			$regexp = '/^'.preg_quote(_DB_PREFIX_).'.+_lang$/';
 			$result = Db::getInstance()->executeS('SHOW TABLES FROM `'._DB_NAME_.'`');
 			foreach ($result as $row)
 				if (isset($row['Tables_in_'._DB_NAME_]) && !empty($row['Tables_in_'._DB_NAME_]) && preg_match($regexp, $row['Tables_in_'._DB_NAME_]))
@@ -502,7 +502,7 @@ class LanguageCore extends ObjectModel
 					}
 					catch (Exception $e)
 					{
-						echo 'ERROR with '.$row['Tables_in_'._DB_NAME_].'<br>';
+						// Ignore
 					}
 				}
 

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -687,7 +687,7 @@ class LanguageCore extends ObjectModel
 	{
 		$result = Db::getInstance()->executeS('SHOW TABLES FROM `'._DB_NAME_.'`');
 		foreach ($result as $row)
-			if (preg_match('/_lang/', $row['Tables_in_'._DB_NAME_]) && $row['Tables_in_'._DB_NAME_] != _DB_PREFIX_.'lang')
+			if (preg_match('/^'.preg_quote(_DB_PREFIX_).'.+_lang$/', $row['Tables_in_'._DB_NAME_]) && $row['Tables_in_'._DB_NAME_] != _DB_PREFIX_.'lang')
 			{
 				$result2 = Db::getInstance()->executeS('SELECT * FROM `'.$row['Tables_in_'._DB_NAME_].'` WHERE `id_lang` = '.(int)$from);
 				if (!count($result2))

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -489,12 +489,22 @@ class LanguageCore extends ObjectModel
 				$this->iso_code = Language::getIsoById($this->id);
 
 			// Database translations deletion
+			$regexp = '/^'.preg_quote(_DB_PREFIX_).'.*_lang$/';
 			$result = Db::getInstance()->executeS('SHOW TABLES FROM `'._DB_NAME_.'`');
 			foreach ($result as $row)
-				if (isset($row['Tables_in_'._DB_NAME_]) && !empty($row['Tables_in_'._DB_NAME_]) && preg_match('/'.preg_quote(_DB_PREFIX_).'_lang/', $row['Tables_in_'._DB_NAME_]))
-					if (!Db::getInstance()->execute('DELETE FROM `'.$row['Tables_in_'._DB_NAME_].'` WHERE `id_lang` = '.(int)$this->id))
-						return false;
-
+				if (isset($row['Tables_in_'._DB_NAME_]) && !empty($row['Tables_in_'._DB_NAME_]) && preg_match($regexp, $row['Tables_in_'._DB_NAME_]))
+				{
+					// TO BE DISCUSSED:
+					// Ignore errors because of tables from additional modules that may not respect id_lang column convention
+					try
+					{
+						Db::getInstance()->execute('DELETE FROM `'.$row['Tables_in_'._DB_NAME_].'` WHERE `id_lang` = '.(int)$this->id);
+					}
+					catch (Exception $e)
+					{
+						echo 'ERROR with '.$row['Tables_in_'._DB_NAME_].'<br>';
+					}
+				}
 
 			// Delete tags
 			Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'tag WHERE id_lang = '.(int)$this->id);


### PR DESCRIPTION
It seems there was an error in the regexp used to identify language related tables (no table was processed).
In addition, database deletion errors are now ignored in order not to fail when tables from additional modules don't respect the id_lang column convention (e.g. Affinity Items v2.0.0). This is to be discussed.
