### PR TITLE
Fix: Unable to select (new) warehouse on adding stock

### DIFF
--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -138,7 +138,8 @@ class AdminStockManagementControllerCore extends AdminController
         $id_product_attribute = (int)Tools::getValue('id_product_attribute');
 
         // gets warehouses
-        $warehouses_add = $warehouses_remove = Warehouse::getWarehousesByProductId($id_product, $id_product_attribute);
+        $warehouses_add = Warehouse::getWarehouses(true);
+        $warehouses_remove = Warehouse::getWarehousesByProductId($id_product, $id_product_attribute);
 
         // displays warning if no warehouses
         if (!$warehouses_add) {


### PR DESCRIPTION
List of warehouses is empty on adding stock for a new product using Stock->Stock Management
Also new warehouses don't appear in the list on old products.

Editing a product to add a warehouse is a possible workaround for this, but not a comfortable way of adding stock.
