### PR TITLE
// BO : updated product form specific price subpart

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -147,10 +147,12 @@ class ProductSpecificPrice extends CommonAbstractType
             'required' => false,
         ))
         ->add('sp_reduction', 'money', array(
+            'label' => $this->translator->trans('Reduction', [], 'AdminProducts'),
             'required' => false,
             'currency' => $this->currency->iso_code,
         ))
         ->add('sp_reduction_type', 'choice', array(
+            'label' => $this->translator->trans('Reduction type', [], 'AdminProducts'),
             'choices'  => array(
                 'amount' => '€',
                 'percentage' => $this->translator->trans('%', [], 'AdminProducts'),
@@ -158,6 +160,7 @@ class ProductSpecificPrice extends CommonAbstractType
             'required' => true,
         ))
         ->add('sp_reduction_tax', 'choice', array(
+            'label' => $this->translator->trans('Reduction tax', [], 'AdminProducts'),
             'choices'  => array(
                 '0' => $this->translator->trans('Tax excluded', [], 'AdminProducts'),
                 '1' => $this->translator->trans('Tax included', [], 'AdminProducts'),

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-specific-price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-specific-price.html.twig
@@ -1,0 +1,47 @@
+ {{ form_errors(form) }}
+    {{ form_row(form.sp_id_shop) }}
+    <div class="form-group">
+        <div class="col-sm-4">{{ form_row(form.sp_id_currency) }}</div>
+        <div class="col-sm-4">{{ form_row(form.sp_id_country) }}</div>
+        <div class="col-sm-4">{{ form_row(form.sp_id_group) }}</div>
+    </div>
+
+    {{ form_row(form.sp_id_product_attribute) }}
+    <div class="form-group">
+        <div class="col-sm-6">
+            {{ form_row(form.sp_from) }}
+        </div>
+        <div class="col-sm-6">
+            {{ form_row(form.sp_to) }}
+        </div>
+    </div>
+
+    <div class="form-group form-inline">
+        <div class="col-sm-4">
+            <label class="control-label">{{ form.sp_from_quantity.vars.label }} </label>
+            {{ form_widget(form.sp_from_quantity) }}
+        </div>
+        <div class="col-sm-4">
+            <label class="control-label">{{ form.sp_price.vars.label }} </label>
+            {{ form_widget(form.sp_price) }}
+        </div>
+        <div class="col-sm-4">
+            {{ form_widget(form.leave_bprice) }}
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-4">
+            <label class="control-label">{{ form.sp_reduction.vars.label }}</label>
+            {{ form_widget(form.sp_reduction) }}
+        </div>
+        <div class="col-sm-4">
+            <label class="control-label">{{ form.sp_reduction_type.vars.label }}</label>
+            {{ form_widget(form.sp_reduction_type) }}
+        </div>
+        <div class="col-sm-4">
+            <label class="control-label">{{ form.sp_reduction_tax.vars.label }}</label>
+            {{ form_widget(form.sp_reduction_tax) }}
+        </div>
+    </div>
+{{ form_row(form.save) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -400,8 +400,8 @@
                                         {{ trans('Add a specific price', {}, 'AdminProducts') }}
                                     </a>
                                     <div class="collapse" id="specific_price_form" data-action="{{ path('admin_specific_price_add') }}">
-                                        {{ form_errors(form.step2.specific_price) }}
-                                        {{ form_widget(form.step2.specific_price) }}
+                                        <br />
+                                        {{ include('PrestaShopBundle:Admin:Product/Include/form-specific-price.html.twig', {'form': form.step2.specific_price}) }}
                                     </div>
                                 </div>
                             </div>
@@ -412,12 +412,13 @@
                             </div>
                             <label class="col-sm-2 control-label">{{ trans('Priorities', {}, 'AdminProducts') }}</label>
                             <div class="col-sm-10">
-                                {{ form_widget(form.step2.specificPricePriority_0) }}
-                                {{ form_widget(form.step2.specificPricePriority_1) }}
-                                {{ form_widget(form.step2.specificPricePriority_2) }}
-                                {{ form_widget(form.step2.specificPricePriority_3) }}
 
-                                {{ form_widget(form.step2.specificPricePriorityToAll) }}
+                                {{ form_row(form.step2.specificPricePriority_0) }}
+                                {{ form_row(form.step2.specificPricePriority_1) }}
+                                {{ form_row(form.step2.specificPricePriority_2) }}
+                                {{ form_row(form.step2.specificPricePriority_3) }}
+
+                                {{ form_row(form.step2.specificPricePriorityToAll) }}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Hi,

I moved specific price part on this own template, I also added some missing labels.

I join a screenshoot.

Regards,

![form](https://cloud.githubusercontent.com/assets/1247388/12263636/22303042-b931-11e5-9a3c-32b10627af91.png)
