### PR TITLE
[-] TR : #PSCSX-5938 Emails not copied into theme folder

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2682,7 +2682,7 @@ class AdminTranslationsControllerCore extends AdminController
                     if (!in_array($file, self::$ignore_folder)) {
                         $files_to_copy_iso[] = array(
                                 "from" => $dir.$file,
-                                "to" => str_replace(_PS_ROOT_DIR_, _PS_ROOT_DIR_.'/themes/'.$current_theme, $dir).$file
+                                "to" => str_replace((strpos($dir, _PS_CORE_DIR_) !== false) ? _PS_CORE_DIR_ : _PS_ROOT_DIR_, _PS_ROOT_DIR_.'/themes/'.$current_theme, $dir).$file
                             );
                     }
                 }


### PR DESCRIPTION
On PrestaShop Cloud, we were trying to copy emails into core folder and not into the shop theme folder because $dir is based on _PS_MAIL_DIR_ based himself on _PS_CORE_DIR_
