### PR TITLE
[+] BO : In the webservice settings warn about missing .htaccess file

### DIFF
--- a/controllers/admin/AdminWebserviceController.php
+++ b/controllers/admin/AdminWebserviceController.php
@@ -274,6 +274,9 @@ class AdminWebserviceControllerCore extends AdminController
 			else
 				$this->warnings[] = $this->l('We could not check to see if basic authentication and rewrite extensions have been activated. Please manually check if they\'ve been activated in order to use the PrestaShop webservice.');
 		}
+
+        if (configuration::get('PS_WEBSERVICE') && !file_exists(_PS_ROOT_DIR_.'/.htaccess'))
+            $this->warnings[] = $this->l('The .htaccess file is missing. Please check if the server has write access to PrestaShop\'s main folder and reenable webservice in order to generate that file.');
 		if (!extension_loaded('SimpleXML'))
 			$this->warnings[] = $this->l('Please activate the \'SimpleXML\' PHP extension to allow testing of PrestaShop\'s webservice.');
 		if (!configuration::get('PS_SSL_ENABLED'))


### PR DESCRIPTION
During a webservice activation, Presta generates the .htaccess file with rewrite settings. This is required, otherwise path presta/api/ won't work.

However, if server doesn't have a write permission to shop's main folder (this is not a part of installation check - imho that's right, not everyone will turn on webservice), Presta will fail silently. I lost about one day, trying to figure what's wrong.

This 3-lines commit adds warning about missing .htaccess file if webservice is enabled. 
