### PR TITLE
Allow import combination with a quantity of 0

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2733,7 +2733,7 @@ class AdminImportControllerCore extends AdminController
                 }
 
                 // This code allows us to set qty and disable depends on stock
-                if (isset($info['quantity']) && (int)$info['quantity']) {
+                if (isset($info['quantity'])) {
                     // if depends on stock and quantity, add quantity to stock
                     if ($info['depends_on_stock'] == 1) {
                         $stock_manager = StockManagerFactory::getManager();


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This change allow to import qty change for a combination product to set qty to 0 |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | no |
| How to test? |  |

Currently, it's not possible to import a combination with a quantity of 0 because stock updating depends of the next condition `if (isset($info['quantity']) && (int)$info['quantity'])` and this condition converts 0 to false.
