### PR TITLE
fix newsletter_date_add to be (more) useful

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -230,8 +230,9 @@ class CustomerCore extends ObjectModel
 	public function update($nullValues = false)
 	{
 		$this->birthday = (empty($this->years) ? $this->birthday : (int)$this->years.'-'.(int)$this->months.'-'.(int)$this->days);
-
-		if ($this->newsletter && !Validate::isDate($this->newsletter_date_add))
+		$previous_Customer_settings = new Customer($this->id);
+		if (($this->newsletter && !Validate::isDate($this->newsletter_date_add)) || // initial addition
+				($this->newsletter && !$previous_Customer_settings->newsletter)) // successive addition(s)
 			$this->newsletter_date_add = date('Y-m-d H:i:s');
 		if (isset(Context::getContext()->controller) && Context::getContext()->controller->controller_type == 'admin')
 			$this->updateGroup($this->groupBox);


### PR DESCRIPTION
When the "newsletter" subscription setting is modified, the date (newsletter_date_add)
should be updated (in case of a re-inscription) since the date where someone last
subscribed is more often important (eg: synchronisation with remote lists) than the
time the user initially subscribed (he may have been unsubscribed in the meantime)

The patch uses newsletter_date_add like a "last time the user activated its subscription
to the newsletter" (it's an _add_ition from the point of view of the user)
