### PR TITLE
[-] Class: AdminController / Remove displayNoSmarty() method

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1627,10 +1627,6 @@ class AdminControllerCore extends Controller
 		return false;
 	}
 
-	public function displayNoSmarty()
-	{
-	}
-
 	/**
 	 * @return void
 	 */


### PR DESCRIPTION
This method was introduced in 1.5.0.1 but never used.
