### PR TITLE
[-] BO : Fix AdminSearch customer count

### DIFF
--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -121,13 +121,14 @@ $(function() {
 	</div>
 	{/if}
 
-	{if isset($customers) && $customers}
+	{if isset($customers) && $customers &&
+        isset($customerCount) && $customerCount}
 	<div class="panel">
 		<h3>
-			{if $customers|@count == 1}
+			{if $customerCount == 1}
 				{l s='1 customer'}
 			{else}
-				{l s='%d customers' sprintf=$customers|@count}
+				{l s='%d customers' sprintf=$customerCount}
 			{/if}
 		</h3>
 		{$customers}

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -399,6 +399,7 @@ class AdminSearchControllerCore extends AdminController
                     $view = $helper->generateList($this->_list['customers'], $this->fields_list['customers']);
                 }
                 $this->tpl_view_vars['customers'] = $view;
+                $this->tpl_view_vars['customerCount'] = count($this->_list['customers']);
             }
             if (isset($this->_list['orders']) && count($this->_list['orders'])) {
                 $view = '';


### PR DESCRIPTION
Customer counter on the AdminSearch page tries to count a single piece of HTML code whereas this does work for other items (i.e. amount of HTML pcs for addons). This PR introduces a new variable: customerCount in order to pass and show the correct number on the AdminSearch page.
