### PR TITLE
[-] BO: badges in quickview modal

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/quickview.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/quickview.tpl
@@ -27,7 +27,13 @@
 		<img src="{$image}" alt="{$displayName}" class="img-thumbnail" />
 		{if isset($badges)}
 			{foreach $badges as $badge}
-				<img src="{$badge}" alt="" class="clearfix quickview-badge" />
+				{if is_array($badge)}
+					{foreach $badge as $_badge}
+						<img src="{$_badge}" alt="" class="clearfix quickview-badge" />
+					{/foreach}
+				{else}
+					<img src="{$badge}" alt="" class="clearfix quickview-badge" />
+				{/if}
 			{/foreach}
 		{/if}
 	</div>


### PR DESCRIPTION
If you have more than one badge (like "Selected" and "Partner Agency"), no badge shown cause it's an array.

Now, with this PR, all badges are visible.
