### PR TITLE
[*] CORE : Fix #PSCSX-5128, set tax correctly with specific price

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -523,11 +523,11 @@ class OrderDetailCore extends ObjectModel
 					if ($this->reduction_tax)
 					{
 						$this->reduction_amount_tax_incl = $this->reduction_amount;
-						$this->reduction_amount_tax_excl = Tools::ps_round($this->tax_calculator->removeTaxes($this->reduction_amount), 2);
+						$this->reduction_amount_tax_excl = Tools::ps_round($this->tax_calculator->removeTaxes($this->reduction_amount), _PS_PRICE_COMPUTE_PRECISION_);
 					}
 					else
 					{
-						$this->reduction_amount_tax_incl = Tools::ps_round($this->tax_calculator->addTaxes($this->reduction_amount), 2);
+						$this->reduction_amount_tax_incl = Tools::ps_round($this->tax_calculator->addTaxes($this->reduction_amount), _PS_PRICE_COMPUTE_PRECISION_);
 						$this->reduction_amount_tax_excl = $this->reduction_amount;
 					}
 				break;

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -520,8 +520,16 @@ class OrderDetailCore extends ObjectModel
 					$tax_manager = TaxManagerFactory::getManager($this->vat_address, $id_tax_rules);
 					$this->tax_calculator = $tax_manager->getTaxCalculator();
 
-					$this->reduction_amount_tax_incl = $this->reduction_amount;
-					$this->reduction_amount_tax_excl = Tools::ps_round($this->tax_calculator->removeTaxes($this->reduction_amount_tax_incl), 2);
+					if ($this->reduction_tax)
+					{
+						$this->reduction_amount_tax_incl = $this->reduction_amount;
+						$this->reduction_amount_tax_excl = Tools::ps_round($this->tax_calculator->removeTaxes($this->reduction_amount), 2);
+					}
+					else
+					{
+						$this->reduction_amount_tax_incl = Tools::ps_round($this->tax_calculator->addTaxes($this->reduction_amount), 2);
+						$this->reduction_amount_tax_excl = $this->reduction_amount;
+					}
 				break;
 			}
 	}


### PR DESCRIPTION
Since this commit 348433bbfd1dff9839d74fb87e571b4b525ab39e we can create a
specific price before tax. Values `OrderDetails::reduction_amount_tax_incl` and `OrderDetails::reduction_amount_tax_excl`
weren't set correctly if the specific price was before tax.
