### PR TITLE
[-] CORE : Set correct customization quantity value.

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -479,7 +479,7 @@ abstract class PaymentModuleCore extends Module
 								if (isset($customization['datas'][Product::CUSTOMIZE_FILE]))
 									$customization_text .= sprintf(Tools::displayError('%d image(s)'), count($customization['datas'][Product::CUSTOMIZE_FILE])).'<br />';
 
-								$customization_quantity = (int)$product['customization_quantity'];
+								$customization_quantity = (int)$customization['quantity'];
 
 								$product_var_tpl['customization'][] = array(
 									'customization_text' => $customization_text,


### PR DESCRIPTION
While looping through the customizations for a product, the customization quantity was being pulled from the wrong place, giving incorrect quantity values for the customizations in the order confirmation email. This small changes fixes the bug.
