### PR TITLE
[-] FO : Prevent errors after page redirect

### DIFF
--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -498,7 +498,10 @@ function init()
 						if (data.result)
 						{
 							if (data.refresh)
+							{
 								location.reload();
+								return;
+							}
 							go = false;
 							addViewOrderDetailRow(data.view);
 							updateAmounts(data.order);

--- a/themes/default-bootstrap/js/cart-summary.js
+++ b/themes/default-bootstrap/js/cart-summary.js
@@ -420,7 +420,10 @@ function deleteProductFromSummary(id)
 			else
 			{
 				if (jsonData.refresh)
+				{
 					location.reload();
+					return;
+				}
 				if (parseInt(jsonData.summary.products.length) == 0)
 				{
 					if (typeof(orderProcess) == 'undefined' || orderProcess !== 'order-opc')
@@ -855,7 +858,10 @@ function updateCartSummary(json)
 	else
 	{
 		if ($('.cart_discount').length == 0)
+		{
 			location.reload();
+			return;
+		}
 
 		if (priceDisplayMethod !== 0)
 			$('#total_discount').html('-' + formatCurrency(json.total_discounts_tax_exc, currencyFormat, currencySign, currencyBlank));

--- a/themes/default-bootstrap/js/order-opc.js
+++ b/themes/default-bootstrap/js/order-opc.js
@@ -382,7 +382,10 @@ function updateAddressSelection()
 			else
 			{
 				if (jsonData.refresh)
+				{
 					location.reload();
+					return;
+				}
 				// Update all product keys with the new address id
 				$('#cart_summary .address_' + deliveryAddress).each(function() {
 					$(this)


### PR DESCRIPTION
Functions should be aborted after a page redirect, otherwise errors might be triggered.
E.g. because there is no expected xhr response data to render
