### PR TITLE
Accessory product names are not the product name (Schema.org)

### DIFF
--- a/themes/default-bootstrap/product.tpl
+++ b/themes/default-bootstrap/product.tpl
@@ -520,7 +520,7 @@
 											</div>
 										</div>
 										<div class="s_title_block">
-											<h5 itemprop="name" class="product-name">
+											<h5 class="product-name">
 												<a href="{$accessoryLink|escape:'html':'UTF-8'}">
 													{$accessory.name|truncate:20:'...':true|escape:'html':'UTF-8'}
 												</a>


### PR DESCRIPTION
 The product name for schema.org is already defined on line 158 for the product. The accessory product names are associated products but are neither the product itself nor part of the product name to be used for Schema.org
