### PR TITLE
Order slips fails to include taxes

### DIFF
--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -374,7 +374,7 @@ class OrderSlipCore extends ObjectModel
 		}
 
 		$order_slip->{'total_products_tax_'.$inc_or_ex_2} -= (float)$amount && !$amount_choosen ? (float)$amount : 0;
-		$order_slip->amount = $amount_choosen ? (float)$amount : $order_slip->{'total_products_tax_'.$inc_or_ex_1};
+		$order_slip->amount = $amount_choosen ? (float)$amount : $order_slip->{'total_products_tax_'.$inc_or_ex_2};
 		$order_slip->shipping_cost_amount = $order_slip->{'total_shipping_tax_'.$inc_or_ex_1};
 
 		if ((float)$amount && !$amount_choosen)


### PR DESCRIPTION
When calculating the total amount, it uses $inc_or_ex_1, whose value is 'excl' in the case of tax add, which leads to the wrong amount.
I changed it to use $inc_or_ex_2
