### PR TITLE
[-] FO : Block top menu - Menu label translation fix

### DIFF
--- a/admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl
@@ -439,10 +439,10 @@
 								</td>
 								<td>{if $discount['quantity'] > 0}{$discount['quantity_for_user']|intval}{else}0{/if}</td>
 								<td>
-									<a href="?tab=AdminCartRules&amp;id_cart_rule={$discount['id_cart_rule']|intval}&amp;addcart_rule&amp;token={getAdminToken tab='AdminCartRules'}">
+									<a href="?tab=AdminCartRules&amp;id_cart_rule={$discount['id_cart_rule']|intval}&amp;addcart_rule&amp;token={getAdminToken tab='AdminCartRules'}&amp;back={$smarty.server.REQUEST_URI|urlencode}">
 										<i class="icon-pencil"></i>
 									</a>
-									<a href="?tab=AdminCartRules&amp;id_cart_rule={$discount['id_cart_rule']|intval}&amp;deletecart_rule&amp;token={getAdminToken tab='AdminCartRules'}">
+									<a href="?tab=AdminCartRules&amp;id_cart_rule={$discount['id_cart_rule']|intval}&amp;deletecart_rule&amp;token={getAdminToken tab='AdminCartRules'}&amp;back={$smarty.server.REQUEST_URI|urlencode}">
 										<i class="icon-remove"></i>
 									</a>
 								</td>

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -324,7 +324,7 @@ class ConfigurationCore extends ObjectModel
     public static function set($key, $values, $id_shop_group = null, $id_shop = null)
     {
         if (!Validate::isConfigName($key)) {
-            die(sprintf(Tools::displayError('[%s] is not a valid configuration key'), $key));
+            die(sprintf(Tools::displayError('[%s] is not a valid configuration key'), Tools::htmlentitiesUTF8($key)));
         }
 
         if ($id_shop === null) {
@@ -379,7 +379,7 @@ class ConfigurationCore extends ObjectModel
     public static function updateValue($key, $values, $html = false, $id_shop_group = null, $id_shop = null)
     {
         if (!Validate::isConfigName($key)) {
-            die(sprintf(Tools::displayError('[%s] is not a valid configuration key'), $key));
+            die(sprintf(Tools::displayError('[%s] is not a valid configuration key'), Tools::htmlentitiesUTF8($key)));
         }
 
         if ($id_shop === null || !Shop::isFeatureActive()) {

--- a/classes/ConnectionsSource.php
+++ b/classes/ConnectionsSource.php
@@ -81,7 +81,7 @@ class ConnectionsSourceCore extends ObjectModel
             // If the referrer is internal (i.e. from your own website), then we drop the connection
             $parsed = parse_url($_SERVER['HTTP_REFERER']);
             $parsed_host = parse_url(Tools::getProtocol().Tools::getHttpHost(false, false).__PS_BASE_URI__);
-            if ((!isset($parsed['path']) || !isset($parsed_host['path'])) || (preg_replace('/^www./', '', $parsed['host']) == preg_replace('/^www./', '', Tools::getHttpHost(false, false))) && !strncmp($parsed['path'], $parsed_host['path'], strlen(__PS_BASE_URI__))) {
+            if ((!isset($parsed['host']) || (!isset($parsed['path']) || !isset($parsed_host['path'])) || (preg_replace('/^www./', '', $parsed['host']) == preg_replace('/^www./', '', Tools::getHttpHost(false, false))) && !strncmp($parsed['path'], $parsed_host['path'], strlen(__PS_BASE_URI__))) {
                 return false;
             }
 

--- a/classes/ConnectionsSource.php
+++ b/classes/ConnectionsSource.php
@@ -81,7 +81,7 @@ class ConnectionsSourceCore extends ObjectModel
             // If the referrer is internal (i.e. from your own website), then we drop the connection
             $parsed = parse_url($_SERVER['HTTP_REFERER']);
             $parsed_host = parse_url(Tools::getProtocol().Tools::getHttpHost(false, false).__PS_BASE_URI__);
-            if ((!isset($parsed['host']) || (!isset($parsed['path']) || !isset($parsed_host['path'])) || (preg_replace('/^www./', '', $parsed['host']) == preg_replace('/^www./', '', Tools::getHttpHost(false, false))) && !strncmp($parsed['path'], $parsed_host['path'], strlen(__PS_BASE_URI__))) {
+            if ((!isset($parsed['host']) || (!isset($parsed['path']) || !isset($parsed_host['path'])) || (preg_replace('/^www./', '', $parsed['host']) == preg_replace('/^www./', '', Tools::getHttpHost(false, false))) && !strncmp($parsed['path'], $parsed_host['path'], strlen(__PS_BASE_URI__)))) {
                 return false;
             }
 

--- a/classes/ConnectionsSource.php
+++ b/classes/ConnectionsSource.php
@@ -81,7 +81,12 @@ class ConnectionsSourceCore extends ObjectModel
             // If the referrer is internal (i.e. from your own website), then we drop the connection
             $parsed = parse_url($_SERVER['HTTP_REFERER']);
             $parsed_host = parse_url(Tools::getProtocol().Tools::getHttpHost(false, false).__PS_BASE_URI__);
-            if ((!isset($parsed['host']) || (!isset($parsed['path']) || !isset($parsed_host['path'])) || (preg_replace('/^www./', '', $parsed['host']) == preg_replace('/^www./', '', Tools::getHttpHost(false, false))) && !strncmp($parsed['path'], $parsed_host['path'], strlen(__PS_BASE_URI__)))) {
+
+            if (!isset($parsed['host']) || (!isset($parsed['path']) || !isset($parsed_host['path']))) {
+                return false;
+            }
+
+            if ((preg_replace('/^www./', '', $parsed['host']) == preg_replace('/^www./', '', Tools::getHttpHost(false, false))) && !strncmp($parsed['path'], $parsed_host['path'], strlen(__PS_BASE_URI__))) {
                 return false;
             }
 

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -201,8 +201,8 @@ class MetaCore extends ObjectModel
      */
     public static function getMetaTags($id_lang, $page_name, $title = '')
     {
-        global $maintenance;
-        if (!(isset($maintenance) && (!in_array(Tools::getRemoteAddr(), explode(',', Configuration::get('PS_MAINTENANCE_IP')))))) {
+        if (!(!Configuration::get('PS_SHOP_ENABLE')
+            && !in_array(Tools::getRemoteAddr(), explode(',', Configuration::get('PS_MAINTENANCE_IP'))))) {
             if ($page_name == 'product' && ($id_product = Tools::getValue('id_product'))) {
                 return Meta::getProductMetas($id_product, $id_lang, $page_name);
             } elseif ($page_name == 'category' && ($id_category = Tools::getValue('id_category'))) {

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -786,7 +786,7 @@ class AdminControllerCore extends Controller
         }
 
         $filters = $this->context->cookie->getFamily($prefix.$this->list_id.'Filter_');
-
+        $definition = false;
         if (isset($this->className) && $this->className) {
             $definition = ObjectModel::getDefinition($this->className);
         }

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1565,7 +1565,10 @@ class WebserviceRequestCore
             } elseif ($matches[1] == '<') {
                 $ret .= ' AND '.$tableAlias.'`'.bqSQL($sqlId).'` < "'.pSQL($matches[2])."\"\n";
             } elseif ($matches[1] == '!') {
-                $ret .= ' AND '.$tableAlias.'`'.bqSQL($sqlId).'` != "'.pSQL($matches[2])."\"\n";
+                $multiple_values = explode('|', $matches[2]);
+                foreach ($multiple_values as $value) {
+                    $ret .= ' AND '.$tableAlias.'`'.bqSQL($sqlId).'` != "'.pSQL($value)."\"\n";
+                }
             }
         } else {
             $ret .= ' AND '.$tableAlias.'`'.bqSQL($sqlId).'` '.(Validate::isFloat(pSQL($filterValue)) ? 'LIKE' : '=').' "'.pSQL($filterValue)."\"\n";

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -227,8 +227,19 @@ class AdminCartRulesControllerCore extends AdminController
                 $this->errors[] = Tools::displayError('An action is required for this cart rule.');
             }
         }
-
         return parent::postProcess();
+    }
+
+    public function processDelete()
+    {
+        $res = parent::processDelete();
+        if (Tools::isSubmit('delete'.$this->table)) {
+            $back = urldecode(Tools::getValue('back', ''));
+            if (!empty($back)) {
+                $this->redirect_after = $back;
+            }
+        }
+        return $res;
     }
 
     protected function afterUpdate($current_object)
@@ -583,11 +594,6 @@ class AdminCartRulesControllerCore extends AdminController
     public function renderForm()
     {
         $limit = 40;
-        $back = Tools::safeOutput(Tools::getValue('back', ''));
-        if (empty($back)) {
-            $back = self::$currentIndex.'&token='.$this->token;
-        }
-
         $this->toolbar_btn['save-and-stay'] = array(
             'href' => '#',
             'desc' => $this->l('Save and Stay')

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -1081,7 +1081,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         $message = nl2br($message);
                         $cm = new CustomerMessage();
                         $cm->id_customer_thread = $ct->id;
-                        if (empty($message) || !Validate::isCleanHtml($message)) {
+                        if (empty($message) || !Validate::isCleanHtml($message)) {
                             $str_errors.= Tools::displayError(sprintf('Invalid Message Content for subject: %1s', $subject));
                         } else {
                             $cm->message = $message;

--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -250,7 +250,7 @@ class AdminCustomersControllerCore extends AdminController
                 if (($customer = $this->loadObject(true)) && Validate::isLoadedObject($customer)) {
                     array_pop($this->toolbar_title);
                 }
-                    $this->toolbar_title[] = sprintf('Information about Customer: %s', Tools::substr($customer->firstname, 0, 1).'. '.$customer->lastname);
+                    $this->toolbar_title[] = sprintf($this->l('Information about Customer: %s'), Tools::substr($customer->firstname, 0, 1).'. '.$customer->lastname);
                 break;
             case 'add':
             case 'edit':

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1531,7 +1531,7 @@ class AdminImportControllerCore extends AdminController
                     }
                 }
                 $product->id_category = array_values(array_unique($product->id_category));
-                
+
                 // Will update default category if category column is not ignored AND if there is categories that are set in the import file row.
                 if (isset($product->id_category[0])) {
                     $product->id_category_default = (int)$product->id_category[0];
@@ -1737,7 +1737,8 @@ class AdminImportControllerCore extends AdminController
                         $specific_price->price = -1;
                         $specific_price->id_customer = 0;
                         $specific_price->from_quantity = 1;
-                        $specific_price->reduction = (isset($info['reduction_price']) && $info['reduction_price']) ? $info['reduction_price'] : $info['reduction_percent'] / 100;
+
+                        $specific_price->reduction = (isset($info['reduction_price']) && $info['reduction_price']) ? (float)str_replace(',', '.', $info['reduction_price']) : $info['reduction_percent'] / 100;
                         $specific_price->reduction_type = (isset($info['reduction_price']) && $info['reduction_price']) ? 'amount' : 'percentage';
                         $specific_price->from = (isset($info['reduction_from']) && Validate::isDate($info['reduction_from'])) ? $info['reduction_from'] : '0000-00-00 00:00:00';
                         $specific_price->to = (isset($info['reduction_to']) && Validate::isDate($info['reduction_to']))  ? $info['reduction_to'] : '0000-00-00 00:00:00';

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1099,6 +1099,14 @@ class AdminImportControllerCore extends AdminController
                         if ($tgt_width <= $src_width && $tgt_height <= $src_height) {
                             $path_infos[] = array($tgt_width, $tgt_height, $path.'-'.stripslashes($image_type['name']).'.jpg');
                         }
+                        if ($entity == 'products') {
+                            if (is_file(_PS_TMP_IMG_DIR_.'product_mini_'.(int)$id_entity.'.jpg')) {
+                               unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int)$id_entity.'.jpg');
+                            }
+                            if (is_file(_PS_TMP_IMG_DIR_.'product_mini_'.(int)$id_entity.'_'.(int)Context::getContext()->shop->id.'.jpg')) {
+                               unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int)$id_entity.'_'.(int)Context::getContext()->shop->id.'.jpg');
+                            }
+                        }
                     }
                     if (in_array($image_type['id_image_type'], $watermark_types)) {
                         Hook::exec('actionWatermark', array('id_image' => $id_image, 'id_product' => $id_entity));
@@ -1531,7 +1539,7 @@ class AdminImportControllerCore extends AdminController
                     }
                 }
                 $product->id_category = array_values(array_unique($product->id_category));
-                
+
                 // Will update default category if category column is not ignored AND if there is categories that are set in the import file row.
                 if (isset($product->id_category[0])) {
                     $product->id_category_default = (int)$product->id_category[0];

--- a/themes/default-bootstrap/supplier-list.tpl
+++ b/themes/default-bootstrap/supplier-list.tpl
@@ -47,7 +47,7 @@
 {if $nbSuppliers > 0}
 	<div class="content_sortPagiBar">
         <div class="sortPagiBar clearfix">
-			{if isset($supplier) && $supplier.nb_products > 0}
+			{if isset($supplier) && isset($supplier.nb_products) && $supplier.nb_products > 0}
 				<ul class="display hidden-xs">
 					<li class="display-title">
 						{l s='View:'}
@@ -89,11 +89,11 @@
 		            	<div class="left-side col-xs-12 col-sm-3">
 							<!-- logo -->
 							<div class="logo">
-								{if $supplier.nb_products > 0}
+								{if isset($supplier.nb_products) && $supplier.nb_products > 0}
 									<a href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}" title="{$supplier.name|escape:'html':'UTF-8'}">
 								{/if}
 								<img src="{$img_sup_dir}{$supplier.image|escape:'html':'UTF-8'}-medium_default.jpg" alt="" width="{$mediumSize.width}" height="{$mediumSize.height}" />
-								{if $supplier.nb_products > 0}
+								{if isset($supplier.nb_products) && $supplier.nb_products > 0}
 									</a>
 								{/if}
 							</div> <!-- .logo -->
@@ -101,11 +101,11 @@
 
 						<div class="middle-side col-xs-12 col-sm-5">
 							<h3>
-								{if $supplier.nb_products > 0}
+								{if isset($supplier.nb_products) && $supplier.nb_products > 0}
 									<a class="product-name" href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}">
 								{/if}
 								{$supplier.name|truncate:60:'...'|escape:'html':'UTF-8'}
-								{if $supplier.nb_products > 0}
+								{if isset($supplier.nb_products) && $supplier.nb_products > 0}
 									</a>
 								{/if}
 							</h3>
@@ -117,15 +117,15 @@
 						<div class="right-side col-xs-12 col-sm-4">
 			            	<div class="right-side-content">
 			                    <p class="product-counter">
-			                        {if $supplier.nb_products > 0}
+			                        {if isset($supplier.nb_products) && $supplier.nb_products > 0}
 			                            <a href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}">
 			                        {/if}
-			                        {if $supplier.nb_products == 1}{l s='%d product' sprintf=$supplier.nb_products|intval}{else}{l s='%d products' sprintf=$supplier.nb_products|intval}{/if}
-			                    	{if $supplier.nb_products > 0}
+			                        {if isset($supplier.nb_products) && $supplier.nb_products == 1}{l s='%d product' sprintf=$supplier.nb_products|intval}{else}{l s='%d products' sprintf=$supplier.nb_products|intval}{/if}
+			                    	{if isset($supplier.nb_products) && $supplier.nb_products > 0}
 			                        	</a>
 			                    	{/if}
 			                    </p>
-			                    {if $supplier.nb_products > 0}
+			                    {if isset($supplier.nb_products) && $supplier.nb_products > 0}
 			                        <a class="btn btn-default button exclusive-medium" href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}"><span>{l s='View products'} <i class="icon-chevron-right right"></i></span></a>
 			                    {/if}
 			                </div>


### PR DESCRIPTION
The "Menu" label was double quoted and therefore was not translated. single quoting the Menu label allows translation.
