### PR TITLE
[-] FO : Fix combination price calculation with impact and reduction

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3027,7 +3027,7 @@ class ProductCore extends ObjectModel
         // convert only if the specific price is in the default currency (id_currency = 0)
         if (!$specific_price || !($specific_price['price'] >= 0 && $specific_price['id_currency'])) {
             $price = Tools::convertPrice($price, $id_currency);
-            if (isset($specific_price['price'])) {
+            if (isset($specific_price['price']) && $specific_price['price'] >= 0) {
                 $specific_price['price'] = $price;
             }
         }


### PR DESCRIPTION
Follow-up to my comment on this pull request : https://github.com/PrestaShop/PrestaShop/pull/4261

When a product as combinations with impacts, if you apply a specific price in percent (so price==-1 et reduction=XXX), you shouldn't erase the "-1" because the javascript in the front office doesn't know what kind of specific price this is, and just applies the "price" instead of the reduction on the base_price+combination_price. (thus the displayed price is wrong).

Easily doable on 1.6.1.4 by adding amount impacts on combination for the product "Robe d'été imprimée" for instance.

(maybe it's the JS that needs to be fixed if erasing the -1 is actually useful somewhere else).
