### PR TITLE
[*] Fixed bug in core StockManager

### DIFF
--- a/Core/Business/Stock/StockManager.php
+++ b/Core/Business/Stock/StockManager.php
@@ -125,6 +125,7 @@ class StockManager
             // The product is not a pack
             $stockAvailable->quantity = $stockAvailable->quantity + $delta_quantity;
             $stockAvailable->id_product = (int)$product->id;
+            $stockAvailable->id_product_attribute = (int)$id_product_attribute;
             $stockAvailable->update();
 
             // Decrease case only: the stock of linked packs should be decreased too.


### PR DESCRIPTION
without this line it can causes this error:

```
<b>Fatal error</b>:  Uncaught exception 'PrestaShopException' with message 'Property StockAvailable->id_product_attribute is empty' in /home/bridge79/public_html/classes/ObjectModel.php:909
Stack trace:
#0 /home/bridge79/public_html/classes/ObjectModel.php(246): ObjectModelCore->validateFields()
#1 /home/bridge79/public_html/classes/ObjectModel.php(652): ObjectModelCore->getFields()
#2 /home/bridge79/public_html/classes/stock/StockAvailable.php(406): ObjectModelCore->update(false)
#3 /home/bridge79/public_html/Core/Business/Stock/Core_Business_Stock_StockManager.php(128): StockAvailableCore->update()
#4 /home/bridge79/public_html/classes/stock/StockAvailable.php(473): Core_Business_Stock_StockManager->updateQuantity(Object(Product), '0', -1, NULL)
#5 /home/bridge79/public_html/classes/order/OrderDetail.php(473): StockAvailableCore::updateQuantity('30', '0', -1)
#6 /home/bridge79/public_html/classes/order/OrderDetail.php(638): OrderDetailCore-&gt;checkProductStock(Array, 13)
#7 /home/bridge79/public_html/classes/order/OrderDetail.php in <b>/home/bridge79/public_html/classes/ObjectModel.php</b> on line <b>909</b><br />
```
