### PR TITLE
[*] PDF : wording invoice.product-tab.tpl

### DIFF
--- a/pdf/invoice.product-tab.tpl
+++ b/pdf/invoice.product-tab.tpl
@@ -31,7 +31,7 @@
 		<th class="product header small" width="{$layout.tax_code.width}%">{l s='Tax Rate' pdf='true'}</th>
 
 		{if isset($layout.before_discount)}
-			<th class="product header small" width="{$layout.unit_price_tax_excl.width}%">{l s='Base price' pdf='true'} <br /> {l s='(Tax excl.)' pdf='true'}</th>
+			<th class="product header small" width="{$layout.unit_price_tax_excl.width}%">{l s='Regular price' pdf='true'} <br /> {l s='(Tax excl.)' pdf='true'}</th>
 		{/if}
 
 		<th class="product header-right small" width="{$layout.unit_price_tax_excl.width}%">{l s='Unit Price' pdf='true'} <br /> {l s='(Tax excl.)' pdf='true'}</th>


### PR DESCRIPTION
In commercial use the term 'base price' indicates the price per unit, including VAT and other price components which allows an easier price comparison for the costumer, especially with packages of different capacity. What you mean is the 'regular price', which indicates the price before discounts.
