### PR TITLE
[-] BO : Change only active state on bulk status change

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3848,6 +3848,7 @@ class AdminControllerCore extends Controller
             foreach ($this->boxes as $id) {
                 /** @var ObjectModel $object */
                 $object = new $this->className((int)$id);
+                $object->setFieldsToUpdate(array('active' => true));
                 $object->active = (int)$status;
                 $result &= $object->update();
             }


### PR DESCRIPTION
1. Edit a product and set a unit price
2. Select the product and perform the bulk action "Disable selection" => The unit price has been reset to 0
3. Enable the product again => The unit price is still 0
