### PR TITLE
[*] blocktopmenu: mark all parent li as sfHoverForce

### DIFF
--- a/themes/default-bootstrap/js/modules/blocktopmenu/js/blocktopmenu.js
+++ b/themes/default-bootstrap/js/modules/blocktopmenu/js/blocktopmenu.js
@@ -28,6 +28,7 @@ var categoryMenu = $('ul.sf-menu');
 var mCategoryGrover = $('.sf-contener .cat-title');
 
 $(document).ready(function(){
+	$('ul.sf-menu .sfHoverForce').parentsUntil('ul.sf-menu', 'li').addClass('sfHoverForce');
 	categoryMenu = $('ul.sf-menu');
 	mCategoryGrover = $('.sf-contener .cat-title');
 	responsiveMenu();


### PR DESCRIPTION
that way the top menu glows as selected

via. https://github.com/PrestaShop/blocktopmenu/pull/26
