### PR TITLE
[-] WS : Error when using id_shop=all

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -394,6 +394,10 @@ class ShopCore extends ObjectModel
                 }
             }
         } else {
+			if ($id_shop == 'all'){
+                $id_shop = (int)Configuration::get('PS_SHOP_DEFAULT');
+            }
+			
             $shop = new Shop($id_shop);
             if (!Validate::isLoadedObject($shop) || !$shop->active) {
                 // No shop found ... too bad, let's redirect to default shop


### PR DESCRIPTION
If we want to make a POST to all shops, we must use the parameters
id_shop=all, but, right now, if we use that Prestashop will redirect
because 'all' is an unknown shop.

With this commit we fix this problem and we can use id_shop=all again
