### PR TITLE
// added toplevel link when menu is open

### DIFF
--- a/themes/classic/modules/blocktopmenu/blocktopmenu.tpl
+++ b/themes/classic/modules/blocktopmenu/blocktopmenu.tpl
@@ -1,5 +1,8 @@
-{function name="menu" nodes=[] depth=0}
+{function name="menu" nodes=[] depth=0 parent=null}
   {strip}
+    {if $depth === 1}
+      <a href="{$node.url nofilter}">{$node.label}</a>
+    {/if}
     {if $nodes|count}
       <ul aria-labelledby="dLabel" data-depth="{$depth}" class="top-menu">
         {foreach from=$nodes item=node}
@@ -14,7 +17,7 @@
                 {$node.label}
               </a>
               <div {if $depth === 0} class="dropdown-menu sub-menu" {/if}>
-                {menu nodes=$node.children depth=$node.depth}
+                {menu nodes=$node.children depth=$node.depth parent=$node}
               </div>
             </li>
           {else}


### PR DESCRIPTION
Because the menu opens on click, in order to access the first level link we need to repeat it in the drop-down menu.

This PR introduces this behavior but without styling:

![image](https://cloud.githubusercontent.com/assets/1460499/12746508/4f5b7e40-c99f-11e5-8070-c5b4a9a745ed.png)
