### PR TITLE
[-]BO: Fix unknown iso_user JS var while in AdminTab

### DIFF
--- a/admin-dev/header.inc.php
+++ b/admin-dev/header.inc.php
@@ -39,6 +39,7 @@ Context::getContext()->smarty->assign(array(
     'navigationPipe', Configuration::get('PS_NAVIGATION_PIPE'),
     'meta_title' => implode(' '.Configuration::get('PS_NAVIGATION_PIPE').' ', $title),
     'display_header' => true,
+    'display_header_javascript' => true,
     'display_footer' => true,
 ));
 $dir = Context::getContext()->smarty->getTemplateDir(0).'controllers'.DIRECTORY_SEPARATOR.trim($con->override_folder, '\\/').DIRECTORY_SEPARATOR;


### PR DESCRIPTION
While in AdminTab in back office (not AdminController), the 'iso_user' javacript is unknown due to this missing tpl var
