### PR TITLE
[-] FO: Fix current_url variable used in pagination

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1151,7 +1151,7 @@ class FrontControllerCore extends Controller
         }
 
         // Remove the page parameter in order to get a clean URL for the pagination template
-        $current_url = preg_replace('/(\?)?(&amp;)?p=\d+/', '$1', Tools::htmlentitiesUTF8($_SERVER['REQUEST_URI']));
+        $current_url = preg_replace('/(?:(\?)|&amp;)p=\d+/', '$1', Tools::htmlentitiesUTF8($_SERVER['REQUEST_URI']));
 
         if ($this->n != $default_products_per_page || isset($this->context->cookie->nb_item_per_page)) {
             $this->context->cookie->nb_item_per_page = $this->n;


### PR DESCRIPTION
Basically, the regex is wrong. Parameter `p` **must** be preceded by either an ampersand or question mark, and the previous regex didn't enforce that.

Test case: `/16-some-category?cp=40&amp;cp_d=5&amp;tt=0&amp;fr=0&amp;p=2` (URL generated by a custom module)
