### PR TITLE
[-] FO : make the order available in order confirmation step

### DIFF
--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -81,11 +81,13 @@ class OrderConfirmationControllerCore extends FrontController
     public function initContent()
     {
         parent::initContent();
+        $order = new Order(Order::getOrderByCartId((int)($this->id_cart)));
 
         $this->context->smarty->assign(array(
             'is_guest' => $this->context->customer->is_guest,
             'HOOK_ORDER_CONFIRMATION' => $this->displayOrderConfirmation(),
-            'HOOK_PAYMENT_RETURN' => $this->displayPaymentReturn()
+            'HOOK_PAYMENT_RETURN' => $this->displayPaymentReturn(),
+            'url_to_invoice' => HistoryController::getUrlToInvoice($order, $this->context)
         ));
 
         if ($this->context->customer->is_guest) {


### PR DESCRIPTION
@nihco2 note you can already use `$is_guest` to check if you need to include a subscription form.

Now `order` is available, you can do `$url_to_invoice` to get the invoice url (the availability depends on many factors ).

Let me know if you need more :)
