### PR TITLE
Fix advanced stock manager that prevented admin from removing stock quantity

### DIFF
--- a/classes/stock/StockManager.php
+++ b/classes/stock/StockManager.php
@@ -363,10 +363,10 @@ class StockManagerCore implements StockManagerInterface
                         );
 
                         while ($row = Db::getInstance()->nextRow($resource)) {
-                            // break - in FIFO mode, we have to retreive the oldest positive mvts for which there are left quantities
+                            // continue - in FIFO mode, we have to retreive the oldest positive mvts for which there are left quantities
                             if ($warehouse->management_type == 'FIFO') {
                                 if ($row['qty'] == 0) {
-                                    break;
+                                    continue;
                                 }
                             }
 


### PR DESCRIPTION
I couldnt reduce my stock quantities and it drived me nuts for many months
I kept getting the error message: You don't have enough usable quantity. Cannot remove 1 items out of 0.
Investigated for days and finally I think i nailed it :)
Hope my bugfix is correct and helping many others
