### PR TITLE
[-] Project: Updated Monolog bundle to remove deprecated notices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "doctrine/orm": "~2.5.0",
     "doctrine/doctrine-bundle": "1.5.2",
     "symfony/swiftmailer-bundle": "2.3.8",
-    "symfony/monolog-bundle": "2.8.1",
+    "symfony/monolog-bundle": "2.8.2",
     "sensio/distribution-bundle": "4.0.1",
     "sensio/framework-extra-bundle": "3.0.10",
     "composer/installers": "1.0.21",


### PR DESCRIPTION
Hi,

release 2.8.2 of MonologBundle avoid all deprecated notices from Symfony 2.8.

Regards,
