### PR TITLE
Introduce Widgets for modules

### DIFF
--- a/Core/Business/Module/WidgetInterface.php
+++ b/Core/Business/Module/WidgetInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Business\Module;
+
+interface WidgetInterface {
+    public function renderWidget($hookName, array $configuration);
+    public function getWidgetVariables($hookName, array $configuration);
+}

--- a/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
@@ -39,7 +39,7 @@
 			<div class="col-lg-9">
 				<select class="chosen" name="id_module" {if $edit_graft} disabled="disabled"{/if}>
 					{if !$hooks}
-						<option value="0">{l s='Please select a module'}</option>
+						<option value="0" selected disabled>{l s='Please select a module'}</option>
 					{/if}
 					{foreach $modules as $module}
 						<option value="{$module->id|intval}"{if $id_module == $module->id || (!$id_module && $show_modules == $module->id)} selected="selected"{/if}>{$module->displayName|stripslashes}</option>

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -89,19 +89,46 @@ class HookCore extends ObjectModel
         return parent::add($autodate, $null_values);
     }
 
+    public static function isDisplayHookName($hook_name)
+    {
+        $hook_name = strtolower($hook_name);
+
+        if ($hook_name === 'header') {
+            // this hook is to add resources to the <head> section of the page
+            // so it doesn't display anything by itself
+            return false;
+        }
+
+        if (strpos($hook_name, 'display') === 0) {
+            return true;
+        } else if (strpos($hook_name, 'action') === 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
     /**
      * Return Hooks List
      *
      * @param bool $position
      * @return array Hooks List
      */
-    public static function getHooks($position = false)
+    public static function getHooks($position = false, $only_display_hooks = false)
     {
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+        $hooks = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 			SELECT * FROM `'._DB_PREFIX_.'hook` h
 			'.($position ? 'WHERE h.`position` = 1' : '').'
 			ORDER BY `name`'
         );
+
+        if ($only_display_hooks) {
+            return array_filter($hooks, function ($hook) {
+                return self::isDisplayHookName($hook['name']);
+            });
+        } else {
+            return $hooks;
+        }
     }
 
     /**

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -91,9 +91,21 @@ class HookCore extends ObjectModel
         return parent::add($autodate, $null_values);
     }
 
+    public static function normalizeHookName($hookName)
+    {
+        if (strtolower($hookName) == 'displayheader') {
+            return 'displayHeader';
+        }
+        $hookAliasList = Hook::getHookAliasList();
+        if (isset($hookAliasList[strtolower($hookName)])) {
+            return $hookAliasList[strtolower($hookName)];
+        }
+        return $hookName;
+    }
+
     public static function isDisplayHookName($hook_name)
     {
-        $hook_name = strtolower($hook_name);
+        $hook_name = strtolower(self::normalizeHookName($hook_name));
 
         if ($hook_name === 'header') {
             // this hook is to add resources to the <head> section of the page

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -24,6 +24,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+ use PrestaShop\PrestaShop\Core\Business\Module\WidgetInterface;
+
 class HookCore extends ObjectModel
 {
     /**
@@ -581,6 +583,16 @@ class HookCore extends ObjectModel
                     $output[$moduleInstance->name] = $display;
                 } else {
                     $output .= $display;
+                }
+            } else {
+                if ($moduleInstance instanceof WidgetInterface) {
+                    $display = $moduleInstance->renderWidget($hook_name, $hook_args);
+
+                    if ($array_return) {
+                        $output[$moduleInstance->name] = $display;
+                    } else {
+                        $output .= $display;
+                    }
                 }
             }
         }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1361,7 +1361,7 @@ abstract class ModuleCore
 
                     // If (false) is a trick to not load the class with "eval".
                     // This way require_once will works correctly
-                    if (eval('if (false){	'.$file.' }') !== false) {
+                    if (eval('if (false){	'.preg_replace('/\n[\s\t]*?use\s.*?;/', '', $file).' }') !== false) {
                         require_once(_PS_MODULE_DIR_.$module.'/'.$module.'.php');
                     } else {
                         $errors[] = sprintf(Tools::displayError('%1$s (parse error in %2$s)'), $module, substr($file_path, strlen(_PS_ROOT_DIR_)));

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -24,6 +24,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+use PrestaShop\PrestaShop\Core\Business\Module\WidgetInterface;
+
 abstract class ModuleCore
 {
     /** @var int Module ID */
@@ -2500,6 +2502,10 @@ abstract class ModuleCore
      */
     public function isHookableOn($hook_name)
     {
+        if ($this instanceof WidgetInterface) {
+            return Hook::isDisplayHookName($hook_name);
+        }
+
         $retro_hook_name = Hook::getRetroHookName($hook_name);
         return (is_callable(array($this, 'hook'.ucfirst($hook_name))) || is_callable(array($this, 'hook'.ucfirst($retro_hook_name))));
     }
@@ -3065,6 +3071,11 @@ abstract class ModuleCore
         return true;
     }
 
