### PR TITLE
Fix error occurred during installation. SQL error on query All parts …

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -311,7 +311,7 @@ CREATE TABLE `PREFIX_cart_product` (
   `id_product` int(10) unsigned NOT NULL,
   `id_address_delivery` int(10) UNSIGNED DEFAULT '0',
   `id_shop` int(10) unsigned NOT NULL DEFAULT '1',
-  `id_product_attribute` int(10) unsigned DEFAULT NULL,
+  `id_product_attribute` int(10) unsigned DEFAULT '0',
   `quantity` int(10) unsigned NOT NULL DEFAULT '0',
   `date_add` datetime NOT NULL,
   PRIMARY KEY (`id_cart`,`id_product`,`id_product_attribute`,`id_address_delivery`),


### PR DESCRIPTION
…of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
#4550 also need to apply to 1.6.1.x branch

Signed-off-by: Ian Fung cfsscfsshk@yahoo.com.hk
