### PR TITLE
[*] Core : Use more modern hashing methods (PSCFV-11357)

### DIFF
--- a/Core/Business/ContainerBuilder.php
+++ b/Core/Business/ContainerBuilder.php
@@ -40,6 +40,7 @@ class ContainerBuilder
         $container->bind('PrestaShop\\PrestaShop\\Core\\Business\\ConfigurationInterface', '\\PrestaShop\\PrestaShop\\Adapter\\Configuration', true);
         $container->bind('\\PrestaShop\\PrestaShop\\Core\\Foundation\\Database\\DatabaseInterface', '\\PrestaShop\\PrestaShop\\Adapter\\Database', true);
         $container->bind('PrestaShop\\PrestaShop\\Core\\Foundation\\Database\\DatabaseInterface', '\\PrestaShop\\PrestaShop\\Adapter\\Database', true);
+        $container->bind('PrestaShop\\PrestaShop\\Core\\Foundation\\Crypto\\Hashing', '\\PrestaShop\\PrestaShop\\Core\\Foundation\\Crypto\\Hashing', true);
 
         return $container;
     }

--- a/Core/Foundation/Crypto/Hashing.php
+++ b/Core/Foundation/Crypto/Hashing.php
@@ -106,4 +106,34 @@ class Hashing
     {
         return password_hash($passwd, PASSWORD_DEFAULT);
     }
+
+    /**
+     * Registers a new hash method so we can support other kinds of hashes.
+     *
+     * @param string    The hash name.
+     * @param callback  A callback to use for checking a hash.
+     *                  Expected signature is $callback($passwd, $hash, $options)
+     * @param array     Options to use for the hash method.
+     *
+     */
+    public function registerHashMethod($name, $verifyCallback, $options = array()) {
+        if (!count($this->hash_methods)) {
+            $this->initHashMethods();
+        }
+
+        if (isset($this->hash_methods[$name])) {
+            // We already have a registered method with that name
+            return;
+        }
+
+        if (!is_callable($verifyCallback)) {
+            throw new Core_Foundation_Exception_Exception('$verifyCallback must be callable');
+        }
+
+        $method = array();
+        $method['verify'] = $verifyCallback;
+        $method['options'] = $options;
+
+        $this->hash_methods[$name] = $method;
+    }
 }

--- a/Core/Foundation/Crypto/Hashing.php
+++ b/Core/Foundation/Crypto/Hashing.php
@@ -18,7 +18,7 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author 	PrestaShop SA <contact@prestashop.com>
+ *  @author     PrestaShop SA <contact@prestashop.com>
  *  @copyright  2007-2015 PrestaShop SA
  *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *  International Registered Trademark & Property of PrestaShop SA
@@ -27,7 +27,7 @@ namespace PrestaShop\PrestaShop\Core\Foundation\Crypto;
 
 class Hashing
 {
-    /** @var array should contain encryption methods */
+    /** @var array should contain additional hashing methods */
     private $hash_methods = [];
 
     /**
@@ -37,82 +37,73 @@ class Hashing
     private function initHashMethods()
     {
         $this->hash_methods = [
-                'BCryptSHA256' => [
-                    'option' => [],
-                    'encrypt' => function ($passwd, $cookie_key, $option) {
-                        return password_hash($cookie_key.$passwd, PASSWORD_BCRYPT);
-                    },
-                    'verify' => function ($passwd, $hash, $cookie_key) {
-                        return password_verify($cookie_key.$passwd, $hash);
-                    }
-                ],
                 'md5' => [
-                    'option' => [],
-                    'encrypt' => function ($passwd, $cookie_key, $option) {
+                    'options' => ['should_rehash' => TRUE],
+                    'hash' => function ($passwd, $options) {
+                        $cookie_key = (isset($options['cookie_key']) ? $options['cookie_key'] : '');
                         return md5($cookie_key.$passwd);
                     },
-                    'verify' => function ($passwd, $hash, $cookie_key) {
+                    'verify' => function ($passwd, $hash, $options) {
+                        $cookie_key = (isset($options['cookie_key']) ? $options['cookie_key'] : '');
+                        /* FIXME: This should be a constant time string check */
                         return md5($cookie_key.$passwd) === $hash;
-                    }
-                ]
+                    },
+                ],
             ];
     }
 
     /**
-     * check if it's the first function of the array that was used for encryption
-     * @param  string  $passwd     the password you want to check
-     * @param  string  $hash       the hash you want to check
-     * @param  string  $cookie_key the define _COOKIE_KEY_
-     * @return bool                result of the verify function
+     * Check a password against a given hash.
+     *
+     * @param  string  $passwd        the password you want to check
+     * @param  string  $hash          the hash to check against. Note that this is passed by reference,
+     *                                so the hash can be transparently updated if needed.
+     * @param  string  $options       some additional options :
+     *                 - 'cookie_key' the _COOKIE_KEY_ define, used for backward compatibility
+     *                                with the deprecated md5 hashing method.
+     *
+     * @return bool/string            true if the password matches the hash,
+     *                                a string if the hash has been updated,
+     *                                false otherwise.
      */
