### PR TITLE
[*][–] FO : improve smarty hook fct : add exclude param

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -192,20 +192,42 @@ function smartyRegisterFunction($smarty, $type, $function, $params, $lazy = true
 
 function smartyHook($params, &$smarty)
 {
-    if (!empty($params['h'])) {
-        $id_module = null;
-        $hook_params = $params;
-        $hook_params['smarty'] = $smarty;
-        if (!empty($params['mod'])) {
-            $module = Module::getInstanceByName($params['mod']);
-            if ($module && $module->id) {
-                $id_module = $module->id;
+            $id_module = null;
+            $hook_params = $params;
+            $hook_params['smarty'] = $smarty;
+            if (!empty($params['mod']))
+            {
+                $module = Module::getInstanceByName($params['mod']);
+                unset($hook_params['mod']);
+                if ($module && $module->id) {
+                    $id_module = $module->id;
+                } else {
+                    unset($hook_params['h']);
+                    return '';
+                }
+
             }
-            unset($hook_params['mod']);
+            if(!empty($params['excl']))
+            {
+                $result = '';
+                $modules = Hook::getHookModuleExecList($hook_params['h']);
+
+                $moduleexcl = explode(',', $params['excl']);
+                foreach ($modules as $module)
+                {
+                    if (!in_array($module['module'], $moduleexcl))
+                        {
+                            $result .= Hook::exec($params['h'], $hook_params, $module['id_module']);
+                        }
+                }
+
+                unset($hook_params['h']);
+                unset($hook_params['excl']);
+                return $result;
+            }
+            unset($hook_params['h']);
+            return Hook::exec($params['h'], $hook_params, $id_module);
         }
-        unset($hook_params['h']);
-        return Hook::exec($params['h'], $hook_params, $id_module);
-    }
 }
 
 function smartyCleanHtml($data)


### PR DESCRIPTION
If you call a module with {hook h="displayNav" mod="blockcontact"} and blockcontact module is uninstalled or doesn't exist anymore, all modules enabled in the hook displayNav are displayed;
You can test it with this code in your tpl :
{hook h="displayNav" mod="modulenoexist"}

I also add a parameter to exclude some module form the hook calling
