### PR TITLE
MySQL 5.7 SQL Incection FIX

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1190,9 +1190,12 @@ class OrderCore extends ObjectModel
         if ($number) {
             $sql .= (int)$number;
         } else {
-            $sql .= '(SELECT new_number FROM (SELECT (MAX(`number`) + 1) AS new_number
-            FROM `'._DB_PREFIX_.'order_invoice`'.(Configuration::get('PS_INVOICE_RESET') ?
+            $getNumberSql = '(SELECT new_number FROM (SELECT (MAX(`number`) + 1) AS new_number
+			FROM `'._DB_PREFIX_.'order_invoice`'.(Configuration::get('PS_INVOICE_RESET') ?
                 ' WHERE DATE_FORMAT(`date_add`, "%Y") = '.(int)date('Y') : '').') AS result)';
+			$getNumberSqlRow = Db::getInstance()->getRow($getNumberSql);
+			$newInvoiceNumber = $getNumberSqlRow['new_number'];
+			$sql .= $newInvoiceNumber;
         }
 
         $sql .= ' WHERE `id_order_invoice` = '.(int)$order_invoice_id;


### PR DESCRIPTION
Fixes Error with MySQL 5.7, where is not possible to inject SELECT with alias into the UPDATE statement that way.
(Error Code: 1093. You can't specify target table 'ps_order_invoice' for update in FROM clause  0.015 sec)
