### PR TITLE
Change Phone Fields Shown in Guest Checkout

### DIFF
--- a/themes/default-bootstrap/order-opc-new-account.tpl
+++ b/themes/default-bootstrap/order-opc-new-account.tpl
@@ -248,7 +248,7 @@
 						<label for="other">{l s='Additional information'}</label>
 						<textarea class="form-control" name="other" id="other" cols="26" rows="7"></textarea>
 					</div>
-					<div class="form-group is_customer_param">
+					<div class="form-group">
 						<label for="phone">{l s='Home phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
 						<input type="text" class="text form-control validate" name="phone" id="phone" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone) && $guestInformations.phone}{$guestInformations.phone}{/if}" />
 					</div>


### PR DESCRIPTION
While most people do have a Mobile phone these days not everyone does so removing this code from the file will show both fields in the Guest checkout.
This will also help customers not get confused as to what they are supposed to enter.
