### PR TITLE
// Do not block execution when Addons API not available

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -418,6 +418,9 @@ class AdminModuleDataProvider extends AbstractAdminQueryBuilder implements Modul
                     $product->price->USD = 0;
                     $product->price->GBP = 0;
                 }
+                if (! isset($product->url)) {
+                    $product->url = '';
+                }
                 // ToDo: Does this test should be in the Addon service ?
                 //if (isset($product->installed) && $product->installed == 1) {
                     foreach (['logo.png', 'logo.gif'] as $logo) {

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -237,10 +237,15 @@ class ModuleController extends Controller
             }
         }
 
-        foreach ($modulesProvider->getCatalogModules() as $product) {
-            if (isset($product->origin) && $product->origin === 'customer') {
-                $products->to_install[] = (object)$product;
+        try {
+            foreach ($modulesProvider->getCatalogModules() as $product) {
+                if (isset($product->origin) && $product->origin === 'customer') {
+                    $products->to_install[] = (object)$product;
+                }
             }
+        } catch (Exception $e) {
+            // Todo: To be replaced by a warning when implemented
+            $this->addFlash('error', 'Cannot get catalog data from PrestaShop Addons. This page can be incomplete.');
         }
 
         foreach ($products as $product_label => $products_part) {

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/catalog.html.twig
@@ -30,6 +30,8 @@
     {# Actual Page Content #}
     {% include 'PrestaShopBundle:Admin/Module/_partials:_modules_grid.html.twig' %}
     {# Module Categories Grid #}
-    {% include 'PrestaShopBundle:Admin/Module/_partials:_modules_categories_grid.html.twig' with { 'categories' : topMenuData.categories }  %}
+    {% if topMenuData.categories is defined %}
+        {% include 'PrestaShopBundle:Admin/Module/_partials:_modules_categories_grid.html.twig' with { 'categories' : topMenuData.categories }  %}
+    {% endif %}
 
 {% endblock %}

--- a/tests/Unit/Adapter/Module/AdminModuleDataProviderTest.php
+++ b/tests/Unit/Adapter/Module/AdminModuleDataProviderTest.php
@@ -58,6 +58,16 @@ class AdminModuleDataProviderTest extends UnitTestCase
         }
 
         $this->setupSfKernel();
+
+        // We try to load the Addons catalog. If it fails, we skip the tests of this file.
+        try {
+            $dataProvider = new AdminModuleDataProvider($this->sfKernel);
+            $dataProvider->getCatalogModules();
+        } catch (\Exception $e) {
+            if ($e->getMessage() == 'Data from PrestaShop Addons is invalid, and cannot fallback on cache') {
+                $this->markTestSkipped('The Addons catalog is not available, test skipped x_x');
+            }
+        }
     }
 
     public function test_modules_in_catalog()


### PR DESCRIPTION
When the Addons API cannot send data, we should be able to handle it.

With this PR, we just make this specific error silent.
![b49fbd6541e373303ae7debfb0ff843b](https://cloud.githubusercontent.com/assets/6768917/12715844/df45c614-c8dc-11e5-90f5-5e2c78ecc823.jpg)
