### PR TITLE
[-] CORE : format currency Switzerland

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -558,7 +558,7 @@ class ToolsCore
 				break;
 			/* X 0'000.00  Added for the switzerland currency */
 			case 5:
-				$ret = $c_char.$blank.number_format($price, $c_decimals, '.', "'");
+				$ret = number_format($price, $c_decimals, '.', "'").$blank.$c_char;
 				break;
 		}
 		if ($is_negative)


### PR DESCRIPTION
In Switzerland the official format for displaying currency is as follows :
10.00 CHF
1'000.00 CHF
The sign of the currency is set to end with a space.
- Original - 

En Suisse le format officiel pour afficher une monnaie est la suivante :
10.00 CHF
1'000.00 CHF
Le signe de la devise est mis à la fin avec un espace.
