### PR TITLE
[*] CORE : Quick fix to improve CLDR performance. 

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -90,7 +90,7 @@ class CurrencyCore extends ObjectModel
 
     public function __construct($id = null, $id_lang = null, $id_shop = null)
     {
-        $this->cldr = new Repository(Context::getContext()->language);
+        $this->cldr = Tools::getCldr(Context::getContext());
 
         parent::__construct($id, $id_lang, $id_shop);
 

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -650,7 +650,13 @@ class ToolsCore
             $currency = Currency::getCurrencyInstance((int)$currency);
         }
 
-        $cldr = new PrestaShop\PrestaShop\Core\Cldr\Repository(Context::getContext()->language);
+        static $cldr_cache;
+        if (!empty($cldr_cache[Context::getContext()->language->language_code])) {
+            $cldr = $cldr_cache[Context::getContext()->language->language_code];
+        } else {
+            $cldr = new PrestaShop\PrestaShop\Core\Cldr\Repository(Context::getContext()->language->language_code);
+            $cldr_cache[Context::getContext()->language->language_code] = $cldr;
+        }
 
         return $cldr->getPrice($price, is_array($currency) ? $currency['iso_code'] : $currency->iso_code);
     }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -642,9 +642,7 @@ class ToolsCore
         if ($context) {
             $language_code = $context->language->language_code;
         }
-        if (empty($language_code)) {
-            throw new PrestaShopException('Invalid language code');
-        }
+
         if (!empty($cldr_cache[$language_code])) {
             $cldr = $cldr_cache[$language_code];
         } else {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -628,6 +628,14 @@ class ToolsCore
         return $currency;
     }
 
+    /**
+     * Return the CLDR associated with the context or given language_code
+     *
+     * @param Context|null $context
+     * @param null         $language_code
+     * @return \PrestaShop\PrestaShop\Core\Cldr\Repository
+     * @throws PrestaShopException
+     */
     public static function getCldr(Context $context = null, $language_code = null)
     {
         static $cldr_cache;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -651,11 +651,12 @@ class ToolsCore
         }
 
         static $cldr_cache;
-        if (!empty($cldr_cache[Context::getContext()->language->language_code])) {
-            $cldr = $cldr_cache[Context::getContext()->language->language_code];
+        $language_code = strtolower(is_object($context) ? $context->language_code : $context);
+        if (!empty($cldr_cache[$language_code])) {
+            $cldr = $cldr_cache[$language_code];
         } else {
-            $cldr = new PrestaShop\PrestaShop\Core\Cldr\Repository(Context::getContext()->language->language_code);
-            $cldr_cache[Context::getContext()->language->language_code] = $cldr;
+            $cldr = new PrestaShop\PrestaShop\Core\Cldr\Repository($language_code);
+            $cldr_cache[$language_code] = $cldr;
         }
 
         return $cldr->getPrice($price, is_array($currency) ? $currency['iso_code'] : $currency->iso_code);

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -628,6 +628,25 @@ class ToolsCore
         return $currency;
     }
 
+    public static function getCldr(Context $context = null, $language_code = null)
+    {
+        static $cldr_cache;
+        if ($context) {
+            $language_code = $context->language->language_code;
+        }
+        if (empty($language_code)) {
+            throw new PrestaShopException('Invalid language code');
+        }
+        if (!empty($cldr_cache[$language_code])) {
+            $cldr = $cldr_cache[$language_code];
+        } else {
+            $cldr = new PrestaShop\PrestaShop\Core\Cldr\Repository($language_code);
+            $cldr_cache[$language_code] = $cldr;
+        }
+
+        return $cldr;
+    }
+
     /**
     * Return price with currency sign for a given product
     *
@@ -650,14 +669,8 @@ class ToolsCore
             $currency = Currency::getCurrencyInstance((int)$currency);
         }
 
-        static $cldr_cache;
-        $language_code = strtolower(is_object($context->language) ? $context->language->language_code : $context->language);
-        if (!empty($cldr_cache[$language_code])) {
-            $cldr = $cldr_cache[$language_code];
-        } else {
-            $cldr = new PrestaShop\PrestaShop\Core\Cldr\Repository($language_code);
-            $cldr_cache[$language_code] = $cldr;
-        }
+        $cldr = self::getCldr($context);
+
 
         return $cldr->getPrice($price, is_array($currency) ? $currency['iso_code'] : $currency->iso_code);
     }
@@ -669,7 +682,7 @@ class ToolsCore
      */
     public static function displayNumber($number, $currency = null)
     {
-        $cldr = new PrestaShop\PrestaShop\Core\Cldr\Repository(Context::getContext()->language);
+        $cldr = self::getCldr(Context::getContext());
 
         return $cldr->getNumber($number);
     }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -651,7 +651,7 @@ class ToolsCore
         }
 
         static $cldr_cache;
-        $language_code = strtolower(is_object($context) ? $context->language_code : $context);
+        $language_code = strtolower(is_object($context->language) ? $context->language->language_code : $context->language);
         if (!empty($cldr_cache[$language_code])) {
             $cldr = $cldr_cache[$language_code];
         } else {

--- a/controllers/admin/AdminCurrenciesController.php
+++ b/controllers/admin/AdminCurrenciesController.php
@@ -38,7 +38,7 @@ class AdminCurrenciesControllerCore extends AdminController
         $this->table = 'currency';
         $this->className = 'Currency';
         $this->lang = false;
-        $this->cldr = new Repository(Context::getContext()->language);
+        $this->cldr = Tools::getCldr(Context::getContext());
 
         $this->fields_list = array(
             'name' => array('title' => $this->l('Currency'), 'orderby' => false, 'search' => false),

--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -41,7 +41,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
         $this->className = 'SpecificPriceRule';
         $this->lang = false;
         $this->multishop_context = Shop::CONTEXT_ALL;
-        $this->cldr = new Repository(Context::getContext()->language);
+        $this->cldr = Tools::getCldr(Context::getContext());
 
         /* if $_GET['id_shop'] is transmitted, virtual url can be loaded in config.php, so we wether transmit shop_id in herfs */
         if ($this->id_shop = (int)Tools::getValue('shop_id')) {

--- a/src/Core/Cldr/Update.php
+++ b/src/Core/Cldr/Update.php
@@ -114,7 +114,7 @@ class Update extends Repository
             throw new \Exception('Error : the locale is not valid');
         }
 
-        $cldrRepository = new Repository($locale);
+        $cldrRepository = \Tools::getCldr(null, $locale);
         $locale = $cldrRepository->getCulture();
 
         $file = $this->cldrCacheFolder.DIRECTORY_SEPARATOR.'core.zip';

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -89,7 +89,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         $this->context = $legacyContext;
         $this->contextShop = $this->context->getContext();
         $this->adminProductWrapper = $adminProductWrapper;
-        $this->cldrRepository = new cldrRepository($this->contextShop->language);
+        $this->cldrRepository = \Tools::getCldr($this->contextShop);
         $this->locales = $this->context->getLanguages();
         $this->defaultLocale = $this->locales[0]['id_lang'];
         $this->tools = $toolsAdapter;


### PR DESCRIPTION
Avoid to keep calling ICanBoogie\CLDR\FileProvider::retrieve which is quite heavy.
A better fix will be to change PrestaShop\PrestaShop\Core\Cldr\Repository to be a singleton, to avoid the construct & CLDR init cost.
