### PR TITLE
Fix the behaviour of actionProductOutOfStock hook

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -654,9 +654,17 @@ abstract class PaymentModuleCore extends Module
 						'orderStatus' => $order_status
 					));
 
-					foreach ($this->context->cart->getProducts() as $product)
-						if ($order_status->logable)
+					foreach ($this->context->cart->getProducts() as $product) {
+						if ($order_status->logable) {
 							ProductSale::addProductSale((int)$product['id_product'], (int)$product['cart_quantity']);
+						}
+
+						if ($product['quantity_available'] == 0) {
+							Hook::exec('actionProductOutOfStock', array(
+								'product' => $product
+							));
+						}
+					}
 
 					if (self::DEBUG_MODE)
 						PrestaShopLogger::addLog('PaymentModule::validateOrder - Order Status is about to be added', 1, null, 'Cart', (int)$id_cart, true);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -270,7 +270,7 @@ class ProductControllerCore extends FrontController
 				'last_qties' =>  (int)Configuration::get('PS_LAST_QTIES'),
 				'HOOK_EXTRA_LEFT' => Hook::exec('displayLeftColumnProduct'),
 				'HOOK_EXTRA_RIGHT' => Hook::exec('displayRightColumnProduct'),
-				'HOOK_PRODUCT_OOS' => Hook::exec('actionProductOutOfStock', array('product' => $this->product)),
+				'HOOK_PRODUCT_OOS' => Hook::exec('displayProductOutOfStock', array('product' => $this->product)),
 				'HOOK_PRODUCT_ACTIONS' => Hook::exec('displayProductButtons', array('product' => $this->product)),
 				'HOOK_PRODUCT_TAB' =>  Hook::exec('displayProductTab', array('product' => $this->product)),
 				'HOOK_PRODUCT_TAB_CONTENT' =>  Hook::exec('displayProductTabContent', array('product' => $this->product)),


### PR DESCRIPTION
I opened 2 tickets:
- actually, actionProductOutOfStock was misnamed and should be named displayProductOutOfStock: http://forge.prestashop.com/browse/PSCSX-5928
- a real actionProductOutOfStock should exist: http://forge.prestashop.com/browse/PSCSX-5929

These are the 2 commits reflecting them.
