### PR TITLE
Allow registering custom Smarty plugins.

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -29,6 +29,8 @@ $smarty->setTemplateDir(array(
     _PS_THEME_DIR_.'templates',
 ));
 
+$smarty->addPluginsDir(_PS_THEME_DIR_.'plugins');
+
 if (Configuration::get('PS_HTML_THEME_COMPRESSION')) {
     $smarty->registerFilter('output', 'smartyMinifyHTML');
 }


### PR DESCRIPTION
Plugins can be registered by adding files following the [naming conventions](http://www.smarty.net/docsv2/en/plugins.naming.conventions.tpl)
