### PR TITLE
[-] CORE: Use math_round for tax rates in getAverageProductsTaxRate

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -348,7 +348,7 @@ class CartCore extends ObjectModel
         if ($cart_vat_amount == 0 || $cart_amount_te == 0) {
             return 0;
         } else {
-            return Tools::ps_round($cart_vat_amount / $cart_amount_te, 3);
+            return Tools::math_round($cart_vat_amount / $cart_amount_te, 3);
         }
     }
 


### PR DESCRIPTION
Please use ps_round only for currency amounts and not for other values (f.e. tax rates) because it makes no sense / is not necessary but  can produce wrong values.
