### PR TITLE
[-] CORE : Fix AdminTab PHP 7 compatibility

### DIFF
--- a/classes/AdminTab.php
+++ b/classes/AdminTab.php
@@ -1095,8 +1095,9 @@ abstract class AdminTabCore
     protected function validateField($value, $field)
     {
         if (isset($field['validation'])) {
+            $field_validation = $field['validation'];
             if ((!isset($field['empty']) || !$field['empty'] || (isset($field['empty']) && $field['empty'] && $value)) && method_exists('Validate', $field['validation'])) {
-                if (!Validate::$field['validation']($value)) {
+                if (!Validate::$field_validation($value)) {
                     $this->_errors[] = Tools::displayError($field['title'].' : Incorrect value');
                     return false;
                 }


### PR DESCRIPTION
Apparently, AdminTab.php also needed a change for PHP 7.
I've been running PrestaShop just fine in production without this change, but it could be necessary for some users, see #4503. Can't hurt to make this change, I think.
