### PR TITLE
[*] FO: put SSL CMS page IDs in a subfunction to ease overriding

### DIFF
--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -59,7 +59,7 @@ class CmsControllerCore extends FrontController
         }
 
         if (Configuration::get('PS_SSL_ENABLED') && Tools::getValue('content_only') && $id_cms && Validate::isLoadedObject($this->cms)
-            && in_array($id_cms, array((int)Configuration::get('PS_CONDITIONS_CMS_ID'), (int)Configuration::get('LEGAL_CMS_ID_REVOCATION')))) {
+            && in_array($id_cms, $this->getSSLCMSPageIds())) {
             $this->ssl = true;
         }
 
@@ -138,4 +138,13 @@ class CmsControllerCore extends FrontController
 
         $this->setTemplate(_PS_THEME_DIR_.'cms.tpl');
     }
+    
+    /**
+	 * @return An array of IDs of CMS pages, which shouldn't be forwared to their canonical URLs in SSL environment.
+	 * Required for pages which are shown in iframes. 
+	 */
+	protected function getSSLCMSPageIds()
+	{
+		return array((int)Configuration::get('PS_CONDITIONS_CMS_ID'), (int)Configuration::get('LEGAL_CMS_ID_REVOCATION'));
+	}
 }


### PR DESCRIPTION
With this improvement, coders don't have to override the whole init method to be able to load more CMS pages via SSL, but only a compact function.
