### PR TITLE
[-] Project : multistore product deletion should update search indexes

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -923,6 +923,7 @@ class ProductCore extends ObjectModel
         $result &= ($this->deleteProductAttributes() && $this->deleteImages() && $this->deleteSceneProducts());
         // If there are still entries in product_shop, don't remove completely the product
         if ($this->hasMultishopEntries()) {
+            Search::removeProductsSearchIndex([$this]);
             return true;
         }
 
@@ -1893,7 +1894,7 @@ class ProductCore extends ObjectModel
                 'DELETE `'._DB_PREFIX_.'search_index`, `'._DB_PREFIX_.'search_word`
 				FROM `'._DB_PREFIX_.'search_index` JOIN `'._DB_PREFIX_.'search_word`
 				WHERE `'._DB_PREFIX_.'search_index`.`id_product` = '.(int)$this->id.'
-						AND `'._DB_PREFIX_.'search_word`.`id_word` = `'._DB_PREFIX_.'search_index`.id_word'
+				AND `'._DB_PREFIX_.'search_word`.`id_word` = `'._DB_PREFIX_.'search_index`.`id_word`'
             )
         );
     }


### PR DESCRIPTION
Hi,

when a product is deleted, words related to that product are removed from the index for all products.
The first step is to remove the words deletion part from `deleteSearchIndexes()`: this fix the bug _but_ this way we keep all words in table, even if they are not used.

Should we create a new `deleteWords()` function that need to be called after deletion to delete all orphan words or does this feature already exists ?

Mickaël
