### PR TITLE
[-] BO: Wrong multi-language features

### DIFF
--- a/admin-dev/themes/default/template/controllers/products/features.tpl
+++ b/admin-dev/themes/default/template/controllers/products/features.tpl
@@ -101,7 +101,7 @@
 								name="custom_{$available_feature.id_feature}_{$language.id_lang}"
 								cols="40"
 								rows="1"
-								onkeyup="if (isArrowKey(event)) return ;$('#feature_{$available_feature.id_feature}_value').val(0);" >{$available_feature.val[$k].value|escape:'html':'UTF-8'|default:""}</textarea>
+								onkeyup="if (isArrowKey(event)) return ;$('#feature_{$available_feature.id_feature}_value').val(0);" >{$available_feature.val[$language.id_lang].value|escape:'html':'UTF-8'|default:""}</textarea>
 
 					{if $languages|count > 1}
 						</div>

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -4727,9 +4727,6 @@ class AdminProductsControllerCore extends AdminController
 									$custom = false;
 
 						if ($custom)
-							$features[$k]['val'] = FeatureValue::getFeatureValueLang($features[$k]['current_item']);
-
-						if ($custom)
 						{
 							$feature_values_lang = FeatureValue::getFeatureValueLang($features[$k]['current_item']);
 							foreach($feature_values_lang as $feature_value)

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -4728,6 +4728,13 @@ class AdminProductsControllerCore extends AdminController
 
 						if ($custom)
 							$features[$k]['val'] = FeatureValue::getFeatureValueLang($features[$k]['current_item']);
+
+						if ($custom)
+						{
+							$feature_values_lang = FeatureValue::getFeatureValueLang($features[$k]['current_item']);
+							foreach($feature_values_lang as $feature_value)
+								$features[$k]['val'][$feature_value['id_lang']] = $feature_value;
+						}
 					}
 
 					$data->assign('available_features', $features);


### PR DESCRIPTION
The easiest way to describe it like this: the front-office shows good values, back-office bad

why?
1. We updated PrestaShop from 1.4 to 1.6
2. We deleted few languages, custom feature values was not deleted (and maybe this is something what we should fix too)
3. array looked like this:

[0] => array with values for id_lang = 1
[1] => array with values for id_lang = 2
[2] => array with values for id_lang = 3

Now when we have one language PrestaShop tried to get [0] but should get [2], it's because for some reason you try to get array value by key, I think this change prevents such a problem and make sure that array is always provided by correct language_id

After the change array looks like this:
[1] => array with values for id_lang = 1
[2] => array with values for id_lang = 2
[3] => array with values for id_lang = 3

of course in our case we could change $k to $k+1 but I think it's not the effective solution.

Let me know if you neeed more information about this problem.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Sponsor company | impSolutions
