### PR TITLE
[-] BO: Fixed bug on product save with pack items

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -4944,6 +4944,7 @@ class AdminProductsControllerCore extends AdminController
 	 */
 	public function updatePackItems($product)
 	{
+		if(!Tools::isSubmit('inputPackItems')) return; //dont update if no data
 		Pack::deleteItems($product->id);
 		// lines format: QTY x ID-QTY x ID
 		if (Tools::getValue('type_product') == Product::PTYPE_PACK)


### PR DESCRIPTION
When clicked on save fast enough, the Pack tab was not loaded, causing product to remove all packed items and revert to normal product
