### PR TITLE
// gitignore: include /classe/cache/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 
 .htaccess
 *.log
-cache/*
+/cache/*
 download/*
 img/*
 log/*


### PR DESCRIPTION
Thanks to @PrestanceDesign who noticed the folder classes/cache folder was ignored.
https://github.com/github/gitignore/pull/1693

Any modifications of the existing files are still taken into account but if we add a file inside, it will be ignored.
