### PR TITLE
[-] CORE : Some rounding correction

### DIFF
--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -294,10 +294,15 @@ class OrderSlipCore extends ObjectModel
             $tax_calculator = $carrier->getTaxCalculator($address);
             $order_slip->{'total_shipping_tax_'.$inc_or_ex_1} = ($shipping_cost === null ? $order->{'total_shipping_tax_'.$inc_or_ex_1} : (float)$shipping_cost);
 
-            if ($tax_calculator instanceof TaxCalculator) {
-                $order_slip->{'total_shipping_tax_'.$inc_or_ex_2} = Tools::ps_round($tax_calculator->{$add_or_remove.'Taxes'}($order_slip->{'total_shipping_tax_'.$inc_or_ex_1}), _PS_PRICE_COMPUTE_PRECISION_);
+
+            if ($shipping_cost === null) {
+                $order_slip->{'total_shipping_tax_' . $inc_or_ex_2} = $order->{'total_shipping_tax_'.$inc_or_ex_2};
             } else {
-                $order_slip->{'total_shipping_tax_'.$inc_or_ex_2} = $order_slip->{'total_shipping_tax_'.$inc_or_ex_1};
+                if ($tax_calculator instanceof TaxCalculator) {
+                    $order_slip->{'total_shipping_tax_'.$inc_or_ex_2} = Tools::ps_round($tax_calculator->{$add_or_remove.'Taxes'}($order_slip->{'total_shipping_tax_'.$inc_or_ex_1}), _PS_PRICE_COMPUTE_PRECISION_);
+                } else {
+                    $order_slip->{'total_shipping_tax_'.$inc_or_ex_2} = $order_slip->{'total_shipping_tax_'.$inc_or_ex_1};
+                }
             }
         } else {
             $order_slip->shipping_cost = false;
@@ -381,8 +386,8 @@ class OrderSlipCore extends ObjectModel
         }
 
         $order_slip->{'total_products_tax_'.$inc_or_ex_2} -= (float)$amount && !$amount_choosen ? (float)$amount : 0;
-        $order_slip->amount = $amount_choosen ? (float)$amount : $order_slip->{'total_products_tax_'.$inc_or_ex_1};
-        $order_slip->shipping_cost_amount = $order_slip->{'total_shipping_tax_'.$inc_or_ex_1};
+        $order_slip->amount = $amount_choosen ? (float)$amount : $order_slip->{'total_products_tax_'.$inc_or_ex_2};
+        $order_slip->shipping_cost_amount = $order_slip->{'total_shipping_tax_'.$inc_or_ex_2};
 
         if ((float)$amount && !$amount_choosen) {
             $order_slip->order_slip_type = 1;


### PR DESCRIPTION
When we are creating a slip with total shipping_cost refund, we should use the calculated taxes in the order, to avoid rounding errors and differences between the order and the slip.

The amount should also be the tax included amount

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/3834)
<!-- Reviewable:end -->
