### PR TITLE
Bugs fixed on product stock transfer

### DIFF
--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -731,11 +731,22 @@ class AdminStockManagementControllerCore extends AdminController
 					$usable_from,
 					$usable_to
 				);
-				StockAvailable::synchronize($id_product);
-				if ($is_transfer)
-					Tools::redirectAdmin($redirect.'&conf=3');
-				else
-					$this->errors[] = Tools::displayError('It is not possible to transfer the specified quantity. No stock was transferred.');
+				if ($is_transfer) {
+                    			// Create warehouse_product_location entry if we add stock to a new warehouse
+                    			$id_wpl = (int)WarehouseProductLocation::getIdByProductAndWarehouse($id_product, $id_product_attribute, $id_warehouse_to);
+                    			if(!$id_wpl)
+                    			{
+			                        $wpl = new WarehouseProductLocation();
+			                        $wpl->id_product = (int)$id_product;
+			                        $wpl->id_product_attribute = (int)$id_product_attribute;
+			                        $wpl->id_warehouse = (int)$id_warehouse_to;
+			                        $wpl->save();
+                    			}
+                    			StockAvailable::synchronize($id_product);
+                    			Tools::redirectAdmin($redirect.'&conf=3');
+                		}else{
+                    			$this->errors[] = Tools::displayError('It is not possible to transfer the specified quantity. No stock was transferred.');
+                		}
 			}
 		}
 	}

--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -100,7 +100,7 @@ class AdminStockManagementControllerCore extends AdminController
 		$this->addRowAction('addstock');
 		$this->addRowAction('removestock');
 
-		if (count(Warehouse::getWarehouses()) > 1)
+		if (count(Warehouse::getWarehouses(true)) > 1)
 			$this->addRowAction('transferstock');
 
 		// no link on list rows


### PR DESCRIPTION
The first commit solve the visibility of transfer button in the advanced stock management when there are many warehouses with distinct shops.

The second commit fixed the creation of warehouse_product_location if the transfer add stock to a new warehouse.