+    private function getWidgetHooks()
+    {
+        return array_values(Hook::getHooks(false, true));
+    }
+
     /**
      * Return the hooks list where this module can be hooked.
      *
@@ -3072,6 +3083,10 @@ abstract class ModuleCore
      */
     public function getPossibleHooksList()
     {
+        if ($this instanceof WidgetInterface) {
+            return $this->getWidgetHooks();
+        }
+
         $hooks_list = Hook::getHooks();
         $possible_hooks_list = array();
         foreach ($hooks_list as &$current_hook) {

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -86,6 +86,7 @@ smartyRegisterFunction($smarty, 'block', 'addJsDefL', array('Media', 'addJsDefL'
 smartyRegisterFunction($smarty, 'modifier', 'boolval', array('Tools', 'boolval'));
 smartyRegisterFunction($smarty, 'modifier', 'cleanHtml', 'smartyCleanHtml');
 smartyRegisterFunction($smarty, 'function', 'widget', 'smartyWidget');
+smartyRegisterFunction($smarty, 'block', 'widget_block', 'smartyWidgetBlock');
 
 function smartyDieObject($params, &$smarty)
 {
@@ -250,6 +251,16 @@ function smartyWidget($params, &$smarty)
     });
 }
 
+function smartyWidgetBlock($params, $content, &$smarty)
+{
+    if (null === $content) {
+        withWidget($params, function ($widget, $params) use (&$smarty) {
+            $smarty->assign($widget->getWidgetVariables(null, $params));
+        });
+        return '';
+    } else {
+        return $content;
+    }
 }
 
 /**

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -85,6 +85,7 @@ smartyRegisterFunction($smarty, 'function', 'addJsDef', array('Media', 'addJsDef
 smartyRegisterFunction($smarty, 'block', 'addJsDefL', array('Media', 'addJsDefL'));
 smartyRegisterFunction($smarty, 'modifier', 'boolval', array('Tools', 'boolval'));
 smartyRegisterFunction($smarty, 'modifier', 'cleanHtml', 'smartyCleanHtml');
+smartyRegisterFunction($smarty, 'function', 'render_widget', 'smartyRenderWidget');
 
 function smartyDieObject($params, &$smarty)
 {
@@ -219,6 +220,27 @@ function smartyCleanHtml($data)
 function toolsConvertPrice($params, &$smarty)
 {
     return Tools::convertPrice($params['price'], Context::getContext()->currency);
+}
+
+function smartyRenderWidget($params, &$smarty)
+{
+    if (!isset($params['name'])) {
+        throw new Exception('Smarty helper `render_widget` expects at least the `name` parameter.');
+    }
+
+    $moduleName = $params['name'];
+    unset($params['name']);
+
+    $moduleInstance = Module::getInstanceByName($moduleName);
+
+    if (!$moduleInstance instanceof PrestaShop\PrestaShop\Core\Business\Module\WidgetInterface) {
+        throw new Exception(sprintf(
+            'Module `%1$s` is not a WidgetInterface.',
+            $moduleName
+        ));
+    }
+
+    return $moduleInstance->renderWidget(null, $params);
 }
 
 /**

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -85,7 +85,7 @@ smartyRegisterFunction($smarty, 'function', 'addJsDef', array('Media', 'addJsDef
 smartyRegisterFunction($smarty, 'block', 'addJsDefL', array('Media', 'addJsDefL'));
 smartyRegisterFunction($smarty, 'modifier', 'boolval', array('Tools', 'boolval'));
 smartyRegisterFunction($smarty, 'modifier', 'cleanHtml', 'smartyCleanHtml');
-smartyRegisterFunction($smarty, 'function', 'render_widget', 'smartyRenderWidget');
+smartyRegisterFunction($smarty, 'function', 'widget', 'smartyWidget');
 
 function smartyDieObject($params, &$smarty)
 {
@@ -222,7 +222,7 @@ function toolsConvertPrice($params, &$smarty)
     return Tools::convertPrice($params['price'], Context::getContext()->currency);
 }
 
-function smartyRenderWidget($params, &$smarty)
+function withWidget($params, callable $cb)
 {
     if (!isset($params['name'])) {
         throw new Exception('Smarty helper `render_widget` expects at least the `name` parameter.');
@@ -240,7 +240,16 @@ function smartyRenderWidget($params, &$smarty)
         ));
     }
 
-    return $moduleInstance->renderWidget(null, $params);
+    return $cb($moduleInstance, $params);
+}
+
+function smartyWidget($params, &$smarty)
+{
+    return withWidget($params, function ($widget, $params) {
+        return $widget->renderWidget(null, $params);
+    });
+}
+
 }
 
 /**

--- a/controllers/admin/AdminModulesPositionsController.php
+++ b/controllers/admin/AdminModulesPositionsController.php
@@ -279,7 +279,7 @@ class AdminModulesPositionsControllerCore extends AdminController
             }
         }
         ksort($module_instances);
-        $hooks = Hook::getHooks();
+        $hooks = Hook::getHooks(false, true);
         foreach ($hooks as $key => $hook) {
             // Get all modules for this hook or only the filtered module
             $hooks[$key]['modules'] = Hook::getModulesFromHook($hook['id_hook'], $this->display_key);

--- a/js/admin/modules-position.js
+++ b/js/admin/modules-position.js
@@ -168,7 +168,6 @@ $(function(){
 
 		if ($this.val() != 0)
 		{
-			$this.find("[value='0']").remove();
 			hook_select.find("option").remove();
 
 			$.ajax({

--- a/setup-workspace
+++ b/setup-workspace
@@ -6,7 +6,7 @@
 # - add the .editorconfig to wherever it is needed
 
 # modified modules to install
-modules=( blocklanguages blockbanner blockuserinfo )
+modules=( blocklanguages blockbanner blockuserinfo blocktopmenu )
 
 dependencies=( php curl git awk )
 for dependency in ${dependencies[@]}

--- a/tests/Unit/classes/HookTest.php
+++ b/tests/Unit/classes/HookTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Tests\Unit\Classes;
+
+use PrestaShop\PrestaShop\Tests\TestCase\UnitTestCase;
+
+use Hook;
+
+class HookTest extends UnitTestCase
+{
+    public function test_isDisplayHookName__display_hooks_start_with_display()
+    {
+        $this->assertTrue(Hook::isDisplayHookName('displaySomething'));
+    }
+
+    public function test_isDisplayHookName__display_hooks_cannot_start_with_action()
+    {
+        $this->assertFalse(Hook::isDisplayHookName('actionDoWeirdStuff'));
+    }
+
+    public function test_isDisplayHookName__header_is_not_a_display_hook()
+    {
+        $this->assertFalse(Hook::isDisplayHookName('header'));
+    }
+}


### PR DESCRIPTION
This is an implementation of the specification described here: https://trello.com/c/pcKZ4qOA/102-widget-system-proposal.

In a few words, it allows a module to hook a "widget" to any display hook.

This means you don't need to know the name of a hook to display the module and you can just do:

``` smarty
{widget name="blocklanguages"}
```

In any template!

Here is an example of a module implementing the widget interface: PrestaShop/blocklanguages#8

Also introducing the `wiget_block` syntax, that you can use like this:

``` smarty
{widget_block name="blocklanguages"}
    {* $languages and $current_language are assigned by "blocklanguages", not the controller *}
    <div>
        <div>{$current_language.name}</div>
        {foreach from=$languages item="language"}
            {$language.name}
        {/foreach}
    </div>
{/widget_block}
```

What happens here is that the widget variables are passed to your block so you can override any widget!
