### PR TITLE
[-] FO : Fixed missing HOOK_TOP_PAYMENT in order-payment-advanced.tpl

### DIFF
--- a/themes/default-bootstrap/order-payment-advanced.tpl
+++ b/themes/default-bootstrap/order-payment-advanced.tpl
@@ -53,6 +53,7 @@
 <p class="alert alert-warning">{l s='This store has not accepted your new order.'}</p>
 {else}
     <p id="emptyCartWarning" class="alert alert-warning unvisible">{l s='Your shopping cart is empty.'}</p>
+    <div id="HOOK_TOP_PAYMENT">{$HOOK_TOP_PAYMENT}</div>
     <h2>{l s='Payment Options'}</h2>
     <!-- HOOK_ADVANCED_PAYMENT -->
     <div id="HOOK_ADVANCED_PAYMENT">


### PR DESCRIPTION
Advanced EU Compliance module executes `displayPaymentTop` hook, but does not display results in order-payment-advanced.tpl. This pull request displays the results the same way as order-payment-classic.tpl.
