### PR TITLE
[*] FO: Add SEO WebPage microdata property to body element

### DIFF
--- a/themes/default-bootstrap/header.tpl
+++ b/themes/default-bootstrap/header.tpl
@@ -61,7 +61,7 @@
 		<script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
 		<![endif]-->
 	</head>
-	<body{if isset($page_name)} id="{$page_name|escape:'html':'UTF-8'}"{/if} class="{if isset($page_name)}{$page_name|escape:'html':'UTF-8'}{/if}{if isset($body_classes) && $body_classes|@count} {implode value=$body_classes separator=' '}{/if}{if $hide_left_column} hide-left-column{else} show-left-column{/if}{if $hide_right_column} hide-right-column{else} hide-right-column{/if}{if isset($content_only) && $content_only} content_only{/if} lang_{$lang_iso}">
+	<body{if isset($page_name)} id="{$page_name|escape:'html':'UTF-8'}"{/if} class="{if isset($page_name)}{$page_name|escape:'html':'UTF-8'}{/if}{if isset($body_classes) && $body_classes|@count} {implode value=$body_classes separator=' '}{/if}{if $hide_left_column} hide-left-column{else} show-left-column{/if}{if $hide_right_column} hide-right-column{else} hide-right-column{/if}{if isset($content_only) && $content_only} content_only{/if} lang_{$lang_iso}" itemscope itemtype="http://schema.org/WebPage">
 	{if !isset($content_only) || !$content_only}
 		{if isset($restricted_country_mode) && $restricted_country_mode}
 			<div id="restricted-country">


### PR DESCRIPTION
Adding this property wlll allow to implement a bunch of other properties useful for SEO. Adding WebPage properties (like breadcrumb) without declaring WebPage item still works because every page is assumed to be a WebPage. However, it is recommended in the documentation to implicitly specify it [schema.org/WebPage](http://schema.org/WebPage).

Some of the propeties that could be added in `WebPage` scope:
- [Sitelinks Search Box](https://developers.google.com/structured-data/slsb-overview)
- [mainContentOfPage](http://schema.org/mainContentOfPage) 
- [primaryImageOfPage](http://schema.org/primaryImageOfPage) Could be used in Category, Product pages
- [WebPageElement](http://schema.org/WebPageElement) Does't need to be in `WebPage`, but still related.

`WebPage` has a bunch of more specific types, for example:
- AboutPage
- CheckoutPage
- CollectionPage
- ContactPage
- ItemPage
- QAPage
- SearchResultsPage
