### PR TITLE
[-] CORE: Fix inserting HTML configuration variable first time

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -411,16 +411,19 @@ class ConfigurationCore extends ObjectModel
 			{
 				if (!$configID = Configuration::getIdByName($key, $id_shop_group, $id_shop))
 				{
-					$newConfig = new Configuration();
-					$newConfig->name = $key;
-					if ($id_shop)
-						$newConfig->id_shop = (int)$id_shop;
-					if ($id_shop_group)
-						$newConfig->id_shop_group = (int)$id_shop_group;
-					if (!$lang)
-						$newConfig->value = $value;
-					$result &= $newConfig->add(true, true);
-					$configID = $newConfig->id;
+					$now = date('Y-m-d H:i:s');
+					$data = array(
+						'id_shop_group' => $id_shop_group ? (int)$id_shop_group : null,
+						'id_shop'       => $id_shop ? (int)$id_shop : null,
+						'name'          => pSQL($key),
+						'value'         => $lang ? null : pSQL($value, $html),
+						'date_add'      => $now,
+						'date_upd'      => $now,
+					);
+
+					Db::getInstance()->insert('configuration', $data, true);
+
+					$configID = Db::getInstance()->Insert_ID();
 				}
 
 				if ($lang)


### PR DESCRIPTION
This method `updateValue` uses direct SQL to insert/update data everywhere except when inserting 
non-lang new configration key (doesn't exist yet). In this case object model is used. Adding via ObjectModel cannot insert HTML, because `'validate' = 'isCleanHtml'` is not set for `value` column in `Configuration` model definition (I assume to avoid overhead calls). The fixes are:
- use direct SQL to insert this new variable (used in this case)
- add a new property to `ObjectModel` column definitions `'html' = true`.

I don't know which one do you prefer, please tell me.

Also, I noticed a lot of `Db::getInstance` calls in this method. Maybe i would be better to save the instance outsite `foreach` loop ? `$db = Db::getInstance` or even `if (!ObjectModel::$db) { ObjectModel::$db =  Db::getInstance }`. Can you comment on that ?
