### PR TITLE
// Add exceptions to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ config.codekit
 *.sublime-workspace
 nbproject
 bower_components
+composer.lock
 
 # Cache, temp and personal files
 
@@ -22,9 +23,11 @@ download/*
 img/*
 log/*
 upload/*
+vendor/*
 
 admin-dev/autoupgrade/*
 admin-dev/backups/*
+admin-dev/import/*
 
 themes/*/cache/*
 


### PR DESCRIPTION
// Switching between develop and 1.6.x.x branches causes composer vendor folder to be detected as untracked files.
