### PR TITLE
API => Allowing updates by specifying only partial data

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1508,11 +1508,16 @@ class WebserviceRequestCore
 				}
 				elseif (isset($fieldProperties['required']) && $fieldProperties['required'] && !$fieldProperties['i18n'])
 				{
-					$this->setError(400, 'parameter "'.$fieldName.'" required', 41);
-					return false;
+					if ($this->method == 'POST') {
+						$this->setError(400, 'parameter "'.$fieldName.'" required', 41);
+						return false;
+					}
 				}
 				elseif ((!isset($fieldProperties['required']) || !$fieldProperties['required']) && property_exists($object, $sqlId))
-					$object->$sqlId = null;
+				{
+					if ($this->method == 'POST')
+						$object->$sqlId = null;
+				}
 				if (isset($fieldProperties['i18n']) && $fieldProperties['i18n'])
 				{
 					$i18n = true;
@@ -1522,7 +1527,7 @@ class WebserviceRequestCore
 							/** @var SimpleXMLElement $lang */
 							$object->{$fieldName}[(int)$lang->attributes()->id] = (string)$lang;
 						}
-					else
+					elseif ($this->method == 'POST' || isset($attributes->$fieldName))
 						$object->{$fieldName} = (string)$attributes->$fieldName;
 				}
 			}


### PR DESCRIPTION
The goal of this pull request is to allow updates in the API by only specifying partial data (i.e. only specifying the data that you want to update, and not the whole object).
This improvement is quite useful for the following reasons:
- It's way easier to update a single field
- You don't need to get the object to have the latest values before updating the field that you are interested into
- Getting before updating is open to race conditions when different parts of the system are responsible for different fields. So you're taking the risk to revert the changes made by another update between your get and your update.

The changes are pretty simple and consist on:
- do not require all required fields to be set (this is an update, so the values must already be there)
- do not set to null fields that are not in request (if you want to nullify, you should just set an empty tag, which is the logical and safe way to do it)
- do not reset i18n fields that are not in the request
  These cover all the cases where fields are updated through the api.

Note: This also makes the api quite more robust to adding new available fields as otherwise the same call than before would nullify this new field unexpectedly.

You can easily test it with (as long as you have a product with id=1):

```
curl -X PUT -H "Content-Type: application/xml" -H 'Authorization:Basic ***' 'http://127.0.0.1/api/products' --data "@products.xml"
```

where products.xml is:

```
<prestashop xmlns:xlink="http://www.w3.org/1999/xlink">
  <product>
    <id><![CDATA[1]]></id>
    <reference><![CDATA[my new value]]></reference>
  </product>
</prestashop>
```
