### PR TITLE
Use floor() instead of round() to show correct amount of loyalty points

### DIFF
--- a/themes/default-bootstrap/js/modules/loyalty/js/loyalty.js
+++ b/themes/default-bootstrap/js/modules/loyalty/js/loyalty.js
@@ -33,7 +33,7 @@ function updateLoyaltyView(new_price) {
 	if (typeof(new_price) == 'undefined' || typeof(productPriceWithoutReduction) == 'undefined')
 			return;
 
-	var points = Math.round(new_price / point_rate);
+	var points = Math.floor(new_price / point_rate);
 	var total_points = points_in_cart + points;
 	var voucher = total_points * point_value;
 


### PR DESCRIPTION
[-] FO : Show correct amount of earnable loyalty points.
