### PR TITLE
 i18n override specifying a custom file path

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -531,6 +531,7 @@ class ToolsCore
 
         $iso = Language::getIsoById((int)$cookie->id_lang);
         @include_once(_PS_THEME_DIR_.'lang/'.$iso.'.php');
+        @include_once(Configuration::get('PS_TRANSLATIONS_OVERRIDE'));
 
         return $iso;
     }

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -57,6 +57,9 @@ class TranslateCore
             if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php')) {
                 include_once(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php');
             }
+            if (file_exists(Configuration::get('PS_TRANSLATIONS_OVERRIDE'))) {
+                include_once(Configuration::get('PS_TRANSLATIONS_OVERRIDE'));
+            }
         }
 
         if (isset($modules_tabs[strtolower($class)])) {
@@ -139,6 +142,7 @@ class TranslateCore
 
         if (!isset($translations_merged[$name]) && isset(Context::getContext()->language)) {
             $files_by_priority = array(
+                Configuration::get('PS_TRANSLATIONS_OVERRIDE'),
                 // Translations in theme
                 _PS_THEME_DIR_.'modules/'.$name.'/translations/'.$language->iso_code.'.php',
                 _PS_THEME_DIR_.'modules/'.$name.'/'.$language->iso_code.'.php',


### PR DESCRIPTION
 Allow the override of the translation of almost any strings among admin ($_LANGADM) and modules ($_MODULE) using a unique, user-specific and language agnostic file.
This allow to store site-specific overrides in a easily manageable, trackable (and versionable) PHP file.

Advised PHP file header for the suggested file:

``` php
global $_ERRORS, $_LANGADM, $_MODULE;
$_MODULE = array(); // Since the way $_MODULES is fetched depends on an initially empty $_MODULE variable

// examples
$_LANGADM['AdminCustomersffb7e666a70151215b4c55c6268d7d72'] = 'My string';
$_MODULE['<{homefeatured}prestashop>tab_2cc1943d4c0b46bfcf503a75c44f988b'] = 'Another string';
?>
```

Note: This file is not overridden by PrestaShop language export feature.
