### PR TITLE
[*] BO: Trigger actionOrderSlipAdd each time an order slip is created, with additional parameter

### DIFF
--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -387,8 +387,24 @@ class OrderSlipCore extends ObjectModel
 
 		$res = true;
 
+		// Ensure compliance with previous hook params
+		$hook_product_list = array();
+		$hook_quantity_list = array();
+		
 		foreach ($product_list as $product)
+		{
 			$res &= $order_slip->addProductOrderSlip($product);
+			$hook_product_list[] = (int)$product['id_order_detail'];
+			$hook_quantity_list[] = (int)$product['quantity'];
+		}
+
+		if ($res)
+			Hook::exec('actionOrderSlipAdd', array(
+					'order' => $order,
+					'productList' => $hook_product_list,
+					'qtyList' => $hook_quantity_list,
+					'order_slip' => $order_slip,
+				), null, false, true, false, $order->id_shop);
 
 		return $res;
 	}

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -956,7 +956,6 @@ class AdminOrdersControllerCore extends AdminController
 								$this->errors[] = Tools::displayError('A credit slip cannot be generated. ');
 							else
 							{
-								Hook::exec('actionOrderSlipAdd', array('order' => $order, 'productList' => $full_product_list, 'qtyList' => $full_quantity_list), null, false, true, false, $order->id_shop);
 								@Mail::Send(
 									(int)$order->id_lang,
 									'credit_slip',


### PR DESCRIPTION
The actionOrderSlipAdd hook was triggered only when returning products and not when refunding.
Additionally, it is easier (may be necessary?) to get directly the created order slip for post processing.
