### PR TITLE
[-] BO : Fixed bug while testing module

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1359,7 +1359,7 @@ abstract class ModuleCore
 
                     // If (false) is a trick to not load the class with "eval".
                     // This way require_once will works correctly
-                    if (eval('if (false){	'.$file.' }') !== false) {
+                    if (eval('if (false){	'.$file."\n".' }') !== false) {
                         require_once(_PS_MODULE_DIR_.$module.'/'.$module.'.php');
                     } else {
                         $errors[] = sprintf(Tools::displayError('%1$s (parse error in %2$s)'), $module, substr($file_path, strlen(_PS_ROOT_DIR_)));


### PR DESCRIPTION
if module end by a comment like :

```
// endof function exists
```

An error occur, so just add a carriage return avoid it.
