### PR TITLE
// BO : added tooltip system

### DIFF
--- a/src/PrestaShopBundle/Resources/public/admin/js/default.js
+++ b/src/PrestaShopBundle/Resources/public/admin/js/default.js
@@ -1,0 +1,6 @@
+/**
+ * Tooltip initiation
+ */
+$(function () {
+    $('[data-toggle="tooltip"]').tooltip();
+});

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_3_horizontal_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_3_horizontal_layout.html.twig
@@ -1,5 +1,4 @@
 {% use "PrestaShopBundle:Admin/TwigTemplateForm:bootstrap_3_layout.html.twig" %}
-
 {% block form_start -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-horizontal')|trim}) %}
     {{- parent() -}}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
@@ -205,22 +205,26 @@
 {%- block form_label -%}
     {% if label is not sameas(false) -%}
         {% if not compound -%}
-    {% set label_attr = label_attr|merge({'for': id}) %}
-{%- endif %}
+            {% set label_attr = label_attr|merge({'for': id}) %}
+        {%- endif %}
         {% if required -%}
-    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
-{%- endif %}
+            {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
+        {%- endif %}
         {% if label is empty -%}
-    {%- if label_format is not empty -%}
-        {% set label = label_format|replace({
-        '%name%': name,
-        '%id%': id,
-        }) %}
-    {%- else -%}
-        {% set label = name|humanize %}
-    {%- endif -%}
-{%- endif -%}
+            {%- if label_format is not empty -%}
+                {% set label = label_format|replace({
+                    '%name%': name,
+                    '%id%': id,
+                }) %}
+            {%- else -%}
+                {% set label = name|humanize %}
+            {%- endif -%}
+        {%- endif -%}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ translation_domain is sameas(false) ? label|raw : label|raw }}</label>
+        {% if label_attr['tooltip'] is defined %}
+            {% set placement = label_attr['tooltip_placement'] is defined ? label_attr['tooltip_placement'] : 'top' %}
+            <i class="icon-question" data-toggle="tooltip" data-placement="{{ placement }}" title="{{ label_attr['tooltip'] }}"></i>
+        {% endif %}
     {%- endif -%}
 {%- endblock form_label -%}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
@@ -8,6 +8,8 @@
     )
 )) %}
 
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
+
 {% block stylesheets %}
     {% stylesheets '@PrestaShopBundle/Resources/public/admin/css/*' filter='cssrewrite' %}
     <link rel="stylesheet" href="{{ asset_url|admin_asset_path }}" />

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -1,0 +1,3 @@
+{% macro form_label_tooltip(name, tooltip, placement) %}
+    {{ form_label(name, null, {'label_attr': {'tooltip': tooltip, 'tooltip_placement': placement|default('top')}}) }}
+{% endmacro %}


### PR DESCRIPTION
Hi,

I suggest a generic way to add tooltip on each form field label.

I've introduced a macro:

``` twig
ps.form_label_tooltip('field_name', 'this is an important tip, please read it')
```

From Form Types, use the `tooltip` label attribute:

``` php
$formBuilder->add('field_name', 'text', [
    'label_attr' => [
        'tooltip' => 'this is an important tip, please read it'
    ]
]);
```

Regards,
