### PR TITLE
[-] CORE : Don't force module name to be lowercase

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -99,7 +99,6 @@ class TabCore extends ObjectModel
 
         // Set good position for new tab
         $this->position = Tab::getNewLastPosition($this->id_parent);
-        $this->module = Tools::strtolower($this->module);
 
         // Add tab
         if (parent::add($autodate, $null_values)) {


### PR DESCRIPTION
References e501e7f

Don't need to force module name in tabs to lowercase. Doing so will
cause pathing issues in on Linux Servers if the module name contains
capital letters.
