### PR TITLE
// CORE: Only clean compare_product table if entry older than 1 week

### DIFF
--- a/classes/CompareProduct.php
+++ b/classes/CompareProduct.php
@@ -136,23 +136,15 @@ class CompareProductCore extends ObjectModel
      * @param string $period
      * @return void
      */
-    public static function cleanCompareProducts($period = 'week')
+    public static function cleanCompareProducts($period = null)
     {
-        if ($period === 'week') {
-            $interval = '1 WEEK';
-        } elseif ($period === 'month') {
-            $interval = '1 MONTH';
-        } elseif ($period === 'year') {
-            $interval = '1 YEAR';
-        } else {
-            return;
+        if ($period !== null) {
+            Tools::displayParameterAsDeprecated('period');
         }
 
-        if ($interval != null) {
-            Db::getInstance()->execute('
-			DELETE cp, c FROM `'._DB_PREFIX_.'compare_product` cp, `'._DB_PREFIX_.'compare` c
-			WHERE cp.date_upd < DATE_SUB(NOW(), INTERVAL '.$interval.') AND c.`id_compare`=cp.`id_compare`');
-        }
+        Db::getInstance()->execute('
+        DELETE cp, c FROM `'._DB_PREFIX_.'compare_product` cp, `'._DB_PREFIX_.'compare` c
+        WHERE cp.date_upd < DATE_SUB(NOW(), INTERVAL 1 WEEK) AND c.`id_compare`=cp.`id_compare`');
     }
 
     /**


### PR DESCRIPTION
This commit 82c9dead2ac0455c04eb96a14aee75abbec4fe72 introduce a bug, the parameter passed to the function
was ignored and the table was cleaned all entries older than a week
Since the function have been working this way for 4 years, we
decided to not change the behavior and remove the parameter.
