### PR TITLE
[+] StarterTheme: add body classes

### DIFF
--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -164,4 +164,17 @@ class CategoryControllerCore extends ProductListingFrontController
     {
         return $this->category;
     }
+
+    public function getTemplateVarPage()
+    {
+        $page = parent::getTemplateVarPage();
+
+        $page['body_classes']['-id-'.$this->category->id] = true;
+        $page['body_classes']['-'.$this->category->name] = true;
+        $page['body_classes']['-id-parent-'.$this->category->id_parent] = true;
+        $page['body_classes']['-depth-level-'.$this->category->level_depth] = true;
+
+
+        return $page;
+    }
 }


### PR DESCRIPTION
Now we'll add many classes to the HTML body. 2 of them are available on every pages:
- layout name
- page name

Then some pages have extra classes. I only worked on Product, CMS and Category page. We'll see if more page need this kind of variants ([following RSCSS](http://rscss.io/variants.html)).
### Product

``` html
<body id="product" class="layout-full-width page-product -id-3 -robe-imprimee -id-category-9 -id-manufacturer-1 -id-supplier-1 -on-sale -available-for-order -customizable">
```
### Category

``` html
<body id="category" class="layout-full-width page-category -id-8 -robes -id-parent-3 -depth-level-3">
```
### CMS

``` html
<body id="cms" class="layout-full-width page-cms -id-8">
```
