### PR TITLE
// Remove PS_QUICK_VIEW options

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -459,7 +459,6 @@ class FrontControllerCore extends Controller
             'b2b_enable'          => (bool)Configuration::get('PS_B2B_ENABLE'),
             'request'             => $link->getPaginationLink(false, false, false, true),
             'PS_STOCK_MANAGEMENT' => Configuration::get('PS_STOCK_MANAGEMENT'),
-            'quick_view'          => (bool)Configuration::get('PS_QUICK_VIEW'),
         ));
 
         /**

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -790,9 +790,6 @@ Country</value>
   <configuration id="PS_DASHBOARD_SIMULATION" name="PS_DASHBOARD_SIMULATION">
     <value>1</value>
   </configuration>
-  <configuration id="PS_QUICK_VIEW" name="PS_QUICK_VIEW">
-    <value>1</value>
-  </configuration>
   <configuration id="PS_USE_HTMLPURIFIER" name="PS_USE_HTMLPURIFIER">
     <value>1</value>
   </configuration>


### PR DESCRIPTION
This closes: https://trello.com/c/7aZdZS7v/243-ps-quick-view-should-probably-be-removed-from-core-options
