### PR TITLE
[-] CORE : Defined Cache directory not being used

### DIFF
--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -32,7 +32,7 @@ class PrestaShopAutoload
 	/**
 	 * File where classes index is stored
 	 */
-	const INDEX_FILE = 'cache/class_index.php';
+	const INDEX_FILE = 'class_index.php';
 
 	/**
 	 * @var Autoload
@@ -61,7 +61,7 @@ class PrestaShopAutoload
 	protected function __construct()
 	{
 		$this->root_dir = _PS_CORE_DIR_.'/';
-		$file = $this->normalizeDirectory(_PS_ROOT_DIR_).PrestaShopAutoload::INDEX_FILE;
+		$file = $this->normalizeDirectory(_PS_CACHE_DIR_).PrestaShopAutoload::INDEX_FILE;
 		if (@filemtime($file) && is_readable($file))
 			$this->index = include($file);
 		else
@@ -147,7 +147,7 @@ class PrestaShopAutoload
 		$content = '<?php return '.var_export($classes, true).'; ?>';
 
 		// Write classes index on disc to cache it
-		$filename = $this->normalizeDirectory(_PS_ROOT_DIR_).PrestaShopAutoload::INDEX_FILE;
+		$filename = $this->normalizeDirectory(_PS_CACHE_DIR_).PrestaShopAutoload::INDEX_FILE;
 		$filename_tmp = tempnam(dirname($filename), basename($filename.'.'));
 		if ($filename_tmp !== false && file_put_contents($filename_tmp, $content) !== false)
 		{

--- a/install-dev/install_version.php
+++ b/install-dev/install_version.php
@@ -24,4 +24,4 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-define('_PS_INSTALL_VERSION_', '1.6.0.13');
+define('_PS_INSTALL_VERSION_', '1.6.0.14');


### PR DESCRIPTION
Moved recently a cache folder to a faster medium by changing definitions in defines.inc.php. The class_index.php cache file was requested still from the old location because it was hardcoded instead of using _PS_CACHE_DIR_.
