### PR TITLE
[*] CORE : FO Search position considering stocks

### DIFF
--- a/classes/cache/CacheRedis.php
+++ b/classes/cache/CacheRedis.php
@@ -1,0 +1,203 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author Matthieu Deroubaix <matthieu@agence-malttt.fr>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+/**
+ * This class require PHP Redis (PECL) extension
+ */
+
+class CacheRedisCore extends Cache
+{
+
+	/**
+	 * @var Redis
+	 */
+	protected $redis;
+	protected $is_connected = false;
+
+	public function __construct()
+	{
+       
+        $this->is_connected = $this->connect();
+
+        $this->keys = array();
+        $this->localcache = array();
+
+        return $this->is_connected;
+            
+    }
+
+	public function __destruct()
+	{
+		$this->close();
+	}
+
+	/**
+	 * Connect to redis server
+	 */
+	public function connect()
+	{
+        
+		if (class_exists('Redis') && extension_loaded('redis')){
+			$this->redis = new Redis();
+        } else {
+			return false;
+        }
+       
+        if (!defined('_PS_CACHE_REDIS_') || !_PS_CACHE_REDIS_ || !preg_match("/:/",_PS_CACHE_REDIS_)){
+            define('_PS_CACHE_REDIS_', '127.0.0.1:6379');
+        }
+       
+        $params = explode(':',_PS_CACHE_REDIS_);
+       
+        try {
+
+            $result = $this->redis->connect($params[0], $params[1]);
+            $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP); 
+
+            return (bool)$result;
+
+        } catch (Exception $e) {
+
+            return false;
+
+        }
+
+	}
+
+	/**
+	 * @see Cache::_set()
+	 */
+	protected function _set($key, $value, $ttl = 0)
+	{
+		
+        if (!$this->is_connected){
+			return false;
+        }
+
+        $this->localcache[$key] = $value;
+        
+        if ((int)$ttl > 0){
+		    return $this->redis->setex($key, (int)$ttl, $value);
+        }else{
+		    return $this->redis->set($key, $value);
+        }
+
+	}
+
+	/**
+	 * @see Cache::_get()
+	 */
+	protected function _get($key)
+	{
+
+		if (!$this->is_connected){
+            return false;
+        }
+
+        if (isset($this->localcache[$key])) {
+            return $this->localcache[$key];
+        }
+        
+        $value = $this->redis->get(_DB_NAME_.'.'.$key);
+        $this->localcache[$key] = $value;
+        
+        return $value;
+
+    }
+
+	/**
+	 * @see Cache::_exists()
+	 */
+	protected function _exists($key)
+	{
+		return !$this->is_connected ? false : (bool)$this->redis->exists(_DB_NAME_.'.'.$key);
+	}
+
+	/**
+	 * @see Cache::_delete()
+	 */
+	protected function _delete($key)
+	{
+		return !$this->is_connected ? false : (bool)$this->redis->delete(_DB_NAME_.'.'.$key);
+	}
+
+	/**
+	 * @see Cache::_writeKeys()
+	 */
+	protected function _writeKeys()
+	{
+        return $this->is_connected;
+	}
+
+	/**
+	 * @see Cache::flush()
+	 */
+	public function flush()
+	{
+
+		if (!$this->is_connected){
+			return false;
+        }
+
+        // Case if redis is shared with other apps
+        $keys = $this->redis->keys(_DB_NAME_.'.*');
+        $this->redis->delete(implode(' ',$keys));
+        
+        return true;
+
+	}
+
+	/**
+	 * Close connection to redis server
+	 *
+	 * @return bool
+	 */
+	protected function close()
+	{ 
+		return !$this->is_connected ? true : (bool)$this->redis->close();
+	}
+
+    public function get($key) 
+    {
+        return !$this->is_connected ? false : (bool)$this->_get($key);
+    }
+
+    public function set($key, $value, $ttl = 3600)
+    { 
+        return !$this->is_connected ? false : (bool)$this->_set($key,$value,$ttl);
+    }
+
+    public function exists($key) 
+    {
+        return !$this->is_connected ? false : (bool)$this->_exists($key);
+    }
+
+    public function delete($key)
+    {
+	   return !$this->is_connected ? false : (bool)$this->_delete($key);
+    }
+
+}

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -522,6 +522,10 @@ class AdminPerformanceControllerCore extends AdminController
 		$warning_xcache = str_replace('[a]', '<a href="http://xcache.lighttpd.net" target="_blank">', $warning_xcache);
 		$warning_xcache = str_replace('[/a]', '</a>', $warning_xcache);
 
+		$warning_redis = ' '.$this->l('(you must install the [a]Redis extension[/a])');
+		$warning_redis = str_replace('[a]', '<a href="https://pecl.php.net/package/redis" target="_blank">', $warning_redis);
+		$warning_redis = str_replace('[/a]', '</a>', $warning_redis);
+
 		$warning_fs = ' '.sprintf($this->l('(the directory %s must be writable)'), realpath(_PS_CACHEFS_DIRECTORY_));
 
 		$this->fields_form[6]['form'] = array(
@@ -577,6 +581,11 @@ class AdminPerformanceControllerCore extends AdminController
 							'id' => 'CacheXcache',
 							'value' => 'CacheXcache',
 							'label' => $this->l('Xcache').(extension_loaded('xcache') ? '' : $warning_xcache)
+						),
+						array(
+							'id' => 'CacheRedis',
+							'value' => 'CacheRedis',
+							'label' => $this->l('Redis').(extension_loaded('redis') ? '' : $warning_xcache)
 						),
 
 					)
@@ -915,6 +924,9 @@ class AdminPerformanceControllerCore extends AdminController
 					elseif ($caching_system == 'CacheXcache' && !ini_get('xcache.var_size'))
 						$this->errors[] = Tools::displayError('To use Xcache, you must configure "xcache.var_size" for the Xcache extension (recommended value 16M to 64M).').'
 							<a href="http://xcache.lighttpd.net/wiki/XcacheIni">http://xcache.lighttpd.net/wiki/XcacheIni</a>';
+					elseif ($caching_system == 'CacheRedis' && !extension_loaded('redis'))
+						$this->errors[] = Tools::displayError('To use Redis, you must install the Redis extension on your server.').'
+							<a href="https://pecl.php.net/package/redis">https://pecl.php.net/package/redis</a>';
 					elseif ($caching_system == 'CacheFs')
 						if (!is_dir(_PS_CACHEFS_DIRECTORY_))
 							@mkdir(_PS_CACHEFS_DIRECTORY_, 0777, true);


### PR DESCRIPTION
Even if products are listed by position (calculated by word matching), we must consider that this is not an absolute value.

For example : I search for a brand name with ajax search, only 10 (by default) products are shown, which is not much, customer should see available products. If 10 first products are out of stock and not the one after, this one should be positionned first.

We should also consider number of element shown by pages for ajax search instead of 10, search results are defined through templates, taking care of. 

I also used PS_PRODUCTS_PER_PAGE for classic searches.
