### PR TITLE
[POC] Implement Dependency Injection into Legacy controllers

### DIFF
--- a/classes/container/LegacyCompilerPass.php
+++ b/classes/container/LegacyCompilerPass.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * 2007-2015 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+
+class LegacyCompilerPass implements CompilerPassInterface
+{
+    /**
+     * Add legacy services that need to be built using Context::getContext().
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $context = Context::getContext();
+
+        $this->buildSyntheticDefinitions([
+            'configuration',
+            'context',
+            'db',
+            'shop',
+            'employee',
+        ], $container);
+
+        $container->set('context', $context);
+        $container->set('configuration', new Configuration($context->shop));
+        $container->set('db', Db::getInstance());
+        $container->set('shop', $context->shop);
+        $container->set('employee', $context->employee);
+    }
+
+    private function buildSyntheticDefinitions(array $keys, ContainerBuilder $container)
+    {
+        foreach ($keys as $key) {
+            $definition = new Definition();
+            $definition->setSynthetic(true);
+            $container->setDefinition($key, $definition);
+        }
+    }
+}

--- a/config/services/ps_dev.yml
+++ b/config/services/ps_dev.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: ps_prod.yml }

--- a/config/services/ps_prod.yml
+++ b/config/services/ps_prod.yml
@@ -1,0 +1,21 @@
+parameters:
+
+services:
+  sf_filesystem:
+    class: Symfony\Component\Filesystem\Filesystem
+  sf_finder:
+    class: Symfony\Component\Finder\Finder
+
+  hook_provider:
+    class: PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider
+  hook_repository:
+    class: PrestaShop\PrestaShop\Core\Module\HookRepository
+    arguments: ["@hook_provider", "@shop", "@db"]
+  hook_configurator:
+    class: PrestaShop\PrestaShop\Core\Module\HookConfigurator
+    arguments: ["@hook_repository"]
+  theme_checker:
+    class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeChecker
+  theme_manager:
+    class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager
+    arguments: ["@shop", "@configuration", "@theme_checker", "@employee", "@sf_filesystem", "@sf_finder", "@hook_configurator"]


### PR DESCRIPTION
**This is a POC don't merge it for now /!\**

The idea behind this contribution is to make dependency injection available in legacy parts of PrestaShop.

This way we can start a better refactoring, and introduce later a LegacyKernel... note that containers are not shared between Symfony application and PrestaShop legacy for now.

You can do:

``` php
$this->get('service_declared');
```

in every class that extends `Controller`.

I introduce also 2 configurations files in `config/services` folder: `ps_prod.yml` and `ps_dev.yml`. Obviously, this is to allow service configuration regarding PrestaShop debug configuration :)

You can see an example of configuration in this pull request.

Remains:
- [x] Container cache
- [ ] Docs
- [ ] Tests /!\

Mickaël
