### PR TITLE
[-] BO: Optimize product search query

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3571,7 +3571,7 @@ class ProductCore extends ObjectModel
 
 		if (Combination::isFeatureActive())
 		{
-			$sql->leftJoin('product_attribute', 'pa', 'pa.`id_product` = p.`id_product`');
+			$sql->leftJoin('product_attribute', 'pa', 'pa.`id_product` = p.`id_product` AND pa.`id_product_attribute` = sp.`id_product_attribute`');
 			$sql->join(Shop::addSqlAssociation('product_attribute', 'pa', false));
 			$where .= ' OR pa.`reference` LIKE \'%'.pSQL($query).'%\'
 			OR pa.`supplier_reference` LIKE \'%'.pSQL($query).'%\'


### PR DESCRIPTION
Complete ps_product_attribute JOIN condition.

Previous condition caused systematically MySQL error 1317 on one (not performant enough?) server. After modification, number of rows (before WHERE and GROUP BY) for each product changes from nb_combinations x nb_combinations to nb_combinations.
