### PR TITLE
priceTEReal decimals problem

### DIFF
--- a/js/admin/price.js
+++ b/js/admin/price.js
@@ -153,7 +153,7 @@ function calcPriceTE()
 	var newPrice = removeTaxes(ps_round(priceTI - getEcotaxTaxIncluded(), priceDisplayPrecision));
 	document.getElementById('priceTE').value = (isNaN(newPrice) == true || newPrice < 0) ? '' :
 		ps_round(newPrice, 6).toFixed(6);
-	document.getElementById('priceTEReal').value = (isNaN(newPrice) == true || newPrice < 0) ? 0 : ps_round(newPrice, 9);
+	document.getElementById('priceTEReal').value = (isNaN(newPrice) == true || newPrice < 0) ? 0 : ps_round(newPrice, 6);
 	document.getElementById('finalPrice').innerHTML = (isNaN(newPrice) == true || newPrice < 0) ? '' :
 		ps_round(priceTI, priceDisplayPrecision).toFixed(priceDisplayPrecision);
 	document.getElementById('finalPriceWithoutTax').innerHTML = (isNaN(newPrice) == true || newPrice < 0) ? '' :


### PR DESCRIPTION
En changeant le prix en utilisant le prix TTC, le champs hidden priceTEReal est populé par un prix HT avec 9 chiffres après la virgule au lieu de 6.
C'est problématique puisque les commandes remontent avec un prix total correct mais un prix par article et par ligne à 0.
