### PR TITLE
[*] CORE : Redis cache manager

### DIFF
--- a/classes/cache/CacheRedis.php
+++ b/classes/cache/CacheRedis.php
@@ -1,0 +1,203 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author Matthieu Deroubaix <matthieu@agence-malttt.fr>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+/**
+ * This class require PHP Redis (PECL) extension
+ */
+
+class CacheRedisCore extends Cache
+{
+
+	/**
+	 * @var Redis
+	 */
+	protected $redis;
+	protected $is_connected = false;
+
+	public function __construct()
+	{
+       
+        $this->is_connected = $this->connect();
+
+        $this->keys = array();
+        $this->localcache = array();
+
+        return $this->is_connected;
+            
+    }
+
+	public function __destruct()
+	{
+		$this->close();
+	}
+
+	/**
+	 * Connect to redis server
+	 */
+	public function connect()
+	{
+        
+		if (class_exists('Redis') && extension_loaded('redis')){
+			$this->redis = new Redis();
+        } else {
+			return false;
+        }
+       
+        if (!defined('_PS_CACHE_REDIS_') || !_PS_CACHE_REDIS_ || !preg_match("/:/",_PS_CACHE_REDIS_)){
+            define('_PS_CACHE_REDIS_', '127.0.0.1:6379');
+        }
+       
+        $params = explode(':',_PS_CACHE_REDIS_);
+       
+        try {
+
+            $result = $this->redis->connect($params[0], $params[1]);
+            $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP); 
+
+            return (bool)$result;
+
+        } catch (Exception $e) {
+
+            return false;
+
+        }
+
+	}
+
+	/**
+	 * @see Cache::_set()
+	 */
+	protected function _set($key, $value, $ttl = 0)
+	{
+		
+        if (!$this->is_connected){
+			return false;
+        }
+
+        $this->localcache[$key] = $value;
+        
+        if ((int)$ttl > 0){
+		    return $this->redis->setex($key, (int)$ttl, $value);
+        }else{
+		    return $this->redis->set($key, $value);
+        }
+
+	}
+
+	/**
+	 * @see Cache::_get()
+	 */
+	protected function _get($key)
+	{
+
+		if (!$this->is_connected){
+            return false;
+        }
+
+        if (isset($this->localcache[$key])) {
+            return $this->localcache[$key];
+        }
+        
+        $value = $this->redis->get(_DB_NAME_.'.'.$key);
+        $this->localcache[$key] = $value;
+        
+        return $value;
+
+    }
+
+	/**
+	 * @see Cache::_exists()
+	 */
+	protected function _exists($key)
+	{
+		return !$this->is_connected ? false : (bool)$this->redis->exists(_DB_NAME_.'.'.$key);
+	}
+
+	/**
+	 * @see Cache::_delete()
+	 */
+	protected function _delete($key)
+	{
+		return !$this->is_connected ? false : (bool)$this->redis->delete(_DB_NAME_.'.'.$key);
+	}
+
+	/**
+	 * @see Cache::_writeKeys()
+	 */
+	protected function _writeKeys()
+	{
+        return $this->is_connected;
+	}
+
+	/**
+	 * @see Cache::flush()
+	 */
+	public function flush()
+	{
+
+		if (!$this->is_connected){
+			return false;
+        }
+
+        // Case if redis is shared with other apps
+        $keys = $this->redis->keys(_DB_NAME_.'.*');
+        $this->redis->delete(implode(' ',$keys));
+        
+        return true;
+
+	}
+
+	/**
+	 * Close connection to redis server
+	 *
+	 * @return bool
+	 */
+	protected function close()
+	{ 
+		return !$this->is_connected ? true : (bool)$this->redis->close();
+	}
+
+    public function get($key) 
+    {
+        return !$this->is_connected ? false : (bool)$this->_get($key);
+    }
+
+    public function set($key, $value, $ttl = 3600)
+    { 
+        return !$this->is_connected ? false : (bool)$this->_set($key,$value,$ttl);
+    }
+
+    public function exists($key) 
+    {
+        return !$this->is_connected ? false : (bool)$this->_exists($key);
+    }
+
+    public function delete($key)
+    {
+	   return !$this->is_connected ? false : (bool)$this->_delete($key);
+    }
+
+}

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -552,6 +552,10 @@ class AdminPerformanceControllerCore extends AdminController
 
         $warning_fs = ' '.sprintf($this->l('(the directory %s must be writable)'), realpath(_PS_CACHEFS_DIRECTORY_));
 
+        $warning_redis = ' '.$this->l('(you must install the [a]Redis extension[/a])');
+        $warning_redis = str_replace('[a]', '<a href="https://pecl.php.net/package/redis" target="_blank">', $warning_redis);
+        $warning_redis = str_replace('[/a]', '</a>', $warning_redis);
+
         $this->fields_form[6]['form'] = array(
             'legend' => array(
                 'title' => $this->l('Caching'),
@@ -605,6 +609,11 @@ class AdminPerformanceControllerCore extends AdminController
                             'id' => 'CacheApc',
                             'value' => 'CacheApc',
                             'label' => $this->l('APC').(extension_loaded('apc') ? '' : $warning_apc)
+                        ),
+                        array(
+                            'id' => 'CacheRedis',
+                            'value' => 'CacheRedis',
+                            'label' => $this->l('Redis').(extension_loaded('redis') ? '' : $warning_apc)
                         ),
                         array(
                             'id' => 'CacheXcache',
@@ -950,6 +959,9 @@ class AdminPerformanceControllerCore extends AdminController
                         } elseif (!is_writable(_PS_CACHEFS_DIRECTORY_)) {
                             $this->errors[] = sprintf(Tools::displayError('To use CacheFS, the directory %s must be writable.'), realpath(_PS_CACHEFS_DIRECTORY_));
                         }
+                    } elseif ($caching_system == 'CacheRedis' && !extension_loaded('redis')){
+                        $this->errors[] = Tools::displayError('To use Redis, you must install the Redis extension on your server.').'
+                            <a href="https://pecl.php.net/package/redis">https://pecl.php.net/package/redis</a>';
                     }
 
                     if ($caching_system == 'CacheFs') {


### PR DESCRIPTION
# Redis Cache in Prestashop
## What ?

We want to implement a reliable way to use Redis Cache into Prestashop. There is a PECL package for PHP which is old enough now to be reliable in production.
## Why ?

Redis is faster, less restrictive, reliable and stable.
(see here for more technical infos : http://stackoverflow.com/questions/10558465/memcached-vs-redis)
## How ?

Include it aside of Memcached, APC and file system cache already included in Prestashop.
Like @firstred did on his own plugin, as it's done with Memcached, we should also implement multi-server redis feature. 
Localhost should also be specified by default.
# TODO
- New SQL DB for Multi server ( @xBorderie this is the point where we need help indications )
- Form in controllers/admin/AdminPerformanceController.php
- Multi server in classes/cache/CacheRedis.php > Following @firstred proposal
- Speficy and test localhost first

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/4510)
<!-- Reviewable:end -->
