### PR TITLE
Prevent index page with multiple slash

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -795,7 +795,7 @@ class DispatcherCore
                 }
             }
 
-            if ($controller == 'index' || preg_match('/^\/index.php(?:\?.*)?$/', $this->request_uri)) {
+	    if ($controller == 'index' || preg_match('/^\/index.php(?:\?.*)?$/', $this->request_uri) || preg_match('#/+(?:\?.*)?$#',$this->request_uri)) {
                 $controller = $this->useDefaultController();
             }
         }


### PR DESCRIPTION
Go to index page when we have too slash in uri as http://www.example.com//
