### PR TITLE
Added zip extension as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "symfony/symfony": "~2.8.0",
     "doctrine/dbal": "~2.5.0",
     "doctrine/orm": "~2.5.0",
+    "ext-zip": "*",
     "doctrine/doctrine-bundle": "1.5.2",
     "symfony/swiftmailer-bundle": "2.3.8",
     "symfony/monolog-bundle": "2.8.1",


### PR DESCRIPTION
Hi,
PrestaShop use ZipArchive class that depends on php zip extension.

Instead of try to catch some exceptions in code, I think it's better to let composer deal with it.

Regards,
