### PR TITLE
[*] BO : Check for transient fields before building select

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3116,6 +3116,11 @@ class AdminControllerCore extends Controller
 					if (isset($this->_select) && preg_match('/[\s]`?'.preg_quote($key, '/').'`?\s*,/', $this->_select))
 						continue;
 
+					// Check that our object really has that column
+					$klass = $this->className;
+					$def = $klass::getDefinition($klass);
+					if ($def['primary'] !== $key && !isset($def['fields'][$key])) continue;
+
 					if (isset($array_value['filter_key']))
 						$this->_listsql .= str_replace('!', '.', $array_value['filter_key']).' as '.$key.',';
 					elseif ($key == 'id_'.$this->table)


### PR DESCRIPTION
This allows modules to override both `action{$controller}ListingFieldsModifier` and `action{$controller}ListingResultsModifier` to provide additional columns to show, without that column being backed by something in the database.
