### PR TITLE
[+] BO: add show_condition field (checkbox) to Product

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -181,6 +181,9 @@ class ProductCore extends ObjectModel
     /** @var string Object available order date */
     public $available_date = '0000-00-00';
 
+    /** @var bool Will the condition select should be visible for this product ? */
+    public $show_condition = true;
+
     /** @var string Enumerated (enum) product condition (new, used, refurbished) */
     public $condition;
 
@@ -306,6 +309,7 @@ class ProductCore extends ObjectModel
             'id_product_redirected' =>        array('type' => self::TYPE_INT, 'shop' => true, 'validate' => 'isUnsignedId'),
             'available_for_order' =>        array('type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'),
             'available_date' =>            array('type' => self::TYPE_DATE, 'shop' => true, 'validate' => 'isDateFormat'),
+            'show_condition' =>            array('type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'),
             'condition' =>                    array('type' => self::TYPE_STRING, 'shop' => true, 'validate' => 'isGenericName', 'values' => array('new', 'used', 'refurbished'), 'default' => 'new'),
             'show_price' =>                array('type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'),
             'indexed' =>                    array('type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'),

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -364,6 +364,10 @@ class AdminProductsControllerCore extends AdminController
             if ($this->checkMultishopBox('online_only', $this->context)) {
                 $object->online_only = (int)Tools::getValue('online_only');
             }
+
+            if ($this->checkMultishopBox('show_condition', $this->context)) {
+                $object->show_condition = (int)Tools::getValue('show_condition');
+            }
         }
         if ($this->isTabSubmitted('Prices')) {
             $object->on_sale = (int)Tools::getValue('on_sale');

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -31,6 +31,10 @@ ALTER TABLE  `PREFIX_product_attribute` ADD  `isbn` VARCHAR( 13 ) NULL DEFAULT N
 ALTER TABLE  `PREFIX_stock` ADD  `isbn` VARCHAR( 13 ) NULL DEFAULT NULL;
 ALTER TABLE  `PREFIX_supply_order_detail` ADD  `isbn` VARCHAR( 13 ) NULL DEFAULT NULL;
 
+ALTER TABLE `PREFIX_product` ADD `show_condition` TINYINT(1) NOT NULL DEFAULT '1' AFTER `available_date`;
+ALTER TABLE `PREFIX_product_shop` ADD `show_condition` TINYINT(1) NOT NULL DEFAULT '1' AFTER `available_date`;
+
+
 /* Add Payment Preferences tab. SuperAdmin profile is the only one to access it. */
 /* PHP:ps_1701_add_payment_preferences_tab(); */;
 UPDATE `PREFIX_access` SET `view` = '0', `add` = '0', `edit` = '0', `delete` = '0' WHERE `id_tab` = (SELECT `id_tab` FROM `PREFIX_tab` t WHERE t.`class_name` = 'AdminPaymentPreferences' LIMIT 1) AND `id_profile` > 1;

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
@@ -153,6 +153,10 @@ class ProductOptions extends CommonAbstractType
             'required' => false,
             'label' => $this->translator->trans('Reference code', [], 'AdminProducts')
         ))
+        ->add('show_condition', 'checkbox', array(
+            'required' => false,
+            'label' => $this->translator->trans('Display condition', [], 'AdminProducts'),
+        ))
         ->add('condition', 'choice', array(
             'choices'  => array(
                 'new' => $this->translator->trans('New', [], 'AdminProducts'),

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -491,6 +491,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
                 'ean13' => $this->product->ean13,
                 'isbn' => $this->product->isbn,
                 'reference' => $this->product->reference,
+                'show_condition' => (bool) $this->product->show_condition,
                 'condition' => $this->product->condition,
                 'suppliers' => array_map(
                     function ($s) {

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -151,6 +151,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             'available_for_order',
             'show_price',
             'online_only',
+            'show_condition',
             'condition',
             'wholesale_price',
             'price',

--- a/src/PrestaShopBundle/Resources/public/admin/extra-js/product/form.js
+++ b/src/PrestaShopBundle/Resources/public/admin/extra-js/product/form.js
@@ -46,11 +46,7 @@ $(document).ready(function() {
 	imagesProduct.init();
 	priceCalculation.init();
 	displayFieldsManager.refresh();
-
-	/** Type product fields display management */
-	$('#form_step1_type_product').change(function(){
-		displayFieldsManager.refresh();
-	});
+	displayFieldsManager.init();
 });
 
 
@@ -64,6 +60,17 @@ var displayFieldsManager = (function() {
 	var combinations = $('#combinations');
 
 	return {
+		'init': function() {
+			/** Type product fields display management */
+			$('#form_step1_type_product').change(function(){
+				displayFieldsManager.refresh();
+			});
+
+			/** Show condition and condition fields management */
+			$('#form_step6_show_condition').on('change', function() {
+				displayFieldsManager.refresh();
+			});
+		},
 		'refresh': function() {
 			$('#virtual_product').hide();
 			$('#form-nav a[href="#step3"]').text(translate_javascripts['Quantity']);
@@ -98,6 +105,9 @@ var displayFieldsManager = (function() {
 				combinations.hide();
 				$('#product_qty_0_shortcut_div, #quantity-no-attribute, #step3_minimal_quantity').show();
 			}
+
+			/** check condition field enabler */
+			$('#form_step6_condition').prop('disabled', ($('#form_step6_show_condition:checked').length == 0));
 		}
 	};
 })();

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -475,6 +475,7 @@
                         {{ form_row(form.step6.ean13) }}
                         {{ form_row(form.step6.isbn) }}
                         {{ form_row(form.step6.reference) }}
+                        {{ form_row(form.step6.show_condition) }}
                         {{ form_row(form.step6.condition) }}
                         {{ form_row(form.step6.suppliers) }}
                         {{ form_row(form.step6.default_supplier) }}


### PR DESCRIPTION
Please run these to add the new fields to an existing DB:
ALTER TABLE `ps_product` ADD `show_condition` TINYINT(1) NOT NULL DEFAULT '1' AFTER `available_date`;
ALTER TABLE `ps_product_shop` ADD `show_condition` TINYINT(1) NOT NULL DEFAULT '1' AFTER `available_date`;

Or re-run install script.
