### PR TITLE
[-]BO: radio category tree selector must not always redirect

### DIFF
--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -97,8 +97,9 @@ Tree.prototype =
 			}
 			if (name != 'id_parent')
 			{
-				this.$element.find(":input[type=radio]").unbind('click');
-				this.$element.find(":input[type=radio]").click(
+				this.$element.find(':input[name="id-category"][type=radio]')
+				.unbind('click');
+				.click(
 					function()
 					{
 						location.href = location.href.replace(

--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -98,7 +98,7 @@ Tree.prototype =
 			if (name != 'id_parent')
 			{
 				this.$element.find(':input[name="id-category"][type=radio]')
-				.unbind('click');
+				.unbind('click')
 				.click(
 					function()
 					{


### PR DESCRIPTION
In Back-Office, the category tree selector, in radio selector mode, must redirect only on the products page list while selecting a category.
When used in a form, like in the AdminPatterns.php controller, we must be able to select 1 category, without page redirection.

The fix proposes to redirect only when the inputs name is 'id-category', as this value is set in the redirected url. Other names won't redirect.
