### PR TITLE
[-] BO : Fix KPI refresh functions

### DIFF
--- a/admin-dev/themes/default/template/helpers/kpi/kpi.tpl
+++ b/admin-dev/themes/default/template/helpers/kpi/kpi.tpl
@@ -41,7 +41,7 @@
 	
 </{if isset($href) && $href}a{else}div{/if}>
 
-{if isset($source) && $source != ''}
+{if isset($source) && $source != '' && isset($refresh) && $refresh != ''}
 <script>
 	function refresh_{$id|replace:'-':'_'|addslashes}()
 	{
@@ -65,9 +65,6 @@
 			}
 		});
 	}
-	{if isset($refresh) && $refresh != ''}
-		refresh_{$id|replace:'-':'_'|addslashes}();
-	{/if}
 </script>
 {/if}
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -1528,7 +1528,11 @@ function parseDate(date){
 function refresh_kpis()
 {
 	$('.box-stats').each(function(){
-		window['refresh_' + $(this).attr('id').replace(/-/g, '_')]();
+		var functionName = 'refresh_' + $(this).attr('id').replace(/-/g, '_');
+
+		if (typeof window[functionName] === 'function') {
+			window[functionName]();
+		}
 	});
 }
 


### PR DESCRIPTION
In kpi.tpl the refresh on page load function was taken out because the
data is already loaded from the HelperKpi class with the variable
'source'. Moved the 'refresh' conditions up so the script isn't loaded
in unnecessarily.

In admin.js checked if the particular refresh function for the kpi box
exists before calling it.
