### PR TITLE
[+] Project : Add hooks on Object init

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -232,6 +232,11 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
             $entity_mapper = Adapter_ServiceLocator::get("Adapter_EntityMapper");
             $entity_mapper->load($id, $id_lang, $this, $this->def, $this->id_shop, self::$cache_objects);
         }
+	
+	// @hook actionObject*Init
+	Hook::exec('actionObjectInit', array('object' => $this));
+	Hook::exec('actionObject'.get_class($this).'Init', array('object' => $this));
+
     }
 
     /**

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -234,9 +234,8 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
         }
 	
 	// @hook actionObject*Init
-	Hook::exec('actionObjectInit', array('object' => $this));
-	Hook::exec('actionObject'.get_class($this).'Init', array('object' => $this));
-
+        Hook::exec('actionObjectInit', array('object' => $this));
+        Hook::exec('actionObject'.get_class($this).'Init', array('object' => $this));
     }
 
     /**


### PR DESCRIPTION
For example, it gives possibility to add properties to the object.

``` php
class MyModule extends Module
{
    public function hookActionObjectProductInit($params)
    {
        $property = $this->getProductProperty($params['object']->id);
        $params['object']->my_property = $property;
    }

    public function hookActionObjectProductUpdateAfter($params)
    {
        $this->setProductProperty($params['object']->id, $params['object']->my_property);
    }

    public function hookActionObjectProductAddAfter($params)
    {
        $this->setProductProperty($params['object']->id, $params['object']->my_property);
    }

    public function hookActionObjectProductDeleteAfter($params)
    {
        $this->deleteProductProperty($params['object']->id);
    }
}
```
