### PR TITLE
[-] FO: auth error if $back is not defined

### DIFF
--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -327,12 +327,13 @@ class AuthControllerCore extends FrontController
                 CartRule::autoRemoveFromCart($this->context);
                 CartRule::autoAddToCart($this->context);
 
-                if (!$this->ajax && $back = Tools::getValue('back')) {
-                    if ($back == Tools::secureReferrer(Tools::getValue('back'))) {
+                if (!$this->ajax) {
+                    $back = Tools::getValue('back','my-account')
+                    
+                    if ($back == Tools::secureReferrer($back)) {
                         Tools::redirect(html_entity_decode($back));
                     }
 
-                    $back = $back ? $back : 'my-account';
                     Tools::redirect('index.php?controller='.(($this->authRedirection !== false) ? urlencode($this->authRedirection) : $back));
                 }
             }


### PR DESCRIPTION
If $back is not set, when loggin never arrives to 'my-account' and falls into the last else, that is authentification_error and user goes to authentication page, logged in but without errors
