### PR TITLE
Update ParentOrderController.php

### DIFF
--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -328,7 +328,7 @@ class ParentOrderControllerCore extends FrontController
             if (Product::getTaxCalculationMethod()) {
                 $product['is_discounted'] = Tools::ps_round($product['price_without_specific_price'], _PS_PRICE_COMPUTE_PRECISION_) != Tools::ps_round($product['price'], _PS_PRICE_COMPUTE_PRECISION_);
             } else {
-                $product['is_discounted'] = Tools::ps_round($product['price_without_specific_price'], _PS_PRICE_COMPUTE_PRECISION_) != Tools::ps_round($product['price_wt'], _PS_PRICE_COMPUTE_PRECISION_);
+                $product['is_discounted'] = Tools::ps_round($product['price_without_specific_price'] - $product['ecotax'], _PS_PRICE_COMPUTE_PRECISION_) != Tools::ps_round($product['price_wt'], _PS_PRICE_COMPUTE_PRECISION_);
             }
         }
 


### PR DESCRIPTION
`price_without_specific_price` contains the `ecotax` unlike `price_wt` which doesn't. Must subtract it for proper comparison.
