### PR TITLE
[*] Update AdminCurrenciesController.php

### DIFF
--- a/controllers/admin/AdminCurrenciesController.php
+++ b/controllers/admin/AdminCurrenciesController.php
@@ -151,7 +151,7 @@ class AdminCurrenciesControllerCore extends AdminController
 							array('key' => 2, 'name' => '0 000,00X ('.$this->l('Such as with Euros').')'),
 							array('key' => 3, 'name' => 'X0.000,00'),
 							array('key' => 4, 'name' => '0,000.00X'),
-							array('key' => 5, 'name' => '0\'000.00X') // Added for the switzerland currency
+							array('key' => 5, 'name' => 'X0\'000.00' ('.$this->l('Switzerland format').')') // Added for the switzerland currency
 						),
 						'name' => 'name',
 						'id' => 'key'


### PR DESCRIPTION
Currency sign has to be in front of the price!
But there's another bug, because this modification just seems to work in product details view, but not in list view.
