### PR TITLE
Improved PDF pagination on invoices

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -508,4 +508,14 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             date('Y', strtotime($this->order_invoice->date_add))
         ).'.pdf';
     }
+
+    /**
+     * Returns the template's HTML pagination block
+     *
+     * @return string HTML pagination block
+     */
+    public function getPagination()
+    {
+        return $this->smarty->fetch($this->getTemplate('pagination'));
+    }
 }

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -91,6 +91,7 @@ class PDFCore
 
             $this->pdf_renderer->createHeader($template->getHeader());
             $this->pdf_renderer->createFooter($template->getFooter());
+            $this->pdf_renderer->createPagination($template->getPagination());
             $this->pdf_renderer->createContent($template->getContent());
             $this->pdf_renderer->writePage();
             $render = true;

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -75,6 +75,7 @@ class PDFCore
         $render = false;
         $this->pdf_renderer->setFontForLang(Context::getContext()->language->iso_code);
         foreach ($this->objects as $object) {
+            $this->pdf_renderer->startPageGroup();
             $template = $this->getTemplateObject($object);
             if (!$template) {
                 continue;

--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -36,6 +36,7 @@ class PDFGeneratorCore extends TCPDF
 
     public $header;
     public $footer;
+    public $pagination;
     public $content;
     public $font;
 
@@ -126,21 +127,33 @@ class PDFGeneratorCore extends TCPDF
     }
 
     /**
+     *
+     * create the PDF pagination
+     *
+     * @param string $pagination HTML
+     */
+    public function createPagination($pagination)
+    {
+        $this->pagination = $pagination;
+    }
+
+    /**
      * Change the font
      *
      * @param string $iso_lang
      */
     public function setFontForLang($iso_lang)
     {
-        $this->font = PDFGenerator::DEFAULT_FONT;
         if (array_key_exists($iso_lang, $this->font_by_lang)) {
             $this->font = $this->font_by_lang[$iso_lang];
+        }else {
+            $this->font = self::DEFAULT_FONT;
         }
 
-        $this->setHeaderFont(array($this->font, '', PDF_FONT_SIZE_MAIN));
-        $this->setFooterFont(array($this->font, '', PDF_FONT_SIZE_MAIN));
+        $this->setHeaderFont(array($this->font, '', PDF_FONT_SIZE_MAIN, '', false));
+        $this->setFooterFont(array($this->font, '', PDF_FONT_SIZE_MAIN, '', false));
 
-        $this->setFont($this->font);
+        $this->setFont($this->font, '', PDF_FONT_SIZE_MAIN, '', false);
     }
 
     /**
@@ -157,6 +170,8 @@ class PDFGeneratorCore extends TCPDF
     public function Footer()
     {
         $this->writeHTML($this->footer);
+        $this->FontFamily = self::DEFAULT_FONT;
+        $this->writeHTML($this->pagination);
     }
 
     /**
@@ -198,7 +213,7 @@ class PDFGeneratorCore extends TCPDF
     public function writePage()
     {
         $this->SetHeaderMargin(5);
-        $this->SetFooterMargin(18);
+        $this->SetFooterMargin(21);
         $this->setMargins(10, 40, 10);
         $this->AddPage();
         $this->writeHTML($this->content, true, false, true, false, '');

--- a/pdf/footer.tpl
+++ b/pdf/footer.tpl
@@ -24,7 +24,7 @@
 *}
 <table style="width: 100%;">
 	<tr>
-		<td style="text-align: center; font-size: 6pt; color: #444;  width:87%;">
+		<td style="text-align: center; font-size: 6pt; color: #444;  width:100%;">
 			{if $available_in_your_account}
 				{l s='An electronic version of this invoice is available in your account. To access it, log in to our website using your e-mail address and password (which you created when placing your first order).' pdf='true'}
 				<br />
@@ -51,9 +51,6 @@
 				{$free_text|escape:'html':'UTF-8'}<br />
 			{/if}
 		</td>
-		<td style="text-align: right; font-size: 8pt; color: #444;  width:13%;">
-            {literal}{:pnp:} / {:ptp:}{/literal}
-        </td>
 	</tr>
 </table>
 

--- a/pdf/pagination.tpl
+++ b/pdf/pagination.tpl
@@ -1,0 +1,1 @@
+<p style="text-align: right; vertical-align: text-top;">{literal} {:pnp:} / {:ptp:} {/literal}</p>

--- a/pdf/pagination.tpl
+++ b/pdf/pagination.tpl
@@ -1,1 +1,1 @@
-<p style="text-align: right; vertical-align: text-top;">{literal} {:pnp:} / {:ptp:} {/literal}</p>
+<p style="text-align: right; vertical-align: text-top;">{literal} {:png:} / {:ptg:} {/literal}</p>


### PR DESCRIPTION
Hi,

first, the pagination is broken with some fonts (like `dejavusans`), I've added a template to still use the default font for this block.

Then, when printing multiples invoices the page total was irrelevant: now each invoice is considerated as a single page group, making the pagination relevant (each invoice start from page 1 and finish to the total number of pages of invoice, and not the total number of pages of generated pdf ...).

Mickaël
