### PR TITLE
Fix bug loading Product object to Cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -886,6 +886,10 @@ class CartCore extends ObjectModel
 	{
 		if (!$shop)
 			$shop = Context::getContext()->shop;
+			
+		//use the context language
+		if (!$id_lang)
+			$id_lang = Context::getContext()->language->id;
 
 		if (Context::getContext()->customer->id)
 		{
@@ -900,7 +904,7 @@ class CartCore extends ObjectModel
 		$quantity = (int)$quantity;
 		$id_product = (int)$id_product;
 		$id_product_attribute = (int)$id_product_attribute;
-		$product = new Product($id_product, false, Configuration::get('PS_LANG_DEFAULT'), $shop->id);
+		$product = new Product($id_product, false, $id_lang, $shop->id);
 
 		if ($id_product_attribute)
 		{


### PR DESCRIPTION
There was a bug by which the Cart class was trying to load a Product object with the default language configured into prestashop (Configuration::get('PS_LANG_DEFAULT')) instead of using the language and the shop in the current context.

Usually the bug doesn't show but if someone tries to add a product to a cart in a multistore system for a shop that has only products in a language which is not the defined as default no product will be loaded by the ObjectModel class. The consecuence is that when the object is Validate:isLoadedObject on the Cart class, it will fail resulting in a quite obscure AJAX error (I had to debug all the way up to the ObjectModel constructor to understand the source of the bug).

The fix consist on using context language id when loading the product object.
