### PR TITLE
[*] BO: Fix max width 96px on module logo on "not trusted module" popin.

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl
@@ -34,7 +34,7 @@
 
 		<div class="row">
 			<div class="col-sm-2" style="text-align: center;">
-				<img id="untrusted-module-logo" class="" src="" alt="">
+				<img id="untrusted-module-logo" class="" src="" alt="" style="max-width:96px;">
 			</div>
 			<div class="col-sm-10">
 				<table class="table">


### PR DESCRIPTION
#3356 reported of 1.6.1.x
