### PR TITLE
[+] FO : Introduce `$this->l()` for FrontController

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -29,6 +29,35 @@
  */
 class TranslateCore
 {
+    public static function getFrontTranslation($string, $class, $addslashes = false, $htmlentities = true, $sprintf = null)
+    {
+        global $_LANG;
+
+        $iso = Context::getContext()->language->iso_code;
+        if (empty($iso)) {
+            $iso = Language::getIsoById((int)Configuration::get('PS_LANG_DEFAULT'));
+        }
+
+        $string = preg_replace("/\\\*'/", "\'", $string);
+        $key = $class.'_'.md5($string);
+
+        if (isset($_LANG[$key])) {
+            $str = $_LANG[$key];
+        } else {
+            $str = $string;
+        }
+
+        if ($htmlentities) {
+            $str = htmlspecialchars($str, ENT_QUOTES, 'utf-8');
+        }
+        $str = str_replace('"', '&quot;', $str);
+
+        if ($sprintf !== null) {
+            $str = Translate::checkAndReplaceArgs($str, $sprintf);
+        }
+
+        return ($addslashes ? addslashes($str) : stripslashes($str));
+    }
     /**
      * Get a translation for an admin controller
      *
@@ -172,9 +201,9 @@ class TranslateCore
             $default_key = strtolower('<{'.$name.'}prestashop>'.$source).'_'.$key;
 
             if ('controller' == substr($source, -10, 10)) {
-                 $file = substr($source, 0, -10);
-                 $current_key_file = strtolower('<{'.$name.'}'._THEME_NAME_.'>'.$file).'_'.$key;
-                 $default_key_file = strtolower('<{'.$name.'}prestashop>'.$file).'_'.$key;
+                $file = substr($source, 0, -10);
+                $current_key_file = strtolower('<{'.$name.'}'._THEME_NAME_.'>'.$file).'_'.$key;
+                $default_key_file = strtolower('<{'.$name.'}prestashop>'.$file).'_'.$key;
             }
 
             if (isset($current_key_file) && !empty($_MODULES[$current_key_file])) {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -545,6 +545,34 @@ class FrontControllerCore extends Controller
     }
 
     /**
+     * Non-static translation method for frontoffice
+     *
+     * @param string  $string Term or expression in english
+     * @param false|string  $specific Specific name, only for ModuleFrontController
+     * @param string|null $class Name of the class
+     * @param bool $addslashes If set to true, the return value will pass through addslashes(). Otherwise, stripslashes().
+     * @param bool $htmlentities If set to true(default), the return value will pass through htmlentities($string, ENT_QUOTES, 'utf-8')
+     * @return string The translation if available, or the english default text.
+     */
+    protected function l($string, $specific = false, $class = null, $addslashes = false, $htmlentities = true)
+    {
+        if ($class === null) {
+            $class = get_class($this);
+        }
+
+        if (is_a($this, 'ModuleFrontController')) {
+            // ModuleFrontController must assign $this->module
+            if (isset($this->module) && is_a($this->module, 'Module')) {
+                return $this->module->l($string, $specific);
+            } else {
+                return $string;
+            }
+        }
+
+        return Translate::getFrontTranslation($string, $class, $addslashes, $htmlentities);
+    }
+
+    /**
      * Redirects to redirect_after link
      *
      * @see $redirect_after

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1121,6 +1121,12 @@ class AdminTranslationsControllerCore extends AdminController
 
         switch ($this->type_selected) {
             case 'front':
+                $directories['php'] = array(
+                    _PS_FRONT_CONTROLLER_DIR_ => scandir(_PS_FRONT_CONTROLLER_DIR_),
+                    _PS_OVERRIDE_DIR_.'controllers/front/' => scandir(_PS_OVERRIDE_DIR_.'controllers/front/'),
+                    _PS_CLASS_DIR_.'controller/' => array('FrontController.php'),
+                );
+
                 $directories['tpl'] = array(_PS_ALL_THEMES_DIR_ => scandir(_PS_ALL_THEMES_DIR_));
                 self::$ignore_folder[] = 'modules';
                 $directories['tpl'] = array_merge($directories['tpl'], $this->listFiles(_PS_THEME_SELECTED_DIR_));
@@ -1230,46 +1236,50 @@ class AdminTranslationsControllerCore extends AdminController
     {
         switch ($type_translation) {
             case 'front':
-                    // Parsing file in Front office
+                // Parsing file in Front office
+                if ($type_file == 'php') {
+                    $regex = '/this->l\((\')'._PS_TRANS_PATTERN_.'\'[\)|\,]/U';
+                } else {
                     $regex = '/\{l\s*s=([\'\"])'._PS_TRANS_PATTERN_.'\1(\s*sprintf=.*)?(\s*js=1)?\s*\}/U';
+                }
                 break;
 
             case 'back':
-                    // Parsing file in Back office
-                    if ($type_file == 'php') {
-                        $regex = '/this->l\((\')'._PS_TRANS_PATTERN_.'\'[\)|\,]/U';
-                    } elseif ($type_file == 'specific') {
-                        $regex = '/Translate::getAdminTranslation\((\')'._PS_TRANS_PATTERN_.'\'(?:,.*)*\)/U';
-                    } else {
-                        $regex = '/\{l\s*s\s*=([\'\"])'._PS_TRANS_PATTERN_.'\1(\s*sprintf=.*)?(\s*js=1)?(\s*slashes=1)?.*\}/U';
-                    }
+                // Parsing file in Back office
+                if ($type_file == 'php') {
+                    $regex = '/this->l\((\')'._PS_TRANS_PATTERN_.'\'[\)|\,]/U';
+                } elseif ($type_file == 'specific') {
+                    $regex = '/Translate::getAdminTranslation\((\')'._PS_TRANS_PATTERN_.'\'(?:,.*)*\)/U';
+                } else {
+                    $regex = '/\{l\s*s\s*=([\'\"])'._PS_TRANS_PATTERN_.'\1(\s*sprintf=.*)?(\s*js=1)?(\s*slashes=1)?.*\}/U';
+                }
                 break;
 
             case 'errors':
-                    // Parsing file for all errors syntax
-                    $regex = '/Tools::displayError\((\')'._PS_TRANS_PATTERN_.'\'(,\s*(.+))?\)/U';
+                // Parsing file for all errors syntax
+                $regex = '/Tools::displayError\((\')'._PS_TRANS_PATTERN_.'\'(,\s*(.+))?\)/U';
                 break;
 
             case 'modules':
-                    // Parsing modules file
-                    if ($type_file == 'php') {
-                        $regex = '/->l\((\')'._PS_TRANS_PATTERN_.'\'(, ?\'(.+)\')?(, ?(.+))?\)/U';
-                    } else {
-                        // In tpl file look for something that should contain mod='module_name' according to the documentation
-                        $regex = '/\{l\s*s=([\'\"])'._PS_TRANS_PATTERN_.'\1.*\s+mod=\''.$module_name.'\'.*\}/U';
-                    }
+                // Parsing modules file
+                if ($type_file == 'php') {
+                    $regex = '/->l\((\')'._PS_TRANS_PATTERN_.'\'(, ?\'(.+)\')?(, ?(.+))?\)/U';
+                } else {
+                    // In tpl file look for something that should contain mod='module_name' according to the documentation
+                    $regex = '/\{l\s*s=([\'\"])'._PS_TRANS_PATTERN_.'\1.*\s+mod=\''.$module_name.'\'.*\}/U';
+                }
                 break;
 
             case 'pdf':
-                    // Parsing PDF file
-                    if ($type_file == 'php') {
-                        $regex = array(
-                            '/HTMLTemplate.*::l\((\')'._PS_TRANS_PATTERN_.'\'[\)|\,]/U',
-                            '/->l\((\')'._PS_TRANS_PATTERN_.'\'(, ?\'(.+)\')?(, ?(.+))?\)/U'
-                        );
-                    } else {
-                        $regex = '/\{l\s*s=([\'\"])'._PS_TRANS_PATTERN_.'\1(\s*sprintf=.*)?(\s*js=1)?(\s*pdf=\'true\')?\s*\}/U';
-                    }
+                // Parsing PDF file
+                if ($type_file == 'php') {
+                    $regex = array(
+                        '/HTMLTemplate.*::l\((\')'._PS_TRANS_PATTERN_.'\'[\)|\,]/U',
+                        '/->l\((\')'._PS_TRANS_PATTERN_.'\'(, ?\'(.+)\')?(, ?(.+))?\)/U'
+                    );
+                } else {
+                    $regex = '/\{l\s*s=([\'\"])'._PS_TRANS_PATTERN_.'\1(\s*sprintf=.*)?(\s*js=1)?(\s*pdf=\'true\')?\s*\}/U';
+                }
                 break;
         }
 
@@ -1796,53 +1806,55 @@ class AdminTranslationsControllerCore extends AdminController
         $files_by_directory = $this->getFileToParseByTypeTranslation();
         $count = 0;
         $tabs_array = array();
-        foreach ($files_by_directory['tpl'] as $dir => $files) {
-            $prefix = '';
-            if ($dir == _PS_THEME_OVERRIDE_DIR_) {
-                $prefix = 'override_';
-            }
+        foreach ($files_by_directory as $file_type => $root_directory) {
+            foreach ($root_directory as $dir => $files) {
+                $prefix = '';
+                if ($dir == _PS_THEME_OVERRIDE_DIR_) {
+                    $prefix = 'override_';
+                }
 
-            foreach ($files as $file) {
-                if (preg_match('/^(.*).tpl$/', $file) && (Tools::file_exists_cache($file_path = $dir.$file))) {
-                    $prefix_key = $prefix.substr(basename($file), 0, -4);
-                    $new_lang = array();
+                foreach ($files as $file) {
+                    if (preg_match('/^(.*).(tpl|php)$/', $file) && (Tools::file_exists_cache($file_path = $dir.$file))) {
+                        $prefix_key = $prefix.substr(basename($file), 0, -4);
+                        $new_lang = array();
 
-                    // Get content for this file
-                    $content = file_get_contents($file_path);
+                        // Get content for this file
+                        $content = file_get_contents($file_path);
 
-                    // Parse this content
-                    $matches = $this->userParseFile($content, $this->type_selected);
+                        // Parse this content
+                        $matches = $this->userParseFile($content, $this->type_selected, $file_type);
 
-                    /* Get string translation */
-                    foreach ($matches as $key) {
-                        if (empty($key)) {
-                            $this->errors[] = sprintf($this->l('Empty string found, please edit: "%s"'), $file_path);
-                            $new_lang[$key] = '';
-                        } else {
-                            // Caution ! front has underscore between prefix key and md5, back has not
-                            if (isset($GLOBALS[$name_var][$prefix_key.'_'.md5($key)])) {
-                                $new_lang[$key]['trad'] = stripslashes(html_entity_decode($GLOBALS[$name_var][$prefix_key.'_'.md5($key)], ENT_COMPAT, 'UTF-8'));
+                        /* Get string translation */
+                        foreach ($matches as $key) {
+                            if (empty($key)) {
+                                $this->errors[] = sprintf($this->l('Empty string found, please edit: "%s"'), $file_path);
+                                $new_lang[$key] = '';
                             } else {
-                                if (!isset($new_lang[$key]['trad'])) {
-                                    $new_lang[$key]['trad'] = '';
-                                    if (!isset($missing_translations_front[$prefix_key])) {
-                                        $missing_translations_front[$prefix_key] = 1;
-                                    } else {
-                                        $missing_translations_front[$prefix_key]++;
+                                // Caution ! front has underscore between prefix key and md5, back has not
+                                if (isset($GLOBALS[$name_var][$prefix_key.'_'.md5($key)])) {
+                                    $new_lang[$key]['trad'] = stripslashes(html_entity_decode($GLOBALS[$name_var][$prefix_key.'_'.md5($key)], ENT_COMPAT, 'UTF-8'));
+                                } else {
+                                    if (!isset($new_lang[$key]['trad'])) {
+                                        $new_lang[$key]['trad'] = '';
+                                        if (!isset($missing_translations_front[$prefix_key])) {
+                                            $missing_translations_front[$prefix_key] = 1;
+                                        } else {
+                                            $missing_translations_front[$prefix_key]++;
+                                        }
                                     }
                                 }
+                                $new_lang[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
                             }
-                            $new_lang[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
                         }
-                    }
 
-                    if (isset($tabs_array[$prefix_key])) {
-                        $tabs_array[$prefix_key] = array_merge($tabs_array[$prefix_key], $new_lang);
-                    } else {
-                        $tabs_array[$prefix_key] = $new_lang;
-                    }
+                        if (isset($tabs_array[$prefix_key])) {
+                            $tabs_array[$prefix_key] = array_merge($tabs_array[$prefix_key], $new_lang);
+                        } else {
+                            $tabs_array[$prefix_key] = $new_lang;
+                        }
 
-                    $count += count($new_lang);
+                        $count += count($new_lang);
+                    }
                 }
             }
         }


### PR DESCRIPTION
### How to use it

In a frontcontroller like `StoresControllers`:

``` php
$this->l('My string to translate');
```

In the `FrontController` class:

``` php
$this->l('My string to translate', false, 'FrontController');
```

In a ModuleFrontController, you can still use the old way (example: https://github.com/PrestaShop/blockwishlist/blob/master/controllers/front/mywishlist.php#L76 )

``` php
$this->module->l('My string to translate', 'identifier');
```

or the new way

``` php
$this->l('My string to translate', 'identifier');
```
