### PR TITLE
[*] Installer : Change PS_PRODUCT_WEIGHT_PRECISION

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -842,7 +842,7 @@ Country</value>
       <value>0</value>
     </configuration>
     <configuration id="PS_PRODUCT_WEIGHT_PRECISION" name="PS_PRODUCT_WEIGHT_PRECISION">
-      <value>2</value>
+      <value>3</value>
     </configuration>
     <configuration id="PS_ADVANCED_PAYMENT_API" name="PS_ADVANCED_PAYMENT_API">
       <value>0</value>


### PR DESCRIPTION
Changing PS_PRODUCT_WEIGHT_PRECISION to "3" so we actually can display weight values like these ones:
- 0.001 kg
- 1.001 kg

With the value of "2" those weight values would be displayed on the product page as:
- 0 kg
- 1 kg

This is necessary for shops that have products with a broad variety of products weights. Since they only can set one Weight metric as default they need to be able to use 3 decimal places.

This might seem rather specific, but with the obligation to display the exact product weight (if the shipping is calculated by product weight) in some european countries. This is mandatory and goes along with the new advancedeucompliance module.

An other approach would be to change the "PS_PRODUCT_WEIGHT_PRECISION" value when installing the advancedeucompliance module.
