### PR TITLE
[*] CORE: PHPDoc - replace @return $this for better compatibility

### DIFF
--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -161,7 +161,7 @@ class UpgraderCore
 	/**
 	 * load the last version informations stocked in base
 	 *
-	 * @return $this
+	 * @return Upgrader
 	 */
 	public function loadFromConfig()
 	{

--- a/classes/tree/Tree.php
+++ b/classes/tree/Tree.php
@@ -228,7 +228,8 @@ class TreeCore
 
 	/**
 	 * @param $value
-	 * @return $this
+	 *
+	 * @return Tree
 	 */
 	public function setTemplateDirectory($value)
 	{

--- a/classes/tree/TreeToolbar.php
+++ b/classes/tree/TreeToolbar.php
@@ -142,7 +142,8 @@ class TreeToolbarCore implements ITreeToolbarCore
 
 	/**
 	 * @param ITreeToolbarButton $action
-	 * @return $this
+	 *
+	 * @return TreeToolbar
 	 * @throws PrestaShopException
 	 */
 	public function addAction($action)

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -78,7 +78,9 @@ class WebserviceOutputBuilderCore
 	 *
 	 * @param WebserviceOutputInterface $obj_render
 	 * @throw WebserviceException if the object render is not an instance of WebserviceOutputInterface
-	 * @return $this
+	 *
+	 * @return WebserviceOutputBuilder
+	 * @throws WebserviceException
 	 */
 	public function setObjectRender(WebserviceOutputInterface $obj_render)
 	{
@@ -106,7 +108,8 @@ class WebserviceOutputBuilderCore
 	 * To build
 	 *
 	 * @param array $resources
-	 * @return $this
+	 *
+	 * @return WebserviceOutputBuilder
 	 */
 	public function setWsResources($resources)
 	{
@@ -134,9 +137,9 @@ class WebserviceOutputBuilderCore
 	/**
 	 * @param string $key The normalized key expected for an http response
 	 * @param string $value
-	 * @throw WebserviceException if the key or the value are corrupted
-	 * 		  (use Validate::isCleanHtml method)
-	 * @return $this
+	 *
+	 * @return WebserviceOutputBuilder
+	 * @throws WebserviceException If the key or the value are corrupted (use Validate::isCleanHtml method)
 	 */
 	public function setHeaderParams($key, $value)
 	{
@@ -173,7 +176,7 @@ class WebserviceOutputBuilderCore
 	/**
 	 * Delete all Header parameters previously set.
 	 *
-	 * @return $this
+	 * @return WebserviceOutputBuilder
 	 */
 	public function resetHeaderParams()
 	{
@@ -716,10 +719,14 @@ class WebserviceOutputBuilderCore
 	}
 
 	/**
-	 *
 	 * @param string|object $object
 	 * @param string $method
-	 * @return $this
+	 * @param $field_name
+	 * @param $entity_name
+	 *
+	 * @return WebserviceOutputBuilder
+	 * @throws Exception
+	 * @throws WebserviceException
 	 */
 	public function setSpecificField($object, $method, $field_name, $entity_name)
 	{


### PR DESCRIPTION
Some IDEs might not understand `@return $this`, explicit type is the best choice.
