### PR TITLE
BO: check id before deleting rows

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -170,7 +170,7 @@ class CombinationCore extends ObjectModel
     public function deleteAssociations()
     {
     	if((int)$this->id == 0){
-    		return false;
+    	    return false;
     	}
     	
         $result = Db::getInstance()->delete('product_attribute_combination', '`id_product_attribute` = '.(int)$this->id);

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -169,6 +169,10 @@ class CombinationCore extends ObjectModel
 
     public function deleteAssociations()
     {
+    	if((int)$this->id == 0){
+    		return false;
+    	}
+    	
         $result = Db::getInstance()->delete('product_attribute_combination', '`id_product_attribute` = '.(int)$this->id);
         $result &= Db::getInstance()->delete('cart_product', '`id_product_attribute` = '.(int)$this->id);
         $result &= Db::getInstance()->delete('product_attribute_image', '`id_product_attribute` = '.(int)$this->id);


### PR DESCRIPTION
I hope you agree that in a perfect world id_product_attribute can never be 0.
However, we are a web agency with over 130 PrestaShop-customers and I can tell you: it happens!
When it happens, it will delete "normal" products from table cart_product which can cause several other problems.
Unfortunately until now, we could not find the source of this error.
However we think it's caused by modules and/or/in combination with the caching system.
This pull request will solve this problem.
