### PR TITLE
[-] Installer: Change button logic

### DIFF
--- a/install-dev/theme/views/system.phtml
+++ b/install-dev/theme/views/system.phtml
@@ -23,6 +23,6 @@
 	</ul>
 <?php endforeach; ?>
 
-<p><input class="button" value="<?php echo $this->l('Refresh these settings')?> " type="submit" id="req_bt_refresh" /></p>
+<p><input class="button" value="<?php echo $this->l('Refresh information')?> " type="submit" id="req_bt_refresh" /></p>
 
 <?php $this->displayTemplate('footer') ?>


### PR DESCRIPTION
The installer alert message said:
Oops! Please correct the item(s) below, and then click "Refresh information" to test the compatibility of your new system.

and the button wrongly: "Refresh these settings"
