### PR TITLE
Fix allowing more than one category tree in helper form

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -724,7 +724,7 @@
 								{elseif $input.type == 'shop'}
 									{$input.html}
 								{elseif $input.type == 'categories'}
-									{$categories_tree}
+									{eval var='{$categories_tree_'|cat:$input.name|cat:'}'}
 								{elseif $input.type == 'file'}
 									{$input.file}
 								{elseif $input.type == 'categories_select'}

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -91,44 +91,43 @@ class HelperFormCore extends Helper
                     }
                     switch ($params['type']) {
                         case 'categories':
-                            if ($categories) {
-                                if (!isset($params['tree']['id'])) {
-                                    throw new PrestaShopException('Id must be filled for categories tree');
-                                }
 
-                                $tree = new HelperTreeCategories($params['tree']['id'], isset($params['tree']['title']) ? $params['tree']['title'] : null);
-
-                                if (isset($params['name'])) {
-                                    $tree->setInputName($params['name']);
-                                }
-
-                                if (isset($params['tree']['selected_categories'])) {
-                                    $tree->setSelectedCategories($params['tree']['selected_categories']);
-                                }
-
-                                if (isset($params['tree']['disabled_categories'])) {
-                                    $tree->setDisabledCategories($params['tree']['disabled_categories']);
-                                }
-
-                                if (isset($params['tree']['root_category'])) {
-                                    $tree->setRootCategory($params['tree']['root_category']);
-                                }
-
-                                if (isset($params['tree']['use_search'])) {
-                                    $tree->setUseSearch($params['tree']['use_search']);
-                                }
-
-                                if (isset($params['tree']['use_checkbox'])) {
-                                    $tree->setUseCheckBox($params['tree']['use_checkbox']);
-                                }
-
-                                if (isset($params['tree']['set_data'])) {
-                                    $tree->setData($params['tree']['set_data']);
-                                }
-
-                                $this->context->smarty->assign('categories_tree', $tree->render());
-                                $categories = false;
+                            if (!isset($params['tree']['id'])) {
+                                throw new PrestaShopException('Id must be filled for categories tree');
                             }
+
+                            $tree = new HelperTreeCategories($params['tree']['id'], isset($params['tree']['title']) ? $params['tree']['title'] : null);
+
+                            if (isset($params['name'])) {
+                                $tree->setInputName($params['name']);
+                            }
+
+                            if (isset($params['tree']['selected_categories'])) {
+                                $tree->setSelectedCategories($params['tree']['selected_categories']);
+                            }
+
+                            if (isset($params['tree']['disabled_categories'])) {
+                                $tree->setDisabledCategories($params['tree']['disabled_categories']);
+                            }
+
+                            if (isset($params['tree']['root_category'])) {
+                                $tree->setRootCategory($params['tree']['root_category']);
+                            }
+
+                            if (isset($params['tree']['use_search'])) {
+                                $tree->setUseSearch($params['tree']['use_search']);
+                            }
+
+                            if (isset($params['tree']['use_checkbox'])) {
+                                $tree->setUseCheckBox($params['tree']['use_checkbox']);
+                            }
+
+                            if (isset($params['tree']['set_data'])) {
+                                $tree->setData($params['tree']['set_data']);
+                            }
+
+                            $this->context->smarty->assign('categories_tree_'.$params['name'], $tree->render());
+
                             break;
 
                         case 'file':

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -91,43 +91,41 @@ class HelperFormCore extends Helper
                     }
                     switch ($params['type']) {
                         case 'categories':
+                            if (!isset($params['tree']['id'])) {
+                                throw new PrestaShopException('Id must be filled for categories tree');
+                            }
 
-                                if (!isset($params['tree']['id'])) {
-                                    throw new PrestaShopException('Id must be filled for categories tree');
-                                }
+                            $tree = new HelperTreeCategories($params['tree']['id'], isset($params['tree']['title']) ? $params['tree']['title'] : null);
 
-                                $tree = new HelperTreeCategories($params['tree']['id'], isset($params['tree']['title']) ? $params['tree']['title'] : null);
+                            if (isset($params['name'])) {
+                                $tree->setInputName($params['name']);
+                            }
 
-                                if (isset($params['name'])) {
-                                    $tree->setInputName($params['name']);
-                                }
+                            if (isset($params['tree']['selected_categories'])) {
+                                $tree->setSelectedCategories($params['tree']['selected_categories']);
+                            }
 
-                                if (isset($params['tree']['selected_categories'])) {
-                                    $tree->setSelectedCategories($params['tree']['selected_categories']);
-                                }
+                            if (isset($params['tree']['disabled_categories'])) {
+                                $tree->setDisabledCategories($params['tree']['disabled_categories']);
+                            }
 
-                                if (isset($params['tree']['disabled_categories'])) {
-                                    $tree->setDisabledCategories($params['tree']['disabled_categories']);
-                                }
+                            if (isset($params['tree']['root_category'])) {
+                                $tree->setRootCategory($params['tree']['root_category']);
+                            }
 
-                                if (isset($params['tree']['root_category'])) {
-                                    $tree->setRootCategory($params['tree']['root_category']);
-                                }
+                            if (isset($params['tree']['use_search'])) {
+                                $tree->setUseSearch($params['tree']['use_search']);
+                            }
 
-                                if (isset($params['tree']['use_search'])) {
-                                    $tree->setUseSearch($params['tree']['use_search']);
-                                }
+                            if (isset($params['tree']['use_checkbox'])) {
+                                $tree->setUseCheckBox($params['tree']['use_checkbox']);
+                            }
 
-                                if (isset($params['tree']['use_checkbox'])) {
-                                    $tree->setUseCheckBox($params['tree']['use_checkbox']);
-                                }
+                            if (isset($params['tree']['set_data'])) {
+                                $tree->setData($params['tree']['set_data']);
+                            }
 
-                                if (isset($params['tree']['set_data'])) {
-                                    $tree->setData($params['tree']['set_data']);
-                                }
-
-                                $this->context->smarty->assign('categories_tree_'.$params['name'], $tree->render());
-
+                            $this->context->smarty->assign('categories_tree_'.$params['name'], $tree->render());
                             break;
 
                         case 'file':

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -92,41 +92,41 @@ class HelperFormCore extends Helper
                     switch ($params['type']) {
                         case 'categories':
 
-                            if (!isset($params['tree']['id'])) {
-                                throw new PrestaShopException('Id must be filled for categories tree');
-                            }
+                                if (!isset($params['tree']['id'])) {
+                                    throw new PrestaShopException('Id must be filled for categories tree');
+                                }
 
-                            $tree = new HelperTreeCategories($params['tree']['id'], isset($params['tree']['title']) ? $params['tree']['title'] : null);
+                                $tree = new HelperTreeCategories($params['tree']['id'], isset($params['tree']['title']) ? $params['tree']['title'] : null);
 
-                            if (isset($params['name'])) {
-                                $tree->setInputName($params['name']);
-                            }
+                                if (isset($params['name'])) {
+                                    $tree->setInputName($params['name']);
+                                }
 
-                            if (isset($params['tree']['selected_categories'])) {
-                                $tree->setSelectedCategories($params['tree']['selected_categories']);
-                            }
+                                if (isset($params['tree']['selected_categories'])) {
+                                    $tree->setSelectedCategories($params['tree']['selected_categories']);
+                                }
 
-                            if (isset($params['tree']['disabled_categories'])) {
-                                $tree->setDisabledCategories($params['tree']['disabled_categories']);
-                            }
+                                if (isset($params['tree']['disabled_categories'])) {
+                                    $tree->setDisabledCategories($params['tree']['disabled_categories']);
+                                }
 
-                            if (isset($params['tree']['root_category'])) {
-                                $tree->setRootCategory($params['tree']['root_category']);
-                            }
+                                if (isset($params['tree']['root_category'])) {
+                                    $tree->setRootCategory($params['tree']['root_category']);
+                                }
 
-                            if (isset($params['tree']['use_search'])) {
-                                $tree->setUseSearch($params['tree']['use_search']);
-                            }
+                                if (isset($params['tree']['use_search'])) {
+                                    $tree->setUseSearch($params['tree']['use_search']);
+                                }
 
-                            if (isset($params['tree']['use_checkbox'])) {
-                                $tree->setUseCheckBox($params['tree']['use_checkbox']);
-                            }
+                                if (isset($params['tree']['use_checkbox'])) {
+                                    $tree->setUseCheckBox($params['tree']['use_checkbox']);
+                                }
 
-                            if (isset($params['tree']['set_data'])) {
-                                $tree->setData($params['tree']['set_data']);
-                            }
+                                if (isset($params['tree']['set_data'])) {
+                                    $tree->setData($params['tree']['set_data']);
+                                }
 
-                            $this->context->smarty->assign('categories_tree_'.$params['name'], $tree->render());
+                                $this->context->smarty->assign('categories_tree_'.$params['name'], $tree->render());
 
                             break;
 


### PR DESCRIPTION
This fix allow adding more than one category tree in helper form adding the name of the form element as the example: 'categories_tree_<name>'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/4303)
<!-- Reviewable:end -->
