### PR TITLE
Default back_url behavior

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -849,7 +849,7 @@
 						</button>
 						{/if}
 						{if isset($show_cancel_button) && $show_cancel_button}
-						<a href="{$back_url|escape:'html':'UTF-8'}" class="btn btn-default" onclick="window.history.back();">
+						<a href="{$back_url|escape:'html':'UTF-8'}" class="btn btn-default" onclick="something();">
 							<i class="process-icon-cancel"></i> {l s='Cancel'}
 						</a>
 						{/if}


### PR DESCRIPTION
I've noticed when we cancel any record editing, the page always back preserving any last confirmation previously displayed on the List.

I think this behavior is not right... once the user got any confirmation it shouldn't be displayed again.

How to simulate:

1) Go to Customers;
2) Inactivate any customer;
3) You should get a confirmation like "The status has been successfully updated.";
4) Click button Edit to start editing any Customer;
5) Click footer button Cancel to cancel editing;
6) The confirmation message ("The status has been successfully updated") will be there again.

So... even we don't post anything else, we shouldn't see this confirmation again. That's what I understand, specially because you might have closed the confirmation message by clicking X into the banner.
