### PR TITLE
[*] Update AdminCategoriesController.php

### DIFF
--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -512,21 +512,19 @@ class AdminCategoriesControllerCore extends AdminController
                     'hint' => $this->l('Upload a category logo from your computer.'),
                 ),
                 array(
-                    'type' => 'textarea',
+                    'type' => 'text',
                     'label' => $this->l('Meta title'),
                     'name' => 'meta_title',
                     'lang' => true,
-                    'rows' => 5,
-                    'cols' => 100,
+		    'size' => 70,
                     'hint' => $this->l('Forbidden characters:').' <>;=#{}'
                 ),
                 array(
-                    'type' => 'textarea',
+                    'type' => 'text',
                     'label' => $this->l('Meta description'),
                     'name' => 'meta_description',
                     'lang' => true,
-                    'rows' => 5,
-                    'cols' => 100,
+		    'size' => 160,
                     'hint' => $this->l('Forbidden characters:').' <>;=#{}'
                 ),
                 array(


### PR DESCRIPTION
Dropped type "textarea". I'd suggest that size limit for meta name and meta desciption should be the same like for products.
