### PR TITLE
[*] Core : Introducting the 'termsAndConditions' hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
+    - php: 5.4
+    - php: 5.5
     - php: 7.0
 
 before_install:

--- a/Core/Business/Checkout/TermsAndConditions.php
+++ b/Core/Business/Checkout/TermsAndConditions.php
@@ -28,7 +28,7 @@ class TermsAndConditions
                 return $match[1];
             }
 
-            $replacement = '<a target="_blank" href="' . $this->links[$index] . '">' . $match[1] . '</a>';
+            $replacement = '<a href="' . $this->links[$index] . '">' . $match[1] . '</a>';
             ++$index;
             return $replacement;
         }, $this->rawText);

--- a/Core/Business/Checkout/TermsAndConditions.php
+++ b/Core/Business/Checkout/TermsAndConditions.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Business\Checkout;
+
+class TermsAndConditions
+{
+    private $identifier;
+    private $links;
+    private $rawText;
+
+    public function setText($rawText, ...$links)
+    {
+        $this->links = $links;
+        $this->rawText = $rawText;
+        return $this;
+    }
+
+    /**
+     * Inserts links into the text, replacing all [something] with links to "something", taking
+     * URLs from $this->links
+     * @return an string of HTML
+     */
+    public function format()
+    {
+        $index = 0;
+        return preg_replace_callback('/\[(.*?)\]/', function (array $match) use (&$index) {
+            if (!isset($this->links[$index])) {
+                return $match[1];
+            }
+
+            $replacement = '<a target="_blank" href="' . $this->links[$index] . '">' . $match[1] . '</a>';
+            ++$index;
+            return $replacement;
+        }, $this->rawText);
+    }
+
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+        return $this;
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Takes a list of terms and conditions and return them in
+     * the format templates expect.
+     * @param  array  $conditions An array of TermsAndConditions
+     * @return An associative array with condition identifiers as keys and HTML (text + links) as values
+     */
+    public static function formatForTemplate(array $conditions)
+    {
+        $formatted = [];
+
+        foreach ($conditions as $arrayOfConditions) {
+            if (!is_array($arrayOfConditions)) {
+                $arrayOfConditions = [$arrayOfConditions];
+            }
+            foreach ($arrayOfConditions as $condition) {
+                $formatted[$condition->getIdentifier()] = $condition->format();
+            }
+        }
+
+        return $formatted;
+    }
+}

