### PR TITLE
Product Page : Show cover of the current variant

### DIFF
--- a/Adapter/Adapter_ImageRetriever.php
+++ b/Adapter/Adapter_ImageRetriever.php
@@ -17,6 +17,14 @@ class Adapter_ImageRetriever
             $language->id
         );
         $images = $productInstance->getImages($language->id);
+        $combinationImages = $productInstance->getCombinationImages($language->id);
+        $imageToCombinations = [];
+
+        foreach ($combinationImages as $imgs) {
+            foreach ($imgs as $img) {
+                $imageToCombinations[$img['id_image']][] = $img['id_product_attribute'];
+            }
+        }
 
         if (count($images) <= 0) {
             $images[] = array(
@@ -27,14 +35,18 @@ class Adapter_ImageRetriever
             );
         }
 
-        return array_map(function (array $image) use ($productInstance) {
+        $images = array_map(function (array $image) use ($productInstance, $imageToCombinations) {
             $image =  array_merge($image, $this->getImage(
                 $productInstance,
                 $image['id_image']
             ));
 
+            $image['associatedVariants'] = $imageToCombinations[$image['id_image']];
+
             return $image;
         }, $images);
+
+        return $images;
     }
 
     public function getImage($object, $id_image)

--- a/Core/Business/Product/ProductPresenter.php
+++ b/Core/Business/Product/ProductPresenter.php
@@ -57,6 +57,18 @@ class ProductPresenter
             $language
         );
 
+        if (isset($product['id_product_attribute'])) {
+            foreach ($presentedProduct['images'] as $image) {
+                foreach ($image['associatedVariants'] as $id) {
+                    if ((int)$id === (int)$product['id_product_attribute']) {
+                        $presentedProduct['cover'] = $image;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+
         if (!isset($presentedProduct['cover'])) {
             $presentedProduct['cover'] = $presentedProduct['images'][0];
         }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -778,6 +778,13 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         if (Tools::getValue('refresh_product')) {
             $product['id_product_attribute'] = (int)$this->product->getIdProductAttributesByIdAttributes((int)$this->product->id, Tools::getValue('group'));
+            $url = $this->context->link->getProductLink(
+                $product['id_product'], null, null, null,
+                $this->context->language->id, null,
+                $product['id_product_attribute'],
+                false, false, true
+            );
+            return Tools::redirect($url);
         } else {
             $product['id_product_attribute'] = (int)Tools::getValue('id_product_attribute');
         }

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -35,13 +35,6 @@ ALTER TABLE  `PREFIX_supply_order_detail` ADD  `isbn` VARCHAR( 13 ) NULL DEFAULT
 ALTER TABLE  `PREFIX_product_lang` ADD  `social_sharing_title` VARCHAR( 255 ) NOT NULL;
 ALTER TABLE  `PREFIX_product_lang` ADD  `social_sharing_description` VARCHAR( 255 ) NOT NULL;
 
-/* PHP:ps1700_stores(); */;
-
-
-/* Password reset token for new "Forgot my password screen */
-ALTER TABLE PREFIX_customer ADD `reset_password_token` varchar(40) DEFAULT NULL;
-ALTER TABLE PREFIX_customer ADD `reset_password_validity` datetime DEFAULT NULL;
-ALTER TABLE PREFIX_employee ADD `reset_password_token` varchar(40) DEFAULT NULL;
-ALTER TABLE PREFIX_employee ADD `reset_password_validity` datetime DEFAULT NULL;
+/* PHP:ps1700_stores(); */
 
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_PASSWD_RESET_VALIDITY', '1440', NOW(), NOW());

--- a/tests/Unit/Core/Business/Product/ProductPresenterTest.php
+++ b/tests/Unit/Core/Business/Product/ProductPresenterTest.php
@@ -68,8 +68,13 @@ class ProductPresenterTest extends UnitTestCase
         $link = Phake::mock('Link');
         Phake::when($link)->getAddToCartURL(Phake::anyParameters())->thenReturn('http://add-to-cart.url');
 
+        $imageRetriever = Phake::mock('Adapter_ImageRetriever');
+        Phake::when($imageRetriever)->getProductImages(Phake::anyParameters())->thenReturn([
+            ['id_image' => 0, 'associatedVariants' => []]
+        ]);
+
         $presenter = new ProductPresenter(
-            Phake::mock('Adapter_ImageRetriever'),
+            $imageRetriever,
             $link,
             new PricePresenter,
             Phake::mock('Adapter_ProductColorsRetriever'),


### PR DESCRIPTION
Someone (me, most likely) had broken the display of cover images for variants: it was always the same image displayed regardless of the variant selected. Now the image corresponding to the variant is displayed.

White:

![image](https://cloud.githubusercontent.com/assets/1460499/11029740/44f29d80-86c9-11e5-8923-7b9917549ed4.png)

Black:

![image](https://cloud.githubusercontent.com/assets/1460499/11029757/5b5963f6-86c9-11e5-82ca-98b144f4a65b.png)

While I was there, I also made choosing another variant change the URL too.
