### PR TITLE
Don't override a valid context->shop->id using a (possibly) wrong one from context->cart.

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -176,7 +176,9 @@ abstract class PaymentModuleCore extends Module
         $this->context->cart->setTaxCalculationMethod();
 
         $this->context->language = new Language($this->context->cart->id_lang);
-        $this->context->shop = ($shop ? $shop : new Shop($this->context->cart->id_shop));
+        if(! $this->context->shop->id) {
+          $this->context->shop = ($shop ? $shop : new Shop($this->context->cart->id_shop));
+        }
         ShopUrl::resetMainDomainCache();
         $id_currency = $currency_special ? (int)$currency_special : (int)$this->context->cart->id_currency;
         $this->context->currency = new Currency($id_currency, null, $this->context->shop->id);


### PR DESCRIPTION
Current code description:

fact 1: `$this->context->shop` is _ALWAYS_ initialized
note 1: this is wrong, a lot of previous code _may_ already have initialized
        a context, including `context->shop`

fact 2: `$this->context->shop` is given the value of the `$shop` parameter
note 2: we can safely ignore this since almost no payment module care about
        setting this parameter

fact 3: most of the time `$this->context->shop` is given the value of another
        Context variable: `$this->context->cart->id_shop`
note 3: - how is `$this->context->cart` more safe (guaranted to be available and right)
          than `$this->context->shop`?
        - why would we want to reset an existing value for `$this->context->shop`
          with a new shop from the `Context->cart`?

The patch attempt to avoid a reset of `$this->context->shop`
 based on `$this->context->cart->id_shop` if it's not needed.

Bug encountered which triggered the study:

An update was done to 1.6.1.1 from 1.6.1.0 without doing the SQL backup.
This triggered a bug where the OrderDetail weren't saved while the Order was.
When trying the refresh the POST to Payment page the code path was the following:
validateOrder()
- `$this->context->shop` was ok (id = 1)
- `$this->context->cart->id_shop` was NULL (don't know why)
  Thus `$this->context->shop->id` was wrong (from a NULL Shop())
  To be exhaustive about this example:
  - `$this->context->cart->OrderExists()` was TRUE (page refresh)
  - thus PrestaShopLogger => Mail ... which failed because of the context->shop corruption.

`validateOrder()` is the most important function of PrestaShop. If it fails it's always bad
(loosing track of Order, OrderDetail, Payment, ... ... as I recently experienced) and chance
are that it's impossible to run again (partial data registered = corrupted data).

But this function is no as robust as we should expect. As an exemple:

```
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│( ! ) Fatal error: Uncaught exception 'Core_Foundation_IoC_Exception' with                │
│message 'This doesn't seem to be a class name:                                            │
│`Core_Business_Stock_StockManager`.' in /var/www/prestashop/Core/Foundation/IoC           │
│/Core_Foundation_IoC_Container.php on line 95                                             │
├──────────────────────────────────────────────────────────────────────────────────────────┤
│( ! ) Core_Foundation_IoC_Exception: This doesn't seem to be a class name:                │
│`Core_Business_Stock_StockManager`. in /var/www/prestashop/Core/Foundation/IoC/           │
│Core_Foundation_IoC_Container.php on line 95                                              │
├──────────────────────────────────────────────────────────────────────────────────────────┤
│Call Stack                                                                                │
├──┬──────┬───────┬──────────────────────────────────┬─────────────────────────────────────┤
│# │Time  │Memory │Function                          │Location                             │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│1 │0.0001│ 253776│{main}( )                         │../payment.php:0                     │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│2 │5.1514│9053880│validateOrder( )                  │../payment.php:315                   │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│3 │5.1557│9056568│PayPal->validateOrder( )          │../payment.php:295                   │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│4 │5.1564│9064528│PaymentModuleCore->validateOrder( │../paypal.php:1511                   │
│  │      │       │)                                 │                                     │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│5 │5.2394│9644888│OrderDetailCore->createList( )    │../PaymentModule.php:364             │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│6 │5.2398│9646816│OrderDetailCore->create( )        │../OrderDetail.php:678               │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│7 │5.2421│9907944│OrderDetailCore->checkProductStock│../OrderDetail.php:638               │
│  │      │       │( )                               │                                     │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│8 │5.2425│9908456│StockAvailableCore::updateQuantity│../OrderDetail.php:473               │
│  │      │       │( )                               │                                     │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│9 │5.2427│9909488│Adapter_ServiceLocator::get( )    │../StockAvailable.php:471            │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│10│5.2427│9909488│Core_Foundation_IoC_Container->   │../Adapter_ServiceLocator.php:52     │
│  │      │       │make( )                           │                                     │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│11│5.2427│9909624│Core_Foundation_IoC_Container->   │../Core_Foundation_IoC_Container.php:│
│  │      │       │doMake( )                         │170                                  │
├──┼──────┼───────┼──────────────────────────────────┼─────────────────────────────────────┤
│12│5.2428│9910584│Core_Foundation_IoC_Container->   │../Core_Foundation_IoC_Container.php:│
│  │      │       │makeInstanceFromClassName( )      │157                                  │
└──┴──────┴───────┴──────────────────────────────────┴─────────────────────────────────────┘
```
