### PR TITLE
[*] BO : Add option 'advanced_select' to Select type in HelperForm to get Select2 plugin

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -362,7 +362,7 @@
 										{$input.desc = null}
 									{else}
 										<select name="{$input.name|escape:'html':'utf-8'}"
-												class="{if isset($input.class)}{$input.class|escape:'html':'utf-8'}{/if} fixed-width-xl"
+												class="{if isset($input.class)}{$input.class|escape:'html':'utf-8'}{/if} fixed-width-xl{if isset($input.advanced_select) && $input.advanced_select} advanced_select{/if}"
 												id="{if isset($input.id)}{$input.id|escape:'html':'utf-8'}{else}{$input.name|escape:'html':'utf-8'}{/if}"
 												{if isset($input.multiple) && $input.multiple} multiple="multiple"{/if}
 												{if isset($input.size)} size="{$input.size|escape:'html':'utf-8'}"{/if}
@@ -967,6 +967,11 @@
 			{if isset($use_textarea_autosize)}
 			$(".textarea-autosize").autosize();
 			{/if}
+
+			if ($(".advanced_select").length > 0)
+			$(".advanced_select").each(function(){
+				$(this).select2({ width: 'resolve' });
+			});
 		});
 	state_token = '{getAdminToken tab='AdminStates'}';
 	{block name="script"}{/block}

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -75,6 +75,7 @@ class HelperFormCore extends Helper
         $categories = true;
         $color = true;
         $date = true;
+        $select2 = true;
         $tinymce = true;
         $textarea_autosize = true;
         $file = true;
@@ -191,6 +192,16 @@ class HelperFormCore extends Helper
                                 $date = false;
                             }
                             break;
+
+                        case 'select':
+                            if ($select2) {
+                                if (isset($params['advanced_select']) && $params['advanced_select']) {
+                                    $this->context->controller->addjQueryPlugin(array('select2'));
+                                    $this->context->controller->addJS(_PS_JS_DIR_.'jquery/plugins/select2/select2_locale_'.$this->context->language->iso_code.'.js');
+                                    $select2 = false;
+                                }
+                            }
+                        break;
 
                         case 'textarea':
                             if ($tinymce) {


### PR DESCRIPTION
New option for Select type in renderForm of AdminControllers to get Select2 jQuery plugin associated.

```
'input' => array(
    array(
        'type' => 'select',
        'lang' => false,
        'required' => true,
        'label' => $this->l('Id_vehicle_type:'),
        'name' => 'id_vehicle_type',
        'options' => array(
            'query' => $query,
            'id' =>'id',
            'name' => 'name'
        ),
        'advanced_select' => true,
    ),
```