-    public function isFirstHash($passwd, $hash, $cookie_key)
+    public function checkHash($passwd, $hash, $options = array())
     {
-        if (!count($this->hash_methods)) {
-            $this->initHashMethods();
-        }
-
-        $closure = reset($this->hash_methods);
-
-        return $closure['verify']($passwd, $hash, $cookie_key);
-    }
-
-    /**
-     * Iter on hash_methods array and return true if it match
-     * @param  string  $passwd     the password you want to check
-     * @param  string  $hash       the hash you want to check
-     * @param  string  $cookie_key the define _COOKIE_KEY_
-     * @return bool                true is returned if the function find a match else false
-     */
-    public function checkHash($passwd, $hash, $cookie_key)
-    {
-        if (!count($this->hash_methods)) {
-            $this->initHashMethods();
-        }
-
-        foreach ($this->hash_methods as $closure) {
-            if ($closure['verify']($passwd, $hash, $cookie_key)) {
-                return true;
+        $should_rehash = false;
+        $success = password_verify($passwd, $hash);
+        if (!$success) {
+            // This hash doesn't come from password_hash, check our own hashing methods
+            if (!count($this->hash_methods)) {
+                $this->initHashMethods();
             }
+
+            foreach ($this->hash_methods as $name => $method) {
+                $success = $method['verify']($passwd, $hash, $options);
+                if ($success) {
+                    $should_rehash = isset($method['options']['should_rehash']) && $method['options']['should_rehash'];
+                    break;
+                }
+            }
+        } else {
+            $should_rehash = password_needs_rehash($hash, PASSWORD_DEFAULT, $options);
         }
 
-        return false;
+        // Upgrade the hash only if it's correct, and needs to be upgraded
+        if ($success && $should_rehash) {
+            $success = $this->hash($passwd);
+        }
+
+        return $success;
     }
 
     /**
-     * encrypt the $passwd string and return the result of the 1st encryption method
-     * contained in \PrestaShop\PrestaShop\Core\Foundation\Crypto\Hashing::hash_methods
-     * @param  string  $passwd     the password you want to encrypt
-     * @param  string  $cookie_key the define _COOKIE_KEY_
-     * @return string
+     * Returns the hash of the given password.
+     *
+     * @param  string  $passwd     the password you want to hash.
+     *
+     * @return string              the hashed password.
      */
-    public function encrypt($passwd, $cookie_key)
+    public function hash($passwd)
     {
-        if (!count($this->hash_methods)) {
-            $this->initHashMethods();
-        }
-
-        $closure = reset($this->hash_methods);
-
-        return $closure['encrypt']($passwd, $cookie_key, $closure['option']);
+        return password_hash($passwd, PASSWORD_DEFAULT);
     }
 }

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -334,7 +334,8 @@ class CustomerCore extends ObjectModel
             return false;
         }
 
-        if (isset($passwd) && !$crypto->checkHash($passwd, $hash, _COOKIE_KEY_)) {
+        if (isset($passwd)
+            && !($checked_hash = $crypto->checkHash($passwd, $hash, array('cookie_key' => _COOKIE_KEY_)))) {
             return false;
         }
 
@@ -358,8 +359,9 @@ class CustomerCore extends ObjectModel
             }
         }
 
