### PR TITLE
Bugfix - Create supplier link

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -311,8 +311,8 @@ class LinkCore
         $params = array();
         $params['id'] = $supplier->id;
         $params['rewrite'] = (!$alias) ? $supplier->link_rewrite : $alias;
-        $params['meta_keywords'] =    Tools::str2url($supplier->meta_keywords);
-        $params['meta_title'] = Tools::str2url($supplier->meta_title);
+        $params['meta_keywords'] =    Tools::str2url($supplier->meta_keywords[$id_lang]);
+        $params['meta_title'] = Tools::str2url($supplier->meta_title[$id_lang]);
 
         return $url.$dispatcher->createUrl('supplier_rule', $id_lang, $params, $this->allow, '', $id_shop);
     }


### PR DESCRIPTION
Creating a supplier link will produce a high amount of warnings, since `Tools::str2url()` would try to use an array as a array index. Below is the error message and stack trace of the problem that this is fixing.

Error message:
`E_WARNING: Illegal offset type in isset or empty`

Sample stack trace:

```
in ToolsCore::str2url called at /home/gourmetl/public_html/classes/Tools.php (1394)
in ToolsCore::str2url called at /home/gourmetl/public_html/classes/Link.php (315)
…rLink called at /home/gourmetl/public_html/modules/supplierBox/supplierBox.php (99)
…plier called at /home/gourmetl/public_html/modules/supplierBox/supplierBox.php (42)
…layRightShortDescription called at /home/gourmetl/public_html/classes/Hook.php (587)
in HookCore::coreCallHook called at /home/gourmetl/public_html/classes/Hook.php (542)
…okCore::exec called at /home/gourmetl/public_html/config/smarty.config.inc.php (205)
in smartyHook called at ? (?)
…r_func_array called at /home/gourmetl/public_html/config/smarty.config.inc.php (268)
…compile/94/67/d0/9467d03b1ec840ac0d8ed718dd17855cf491b02f.file.product.tpl.php (449)
…compile/94/67/d0/9467d03b1ec840ac0d8ed718dd17855cf491b02f.file.product.tpl.php (449)
…/gourmetl/public_html/tools/smarty/sysplugins/smarty_internal_templatebase.php (188)
…plateBase::fetch called at /home/gourmetl/public_html/classes/SmartyCustom.php (110)
…ch called at /home/gourmetl/public_html/classes/controller/FrontController.php (713)
…display called at /home/gourmetl/public_html/classes/controller/Controller.php (209)
…ontrollerCore::run called at /home/gourmetl/public_html/classes/Dispatcher.php (367)
in DispatcherCore::dispatch called at /home/gourmetl/public_html/index.php (28)
```
