### PR TITLE
[-] CORE : Set correct customization quantity value.

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3555,6 +3555,7 @@ class CartCore extends ObjectModel
                 $customs_by_id[$custom['id_customization']] = array(
                     'id_product_attribute' => $custom['id_product_attribute'],
                     'id_product' => $custom['id_product'],
+                    'id_address_delivery' => $custom['id_address_delivery'],
                     'quantity' => $custom['quantity']
                 );
             }
@@ -3565,7 +3566,7 @@ class CartCore extends ObjectModel
         foreach ($customs_by_id as $customization_id => $val) {
             Db::getInstance()->execute('
 				INSERT INTO `'._DB_PREFIX_.'customization` (id_cart, id_product_attribute, id_product, `id_address_delivery`, quantity, `quantity_refunded`, `quantity_returned`, `in_cart`)
-				VALUES('.(int)$cart->id.', '.(int)$val['id_product_attribute'].', '.(int)$val['id_product'].', '.(int)$id_address_delivery.', '.(int)$val['quantity'].', 0, 0, 1)'
+				VALUES('.(int)$cart->id.', '.(int)$val['id_product_attribute'].', '.(int)$val['id_product'].', '.(int)$val['id_address_delivery'].', '.(int)$val['quantity'].', 0, 0, 1)'
             );
             $custom_ids[$customization_id] = Db::getInstance(_PS_USE_SQL_SLAVE_)->Insert_ID();
         }

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -483,7 +483,7 @@ abstract class PaymentModuleCore extends Module
                                     $customization_text .= sprintf(Tools::displayError('%d image(s)'), count($customization['datas'][Product::CUSTOMIZE_FILE])).'<br />';
                                 }
 
-                                $customization_quantity = (int)$product['customization_quantity'];
+                                $customization_quantity = (int)$customization['quantity'];
 
                                 $product_var_tpl['customization'][] = array(
                                     'customization_text' => $customization_text,


### PR DESCRIPTION
While looping through the customizations for a product, the customization quantity was being pulled from the wrong place, giving incorrect quantity values for the customizations in the order confirmation email. This small changes fixes the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/4479)
<!-- Reviewable:end -->
