### PR TITLE
[-] FO - change cache for Cart::getProducts to use cache depending on the params passed to the method.

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -488,18 +488,14 @@ class CartCore extends ObjectModel
         if (!$this->id) {
             return array();
         }
+
+        $key = (int)$id_product.'-'.(int)$id_country;
+
         // Product cache must be strictly compared to NULL, or else an empty cart will add dozens of queries
         if ($this->_products !== null && !$refresh) {
             // Return product row with specified ID if it exists
-            if (is_int($id_product)) {
-                foreach ($this->_products as $product) {
-                    if ($product['id_product'] == $id_product) {
-                        return array($product);
-                    }
-                }
-                return array();
-            }
-            return $this->_products;
+            if(isset($this->_products[$key]))
+                return $this->_products[$key];
         }
 
         // Build query
@@ -602,7 +598,7 @@ class CartCore extends ObjectModel
         Product::cacheProductsFeatures($products_ids);
         Cart::cacheSomeAttributesLists($pa_ids, $this->id_lang);
 
-        $this->_products = array();
+        $this->_products[$key] = array();
         if (empty($result)) {
             return array();
         }
@@ -738,10 +734,10 @@ class CartCore extends ObjectModel
 
             $row = Product::getTaxesInformations($row, $cart_shop_context);
 
-            $this->_products[] = $row;
+            $this->_products[$key][] = $row;
         }
 
-        return $this->_products;
+        return $this->_products[$key];
     }
 
     public static function cacheSomeAttributesLists($ipa_list, $id_lang)
@@ -1067,7 +1063,7 @@ class CartCore extends ObjectModel
         }
 
         // refresh cache of self::_products
-        $this->_products = $this->getProducts(true);
+        $this->getProducts(true);
         $this->update();
         $context = Context::getContext()->cloneContext();
         $context->cart = $this;
@@ -1133,7 +1129,7 @@ class CartCore extends ObjectModel
             }
         }
         // refresh cache of self::_products
-        $this->_products = $this->getProducts(true);
+        $this->getProducts(true);
         $this->update();
         return true;
     }
@@ -1280,7 +1276,7 @@ class CartCore extends ObjectModel
             }
 
             // refresh cache of self::_products
-            $this->_products = $this->getProducts(true);
+            $this->getProducts(true);
             return ($customization_quantity == $product_total_quantity && $this->deleteProduct((int)$id_product, (int)$id_product_attribute, null, (int)$id_address_delivery));
         }
 
@@ -1318,7 +1314,7 @@ class CartCore extends ObjectModel
         if ($result) {
             $return = $this->update();
             // refresh cache of self::_products
-            $this->_products = $this->getProducts(true);
+            $this->getProducts(true);
             CartRule::autoRemoveFromCart();
             CartRule::autoAddToCart();
 


### PR DESCRIPTION
Test case : 

``` php
include('config/config.inc.php');
include('init.php');

function display_products($products)
{
    foreach ($products as $product) {
        echo $product['id_product'].' '.$product['name'].'<br/>';
    }
}

$context = Context::getContext();
//We make a first call to getProducts to a specific product => Expected : an array with one product
$products_2 = $context->cart->getProducts(false, 2);
// The second call should retrieve all the products in the cart => Expected : an array with products 2 and 3
$products_cart = $context->cart->getProducts();
// The last call should retrieve only product with ID 3 which is in the cart => Expected : an array with one product
$products_3 = $context->cart->getProducts(false, 3);


echo 'Number of products on first call (product : 2) : '.count($products_2).'<br/>';
display_products($products_2);echo '<br/>';echo '<br/>';
echo 'Number of products in seconde call without parameters (all cart): '.count($products_cart).'<br/>';
display_products($products_cart);echo '<br/>';echo '<br/>';
echo 'Number of products in third call (product : 3) : '.count($products_3).'<br/>';
display_products($products_3);echo '<br/>';echo '<br/>';
```

Branch 1.6.1.x : 
![image](https://cloud.githubusercontent.com/assets/2963059/12035896/302f49d0-ae41-11e5-9f03-0ccb0d7a24f0.png)

With fix : 
![image](https://cloud.githubusercontent.com/assets/2963059/12035911/4e2bfc08-ae41-11e5-9359-39c543870c3f.png)

For the time being if you make a first call to Cart::getProducts() with a specific product ID, then you cannot retrieve all the products if you don't use flush = true. 
You can not retrieve another product neither without using flush = true. 

With this correction all the calls are correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/4627)
<!-- Reviewable:end -->
