### PR TITLE
[*] BO: Display detailled instant stock per warehouse

### DIFF
--- a/controllers/admin/AdminStockInstantStateController.php
+++ b/controllers/admin/AdminStockInstantStateController.php
@@ -227,7 +227,9 @@ class AdminStockInstantStateControllerCore extends AdminController
 			$id_product_attribute = $ids[1];
 			$id_warehouse = Tools::getValue('id_warehouse', -1);
 			$this->_select = 'IFNULL(CONCAT(pl.name, \' : \', GROUP_CONCAT(DISTINCT agl.`name`, \' - \', al.name SEPARATOR \', \')),pl.name) as name,
-				w.id_currency, a.price_te';
+				w.id_currency, w.id_warehouse, w.name AS warehouse_name,
+				a.price_te, a.physical_quantity, a.usable_quantity,
+				(a.price_te * a.physical_quantity) as valuation';
 			$this->_join = ' LEFT JOIN `'._DB_PREFIX_.'warehouse` AS w ON w.id_warehouse = a.id_warehouse';
 			$this->_join .= ' LEFT JOIN `'._DB_PREFIX_.'product_lang` pl ON (
 				a.id_product = pl.id_product
@@ -248,7 +250,7 @@ class AdminStockInstantStateControllerCore extends AdminController
 			if ($id_warehouse != -1)
 				$this->_where .= ' AND a.id_warehouse = '.(int)$id_warehouse;
 
-			$this->_group = 'GROUP BY a.price_te';
+			$this->_group = 'GROUP BY a.id_warehouse';
 
 			self::$currentIndex = self::$currentIndex.'&id_stock='.Tools::getValue('id_stock').'&detailsstock';
 			return parent::renderList();
@@ -271,7 +273,8 @@ class AdminStockInstantStateControllerCore extends AdminController
 			{
 				$item = &$this->_list[$i];
 				$manager = StockManagerFactory::getManager();
-
+				
+				/*
 				// gets quantities and valuation
 				$query = new DbQuery();
 				$query->select('SUM(physical_quantity) as physical_quantity');
@@ -288,10 +291,12 @@ class AdminStockInstantStateControllerCore extends AdminController
 				$item['physical_quantity'] = $res['physical_quantity'];
 				$item['usable_quantity'] = $res['usable_quantity'];
 				$item['valuation'] = $res['valuation'];
+				*/
+				
 				$item['real_quantity'] = $manager->getProductRealQuantities(
 					$item['id_product'],
 					$item['id_product_attribute'],
-					($this->getCurrentCoverageWarehouse() == -1 ? null : array($this->getCurrentCoverageWarehouse())),
+					$item['id_warehouse'],
 					true
 				);
 			}


### PR DESCRIPTION
Related to http://forge.prestashop.com/browse/PSCSX-4567

I don't fully agree with @sfroment42 fix https://github.com/PrestaShop/PrestaShop/commit/da22f0e7c710b3ea3143a173311b6a7d68e96cda
In stock details, quantities are no more multiplied by number of shops \* number of attributes, but they are the same (global quantities) on every line.

As I have no idea of the spec for this view, I made the assumption that it should be a detail per warehouse, and propose this change. If it is the case, product/combination information should be displayed only once, e.g. at the top of page, and warehouse reference/name should be included in the table (not done at the moment).
