### PR TITLE
[-] CORE : Fix #PSCSX-6153 id shop not well set so don't cache

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -262,8 +262,7 @@ abstract class ModuleCore
         if ($this->name != null) {
             // If cache is not generated, we generate it
             if (self::$modules_cache == null && !is_array(self::$modules_cache)) {
-                $id_shop = (Validate::isLoadedObject($this->context->shop) ? $this->context->shop->id : 1);
-                self::$modules_cache = array();
+                $id_shop = (Validate::isLoadedObject($this->context->shop) ? $this->context->shop->id : Configuration::get('PS_SHOP_DEFAULT'));
                 // Join clause is done to check if the module is activated in current shop context
                 $result = Db::getInstance()->executeS('
 				SELECT m.`id_module`, m.`name`, (
@@ -291,6 +290,9 @@ abstract class ModuleCore
                     }
                 }
                 $this->_path = __PS_BASE_URI__.'modules/'.$this->name.'/';
+            }
+            if (!$this->context->controller instanceof Controller) {
+                self::$modules_cache = null;
             }
             $this->local_path = _PS_MODULE_DIR_.$this->name.'/';
         }

--- a/tests/Integration/PrestaShopSecurityTest.php
+++ b/tests/Integration/PrestaShopSecurityTest.php
@@ -50,7 +50,7 @@ class PrestaShopSecurityTest extends IntegrationTestCase
             Assert::assertTrue($extract, 'Fail extract module');
             unlink(_PS_CACHE_DIR_.'sandbox/prestafraud.zip');
         }
-    
+
         self::$prestafraud = Module::getInstanceByName('prestafraud');
 
         Assert::assertTrue(is_object(self::$prestafraud), 'Fail Module::getInstanceByName(\'prestafraud\')');
@@ -58,17 +58,18 @@ class PrestaShopSecurityTest extends IntegrationTestCase
         if (!Module::isInstalled('prestafraud')) {
             Assert::assertTrue((bool)self::$prestafraud->install());
         }
-            
+
         Assert::assertTrue((bool)self::$prestafraud->isRegisteredInHook('actionValidateOrder'), 'Fail Module::isRegisteredInHook(\'actionValidateOrder\')');
-        
+
         $uniqid = uniqid().time();
         $email = 'prestabot+'.$uniqid.'@gmail.com';
         $shop_url = 'http://www.prestashop-unit-test-'.$uniqid.'.com/';
         $result = self::$prestafraud->_createAccount($email, $shop_url);
-        
+
         Assert::assertTrue($result, implode(', ', self::$prestafraud->_errors));
+        Context::getContext()->controller = new FrontController();
     }
-    
+
     public static function tearDownAfterClass()
     {
         Assert::assertTrue((bool)self::$prestafraud->uninstall());

--- a/tests/Integration/PrestaShopSecurityTest.php
+++ b/tests/Integration/PrestaShopSecurityTest.php
@@ -43,36 +43,33 @@ class PrestaShopSecurityTest extends IntegrationTestCase
     public static function setupBeforeClass()
     {
         parent::setUpBeforeClass();
+    }
+
+    public function testInstall()
+    {
         if (!file_exists(_PS_MODULE_DIR_.'/prestafraud/prestafraud.php')) {
             $download = file_put_contents(_PS_CACHE_DIR_.'sandbox/prestafraud.zip', Tools::addonsRequest('module', array('id_module' => 4181)));
-            Assert::assertGreaterThan(20000, $download, 'Fail download module from Addons');
+            $this->assertGreaterThan(20000, $download, 'Fail download module from Addons');
             $extract = Tools::ZipExtract(_PS_CACHE_DIR_.'sandbox/prestafraud.zip', _PS_MODULE_DIR_);
-            Assert::assertTrue($extract, 'Fail extract module');
+            $this->assertTrue($extract, 'Fail extract module');
             unlink(_PS_CACHE_DIR_.'sandbox/prestafraud.zip');
         }
 
         self::$prestafraud = Module::getInstanceByName('prestafraud');
 
-        Assert::assertTrue(is_object(self::$prestafraud), 'Fail Module::getInstanceByName(\'prestafraud\')');
-        Assert::assertEquals('prestafraud', self::$prestafraud->name);
+        $this->assertTrue(is_object(self::$prestafraud), 'Fail Module::getInstanceByName(\'prestafraud\')');
+        $this->assertEquals('prestafraud', self::$prestafraud->name);
         if (!Module::isInstalled('prestafraud')) {
-            Assert::assertTrue((bool)self::$prestafraud->install());
+            $this->assertTrue((bool)self::$prestafraud->install());
         }
-
-        Assert::assertTrue((bool)self::$prestafraud->isRegisteredInHook('actionValidateOrder'), 'Fail Module::isRegisteredInHook(\'actionValidateOrder\')');
 
         $uniqid = uniqid().time();
         $email = 'prestabot+'.$uniqid.'@gmail.com';
         $shop_url = 'http://www.prestashop-unit-test-'.$uniqid.'.com/';
         $result = self::$prestafraud->_createAccount($email, $shop_url);
 
-        Assert::assertTrue($result, implode(', ', self::$prestafraud->_errors));
+        $this->assertTrue($result, implode(', ', self::$prestafraud->_errors));
         Context::getContext()->controller = new FrontController();
-    }
-
-    public static function tearDownAfterClass()
-    {
-        Assert::assertTrue((bool)self::$prestafraud->uninstall());
     }
 
     public function testScoreExistingOrder()
@@ -90,5 +87,10 @@ class PrestaShopSecurityTest extends IntegrationTestCase
         $scoring = self::$prestafraud->_getScoring($id_order, Configuration::get('PS_LANG_DEFAULT'));
         $this->assertEquals(0, (int)$scoring['scoring']);
         $this->assertEquals('', (string)$scoring['comment']);
+    }
+
+    public function testUninstall()
+    {
+        $this->assertTrue((bool)self::$prestafraud->uninstall());
     }
 }

--- a/tests/Integration/classes/module/ModulesInstallUninstallTest.php
+++ b/tests/Integration/classes/module/ModulesInstallUninstallTest.php
@@ -35,6 +35,7 @@ class ModulesInstallUninstallTest extends IntegrationTestCase
 {
     public static function setUpBeforeClass()
     {
+        parent::setUpBeforeClass();
         Module::updateTranslationsAfterInstall(false);
         Context::getContext()->employee = new Employee();
         Context::getContext()->employee->id = 1;
@@ -62,7 +63,7 @@ class ModulesInstallUninstallTest extends IntegrationTestCase
      */
     public function testInstallationAndUnInstallation($moduleName)
     {
-        $module = Module::getInstanceByName($moduleName);
+        $module = Module::getInstanceByName($moduleName);        
         if ($module->id) {
             $this->assertTrue((bool)$module->uninstall(), 'Module uninstall failed : '.$moduleName);
             $this->assertTrue((bool)$module->install(), 'Module install failed : '.$moduleName);


### PR DESCRIPTION
If a module is hooked on moduleRoutes the controller isn't set already so we mustn't cache the module cause id shop won't be good
http://forge.prestashop.com/browse/PSCSX-6153
