### PR TITLE
[-] FO : fixed wrong Canadian postcode regexp validation

### DIFF
--- a/js/validate.js
+++ b/js/validate.js
@@ -126,7 +126,7 @@ function validate_isPostCode(s, pattern, iso_code)
 	else
 	{
 		var replacements = {
-			' ': '(?: |)',
+			' ': '(?:\ |)',
 			'-': '(?:-|)',
 			'N': '[0-9]',
 			'L': '[a-zA-Z]',


### PR DESCRIPTION
For example with this postcode : L2Y 7R7, you won't be able to validate your address.
