### PR TITLE
[-] BO : Fix generation of export themes

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -861,7 +861,7 @@ class AdminThemesControllerCore extends AdminController
 	{
 		$zip = new ZipArchive();
 		$zip_file_name = md5(time()).'.zip';
-		if ($zip->open(_PS_CACHE_DIR_.$zip_file_name, ZipArchive::OVERWRITE) === true)
+		if ($zip->open(_PS_CACHE_DIR_.$zip_file_name, ZipArchive::OVERWRITE | ZipArchive::CREATE) === true)
 		{
 			if (!$zip->addFromString('Config.xml', $this->xml_file))
 				$this->errors[] = $this->l('Cannot create config file.');
@@ -1297,7 +1297,7 @@ class AdminThemesControllerCore extends AdminController
 		{
 			foreach ($to_install as $module)
 				$fields_value['modulesToExport_module'.$module] = true;
-				
+
 			$fields_form['form']['input'][] = array(
 				'type' => 'checkbox',
 				'label' => $this->l('Select the theme\'s modules that you wish to export'),


### PR DESCRIPTION
ZipArchive::Overwrite doesn't create the zip since php 5.2.8 cf:http://nz2.php.net/manual/en/ziparchive.open.php#88765
