### PR TITLE
Update Cart.php

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3035,7 +3035,7 @@ class CartCore extends ObjectModel
             }
         }
 
-        $shipping_cost = (float)Tools::ps_round((float)$shipping_cost, 2);
+        $shipping_cost = (float)Tools::ps_round((float)$shipping_cost, (Currency::getCurrencyInstance((int)$this->id_currency)->decimals * _PS_PRICE_DISPLAY_PRECISION_));
         Cache::store($cache_id, $shipping_cost);
 
         return $shipping_cost;


### PR DESCRIPTION
Correct the shipping cost calculation method. The shipping cost is not rounded correctly, and it causes errors during the PayPal payment.
