### PR TITLE
[-] CORE : Fix #PSCSX-5724 avoid db exception

### DIFF
--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -225,7 +225,7 @@ class ProductSaleCore
 		if ($total_sales > 1)
 			return Db::getInstance()->execute('
 				UPDATE '._DB_PREFIX_.'product_sale
-				SET `quantity` = `quantity` - '.(int)$qty.', `sale_nbr` = `sale_nbr` - 1, `date_upd` = NOW()
+				SET `quantity` = CAST(`quantity` AS SIGNED) - '.(int)$qty.', `sale_nbr` = CAST(`sale_nbr` AS SIGNED) - 1, `date_upd` = NOW()
 				WHERE `id_product` = '.(int)$id_product
 			);
 		elseif ($total_sales == 1)


### PR DESCRIPTION
There are 2 solution to avoid the problem:
- Enable the parameter NO_UNSIGNED_SUBSTRACTION in the mysql config cf:https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_unsigned_subtraction
- Cast the db value as signed

Cause we can't force people to enable the mysql parameter we should cast the value
