### PR TITLE
// Typo: it is indeed the root directory we're talking about here, …

### DIFF
--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -57,7 +57,7 @@ class MetaCore extends ObjectModel
     {
         $selected_pages = array();
         if (!$files = Tools::scandir(_PS_CORE_DIR_.DIRECTORY_SEPARATOR.'controllers'.DIRECTORY_SEPARATOR.'front'.DIRECTORY_SEPARATOR, 'php', '', true)) {
-            die(Tools::displayError('Cannot scan "root" directory'));
+            die(Tools::displayError('Cannot scan root directory'));
         }
 
         if (!$override_files = Tools::scandir(_PS_CORE_DIR_.DIRECTORY_SEPARATOR . 'override' . DIRECTORY_SEPARATOR . 'controllers' . DIRECTORY_SEPARATOR . 'front' . DIRECTORY_SEPARATOR, 'php', '', true)) {


### PR DESCRIPTION
…not a "/root" folder.
