### PR TITLE
[-] BO : Remove redundant and false checking

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3185,7 +3185,7 @@ class AdminControllerCore extends Controller
                         $this->_listsql .= str_replace('!', '.`', $array_value['filter_key']).'` AS `'.$key.'`, ';
                     } elseif ($key == 'id_'.$this->table) {
                         $this->_listsql .= 'a.`'.bqSQL($key).'`, ';
-                    } elseif ($key != 'image' && !preg_match('/'.preg_quote($key, '/').'/i', $this->_select)) {
+                    } elseif ($key != 'image') {
                         $this->_listsql .= '`'.bqSQL($key).'`, ';
                     }
                 }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3177,7 +3177,7 @@ class AdminControllerCore extends Controller
             if ($this->explicitSelect) {
                 foreach ($this->fields_list as $key => $array_value) {
                     // Add it only if it is not already in $this->_select
-                    if (isset($this->_select) && preg_match('/[\s]`?'.preg_quote($key, '/').'`?\s*,/', $this->_select)) {
+                    if (isset($this->_select) && (preg_match('/[\s]`?'.preg_quote($key, '/').'`?\s*,/', $this->_select)  || preg_match('/as[\s]`?'.preg_quote($key, '/').'`?\s*$/', $this->_select))) {
                         continue;
                     }
 


### PR DESCRIPTION
If there was a field like "product_reference" in the select, the field "reference" would not have been added with the preg_match that i removed.
