### PR TITLE
[+] BO - Add a quick access to quick access management page

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -236,6 +236,12 @@
 									{l s='Add current page to QuickAccess'}
 								</a>
 							</li>
+							<li>
+								<a href="{$link->getAdminLink("AdminQuickAccesses")|addslashes}">
+									<i class="icon-cog"></i>
+									{l s='Manage quick accesses'}
+								</a>
+							</li>
 						</ul>
 					</li>
 				</ul>


### PR DESCRIPTION
Hi,

I've just added a link to access directly to "Quick Accesses" management page.

Regards

![capture_boom](https://cloud.githubusercontent.com/assets/1247388/12426716/65d22a62-bedb-11e5-8dd2-e071cb0ecf50.png)
