### PR TITLE
[-] BO : Fixed checking if module is trusted #PSCX-6883

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1708,7 +1708,9 @@ abstract class ModuleCore
         static $untrusted_modules_list_content = null;
 
         $context = Context::getContext();
-
+        
+        $module_name = Tools::strtolower($module_name);
+        
         // If the xml file exist, isn't empty, isn't too old
         // and if the theme hadn't change
         // we use the file, otherwise we regenerate it


### PR DESCRIPTION
It's an example to fix PSCX-6883, we can also don't strotolwer module name while creating the list of untrusted module or disallow module without lowercase name
