### PR TITLE
[-] Installer : Fixed bug that prevents several customizations on sam…

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -679,8 +679,7 @@ CREATE TABLE `PREFIX_customization` (
   `quantity_returned` INT NOT NULL DEFAULT '0',
   `in_cart` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_customization`,`id_cart`,`id_product`, `id_address_delivery`),
-  KEY `id_product_attribute` (`id_product_attribute`),
-  UNIQUE `id_cart_product` (`id_cart`, `id_product`, `id_product_attribute`)
+  KEY `id_product_attribute` (`id_product_attribute`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 
 CREATE TABLE `PREFIX_customization_field` (


### PR DESCRIPTION
…e product

In DB table _customization this line:
-  UNIQUE `id_cart_product` (`id_cart`, `id_product`, `id_product_attribute`)

prevents adding several different customizations to the same product. (tested on an additional custom text field) 

ie: Company sells T-Shirts with custom printed text.
Customer orders one t-shirt with his name and another one with his brothers name.
because 'id_cart_product' is Unique, while saving the customization of the second name he gets:

[PrestaShopDatabaseException]
Duplicate entry '1-1-0' for key 'id_cart_product'
INSERT INTO `ps_customization` (`id_cart`, `id_product`, `id_product_attribute`, `quantity`)
                VALUES (1, 1, 0, 0)

classes/cart.php:
1.           Db::getInstance()->execute(
2.               'INSERT INTO `'._DB_PREFIX_.'customization` (`id_cart`, `id_product`, `id_product_attribute`, `quantity`)
3.               VALUES ('.(int)$this->id.', '.(int)$id_product.', '.(int)$id_product_attribute.', '.(int)$quantity.')'
4.           );
5.           $id_customization = Db::getInstance()->Insert_ID();
