### PR TITLE
[-] BO : Fix logic of warnings about missing Apache modules

### DIFF
--- a/controllers/admin/AdminWebserviceController.php
+++ b/controllers/admin/AdminWebserviceController.php
@@ -266,18 +266,19 @@ class AdminWebserviceControllerCore extends AdminController
 		if (strpos($_SERVER['SERVER_SOFTWARE'], 'Apache') === false)
 		{
 			$this->warnings[] = $this->l('To avoid operating problems, please use an Apache server.');
-			if (function_exists('apache_get_modules'))
-			{
-				$apache_modules = apache_get_modules();
-				if (!in_array('mod_auth_basic', $apache_modules))
-					$this->warnings[] = $this->l('Please activate the \'mod_auth_basic\' Apache module to allow authentication of PrestaShop\'s webservice.');
-				if (!in_array('mod_rewrite', $apache_modules))
-					$this->warnings[] = $this->l('Please activate the \'mod_rewrite\' Apache module to allow the PrestaShop webservice.');
-			}
-			else
-				$this->warnings[] = $this->l('We could not check to see if basic authentication and rewrite extensions have been activated. Please manually check if they\'ve been activated in order to use the PrestaShop webservice.');
 		}
-		if (!extension_loaded('SimpleXML'))
+
+        if (function_exists('apache_get_modules'))
+        {
+            $apache_modules = apache_get_modules();
+            if (!in_array('mod_auth_basic', $apache_modules))
+                $this->warnings[] = $this->l('Please activate the \'mod_auth_basic\' Apache module to allow authentication of PrestaShop\'s webservice.');
+            if (!in_array('mod_rewrite', $apache_modules))
+                $this->warnings[] = $this->l('Please activate the \'mod_rewrite\' Apache module to allow the PrestaShop webservice.');
+        }
+        else
+            $this->warnings[] = $this->l('We could not check to see if basic authentication and rewrite extensions have been activated. Please manually check if they\'ve been activated in order to use the PrestaShop webservice.');
+        if (!extension_loaded('SimpleXML'))
 			$this->warnings[] = $this->l('Please activate the \'SimpleXML\' PHP extension to allow testing of PrestaShop\'s webservice.');
 		if (!configuration::get('PS_SSL_ENABLED'))
 			$this->warnings[] = $this->l('It is preferable to use SSL (https:) for webservice calls, as it avoids the "man in the middle" type security issues.');


### PR DESCRIPTION
Webservice settings panel has code to warn about missing Apache modules: 
- mod_auth_basic,
- mod_rewrite.

However, that code was executed inside condition that server is not an Apache:

```
if (strpos($_SERVER['SERVER_SOFTWARE'], 'Apache') === false)
```

... thus, they were never showed.

This commit moves checks about missing modules out of not-an-Apache condition block. Suppose, that was original intention of this code. 
