### PR TITLE
[*] Fix #PSCSX-7167, Fatal error for Product::getPublicPrice()

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3175,8 +3175,9 @@ class ProductCore extends ObjectModel
     public function getPublicPrice($tax = true, $id_product_attribute = null, $decimals = 6,
             $divisor = null, $only_reduc = false, $usereduc = true, $quantity = 1)
     {
+        $specific_price_output = null;
         return Product::getPriceStatic((int)$this->id, $tax, $id_product_attribute, $decimals, $divisor, $only_reduc, $usereduc, $quantity,
-            false, null, null, null, null, true, true, null, false);
+            false, null, null, null, $specific_price_output, true, true, null, false);
     }
 
     public function getIdProductAttributeMostExpensive()


### PR DESCRIPTION
- Reverts PrestaShop/PrestaShop#3766
- http://forge.prestashop.com/browse/PSCSX-7167

getPriceStatic expects a variable passed à reference: https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/Product.php#L2780

Error message from forge issue

```
PHP Fatal error: Cannot pass parameter 13 by reference in /var/mysite/classes/Product.php on line 3179
```
