### PR TITLE
[*] FO : Add availability microdata even when stock management is disabled

### DIFF
--- a/themes/default-bootstrap/product.tpl
+++ b/themes/default-bootstrap/product.tpl
@@ -259,7 +259,7 @@
 							<!-- prices -->
 							<div>
 								<p class="our_price_display" itemprop="offers" itemscope itemtype="https://schema.org/Offer">{strip}
-									{if $product->quantity > 0}<link itemprop="availability" href="https://schema.org/InStock"/>{/if}
+									{if $product->quantity > 0 || $allow_oosp}<link itemprop="availability" href="https://schema.org/InStock"/>{/if}
 									{if $priceDisplay >= 0 && $priceDisplay <= 2}
 										<span id="our_price_display" class="price" itemprop="price" content="{$productPrice}">{convertPrice price=$productPrice|floatval}</span>
 										{if $tax_enabled  && ((isset($display_tax_label) && $display_tax_label == 1) || !isset($display_tax_label))}


### PR DESCRIPTION
Following the example of the [product_list.tpl](https://github.com/PrestaShop/PrestaShop/blob/develop/themes/default-bootstrap/product-list.tpl#L85) template file, there should be an availability microdata tag even when the stock management is disabled, or the product can be purchased even if the quantities are zero or less.
