### PR TITLE
Fix Product customization duplication

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3900,9 +3900,9 @@ class ProductCore extends ObjectModel
 			$customization_field_ids[] = (int)$customization_field['id_customization_field'];
 
 		if (($customization_labels = Db::getInstance()->executeS('
-			SELECT `id_customization_field`, `id_lang`, `name`
-			FROM `'._DB_PREFIX_.'customization_field_lang`
-			WHERE `id_customization_field` IN ('.implode(', ', $customization_field_ids).')'.($id_shop ? ' AND cfl.`id_shop` = '.$id_shop : '').'
+			SELECT `id_customization_field`, `id_lang`, `id_shop`, `name`
+			FROM `'._DB_PREFIX_.'customization_field_lang` AS cfl
+			WHERE `id_customization_field` IN ('.implode(', ', $customization_field_ids).')'.($id_shop ? ' AND cfl.`id_shop` = '.(int)$id_shop : '').'
 			ORDER BY `id_customization_field`')) === false)
 			return false;
 
@@ -3951,6 +3951,7 @@ class ProductCore extends ObjectModel
 					$data = array(
 						'id_customization_field' => (int)$customization_field_id,
 						'id_lang' => (int)$customization_label['id_lang'],
+						'id_shop' => (int)$customization_label['id_shop'],
 						'name' => pSQL($customization_label['name']),
 					);
 


### PR DESCRIPTION
SQL error caused by the id_shop column added in the customization_field_lang table with PrestaShop 1.6.0.12.
