### PR TITLE
[-] CORE : Fix the arsort() so that it performs on the correct array.

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1843,7 +1843,7 @@ class CartCore extends ObjectModel
         }
         unset($product);
 
-        arsort($warehouse_count_by_address);
+        arsort($warehouse_count_by_address[0]);
 
         // Step 2 : Group product by warehouse
         $grouped_by_warehouse = array();


### PR DESCRIPTION
Issue fixed as per this article: http://www.tubbydev.com/2015/11/bug-de-prestashop-sur-le-doublement-des-frais-de-port-ou-commandes-d%C3%A9doubl%C3%A9es.html

In short: an issue made it that orders were split even though they came from the same warehouse -- and thus the shipping fees were doubled. This should fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/4519)
<!-- Reviewable:end -->
