### PR TITLE
[ - ] FO : fixed bug with dynamic hook and module uninstalled

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -196,10 +196,14 @@ function smartyHook($params, &$smarty)
         $hook_params['smarty'] = $smarty;
         if (!empty($params['mod'])) {
             $module = Module::getInstanceByName($params['mod']);
+            unset($hook_params['mod']);
             if ($module && $module->id) {
                 $id_module = $module->id;
+            } else {
+                unset($hook_params['h']);
+                return '';
             }
-            unset($hook_params['mod']);
+            
         }
         unset($hook_params['h']);
         return Hook::exec($params['h'], $hook_params, $id_module);


### PR DESCRIPTION
If you call a module with   {hook h="displayNav" mod="blockcontact"} and blockcontact module is uninstalled or doesn't exist anymore, all modules enabled in the hook displayNav are displayed;
You can test it with this code in your tpl :
{hook h="displayNav" mod="modulenoexist"}
