### PR TITLE
removed bash script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
 
 before_install:
   - sudo apt-get update
+  - /home/travis/.phpenv/versions/$(phpenv version-name)/bin/composer self-update
+
+install:
+  - composer update --prefer-source --no-interaction
 
 before_script:
   - sudo apt-get install apache2 libapache2-mod-fastcgi
@@ -28,9 +32,9 @@ before_script:
 notifications:
   slack: prestashop:Eovjydk55zPrwPkoQIOF0cZn
   hipchat: ec4e21c5eb82066ba8be5fd1afefde@1184657
+
 script:
   - cd /var/www/prestashop.unit.test && cp tests/parameters.yml.travis app/config/parameters.yml
-  - cd /var/www/prestashop.unit.test && bash getcomposer.sh && php composer.phar install
   - /var/www/prestashop.unit.test/tests/check_php_parse_errors.sh
   - php /var/www/prestashop.unit.test/install-dev/index_cli.php --language=en --country=us --domain=localhost --base_uri=/prestashop.unit.test --db_name=prestashop.unit.test --db_create=0 --name=prestashop.unit.test --password=123456789
   - cd /var/www/prestashop.unit.test && php bin/phpunit -c tests/

--- a/getcomposer.sh
+++ b/getcomposer.sh
@@ -1,1 +1,0 @@
-curl -sS https://getcomposer.org/installer | php


### PR DESCRIPTION
Hi,
as Travis already provide composer in a PHP environment, the `getcomposer.sh` script sounds useless: do you have a reason to keep it ?

Regards
