### PR TITLE
[+] BO: added quick access to SEO&URL category from SEO part of Product

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
@@ -26,8 +26,8 @@
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslateType;
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * This form class is responsible to generate the product SEO form

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-seo.html.twig
@@ -1,0 +1,25 @@
+<div class="col-lg-9">
+    {{ form_widget(form) }}
+</div>
+<div class="col-lg-3">
+    {% render controller('PrestaShopBundle:Admin\\Common:recommendedModules',
+    {'limit': 3, 'randomize': 1, 'domain': 'products_seo' })
+    %}
+</div>
+<div class="clearfix"></div>
+
+<div class="alert alert-info">
+    {{ trans('Urls management is done in URLS and SEO section. You can improve the URL format of products by following this link.', [], 'AdminProducts') }}
+    <a href="{{ getAdminLink("AdminMeta") }}">{{ trans('SEO and URLS', [], 'AdminProducts') }}</a>
+
+    <p>
+        {% if 'PS_REWRITING_SETTINGS'|configuration == 0 %}
+            {{ trans('The management of simplified urls is disabled. To enable it, click on the following link.', [], 'AdminProducts') }}
+            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ trans('SEO and URLS', [], 'AdminProducts') }}</a>
+        {% else %}
+            {{ trans('The management of simplified urls is enabled. To disable it, click on the following link.', [], 'AdminProducts') }}
+            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ trans('SEO and URLS', [], 'AdminProducts') }}</a>
+        {% endif %}
+    </p>
+
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -457,15 +457,7 @@
                     <div class="clearfix"></div>
                 </div>
                 <div role="tabpanel" class="tab-pane panel panel-default" id="step5">
-                    <div class="col-lg-9">
-                        {{ form_widget(form.step5) }}
-                    </div>
-                    <div class="col-lg-3">
-                        {% render controller('PrestaShopBundle:Admin\\Common:recommendedModules',
-                            {'limit': 3, 'randomize': 1, 'domain': 'products_seo' })
-                        %}
-                    </div>
-                    <div class="clearfix"></div>
+                    {{ include('PrestaShopBundle:Admin/Product/Include:form-seo.html.twig',{'form' : form.step5}) }}
                 </div>
                 <div role="tabpanel" class="tab-pane panel panel-default" id="step6">
                     <div class="col-lg-9">

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -81,6 +81,7 @@ class LayoutExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFunction('getLegacyLayout', array($this, 'getLegacyLayout')),
+            new \Twig_SimpleFunction('getAdminLink', array($this, 'getAdminLink')),
         );
     }
 
@@ -143,6 +144,20 @@ EOF;
         );
 
         return $content;
+    }
+
+    /**
+     * This is a Twig port of the Smarty {$link->getAdminLink()} function
+     *
+     * @param string $controller the controller name
+     * @param bool $withToken
+     * @param array[string] $extraParams
+     *
+     * @return string
+     */
+    public function getAdminLink($controllerName, $withToken = true, $extraParams = [])
+    {
+        return $this->context->getAdminLink($controllerName, $withToken = true, $extraParams = []);
     }
 
     /**


### PR DESCRIPTION
Hi,

a little improvement of SEO section in Product page.

We can know access directly to the SEO & URL category.

Regards,

![boom170](https://cloud.githubusercontent.com/assets/1247388/12483887/b57c1758-c057-11e5-91b8-aba1e80055c7.png)
