### PR TITLE
[+] MySQL 5.7 Compatibility

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -107,6 +107,8 @@ class DbPDOCore extends Db
             die(Tools::displayError('PrestaShop Fatal error: no utf-8 support. Please check your server configuration.'));
         }
 
+        $this->link->exec('SET SESSION sql_mode = \'\'');
+
         return $this->link;
     }
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1,3 +1,4 @@
+SET SESSION sql_mode = '';
 SET NAMES 'utf8';
 
 CREATE TABLE `PREFIX_access` (


### PR DESCRIPTION
## MySQL 5.7 default modes

MySQL 5.7 default configuration is very different from MySQL < 5.6.
Few modes are activated and some are causing a lot of troubles in PrestaShop.

| Mode | Desc |
| :-: | --- |
| NO_ZERO_DATE | This mode disallow `date` and `datetime` like `0000-00-00`. They are widely used in PrestaShop. |
| ONLY_FULL_GROUP_BY | This mode changes the behavior of `group by` and break **a lot** of SQL request in PrestaShop |

About ONLY_FULL_GROUP_BY: http://mysqlserverteam.com/mysql-5-7-only_full_group_by-improved-recognizing-functional-dependencies-enabled-by-default/

If you have the following error during install, this is the patch.

> SQL error on query All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
#### MySQL 5.7

```
mysql> SELECT @@GLOBAL.sql_mode;
+-------------------------------------------------------------------------------------------------------------------------------------------+
| @@GLOBAL.sql_mode                                                                                                                         |
+-------------------------------------------------------------------------------------------------------------------------------------------+
| ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION |
+-------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```
#### MySQL 5.6

```
mysql> SELECT @@GLOBAL.sql_mode;
+----------------------------------+
| @@GLOBAL.sql_mode                |
+----------------------------------+
|                                  |
+----------------------------------+
1 row in set (0.00 sec)
```

Thanks to @jnadaud for this fix #4468.

**NOTE:** I believe this can be cherry-picked easily to PrestaShop 1.6.1.x branch.
