### PR TITLE
1.6.1.x

### DIFF
--- a/js/admin/products.js
+++ b/js/admin/products.js
@@ -1042,7 +1042,7 @@ product_tabs['Informations'] = new function(){
 		});
 
 		$('#related_product_autocomplete_input')
-			.autocomplete('ajax_products_list.php?excludeIds='+id_product, {
+			.autocomplete('ajax_products_list.php?exclude_packs=0&excludeVirtuals=0&excludeIds='+id_product, {
 				minChars: 1,
 				autoFill: true,
 				max:20,

--- a/js/admin/products.js
+++ b/js/admin/products.js
@@ -808,7 +808,7 @@ product_tabs['Associations'] = new function(){
 	var self = this;
 	this.initAccessoriesAutocomplete = function (){
 		$('#product_autocomplete_input')
-			.autocomplete('ajax_products_list.php', {
+			.autocomplete('ajax_products_list.php?exclude_packs=0&excludeVirtuals=0', {
 				minChars: 1,
 				autoFill: true,
 				max:20,


### PR DESCRIPTION
There's 2 fixes.
1. Show the packs and the products dematerialized in the autocomplete field when you want to do a redirection from a deactivated product.
2. Show the packs and the products dematerialized in the autocomplete field when you want to add an accessories to a product.
