### PR TITLE
[-] FO: Fix robots.txt rules for default language URLs

### DIFF
--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -505,12 +505,16 @@ class AdminMetaControllerCore extends AdminController
 
             // Files
             if (count($this->rb_data['Files'])) {
-                $language_ids = Language::getIDs();
+                $activeLanguageCount = count(Language::getIDs());
                 fwrite($write_fd, "# Files\n");
                 foreach ($this->rb_data['Files'] as $iso_code => $files) {
                     foreach ($files as $file) {
-                        if (!empty($language_ids)) {
-                            fwrite($write_fd, 'Disallow: /*'.$iso_code.'/'.$file."\n");
+                        if ($activeLanguageCount > 1) {
+                            // Friendly URLs have language ISO code when multiple languages are active
+                            fwrite($write_fd, 'Disallow: /*' . $iso_code . '/' . $file . "\n");
+                        } elseif ($activeLanguageCount == 1) {
+                            // Friendly URL does not have language ISO when only one language is active
+                            fwrite($write_fd, 'Disallow: /*' . $file . "\n");
                         } else {
                             fwrite($write_fd, 'Disallow: /'.$file."\n");
                         }


### PR DESCRIPTION
Let's say are multiple languages on the site. But only language is active.
Then the URLs are not prefixed with ISO code:

```
example.com/login
```

However, the `AdminMeta` controller generates the ignore rules for this URL:

```
example.com/en/login
```

Therefore the disallow rules is ineffective, which is a SEO bug. Someone should do a double check for this fix :)
