### PR TITLE
[-] Installer : Fix syntax error in SQL file 1.6.1.0

### DIFF
--- a/install-dev/upgrade/sql/1.6.1.0.sql
+++ b/install-dev/upgrade/sql/1.6.1.0.sql
@@ -218,6 +218,6 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`)
 
 ALTER TABLE `PREFIX_pack` ADD KEY `product_item` (`id_product_item`,`id_product_attribute_item`);
 
-ALTER TABLE `PREFIX_supply_order_detail DROP KEY `id_supply_order`, DROP KEY `id_product`, ADD KEY `id_supply_order` (`id_supply_order`, `id_product`);
+ALTER TABLE `PREFIX_supply_order_detail` DROP KEY `id_supply_order`, DROP KEY `id_product`, ADD KEY `id_supply_order` (`id_supply_order`, `id_product`);
 
 ALTER TABLE `PREFIX_carrier` ADD KEY `reference` (`id_reference`, `deleted`, `active`);


### PR DESCRIPTION
Currently, an upgrade 1.6.0.14 -> 1.6.10 throws the following warning:

``` sql
SQL 1.6.1.0 1103 in ALTER TABLE `ps_supply_order_detail DROP KEY
`id_supply_order`, DROP KEY `id_product`, ADD KEY `id_supply_order`
(`id_supply_order`, `id_product`): Incorrect table name
'ps_supply_order_detail DROP KEY '
```
