### PR TITLE
[*] BO : Avoid using Module::getModulesOnDisk()

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2050,11 +2050,11 @@ class AdminControllerCore extends Controller
 
         $this->tab_modules_list = Tab::getTabModulesList($this->id);
 
-        $modules = Module::getModulesOnDisk();
+        $modules = Module::getModulesInstalled();
 
         $tmp = array();
         foreach ($modules as $module) {
-            $tmp[] = $module->name;
+            $tmp[] = $module['name'];
         }
 
         foreach ($this->tab_modules_list['slider_list'] as $key => $module) {


### PR DESCRIPTION
When having a lot of modules, Module::getModulesOnDisk() can spend more than 5 secs. So at each page load, the execution time is 5 secs more.
Using the DB with Module::getModulesInstalled() is much more quick.
