### PR TITLE
[*] CORE : allow $to to be a string list separated by ';' in Mail::Se…

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -146,6 +146,12 @@ class MailCore extends ObjectModel
             $from_name = null;
         }
 
+		// If $to is a string list of e-mail addresses separated by ';' => conversion to array()
+		$is_to_string_list = strpos($to, ';');
+		if (false !== $is_to_string_list) {
+			$to = explode(';', $to);
+		}
+
         // It would be difficult to send an e-mail if the e-mail is not valid, so this time we can die if there is a problem
         if (!is_array($to) && !Validate::isEmail($to)) {
             Tools::dieOrLog(Tools::displayError('Error: parameter "to" is corrupted'), $die);


### PR DESCRIPTION
…nd()

If $to contains ';' (standard e-mail addresses list separator), conversion of the string in array to be processed as a list in in multiple recipients creation.
