### PR TITLE
Starter theme/fix/template override

### DIFF
--- a/config/defines_uri.inc.php
+++ b/config/defines_uri.inc.php
@@ -33,26 +33,6 @@ define('_THEME_IMG_DIR_', _THEME_DIR_.'assets/img/');
 define('_THEME_CSS_DIR_', _THEME_DIR_.'assets/css/');
 define('_THEME_JS_DIR_', _THEME_DIR_.'assets/js/');
 
-/* For mobile devices */
-if (file_exists(_PS_THEME_DIR_.'mobile/')) {
-    define('_PS_THEME_MOBILE_DIR_', _PS_THEME_DIR_.'mobile/');
-    define('_THEME_MOBILE_DIR_', _THEMES_DIR_._THEME_NAME_.'/mobile/');
-} else {
-    define('_PS_THEME_MOBILE_DIR_', _PS_ROOT_DIR_.'/themes/'._PS_DEFAULT_THEME_NAME_);
-    define('_THEME_MOBILE_DIR_', _PS_THEME_DIR_);
-}
-define('_PS_THEME_MOBILE_OVERRIDE_DIR_', _PS_THEME_OVERRIDE_DIR_);
-
-define('_THEME_MOBILE_IMG_DIR_', _THEME_IMG_DIR_);
-define('_THEME_MOBILE_CSS_DIR_', _THEME_CSS_DIR_);
-define('_THEME_MOBILE_JS_DIR_', _THEME_JS_DIR_);
-
-/* For touch pad devices */
-define('_PS_THEME_TOUCHPAD_DIR_', _PS_THEME_DIR_);
-define('_THEME_TOUCHPAD_DIR_', _THEMES_DIR_._THEME_NAME_);
-define('_THEME_TOUCHPAD_CSS_DIR_', _THEME_CSS_DIR_);
-define('_THEME_TOUCHPAD_JS_DIR_', _THEME_JS_DIR_);
-
 /* Image URLs */
 define('_PS_IMG_', __PS_BASE_URI__.'img/');
 define('_PS_ADMIN_IMG_', _PS_IMG_.'admin/');


### PR DESCRIPTION
## Custom templates

We distinguished layout and template:
- **Layout**: The way the page is arranged (full width, 2 columns, content only, etc)
- **Template**: The actual smarty file loaded: `cms/page.tpl`, `catalog/product.tpl`

This seems pretty obvious but the code wasn't exactly working this way.
PrestaShop used to call it _theme overrides_ now there is no `override/` folder anymore, only specific template.

FrontControllers usually assign template this way:

``` php
$this->setTemplate('catalog/product.tpl');
```

and we load the file found at this exact location in the theme.

Now `setTemplate()` we look for more specific templates before. As of today (for the `catalog/product.tpl` example):
1. catalog/product-{id_product}.tpl
2. catalog/product.tpl

**Do you have any idea for extra rules ?**

**Note:** _product-{id_product}.tpl_ can extend _product.tpl_ and simply override one smart block.
## Module Smarty Resource for templates

This is some sort of namespace for module template. Instead of loading
a file from the given path, Smarty will look for a corresponding template
in multiple locations (following priority order). Thanks to [Smarty Custom Resources](http://www.smarty.net/docs/en/resources.custom.tpl).

PrestaShop already allow theme to override module templates but if they
were using `include` statement, you had to override theme all.

Now module can allow theme to override only one template by using the following
syntax.

``` smarty
{include file="module:module_directory_name/path/to/template/file.tpl"}
```
### Example with blockcart module

If we want to allow theme to override only the product line template
but not the main one (and vice versa), you simply need to replace:

``` smarty
<li>{include './blockcart-product-line.tpl' product=$product}</li>
```

by

``` smarty
<li>{include file="module:blockcart/blockcart-product-line.tpl" product=$product}</li>
```
