### PR TITLE
[-] BO : Fixed bug in HTMLTemplateInvoice prevents problems with invoice prefixs

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -58,7 +58,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
         $this->date = Tools::displayDate($order_invoice->date_add);
 
         $id_lang = Context::getContext()->language->id;
-        $this->title = $order_invoice->getInvoiceNumberFormatted($id_lang);
+        $this->title = $order_invoice->getInvoiceNumberFormatted($id_lang,(int)$this->order->id_shop);
 
         $this->shop = new Shop((int)$this->order->id_shop);
     }


### PR DESCRIPTION
This parameter is neccesary or the id_shop will be 0. This is used also in /controllers/admin/AdminOrdersController.php line 2517.

In some cases the prefix can be different in the documents list (inside the order) and the prefix in the invoice PDF.
