### PR TITLE
Edit iso code of an existing country

### DIFF
--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -403,7 +403,7 @@ class AdminCountriesControllerCore extends AdminController
             }
         } elseif (Validate::isLanguageIsoCode(Tools::getValue('iso_code'))) {
             $id_country = (int)Country::getByIso(Tools::getValue('iso_code'));
-            if (!is_null($id_country) && $id_country != Tools::getValue('id_'.$this->table)) {
+            if ($id_country != 0 && $id_country != Tools::getValue('id_'.$this->table)) {
                 $this->errors[] = Tools::displayError('This ISO code already exists.You cannot create two countries with the same ISO code.');
             }
         }


### PR DESCRIPTION
is_null($id_country) will always return false because of (int)Country::getByISO. 
This blocks iso editing of an existing country
