### PR TITLE
// Report 1.6.1.4.sql to 1.6.1.2.sql

### DIFF
--- a/install-dev/upgrade/sql/1.6.1.1.sql
+++ b/install-dev/upgrade/sql/1.6.1.1.sql
@@ -8,3 +8,4 @@ ALTER TABLE  `PREFIX_order_detail` ADD  `original_wholesale_price` DECIMAL( 20, 
 ALTER TABLE `PREFIX_specific_price` DROP KEY `id_product_2`;
 
 ALTER IGNORE TABLE `PREFIX_specific_price` ADD UNIQUE KEY `id_product_2` (`id_cart`, `id_product`,`id_shop`,`id_shop_group`,`id_currency`,`id_country`,`id_group`,`id_customer`,`id_product_attribute`,`from_quantity`,`id_specific_price_rule`,`from`,`to`);
+

--- a/install-dev/upgrade/sql/1.6.1.2.sql
+++ b/install-dev/upgrade/sql/1.6.1.2.sql
@@ -29,4 +29,8 @@ REPLACE INTO `PREFIX_tag_count` (id_group, id_tag, id_lang, id_shop, counter)
 				AND product_shop.id_shop = ps.id_shop
 				GROUP BY pt.id_tag, pt.id_lang, ps.id_shop;
 
+ALTER TABLE `PREFIX_cart_product` DROP KEY `cart_product_index`;
+ALTER TABLE `PREFIX_shop` DROP KEY `id_group_shop`;
+INSERT INTO  `PREFIX_configuration` (`id_configuration` ,`id_shop_group` ,`id_shop` ,`name` ,`value` ,`date_add` ,`date_upd`) VALUES (NULL , NULL , NULL ,  'PS_ACTIVE_CRONJOB_EXCHANGE_RATE',  '0',  '0000-00-00 00:00:00',  '0000-00-00 00:00:00');
+
 TRUNCATE TABLE `PREFIX_smarty_last_flush`;


### PR DESCRIPTION
On `develop` branch there is a random file named `1.6.1.4.sql`. Most of the sql commands are already in `1.6.1.0.sql` or `1.6.1.1.sql` .

The missing commands moved to `1.6.1.2.sql`

![1____sites_prestashop_install-dev_upgrade_sql__bash_](https://cloud.githubusercontent.com/assets/1525636/9871152/d95cc18e-5b91-11e5-95d8-e74558931ea7.png)

Once merged, this commit have to be cherry-picked to develop branch and `1.6.1.4.sql` removed.
