### PR TITLE
[-] CORE: Fix object model shop field filter

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -338,12 +338,12 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
             // E.g. if only lang fields are filtered, ignore fields without lang => true
             if (($type == self::FORMAT_LANG && empty($data['lang']))
                 || ($type == self::FORMAT_SHOP && empty($data['shop']))
-                || ($type == self::FORMAT_COMMON && ((!empty($data['shop']) && $data['shop'] != 'both') || !empty($data['lang'])))) {
+                || ($type == self::FORMAT_COMMON && ((!empty($data['shop']) && $data['shop'] !== 'both') || !empty($data['lang'])))) {
                 continue;
             }
 
             if (is_array($this->update_fields)) {
-                if ((!empty($data['lang']) || (!empty($data['shop']) && $data['shop'] != 'both')) && (empty($this->update_fields[$field]) || ($type == self::FORMAT_LANG && empty($this->update_fields[$field][$id_lang])))) {
+                if ((!empty($data['lang']) || (!empty($data['shop']) && $data['shop'] !== 'both')) && (empty($this->update_fields[$field]) || ($type == self::FORMAT_LANG && empty($this->update_fields[$field][$id_lang])))) {
                     continue;
                 }
             }


### PR DESCRIPTION
I actually don't know it is a bug or if it will break things, but I'm `95%` sure it is. Probably went unnoticed since it does't affect many functions. Where I encountered it:
In my custom `ObjectModel` I declared a field `'shop' => true`, I wan to have a column inside `_shop` table, but not in the primary (common) table. This bug causes me to have the column in the primary table even though it will be filled with dummy values by PrestaShop.

I'd be great if someone could check this
