### PR TITLE
[-] CORE : Don't minify email HTML, long lines break html on many emails

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -997,7 +997,7 @@ abstract class PaymentModuleCore extends Module
 
         if (Tools::file_exists_cache($default_mail_template_path)) {
             $this->context->smarty->assign('list', $var);
-            return $this->context->smarty->fetch($default_mail_template_path);
+            return $this->context->smarty->fetch($default_mail_template_path,null,null,null,false,true,true);
         }
         return '';
     }


### PR DESCRIPTION
If Minify HTML is on in CCC, then large orders can break emails.

HTML email spec states emails should have a line length must be under 998 characters, and ideally under 78 characters [See here: (Section 2.1.1)
](https://tools.ietf.org/html/rfc2822#section-2.1.1)
More complex themes that override mail/order_conf_product_list.tpl can easily cause this limit to appear even on small orders.
