### PR TITLE
[*] FO: Use email input type

### DIFF
--- a/admin-dev/themes/default/template/controllers/addresses/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/addresses/helpers/form/form.tpl
@@ -86,7 +86,7 @@
 			</script>
 
 			<div class="col-lg-4">
-				<input type="text" id="email" name="email" value="{$fields_value[$input.name]|escape:'html':'UTF-8'}"/>
+				<input type="email" id="email" name="email" value="{$fields_value[$input.name]|escape:'html':'UTF-8'}"/>
 			</div>
 		{/if}
 	{else}

--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl
@@ -46,7 +46,7 @@
 			<div id="message_forward_email" class="row row-margin-bottom" style="display:none">
 				<label class="control-label col-lg-3">{l s='Email'}</label>
 				<div class="col-lg-3"> 
-					<input type="text" name="email" />
+					<input type="email" name="email" />
 				</div>
 			</div>
 			<div id="message_forward" style="display:none;">

--- a/admin-dev/themes/default/template/controllers/login/content.tpl
+++ b/admin-dev/themes/default/template/controllers/login/content.tpl
@@ -65,7 +65,7 @@
 						<label class="control-label" for="email">{l s='Email address'}</label>
 						<div class="input-group">
 							<span class="input-group-addon"><i class="icon-envelope"></i></span>
-							<input name="email" type="text" id="email" class="form-control" value="{if isset($email)}{$email|escape:'html':'UTF-8'}{/if}" autofocus="autofocus" tabindex="1" placeholder="test@example.com" />
+							<input name="email" type="email" id="email" class="form-control" value="{if isset($email)}{$email|escape:'html':'UTF-8'}{/if}" autofocus="autofocus" tabindex="1" placeholder="test@example.com" />
 						</div>
 					</div>
 					<div class="form-group">

--- a/themes/default-bootstrap/authentication.tpl
+++ b/themes/default-bootstrap/authentication.tpl
@@ -58,7 +58,7 @@
 					<div class="alert alert-danger" id="create_account_error" style="display:none"></div>
 					<div class="form-group">
 						<label for="email_create">{l s='Email address'}</label>
-						<input type="text" class="is_required validate account_input form-control" data-validate="isEmail" id="email_create" name="email_create" value="{if isset($smarty.post.email_create)}{$smarty.post.email_create|stripslashes}{/if}" />
+						<input type="email" class="is_required validate account_input form-control" data-validate="isEmail" id="email_create" name="email_create" value="{if isset($smarty.post.email_create)}{$smarty.post.email_create|stripslashes}{/if}" />
 					</div>
 					<div class="submit">
 						{if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
@@ -79,7 +79,7 @@
 				<div class="form_content clearfix">
 					<div class="form-group">
 						<label for="email">{l s='Email address'}</label>
-						<input class="is_required validate account_input form-control" data-validate="isEmail" type="text" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email|stripslashes}{/if}" />
+						<input class="is_required validate account_input form-control" data-validate="isEmail" type="email" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email|stripslashes}{/if}" />
 					</div>
 					<div class="form-group">
 						<label for="passwd">{l s='Password'}</label>
@@ -450,7 +450,7 @@
 			</div>
 			<div class="required form-group">
 				<label for="email">{l s='Email'} <sup>*</sup></label>
-				<input type="text" class="is_required validate form-control" data-validate="isEmail" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email}{/if}" />
+				<input type="email" class="is_required validate form-control" data-validate="isEmail" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email}{/if}" />
 			</div>
 			<div class="required password form-group">
 				<label for="passwd">{l s='Password'} <sup>*</sup></label>

--- a/themes/default-bootstrap/guest-tracking.tpl
+++ b/themes/default-bootstrap/guest-tracking.tpl
@@ -110,7 +110,7 @@
                     </div>
                     <div class="text form-group">
                         <label>{l s='Email:'}</label>
-                        <input class="form-control" type="text" name="email" value="{if isset($smarty.get.email)}{$smarty.get.email|escape:'html':'UTF-8'}{else}{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'}{/if}{/if}" />
+                        <input class="form-control" type="email" name="email" value="{if isset($smarty.get.email)}{$smarty.get.email|escape:'html':'UTF-8'}{else}{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'}{/if}{/if}" />
                     </div>
 			<p>
                 <button type="submit" name="submitGuestTracking" class="button btn btn-default button-medium"><span>{l s='Send'}<i class="icon-chevron-right right"></i></span></button>

--- a/themes/default-bootstrap/order-opc-new-account.tpl
+++ b/themes/default-bootstrap/order-opc-new-account.tpl
@@ -11,7 +11,7 @@
 				<!-- END Error return block -->
 				<p class="form-group">
 					<label for="login_email">{l s='Email address'}</label>
-					<input type="text" class="form-control validate" id="login_email" name="email" data-validate="isEmail" />
+					<input type="email" class="form-control validate" id="login_email" name="email" data-validate="isEmail" />
 				</p>
 				<p class="form-group">
 					<label for="login_passwd">{l s='Password'}</label>
@@ -60,7 +60,7 @@
 					<input type="hidden" id="opc_id_address_invoice" name="opc_id_address_invoice" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
 					<div class="required text form-group">
 						<label for="email">{l s='Email'} <sup>*</sup></label>
-						<input type="text" class="text form-control validate" id="email" name="email" data-validate="isEmail" value="{if isset($guestInformations) && isset($guestInformations.email) && $guestInformations.email}{$guestInformations.email}{/if}" />
+						<input type="email" class="text form-control validate" id="email" name="email" data-validate="isEmail" value="{if isset($guestInformations) && isset($guestInformations.email) && $guestInformations.email}{$guestInformations.email}{/if}" />
 					</div>
 					<div class="required password is_customer_param form-group">
 						<label for="passwd">{l s='Password'} <sup>*</sup></label>

--- a/themes/default-bootstrap/password.tpl
+++ b/themes/default-bootstrap/password.tpl
@@ -39,7 +39,7 @@
 	<fieldset>
 		<div class="form-group">
 			<label for="email">{l s='Email address'}</label>
-			<input class="form-control" type="text" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'|stripslashes}{/if}" />
+			<input class="form-control" type="email" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'|stripslashes}{/if}" />
 		</div>
 		<p class="submit">
             <button type="submit" class="btn btn-default button button-medium"><span>{l s='Retrieve Password'}<i class="icon-chevron-right right"></i></span></button>


### PR DESCRIPTION
- Falls back to `type="text"` if the browser doesn't support this type
- Doesn't add any extra styles
- May add special input depending on device (Symbol @ in mobile keyboards)
- May add extra client side (browser) validation (for example, Chrome reminds to type in @ symbol)
