### PR TITLE
[-] Project: Authentified from Github in travis build

### DIFF
--- a/.travis.composer.config.json
+++ b/.travis.composer.config.json
@@ -1,0 +1,7 @@
+{
+   "config":{
+      "github-oauth":{
+         "github.com":"0436deaf8a25dbb100780570d4da244d5207bab3"
+      }
+   }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ before_install:
 
 before_script:
   - phpenv config-rm xdebug.ini
+  - "mkdir -p ~/.composer"
+  - cp .travis.composer.config.json ~/.composer/config.json
 
 notifications:
   slack: prestashop:Eovjydk55zPrwPkoQIOF0cZn


### PR DESCRIPTION
Hi,
in travis build, we need to be authenticated against Github because the limit of API calls for non authenticated user is too limited for our needs (60 requests/h).

Now we are allowed to make 5000 requests/h.

Regards,
