### PR TITLE
// disable test, but don't mask it

### DIFF
--- a/tests/Unit/Adapter/Admin/UrlGeneratorTest.php
+++ b/tests/Unit/Adapter/Admin/UrlGeneratorTest.php
@@ -39,7 +39,7 @@ class UrlGeneratorTest extends UnitTestCase
     {
         parent::setUp();
 
-        $this->context->language = new \stdClass();
+        $this->context->language = new \Language;
         $this->context->language->id = 42;
         $this->legacyContext = Phake::partialMock('PrestaShop\\PrestaShop\\Adapter\\LegacyContext');
         Phake::when($this->legacyContext)->getAdminBaseUrl()->thenReturn('admin_fake_base');

--- a/tests/Unit/Adapter/Admin/UrlGeneratorTest.php
+++ b/tests/Unit/Adapter/Admin/UrlGeneratorTest.php
@@ -49,8 +49,9 @@ class UrlGeneratorTest extends UnitTestCase
 
     public function test_generate_equivalent_route()
     {
-        // FIXME: cannot use kernel in unit tests while legacy is here. To fix when legacy will be fully refactored.
-        /*
+        return $this->markTestSkipped(
+            "Cannot use kernel in unit tests while legacy is here. To fix when legacy will be fully refactored."
+        );
         $router = $this->sfKernel->getContainer()->get('router');
         $generator = new UrlGenerator($this->legacyContext, $router);
 
@@ -58,6 +59,5 @@ class UrlGeneratorTest extends UnitTestCase
         list($controller, $parameters) = $generator->getLegacyOptions('admin_product_catalog');
         $this->assertEquals('AdminProducts', $controller);
         $this->assertCount(0, $parameters);
-        */
     }
 }


### PR DESCRIPTION
Just commenting out the test gives the impression that it passes, whereas `markTestSkipped` doesn't count as an error but is visible.

As a bonus, with a skipped test it is no problem if the `setup` fails (which it does on my computer).
