### PR TITLE
[-]FO: theme retro-compatibility regarding the CGV

### DIFF
--- a/themes/default-bootstrap/order-carrier.tpl
+++ b/themes/default-bootstrap/order-carrier.tpl
@@ -350,7 +350,7 @@
 				{/if}
 				{/if}
 			{/if}
-			{if $conditions && $cms_id && (isset($advanced_payment_api) && !$advanced_payment_api)}
+			{if $conditions && $cms_id && (! isset($advanced_payment_api) || !$advanced_payment_api)}
 				{if $opc}
 					<hr style="" />
 				{/if}


### PR DESCRIPTION
1.6.1 theme compatibility with 1.6.0.x: 
on 1.6.0.x, the advanced_payment_api is never defined, the CGV must be displayed here on the carriers page
on 1.6.1, variable value is tested (if defined. If not defined, 1.6.0.x behavior)
