### PR TITLE
// Removed event dispatch notices from Symfony log files

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -43,6 +43,7 @@ monolog:
             type: stream
             path: %kernel.logs_dir%/%kernel.environment%.log
             level: notice
+            channels: [!event]
         legacy:
             type: service
             id: prestashop.handler.log

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -17,6 +17,7 @@ monolog:
             type:   stream
             path:   "%kernel.logs_dir%/%kernel.environment%.log"
             level:  debug
+            channels: [!event]
         console:
             type:   console
             bubble: false


### PR DESCRIPTION
Hi,

some informations from log files does'nt bring any value, so it's better to remove them from log files (http://symfony.com/blog/new-in-symfony-streamlined-log-files).

Regards,
