### PR TITLE
Error in PDF php file parsing

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -83,7 +83,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
      *
      * @return Array Layout elements columns size
      */
-    private function computeLayout($params)
+    protected function computeLayout($params)
     {
         $layout = array(
             'reference' => array(

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -185,7 +185,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             $tax_temp = array();
             foreach ($taxes as $tax) {
                 $obj = new Tax($tax['id_tax']);
-                $tax_temp[] = sprintf($this->l('%1$s%2$s%%'), ($obj->rate + 0), '&nbsp;');
+                $tax_temp[] = sprintf(HTMLTemplateInvoice::l('%1$s%2$s%%'), ($obj->rate + 0), '&nbsp;');
             }
 
             $order_detail['order_detail_tax'] = $taxes;

--- a/classes/pdf/HTMLTemplateOrderReturn.php
+++ b/classes/pdf/HTMLTemplateOrderReturn.php
@@ -117,7 +117,7 @@ class HTMLTemplateOrderReturnCore extends HTMLTemplate
     {
         $this->assignCommonHeaderData();
         $this->smarty->assign(array(
-            'header' => $this->l('Order return'),
+            'header' => HTMLTemplateOrderReturn::l('Order return'),
         ));
 
         return $this->smarty->fetch($this->getTemplate('header'));

--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -66,7 +66,7 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
     {
         $this->assignCommonHeaderData();
         $this->smarty->assign(array(
-            'header' => $this->l('Credit slip'),
+            'header' => HTMLTemplateOrderSlip::l('Credit slip'),
         ));
 
         return $this->smarty->fetch($this->getTemplate('header'));

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1249,8 +1249,7 @@ class AdminTranslationsControllerCore extends AdminController
                     // Parsing PDF file
                     if ($type_file == 'php') {
                         $regex = array(
-                            '/HTMLTemplate.*::l\((\')'._PS_TRANS_PATTERN_.'\'[\)|\,]/U',
-                            '/->l\((\')'._PS_TRANS_PATTERN_.'\'(, ?\'(.+)\')?(, ?(.+))?\)/U'
+                            '/HTMLTemplate.*::l\((\')'._PS_TRANS_PATTERN_.'\'[\)|\,]/U'
                         );
                     } else {
                         $regex = '/\{l\s*s=([\'\"])'._PS_TRANS_PATTERN_.'\1(\s*sprintf=.*)?(\s*js=1)?(\s*pdf=\'true\')?\s*\}/U';


### PR DESCRIPTION
Since the "l" method is a static method, we should limit the translation regex to '/HTMLTemplate.*::l((\')'._PS_TRANS_PATTERN_.'\'[)|\,]/U'
and so avoid the false PDF translation when filtering the classes folder of modules.
