### PR TITLE
Functions should be aborted after a page redirect

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/js.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/js.tpl
@@ -141,8 +141,9 @@
 						$('#moduleContainer').html('<img id="loader_module_list" src="../img/loader.gif" alt="" border="0" />');
 					},
 					success: function(data, status, request){
-						if (request.getResponseHeader('Login') === 'true')
+						if (request.getResponseHeader('Login') === 'true') {
 							return window.location.reload();
+						}
 
 						$('#moduleContainer').html(data);
 						$('.dropdown-toggle').dropdown();

--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -497,8 +497,10 @@ function init()
 					success : function(data) {
 						if (data.result)
 						{
-							if (data.refresh)
+							if (data.refresh) {
 								location.reload();
+								return;
+							}
 							go = false;
 							addViewOrderDetailRow(data.view);
 							updateAmounts(data.order);

--- a/themes/default-bootstrap/js/cart-summary.js
+++ b/themes/default-bootstrap/js/cart-summary.js
@@ -418,8 +418,10 @@ function deleteProductFromSummary(id)
 			}
 			else
 			{
-				if (jsonData.refresh)
+				if (jsonData.refresh) {
 					location.reload();
+					return;
+				}
 				if (parseInt(jsonData.summary.products.length) == 0)
 				{
 					if (typeof(orderProcess) == 'undefined' || orderProcess !== 'order-opc')
@@ -853,8 +855,10 @@ function updateCartSummary(json)
 	}
 	else
 	{
-		if ($('.cart_discount').length == 0)
+		if ($('.cart_discount').length == 0) {
 			location.reload();
+			return;
+		}
 
 		if (priceDisplayMethod !== 0)
 			$('#total_discount').html('-' + formatCurrency(json.total_discounts_tax_exc, currencyFormat, currencySign, currencyBlank));

--- a/themes/default-bootstrap/js/order-opc.js
+++ b/themes/default-bootstrap/js/order-opc.js
@@ -381,8 +381,10 @@ function updateAddressSelection()
 			}
 			else
 			{
-				if (jsonData.refresh)
+				if (jsonData.refresh) {
 					location.reload();
+					return;
+				}
 				// Update all product keys with the new address id
 				$('#cart_summary .address_'+deliveryAddress).each(function() {
 					$(this)


### PR DESCRIPTION
Functions should be aborted after a page redirect, otherwise errors might be triggered (because there is no expected xhr response data)
