### PR TITLE
[-] Core : Module. New line replacement

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2693,7 +2693,7 @@ abstract class ModuleCore
 		if (!file_exists($path_override))
 			return false;
 		else
-			file_put_contents($path_override, preg_replace('#(\r|\r\n)#ism', "\n", file_get_contents($path_override)));
+			file_put_contents($path_override, preg_replace('#(\r\n|\r)#ism', "\n", file_get_contents($path_override)));
 
 		$pattern_escape_com = '#(^\s*?\/\/.*?\n|\/\*(?!\n\s+\* module:.*?\* date:.*?\* version:.*?\*\/).*?\*\/)#ism';
 		// Check if there is already an override file, if not, we just need to copy the file
@@ -2847,7 +2847,7 @@ abstract class ModuleCore
 		if (!is_file($override_path) || !is_writable($override_path))
 			return false;
 
-		file_put_contents($override_path, preg_replace('#(\r|\r\n)#ism', "\n", file_get_contents($override_path)));
+		file_put_contents($override_path, preg_replace('#(\r\n|\r)#ism', "\n", file_get_contents($override_path)));
 
 		if ($orig_path)
 		{


### PR DESCRIPTION
When I changed some code in an overidden Class in my module, I make an upgrade script which remove override and add override.
I had some problems because new lines were doubled.
I've noticed a replacement of \r\n and \r by \n in ModuleCore.
But in the order \r -> \n and \r\n -> \n
So \r\n were replaced by \n\n ...
After module upgrade, overidden class contained two open braces ...

This fix don't double new lines... I've just change order in pattern.
