### PR TITLE
[*] CORE : Allow GoogleBot to access JS, CSS and images (robots.txt)

### DIFF
--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -526,6 +526,13 @@ class AdminMetaControllerCore extends AdminController
                     .__PS_BASE_URI__.$sitemap_filename."\n");
             }
 
+            // Allow Google to access to CSS & JS files and images (modules & themes)
+            fwrite($write_fd, "User-agent: Googlebot\n");
+            fwrite($write_fd, "Allow: */css/\n");
+            fwrite($write_fd, "Allow: */js/\n");
+            fwrite($write_fd, "Allow: */img/\n");
+            fwrite($write_fd, "Allow: */images/\n");
+
             Hook::exec('actionAdminMetaAfterWriteRobotsFile', array(
                 'rb_data' => $this->rb_data,
                 'write_fd' => &$write_fd


### PR DESCRIPTION
Currently if you check your robots.txt in Google Web Master Tools, the GoogleBot can't access the css, js and images which are included in modules directories.
