### PR TITLE
[-] PDF: Fix shop_address missing in old order_invoice outside of upgrade process

### DIFF
--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -36,7 +36,7 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
      * @param $smarty
      * @throws PrestaShopException
      */
-    public function __construct(OrderInvoice $order_invoice, $smarty)
+    public function __construct(OrderInvoice $order_invoice, $smarty, $bulk_mode = false)
     {
         $this->order_invoice = $order_invoice;
         $this->order = new Order($this->order_invoice->id_order);
@@ -47,6 +47,9 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
         // (DB: bug fixed in 1.6.1.1 with upgrade SQL script to avoid null shop_address in old orderInvoices)
         if (!isset($this->order_invoice->shop_address) || !$this->order_invoice->shop_address) {
             $this->order_invoice->shop_address = OrderInvoice::getCurrentFormattedShopAddress((int)$this->order->id_shop);
+            if (!$bulk_mode) {
+                OrderInvoice::fixAllShopAddresses();
+            }
         }
 
         // header informations

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -38,7 +38,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
      * @param $smarty
      * @throws PrestaShopException
      */
-    public function __construct(OrderInvoice $order_invoice, $smarty)
+    public function __construct(OrderInvoice $order_invoice, $smarty, $bulk_mode = false)
     {
         $this->order_invoice = $order_invoice;
         $this->order = new Order((int)$this->order_invoice->id_order);
@@ -49,6 +49,9 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
         // (DB: bug fixed in 1.6.1.1 with upgrade SQL script to avoid null shop_address in old orderInvoices)
         if (!isset($this->order_invoice->shop_address) || !$this->order_invoice->shop_address) {
             $this->order_invoice->shop_address = OrderInvoice::getCurrentFormattedShopAddress((int)$this->order->id_shop);
+            if (!$bulk_mode) {
+                OrderInvoice::fixAllShopAddresses();
+            }
         }
         
         // header informations

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -59,14 +59,7 @@ class PDFCore
         }
         
         if (count($this->objects)>1) { // when bulk mode only
-            $class_name = 'HTMLTemplate'.$this->template;
-            if (class_exists($class_name)) {
-                $classMethod = new ReflectionMethod($class_name,'__construct');
-                $argumentCount = count($classMethod->getParameters());
-                if ($argumentCount == 3) { // For Core templates (and other if exists) that accepts optional third param $bulk_mode
-                    $this->send_bulk_flag = true;
-                }
-            }
+            $this->send_bulk_flag = true;
         }
     }
 
@@ -127,11 +120,9 @@ class PDFCore
         $class_name = 'HTMLTemplate'.$this->template;
 
         if (class_exists($class_name)) {
-            if ($this->send_bulk_flag) {
-                $class = new $class_name($object, $this->smarty, true);
-            } else {
-                $class = new $class_name($object, $this->smarty);
-            }
+            // Some HTMLTemplateXYZ implementations won't use the third param but this is not a problem (no warning in PHP),
+            // the third param is then ignored if not added to the method signature.
+            $class = new $class_name($object, $this->smarty, $this->send_bulk_flag);
 
             if (!($class instanceof HTMLTemplate)) {
                 throw new PrestaShopException('Invalid class. It should be an instance of HTMLTemplate');


### PR DESCRIPTION
To bypass missing environment (PS classes, context, etc...) during PS upgrade, this fix is made ONCE during a single PDF creation.
Waiting for feedback, especially on performances.
