### PR TITLE
[*] Installer : Add check for PHP zip extension

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -89,6 +89,7 @@ class ConfigurationTestCore
                 'config_dir' => 'config',
                 'files' => false,
                 'mails_dir' => 'mails',
+                'zip' => false,
             ));
         }
 
@@ -196,6 +197,11 @@ class ConfigurationTestCore
             return @gzencode('dd') !== false;
         }
         return false;
+    }
+
+    public static function test_zip()
+    {
+        return extension_loaded('zip');
     }
 
     public static function test_dir($relative_dir, $recursive = false, &$full_report = null)

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -95,6 +95,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp
                         'system' => $this->l('Cannot create new files and folders'),
                         'gd' => $this->l('GD library is not installed'),
                         'mysql_support' => $this->l('MySQL support is not activated'),
+                        'zip' => $this->l('ZIP extension is not enabled'),
                     )
                 ),
                 array(


### PR DESCRIPTION
During the installation, if the extension `zip` is not installed with PHP, the demo products cannot be created because of the following fatal error:

![capture du 2015-09-30 16 31 48](https://cloud.githubusercontent.com/assets/6768917/10196135/9508b77a-6791-11e5-85ab-398eb5e30cc8.png)
This PR add a check in the compatibility step.
