### PR TITLE
[-] FO: Fix bootstrap .has-* form state class colors

### DIFF
--- a/themes/default-bootstrap/css/global.css
+++ b/themes/default-bootstrap/css/global.css
@@ -1513,50 +1513,50 @@ textarea.input-lg, .input-group-lg > textarea.form-control,
 
 .has-warning .help-block,
 .has-warning .control-label {
-  color: #fff; }
+  color: #e4752b; }
 .has-warning .form-control {
-  border-color: #fff;
+  border-color: #e4752b;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
-  .has-warning .form-control:focus {
-    border-color: #e6e6e6;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px white;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px white; }
+.has-warning .form-control:focus {
+    border-color: #c35d19;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0b085;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0b085; }
 .has-warning .input-group-addon {
-  color: #fff;
-  border-color: #fff;
+  color: #e4752b;
+  border-color: #e4752b;
   background-color: #fe9126; }
 
 .has-error .help-block,
 .has-error .control-label {
-  color: #fff; }
+  color: #d4323d; }
 .has-error .form-control {
-  border-color: #fff;
+  border-color: #d4323d;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
-  .has-error .form-control:focus {
-    border-color: #e6e6e6;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px white;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px white; }
+.has-error .form-control:focus {
+    border-color: #ae252e;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #e6868d;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #e6868d; }
 .has-error .input-group-addon {
-  color: #fff;
-  border-color: #fff;
+  color: #d4323d;
+  border-color: #d4323d;
   background-color: #f3515c; }
 
 .has-success .help-block,
 .has-success .control-label {
-  color: #fff; }
+  color: #48b151; }
 .has-success .form-control {
-  border-color: #fff;
+  border-color: #48b151;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
-  .has-success .form-control:focus {
-    border-color: #e6e6e6;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px white;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px white; }
+.has-success .form-control:focus {
+    border-color: #398d40;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #8ed194;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #8ed194; }
 .has-success .input-group-addon {
-  color: #fff;
-  border-color: #fff;
+  color: #48b151;
+  border-color: #48b151;
   background-color: #55c65e; }
 
 .form-control-static {

--- a/themes/default-bootstrap/sass/bootstrap_lib/_forms.scss
+++ b/themes/default-bootstrap/sass/bootstrap_lib/_forms.scss
@@ -235,15 +235,15 @@ input[type="checkbox"],
 
 // Warning
 .has-warning {
-  @include form-control-validation($state-warning-text, $state-warning-text, $state-warning-bg);
+  @include form-control-validation($state-warning-border, $state-warning-border, $state-warning-bg);
 }
 // Error
 .has-error {
-  @include form-control-validation($state-danger-text, $state-danger-text, $state-danger-bg);
+  @include form-control-validation($state-danger-border, $state-danger-border, $state-danger-bg);
 }
 // Success
 .has-success {
-  @include form-control-validation($state-success-text, $state-success-text, $state-success-bg);
+  @include form-control-validation($state-success-border, $state-success-border, $state-success-bg);
 }
 
 


### PR DESCRIPTION
- Currently, if you put `.has-error, .has-success, .has-warning` on `.form-group`, the input element and the text go white. This is because white color was used in alerts.
- If someone uses these classes (I have) and forgets to check the colors, it will be very confusing. There is also a JS script using these classes.

I don't work with sass, I hope this is ok. I didn't want to add extra variables. Also, I had some trouble compiling scss, the color codes for the whole project were different `white` instead of `#fff`.
Let me know if your tools compile this the same way.
