### PR TITLE
Newsletter preference fix

### DIFF
--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -91,7 +91,7 @@ class AuthControllerCore extends FrontController
 
 		$this->assignCountries();
 
-		$newsletter = Configuration::get('PS_CUSTOMER_NWSL') || (Module::isInstalled('blocknewsletter') && Module::getInstanceByName('blocknewsletter')->active);
+		$newsletter = Configuration::get('PS_CUSTOMER_NWSL') && (Module::isInstalled('blocknewsletter') && Module::getInstanceByName('blocknewsletter')->active);
 		$this->context->smarty->assign('newsletter', $newsletter);
 		$this->context->smarty->assign('optin', (bool)Configuration::get('PS_CUSTOMER_OPTIN'));
 


### PR DESCRIPTION
The newsletter module should be installed and enabled in the preferences. Turning it off in the preferences should make a difference instead of trying to figure out why it's still showing up.
