### PR TITLE
fix error report when loading back office module list

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1475,6 +1475,7 @@ abstract class ModuleCore
                         if ($flag_found == 0) {
                             $item = new stdClass();
                             $item->id = 0;
+                            $item->price = 0;
                             $item->warning = '';
                             $item->type = strip_tags((string)$f['type']);
                             $item->name = strip_tags((string)$modaddons->name);


### PR DESCRIPTION
Remove error on
PHP Notice:  Undefined property: stdClass::$price in /cache/smarty/compile/02/3c/1d/023c1db63dd9ad75a7c39cf8027523d2cccaa059.file.list.tpl.php on line 136
