### PR TITLE
[+] FO : Introduce {Url} smarty function

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -707,17 +707,17 @@ class LinkCore
     {
         $context = Context::getContext();
 
-        if (!isset($params['args'])) {
-            $params['args'] = [];
+        if (!isset($params['params'])) {
+            $params['params'] = [];
         }
 
         if (isset($params['id'])) {
             $entity = str_replace('-', '_', $params['entity']);
             $id = ['id_'.$entity => $params['id']];
-            $params['args'] = array_merge($id, $params['args']);
+            $params['params'] = array_merge($id, $params['params']);
         }
 
-        $url_parameters = http_build_query($params['args']);
+        $url_parameters = http_build_query($params['params']);
 
         switch ($params['entity']) {
             default:

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -702,4 +702,17 @@ class LinkCore
             return false;
         }
     }
+
+    public static function getUrlSmarty($params, &$smarty)
+    {
+        $context = Context::getContext();
+
+        $str = '';
+        foreach ($params['args'] as $key => $val) {
+            $str = $key.'='.$val.'&';
+        }
+        $str = rtrim($str, '&');
+
+        return $context->link->getPageLink($params['name'], true, null, $str);
+    }
 }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -707,12 +707,28 @@ class LinkCore
     {
         $context = Context::getContext();
 
+        if (!isset($params['args'])) {
+            $params['args'] = [];
+        }
+
+        if (isset($params['id'])) {
+            $entity = str_replace('-', '_', $params['entity']);
+            $id = ['id_'.$entity => $params['id']];
+            $params['args'] = array_merge($id, $params['args']);
+        }
+
         $str = '';
         foreach ($params['args'] as $key => $val) {
-            $str = $key.'='.$val.'&';
+            $str .= $key.'='.$val.'&';
         }
         $str = rtrim($str, '&');
 
-        return $context->link->getPageLink($params['name'], true, null, $str);
+        switch ($params['entity']) {
+            default:
+                $link = $context->link->getPageLink($params['entity'], true, null, $str);
+                break;
+        }
+
+        return $link;
     }
 }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -717,15 +717,11 @@ class LinkCore
             $params['args'] = array_merge($id, $params['args']);
         }
 
-        $str = '';
-        foreach ($params['args'] as $key => $val) {
-            $str .= $key.'='.$val.'&';
-        }
-        $str = rtrim($str, '&');
+        $url_parameters = http_build_query($params['args']);
 
         switch ($params['entity']) {
             default:
-                $link = $context->link->getPageLink($params['entity'], true, null, $str);
+                $link = $context->link->getPageLink($params['entity'], true, null, $url_parameters);
                 break;
         }
 

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -88,7 +88,7 @@ smartyRegisterFunction($smarty, 'modifier', 'cleanHtml', 'smartyCleanHtml');
 smartyRegisterFunction($smarty, 'function', 'widget', 'smartyWidget');
 smartyRegisterFunction($smarty, 'block', 'widget_block', 'smartyWidgetBlock');
 smartyRegisterFunction($smarty, 'modifier', 'classnames', 'smartyClassnames');
-smartyRegisterFunction($smarty, 'function', 'getUrl', array('Link', 'getUrlSmarty'));
+smartyRegisterFunction($smarty, 'function', 'url', array('Link', 'getUrlSmarty'));
 
 function smartyDieObject($params, &$smarty)
 {

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -88,6 +88,7 @@ smartyRegisterFunction($smarty, 'modifier', 'cleanHtml', 'smartyCleanHtml');
 smartyRegisterFunction($smarty, 'function', 'widget', 'smartyWidget');
 smartyRegisterFunction($smarty, 'block', 'widget_block', 'smartyWidgetBlock');
 smartyRegisterFunction($smarty, 'modifier', 'classnames', 'smartyClassnames');
+smartyRegisterFunction($smarty, 'function', 'getUrl', array('Link', 'getUrlSmarty'));
 
 function smartyDieObject($params, &$smarty)
 {


### PR DESCRIPTION
If you need to generate a url you can use this smarty function.

Example:

``` smarty
{url entity=address id=$id_address}
or
{url entity=address params=['id_address' => $id_address]}

and

{url entity=address id=$id_address params=['delete' => 1]}
```

will render (this is an example with my config, but you get the idea)

```
http://prestashop.ps/it/address?id_address=3

and

http://prestashop.ps/it/address?id_address=3&delete=1
```

This will take care of SSL, domain, virtual urls and params concat (& or ? for first arg).

The goal is to replace:

``` smarty
{$link->getPageLink('address', true, null, "id_address={$id_address}")}
```
