### PR TITLE
[-] FO : Block top menu - Menu label translation fix

### DIFF
--- a/themes/default-bootstrap/modules/blocktopmenu/blocktopmenu.tpl
+++ b/themes/default-bootstrap/modules/blocktopmenu/blocktopmenu.tpl
@@ -1,7 +1,7 @@
 {if $MENU != ''}
 	<!-- Menu -->
 	<div id="block_top_menu" class="sf-contener clearfix col-lg-12">
-		<div class="cat-title">{l s="Menu" mod="blocktopmenu"}</div>
+		<div class="cat-title">{l s='Menu' mod='blocktopmenu'}</div>
 		<ul class="sf-menu clearfix menu-content">
 			{$MENU}
 			{if $MENU_SEARCH}


### PR DESCRIPTION
The Menu label is double quoted instead of single quoted.
