### PR TITLE
[*] Modules : Enable updatePosition() at the  module's installation

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2005,29 +2005,32 @@ abstract class ModuleCore
                     break;
                 }
             }
-            if (!isset($k) || !isset($res[$k]) || !isset($res[$k + 1])) {
+            if (!isset($k)) {
                 return false;
             }
 
             $from = $res[$k];
-            $to = $res[$k + 1];
-
-            if (isset($position) && !empty($position)) {
-                $to['position'] = (int)$position;
+            if (!$way) {
+				$to = (int)$from['position'] - 1;
             }
-
+			else {
+				$to = (int)$from['position'] + 1;
+			}	
+			if (!empty($position)) {
+				$to = (int)$position;
+			}
             $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
-                SET `position`= position '.($way ? '-1' : '+1').'
-                WHERE position between '.(int)(min(array($from['position'], $to['position']))).' AND '.max(array($from['position'], $to['position'])).'
-                AND `id_hook` = '.(int)$from['id_hook'].' AND `id_shop` = '.$shop_id;
-            if (!Db::getInstance()->execute($sql)) {
-                return false;
-            }
-
+				SET `position`= position '.($way ? '-1' : '+1').'
+				WHERE position between '.(int)(min(array($from['position'], $to))).' AND '.max(array($from['position'], $to)).'
+				AND `id_module` != '.(int)$from['id_module'].'
+				AND `id_hook` = '.(int)$from['id_hook'].' AND `id_shop` = '.$shop_id;
+			if (!Db::getInstance()->execute($sql)) {
+				return false;
+			}
             $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
-                SET `position`='.(int)$to['position'].'
-                WHERE `'.pSQL($this->identifier).'` = '.(int)$from[$this->identifier].'
-                AND `id_hook` = '.(int)$to['id_hook'].' AND `id_shop` = '.$shop_id;
+				SET `position`='.(int)$to.'
+				WHERE `id_module` = '.(int)$from['id_module'].'
+				AND `id_hook` = '.(int)$from['id_hook'].' AND `id_shop` = '.$shop_id;
             if (!Db::getInstance()->execute($sql)) {
                 return false;
             }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1996,7 +1996,7 @@ abstract class ModuleCore
                     WHERE hm.`id_hook` = '.(int)$id_hook.' AND hm.`id_shop` = '.$shop_id.'
                     ORDER BY hm.`position` '.($way ? 'ASC' : 'DESC');
             if (!$res = Db::getInstance()->executeS($sql)) {
-                continue;
+                    continue;
             }
 
             foreach ($res as $key => $values) {
@@ -2006,36 +2006,36 @@ abstract class ModuleCore
                 }
             }
             if (!isset($k)) {
-                return false;
+                    return false;
             }
 
             $from = $res[$k];
             if (!$way) {
-		$to = (int)$from['position'] - 1;
+		    $to = (int)$from['position'] - 1;
             }
-	    else {
-		$to = (int)$from['position'] + 1;
+	     else {
+		    $to = (int)$from['position'] + 1;
 	     }	
 	     if (!empty($position)) {
-		$to = (int)$position;
+		    $to = (int)$position;
 	     }
              $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
-		SET `position`= position '.($way ? '-1' : '+1').'
-		WHERE position between '.(int)(min(array($from['position'], $to))).' 
-		AND '.max(array($from['position'], $to)).'
-		AND `id_module` != '.(int)$from['id_module'].'
-		AND `id_hook` = '.(int)$from['id_hook'].' 
-		AND `id_shop` = '.$shop_id;
+		    SET `position`= position '.($way ? '-1' : '+1').'
+		    WHERE position between '.(int)(min(array($from['position'], $to))).' 
+		    AND '.max(array($from['position'], $to)).'
+		    AND `id_module` != '.(int)$from['id_module'].'
+		    AND `id_hook` = '.(int)$from['id_hook'].' 
+		    AND `id_shop` = '.$shop_id;
 	      if (!Db::getInstance()->execute($sql)) {
-		return false;
+		    return false;
 	      }
              $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
-		SET `position`='.(int)$to.'
-		WHERE `id_module` = '.(int)$from['id_module'].'
-		AND `id_hook` = '.(int)$from['id_hook'].' 
-		AND `id_shop` = '.$shop_id;
+		    SET `position`='.(int)$to.'
+		    WHERE `id_module` = '.(int)$from['id_module'].'
+		    AND `id_hook` = '.(int)$from['id_hook'].' 
+		    AND `id_shop` = '.$shop_id;
              if (!Db::getInstance()->execute($sql)) {
-                return false;
+                    return false;
              }
         }
         return true;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2020,20 +2020,20 @@ abstract class ModuleCore
 		$to = (int)$position;
 	    }
             $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
-			SET `position`= position '.($way ? '-1' : '+1').'
-			WHERE position between '.(int)(min(array($from['position'], $to))).' 
-			AND '.max(array($from['position'], $to)).'
-			AND `id_module` != '.(int)$from['id_module'].'
-			AND `id_hook` = '.(int)$from['id_hook'].' 
-			AND `id_shop` = '.$shop_id;
-	    if (!Db::getInstance()->execute($sql)) {
+		SET `position`= position '.($way ? '-1' : '+1').'
+		WHERE position between '.(int)(min(array($from['position'], $to))).' 
+		AND '.max(array($from['position'], $to)).'
+		AND `id_module` != '.(int)$from['id_module'].'
+		AND `id_hook` = '.(int)$from['id_hook'].' 
+		AND `id_shop` = '.$shop_id;
+	     if (!Db::getInstance()->execute($sql)) {
 		return false;
-	    }
+	     }
             $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
