### PR TITLE
[-] CORE : wrong language link on mail when change order status on BO

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -334,10 +334,10 @@ class MailCore extends ObjectModel
             }
 
             $template_vars['{shop_name}'] = Tools::safeOutput(Configuration::get('PS_SHOP_NAME', null, null, $id_shop));
-            $template_vars['{shop_url}'] = Context::getContext()->link->getPageLink('index', true, Context::getContext()->language->id, null, false, $id_shop);
-            $template_vars['{my_account_url}'] = Context::getContext()->link->getPageLink('my-account', true, Context::getContext()->language->id, null, false, $id_shop);
-            $template_vars['{guest_tracking_url}'] = Context::getContext()->link->getPageLink('guest-tracking', true, Context::getContext()->language->id, null, false, $id_shop);
-            $template_vars['{history_url}'] = Context::getContext()->link->getPageLink('history', true, Context::getContext()->language->id, null, false, $id_shop);
+			$template_vars['{shop_url}'] = Context::getContext()->link->getPageLink('index', true, Context::getContext()->cart->id_lang, null, false, $id_shop);
+			$template_vars['{my_account_url}'] = Context::getContext()->link->getPageLink('my-account', true, Context::getContext()->cart->id_lang, null, false, $id_shop);
+			$template_vars['{guest_tracking_url}'] = Context::getContext()->link->getPageLink('guest-tracking', true, Context::getContext()->cart->id_lang, null, false, $id_shop);
+			$template_vars['{history_url}'] = Context::getContext()->link->getPageLink('history', true, Context::getContext()->cart->id_lang, null, false, $id_shop);
             $template_vars['{color}'] = Tools::safeOutput(Configuration::get('PS_MAIL_COLOR', null, null, $id_shop));
             // Get extra template_vars
             $extra_template_vars = array();

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -333,11 +333,19 @@ class MailCore extends ObjectModel
                 Context::getContext()->link = new Link();
             }
 
+            if (Context::getContext()->cart->id_lang) 
+            {
+            	$template_lang_id=Context::getContext()->cart->id_lang; 
+            } 
+            else 
+            {
+            	$template_lang_id=Context::getContext()->language->id; 
+            } 
+            $template_vars['{shop_url}'] = Context::getContext()->link->getPageLink('index', true, $template_lang_id, null, false, $id_shop); 
+            $template_vars['{my_account_url}'] = Context::getContext()->link->getPageLink('my-account', true, $template_lang_id, null, false, $id_shop); 
+            $template_vars['{guest_tracking_url}'] = Context::getContext()->link->getPageLink('guest-tracking', true, $template_lang_id, null, false, $id_shop); 
+            $template_vars['{history_url}'] = Context::getContext()->link->getPageLink('history', true, $template_lang_id, null, false, $id_shop);
             $template_vars['{shop_name}'] = Tools::safeOutput(Configuration::get('PS_SHOP_NAME', null, null, $id_shop));
-			$template_vars['{shop_url}'] = Context::getContext()->link->getPageLink('index', true, Context::getContext()->cart->id_lang, null, false, $id_shop);
-			$template_vars['{my_account_url}'] = Context::getContext()->link->getPageLink('my-account', true, Context::getContext()->cart->id_lang, null, false, $id_shop);
-			$template_vars['{guest_tracking_url}'] = Context::getContext()->link->getPageLink('guest-tracking', true, Context::getContext()->cart->id_lang, null, false, $id_shop);
-			$template_vars['{history_url}'] = Context::getContext()->link->getPageLink('history', true, Context::getContext()->cart->id_lang, null, false, $id_shop);
             $template_vars['{color}'] = Tools::safeOutput(Configuration::get('PS_MAIL_COLOR', null, null, $id_shop));
             // Get extra template_vars
             $extra_template_vars = array();


### PR DESCRIPTION
When you change order status from BO you will send link to email template whit BO context language and not with customer language.
