### PR TITLE
Rewrite layout mechanism.

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -653,36 +653,11 @@ class FrontControllerCore extends Controller
             'display_footer' => $this->display_footer,
         ));
 
-        $layout = $this->getLayout();
-        if ($layout) {
-            if ($this->template) {
-                $template = $this->context->smarty->fetch($this->template);
-            } else {
-                // For retrocompatibility with 1.4 controller
-
-                ob_start();
-                $this->displayContent();
-                $template = ob_get_contents();
-                ob_clean();
-            }
-            $this->context->smarty->assign('template', $template);
-            $this->smartyOutputContent($layout);
-        } else {
-            Tools::displayAsDeprecated('layout.tpl is missing in your theme directory');
-            if ($this->display_header) {
-                $this->smartyOutputContent(_PS_THEME_DIR_.'header.tpl');
-            }
-
-            if ($this->template) {
-                $this->smartyOutputContent($this->template);
-            } else { // For retrocompatibility with 1.4 controller
-                $this->displayContent();
-            }
-
-            if ($this->display_footer) {
-                $this->smartyOutputContent(_PS_THEME_DIR_.'footer.tpl');
-            }
+        if ($layout = $this->getLayout()) {
+            $this->context->smarty->assign('layout', $layout);
         }
+
+        $this->smartyOutputContent($this->template);
 
         return true;
     }
@@ -1480,14 +1455,14 @@ class FrontControllerCore extends Controller
         $layout = false;
         if ($entity) {
             if ($id_item > 0 && file_exists($layout_override_dir.'layout-'.$entity.'-'.$id_item.'.tpl')) {
-                $layout = $layout_override_dir.'layout-'.$entity.'-'.$id_item.'.tpl';
+                $layout = basename($layout_override_dir).'/layout-'.$entity.'-'.$id_item.'.tpl';
             } elseif (file_exists($layout_override_dir.'layout-'.$entity.'.tpl')) {
-                $layout = $layout_override_dir.'layout-'.$entity.'.tpl';
+                $layout = basename($layout_override_dir).'/layout-'.$entity.'.tpl';
             }
         }
 
         if (!$layout && file_exists($layout_dir.'layout.tpl')) {
-            $layout = $layout_dir.'layout.tpl';
+            $layout = 'layout.tpl';
         }
 
         return $layout;

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -25,7 +25,9 @@
  */
 
 global $smarty;
-$smarty->setTemplateDir(_PS_THEME_DIR_.'tpl');
+$smarty->setTemplateDir(array(
+    _PS_THEME_DIR_.'templates',
+));
 
 if (Configuration::get('PS_HTML_THEME_COMPRESSION')) {
     $smarty->registerFilter('output', 'smartyMinifyHTML');

--- a/controllers/front/IndexController.php
+++ b/controllers/front/IndexController.php
@@ -41,6 +41,6 @@ class IndexControllerCore extends FrontController
             'HOOK_HOME_TAB' => Hook::exec('displayHomeTab'),
             'HOOK_HOME_TAB_CONTENT' => Hook::exec('displayHomeTabContent')
         ));
-        $this->setTemplate(_PS_THEME_DIR_.'index.tpl');
+        $this->setTemplate('index.tpl');
     }
 }


### PR DESCRIPTION
This implements real layouts using template inheritance. 
Also, it uses `Smarty::setTemplateDir` to avoid using the `$tpl_dir` variable every time you want to include a file. 

Controller templates now _can_ to be written like this (example with a layout defining a block named "content"):

``` smarty
{extends "{$layout}"}

{block "content"}
  // Content goes here
{/block
```

Please not the while the `$layout` variable will be defined if a layout file is found, it is _not mandatory_ for templates to extend another template.

As a result controllers can either specify the full or relative path to the template, but it would be cleaner to use relative paths everywhere (see example commit 6f8352b6df5758b09b94ad26a880e1f7cd94bd85)
