### PR TITLE
fixes for order-detail links and one slow-(delete)-query

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -747,7 +747,7 @@ class SearchCore
     public static function removeProductsSearchIndex($products)
     {
         if (is_array($products) && !empty($products)) {
-            Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'search_index WHERE id_product IN ('.implode(',', array_map('intval', $products)).')');
+            Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'search_index WHERE id_product IN ('.implode(',', array_unique(array_map('intval', $products))).')');
             ObjectModel::updateMultishopTable('Product', array('indexed' => 0), 'a.id_product IN ('.implode(',', array_map('intval', $products)).')');
         }
     }

--- a/themes/default-bootstrap/history.tpl
+++ b/themes/default-bootstrap/history.tpl
@@ -56,7 +56,7 @@
 							{if isset($order.invoice) && $order.invoice && isset($order.virtual) && $order.virtual}
 								<img class="icon" src="{$img_dir}icon/download_product.gif"	alt="{l s='Products to download'}" title="{l s='Products to download'}" />
 							{/if}
-							<a class="color-myaccount" href="javascript:showOrder(1, {$order.id_order|intval}, '{$link->getPageLink('order-detail', true)|escape:'html':'UTF-8'}');">
+							<a class="color-myaccount" href="javascript:showOrder(1, {$order.id_order|intval}, '{$link->getPageLink('order-detail', true, NULL, "id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}');">
 								{Order::getUniqReferenceOf($order.id_order)}
 							</a>
 						</td>
@@ -86,7 +86,7 @@
 							{/if}
 						</td>
 						<td class="history_detail">
-							<a class="btn btn-default button button-small" href="javascript:showOrder(1, {$order.id_order|intval}, '{$link->getPageLink('order-detail', true)|escape:'html':'UTF-8'}');">
+							<a class="btn btn-default button button-small" href="javascript:showOrder(1, {$order.id_order|intval}, '{$link->getPageLink('order-detail', true, NULL, "id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}');">
 								<span>
 									{l s='Details'}<i class="icon-chevron-right right"></i>
 								</span>


### PR DESCRIPTION
- bugfix: id_order is not passed to the URL in the order history, cf link in /historique-des-commandes
-  search_index: avoid slow DELETE queries including multiple duplicated id_product in the the WHERE IN () clause  (based on slow-query log analysis. Yes, mysql optimizer still needs work)

Replace PR #3164
