### PR TITLE
[+] BO: Param: Default activation state for product at creation

### DIFF
--- a/controllers/admin/AdminPPreferencesController.php
+++ b/controllers/admin/AdminPPreferencesController.php
@@ -108,6 +108,14 @@ class AdminPPreferencesControllerCore extends AdminController
                         'cast' => 'intval',
                         'required' => false,
                         'type' => 'bool'
+                    ),
+                    'PS_PRODUCT_ACTIVATION_DEFAULT' => array(
+                        'title' => $this->l('Default activation state'),
+                        'hint' => $this->l('When active, new products will be activated by default during creation.'),
+                        'validation' => 'isBool',
+                        'cast' => 'intval',
+                        'required' => false,
+                        'type' => 'bool'
                     )
                 ),
                 'submit' => array('title' => $this->l('Save'))

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -379,4 +379,12 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
 
         return $paginationLimitChoices;
     }
+
+    /* (non-PHPdoc)
+     * @see \PrestaShopBundle\Service\DataProvider\Admin\ProductInterface::isNewProductDefaultActivated()
+     */
+    public function isNewProductDefaultActivated()
+    {
+        return (bool) \Configuration::get('PS_PRODUCT_ACTIVATION_DEFAULT');
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -310,6 +310,8 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function newAction()
     {
+        $productProvider = $this->container->get('prestashop.core.admin.data_provider.product_interface');
+        /* @var $productProvider ProductInterfaceProvider */
         $contextAdapter = $this->get('prestashop.adapter.legacy.context');
         $context = $contextAdapter->getContext();
         $toolsAdapter = $this->container->get('prestashop.adapter.tools');
@@ -318,7 +320,7 @@ class ProductController extends FrameworkBundleAdminController
         $name = $translator->trans('New product', [], 'AdminProducts');
 
         $product = $productAdapter->getProductInstance();
-        $product->active = 0;
+        $product->active = $productProvider->isNewProductDefaultActivated()? 1 : 0;
         $product->id_category_default = $context->shop->id_category;
 
         //set name and link_rewrite in each lang

--- a/src/PrestaShopBundle/Service/DataProvider/Admin/ProductInterface.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Admin/ProductInterface.php
@@ -109,4 +109,13 @@ interface ProductInterface
      * @return string The last SQL query that was compiled with $this->compileSqlQuery()
      */
     public function getLastCompiledSql();
+
+    /**
+     * Returns default activation state for new product.
+     *
+     * Duplication process could be different since duplicated product is always deactivated after duplication.
+     *
+     * @return boolean True if a newly created product should be activated by default.
+     */
+    public function isNewProductDefaultActivated();
 }


### PR DESCRIPTION
New parameter to auto activate (or not) a new product during creation on the Backoffice.
