### PR TITLE
[-] CORE : Fix date_add in multishop

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -631,6 +631,14 @@ abstract class ObjectModelCore
 				$this->update_fields['date_upd'] = true;
 		}
 
+		// Automatically fill dates
+		if (array_key_exists('date_add', $this) && $this->date_add == null)
+		{
+			$this->date_add = date('Y-m-d H:i:s');
+			if (isset($this->update_fields) && is_array($this->update_fields) && count($this->update_fields))
+				$this->update_fields['date_add'] = true;
+		}
+
 		$id_shop_list = Shop::getContextListShopID();
 		if (count($this->id_shop_list) > 0)
 			$id_shop_list = $this->id_shop_list;

--- a/install-dev/upgrade/sql/1.6.1.0.sql
+++ b/install-dev/upgrade/sql/1.6.1.0.sql
@@ -163,5 +163,5 @@ ALTER TABLE `PREFIX_customer` ADD KEY `id_shop` (`id_shop`, `date_add`);
 
 ALTER TABLE `PREFIX_cart` DROP KEY `id_shop`;
 ALTER TABLE `PREFIX_cart` ADD KEY `id_shop_2` (`id_shop`,`date_upd`), ADD KEY `id_shop` (`id_shop`,`date_add`);
-
 ALTER TABLE `PREFIX_product_shop` ADD KEY `indexed` (`indexed`, `active`, `id_product`);
+UPDATE `PREFIX_product_shop` SET `date_add` = NOW() WHERE `date_add` = "0000-00-00 00:00:00";


### PR DESCRIPTION
In multishop when you create in shop 1 a product since the product page swap to shop 2 and save date_add isn't set in table
