### PR TITLE
[+] FO : displayAjax default method in FrontController

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -742,6 +742,24 @@ class FrontControllerCore extends Controller
     }
 
     /**
+     * Display ajax outputs page content
+     *
+     * @return bool
+     * @throws Exception
+     * @throws SmartyException
+     */
+    public function displayAjax()
+    {
+        if ($this->json) {
+            $this->context->smarty->assign(array(
+                'json' => true,
+                'status' => $this->status,
+            ));
+        }
+        return $this->display();
+    }
+
+    /**
      * Displays maintenance page if shop is closed.
      */
     protected function displayMaintenancePage()

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -225,7 +225,7 @@ class StoresControllerCore extends FrontController
     /**
      * Display the Xml for showing the nodes in the google map
      */
-    protected function displayAjax()
+    public function displayAjax()
     {
         $stores = $this->getStores();
         $parnode = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><markers></markers>');


### PR DESCRIPTION
Any request on _Front Controllers_, with the **ajax** parameter setted returns an HTTP 200 with empty body (if no displayAjax exists)

see [#PSCSX-6471](http://forge.prestashop.com/browse/PSCSX-6471)