-			SET `position`='.(int)$to.'
-			WHERE `id_module` = '.(int)$from['id_module'].'
-			AND `id_hook` = '.(int)$from['id_hook'].' 
-			AND `id_shop` = '.$shop_id;
+		SET `position`='.(int)$to.'
+		WHERE `id_module` = '.(int)$from['id_module'].'
+		AND `id_hook` = '.(int)$from['id_hook'].' 
+		AND `id_shop` = '.$shop_id;
             if (!Db::getInstance()->execute($sql)) {
                 return false;
             }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1996,7 +1996,7 @@ abstract class ModuleCore
                     WHERE hm.`id_hook` = '.(int)$id_hook.' AND hm.`id_shop` = '.$shop_id.'
                     ORDER BY hm.`position` '.($way ? 'ASC' : 'DESC');
             if (!$res = Db::getInstance()->executeS($sql)) {
-                    continue;
+                continue;
             }
 
             foreach ($res as $key => $values) {
@@ -2006,7 +2006,7 @@ abstract class ModuleCore
                 }
             }
             if (!isset($k)) {
-                    return false;
+                return false;
             }
 
             $from = $res[$k];

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2015,28 +2015,28 @@ abstract class ModuleCore
             }
 	    else {
 		$to = (int)$from['position'] + 1;
-	    }	
-	    if (!empty($position)) {
+	     }	
+	     if (!empty($position)) {
 		$to = (int)$position;
-	    }
-            $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
+	     }
+             $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
 		SET `position`= position '.($way ? '-1' : '+1').'
 		WHERE position between '.(int)(min(array($from['position'], $to))).' 
 		AND '.max(array($from['position'], $to)).'
 		AND `id_module` != '.(int)$from['id_module'].'
 		AND `id_hook` = '.(int)$from['id_hook'].' 
 		AND `id_shop` = '.$shop_id;
-	     if (!Db::getInstance()->execute($sql)) {
+	      if (!Db::getInstance()->execute($sql)) {
 		return false;
-	     }
-            $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
+	      }
+             $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
 		SET `position`='.(int)$to.'
 		WHERE `id_module` = '.(int)$from['id_module'].'
 		AND `id_hook` = '.(int)$from['id_hook'].' 
 		AND `id_shop` = '.$shop_id;
-            if (!Db::getInstance()->execute($sql)) {
+             if (!Db::getInstance()->execute($sql)) {
                 return false;
-            }
+             }
         }
         return true;
     }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2011,26 +2011,29 @@ abstract class ModuleCore
 
             $from = $res[$k];
             if (!$way) {
-				$to = (int)$from['position'] - 1;
+		$to = (int)$from['position'] - 1;
             }
-			else {
-				$to = (int)$from['position'] + 1;
-			}	
-			if (!empty($position)) {
-				$to = (int)$position;
-			}
+	    else {
+		$to = (int)$from['position'] + 1;
+	    }	
+	    if (!empty($position)) {
+		$to = (int)$position;
+	    }
             $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
-				SET `position`= position '.($way ? '-1' : '+1').'
-				WHERE position between '.(int)(min(array($from['position'], $to))).' AND '.max(array($from['position'], $to)).'
-				AND `id_module` != '.(int)$from['id_module'].'
-				AND `id_hook` = '.(int)$from['id_hook'].' AND `id_shop` = '.$shop_id;
-			if (!Db::getInstance()->execute($sql)) {
-				return false;
-			}
+			SET `position`= position '.($way ? '-1' : '+1').'
+			WHERE position between '.(int)(min(array($from['position'], $to))).' 
+			AND '.max(array($from['position'], $to)).'
+			AND `id_module` != '.(int)$from['id_module'].'
+			AND `id_hook` = '.(int)$from['id_hook'].' 
+			AND `id_shop` = '.$shop_id;
+	    if (!Db::getInstance()->execute($sql)) {
+		return false;
+	    }
             $sql = 'UPDATE `'._DB_PREFIX_.'hook_module`
-				SET `position`='.(int)$to.'
-				WHERE `id_module` = '.(int)$from['id_module'].'
-				AND `id_hook` = '.(int)$from['id_hook'].' AND `id_shop` = '.$shop_id;
+			SET `position`='.(int)$to.'
+			WHERE `id_module` = '.(int)$from['id_module'].'
+			AND `id_hook` = '.(int)$from['id_hook'].' 
+			AND `id_shop` = '.$shop_id;
             if (!Db::getInstance()->execute($sql)) {
                 return false;
             }


### PR DESCRIPTION
Allows you to use $this->updatePosition($ id_hook, $ way, $ position) after the attachment of a new module to a hook.
Currently impossible, because : if (! Isset ($ res [$ k + 1])).
The new module is inevitably in last place, so, $ res [$ k + 1] does not exist and the function always returns false.
Tested in normal mode, ajax and on module install.
