### PR TITLE
[-] FO : Stores search didn't work with keyboard validation

### DIFF
--- a/themes/default-bootstrap/js/stores.js
+++ b/themes/default-bootstrap/js/stores.js
@@ -40,7 +40,7 @@ $(document).ready(function(){
 
 	$('#addressInput').keypress(function(e) {
 		code = e.keyCode ? e.keyCode : e.which;
-		if(code.toString() === 13)
+		if(code.toString() == 13)
 			searchLocations();
 	});
 


### PR DESCRIPTION
Nothing happened when validating a stores search by pressing Enter key, due to a strict type comparison between a string and a number when checking pressed keyCode. This minor fix will correct the problem.
