### PR TITLE
+[Core] Allows default value

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -174,7 +174,7 @@ class ConfigurationCore extends ObjectModel
      * @param int $id_lang Language ID
      * @return string Value
      */
-    public static function get($key, $id_lang = null, $id_shop_group = null, $id_shop = null)
+    public static function get($key, $id_lang = null, $id_shop_group = null, $id_shop = null, $default = false)
     {
         if (defined('_PS_DO_NOT_LOAD_CONFIGURATION_') && _PS_DO_NOT_LOAD_CONFIGURATION_) {
             return false;
@@ -206,7 +206,7 @@ class ConfigurationCore extends ObjectModel
         } elseif (Configuration::hasKey($key, $id_lang)) {
             return self::$_cache[self::$definition['table']][$id_lang]['global'][$key];
         }
-        return false;
+        return $default;
     }
 
     public static function getGlobalValue($key, $id_lang = null)


### PR DESCRIPTION
Usefull if default value is missing, eg after an update that went wrong 

if (Validate::isLoadedObject($customer))
            $id_group = (int)$customer->id_default_group;
        else
            $id_group = (int)Configuration::get('PS_UNIDENTIFIED_GROUP');

'PS_UNIDENTIFIED_GROUP' has disappears and $id_group is assign to 0...
