### PR TITLE
[-] BO: Pass empty firstname and lastname email vars to mail template

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -357,7 +357,9 @@ class AdminCustomerThreadsControllerCore extends AdminController
                     $params = array(
                         '{messages}' => Tools::nl2br(stripslashes($output)),
                         '{employee}' => $current_employee->firstname.' '.$current_employee->lastname,
-                        '{comment}' => stripslashes($_POST['message_forward'])
+                        '{comment}' => stripslashes($_POST['message_forward']),
+                        '{firstname}' => '',
+                        '{lastname}' => '',
                     );
 
                     if (Mail::Send(


### PR DESCRIPTION
If an employee is selected, `{firstname}` and `{lastname}` are passed to `forward_msg` mail template.

When the thread is forwarded by entering an email (not employee), we should atleast pass empty firstname/lastname because in both cases the same mail template is used.
