### PR TITLE
[*] Adding getter for DB link

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -871,4 +871,14 @@ abstract class DbCore
 		Db::s($sql, $use_cache);
 		die();
 	}
+	
+	/**
+	 * Get used link instance
+	 *
+	 * @return PDO|mysqli|resource Resource
+	 */
+	public function getLink()
+	{
+		return $this -> link;
+	}
 }

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -879,6 +879,6 @@ abstract class DbCore
 	 */
 	public function getLink()
 	{
-		return $this -> link;
+		return $this->link;
 	}
 }


### PR DESCRIPTION
this getter help to use some database specific methods exposed by $link instance.

For example with PDO and the `beginTransaction()` and `commit()` methods
