### PR TITLE
Move sub-cats up into the main <section> to keep semantic relationship

### DIFF
--- a/themes/StarterTheme/templates/catalog/category.tpl
+++ b/themes/StarterTheme/templates/catalog/category.tpl
@@ -5,26 +5,21 @@
 
     {block name="category_header"}
       <h1>{$category.name}</h1>
-
       <div class="category-cover">
         <img src="{$category.image.large.url}" alt="{$category.image.legend}">
       </div>
-
       <div id="category-description">{$category.description nofilter}</div>
     {/block}
 
     {block name="category_subcategories"}
       {if $subcategories|count}
-        <section id="subcategories">
-          <h1>{l s='Subcategories'}</h1>
-          <div class="subcategories">
+        <div class="subcategories">
             {foreach from=$subcategories item="subcategory"}
               {block name="category_miniature"}
                 {include './category-miniature.tpl' category=$subcategory}
               {/block}
             {/foreach}
           </div>
-        </section>
       {/if}
     {/block}
 


### PR DESCRIPTION
The semantic relationship the sub-cats had before was to the word, "Subcategories". This modification relates within the outline, the name of the sub-cat directly related to the H1 Category name. e.i. Athletic Wear >> Shoes, Athletic Wear >> Jackets.
