### PR TITLE
// gitignore: include /classe/log/ and /modules/**/img/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@
 *.log
 /cache/*
 download/*
-img/*
-log/*
+/img/*
+/log/*
 upload/*
 vendor/*
 


### PR DESCRIPTION
Like PR #4246, this one fix the `classes/log`folder was ignored and all `img` module subdirectory.
