### PR TITLE
[-] MO : Fixed h2 bug in blockcategories module

### DIFF
--- a/themes/default-bootstrap/css/modules/blockcategories/blockcategories.css
+++ b/themes/default-bootstrap/css/modules/blockcategories/blockcategories.css
@@ -42,6 +42,8 @@
     #categories_block_top .sf-menu .category_thumb {
       display: none; }
 
+#categories_block_left h2 {
+  margin-top: 0px}
 #categories_block_left .block_content > ul {
   border-top: 1px solid #d6d4d4; }
 #categories_block_left li {


### PR DESCRIPTION
Fixed a bug in blockcategories module when h2.title_block adds additional 18px of margin on top of the block when its positioned in the left coloumn.
