### PR TITLE
getPriceWithoutReduct Fix

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3211,7 +3211,7 @@ class ProductCore extends ObjectModel
         );
     }
 
-    public function getPriceWithoutReduct($notax = false, $id_product_attribute = false, $decimals = 6)
+    public function getPriceWithoutReduct($notax = false, $id_product_attribute = null, $decimals = 6)
     {
         return Product::getPriceStatic((int)$this->id, !$notax, $id_product_attribute, $decimals, null, false, false);
     }


### PR DESCRIPTION
If $id_product_attribute is set to false by default :
In Product::getPriceStatic, you call Product::priceCalculation with $id_product_attribute set to false.
This method tests if ($id_product_attribute === null) on line 2955.
That leads to bugs on some themes regarding price display.
