### PR TITLE
[-] FO: Footer fix in default-bootstrap theme: nocache on copyright year

### DIFF
--- a/themes/default-bootstrap/modules/blockcms/blockcms.tpl
+++ b/themes/default-bootstrap/modules/blockcms/blockcms.tpl
@@ -126,7 +126,7 @@
 	{if $display_poweredby}
 	<section class="bottom-footer col-xs-12">
 		<div>
-			&copy; {'Y'|date} {l s='[1]Ecommerce software by %s[/1]' mod='blockcms' sprintf=['PrestaShop™'] tags=['<a class="_blank" href="http://www.prestashop.com">']}
+			{l s='[1] %3$s %2$s - Ecommerce software by %1$s [/1]' mod='blockcms' sprintf=['PrestaShop™', 'Y'|date, '©'] tags=['<a class="_blank" href="http://www.prestashop.com">'] nocache}
 		</div>
 	</section>
 	{/if}


### PR DESCRIPTION
// to avoid old smarty cache displays past year, #PSCSX-6024
