### PR TITLE
[*] Contact-form : Order reference in contact form

### DIFF
--- a/controllers/front/ContactController.php
+++ b/controllers/front/ContactController.php
@@ -169,10 +169,14 @@ class ContactControllerCore extends FrontController
                     }
 
                     $id_product = (int)Tools::getValue('id_product');
-
+			
                     if (isset($ct) && Validate::isLoadedObject($ct) && $ct->id_order) {
                         $order = new Order((int)$ct->id_order);
-                        $var_list['{order_name}'] = $order->getUniqReference();
+                    } elseif($id_order) {
+                    	$order = new Order((int)$id_order);
+                    }
+                    if(Validate::isLoadedObject($order)) {
+                    	$var_list['{order_name}'] = $order->getUniqReference();
                         $var_list['{id_order}'] = (int)$order->id;
                     }
 


### PR DESCRIPTION
Add the order reference in the contact form email, even if the $contact->customer_service is to false
Actually if the 'Contact' have set 'Save the message ?' to false, the email never contain the order reference.
