### PR TITLE
Memcached

### DIFF
--- a/cache/class_index.php
+++ b/cache/class_index.php
@@ -1403,6 +1403,18 @@
     'type' => 'class',
     'override' => false,
   ),
+  'CacheMemcached' => 
+  array (
+    'path' => '',
+    'type' => 'class',
+    'override' => false,
+  ),
+  'CacheMemcachedCore' => 
+  array (
+    'path' => 'classes/cache/CacheMemcached.php',
+    'type' => 'class',
+    'override' => false,
+  ),
   'CacheXcache' => 
   array (
     'path' => '',

--- a/classes/cache/CacheMemcached.php
+++ b/classes/cache/CacheMemcached.php
@@ -1,0 +1,151 @@
+<?php
+/*
+* 2015 Raphaël Droz
+*/
+/**
+ * This class require PECL Memcached extension
+ *
+ */
+class CacheMemcachedCore extends Cache
+{
+	/**
+	 * @var Memcached
+	 */
+	protected $memcached;
+
+	/**
+	 * @var bool Connection status
+	 */
+	protected $is_connected = false;
+
+	public function __construct()
+	{
+		$this->connect();
+		if($this->is_connected)
+		{
+			$this->keys = array_flip($this->memcached->getAllKeys());
+		}
+
+	}
+
+	public function __destruct()
+	{
+		$this->close();
+	}
+
+	/**
+	 * Connect to memcached server
+	 */
+	public function connect()
+	{
+		if (class_exists('Memcached') && extension_loaded('memcached'))
+			$this->memcached = new Memcached();
+		else
+			return;
+		
+		$servers = self::getMemcachedServers();
+		if (!$servers)
+			return;
+		foreach ($servers as $server)
+			$this->memcached->addServer($server['ip'], $server['port'], (int) $server['weight']);
+
+		$this->is_connected = true;
+	}
+
+	/**
+	 * @see Cache::_set()
+	 */
+	protected function _set($key, $value, $ttl = 0)
+	{
+		if (!$this->is_connected)
+			return false;
+		return $this->memcached->set($key, $value, $ttl);
+	}
+
+	/**
+	 * @see Cache::_get()
+	 */
+	protected function _get($key)
+	{
+		if (!$this->is_connected)
+			return false;
+		return $this->memcached->get($key);
+	}
+
+	/**
+	 * @see Cache::_exists()
+	 */
+	protected function _exists($key)
+	{
+		if (!$this->is_connected)
+			return false;
+		return isset($this->keys[$key]);
+	}
+
+	/**
+	 * @see Cache::_delete()
+	 */
+	protected function _delete($key)
+	{
+		if (!$this->is_connected)
+			return false;
+		return $this->memcached->delete($key);
+	}
+
+	/**
+	 * @see Cache::_writeKeys()
+	 */
+	protected function _writeKeys() { }
+
+	/**
+	 * @see Cache::flush()
+	 */
+	public function flush()
+	{
+		if (!$this->is_connected)
+			return false;
+		return $this->memcached->flush();
+	}
+
+	/**
+	 * Close connection to memcached server
+	 *
+	 * @return bool
+	 */
+	protected function close()
+	{
+		return $this->memcached->quit();
+	}
+
+	/**
+	 * Add a memcached server
+	 *
+	 * @param string $ip
+	 * @param int $port
+	 * @param int $weight
+	 */
+	public static function addServer($ip, $port, $weight)
+	{
+		return Db::getInstance()->execute('INSERT INTO '._DB_PREFIX_.'memcached_servers (ip, port, weight) VALUES(\''.pSQL($ip).'\', '.(int)$port.', '.(int)$weight.')', false);
+	}
+
+	/**
+	 * Get list of memcached servers
+	 *
+	 * @return array
+	 */
+	public static function getMemcachedServers()
+	{
+		return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('SELECT * FROM '._DB_PREFIX_.'memcached_servers', true, false);
+	}
+
+	/**
+	 * Delete a memcached server
+	 *
+	 * @param int $id_server
+	 */
+	public static function deleteServer($id_server)
+	{
+		return Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'memcached_servers WHERE id_memcached_server='.(int)$id_server);
+	}
+}

--- a/classes/cache/CacheMemcached.php
+++ b/classes/cache/CacheMemcached.php
@@ -49,7 +49,7 @@ class CacheMemcachedCore extends Cache
 		foreach ($servers as $server)
 			$this->memcached->addServer($server['ip'], $server['port'], (int) $server['weight']);
 
