### PR TITLE
[*] Core : Smarty now automatically escapes HTML

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -32,6 +32,8 @@ if (Configuration::get('PS_SMARTY_LOCAL')) {
 } else {
     $smarty = new Smarty();
 }
+$smarty->escape_html = true;
+
 $smarty->setCompileDir(_PS_CACHE_DIR_.'smarty/compile');
 $smarty->setCacheDir(_PS_CACHE_DIR_.'smarty/cache');
 if (!Tools::getSafeModeStatus()) {
@@ -89,6 +91,21 @@ smartyRegisterFunction($smarty, 'function', 'widget', 'smartyWidget');
 smartyRegisterFunction($smarty, 'block', 'widget_block', 'smartyWidgetBlock');
 smartyRegisterFunction($smarty, 'modifier', 'classnames', 'smartyClassnames');
 smartyRegisterFunction($smarty, 'function', 'url', array('Link', 'getUrlSmarty'));
+smartyRegisterFunction($smarty, 'modifier', 'escape', 'smartyEscape');
+
+function smartyEscape($string, $esc_type = 'html', $char_set = null, $double_encode = true)
+{
+    require_once implode(DIRECTORY_SEPARATOR, [
+        _PS_VENDOR_DIR_, 'smarty', 'smarty', 'libs', 'plugins',
+        'modifier.escape.php'
+    ]);
+    global $smarty;
+    if ($esc_type === 'html' && $smarty->escape_html) {
+        return $string;
+    } else {
+        return smarty_modifier_escape($string, $esc_type, $char_set, $double_encode);
+    }
+}
 
 function smartyDieObject($params, &$smarty)
 {

--- a/tests/Integration/SmartySettingsTest.php
+++ b/tests/Integration/SmartySettingsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Tests\Integration;
+
+use PrestaShop\PrestaShop\Tests\TestCase\IntegrationTestCase;
+
+class SmartySettingsTest extends IntegrationTestCase
+{
+    private $smarty;
+
+    public function setup()
+    {
+        global $smarty;
+        $this->smarty = $smarty;
+        $this->smarty->force_compile = true;
+    }
+
+    private function render($templateString, array $parameters)
+    {
+        $this->smarty->assign($parameters);
+        return $this->smarty->fetch('string:' . $templateString);
+    }
+
+    public function test_a_link_is_escaped_automatically()
+    {
+        $str = '<a>hello</a>';
+        $this->assertEquals('&lt;a&gt;hello&lt;/a&gt;', $this->render('{$str}', ['str' => $str]));
+    }
+
+    public function test_nofilter_prevents_escape()
+    {
+        $str = '<a>hello</a>';
+        $this->assertEquals($str, $this->render('{$str nofilter}', ['str' => $str]));
+    }
+
+    public function test_html_is_not_escaped_twice()
+    {
+        $str = '<a>hello</a>';
+        $this->assertEquals(
+            '&lt;a&gt;hello&lt;/a&gt;',
+            $this->render('{$str|escape:"html"}', ['str' => $str])
+        );
+    }
+}


### PR DESCRIPTION
Bye bye `{$var|escape:'html':'UTF-8'}`!

With this, all variables are escaped for HTML by default.

If you want to **not** escape HTML, add `nofilter` like this: `{$var nofilter}`.

Since Smarty doesn't check whether the global `$escape_html` option is set to false before escaping and thus double encodes HTML, I've also added a workaround that allows existing code with `escape`s to work unchanged with the new defaults.
