### PR TITLE
[*] TR : Change invoice + delivery slip prefixes

### DIFF
--- a/install-dev/langs/nl/data/configuration.xml
+++ b/install-dev/langs/nl/data/configuration.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0'?>
 <entity_configuration>
   <configuration id='PS_INVOICE_PREFIX'>
-    <value>#IN</value>
+    <value>#FA</value>
   </configuration>
   <configuration id='PS_DELIVERY_PREFIX'>
-    <value>#DE</value>
+    <value>#PB</value>
   </configuration>
   <configuration id="PS_RETURN_PREFIX">
     <value>#RE</value>


### PR DESCRIPTION
I noticed in the user guide that prefixes are abbreviations of the terms being used.
For Dutch, I'd like to propose FA for 'factuur' and PB for 'pakbon'.
RE for 'retour' is just fine.
