### PR TITLE
+[BO] Hide div results if #free_gift_off checked

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -259,7 +259,8 @@ $('#free_gift_on').click(function(){
 	toggleGiftProduct();}
 );
 $('#free_gift_off').click(function(){
-	toggleGiftProduct();}
+	toggleGiftProduct();
+	$('#gift_products_found').hide();}
 );
 toggleGiftProduct();
 


### PR DESCRIPTION
Actually, when you turn off this option, and if a previous result exists, the div is emptied but remains open
