### PR TITLE
Update StockAvailable.php

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -192,7 +192,8 @@ class StockAvailableCore extends ObjectModel
 									array(
 										'id_product' => $id_product,
 										'id_product_attribute' => 0,
-										'quantity' => $product_quantity
+										'quantity' => $product_quantity,
+										'id_shop' => $id_shop
 										)
 					);
 				}
@@ -250,7 +251,8 @@ class StockAvailableCore extends ObjectModel
 									array(
 										'id_product' => $id_product,
 										'id_product_attribute' => $id_product_attribute,
-										'quantity' => $quantity
+										'quantity' => $quantity,
+										'id_shop' => $id_shop
 									)
 						);
 					}


### PR DESCRIPTION
I'm currently developing a module which send alert by mail when quantity is changing for products. 
I have noticed that the hook "actionUpdateQuantity" is not properly set if my database contains many shops which sell a same product. 
It's impossible to make a difference between two execution of "actionUpdateQuantity" without the id_shop attribute for a same product.
