### PR TITLE
[-] BO : Fix bought module that can't be installed because of the "must have" type

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1418,8 +1418,8 @@ abstract class ModuleCore
 		// Get Default Country Modules and customer module
 		$files_list = array(
 			array('type' => 'addonsNative', 'file' => _PS_ROOT_DIR_.self::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, 'loggedOnAddons' => 0),
-			array('type' => 'addonsBought', 'file' => _PS_ROOT_DIR_.self::CACHE_FILE_CUSTOMER_MODULES_LIST, 'loggedOnAddons' => 1),
 			array('type' => 'addonsMustHave', 'file' => _PS_ROOT_DIR_.self::CACHE_FILE_MUST_HAVE_MODULES_LIST, 'loggedOnAddons' => 0),
+			array('type' => 'addonsBought', 'file' => _PS_ROOT_DIR_.self::CACHE_FILE_CUSTOMER_MODULES_LIST, 'loggedOnAddons' => 1),
 		);
 		foreach ($files_list as $f)
 			if (file_exists($f['file']) && ($f['loggedOnAddons'] == 0 || $logged_on_addons))


### PR DESCRIPTION
If a module has been bought on PS Addons, but is marked as "must have", you are not able to install it directly through the BO (when logged into PS Addons of course).
Putting "addonsBought" at the end of the $files_list var fix the issue (set max priority to addonsBought).
