### PR TITLE
Fixing PSCSX-4423 => read order API broken

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2093,7 +2093,7 @@ class OrderCore extends ObjectModel
 		return true;
 	}
 
-	public function getWsCurrentState($state)
+	public function getWsCurrentState()
 	{
 		return $this->getCurrentState();
 	}


### PR DESCRIPTION
Order.php. Issue PSCSX-4423 on Forge

Note: This is just a cherry-pick of https://github.com/PrestaShop/PrestaShop/commit/e40f97157d06f7ac71dbe2ee7533df9d686352dc on master so that this fix is included in the next release - not waiting for 1.6.1.0

As this is a very annoying bug for those relying on the API so it'd be great to have it released with 1.6.0.15

Thanks
