### PR TITLE
Moved MySQL plaform configuration requirement

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -69,7 +69,7 @@ doctrine:
                 dbname:   "%database_name%"
                 user:     "%database_user%"
                 password: "%database_password%"
-                server_version: %database_server_version%
+                server_version: 5.1
                 charset:  UTF8
                 # if using pdo_sqlite as your database driver:
                 #   1. add the path in parameters.yml

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -8,7 +8,6 @@ parameters:
     database_user:     root
     database_password: ~
     database_prefix:   ps_
-    database_server_version: 5.1
     # You should uncomment this if you want use pdo_sqlite
     # database_path: "%kernel.root_dir%/data.db3"
 


### PR DESCRIPTION
Hi,

to avoid conflits on migration, it's better to set the minimal requirements in configuration instead of make it part of web installation process.

Regards,

ping @xGouley 
