### PR TITLE
[*] CORE: PHPDoc - update Db::executeS return types

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -553,7 +553,8 @@ abstract class DbCore
 	 * @param string|DbQuery $sql Query to execute
 	 * @param bool $array Return an array instead of a result object (deprecated since 1.5.0.1, use query method instead)
 	 * @param bool $use_cache
-	 * @return array|false|null|mysqli_result|PDOStatement|resource
+	 *
+	 * @return array|false
 	 * @throws PrestaShopDatabaseException
 	 */
 	public function executeS($sql, $array = true, $use_cache = true)

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -151,7 +151,8 @@ class DbPDOCore extends Db
 	 *
 	 * @see DbCore::getAll()
 	 * @param bool $result
-	 * @return array|false|null
+	 *
+	 * @return array|false
 	 */
 	protected function getAll($result = false)
 	{


### PR DESCRIPTION
- parameter `$array` is deprecated, therefore no one should use it and the return types resulting fromusing it shouldn't be shown. Also, it's ugly `array|false|null|mysqli_result|PDOStatement|resource` type hinting.
