### PR TITLE
Re-instate default id for product list

### DIFF
--- a/themes/default-bootstrap/product-list.tpl
+++ b/themes/default-bootstrap/product-list.tpl
@@ -38,7 +38,7 @@
 	{math equation="nbLi/nbItemsPerLine" nbLi=$nbLi nbItemsPerLine=$nbItemsPerLine assign=nbLines}
 	{math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
 	<!-- Products list -->
-	<ul{if isset($id) && $id} id="{$id}"{/if} class="product_list grid row{if isset($class) && $class} {$class}{/if}">
+	<ul{if isset($id) && $id} id="{$id}"{else} id="product_list"{/if} class="product_list grid row{if isset($class) && $class} {$class}{/if}">
 	{foreach from=$products item=product name=products}
 		{math equation="(total%perLine)" total=$smarty.foreach.products.total perLine=$nbItemsPerLine assign=totModulo}
 		{math equation="(total%perLineT)" total=$smarty.foreach.products.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}


### PR DESCRIPTION
Fixes broken blocklayered ajax product-list refresh and maybe other modules that don't pass the $id parameter to the tpl. As a reminder, the long standing id was pushed into the class list, then it was added again as a parameter but conditionally and without a default. There are other ways to fix this but not as easily while maintaining compatibility (refactoring blocklayered.js like on demo.ps.com doesn't seem right nor necessary). It is not blocklayered's fault that this happened.

PS: Do I need to push this anywhere else as well?
