### PR TITLE
[-] CORE: Fixed currency convertion

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -815,7 +815,7 @@ class ToolsCore
      */
     public static function convertPriceFull($amount, Currency $currency_from = null, Currency $currency_to = null)
     {
-        if ($currency_from === $currency_to) {
+        if ($currency_from == $currency_to) {
             return $amount;
         }
 


### PR DESCRIPTION
When using the identity operator (===), object variables are identical if and only if they refer to the same instance of the same class.
In some cases $currency_from and $currency_to are same, but they refer don't refer to the same instance

See DiscountController.php: 

```
$discount['value'] = Tools::convertPriceFull(
    $discount['value'],
    new Currency((int)$discount['reduction_currency']),
    new Currency((int)$this->context->cart->id_currency)
);
```
