### PR TITLE
[-] CORE : Category::updateGroup fix

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1244,6 +1244,7 @@ class CategoryCore extends ObjectModel
 		$this->cleanGroups();
 		if (empty($list))
 			$list = array(Configuration::get('PS_UNIDENTIFIED_GROUP'), Configuration::get('PS_GUEST_GROUP'), Configuration::get('PS_CUSTOMER_GROUP'));
+		$list = array_unique($list);
 		$this->addGroups($list);
 	}
 


### PR DESCRIPTION
When `$list` contains duplicate ID_GROUPs, database throws duplicate key error.

This can happen because an administrator has to option to merge default groups, eg. Guest and Visitor, into one single group, or modify the default groups in a different way that result into

```
$list = array(Configuration::get('PS_UNIDENTIFIED_GROUP'), Configuration::get('PS_GUEST_GROUP'), Configuration::get('PS_CUSTOMER_GROUP'));
```

having duplicates.
