### PR TITLE
[-] FO : Fix incorrect product-list-colors caching (PSCSX-7531)

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1617,21 +1617,14 @@ class FrontControllerCore extends Controller
         Tools::enableCache();
         foreach ($products as &$product) {
             $tpl = $this->context->smarty->createTemplate(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
-            if (isset($colors[$product['id_product']])) {
-                $tpl->assign(array(
-                    'id_product'  => $product['id_product'],
-                    'colors_list' => $colors[$product['id_product']],
-                    'link'        => Context::getContext()->link,
-                    'img_col_dir' => _THEME_COL_DIR_,
-                    'col_img_dir' => _PS_COL_IMG_DIR_
-                ));
-            }
-
-            if (!in_array($product['id_product'], $products_need_cache) || isset($colors[$product['id_product']])) {
-                $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
-            } else {
-                $product['color_list'] = '';
-            }
+            $tpl->assign(array(
+                'id_product'  => $product['id_product'],
+                'colors_list' => isset($colors[$product['id_product']]) ? $colors[$product['id_product']] : null,
+                'link'        => Context::getContext()->link,
+                'img_col_dir' => _THEME_COL_DIR_,
+                'col_img_dir' => _PS_COL_IMG_DIR_
+            ));
+            $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
         }
         Tools::restoreCacheSettings();
     }


### PR DESCRIPTION
In case of a product without any color declinaison, product-list-color cache is declared anyway but not complete. Then category page loading generates counter-performant DELETE/INSERT queries in ps_smarty_lazy_cache.
Cf. https://www.prestashop.com/forums/topic/496428-1612-cache-product-list-et-ps-smarty-lazy-cache/
