### PR TITLE
Change default prefix

### DIFF
--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -97,8 +97,9 @@ class Datas
         ),
         'database_prefix' => array(
             'name' => 'prefix',
-            'default' => 'ps_',
+            'default' => '',
             'validate' => 'isGenericName',
+            'help' => 'Set a prefix for your database'
         ),
         'database_engine' => array(
             'name' => 'engine',


### PR DESCRIPTION
On default prefix with "ps_" you are not allowed to install prestashop without prefix! The easiest way is to don't use one.
