### PR TITLE
[-] LO : Fix Intra-EU VAT

### DIFF
--- a/localization/at.xml
+++ b/localization/at.xml
@@ -63,7 +63,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="AT Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -92,7 +93,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="AT Foodstuff Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -121,7 +123,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="at" id_tax="1"/>

--- a/localization/be.xml
+++ b/localization/be.xml
@@ -66,7 +66,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="BE Reduced Rate (12%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -95,7 +96,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="BE Super Reduced Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -124,7 +126,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="BE Foodstuff Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -153,7 +156,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="BE Books Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -182,7 +186,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="be" id_tax="1"/>

--- a/localization/bg.xml
+++ b/localization/bg.xml
@@ -63,7 +63,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="BG Reduced Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -92,7 +93,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="BG Foodstuff Rate (20%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -121,7 +123,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="BG Books Rate (20%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -150,7 +153,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="bg" id_tax="1"/>

--- a/localization/cy.xml
+++ b/localization/cy.xml
@@ -65,7 +65,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="CY Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -94,7 +95,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="CY Super Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -123,7 +125,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="CY Books Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -152,7 +155,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="cy" id_tax="1"/>

--- a/localization/cz.xml
+++ b/localization/cz.xml
@@ -64,7 +64,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="CZ Reduced Rate (15%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -93,7 +94,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="cz" id_tax="1"/>

--- a/localization/de.xml
+++ b/localization/de.xml
@@ -63,7 +63,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="DE Reduced Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -92,7 +93,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="DE Foodstuff Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -121,7 +123,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="DE Books Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -150,7 +153,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="de" id_tax="1"/>

--- a/localization/dk.xml
+++ b/localization/dk.xml
@@ -62,7 +62,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="DK Foodstuff Rate (25%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -91,7 +92,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="DK Books Rate (25%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -120,7 +122,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="dk" id_tax="1"/>

--- a/localization/ee.xml
+++ b/localization/ee.xml
@@ -63,7 +63,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="EE Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -92,7 +93,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EE Foodstuff Rate (20%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -121,7 +123,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="EE Books Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -150,7 +153,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="ee" id_tax="1"/>

--- a/localization/es.xml
+++ b/localization/es.xml
@@ -66,7 +66,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="ES Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -95,7 +96,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="ES Super Reduced Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -124,7 +126,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="ES Foodstuff Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -153,7 +156,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="ES Books Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -182,7 +186,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="es" id_tax="1"/>

--- a/localization/fi.xml
+++ b/localization/fi.xml
@@ -64,7 +64,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="FI Reduced Rate (13%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -93,7 +94,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="FI Super Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -122,7 +124,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="FI Foodstuff Rate (13%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -151,7 +154,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="FI Books Rate (9%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -180,7 +184,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="fi" id_tax="1"/>

--- a/localization/fr.xml
+++ b/localization/fr.xml
@@ -74,7 +74,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="FR Taux réduit (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -103,7 +104,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="FR Taux réduit (5.5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -132,7 +134,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="FR Taux super réduit (2.1%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -161,7 +164,8 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="uk" id_tax="4"/>
+      <taxRule iso_code_country="gb" id_tax="4"/>
+      <taxRule iso_code_country="hr" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="fr" id_tax="1"/>

--- a/localization/gb.xml
+++ b/localization/gb.xml
@@ -64,6 +64,7 @@
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="UK Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -93,6 +94,7 @@
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="gb" id_tax="1"/>

--- a/localization/gr.xml
+++ b/localization/gr.xml
@@ -67,7 +67,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="GR Reduced Rate (13%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -96,7 +97,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="GR Super Reduced Rate (6.5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -125,7 +127,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="GR islands Standard Rate (16%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -154,7 +157,8 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="uk" id_tax="4"/>
+      <taxRule iso_code_country="gb" id_tax="4"/>
+      <taxRule iso_code_country="hr" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="GR islands Reduced Rate (8%)">
       <taxRule iso_code_country="be" id_tax="5"/>
@@ -183,7 +187,8 @@
       <taxRule iso_code_country="sk" id_tax="5"/>
       <taxRule iso_code_country="fi" id_tax="5"/>
       <taxRule iso_code_country="se" id_tax="5"/>
-      <taxRule iso_code_country="uk" id_tax="5"/>
+      <taxRule iso_code_country="gb" id_tax="5"/>
+      <taxRule iso_code_country="hr" id_tax="5"/>
     </taxRulesGroup>
     <taxRulesGroup name="GR islands Super Reduced Rate (4%)">
       <taxRule iso_code_country="be" id_tax="6"/>
@@ -212,7 +217,8 @@
       <taxRule iso_code_country="sk" id_tax="6"/>
       <taxRule iso_code_country="fi" id_tax="6"/>
       <taxRule iso_code_country="se" id_tax="6"/>
-      <taxRule iso_code_country="uk" id_tax="6"/>
+      <taxRule iso_code_country="gb" id_tax="6"/>
+      <taxRule iso_code_country="hr" id_tax="6"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="gr" id_tax="1"/>

--- a/localization/hr.xml
+++ b/localization/hr.xml
@@ -35,13 +35,94 @@
     <tax id="107" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="108" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="Croatia PDV 5%">
-      <taxRule iso_code_country="hr" behavior="0" id_tax="81"/>
+      <taxRule iso_code_country="be" id_tax="81"/>
+      <taxRule iso_code_country="bg" id_tax="81"/>
+      <taxRule iso_code_country="cz" id_tax="81"/>
+      <taxRule iso_code_country="dk" id_tax="81"/>
+      <taxRule iso_code_country="de" id_tax="81"/>
+      <taxRule iso_code_country="ee" id_tax="81"/>
+      <taxRule iso_code_country="gr" id_tax="81"/>
+      <taxRule iso_code_country="es" id_tax="81"/>
+      <taxRule iso_code_country="fr" id_tax="81"/>
+      <taxRule iso_code_country="ie" id_tax="81"/>
+      <taxRule iso_code_country="it" id_tax="81"/>
+      <taxRule iso_code_country="cy" id_tax="81"/>
+      <taxRule iso_code_country="lv" id_tax="81"/>
+      <taxRule iso_code_country="lt" id_tax="81"/>
+      <taxRule iso_code_country="lu" id_tax="81"/>
+      <taxRule iso_code_country="hu" id_tax="81"/>
+      <taxRule iso_code_country="mt" id_tax="81"/>
+      <taxRule iso_code_country="nl" id_tax="81"/>
+      <taxRule iso_code_country="at" id_tax="81"/>
+      <taxRule iso_code_country="pl" id_tax="81"/>
+      <taxRule iso_code_country="pt" id_tax="81"/>
+      <taxRule iso_code_country="ro" id_tax="81"/>
+      <taxRule iso_code_country="si" id_tax="81"/>
+      <taxRule iso_code_country="sk" id_tax="81"/>
+      <taxRule iso_code_country="fi" id_tax="81"/>
+      <taxRule iso_code_country="se" id_tax="81"/>
+      <taxRule iso_code_country="gb" id_tax="81"/>
+      <taxRule iso_code_country="hr" id_tax="81"/>
     </taxRulesGroup>
     <taxRulesGroup name="Croatia PDV 25%">
-      <taxRule iso_code_country="hr" behavior="0" id_tax="79"/>
+      <taxRule iso_code_country="be" id_tax="79"/>
+      <taxRule iso_code_country="bg" id_tax="79"/>
+      <taxRule iso_code_country="cz" id_tax="79"/>
+      <taxRule iso_code_country="dk" id_tax="79"/>
+      <taxRule iso_code_country="de" id_tax="79"/>
+      <taxRule iso_code_country="ee" id_tax="79"/>
+      <taxRule iso_code_country="gr" id_tax="79"/>
+      <taxRule iso_code_country="es" id_tax="79"/>
+      <taxRule iso_code_country="fr" id_tax="79"/>
+      <taxRule iso_code_country="ie" id_tax="79"/>
+      <taxRule iso_code_country="it" id_tax="79"/>
+      <taxRule iso_code_country="cy" id_tax="79"/>
+      <taxRule iso_code_country="lv" id_tax="79"/>
+      <taxRule iso_code_country="lt" id_tax="79"/>
+      <taxRule iso_code_country="lu" id_tax="79"/>
+      <taxRule iso_code_country="hu" id_tax="79"/>
+      <taxRule iso_code_country="mt" id_tax="79"/>
+      <taxRule iso_code_country="nl" id_tax="79"/>
+      <taxRule iso_code_country="at" id_tax="79"/>
+      <taxRule iso_code_country="pl" id_tax="79"/>
+      <taxRule iso_code_country="pt" id_tax="79"/>
+      <taxRule iso_code_country="ro" id_tax="79"/>
+      <taxRule iso_code_country="si" id_tax="79"/>
+      <taxRule iso_code_country="sk" id_tax="79"/>
+      <taxRule iso_code_country="fi" id_tax="79"/>
+      <taxRule iso_code_country="se" id_tax="79"/>
+      <taxRule iso_code_country="gb" id_tax="79"/>
+      <taxRule iso_code_country="hr" id_tax="79"/>
     </taxRulesGroup>
     <taxRulesGroup name="Croatia PDV 10%">
-      <taxRule iso_code_country="hr" behavior="0" id_tax="80"/>
+      <taxRule iso_code_country="be" id_tax="80"/>
+      <taxRule iso_code_country="bg" id_tax="80"/>
+      <taxRule iso_code_country="cz" id_tax="80"/>
+      <taxRule iso_code_country="dk" id_tax="80"/>
+      <taxRule iso_code_country="de" id_tax="80"/>
+      <taxRule iso_code_country="ee" id_tax="80"/>
+      <taxRule iso_code_country="gr" id_tax="80"/>
+      <taxRule iso_code_country="es" id_tax="80"/>
+      <taxRule iso_code_country="fr" id_tax="80"/>
+      <taxRule iso_code_country="ie" id_tax="80"/>
+      <taxRule iso_code_country="it" id_tax="80"/>
+      <taxRule iso_code_country="cy" id_tax="80"/>
+      <taxRule iso_code_country="lv" id_tax="80"/>
+      <taxRule iso_code_country="lt" id_tax="80"/>
+      <taxRule iso_code_country="lu" id_tax="80"/>
+      <taxRule iso_code_country="hu" id_tax="80"/>
+      <taxRule iso_code_country="mt" id_tax="80"/>
+      <taxRule iso_code_country="nl" id_tax="80"/>
+      <taxRule iso_code_country="at" id_tax="80"/>
+      <taxRule iso_code_country="pl" id_tax="80"/>
+      <taxRule iso_code_country="pt" id_tax="80"/>
+      <taxRule iso_code_country="ro" id_tax="80"/>
+      <taxRule iso_code_country="si" id_tax="80"/>
+      <taxRule iso_code_country="sk" id_tax="80"/>
+      <taxRule iso_code_country="fi" id_tax="80"/>
+      <taxRule iso_code_country="se" id_tax="80"/>
+      <taxRule iso_code_country="gb" id_tax="80"/>
+      <taxRule iso_code_country="hr" id_tax="80"/>
     </taxRulesGroup>
     <tax id="79" name="Croatia PDV 25%" rate="25.000" eu-tax-group="virtual"/>
     <tax id="80" name="Croatia PDV 10%" rate="10.000"/>

--- a/localization/hu.xml
+++ b/localization/hu.xml
@@ -64,7 +64,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="HU Reduced Rate (18%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -93,7 +94,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="HU Super Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -122,7 +124,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="HU Foodstuff Rate (27%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -151,7 +154,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="HU Books Rate (5%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -180,7 +184,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="hu" id_tax="1"/>

--- a/localization/ie.xml
+++ b/localization/ie.xml
@@ -65,7 +65,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="IE Reduced Rate (13.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -94,7 +95,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="IE Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -123,7 +125,8 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="uk" id_tax="4"/>
+      <taxRule iso_code_country="gb" id_tax="4"/>
+      <taxRule iso_code_country="hr" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="IE Super Reduced Rate (4.8%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -152,7 +155,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="ie" id_tax="1"/>

--- a/localization/it.xml
+++ b/localization/it.xml
@@ -64,7 +64,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="IT Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -93,7 +94,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="IT Super Reduced Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -122,7 +124,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="IT Foodstuff Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -151,7 +154,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="IT Books Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -180,7 +184,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="it" id_tax="1"/>

--- a/localization/lt.xml
+++ b/localization/lt.xml
@@ -64,7 +64,8 @@
 			<taxRule iso_code_country="sk" id_tax="1"/>
 			<taxRule iso_code_country="fi" id_tax="1"/>
 			<taxRule iso_code_country="se" id_tax="1"/>
-			<taxRule iso_code_country="uk" id_tax="1"/>
+			<taxRule iso_code_country="gb" id_tax="1"/>
+			<taxRule iso_code_country="hr" id_tax="1"/>
 		</taxRulesGroup>
 		<taxRulesGroup name="LT Reduced Rate (9%)">
 			<taxRule iso_code_country="be" id_tax="2"/>
@@ -93,7 +94,8 @@
 			<taxRule iso_code_country="sk" id_tax="2"/>
 			<taxRule iso_code_country="fi" id_tax="2"/>
 			<taxRule iso_code_country="se" id_tax="2"/>
-			<taxRule iso_code_country="uk" id_tax="2"/>
+			<taxRule iso_code_country="gb" id_tax="2"/>
+			<taxRule iso_code_country="hr" id_tax="2"/>
 		</taxRulesGroup>
 		<taxRulesGroup name="LT Super Reduced Rate (5%)">
 			<taxRule iso_code_country="be" id_tax="3"/>
@@ -122,7 +124,8 @@
 			<taxRule iso_code_country="sk" id_tax="3"/>
 			<taxRule iso_code_country="fi" id_tax="3"/>
 			<taxRule iso_code_country="se" id_tax="3"/>
-			<taxRule iso_code_country="uk" id_tax="3"/>
+			<taxRule iso_code_country="gb" id_tax="3"/>
+			<taxRule iso_code_country="hr" id_tax="3"/>
 		</taxRulesGroup>
 		<taxRulesGroup name="LT Foodstuff Rate (21%)">
 			<taxRule iso_code_country="be" id_tax="1"/>
@@ -151,7 +154,8 @@
 			<taxRule iso_code_country="sk" id_tax="1"/>
 			<taxRule iso_code_country="fi" id_tax="1"/>
 			<taxRule iso_code_country="se" id_tax="1"/>
-			<taxRule iso_code_country="uk" id_tax="1"/>
+			<taxRule iso_code_country="gb" id_tax="1"/>
+			<taxRule iso_code_country="hr" id_tax="1"/>
 		</taxRulesGroup>
 		<taxRulesGroup name="LT Books Rate (9%)">
 			<taxRule iso_code_country="be" id_tax="2"/>
@@ -180,7 +184,8 @@
 			<taxRule iso_code_country="sk" id_tax="2"/>
 			<taxRule iso_code_country="fi" id_tax="2"/>
 			<taxRule iso_code_country="se" id_tax="2"/>
-			<taxRule iso_code_country="uk" id_tax="2"/>
+			<taxRule iso_code_country="gb" id_tax="2"/>
+			<taxRule iso_code_country="hr" id_tax="2"/>
 		</taxRulesGroup>
 		<taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
 			<taxRule iso_code_country="lt" id_tax="1"/>

--- a/localization/lu.xml
+++ b/localization/lu.xml
@@ -66,7 +66,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Reduced Rate (14%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -95,7 +96,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Reduced Rate (8%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -124,7 +126,8 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="uk" id_tax="4"/>
+      <taxRule iso_code_country="gb" id_tax="4"/>
+      <taxRule iso_code_country="hr" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Super Reduced Rate (3%)">
       <taxRule iso_code_country="be" id_tax="5"/>
@@ -153,7 +156,8 @@
       <taxRule iso_code_country="sk" id_tax="5"/>
       <taxRule iso_code_country="fi" id_tax="5"/>
       <taxRule iso_code_country="se" id_tax="5"/>
-      <taxRule iso_code_country="uk" id_tax="5"/>
+      <taxRule iso_code_country="gb" id_tax="5"/>
+      <taxRule iso_code_country="hr" id_tax="5"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Foodstuff Rate (3%)">
       <taxRule iso_code_country="be" id_tax="5"/>
@@ -182,7 +186,8 @@
       <taxRule iso_code_country="sk" id_tax="5"/>
       <taxRule iso_code_country="fi" id_tax="5"/>
       <taxRule iso_code_country="se" id_tax="5"/>
-      <taxRule iso_code_country="uk" id_tax="5"/>
+      <taxRule iso_code_country="gb" id_tax="5"/>
+      <taxRule iso_code_country="hr" id_tax="5"/>
     </taxRulesGroup>
     <taxRulesGroup name="LU Books Rate (3%)">
       <taxRule iso_code_country="be" id_tax="5"/>
@@ -211,7 +216,8 @@
       <taxRule iso_code_country="sk" id_tax="5"/>
       <taxRule iso_code_country="fi" id_tax="5"/>
       <taxRule iso_code_country="se" id_tax="5"/>
-      <taxRule iso_code_country="uk" id_tax="5"/>
+      <taxRule iso_code_country="gb" id_tax="5"/>
+      <taxRule iso_code_country="hr" id_tax="5"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="lu" id_tax="1"/>

--- a/localization/lv.xml
+++ b/localization/lv.xml
@@ -63,7 +63,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="LV Reduced Rate (12%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -92,7 +93,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="LV Foodstuff Rate (21%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -121,7 +123,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="LV Books Rate (12%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -150,7 +153,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="lv" id_tax="1"/>

--- a/localization/mt.xml
+++ b/localization/mt.xml
@@ -63,7 +63,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="MT Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -92,7 +93,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="MT Books Rate (5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -121,7 +123,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="mt" id_tax="1"/>

--- a/localization/nl.xml
+++ b/localization/nl.xml
@@ -63,7 +63,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="NL Reduced Rate (6%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -92,7 +93,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="NL Foodstuff Rate (6%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -121,7 +123,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="NL Books Rate (6%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -150,7 +153,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="nl" id_tax="1"/>

--- a/localization/pl.xml
+++ b/localization/pl.xml
@@ -65,7 +65,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="PL Reduced Rate (8%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -94,7 +95,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="PL Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="4"/>
@@ -122,7 +124,8 @@
       <taxRule iso_code_country="sk" id_tax="4"/>
       <taxRule iso_code_country="fi" id_tax="4"/>
       <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="uk" id_tax="4"/>
+      <taxRule iso_code_country="gb" id_tax="4"/>
+      <taxRule iso_code_country="hr" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="PL Exempted Rate (0%)">
       <taxRule iso_code_country="be" id_tax="6"/>
@@ -150,7 +153,8 @@
       <taxRule iso_code_country="sk" id_tax="6"/>
       <taxRule iso_code_country="fi" id_tax="6"/>
       <taxRule iso_code_country="se" id_tax="6"/>
-      <taxRule iso_code_country="uk" id_tax="6"/>
+      <taxRule iso_code_country="gb" id_tax="6"/>
+      <taxRule iso_code_country="hr" id_tax="6"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="pl" id_tax="1"/>

--- a/localization/pt.xml
+++ b/localization/pt.xml
@@ -64,7 +64,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="PT Reduced Rate (13%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -93,7 +94,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="PT Super Reduced Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -122,7 +124,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="PT Foodstuff Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -151,7 +154,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="PT Books Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
@@ -180,7 +184,8 @@
       <taxRule iso_code_country="sk" id_tax="3"/>
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="pt" id_tax="1"/>

--- a/localization/ro.xml
+++ b/localization/ro.xml
@@ -64,7 +64,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="RO Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -93,7 +94,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="RO Super Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -122,7 +124,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="RO Foodstuff Rate (24%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -151,7 +154,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="RO Books Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -180,7 +184,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="ro" id_tax="1"/>

--- a/localization/se.xml
+++ b/localization/se.xml
@@ -38,13 +38,94 @@
     <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="SE Standard Rate (25%)">
+      <taxRule iso_code_country="be" id_tax="1"/>
+      <taxRule iso_code_country="bg" id_tax="1"/>
+      <taxRule iso_code_country="cz" id_tax="1"/>
+      <taxRule iso_code_country="dk" id_tax="1"/>
+      <taxRule iso_code_country="de" id_tax="1"/>
+      <taxRule iso_code_country="ee" id_tax="1"/>
+      <taxRule iso_code_country="gr" id_tax="1"/>
+      <taxRule iso_code_country="es" id_tax="1"/>
+      <taxRule iso_code_country="fr" id_tax="1"/>
+      <taxRule iso_code_country="ie" id_tax="1"/>
+      <taxRule iso_code_country="it" id_tax="1"/>
+      <taxRule iso_code_country="cy" id_tax="1"/>
+      <taxRule iso_code_country="lv" id_tax="1"/>
+      <taxRule iso_code_country="lt" id_tax="1"/>
+      <taxRule iso_code_country="lu" id_tax="1"/>
+      <taxRule iso_code_country="hu" id_tax="1"/>
+      <taxRule iso_code_country="mt" id_tax="1"/>
+      <taxRule iso_code_country="nl" id_tax="1"/>
+      <taxRule iso_code_country="at" id_tax="1"/>
+      <taxRule iso_code_country="pl" id_tax="1"/>
+      <taxRule iso_code_country="pt" id_tax="1"/>
+      <taxRule iso_code_country="ro" id_tax="1"/>
+      <taxRule iso_code_country="si" id_tax="1"/>
+      <taxRule iso_code_country="sk" id_tax="1"/>
+      <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="SE Reduced Rate (12%)">
+      <taxRule iso_code_country="be" id_tax="2"/>
+      <taxRule iso_code_country="bg" id_tax="2"/>
+      <taxRule iso_code_country="cz" id_tax="2"/>
+      <taxRule iso_code_country="dk" id_tax="2"/>
+      <taxRule iso_code_country="de" id_tax="2"/>
+      <taxRule iso_code_country="ee" id_tax="2"/>
+      <taxRule iso_code_country="gr" id_tax="2"/>
+      <taxRule iso_code_country="es" id_tax="2"/>
+      <taxRule iso_code_country="fr" id_tax="2"/>
+      <taxRule iso_code_country="ie" id_tax="2"/>
+      <taxRule iso_code_country="it" id_tax="2"/>
+      <taxRule iso_code_country="cy" id_tax="2"/>
+      <taxRule iso_code_country="lv" id_tax="2"/>
+      <taxRule iso_code_country="lt" id_tax="2"/>
+      <taxRule iso_code_country="lu" id_tax="2"/>
+      <taxRule iso_code_country="hu" id_tax="2"/>
+      <taxRule iso_code_country="mt" id_tax="2"/>
+      <taxRule iso_code_country="nl" id_tax="2"/>
+      <taxRule iso_code_country="at" id_tax="2"/>
+      <taxRule iso_code_country="pl" id_tax="2"/>
+      <taxRule iso_code_country="pt" id_tax="2"/>
+      <taxRule iso_code_country="ro" id_tax="2"/>
+      <taxRule iso_code_country="si" id_tax="2"/>
+      <taxRule iso_code_country="sk" id_tax="2"/>
+      <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SE Super Reduced Rate (6%)">
+      <taxRule iso_code_country="be" id_tax="3"/>
+      <taxRule iso_code_country="bg" id_tax="3"/>
+      <taxRule iso_code_country="cz" id_tax="3"/>
+      <taxRule iso_code_country="dk" id_tax="3"/>
+      <taxRule iso_code_country="de" id_tax="3"/>
+      <taxRule iso_code_country="ee" id_tax="3"/>
+      <taxRule iso_code_country="gr" id_tax="3"/>
+      <taxRule iso_code_country="es" id_tax="3"/>
+      <taxRule iso_code_country="fr" id_tax="3"/>
+      <taxRule iso_code_country="ie" id_tax="3"/>
+      <taxRule iso_code_country="it" id_tax="3"/>
+      <taxRule iso_code_country="cy" id_tax="3"/>
+      <taxRule iso_code_country="lv" id_tax="3"/>
+      <taxRule iso_code_country="lt" id_tax="3"/>
+      <taxRule iso_code_country="lu" id_tax="3"/>
+      <taxRule iso_code_country="hu" id_tax="3"/>
+      <taxRule iso_code_country="mt" id_tax="3"/>
+      <taxRule iso_code_country="nl" id_tax="3"/>
+      <taxRule iso_code_country="at" id_tax="3"/>
+      <taxRule iso_code_country="pl" id_tax="3"/>
+      <taxRule iso_code_country="pt" id_tax="3"/>
+      <taxRule iso_code_country="ro" id_tax="3"/>
+      <taxRule iso_code_country="si" id_tax="3"/>
+      <taxRule iso_code_country="sk" id_tax="3"/>
+      <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="se" id_tax="1"/>

--- a/localization/si.xml
+++ b/localization/si.xml
@@ -63,7 +63,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="SI Reduced Rate (9.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -92,7 +93,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SI Foodstuff Rate (9.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -121,7 +123,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SI Books Rate (9.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -150,7 +153,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="si" id_tax="1"/>

--- a/localization/sk.xml
+++ b/localization/sk.xml
@@ -63,7 +63,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="SK Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -92,7 +93,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SK Foodstuff Rate (20%)">
       <taxRule iso_code_country="be" id_tax="1"/>
@@ -121,7 +123,8 @@
       <taxRule iso_code_country="sk" id_tax="1"/>
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+      <taxRule iso_code_country="gb" id_tax="1"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="SK Books Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -150,7 +153,8 @@
       <taxRule iso_code_country="sk" id_tax="2"/>
       <taxRule iso_code_country="fi" id_tax="2"/>
       <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+      <taxRule iso_code_country="gb" id_tax="2"/>
+      <taxRule iso_code_country="hr" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="sk" id_tax="1"/>


### PR DESCRIPTION
Since Croatia has joined the EU, it's become necessary to add this country to standard Tax Rules from EU-members.
Also Sweden was somehow missing its standard Intra-EU Tax rules.
The iso-code for the United Kingdom has been changed from 'uk' to 'gb', because that is its official code and the one that is actually recognized by PrestaShop. Fixes PSCSX-5331 and PSCSX-5208    .
