### PR TITLE
Revert Change Of Swiss Currency Format

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -558,7 +558,7 @@ class ToolsCore
 				break;
 			/* X 0'000.00  Added for the switzerland currency */
 			case 5:
-				$ret = number_format($price, $c_decimals, '.', "'").$blank.$c_char;
+				$ret = $c_char.$blank.number_format($price, $c_decimals, '.', "'");
 				break;
 		}
 		if ($is_negative)


### PR DESCRIPTION
Hi,

Please use the official and most used Swiss currency format:

CHF 9'999'999.00

Examples:

Swiss Post: http://bit.ly/1CjAUeL
Swiss Government: http://bit.ly/1G8VXbw
Largest Swiss Retailers: digitec.ch or brack.ch
Swiss Apple Store: http://store.apple.com/ch-de 
Swiss Microsoft Store: http://bit.ly/1FdOjd2 
Swiss E-Bay: http://ebay.eu/1xHXDWD
Swiss Telecom: https://www.swisscom.ch/de/business/kmu/mobile.html
