### PR TITLE
[-] BO: Fix product import dates

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -308,6 +308,7 @@ class AdminImportControllerCore extends AdminController
                     'condition' => 'new',
                     'available_date' => date('Y-m-d'),
                     'date_add' => date('Y-m-d H:i:s'),
+                    'date_upd' => date('Y-m-d H:i:s'),
                     'customizable' => 0,
                     'uploadable_files' => 0,
                     'text_fields' => 0,


### PR DESCRIPTION
At product import, this is what happens:
- New product is initialized
- `date_add` is filled with default value
- `date_add` is filled in from CSV (if available)
- at this point, `date_add` is ALWAYS set for new products
- At `AdminImportController::productImport@Line1642` : 

```
                    if (isset($product->date_add) && $product->date_add != '') {
                        $res = $product->add(false);
```

This always passes (see point above). However, `date_upd` is `''`, and it is saved in database as `0000-00-00 00:00:00`.

Next time you try to import this CSV (using references), the validation doesn't pass on `date_upd`.

Test file I'm using `https://copy.com/F1opx2EjEQcsCR6C`. Too bad `1.6.1.1` is already released :)
