### PR TITLE
Fixing #PSCSX-5799 => I18n field output when no language is specified in URL

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -476,7 +476,7 @@ class WebserviceRequestCore
 			if (isset($this->urlFragments['language']))
 				$this->_available_languages = $this->filterLanguage();
 			else
-				$this->_available_languages[] = Language::getIDs();
+				$this->_available_languages = Language::getIDs();
 
 			if (empty($this->_available_languages))
 				$this->setError(400, 'language is not available', 81);


### PR DESCRIPTION
API displays 
language id="Array" xlink:href="http://127.0.0.1/api/languages/Array"/
instead of actual value when no language is specified as parameter.

One can see in https://github.com/PrestaShop/PrestaShop/blob/1.6/classes/webservice/WebserviceOutputXML.php#L93-L106 that languages is indeed supposed to be an array of ints and not an array with an array inside.

Bug was introduced in https://github.com/PrestaShop/PrestaShop/commit/836105f5d1d878ffbff5578e89e2414bd5dc055a#diff-6f9aef6c863f595ab49368d3ff7608efL479
