### PR TITLE
// CORE : Handle PHP 7 deprecation notices on legacy libraries

### DIFF
--- a/tools/pear/PEAR.php
+++ b/tools/pear/PEAR.php
@@ -177,6 +177,10 @@ if (!class_exists('PEAR', false))
 			 * @access public
 			 * @return void
 			 */
+			function __construct($error_class = null) {
+					$this->PEAR();
+			}
+
 			function PEAR($error_class = null)
 			{
 					$classname = strtolower(get_class($this));
@@ -216,6 +220,11 @@ if (!class_exists('PEAR', false))
 			 * @access public
 			 * @return void
 			 */
+
+			function __destruct() {
+					$this->_PEAR();
+			}
+
 			function _PEAR() {
 					if ($this->_debug) {
 							printf("PEAR destructor called, class=%s\n", strtolower(get_class($this)));
@@ -861,6 +870,11 @@ if (!class_exists('PEAR_Error', false))
 			 * @access public
 			 *
 			 */
+			function __construct($message = 'unknown error', $code = null,
+													$mode = null, $options = null, $userinfo = null) {
+					$this->PEAR_Error($message, $code, $mode, $options, $userinfo);
+			}
+
 			function PEAR_Error($message = 'unknown error', $code = null,
 													$mode = null, $options = null, $userinfo = null)
 			{

--- a/tools/tar/Archive_Tar.php
+++ b/tools/tar/Archive_Tar.php
@@ -131,6 +131,10 @@ class Archive_Tar extends PEAR
      *
      * @access public
      */
+     function __construct($p_tarname, $p_compress = null) {
+          $this->Archive_Tar($p_tarname, $p_compress);
+    }
+
     function Archive_Tar($p_tarname, $p_compress = null)
     {
         if (version_compare(PHP_VERSION, '5.0.0', '<')) {


### PR DESCRIPTION
This PR will fix these warnings:

> Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; Archive_Tar has a deprecated constructor in /var/www/html/PrestaShop-dev/tools/tar/Archive_Tar.php on line 76
> 
> Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; PEAR has a deprecated constructor in /var/www/html/PrestaShop-dev/tools/pear/PEAR.php on line 112
> 
> Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; PEAR_Error has a deprecated constructor in /var/www/html/PrestaShop-dev/tools/pear/PEAR.php on line 829
