### PR TITLE
[-] FO : Fix block layered infinite loading when not logged in

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2858,8 +2858,8 @@ class ProductCore extends ObjectModel
             }
         } elseif (isset($context->customer->geoloc_id_country)) {
             $id_country = (int)$context->customer->geoloc_id_country;
-            $id_state = (int)$context->customer->id_state;
-            $zipcode = $context->customer->postcode;
+            $id_state = (int)$context->customer->geoloc_id_state;
+            $zipcode = $context->customer->geoloc_postcode;
         }
 
         if (Tax::excludeTaxeOption()) {


### PR DESCRIPTION
Notice with $context->customer->id_state; / $context->customer->postcode; because they don't exist in classes/Customer.php
- Notice: Undefined property: Customer::$id_state in /home/dev/project/high-supplies_new/classes/Product.php on line 2858
- Notice: Undefined property: Customer::$postcode in /home/dev/project/high-supplies_new/classes/Product.php on line 2859
