### PR TITLE
add hooks around Auth

### DIFF
--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -155,6 +155,8 @@ class AdminLoginControllerCore extends AdminController
 	
 	public function processLogin()
 	{
+		Hook::exec('actionBeforeAdminAuthentication');
+
 		/* Check fields validity */
 		$passwd = trim(Tools::getValue('passwd'));
 		$email = trim(Tools::getValue('email'));
@@ -178,11 +180,13 @@ class AdminLoginControllerCore extends AdminController
 			{
 				$this->errors[] = Tools::displayError('The Employee does not exist, or the password provided is incorrect.');
 				$this->context->employee->logout();
+				
 			}
 			elseif (empty($employee_associated_shop) && !$this->context->employee->isSuperAdmin())
 			{
 				$this->errors[] = Tools::displayError('This employee does not manage the shop anymore (Either the shop has been deleted or permissions have been revoked).');
 				$this->context->employee->logout();
+				Hook::exec('actionAdminAuthenticationFailed');
 			}
 			else
 			{
@@ -201,6 +205,8 @@ class AdminLoginControllerCore extends AdminController
 					$cookie->last_activity = time();
 
 				$cookie->write();
+				
+				Hook::exec('actionAdminAuthentication');
 
 				// If there is a valid controller name submitted, redirect to it
 				if (isset($_POST['redirect']) && Validate::isControllerName($_POST['redirect']))

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -269,6 +269,7 @@ class AuthControllerCore extends FrontController
 				$this->errors[] = Tools::displayError('Your account isn\'t available at this time, please contact us');
 			elseif (!$authentication || !$customer->id)
 				$this->errors[] = Tools::displayError('Authentication failed.');
+				Hook::exec('actionAuthenticationFailed');
 			else
 			{
 				$this->context->cookie->id_compare = isset($this->context->cookie->id_compare) ? $this->context->cookie->id_compare: CompareProduct::getIdCompareByIdCustomer($customer->id);


### PR DESCRIPTION
To improve Prestashop I opened this ticket about hooks with Authentication: http://forge.prestashop.com/browse/PSCSX-5822

So this patch add 4 hooks:
- actionAuthenticationFailed
- actionBeforeAdminAuthentication
- actionAdminAuthenticationFailed
- actionAdminAuthentication