--- a/controllers/front/OrderOpcController.php
+++ b/controllers/front/OrderOpcController.php
@@ -24,6 +24,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+use PrestaShop\PrestaShop\Core\Business\Checkout\TermsAndConditions;
+
 class OrderOpcControllerCore extends FrontController
 {
     public $php_self = 'order-opc';
@@ -36,14 +38,27 @@ class OrderOpcControllerCore extends FrontController
 
     private function getConditionsToApprove()
     {
-        return [
-            'terms-and-conditions' => $this->l(
-                'I have read and agree to the terms and conditions.'
-            ),
-            'right-of-withdrawal' => $this->l(
-                'I have been informed about and agree with the conditions of exercise of my right of withdrawal for this order.'
+        $cms = new CMS(Configuration::get('PS_CONDITIONS_CMS_ID'), $this->context->language->id);
+        $link = $this->context->link->getCMSLink($cms, $cms->link_rewrite, (bool)Configuration::get('PS_SSL_ENABLED'));
+
+        $termsAndConditions = new TermsAndConditions;
+        $termsAndConditions
+            ->setText(
+                $this->l('I agree to the [terms of service] and will adhere to them unconditionally.'),
+                $link
             )
-        ];
+            ->setIdentifier('terms-and-conditions')
+        ;
+
+        $allConditions = Hook::exec('termsAndConditions', [], null, true);
+        if (!is_array($allConditions)) {
+            $allConditions = [];
+        }
+
+        array_unshift($allConditions, $termsAndConditions);
+
+        // TODO StarterTheme : currently we don't handle opening the link inside a modal.
+        return TermsAndConditions::formatForTemplate($allConditions);
     }
 
     protected function renderPaymentOptions()

--- a/tests/Unit/Core/Business/Checkout/TermsAndConditionsTest.php
+++ b/tests/Unit/Core/Business/Checkout/TermsAndConditionsTest.php
@@ -16,7 +16,7 @@ class TermsAndConditionsTest extends UnitTestCase
     public function test_SetText_InsertsLinks()
     {
         $this->assertEquals(
-            'hello <a target="_blank" href="http://www.world.com">world</a>',
+            'hello <a href="http://www.world.com">world</a>',
             $this->terms->setText('hello [world]', "http://www.world.com")->format()
         );
     }
@@ -24,7 +24,7 @@ class TermsAndConditionsTest extends UnitTestCase
     public function test_SetText_InsertsSeveralLinks()
     {
         $this->assertEquals(
-            'hello <a target="_blank" href="http://www.world.com">world</a> <a target="_blank" href="http://yay.com">yay</a>',
+            'hello <a href="http://www.world.com">world</a> <a href="http://yay.com">yay</a>',
             $this->terms->setText('hello [world] [yay]', "http://www.world.com", "http://yay.com")->format()
         );
     }

--- a/tests/Unit/Core/Business/Checkout/TermsAndConditionsTest.php
+++ b/tests/Unit/Core/Business/Checkout/TermsAndConditionsTest.php
@@ -1,0 +1,55 @@
+<?php
+namespace PrestaShop\PrestaShop\Tests\Core\Business\Checkout;
+
+use PrestaShop\PrestaShop\Tests\TestCase\UnitTestCase;
+use PrestaShop\PrestaShop\Core\Business\Checkout\TermsAndConditions;
+
+class TermsAndConditionsTest extends UnitTestCase
+{
+    private $terms;
+
+    public function setup()
+    {
+        $this->terms = new TermsAndConditions;
+    }
+
+    public function test_SetText_InsertsLinks()
+    {
+        $this->assertEquals(
+            'hello <a target="_blank" href="http://www.world.com">world</a>',
+            $this->terms->setText('hello [world]', "http://www.world.com")->format()
+        );
+    }
+
+    public function test_SetText_InsertsSeveralLinks()
+    {
+        $this->assertEquals(
+            'hello <a target="_blank" href="http://www.world.com">world</a> <a target="_blank" href="http://yay.com">yay</a>',
+            $this->terms->setText('hello [world] [yay]', "http://www.world.com", "http://yay.com")->format()
+        );
+    }
+
+    public function test_SetText_JustDoesntAddLinksWhenMissing()
+    {
+        $this->assertEquals(
+            'hello world',
+            $this->terms->setText('hello [world]')->format()
+        );
+    }
+
+    public function test_FormatForTemplate_Overrides_Conditions()
+    {
+        $a = new TermsAndConditions;
+        $b = new TermsAndConditions;
+        $newA = new TermsAndConditions;
+
+        $a->setIdentifier('a')->setText('a');
+        $b->setIdentifier('b')->setText('b');
+        $newA->setIdentifier('a')->setText('newA');
+
+        $this->assertEquals(
+            ['a' => 'newA', 'b' => 'b'],
+            TermsAndConditions::formatForTemplate([[$a, $b], $newA])
+        );
+    }
+}


### PR DESCRIPTION
Right now the Core doesn't really know about what needs to be approved before allowing the checkout. 

This leads to JS hacks whenever someone needs to add, say, a checkbox to make customers certify they're above a certain age or when a module wants to change the text of the terms and conditions.

With this feature, any module can hook on `termsAndConditions` and return either an instance or an array of `PrestaShop\PrestaShop\Core\Business\Checkout\TermsAndConditions` objects.

A `TermsAndConditions` is a very simple object that contains an identifier and a text with optional links.
When several instances with the same identifier are returned by the hook, then the last one returned overrides the previous one.

This allows modules to override T&C cleanly, while guaranteeing the checkout will work as usual.