-        if (!$crypto->isFirstHash($passwd, $hash, _COOKIE_KEY_)) {
-            $this->passwd = $crypto->encrypt($passwd, _COOKIE_KEY_);
+        // Upgrade password if the hash was upgraded
+        if (is_string($checked_hash)) {
+            $this->passwd = $checked_hash;
             $this->update();
         }
 
@@ -800,7 +802,7 @@ class CustomerCore extends ObjectModel
 
         $crypto = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Foundation\\Crypto\\Hashing');
         $this->is_guest = 0;
-        $this->passwd = $crypto->encrypt($password, _COOKIE_KEY_);
+        $this->passwd = $crypto->hash($password);
         $this->cleanGroups();
         $this->addGroups(array(Configuration::get('PS_CUSTOMER_GROUP'))); // add default customer group
         if ($this->update()) {
@@ -835,7 +837,7 @@ class CustomerCore extends ObjectModel
         $crypto = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Foundation\\Crypto\\Hashing');
 
         if ($this->id == 0 || $this->passwd != $passwd) {
-            $this->passwd = $crypto->encrypt($passwd, _COOKIE_KEY_);
+            $this->passwd = $crypto->hash($passwd);
         }
         return true;
     }
@@ -929,7 +931,7 @@ class CustomerCore extends ObjectModel
         $crypto = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Foundation\\Crypto\\Hashing');
 
         if ($value = Tools::getValue('passwd')) {
-            $this->passwd = $crypto->encrypt($value, _COOKIE_KEY_);
+            $this->passwd = $crypto->hash($value);
         }
 
         return $errors;

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -182,6 +182,7 @@ class AdminLoginControllerCore extends AdminController
     public function processLogin()
     {
         /* Check fields validity */
+        Hook::exec('actionEmployeeAuthenticationBefore');
         $passwd = trim(Tools::getValue('passwd'));
         $email = trim(Tools::getValue('email'));
         if (empty($email)) {
@@ -224,6 +225,8 @@ class AdminLoginControllerCore extends AdminController
                 }
 
                 $cookie->write();
+
+                Hook::exec('actionEmployeeAuthenticationSuccess', array('employee' => $this->context->employee));
 
                 // If there is a valid controller name submitted, redirect to it
                 if (isset($_POST['redirect']) && Validate::isControllerName($_POST['redirect'])) {

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -737,7 +737,7 @@ CREATE TABLE `PREFIX_employee` (
   `lastname` varchar(32) NOT NULL,
   `firstname` varchar(32) NOT NULL,
   `email` varchar(128) NOT NULL,
-  `passwd` varchar(32) NOT NULL,
+  `passwd` varchar(255) NOT NULL,
   `last_passwd_gen` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `stats_date_from` date DEFAULT NULL,
   `stats_date_to` date DEFAULT NULL,

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -19,6 +19,7 @@ ALTER TABLE PREFIX_employee ADD `reset_password_validity` datetime DEFAULT NULL;
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_PASSWD_RESET_VALIDITY', '1440', NOW(), NOW());
 
 ALTER TABLE `PREFIX_customer` CHANGE COLUMN `passwd` `passwd` varchar(255) NOT NULL;
+ALTER TABLE `PREFIX_employee` CHANGE COLUMN `passwd` `passwd` varchar(255) NOT NULL;
 
 INSERT INTO  `PREFIX_configuration` (`id_configuration` ,`id_shop_group` ,`id_shop` ,`name` ,`value` ,`date_add` ,`date_upd`) VALUES (NULL , NULL , NULL ,  'PS_ACTIVE_CRONJOB_EXCHANGE_RATE',  '0',  '0000-00-00 00:00:00',  '0000-00-00 00:00:00');
 

--- a/tests/Unit/Core/Foundation/Crypto/Core_Foundation_Crypto_Hashing_Test.php
+++ b/tests/Unit/Core/Foundation/Crypto/Core_Foundation_Crypto_Hashing_Test.php
@@ -41,18 +41,30 @@ class Core_Foundation_Crypto_Hashing_Test extends PHPUnit_Framework_TestCase
 
     public function test_simple_check_hash_md5()
     {
-        $this->assertTrue($this->hashing->checkHash("123", md5(_COOKIE_KEY_."123"), _COOKIE_KEY_));
-        $this->assertFalse($this->hashing->checkHash("23", md5(_COOKIE_KEY_."123"), _COOKIE_KEY_));
+        $this->isTrue($this->hashing->checkHash("123", md5(_COOKIE_KEY_."123"), array('cookie_key' => _COOKIE_KEY_)));
+        $this->isFalse($this->hashing->checkHash("23", md5(_COOKIE_KEY_."123"), array('cookie_key' => _COOKIE_KEY_)));
     }
 
-    public function test_simple_encrypt()
+    public function test_simple_hash()
     {
-        $this->assertTrue(is_string($this->hashing->encrypt("123", _COOKIE_KEY_)));
+        $this->assertTrue(is_string($this->hashing->hash("123")));
     }
 
-    public function test_simple_first_hash()
+    public function test_upgrades_md5_hash()
     {
-        $this->assertTrue($this->hashing->isFirstHash("123", $this->hashing->encrypt("123", _COOKIE_KEY_), _COOKIE_KEY_));
-        $this->assertFalse($this->hashing->isFirstHash("123", md5("123", _COOKIE_KEY_), _COOKIE_KEY_));
+        $old_style_hash = md5(_COOKIE_KEY_."123");
+        $success = $this->hashing->checkHash("123", $old_style_hash, array('cookie_key' => _COOKIE_KEY_));
+        $this->isTrue($success);
+        $this->assertTrue(is_string($success));
+        $this->assertNotEquals($old_style_hash, $success);
+    }
+
+    public function test_upgrades_hashes_on_cost_change()
+    {
+        $hash = $this->hashing->hash('123456789');
+        $success = $this->hashing->checkHash('123456789', $hash, array('cost' => 20));
+        $this->isTrue($success);
+        $this->assertTrue(is_string($success));
+        $this->assertNotEquals($success, $hash);
     }
 }

--- a/tests/Unit/Core/Foundation/Crypto/Core_Foundation_Crypto_Hashing_Test.php
+++ b/tests/Unit/Core/Foundation/Crypto/Core_Foundation_Crypto_Hashing_Test.php
@@ -67,4 +67,18 @@ class Core_Foundation_Crypto_Hashing_Test extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_string($success));
         $this->assertNotEquals($success, $hash);
     }
+
+    public function test_register_hash_method()
+    {
+        $callback_called = false;
+        $this->hashing->registerHashMethod('dummy',
+            function ($passwd, $hash, $options) use (&$callback_called) {
+                $callback_called = true;
+                return $passwd == 'dummypass';
+            }
+        );
+        $success = $this->hashing->checkHash('dummypass', 'ignored');
+        $this->isTrue($success);
+        $this->assertTrue($callback_called);
+    }
 }

