### PR TITLE
Fix unity validation

### DIFF
--- a/admin-dev/themes/default/template/controllers/products/prices.tpl
+++ b/admin-dev/themes/default/template/controllers/products/prices.tpl
@@ -213,7 +213,7 @@ $(document).ready(function () {
 				<span class="input-group-addon">{$currency->prefix}{$currency->suffix}</span>
 				<input id="unit_price" name="unit_price" type="text" value="{$unit_price|string_format:'%.6f'}" maxlength="27" onkeyup="if (isArrowKey(event)) return ;this.value = this.value.replace(/,/g, '.'); unitPriceWithTax('unit');"/>
 				<span class="input-group-addon">{l s='per'}</span>
-				<input id="unity" name="unity" type="text" value="{$product->unity|htmlentitiesUTF8}"  maxlength="10" onkeyup="if (isArrowKey(event)) return ;unitySecond();" onchange="unitySecond();"/>
+				<input id="unity" name="unity" type="text" value="{$product->unity|htmlentitiesUTF8}"  maxlength="255" onkeyup="if (isArrowKey(event)) return ;unitySecond();" onchange="unitySecond();"/>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
The unity string is of type VARCHAR(255) in the database, but the client-side validation restricts it to 10 characters.
The CSV-Import, however, does not. When the user tries to edit an imported product with a unity string of more than 10 characters, the unity text field is initialized with the too long / invalid string and the product can not be saved.
This commit fixes this by allowing a longer unity string.
