### PR TITLE
[-] CORE: Fix isEmail() regexp, follow up 62798af

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -47,7 +47,7 @@ class ValidateCore
 	 */
 	public static function isEmail($email)
 	{
-		return !empty($email) && preg_match(Tools::cleanNonUnicodeSupport('/^[a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+(?:[.]?[_a-z\p{L}0-9-])*\.[a-z\p{L}0-9]+$/ui'), $email);
+		return !empty($email) && preg_match(Tools::cleanNonUnicodeSupport('/^[a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[\.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+(?:\.?[_a-z\p{L}0-9-])*\.[a-z\p{L}0-9]+$/ui'), $email);
 	}
 
 	/**


### PR DESCRIPTION
Fix "This e-mail address is invalid" on systems with older PCRE versions.
For details please check my comment on commit https://github.com/PrestaShop/PrestaShop/commit/62798af30aa6769f6042b439503d8ed96b7f084d
