### PR TITLE
[*] BO : Fix supply order PDF generation

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -48,7 +48,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
 
 		$id_lang = Context::getContext()->language->id;
 		$this->title = $order_invoice->getInvoiceNumberFormatted($id_lang);
-		// footer informations
+
 		$this->shop = new Shop((int)$this->order->id_shop);
 	}
 

--- a/classes/pdf/HTMLTemplateOrderReturn.php
+++ b/classes/pdf/HTMLTemplateOrderReturn.php
@@ -45,10 +45,9 @@ class HTMLTemplateOrderReturnCore extends HTMLTemplate
 
 		// header informations
 		$this->date = Tools::displayDate($this->order->invoice_date);
-		$prefix = Configuration::get('PS_RETURN_PREFIX', Context::getContext()->language->id)
+		$prefix = Configuration::get('PS_RETURN_PREFIX', Context::getContext()->language->id);
 		$this->title = sprintf(HTMLTemplateOrderReturn::l('Order Return %1$s%2$06d'), $prefix, $this->order_return->id);
 
-		// footer informations
 		$this->shop = new Shop((int)$this->order->id_shop);
 	}
 

--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -54,7 +54,6 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
 		$prefix = Configuration::get('PS_CREDIT_SLIP_PREFIX', Context::getContext()->language->id);
 		$this->title = sprintf(HTMLTemplateOrderSlip::l('Credit Slip %1$s%2$06d'), $prefix, (int)$this->order_slip->id);
 
-		// footer informations
 		$this->shop = new Shop((int)$this->order->id_shop);
 	}
 

--- a/classes/pdf/HTMLTemplateSupplyOrderForm.php
+++ b/classes/pdf/HTMLTemplateSupplyOrderForm.php
@@ -52,6 +52,8 @@ class HTMLTemplateSupplyOrderFormCore extends HTMLTemplate
 		// header informations
 		$this->date = Tools::displayDate($supply_order->date_add);
 		$this->title = HTMLTemplateSupplyOrderForm::l('Supply order form');
+
+		$this->shop = new Shop((int)$this->order->id_shop);
 	}
 
 	/**


### PR DESCRIPTION
HTMLTemplate::$shop is not only used for footer information,
it's required to locate the template.
See HTMLTemplate::getTemplate()
