### PR TITLE
[*] Allow override of module admin helpers

### DIFF
--- a/classes/helper/Helper.php
+++ b/classes/helper/Helper.php
@@ -81,7 +81,10 @@ class HelperCore
     {
         if ($this->override_folder) {
             if ($this->context->controller instanceof ModuleAdminController) {
-                $override_tpl_path = $this->context->controller->getTemplatePath().$this->override_folder.$this->base_folder.$tpl_name;
+                if(isset($this->context->controller->module->name) && file_exists(_PS_THEME_DIR_.'modules/'.$this->context->controller->module->name.'/views/templates/admin/'.$this->override_folder.$this->base_folder.$tpl_name))
+					$override_tpl_path = _PS_THEME_DIR_.'modules/'.$this->override_folder.'views/templates/admin/'.$this->override_folder.$this->base_folder.$tpl_name;
+				else
+                    $override_tpl_path = $this->context->controller->getTemplatePath().$this->override_folder.$this->base_folder.$tpl_name;
             } elseif ($this->module) {
                 $override_tpl_path = _PS_MODULE_DIR_.$this->module->name.'/views/templates/admin/_configure/'.$this->override_folder.$this->base_folder.$tpl_name;
             } else {


### PR DESCRIPTION
there is no way to override admin helpers of modules
this patch allow this override :
original file : /modules/module_name/views/templates/admin/controller_name/helpers/list/list_content.tpl
override file in theme directory : /themes/theme_name/modules/module_name/views/templates/admin/controller_name/helpers/list/list_content.tpl
