### PR TITLE
[-] FO: Fixed canonical redirects

### DIFF
--- a/controllers/front/ManufacturerController.php
+++ b/controllers/front/ManufacturerController.php
@@ -44,6 +44,8 @@ class ManufacturerControllerCore extends FrontController
         }
         if (Validate::isLoadedObject($this->manufacturer)) {
             parent::canonicalRedirection($this->context->link->getManufacturerLink($this->manufacturer));
+        } elseif ($canonicalURL) {
+            parent::canonicalRedirection($canonicalURL);
         }
     }
 
@@ -53,8 +55,6 @@ class ManufacturerControllerCore extends FrontController
      */
     public function init()
     {
-        parent::init();
-
         if ($id_manufacturer = Tools::getValue('id_manufacturer')) {
             $this->manufacturer = new Manufacturer((int)$id_manufacturer, $this->context->language->id);
             if (!Validate::isLoadedObject($this->manufacturer) || !$this->manufacturer->active || !$this->manufacturer->isAssociatedToShop()) {
@@ -65,6 +65,8 @@ class ManufacturerControllerCore extends FrontController
                 $this->canonicalRedirection();
             }
         }
+
+        parent::init();
     }
 
     /**

--- a/controllers/front/SupplierController.php
+++ b/controllers/front/SupplierController.php
@@ -44,6 +44,8 @@ class SupplierControllerCore extends FrontController
         }
         if (Validate::isLoadedObject($this->supplier)) {
             parent::canonicalRedirection($this->context->link->getSupplierLink($this->supplier));
+        } elseif ($canonicalURL) {
+            parent::canonicalRedirection($canonicalURL);
         }
     }
 
@@ -53,8 +55,6 @@ class SupplierControllerCore extends FrontController
      */
     public function init()
     {
-        parent::init();
-
         if ($id_supplier = (int)Tools::getValue('id_supplier')) {
             $this->supplier = new Supplier($id_supplier, $this->context->language->id);
 
@@ -66,6 +66,8 @@ class SupplierControllerCore extends FrontController
                 $this->canonicalRedirection();
             }
         }
+
+        parent::init();
     }
 
     /**


### PR DESCRIPTION
Fixed canonical redirects for manufacturers and suppliers list pages.
Was only working if the object of the supplier or manufacturer was
loaded, which isn't the case on the lists.

parent::init was moved to the bottom of the init functions so that the
manufacturer's and supplier's cannonical redirect would fire before the
front controller's.
