### PR TITLE
updatePrice() causing discount table to show double the actual discount

### DIFF
--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -808,9 +808,9 @@ function updatePrice()
 	}
 
 	if (noTaxForThisProduct || customerGroupWithoutTax)
-		updateDiscountTable(priceWithDiscountsWithoutTax);
+		updateDiscountTable(priceWithoutDiscountsWithoutTax);
 	else
-		updateDiscountTable(priceWithDiscountsWithTax);
+		updateDiscountTable(priceWithoutDiscountsWithTax);
 }
 
 //update display of the large image


### PR DESCRIPTION
The updatePrice() function is causing product page's discounts table to display prices with double the actual discount. I propose sending updateDiscountTable(...) priceWithoutDiscounts instead of priceWithDiscounts.
