### PR TITLE
[-] Project : Fixed LIFO - FIFO stock management

### DIFF
--- a/classes/stock/StockManager.php
+++ b/classes/stock/StockManager.php
@@ -364,17 +364,13 @@ class StockManagerCore implements StockManagerInterface
 
 						while ($row = Db::getInstance()->nextRow($resource))
 						{
-							// break - in FIFO mode, we have to retreive the oldest positive mvts for which there are left quantities
+							// continue - in FIFO mode, we have to retreive the oldest positive mvts for which there are left quantities
 							if ($warehouse->management_type == 'FIFO')
 								if ($row['qty'] == 0)
-									break;
-
-							// converts date to timestamp
-							$date = new DateTime($row['date_add']);
-							$timestamp = $date->format('U');
+									continue;
 
 							// history of the mvt
-							$stock_history_qty_available[$timestamp] = array(
+							$stock_history_qty_available[(int)$row['id_stock_mvt']] = array(
 								'id_stock' => $stock->id,
 								'id_stock_mvt' => (int)$row['id_stock_mvt'],
 								'qty' => (int)$row['qty']


### PR DESCRIPTION
Fixed : On FIFO management type, if the qty was 0 the script stopped search newest stock to decrement. Continue instead of a break solve this issue.
Fixed : Bad behavior when several stock where added at the exact same second. Removing the timestamp key to $stock_history_qty_available array fix this issue.
