### PR TITLE
[*] BO : Add option not to hash passwords on customer import

### DIFF
--- a/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
@@ -268,6 +268,23 @@
 					</div>
 				</div>
 				<div class="form-group">
+					<label for="hashedPasswords" class="control-label col-lg-4">
+						<span data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='If you enable this option, Prestashop won\'t (re)hash the imported passwords.'}">
+							{l s='Imported passwords are already hashed'}
+						</span>
+					</label>
+					<div class="col-lg-8">
+						<label class="switch-light prestashop-switch fixed-width-lg">
+							<input  id="hashedPasswords" name="hashedPasswords" type="checkbox"/>
+							<span>
+								<span>{l s='Yes'}</span>
+								<span>{l s='No'}</span>
+							</span>
+							<a class="slide-button btn"></a>
+						</label>
+					</div>
+				</div>
+				<div class="form-group">
 					<label for="forceIDs" class="control-label col-lg-4">
 						<span data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='If you enable this option, your imported items\' ID number will be used as-is. If you do not enable this option, the imported ID number will be ignored, and PrestaShop will instead create auto-incremented ID numbers for all the imported items.'}">
 							{l s='Force all ID numbers'}
@@ -463,7 +480,7 @@
 			$('#csv_file_uploader').toggle();
 		})
 		//show selected csv if exists
-		var selected = '{$csv_selected|@addcslashes:'\''}';
+		var selected = "{$csv_selected|@addcslashes:'\''}";
 		if(selected){
 			$('#csv_file_selected').show();
 			$('#csv_file_uploader').hide();
@@ -527,6 +544,11 @@
 			}
 			else {
 				$("#forceIDs").closest('.form-group').hide();
+			}
+			if ($("#entity > option:selected").val() == 3) {
+				$('#hashedPasswords').closest('form-group').show();
+			} else {
+				$('#hashedPasswords').closest('form-group').hide();
 			}
 
 			$("#entitie").html($("#entity > option:selected").text().toLowerCase());

--- a/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
@@ -108,6 +108,9 @@
 			{if $fields_value.match_ref}
 				<input type="hidden" name="match_ref" value="1" />
 			{/if}
+			{if $fields_value.hashedPasswords}
+				<input type="hidden" name="hashedPasswords" value="1" />
+			{/if}
 			<input type="hidden" name="separator" value="{$fields_value.separator}" />
 			<input type="hidden" name="multiple_value_separator" value="{$fields_value.multiple_value_separator}" />
 			<div class="form-group">

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -703,6 +703,7 @@ class AdminImportControllerCore extends AdminController
                 'forceIDs' => Tools::getValue('forceIDs'),
                 'regenerate' => Tools::getValue('regenerate'),
                 'match_ref' => Tools::getValue('match_ref'),
+                'hashedPasswords' => Tools::getValue('hashedPasswords'),
                 'separator' => $this->separator,
                 'multiple_value_separator' => $this->multiple_value_separator
             ),
@@ -2453,6 +2454,7 @@ class AdminImportControllerCore extends AdminController
 
         $shop_is_feature_active = Shop::isFeatureActive();
         $convert = Tools::getValue('convert');
+        $hashed_passwords = Tools::getValue('hashedPasswords');
         $force_ids = Tools::getValue('forceIDs');
 
         for ($current_line = 0; $line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator); $current_line++) {
@@ -2525,7 +2527,7 @@ class AdminImportControllerCore extends AdminController
 
             AdminImportController::arrayWalk($info, array('AdminImportController', 'fillInfo'), $customer);
 
-            if ($customer->passwd) {
+            if (!$hashed_passwords && $customer->passwd) {
                 $customer->passwd = Tools::encrypt($customer->passwd);
             }
 


### PR DESCRIPTION
As it says on the tin.

Since the importer can be used to migrate customer data from some other e-Commerce that securely stores passwords in a hashed form, let's not rehash those.
