### PR TITLE
[-] BO : Fixing search to access a product page with id_product

### DIFF
--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -48,7 +48,7 @@ class AdminSearchControllerCore extends AdminController
                 /* Handle product ID */
                 if ($searchType == 1 && (int)$this->query && Validate::isUnsignedInt((int)$this->query)) {
                     if (($product = new Product($this->query)) && Validate::isLoadedObject($product)) {
-                        Tools::redirectAdmin('index.php?tab=AdminProducts&id_product='.(int)($product->id).'&token='.Tools::getAdminTokenLite('AdminProducts'));
+                        Tools::redirectAdmin('index.php?tab=AdminProducts&id_product='.(int)($product->id).'&updateproduct&token='.Tools::getAdminTokenLite('AdminProducts'));
                     }
                 }
 


### PR DESCRIPTION
When you try to access the product page in your back office by id_product, it does not work, because of updateproduct missing parameter
