### PR TITLE
[-] PDF : Update supply-order-footer.tpl

### DIFF
--- a/pdf/supply-order-footer.tpl
+++ b/pdf/supply-order-footer.tpl
@@ -31,11 +31,11 @@
 			{if !empty($shop_phone) OR !empty($shop_fax)}
 				{l s='For more assistance, contact Support:' pdf='true'}<br />
 				{if !empty($shop_phone)}
-					Tel: {$shop_phone|escape:'html':'UTF-8'}
+					{l s='Tel:' pdf='true'} {$shop_phone|escape:'html':'UTF-8'} | 
 				{/if}
 
 				{if !empty($shop_fax)}
-					Fax: {$shop_fax|escape:'html':'UTF-8'}
+					{l s='Fax:' pdf='true'} {$shop_fax|escape:'html':'UTF-8'}
 				{/if}
 				<br />
 			{/if}


### PR DESCRIPTION
Please avoid hard coded display text and always allow translations. In Poland e.g. it's 'faks' instead of 'fax'!
Added a separator after the phone number, too.
