### PR TITLE
[+] BO : Display warning about active Debug Mode

### DIFF
--- a/admin-dev/themes/default/sass/partials/_header.sass
+++ b/admin-dev/themes/default/sass/partials/_header.sass
@@ -116,6 +116,16 @@
 		.label-tooltip
 			padding: 9px 0
 			color: $brand-warning
+	.debug-mode
+		color: $contrasted-light-default
+		cursor: default
+		display: inline-block
+		margin-left: -13px
+		.label-tooltip
+			padding: 9px 0
+			color: $brand-warning
+	.maintenance-mode + .debug-mode
+		margin-left: 0
 #employee_infos
 	.employee_name
 		position: relative

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -311,6 +311,13 @@
 								title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in maintenance.'}</strong></p><p class='text-left'>{l s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Preferences > Maintenance.' sprintf='<br />'}</p>">{l s='Maintenance mode'}</span>
 							</span>
 						{/if}
+						{if isset($debug_mode) && $debug_mode == true}
+							<span class="debug-mode">
+								&mdash;
+								<span class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
+								title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in debug mode.'}</strong></p><p class='text-left'>{l s='All PHP errors and messages are displayed, when you are done <strong>turn off</strong> this mode.'}</p>">{l s='Debug mode'}</span>
+							</span>
+						{/if}
 					</li>
 {/if}
 					<li id="employee_infos" class="dropdown">

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2038,6 +2038,7 @@ class AdminControllerCore extends Controller
 
         $this->context->smarty->assign(array(
             'maintenance_mode' => !(bool)Configuration::get('PS_SHOP_ENABLE'),
+            'debug_mode' => (bool)_PS_MODE_DEV_,
             'content' => $this->content,
             'lite_display' => $this->lite_display,
             'url_post' => self::$currentIndex.'&token='.$this->token,

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1635,7 +1635,8 @@ class AdminModulesControllerCore extends AdminController
             'modules_uri' => __PS_BASE_URI__.basename(_PS_MODULE_DIR_),
             'dont_filter' => $dont_filter,
             'is_contributor' => (int)$this->context->cookie->is_contributor,
-            'maintenance_mode' => !(bool)Configuration::Get('PS_SHOP_ENABLE')
+            'maintenance_mode' => !(bool)Configuration::Get('PS_SHOP_ENABLE'),
+            'debug_mode' => (bool)_PS_MODE_DEV_
         );
 
         if ($this->logged_on_addons) {


### PR DESCRIPTION
People finding help on forums can easily forget about activated Debug Mode. I propose adding some type of warning in BO, for example this way. Best Regards.
