### PR TITLE
[FO] : Bugfix NM-304

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -545,7 +545,8 @@ function reloadContent(params_plus)
 				$('#pagination').hide();
 				$('#pagination_bottom').hide();
 			}
-
+			current_friendly_url = result.current_friendly_url;
+			
 			paginationButton(result.nbRenderedProducts, result.nbAskedProducts);
 			ajaxLoaderOn = 0;
 
@@ -574,8 +575,6 @@ function reloadContent(params_plus)
 			filters = result.filters;
 			initFilters();
 			initSliders();
-
-			current_friendly_url = result.current_friendly_url;
 
 			// Currente page url
 			if (typeof(current_friendly_url) === 'undefined')


### PR DESCRIPTION
There are several bugs reported with this issue:
Problem was, that current_friendly_url was updates after the pagination buttons -> pagination buttons will have outdated href. (outdated = one click/page too late)
Solution: set the current_friendly_url earlier
