### PR TITLE
Pipes in product names in autocomplete

### DIFF
--- a/admin-dev/ajax_products_list.php
+++ b/admin-dev/ajax_products_list.php
@@ -76,6 +76,7 @@ $items = Db::getInstance()->executeS($sql);
 
 if ($items && ($excludeIds || strpos($_SERVER['HTTP_REFERER'], 'AdminScenes') !== false)) {
     foreach ($items as $item) {
+    	$item['name'] = str_replace('|', '&#124;', $item['name']);
         echo trim($item['name']).(!empty($item['reference']) ? ' (ref: '.$item['reference'].')' : '').'|'.(int)($item['id_product'])."\n";
     }
 } elseif ($items) {


### PR DESCRIPTION
Convert pipe characters with their html entity for product name compatibility with autocomplete.js

How to reproduce bug : 
- Add a pipe in a product name
- Try to add this product as an accessory for an other product
- Autocomplete fails to load this product because of the pipe present in the name
