### PR TITLE
[*] FO, BO: Update jquery typewatch plugin to v2.2.1

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -389,7 +389,7 @@ $('.datepicker').datetimepicker({
 });
 
 $('#giftProductFilter').typeWatch({
-	captureLength: 2,
+	captureLength: 3,
 	highlight: false,
 	wait: 100,
 	callback: function(){ searchProducts(); }
@@ -474,7 +474,7 @@ $('#cart_rule_select_1').jscroll().data('jscrollapi').load_scroll(baseHref+'&typ
 $('#cart_rule_select_2').jscroll().data('jscrollapi').load_scroll(baseHref+'&type=selected&search=');
 
 $('.uncombinable_search_filter').typeWatch({
-	captureLength: -1,
+	captureLength: 0,
 	highlight: true,
 	wait: 500,
 	callback: function(text) { combinable_filter('#cart_rule_select_1', text, 'unselected'); }
@@ -482,7 +482,7 @@ $('.uncombinable_search_filter').typeWatch({
 
 
 $('.combinable_search_filter').typeWatch({
-	captureLength: -1,
+	captureLength: 0,
 	highlight: true,
 	wait: 500,
 	callback: function(text) { combinable_filter('#cart_rule_select_2', text, 'selected'); }

--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -50,13 +50,13 @@
 	$(document).ready(function() {
 
 		$('#customer').typeWatch({
-			captureLength: 1,
+			captureLength: 2,
 			highlight: true,
 			wait: 100,
 			callback: function(){ searchCustomers(); }
 			});
 		$('#product').typeWatch({
-			captureLength: 1,
+			captureLength: 2,
 			highlight: true,
 			wait: 750,
 			callback: function(){ searchProducts(); }

--- a/admin-dev/themes/default/template/controllers/products/prices.tpl
+++ b/admin-dev/themes/default/template/controllers/products/prices.tpl
@@ -37,7 +37,7 @@ $(document).ready(function () {
 		"loader": jQuery('#customerLoader'),
 		"init": function() {
 			jQuery(Customer.field).typeWatch({
-				"captureLength": 1,
+				"captureLength": 2,
 				"highlight": true,
 				"wait": 50,
 				"callback": Customer.search

--- a/js/admin/carrier_wizard.js
+++ b/js/admin/carrier_wizard.js
@@ -404,11 +404,11 @@ function bind_inputs()
 	});
 
 	$('tr.range_sup td input:text, tr.range_inf td input:text').typeWatch({
-		captureLength: 0,
+		captureLength: 1,
 		highlight: false,
 		wait: 1000,
 		callback: function() {
-			index = $(this.el).closest('td').index();
+			index = $(this).closest('td').index();
 			range_sup = $('tr.range_sup td:eq('+index+')').find('div.input-group input:text').val().trim();
 			range_inf = $('tr.range_inf td:eq('+index+')').find('div.input-group input:text').val().trim();
 			if (range_sup != '' && range_inf != '')

--- a/themes/default-bootstrap/js/cart-summary.js
+++ b/themes/default-bootstrap/js/cart-summary.js
@@ -46,8 +46,8 @@ $(document).ready(function(){
 	});
 
 	$('.cart_quantity_input').typeWatch({
-		highlight: true, wait: 600, captureLength: 0, callback: function(val){
-			updateQty(val, true, this.el);
+		highlight: true, wait: 600, captureLength: 1, callback: function(val){
+			updateQty(val, true, this);
 		}
 	});
 

--- a/themes/default-bootstrap/js/order-opc.js
+++ b/themes/default-bootstrap/js/order-opc.js
@@ -911,7 +911,7 @@ function multishippingMode(it)
 							cache: false,
 							success: function(data) {
 								$('#cart_summary').replaceWith($(data).find('#cart_summary'));
-								$('.cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 0, callback: function(val) { updateQty(val, true, this.el); } });
+								$('.cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 1, callback: function(val) { updateQty(val, true, this); } });
 							}
 						});
 						updateCarrierSelectionAndGift();
@@ -924,7 +924,7 @@ function multishippingMode(it)
 						});
 					},
 					'afterLoad': function(){
-						$('.fancybox-inner .cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 0, callback: function(val) { updateQty(val, false, this.el);} });
+						$('.fancybox-inner .cart_quantity_input').typeWatch({ highlight: true, wait: 600, captureLength: 1, callback: function(val) { updateQty(val, false, this);} });
 						cleanSelectAddressDelivery();
 						$('.fancybox-outer').append($('<div class="multishipping_close_container"><a id="multishipping-close" class="btn btn-default button button-small" href="#"><span>'+CloseTxt+'</span></a></div>'));
 						$(document).on('click', '#multishipping-close', function(e){


### PR DESCRIPTION
New version of typewatch:
- Adds support for HTML5 input types
- Triggers input event on paste, cut, etc.
- Triggers input when captureLength is less or **equal** to the input string length.

Corresponding files that use this plugin have been updated. Couldn't find any default modules using this plugin.

Also, not sure what effect this will have on `js/retro-compat.js.php` @ Line 28
