### PR TITLE
[-] FO: Fix JavaScript mistake in blocklayered.js

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -463,7 +463,7 @@ function reloadContent(params_plus)
 	}
 
 	var slideUp = true;
-	if (typeof params_plus === undefined || !(typeof params_plus === 'string'))
+	if (typeof params_plus === 'undefined' || !(typeof params_plus === 'string'))
 	{
 		params_plus = '';
 		slideUp = false;


### PR DESCRIPTION
From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof):

> The typeof operator returns a **string** indicating the type of the unevaluated operand.

So checking a variable as `=== undefined` is a mistake.
