### PR TITLE
[*] CORE : escape value for the insert() method

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -463,7 +463,7 @@ abstract class DbCore
 				if ($value['type'] == 'sql')
 					$values[] = $string_value = $value['value'];
 				else
-					$values[] = $string_value = $null_values && ($value['value'] === '' || is_null($value['value'])) ? 'NULL' : "'{$value['value']}'";
+					$values[] = $string_value = $null_values && ($value['value'] === '' || is_null($value['value'])) ? 'NULL' : "'".$this->escape($value['value'], true)."'";
 
 				if ($type == Db::ON_DUPLICATE_KEY)
 					$duplicate_key_stringified .= '`'.bqSQL($key).'` = '.$string_value.',';


### PR DESCRIPTION
For the moment it does't work with something like that : 

Db::getInstance()->insert('product_lang', array('description' => "C'est un test"));
