### PR TITLE
[-] BO: Fix the logo upload to use the actual extension of the file

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -2647,7 +2647,8 @@ class AdminThemesControllerCore extends AdminController
                 return false;
             }
 
-            $ext = ($field_name == 'PS_STORES_ICON') ? '.gif' : '.jpg';
+            $file_ext = pathinfo($_FILES[$field_name]['name'], PATHINFO_EXTENSION);
+            $ext = ($field_name == 'PS_STORES_ICON') ? '.gif' : '.'.$file_ext;
             $logo_name = Tools::link_rewrite(Context::getContext()->shop->name).'-'
                 .$logo_prefix.'-'.(int)Configuration::get('PS_IMG_UPDATE_TIME').(int)$id_shop.$ext;
 


### PR DESCRIPTION
It prevents an issue on IE\* where a png logo renamed as jpg would not load (DOM7009: Unable to decode image at URL)
