### PR TITLE
[*] Removed the modules folder from the robots.txt to allow google to crawl JS, CSS and images

### DIFF
--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -763,7 +763,7 @@ class AdminMetaControllerCore extends AdminController
         $tab = array();
 
         // Special allow directives
-        $tab['Allow'] = array('.css', '.js');
+        $tab['Allow'] = array('*/modules/*.css', '*/modules/*.js');
 
         // Directories
         $tab['Directories'] = array('classes/', 'config/', 'download/', 'mails/', 'modules/', 'translations/', 'tools/');

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -755,7 +755,7 @@ class AdminMetaControllerCore extends AdminController
         $tab = array();
 
         // Directories
-        $tab['Directories'] = array('classes/', 'config/', 'download/', 'mails/', 'modules/', 'translations/', 'tools/');
+        $tab['Directories'] = array('classes/', 'config/', 'download/', 'mails/', 'translations/', 'tools/');
 
         // Files
         $disallow_controllers = array(

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -479,6 +479,14 @@ class AdminMetaControllerCore extends AdminController
             // User-Agent
             fwrite($write_fd, "User-agent: *\n");
 
+            // Allow Directives
+            if (count($this->rb_data['Allow'])) {
+                fwrite($write_fd, "# Allow Directives\n");
+                foreach ($this->rb_data['Allow'] as $allow) {
+                    fwrite($write_fd, 'Allow: '.$allow."\n");
+                }
+            }
+
             // Private pages
             if (count($this->rb_data['GB'])) {
                 fwrite($write_fd, "# Private pages\n");
@@ -754,8 +762,11 @@ class AdminMetaControllerCore extends AdminController
     {
         $tab = array();
 
+        // Special allow directives
+        $tab['Allow'] = array('.css', '.js');
+
         // Directories
-        $tab['Directories'] = array('classes/', 'config/', 'download/', 'mails/', 'translations/', 'tools/');
+        $tab['Directories'] = array('classes/', 'config/', 'download/', 'mails/', 'modules/', 'translations/', 'tools/');
 
         // Files
         $disallow_controllers = array(


### PR DESCRIPTION
Many people got an email from Google Webmaster Tools stating that CSS and JS were not accessible on their website and thus penalizing for SEO. ( http://googlewebmastercentral.blogspot.fr/2014/10/updating-our-technical-webmaster.html ).

It turned out that every CSS and JS (and also images) in the BASE_DIR/modules but also BASE_DIR/themes/THEMES/css/modules/ is also impacted.

With smart cache, is solves this partially, because some modules don't respect the addCSS and addJS. (plus, sometimes you can't use them).