--- a/tests/Unit/Core/Foundation/Crypto/Core_Foundation_Crypto_Hashing_Test.php
+++ b/tests/Unit/Core/Foundation/Crypto/Core_Foundation_Crypto_Hashing_Test.php
@@ -29,11 +29,10 @@ use Exception;
 use PHPUnit_Framework_TestCase;
 use PrestaShop\PrestaShop\Core\Foundation\Crypto\Hashing;
 
-// FIXME: Defining this here will break all other Unit tests using UnitTestCase class!
-//define('_COOKIE_KEY_', '2349123849231-4123');
-
 class Core_Foundation_Crypto_Hashing_Test extends PHPUnit_Framework_TestCase
 {
+    const _COOKIE_KEY_ = '2349123849231-4123';
+
     public function setup()
     {
         $this->hashing = new Hashing();
@@ -41,8 +40,8 @@ class Core_Foundation_Crypto_Hashing_Test extends PHPUnit_Framework_TestCase
 
     public function test_simple_check_hash_md5()
     {
-        $this->isTrue($this->hashing->checkHash("123", md5(_COOKIE_KEY_."123"), array('cookie_key' => _COOKIE_KEY_)));
-        $this->isFalse($this->hashing->checkHash("23", md5(_COOKIE_KEY_."123"), array('cookie_key' => _COOKIE_KEY_)));
+        $this->isTrue($this->hashing->checkHash("123", md5(self::_COOKIE_KEY_."123"), array('cookie_key' => self::_COOKIE_KEY_)));
+        $this->isFalse($this->hashing->checkHash("23", md5(self::_COOKIE_KEY_."123"), array('cookie_key' => self::_COOKIE_KEY_)));
     }
 
     public function test_simple_hash()
@@ -52,8 +51,8 @@ class Core_Foundation_Crypto_Hashing_Test extends PHPUnit_Framework_TestCase
 
     public function test_upgrades_md5_hash()
     {
-        $old_style_hash = md5(_COOKIE_KEY_."123");
-        $success = $this->hashing->checkHash("123", $old_style_hash, array('cookie_key' => _COOKIE_KEY_));
+        $old_style_hash = md5(self::_COOKIE_KEY_."123");
+        $success = $this->hashing->checkHash("123", $old_style_hash, array('cookie_key' => self::_COOKIE_KEY_));
         $this->isTrue($success);
         $this->assertTrue(is_string($success));
         $this->assertNotEquals($old_style_hash, $success);


### PR DESCRIPTION
[PSCFV-11357](http://forge.prestashop.com/browse/PSCFV-11357)

This is my take on #3183 (kudos to @sfroment42 for the initial implementation). This changes the authentication methods to PHP's `password_hash` group of functions to bring Prestashop's security to 2015.

Added but not "discussed" on Forge is the ability to register compatibility hashing algorithms (the old md5 method being one of those, but I need phpass support as well for an upcoming migration). So, I've build this [hashingtest](https://gist.github.com/tiennou/bde3e16d260507b491c2) module to check that it can be done.
