### PR TITLE
[-] BO : Change only active state on bulk status change

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3796,6 +3796,7 @@ class AdminControllerCore extends Controller
 			{
 				/** @var ObjectModel $object */
 				$object = new $this->className((int)$id);
+				$object->setFieldsToUpdate(array('active' => true));
 				$object->active = (int)$status;
 				$result &= $object->update();
 			}


### PR DESCRIPTION
In particular, avoid unit price ratio to be reset in database when disabling a set of products
