### PR TITLE
[-] FO : Fixed canonical redirects

### DIFF
--- a/controllers/front/ManufacturerController.php
+++ b/controllers/front/ManufacturerController.php
@@ -44,6 +44,8 @@ class ManufacturerControllerCore extends FrontController
         }
         if (Validate::isLoadedObject($this->manufacturer)) {
             parent::canonicalRedirection($this->context->link->getManufacturerLink($this->manufacturer));
+        } elseif ($canonicalURL) {
+            parent::canonicalRedirection($canonicalURL);
         }
     }
 

--- a/controllers/front/SupplierController.php
+++ b/controllers/front/SupplierController.php
@@ -44,6 +44,8 @@ class SupplierControllerCore extends FrontController
         }
         if (Validate::isLoadedObject($this->supplier)) {
             parent::canonicalRedirection($this->context->link->getSupplierLink($this->supplier));
+        } elseif ($canonicalURL) {
+            parent::canonicalRedirection($canonicalURL);
         }
     }
 


### PR DESCRIPTION
Fixed canonical redirects for manufacturers and suppliers list pages.
Was only working if the object of the supplier or manufacturer was
loaded, which isn't the case on the lists.
