### PR TITLE
[-] CORE : Fix #PSCSX-5605 correct query syntax error

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1176,7 +1176,9 @@ class CartRuleCore extends ObjectModel
 			'.(in_array($type, array('carrier', 'shop')) ? ' AND t.deleted = 0' : '').'
 			'.($type == 'cart_rule' ? 'AND t.id_cart_rule != '.(int)$this->id : '').
 			$shop_list.
-			' ORDER BY name ASC '.$sql_limit);
+			(in_array($type, array('carrier', 'shop')) ? ' ORDER BY t.name ASC ' : '').
+			(in_array($type, array('country', 'group', 'cart_rule')) && $i18n ? ' ORDER BY tl.name ASC ' : '').
+			$sql_limit);
 		}
 		else
 		{
@@ -1192,7 +1194,9 @@ class CartRuleCore extends ObjectModel
 				WHERE 1 '.($active_only ? ' AND t.active = 1' : '').
 				$shop_list
 				.(in_array($type, array('carrier', 'shop')) ? ' AND t.deleted = 0' : '').
-				' ORDER BY name ASC '.$sql_limit,
+				(in_array($type, array('carrier', 'shop')) ? ' ORDER BY t.name ASC ' : '').
+				(in_array($type, array('country', 'group', 'cart_rule')) && $i18n ? ' ORDER BY tl.name ASC ' : '').
+				$sql_limit,
 				false);
 				while ($row = Db::getInstance()->nextRow($resource))
 					$array[($row['selected'] || $this->{$type.'_restriction'} == 0) ? 'selected' : 'unselected'][] = $row;


### PR DESCRIPTION
- 'carrier', 'shop' table contain name and don't have lang table 
- 'country', 'group', 'cart_rule' table don't contain name field so only order by when lang table is join
