### PR TITLE
[-] BO: Exported CSV not correct

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -913,6 +913,16 @@ class AdminControllerCore extends Controller
 	}
 
 	/**
+	 * @param string $value
+	 * @param string $text_delimiter
+	 * @return string
+	 */
+	private function doubleDelimiter($value, $text_delimiter)
+	{
+		return str_replace($text_delimiter, $text_delimiter.$text_delimiter, $value);
+	}
+	
+	/**
 	 * @param string $text_delimiter
 	 * @throws PrestaShopException
 	 */
@@ -936,7 +946,7 @@ class AdminControllerCore extends Controller
 			if ($datas['title'] == 'PDF')
 				unset($this->fields_list[$key]);
 			else
-				$headers[] = Tools::htmlentitiesDecodeUTF8($datas['title']);
+				$headers[] = $this->doubleDelimiter(Tools::htmlentitiesDecodeUTF8($datas['title']), $text_delimiter);
 		}
 		$content = array();
 		foreach ($this->_list as $i => $row)
@@ -962,7 +972,7 @@ class AdminControllerCore extends Controller
 					if (!preg_match('/<([a-z]+)([^<]+)*(?:>(.*)<\/\1>|\s+\/>)/ism', call_user_func_array(array($callback_obj, $params['callback']), array($field_value, $row))))
 						$field_value = call_user_func_array(array($callback_obj, $params['callback']), array($field_value, $row));
 				}
-				$content[$i][] = $field_value;
+				$content[$i][] = $this->doubleDelimiter($field_value, $text_delimiter);
 			}
 		}
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -917,7 +917,7 @@ class AdminControllerCore extends Controller
 	 * @param string $text_delimiter
 	 * @return string
 	 */
-	private function doubleDelimiter($value, $text_delimiter)
+	protected function doubleDelimiter($value, $text_delimiter)
 	{
 		return str_replace($text_delimiter, $text_delimiter.$text_delimiter, $value);
 	}

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -338,13 +338,13 @@ class AdminRequestSqlControllerCore extends AdminController
 				foreach (array_keys($results[0]) as $key)
 				{
 					$tab_key[] = $key;
-					fputs($csv, $key.';');
+					fputs($csv, '"'.$this->doubleDelimiter($key, '"').'";');
 				}
 				foreach ($results as $result)
 				{
 					fputs($csv, "\n");
 					foreach ($tab_key as $name)
-						fputs($csv, '"'.strip_tags($result[$name]).'";');
+						fputs($csv, '"'.$this->doubleDelimiter(strip_tags($result[$name]), '"').'";');
 				}
 				if (file_exists($export_dir.$file))
 				{


### PR DESCRIPTION
CSV specification requires quotes to be doubled when part of value. As a generalization, the text delimiter is doubled within values. Done in both abstract AdminController (when exporting any list) and SQL Manager (when exporting query results). Maybe it could/should be applied somewhere else...
