### PR TITLE
[*] BO : Allow basic HTML attributes in editor

### DIFF
--- a/js/admin/tinymce.inc.js
+++ b/js/admin/tinymce.inc.js
@@ -1,14 +1,16 @@
 function tinySetup(config)
 {
-	if(!config)
+	if (!config) {
 		config = {};
+	}
 
 	//var editor_selector = 'rte';
 
-	if (typeof config.editor_selector != 'undefined')
+	if (typeof config.editor_selector != 'undefined') {
 		config.selector = '.'+config.editor_selector;
+	}
 
-	default_config = {
+	var default_config = {
 		selector: ".rte" ,
 		plugins : "colorpicker link image paste pagebreak table contextmenu filemanager table code media autoresize textcolor anchor",
 		browser_spellcheck : true,
@@ -23,7 +25,7 @@ function tinySetup(config)
 		relative_urls : false,
 		convert_urls: false,
 		entity_encoding: "raw",
-		extended_valid_elements : "em[class|name|id]",
+		extended_valid_elements : "em[class|name|id],@[role|data-*|aria-*]",
 		valid_children : "+*[*]",
 		valid_elements:"*[*]",
 		menu: {


### PR DESCRIPTION
Role, data and aria attributes are used by Bootstrap, and serve several purposes.
See these:
- http://www.w3.org/TR/wai-aria/states_and_properties#state_prop_def
- http://www.w3.org/TR/role-attribute/
- http://www.w3.org/TR/html5/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes

These are the same modifications from https://github.com/PrestaShop/PrestaShop/pull/3159, done on `develop`. A note: this does not guarantee that the server-side processing will also let the attributes be.
