### PR TITLE
id_image fix for pack items table

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -161,7 +161,7 @@ class PackCore extends Product
 
         $context = Context::getContext();
 
-        $sql = 'SELECT p.*, product_shop.*, pl.*, image_shop.`id_image` id_image, il.`legend`, cl.`name` AS category_default, a.quantity AS pack_quantity, product_shop.`id_category_default`, a.id_product_pack, a.id_product_attribute_item
+        $sql = 'SELECT p.*, product_shop.*, pl.*, MAX(image_shop.`id_image`) id_image, il.`legend`, cl.`name` AS category_default, a.quantity AS pack_quantity, product_shop.`id_category_default`, a.id_product_pack, a.id_product_attribute_item
 				FROM `'._DB_PREFIX_.'pack` a
 				LEFT JOIN `'._DB_PREFIX_.'product` p ON p.id_product = a.id_product_item
 				LEFT JOIN `'._DB_PREFIX_.'product_lang` pl


### PR DESCRIPTION
using image_shop.`id_image` id_image cause problems with empty id_image for product pack items and product image could not be displayed using for example Link::getImageLink method.

fixed using sql MAX function