-		$this->is_connected = true;
+		$this->is_connected = in_array('255.255.255', $this->memcached->getVersion(), TRUE) === FALSE;
 	}
 
 	/**

--- a/classes/cache/CacheMemcached.php
+++ b/classes/cache/CacheMemcached.php
@@ -23,6 +23,9 @@ class CacheMemcachedCore extends Cache
 		$this->connect();
 		if($this->is_connected)
 		{
+			$this->memcached->setOption(Memcached::OPT_PREFIX_KEY, _DB_PREFIX_);
+			if($this->memcached->getOption(Memcached::HAVE_IGBINARY))
+				$this->memcached->setOption(Memcached::OPT_SERIALIZER, Memcached::SERIALIZER_IGBINARY);
 			$this->keys = array_flip($this->memcached->getAllKeys());
 		}
 

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -566,7 +566,12 @@ class AdminPerformanceControllerCore extends AdminController
 						array(
 							'id' => 'CacheMemcache',
 							'value' => 'CacheMemcache',
-							'label' => $this->l('Memcached').(extension_loaded('memcache') ? '' : $warning_memcached)
+							'label' => $this->l('Memcached via PHP::Memcache').(extension_loaded('memcache') ? '' : $warning_memcached)
+						),
+						array(
+							'id' => 'CacheMemcached',
+							'value' => 'CacheMemcached',
+							'label' => $this->l('Memcached via PHP::Memcached').(extension_loaded('memcached') ? '' : $warning_memcached)
 						),
 						array(
 							'id' => 'CacheApc',
@@ -907,6 +912,9 @@ class AdminPerformanceControllerCore extends AdminController
 					if ($caching_system == 'CacheMemcache' && !extension_loaded('memcache'))
 						$this->errors[] = Tools::displayError('To use Memcached, you must install the Memcache PECL extension on your server.').'
 							<a href="http://www.php.net/manual/en/memcache.installation.php">http://www.php.net/manual/en/memcache.installation.php</a>';
+					elseif ($caching_system == 'CacheMemcached' && !extension_loaded('memcached'))
+						$this->errors[] = Tools::displayError('To use Memcached, you must install the Memcached PECL extension on your server.').'
+							<a href="http://www.php.net/manual/en/memcached.installation.php">http://www.php.net/manual/en/memcached.installation.php</a>';
 					elseif ($caching_system == 'CacheApc' && !extension_loaded('apc'))
 						$this->errors[] = Tools::displayError('To use APC cache, you must install the APC PECL extension on your server.').'
 							<a href="http://fr.php.net/manual/fr/apc.installation.php">http://fr.php.net/manual/fr/apc.installation.php</a>';
@@ -937,6 +945,8 @@ class AdminPerformanceControllerCore extends AdminController
 						}
 					}
 					elseif ($caching_system == 'CacheMemcache' && !_PS_CACHE_ENABLED_ && _PS_CACHING_SYSTEM_ == 'CacheMemcache')
+						Cache::getInstance()->flush();
+					elseif ($caching_system == 'CacheMemcached' && !_PS_CACHE_ENABLED_ && _PS_CACHING_SYSTEM_ == 'CacheMemcached')
 						Cache::getInstance()->flush();
 				}
 

--- a/install-dev/install_version.php
+++ b/install-dev/install_version.php
@@ -24,4 +24,4 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-define('_PS_INSTALL_VERSION_', '1.6.0.13');
+define('_PS_INSTALL_VERSION_', '1.6.0.14');

--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -212,7 +212,7 @@ $mysqlEngine = (defined('_MYSQL_ENGINE_') ? _MYSQL_ENGINE_ : 'MyISAM');
 
 if (defined('_PS_CACHING_SYSTEM_') AND _PS_CACHING_SYSTEM_ == 'CacheFS')
 	$cache_engine = 'CacheFs';
-elseif (defined('_PS_CACHING_SYSTEM_') AND _PS_CACHING_SYSTEM_ != 'CacheMemcache')
+elseif (defined('_PS_CACHING_SYSTEM_') AND _PS_CACHING_SYSTEM_ != 'CacheMemcache' AND _PS_CACHING_SYSTEM_ != 'CacheMemcached')
 	$cache_engine = _PS_CACHING_SYSTEM_;
 else
 	$cache_engine = 'CacheMemcache';


### PR DESCRIPTION
This adds a memcached cache backend based on the newer PHP::Memcached API (not the PHP::Memcache one).
It's better:
- quicker
- not more _writeKeys hack
- more robust (the _writeKeys hack could easily timeout)
  The memcached servers add/del things are reused **but** note that data cached with memcache _may_ not function with memcached (serialization differences). If that happens, after changing settings.inc.php, run:

``` php
php -r '$m = new Memcached(); $m->addServer("127.0.0.1", 11211, true); $m->flush();'
```

Some defaults about install/upgrade may need some minors additional tweaks.
