### PR TITLE
[+] PDF: Keep invoice and delivery address for invoicing

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -78,6 +78,12 @@ class OrderInvoiceCore extends ObjectModel
 	/** @var string shop address */
 	public $shop_address;
 
+	/** @var string invoice address */
+	public $invoice_address;
+
+	/** @var string delivery address */
+	public $delivery_address;
+
 	/** @var string note */
 	public $note;
 
@@ -113,6 +119,8 @@ class OrderInvoiceCore extends ObjectModel
 			'total_wrapping_tax_excl' =>array('type' => self::TYPE_FLOAT),
 			'total_wrapping_tax_incl' =>array('type' => self::TYPE_FLOAT),
 			'shop_address' => 		array('type' => self::TYPE_HTML, 'validate' => 'isCleanHtml', 'size' => 1000),
+			'invoice_address' => 		array('type' => self::TYPE_HTML, 'validate' => 'isCleanHtml', 'size' => 1000),
+			'delivery_address' => 		array('type' => self::TYPE_HTML, 'validate' => 'isCleanHtml', 'size' => 1000),
 			'note' => 					array('type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 65000),
 			'date_add' => 				array('type' => self::TYPE_DATE, 'validate' => 'isDate'),
 		),
@@ -130,6 +138,14 @@ class OrderInvoiceCore extends ObjectModel
 		$address->id_country = Configuration::get('PS_SHOP_COUNTRY_ID');
 
 		$this->shop_address = AddressFormat::generateAddress($address, array(), '<br />', ' ');
+
+		$order = new Order($this->id_order);
+
+		$invoice_address = new Address((int)$order->id_address_invoice);
+		$this->invoice_address = AddressFormat::generateAddress($invoice_address, array(), '<br />', ' ');
+
+		$delivery_address = new Address((int)$order->id_address_delivery);
+		$this->delivery_address = AddressFormat::generateAddress($delivery_address, array(), '<br />', ' ');
 
 		return parent::add();
 	}

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -136,14 +136,22 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
 		$invoice_address = new Address((int)$this->order->id_address_invoice);
 		$country = new Country((int)$invoice_address->id_country);
 
-		$formatted_invoice_address = AddressFormat::generateAddress($invoice_address, array(), '<br />', ' ');
+		if ($this->order_invoice->invoice_address)
+			$formatted_invoice_address = $this->order_invoice->invoice_address;
+		else
+			$formatted_invoice_address = AddressFormat::generateAddress($invoice_address, array(), '<br />', ' ');
 
 		$delivery_address = null;
 		$formatted_delivery_address = '';
 		if (isset($this->order->id_address_delivery) && $this->order->id_address_delivery)
 		{
-			$delivery_address = new Address((int)$this->order->id_address_delivery);
-			$formatted_delivery_address = AddressFormat::generateAddress($delivery_address, array(), '<br />', ' ');
+			if ($this->order_invoice->delivery_address)
+				$formatted_delivery_address = $this->order_invoice->delivery_address;
+			else
+			{
+				$delivery_address = new Address((int)$this->order->id_address_delivery);
+				$formatted_delivery_address = AddressFormat::generateAddress($delivery_address, array(), '<br />', ' ');
+			}
 		}
 
 		$customer = new Customer((int)$this->order->id_customer);

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1174,6 +1174,8 @@ CREATE TABLE `PREFIX_order_invoice` (
   `total_wrapping_tax_excl` decimal(20, 6) NOT NULL DEFAULT '0.00',
   `total_wrapping_tax_incl` decimal(20, 6) NOT NULL DEFAULT '0.00',
   `shop_address` text DEFAULT NULL,
+  `invoice_address` text DEFAULT NULL,
+  `delivery_address` text DEFAULT NULL,
   `note` text,
   `date_add` datetime NOT NULL,
   PRIMARY KEY (`id_order_invoice`),

--- a/install-dev/upgrade/sql/1.6.1.0.sql
+++ b/install-dev/upgrade/sql/1.6.1.0.sql
@@ -178,5 +178,7 @@ ALTER TABLE `PREFIX_smarty_lazy_cache` CHANGE `cache_id` `cache_id` varchar(255)
 TRUNCATE TABLE `PREFIX_smarty_lazy_cache`;
 
 ALTER TABLE `PREFIX_order_invoice` ADD `shop_address` TEXT DEFAULT NULL AFTER `total_wrapping_tax_incl`;
+ALTER TABLE `PREFIX_order_invoice` ADD `invoice_address` TEXT DEFAULT NULL AFTER `shop_address`;
+ALTER TABLE `PREFIX_order_invoice` ADD `delivery_address` TEXT DEFAULT NULL AFTER `invoice_address`;
 
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`) VALUES ('displayInvoiceLegalFreeText', 'PDF Invoice - Legal Free Text', 'This hook allows you to modify the legal free text on PDF invoices');


### PR DESCRIPTION
If the customer update his address after order were placed. We will keep using his old (and correct) address for invoicing.
This is a legal requirement since addresses matter for tax calculation.

See related commit https://github.com/PrestaShop/PrestaShop/commit/d4bd0a0bf45e98b0dacfc2d41607a14105e92f67
