### PR TITLE
// Modules page rubber patches

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -418,7 +418,7 @@ class LinkCore
                     $params = array_merge($params, $sfRouteParams);
                 }
                 break;
-            case 'AdminModules':
+            case 'AdminModulesSf':
                 // New architecture modification: temporary behavior to switch between old and new controllers.
                 return $this->getBaseLink().basename(_PS_ADMIN_DIR_).'/module/catalog';
                 break;

--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -195,6 +195,9 @@
             </tab>
 
                 <tab id="Module_Page" id_parent="Modules" active="1" hide_host_mode="0" icon="">
+                    <class_name>AdminModulesSf</class_name>
+                </tab>
+                <tab id="Module_Page_old" id_parent="Modules" active="0" hide_host_mode="0" icon="">
                     <class_name>AdminModules</class_name>
                 </tab>
                 <tab id="Marketing_tools" id_parent="Modules" active="1" hide_host_mode="0" icon="">

--- a/src/Adapter/Addons/AddonsDataProvider.php
+++ b/src/Adapter/Addons/AddonsDataProvider.php
@@ -210,6 +210,16 @@ class AddonsDataProvider implements AddonsInterface
         throw new Exception('Cannot execute request '.$action.' to Addons');
     }
 
+    protected function getAddonsCredentials()
+    {
+        $request = Request::createFromGlobals();
+
+        return [
+           'username_addons' => $request->cookies->get('username_addons'),
+           'password_addons' => $request->cookies->get('password_addons'),
+        ];
+    }
+
     /** Does this function should be in a User related class ? **/
     public function getAddonsEmail()
     {

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -134,13 +134,11 @@ class AdminModuleDataProvider extends AbstractAdminQueryBuilder implements Modul
                 if ($addon->active == 0) {
                     $addon->url_active = 'enable';
                     unset(
-                        $addon->urls['update'],
                         $addon->urls['install']
                     );
                 } elseif ($addon->is_configurable == 1) {
                     $addon->url_active = 'configure';
                     unset(
-                        $addon->urls['update'],
                         $addon->urls['enable'],
                         $addon->urls['install']
                     );
@@ -151,6 +149,11 @@ class AdminModuleDataProvider extends AbstractAdminQueryBuilder implements Modul
                         $addon->urls['install'],
                         $addon->urls['enable'],
                         $addon->urls['configure']
+                    );
+                }
+                if (empty($addon->database_version) || version_compare($addon->database_version, $addon->version, '=')) {
+                    unset(
+                        $addon->urls['update']
                     );
                 }
             } elseif (isset($addon->origin) && in_array($addon->origin, ['native', 'native_all', 'partner', 'customer'])) {
@@ -400,6 +403,9 @@ class AdminModuleDataProvider extends AbstractAdminQueryBuilder implements Modul
                             continue;
                         }
                     }
+
+                    // Legacy fix
+                    $installed_module['installed'] = 1;
                 }
                 $this->manage_modules = $this->convertJsonForNewCatalog(['products' => $all_installed_modules]);
                 $this->manage_categories = $this->getCategoriesFromModules($this->manage_modules);

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -386,7 +386,12 @@ class AdminModuleDataProvider extends AbstractAdminQueryBuilder implements Modul
                 $all_installed_modules = $this->getAllInstalledModules();
 
                 // Why all these foreach ? Because we need to join data from 3 different arrays.
-                foreach ($all_installed_modules as &$installed_module) {
+                foreach ($all_installed_modules as $key => &$installed_module) {
+                    // Be careful, if the module is missing from the modules folder, do not display it !
+                    if (!$this->isModuleOnDisk($installed_module['name'])) {
+                        unset($all_installed_modules[$key]);
+                        continue;
+                    }
                     //
                     foreach ($this->catalog_modules as $catalog_module) {
                         if ($catalog_module->name === $installed_module['name']) {

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -184,10 +184,8 @@ class ModuleController extends Controller
             $ret[$module]['msg'] = 'Invalid action';
         }
 
-        if ($ret[$module]['status']) {
-            $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
-            $modulesProvider->clearManageCache();
-        }
+        $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
+        $modulesProvider->clearManageCache();
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse($ret, 200);

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -56,7 +56,7 @@ class ModuleController extends Controller
             shuffle($products);
             $topMenuData = $this->getTopMenuData();
         } catch (Exception $e) {
-            $this->addFlash('error', 'Cannot get catalog data. Please try again later.');
+            $this->addFlash('error', 'Cannot get catalog data, please try again later.');
             $products = [];
             $topMenuData = [];
         }
@@ -244,7 +244,9 @@ class ModuleController extends Controller
             $products->{$subpart} = [];
         }
 
+        $installed_modules = [];
         foreach ($modulesProvider->getManageModules() as $installed_product) {
+            $installed_modules[] = $installed_product->name;
             if (!empty($installed_product->warning)) {
                 $row = 'to_configure';
             } elseif ($installed_product->installed == 1 && $installed_product->database_version !== 0 && version_compare($installed_product->database_version, $installed_product->version, '<')) {
@@ -260,7 +262,7 @@ class ModuleController extends Controller
 
         try {
             foreach ($modulesProvider->getCatalogModules() as $product) {
-                if (isset($product->origin) && $product->origin === 'customer') {
+                if (isset($product->origin) && $product->origin === 'customer' && !in_array($product->name, $installed_modules)) {
                     $products->to_install[] = (object)$product;
                 }
             }


### PR DESCRIPTION
- Provide the link to the new module page ONLY in the side menu (By doing so, module still works on their configuration page)
- Fixes modules in manage tab not displayed as installed
- Brings back accidentally removed function
- Add calls to module upgrade functions directly in the new module controller (Will change with the ModuleManager)
- In notifications tab, remove already installed module from purchased modules list

![rustines](https://cloud.githubusercontent.com/assets/6768917/12811207/3e94d0d8-cb2b-11e5-88ab-e95baf752a22.jpg)
