### PR TITLE
Add id_product_attribute in WHERE statement in getPriceStatic.

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2784,6 +2784,7 @@ class ProductCore extends ObjectModel
                 $sql = 'SELECT SUM(`quantity`)
 				FROM `'._DB_PREFIX_.'cart_product`
 				WHERE `id_product` = '.(int)$id_product.'
+				AND `id_product_attribute` = '.(int)$id_product_attribute.' 
 				AND `id_cart` = '.(int)$id_cart;
                 $cart_quantity = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
                 Cache::store($cache_id, $cart_quantity);


### PR DESCRIPTION
Added id_product_attribute in getPriceStatic. It was missing. 
When using specific prices based on product_attribute_id it gave wrong price calculations on volume discounts 
