### PR TITLE
New hooks (override static definiton property in any model)

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -271,8 +271,7 @@ abstract class ObjectModelCore
 			{
 				$this->id = (int)$id;
 				foreach ($object_datas as $key => $value)
-					if (array_key_exists($key, $this))
-						$this->{$key} = $value;
+					$this->{$key} = $value;
 			}
 		}
 	}
@@ -1714,8 +1713,7 @@ abstract class ObjectModelCore
 			$this->id = $data[$this->def['primary']];
 
 		foreach ($data as $key => $value)
-			if (array_key_exists($key, $this))
-				$this->$key = $value;
+			$this->$key = $value;
 	}
 
 	/**
@@ -1793,6 +1791,11 @@ abstract class ObjectModelCore
 		{
 			$reflection = new ReflectionClass($class);
 			$definition = $reflection->getStaticPropertyValue('definition');
+
+			Hook::exec(
+				'actionOverride'.$class.'Definition',
+				array('definition'=>&$definition)
+			);
 
 			$definition['classname'] = $class;
 


### PR DESCRIPTION
Creation of a new hook serie in order to override each Model static definition propertie.

New hook are called actionOverride<ModelNameHere>Definition.

For example you can use the hook actionOverrideProductDefinition too override and add fields on Product instance.
Or actionOverrideCustomerDefinition for Customer instance.

With this modification any and multiple module can add onw property on instance like that:
public function hookActionOverrideProductDefinition($params)
    {
        $params['definition']['fields']['new_property_name'] = array('type' => ObjectModel::TYPE_BOOL, 'validate' => 'isBool');

```
    //Dont forget alter table on module installation with this SQL request
    // ALTER TABLE `product` ADD `new_property_name` INT NOT NULL DEFAULT '0' ;
}
```
