### PR TITLE
[-]FO : call autoAddToCart when removing a voucher

### DIFF
--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -130,6 +130,7 @@ class ParentOrderControllerCore extends FrontController
 				elseif (($id_cart_rule = (int)Tools::getValue('deleteDiscount')) && Validate::isUnsignedId($id_cart_rule))
 				{
 					$this->context->cart->removeCartRule($id_cart_rule);
+					CartRule::autoAddToCart($this->context);
 					Tools::redirect('index.php?controller=order-opc');
 				}
 			}


### PR DESCRIPTION
A voucher with code may be not cumulative with an automatic cart rule.

For exemple, a voucher with code THEVOUCHER is not cumulative with an automatic cart rule allowing 10% for more than 100€ of products.
The customer create a cart of 50€, enter the code code THEVOUCHER then add product to have more than 100€.

When removing the voucher code in the cart summary, the automatic cart rule reduction must appear in place of the removed voucher.
