### PR TITLE
Avoid using stale Entity information indirectly from the database cache.

### DIFF
--- a/Adapter/Adapter_EntityMapper.php
+++ b/Adapter/Adapter_EntityMapper.php
@@ -58,7 +58,11 @@ class Adapter_EntityMapper
                 $sql->leftJoin($entity_defs['table'] . '_shop', 'c', 'a.`' . bqSQL($entity_defs['primary']) . '` = c.`' . bqSQL($entity_defs['primary']) . '` AND c.`id_shop` = ' . (int)$id_shop);
             }
 
-            if ($object_datas = Db::getInstance()->getRow($sql)) {
+            /* Don't $use_cache:
+               We try to grab information about an Entity unavailable at $cache_id
+               But old data may very well be in the own database query results cache what
+               very easily lead to double caching of stale results. */
+            if ($object_datas = Db::getInstance()->getRow($sql, FALSE)) {
                 if (!$id_lang && isset($entity_defs['multilang']) && $entity_defs['multilang']) {
                     $sql = 'SELECT *
 							FROM `' . bqSQL(_DB_PREFIX_ . $entity_defs['table']) . '_lang`


### PR DESCRIPTION
The EntityMapper first tries to fetch Entity (partial or full) from a cache_id.
(eg: objectmodel_Product_223_1_0)

But if that fails it will try to fetch information using Db::getRow() which, by
default use it's own cache. In such situation stale results are likely to be
provided. Since database results are intended to be stored, let's _really_ fetch
them from the MySQL database.

Real-case: Using memcached cache it was found that the back-office was providing
old result after a form submission (eg: priceTE input value would be be restored
to its initial value although actually updated in the database).
This was tracked down to this scenario where memcached had kept old mysql result
for which the invalidation was almost impossible.
