### PR TITLE
[-] Project : Fixed constant name in Order::getTotalPaid

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1854,7 +1854,7 @@ class OrderCore extends ObjectModel
                 $total += $payment->amount;
             } else {
                 $amount = Tools::convertPrice($payment->amount, $payment->id_currency, false);
-                if ($currency->id == Configuration::get('PS_DEFAULT_CURRENCY', null, null, $this->id_shop)) {
+                if ($currency->id == Configuration::get('PS_CURRENCY_DEFAULT', null, null, $this->id_shop)) {
                     $total += $amount;
                 } else {
                     $total += Tools::convertPrice($amount, $currency->id, true);


### PR DESCRIPTION
Order::getTotalPaid was loading  configuration::get('PS_DEFAULT_CURRENCY') but the real name of this constant is 'PS_CURRENCY_DEFAULT'
