### PR TITLE
[*] FO : order email product cust.: adjust to FO display

### DIFF
--- a/mails/en/order_conf_product_list.tpl
+++ b/mails/en/order_conf_product_list.tpl
@@ -68,27 +68,13 @@
 </tr>
 	{foreach $product['customization'] as $customization}
 		<tr>
-		<td colspan="2" style="border:1px solid #D6D4D4;">
+		<td colspan="3" style="border:1px solid #D6D4D4;">
 			<table class="table">
 				<tr>
 					<td width="10">&nbsp;</td>
 					<td>
 						<font size="2" face="Open-sans, sans-serif" color="#555454">
-							<strong>{$product['name']}</strong><br>
 							{$customization['customization_text']}
-						</font>
-					</td>
-					<td width="10">&nbsp;</td>
-				</tr>
-			</table>
-		</td>
-		<td style="border:1px solid #D6D4D4;">
-			<table class="table">
-				<tr>
-					<td width="10">&nbsp;</td>
-					<td align="right">
-						<font size="2" face="Open-sans, sans-serif" color="#555454">
-							{$product['unit_price']}
 						</font>
 					</td>
 					<td width="10">&nbsp;</td>
@@ -108,19 +94,7 @@
 				</tr>
 			</table>
 		</td>
-		<td style="border:1px solid #D6D4D4;">
-			<table class="table">
-				<tr>
-					<td width="10">&nbsp;</td>
-					<td align="right">
-						<font size="2" face="Open-sans, sans-serif" color="#555454">
-							{$customization['quantity']}
-						</font>
-					</td>
-					<td width="10">&nbsp;</td>
-				</tr>
-			</table>
-		</td>
+		<td style="border:1px solid #D6D4D4;"></td>
 	</tr>
 	{/foreach}
 {/foreach}

--- a/mails/en/order_conf_product_list.txt
+++ b/mails/en/order_conf_product_list.txt
@@ -10,12 +10,8 @@
 						{$product['price']}
 
 	{foreach $product['customization'] as $customization}
-							{$product['name']} {$customization['customization_text']}
-
-							{$product['price']}
+							{$customization['customization_text']}
 
 							{$product['customization_quantity']}
-
-							{$product['quantity']}
 	{/foreach}
 {/foreach}


### PR DESCRIPTION
Customizations don't change the price of a product and are displayed in
the FO cart without the extra product name and price. Especially
duplicating the price in the confirmation email confuses the customer.

This change makes the displayed information in the FO cart and the
product list in the order confirmation email the same.

(There's no commit category for email templates, I hope FO is ok.)
