### PR TITLE
[*] BO: AdminTaxRulesGroupController - wording dissociation (All)

### DIFF
--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -254,7 +254,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
 						'name' => 'name',
 						'default' => array(
 							'value' => 0,
-							'label' => $this->l('All')
+							'label' => $this->l('All', 'AdminTaxRulesGroupController')
 						)
 					)
 				),
@@ -270,7 +270,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
 						'name' => 'name',
 						'default' => array(
 							'value' => 0,
-							'label' => $this->l('All')
+							'label' => $this->l('All', 'AdminTaxRulesGroupController')
 						)
 					)
 				),


### PR DESCRIPTION
vs 'All' in stats modules

To allow different translations for 'All' in other languages.
(French -> 'Toutes' vs 'Tous')
