### PR TITLE
incorrect check

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3990,7 +3990,7 @@ class CartCore extends ObjectModel
         $product_in_stock = 0;
         foreach ($this->getProducts() as $product) {
             if (!$exclusive) {
-                if (((int)$product['quantity_available'] - (int)$product['cart_quantity']) <= 0
+                if (((int)$product['quantity_available'] - (int)$product['cart_quantity']) < 0
                     && (!$ignore_virtual || !$product['is_virtual'])) {
                     return false;
                 }


### PR DESCRIPTION
isAllProductsInStock function performs an incorrect comparison between the cart_quantity and the quantity_available.
If there is only 1 quantity available for the product and there is a cart with this product, the function says that the cart is out of stock but this is not correct.
