### PR TITLE
[*] Update AdminModulesController.php

### DIFF
--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1502,7 +1502,7 @@ class AdminModulesControllerCore extends AdminController
                     require_once(_PS_MODULE_DIR_.$module->name.'/'.$module->name.'.php');
                 }
 
-                if ($object = new $module->name()) {
+                if ($object = Module::getInstanceByName($module->name)) {
                     /** @var Module $object */
                     $object->runUpgradeModule();
                     if ((count($errors_module_list = $object->getErrors()))) {


### PR DESCRIPTION
After installing the 2.0 update for module AdvancedEUCompliance the modules' page is blank and no longer reachable. This is because the version in database table ps_module isn't updated to 2.0 and stores 1.5 instead. With this bugfix it works.
