### PR TITLE
PSCSX-7138 Bad discount computation when multiple tax rates involved

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -986,7 +986,9 @@ class CartRuleCore extends ObjectModel
                             || in_array($product['id_product'].'-0', $selected_products)) {
                             $price = $product['price'];
                             if ($use_tax) {
-                                $price *= (1 + $context->cart->getAverageProductsTaxRate());
+                                $infos = Product::getTaxesInformations($product, $context);
+                                $tax_rate = $infos['rate'] / 100;
+                                $price *= (1 + $tax_rate);
                             }
 
                             $selected_products_reduction += $price * $product['cart_quantity'];


### PR DESCRIPTION
Compute the tax rate on each product, rather than relying on a meaningless average computing.
Useful if you want to separate discounts per tax rate, to have two distinct lines on the invoice.
