### PR TITLE
The coding norm is incorrect for https://validator.prestashop.com

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -543,6 +543,7 @@ abstract class ModuleCore
 						$list[] = array(
 							'file' => $upgrade_path.$file,
 							'version' => $file_version,
+							/* The coding norm is incorrect, PrestaShop's standards have to be respected. */
 							'upgrade_function' => 'upgrade_module_'.str_replace('.', '_', $file_version));
 					}
 				}


### PR DESCRIPTION
The coding norm is incorrect, PrestaShop's standards have to be respected.

Please take a look at:
http://doc.prestashop.com/display/PS16/Coding+Standards

You could also install PHP_Code_Sniffer:
http://doc.prestashop.com/display/PS16/Coding+Standards#CodingStandards-Installingthecodevalidator%28PHPCodeSniffer%29
