### PR TITLE
[Core] Improve code for making overrides more easy: CmsController.php

### DIFF
--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -56,7 +56,7 @@ class CmsControllerCore extends FrontController
 			$this->cms_category = new CMSCategory($id_cms_category, $this->context->language->id, $this->context->shop->id);
 
 		if (Configuration::get('PS_SSL_ENABLED') && Tools::getValue('content_only') && $id_cms && Validate::isLoadedObject($this->cms)
-			&& in_array($id_cms, array((int)Configuration::get('PS_CONDITIONS_CMS_ID'), (int)Configuration::get('LEGAL_CMS_ID_REVOCATION'))))
+			&& in_array($id_cms, $this->getSSLCMSPageIds()))
 				$this->ssl = true;
 
 		parent::init();
@@ -137,5 +137,14 @@ class CmsControllerCore extends FrontController
 		}
 
 		$this->setTemplate(_PS_THEME_DIR_.'cms.tpl');
+	}
+	
+	/**
+	 * Return an array of IDs of CMS pages, which shouldn't be forwared to their canonical URLs in SSL environment.
+	 * Required for pages which are shown in iframes. 
+	 */
+	protected function getSSLCMSPageIds()
+	{
+		return array((int)Configuration::get('PS_CONDITIONS_CMS_ID'), (int)Configuration::get('LEGAL_CMS_ID_REVOCATION'));
 	}
 }


### PR DESCRIPTION
There might be more SSL pages than conditions and revocation. 
Because of this the IDs should be retrieved in an own method to improve ability to override it. -> No need to override whole init method.
