### PR TITLE
[+] Project : Add hooks on Object init

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -275,6 +275,10 @@ abstract class ObjectModelCore
 						$this->{$key} = $value;
 			}
 		}
+		
+		// @hook actionObject*Init
+		Hook::exec('actionObjectInit', array('object' => $this));
+		Hook::exec('actionObject'.get_class($this).'Init', array('object' => $this));
 	}
 
 	/**


### PR DESCRIPTION
For example, it gives possibility to add properties to the object.

``` php
class MyModule extends Module
{
    public function hookActionObjectProductInit($params)
    {
        $property = $this->getProductProperty($params['object']->id);
        $params['object']->my_property = $property;
    }

    public function hookActionObjectProductUpdateAfter($params)
    {
        $this->setProductProperty($params['object']->id, $params['object']->my_property);
    }

    public function hookActionObjectProductAddAfter($params)
    {
        $this->setProductProperty($params['object']->id, $params['object']->my_property);
    }

    public function hookActionObjectProductDeleteAfter($params)
    {
        $this->deleteProductProperty($params['object']->id);
    }
}
```
