### PR TITLE
Update blocktopmenu.js

### DIFF
--- a/themes/default-bootstrap/js/modules/blocktopmenu/js/blocktopmenu.js
+++ b/themes/default-bootstrap/js/modules/blocktopmenu/js/blocktopmenu.js
@@ -37,12 +37,12 @@ $(document).ready(function(){
 // check resolution
 function responsiveMenu()
 {
-   if ($(document).width() <= 767 && responsiveflagMenu == false)
+   if (window.innerWidth <= 767 && responsiveflagMenu == false)
 	{
 		menuChange('enable');
 		responsiveflagMenu = true;
 	}
-	else if ($(document).width() >= 768)
+	else if (window.innerWidth >= 768)
 	{
 		menuChange('disable');
 		responsiveflagMenu = false;


### PR DESCRIPTION
changed $(document).width() to window.innerWidth in the responsiveMenu function.

when an option which was not force compile was selected the $(document).width() would return a higher number which would disable the toggle function on mobile devices.

the window.innerWidth returned the right value onload and onresize.
