### PR TITLE
// [*] Made pack products available to template...

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -246,8 +246,20 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             $this->assignAttributesCombinations();
 
             // Pack management
-            $pack_items = Pack::isPack($this->product->id) ? Pack::getItemTable($this->product->id, $this->context->language->id, true) : null;
-            $this->context->smarty->assign('packItems', $pack_items);
+            $pack_items = Pack::isPack($this->product->id) ? Pack::getItemTable($this->product->id, $this->context->language->id, true) : [];
+
+            $assembler = new ProductAssembler($this->context);
+            $presenter = $this->getProductPresenter();
+            $presentedPackItems = [];
+            foreach ($pack_items as $item) {
+                $presentedPackItems[] = $presenter->presentForListing(
+                    $this->getProductPresentationSettings(),
+                    $assembler->assembleProduct($item),
+                    $this->context->language
+                );
+            }
+
+            $this->context->smarty->assign('packItems', $presentedPackItems);
             $this->context->smarty->assign('noPackPrice', $this->product->getNoPackPrice());
             $this->context->smarty->assign('displayPackPrice', ($pack_items && $productPrice < $this->product->getNoPackPrice()) ? true : false);
             $this->context->smarty->assign('packs', Pack::getPacksTable($this->product->id, $this->context->language->id, true, 1));

--- a/themes/StarterTheme/templates/catalog/pack-product-miniature.tpl
+++ b/themes/StarterTheme/templates/catalog/pack-product-miniature.tpl
@@ -1,0 +1,10 @@
+<article>
+    <h1>{$product.name}</h1>
+    <img
+      src = "{$product.cover.small.url}"
+      alt = "{$product.cover.legend}"
+      data-full-size-image-url = "{$product.cover.large.url}"
+    >
+    {$product.description_short}
+    {$product.description}
+</article>

--- a/themes/StarterTheme/templates/catalog/product.tpl
+++ b/themes/StarterTheme/templates/catalog/product.tpl
@@ -330,7 +330,7 @@
                 <h3>{l s='Pack content'}</h3>
                 {foreach from=$packItems item="product_pack"}
                   {block name='product_miniature'}
-                    {include file='catalog/product-miniature.tpl' product=$product_pack}
+                    {include file='catalog/pack-product-miniature.tpl' product=$product_pack}
                   {/block}
                 {/foreach}
             </section>


### PR DESCRIPTION
...as usual product arrays and not a special form thereof,
also introduced minimal "pack-product-miniature.tpl" template
because the role is very different form that of the usual product-miniature
