### PR TITLE
[*] BO : Replaced logical operators

### DIFF
--- a/admin-dev/ajax.php
+++ b/admin-dev/ajax.php
@@ -42,7 +42,7 @@ if (Tools::getValue('page') == 'prestastore' and @fsockopen('addons.prestashop.c
     readfile('http://addons.prestashop.com/adminmodules.php?lang='.$context->language->iso_code);
 }
 
-if (Tools::isSubmit('getAvailableFields') and Tools::isSubmit('entity')) {
+if (Tools::isSubmit('getAvailableFields') && Tools::isSubmit('entity')) {
     $jsonArray = array();
     $import = new AdminImportController();
 

--- a/admin-dev/ajax_products_list.php
+++ b/admin-dev/ajax_products_list.php
@@ -31,7 +31,7 @@ include(_PS_ADMIN_DIR_.'/../config/config.inc.php');
 require_once(_PS_ADMIN_DIR_.'/init.php');
 
 $query = Tools::getValue('q', false);
-if (!$query or $query == '' or strlen($query) < 1) {
+if (!$query || $query == '' || strlen($query) < 1) {
     die();
 }
 

--- a/admin-dev/backup.php
+++ b/admin-dev/backup.php
@@ -55,7 +55,7 @@ if (!$backupfile = Tools::getValue('filename')) {
 // Check the realpath so we can validate the backup file is under the backup directory
 $backupfile = realpath($backupdir.DIRECTORY_SEPARATOR.$backupfile);
 
-if ($backupfile === false or strncmp($backupdir, $backupfile, strlen($backupdir)) != 0) {
+if ($backupfile === false || strncmp($backupdir, $backupfile, strlen($backupdir)) != 0) {
     die(Tools::dieOrLog('The backup file does not exist.'));
 }
 

--- a/admin-dev/displayImage.php
+++ b/admin-dev/displayImage.php
@@ -30,7 +30,7 @@ if (!defined('_PS_ADMIN_DIR_')) {
 require_once(_PS_ADMIN_DIR_.'/../config/config.inc.php');
 require_once(_PS_ADMIN_DIR_.'/init.php');
 
-if (isset($_GET['img']) and Validate::isMd5($_GET['img']) and isset($_GET['name']) and Validate::isGenericName($_GET['name']) and file_exists(_PS_UPLOAD_DIR_.$_GET['img'])) {
+if (isset($_GET['img']) && Validate::isMd5($_GET['img']) && isset($_GET['name']) && Validate::isGenericName($_GET['name']) && file_exists(_PS_UPLOAD_DIR_.$_GET['img'])) {
     header('Content-type: image/jpeg');
     header('Content-Disposition: attachment; filename="'.$_GET['name'].'.jpg"');
     echo file_get_contents(_PS_UPLOAD_DIR_.$_GET['img']);

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -133,7 +133,7 @@ class AdminSearchControllerCore extends AdminController
             /* Module search */
             if (!$searchType || $searchType == 7) {
                 /* Handle module name */
-                if ($searchType == 7 && Validate::isModuleName($this->query) and ($module = Module::getInstanceByName($this->query)) && Validate::isLoadedObject($module)) {
+                if ($searchType == 7 && Validate::isModuleName($this->query) && ($module = Module::getInstanceByName($this->query)) && Validate::isLoadedObject($module)) {
                     Tools::redirectAdmin('index.php?tab=AdminModules&tab_module='.$module->tab.'&module_name='.$module->name.'&anchor='.ucfirst($module->name).'&token='.Tools::getAdminTokenLite('AdminModules'));
                 }
 

--- a/controllers/admin/AdminStatesController.php
+++ b/controllers/admin/AdminStatesController.php
@@ -267,7 +267,7 @@ class AdminStatesControllerCore extends AdminController
 		WHERE s.id_country = '.(int)(Tools::getValue('id_country')).' AND s.active = 1 AND c.`contains_states` = 1
 		ORDER BY s.`name` ASC');
 
-        if (is_array($states) and !empty($states)) {
+        if (is_array($states) && !empty($states)) {
             $list = '';
             if ((bool)Tools::getValue('no_empty') != true) {
                 $empty_value = (Tools::isSubmit('empty_value')) ? Tools::getValue('empty_value') : '-';

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -767,7 +767,7 @@ class InstallModelInstall extends InstallAbstractModel
         $content = Tools::addonsRequest('install-modules', $params);
         $xml = @simplexml_load_string($content, null, LIBXML_NOCDATA);
 
-        if ($xml !== false and isset($xml->module)) {
+        if ($xml !== false && isset($xml->module)) {
             foreach ($xml->module as $modaddons) {
                 if (in_array($modaddons->name, $blacklist)) {
                     continue;

--- a/src/Core/Cldr/Localize.php
+++ b/src/Core/Cldr/Localize.php
@@ -174,7 +174,7 @@ class Localize
             $locale = self::getEnvironmentLocale();
         }
 
-        if (($locale === 'auto') or ($locale === null)) {
+        if (($locale === 'auto') || ($locale === null)) {
             $locale = self::getBrowserLocales();
             $locale += self::getEnvironmentLocale();
         }

--- a/tools/pear_xml_parser/Parser/Atom.php
+++ b/tools/pear_xml_parser/Parser/Atom.php
@@ -23,7 +23,7 @@
 
 /**
  * This is the class that determines how we manage Atom 1.0 feeds
- * 
+ *
  * How we deal with constructs:
  *  date - return as unix datetime for use with the 'date' function unless specified otherwise
  *  text - return as is. optional parameter will give access to attributes
@@ -36,37 +36,37 @@
 class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
 {
     /**
-     * The URI of the RelaxNG schema used to (optionally) validate the feed 
+     * The URI of the RelaxNG schema used to (optionally) validate the feed
      * @var string
      */
     protected $relax = 'atom.rng';
 
     /**
-     * We're likely to use XPath, so let's keep it global 
+     * We're likely to use XPath, so let's keep it global
      * @var DOMXPath
      */
     public $xpath;
 
     /**
-     * When performing XPath queries we will use this prefix 
+     * When performing XPath queries we will use this prefix
      * @var string
      */
     private $xpathPrefix = '//';
 
     /**
-     * The feed type we are parsing 
+     * The feed type we are parsing
      * @var string
      */
     public $version = 'Atom 1.0';
 
-    /** 
-     * The class used to represent individual items 
+    /**
+     * The class used to represent individual items
      * @var string
      */
     protected $itemClass = 'XML_Feed_Parser_AtomElement';
-    
-    /** 
-     * The element containing entries 
+
+    /**
+     * The element containing entries
      * @var string
      */
     protected $itemElement = 'entry';
@@ -108,7 +108,7 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
 
     /**
      * Our constructor does nothing more than its parent.
-     * 
+     *
      * @param    DOMDocument    $xml    A DOM object representing the feed
      * @param    bool (optional) $string    Whether or not to validate this feed
      */
@@ -134,7 +134,7 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
      * is available, we also use that to store a reference to the entry in the array
      * used by getEntryByOffset so that method does not have to seek out the entry
      * if it's requested that way.
-     * 
+     *
      * @param    string    $id    any valid Atom ID.
      * @return    XML_Feed_Parser_AtomElement
      */
@@ -149,7 +149,7 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
         if ($entries->length > 0) {
             $xmlBase = $entries->item(0)->baseURI;
             $entry = new $this->itemClass($entries->item(0), $this, $xmlBase);
-            
+
             if (in_array('evaluate', get_class_methods($this->xpath))) {
                 $offset = $this->xpath->evaluate("count(preceding-sibling::atom:entry)", $entries->item(0));
                 $this->entries[$offset] = $entry;
@@ -159,7 +159,7 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
 
             return $entry;
         }
-        
+
     }
 
     /**
@@ -167,7 +167,7 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
      *
      * Get a person construct. We default to the 'name' element but allow
      * access to any of the elements.
-     * 
+     *
      * @param    string    $method    The name of the person construct we want
      * @param    array     $arguments    An array which we hope gives a 'param'
      * @return    string|false
@@ -177,7 +177,7 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
         $offset = empty($arguments[0]) ? 0 : $arguments[0];
         $parameter = empty($arguments[1]['param']) ? 'name' : $arguments[1]['param'];
         $section = $this->model->getElementsByTagName($method);
-        
+
         if ($parameter == 'url') {
             $parameter = 'uri';
         }
@@ -223,11 +223,11 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
         }
         $type = $content->getAttribute('type');
 
-        if (! empty($attribute) and 
-            ! ($method == 'generator' and $attribute == 'name')) {
+        if (! empty($attribute) &&
+            ! ($method == 'generator' && $attribute == 'name')) {
             if ($content->hasAttribute($attribute)) {
                 return $content->getAttribute($attribute);
-            } elseif ($attribute == 'href' and $content->hasAttribute('uri')) {
+            } elseif ($attribute == 'href' && $content->hasAttribute('uri')) {
                 return $content->getAttribute('uri');
             }
             return false;
@@ -235,7 +235,7 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
 
         return $this->parseTextConstruct($content);
     }
-    
+
     /**
      * Extract content appropriately from atom text constructs
      *
@@ -295,7 +295,7 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
      *
      * A feed or entry can have any number of categories. A category can have the
      * attributes term, scheme and label.
-     * 
+     *
      * @param    string    $method    The name of the text construct we want
      * @param    array     $arguments    An array which we hope gives a 'param'
      * @return    string
@@ -315,8 +315,8 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
     }
 
     /**
-     * This element must be present at least once with rel="feed". This element may be 
-     * present any number of further times so long as there is no clash. If no 'rel' is 
+     * This element must be present at least once with rel="feed". This element may be
+     * present any number of further times so long as there is no clash. If no 'rel' is
      * present and we're asked for one, we follow the example of the Universal Feed
      * Parser and presume 'alternate'.
      *
@@ -327,7 +327,7 @@ class XML_Feed_Parser_Atom extends XML_Feed_Parser_Type
      */
     function getLink($offset = 0, $attribute = 'href', $params = false)
     {
-        if (is_array($params) and !empty($params)) {
+        if (is_array($params) && !empty($params)) {
             $terms = array();
             $alt_predicate = '';
             $other_predicate = '';

--- a/tools/pear_xml_parser/Parser/RSS1.php
+++ b/tools/pear_xml_parser/Parser/RSS1.php
@@ -23,7 +23,7 @@
 
 /**
  * This class handles RSS1.0 feeds.
- * 
+ *
  * @author    James Stewart <james@jystewart.net>
  * @version    Release: @package_version@
  * @package XML_Feed_Parser
@@ -32,7 +32,7 @@
 class XML_Feed_Parser_RSS1 extends XML_Feed_Parser_Type
 {
     /**
-     * The URI of the RelaxNG schema used to (optionally) validate the feed 
+     * The URI of the RelaxNG schema used to (optionally) validate the feed
      * @var string
      */
     protected $relax = 'rss10.rng';
@@ -44,19 +44,19 @@ class XML_Feed_Parser_RSS1 extends XML_Feed_Parser_Type
     protected $xpath;
 
     /**
-     * The feed type we are parsing 
+     * The feed type we are parsing
      * @var string
      */
     public $version = 'RSS 1.0';
 
     /**
-     * The class used to represent individual items 
+     * The class used to represent individual items
      * @var string
      */
     protected $itemClass = 'XML_Feed_Parser_RSS1Element';
-    
+
     /**
-     * The element containing entries 
+     * The element containing entries
      * @var string
      */
     protected $itemElement = 'item';
@@ -100,8 +100,8 @@ class XML_Feed_Parser_RSS1 extends XML_Feed_Parser_Type
         'updated' => array('date'));
 
     /**
-     * We will be working with multiple namespaces and it is useful to 
-     * keep them together 
+     * We will be working with multiple namespaces and it is useful to
+     * keep them together
      * @var array
      */
     protected $namespaces = array(
@@ -113,7 +113,7 @@ class XML_Feed_Parser_RSS1 extends XML_Feed_Parser_Type
 
     /**
      * Our constructor does nothing more than its parent.
-     * 
+     *
      * @param    DOMDocument    $xml    A DOM object representing the feed
      * @param    bool (optional) $string    Whether or not to validate this feed
      */
@@ -139,8 +139,8 @@ class XML_Feed_Parser_RSS1 extends XML_Feed_Parser_Type
      * This is not really something that will work with RSS1 as it does not have
      * clear restrictions on the global uniqueness of IDs. We will employ the
      * _very_ hit and miss method of selecting entries based on the rdf:about
-     * attribute. If DOMXPath::evaluate is available, we also use that to store 
-     * a reference to the entry in the array used by getEntryByOffset so that 
+     * attribute. If DOMXPath::evaluate is available, we also use that to store
+     * a reference to the entry in the array used by getEntryByOffset so that
      * method does not have to seek out the entry if it's requested that way.
      *
      * @param    string    $id    any valid ID.
@@ -208,20 +208,20 @@ class XML_Feed_Parser_RSS1 extends XML_Feed_Parser_Type
             $input = $inputs->item(0);
             $results = array();
             $results['title'] = isset(
-                $input->getElementsByTagName('title')->item(0)->value) ? 
+                $input->getElementsByTagName('title')->item(0)->value) ?
                 $input->getElementsByTagName('title')->item(0)->value : null;
             $results['description'] = isset(
-                $input->getElementsByTagName('description')->item(0)->value) ? 
+                $input->getElementsByTagName('description')->item(0)->value) ?
                 $input->getElementsByTagName('description')->item(0)->value : null;
             $results['name'] = isset(
-                $input->getElementsByTagName('name')->item(0)->value) ? 
+                $input->getElementsByTagName('name')->item(0)->value) ?
                 $input->getElementsByTagName('name')->item(0)->value : null;
             $results['link'] = isset(
-                   $input->getElementsByTagName('link')->item(0)->value) ? 
+                   $input->getElementsByTagName('link')->item(0)->value) ?
                    $input->getElementsByTagName('link')->item(0)->value : null;
-            if (empty($results['link']) and 
+            if (empty($results['link']) && 
                 $input->attributes->getNamedItem('resource')) {
-                $results['link'] = 
+                $results['link'] =
                     $input->attributes->getNamedItem('resource')->nodeValue;
             }
             if (! empty($results)) {
@@ -252,10 +252,10 @@ class XML_Feed_Parser_RSS1 extends XML_Feed_Parser_Type
         }
         return false;
     }
-    
+
     /**
      * Retrieve a link
-     * 
+     *
      * In RSS1 a link is a text element but in order to ensure that we resolve
      * URLs properly we have a special function for them.
      *

--- a/tools/pear_xml_parser/Parser/RSS11.php
+++ b/tools/pear_xml_parser/Parser/RSS11.php
@@ -24,7 +24,7 @@
 /**
  * This class handles RSS1.1 feeds. RSS1.1 is documented at:
  * http://inamidst.com/rss1.1/
- * 
+ *
  * @author    James Stewart <james@jystewart.net>
  * @version    Release: @package_version@
  * @package XML_Feed_Parser
@@ -34,7 +34,7 @@
 class XML_Feed_Parser_RSS11 extends XML_Feed_Parser_Type
 {
     /**
-     * The URI of the RelaxNG schema used to (optionally) validate the feed 
+     * The URI of the RelaxNG schema used to (optionally) validate the feed
      * @var string
      */
     protected $relax = 'rss11.rng';
@@ -46,19 +46,19 @@ class XML_Feed_Parser_RSS11 extends XML_Feed_Parser_Type
     protected $xpath;
 
     /**
-     * The feed type we are parsing 
+     * The feed type we are parsing
      * @var string
      */
     public $version = 'RSS 1.0';
 
     /**
-     * The class used to represent individual items 
+     * The class used to represent individual items
      * @var string
      */
     protected $itemClass = 'XML_Feed_Parser_RSS1Element';
-    
+
     /**
-     * The element containing entries 
+     * The element containing entries
      * @var string
      */
     protected $itemElement = 'item';
@@ -101,7 +101,7 @@ class XML_Feed_Parser_RSS11 extends XML_Feed_Parser_Type
         'updated' => array('date'));
 
     /**
-     * We will be working with multiple namespaces and it is useful to 
+     * We will be working with multiple namespaces and it is useful to
      * keep them together. We will retain support for some common RSS1.0 modules
      * @var array
      */
@@ -114,7 +114,7 @@ class XML_Feed_Parser_RSS11 extends XML_Feed_Parser_Type
 
     /**
      * Our constructor does nothing more than its parent.
-     * 
+     *
      * @param    DOMDocument    $xml    A DOM object representing the feed
      * @param    bool (optional) $string    Whether or not to validate this feed
      */
@@ -131,7 +131,7 @@ class XML_Feed_Parser_RSS11 extends XML_Feed_Parser_Type
         $this->xpath = new DOMXPath($model);
         foreach ($this->namespaces as $key => $value) {
             $this->xpath->registerNamespace($key, $value);
-        }            
+        }
         $this->numberEntries = $this->count('item');
     }
 
@@ -178,7 +178,7 @@ class XML_Feed_Parser_RSS11 extends XML_Feed_Parser_Type
                     'title' => $image->getElementsByTagName('title')->item(0)->value,
                     'url' => $image->getElementsByTagName('url')->item(0)->value);
                 if ($image->getElementsByTagName('link')->length > 0) {
-                    $details['link'] = 
+                    $details['link'] =
                         $image->getElementsByTagName('link')->item(0)->value;
                 }
             } else {
@@ -186,7 +186,7 @@ class XML_Feed_Parser_RSS11 extends XML_Feed_Parser_Type
                     'link' => false,
                     'url' => $image->attributes->getNamedItem('resource')->nodeValue);
             }
-            $details = array_merge($details, 
+            $details = array_merge($details,
                 array('description' => false, 'height' => false, 'width' => false));
             if (! empty($details)) {
                 return $details;
@@ -208,18 +208,18 @@ class XML_Feed_Parser_RSS11 extends XML_Feed_Parser_Type
             $input = $inputs->item(0);
             $results = array();
             $results['title'] = isset(
-                $input->getElementsByTagName('title')->item(0)->value) ? 
+                $input->getElementsByTagName('title')->item(0)->value) ?
                 $input->getElementsByTagName('title')->item(0)->value : null;
             $results['description'] = isset(
-                $input->getElementsByTagName('description')->item(0)->value) ? 
+                $input->getElementsByTagName('description')->item(0)->value) ?
                 $input->getElementsByTagName('description')->item(0)->value : null;
             $results['name'] = isset(
-                $input->getElementsByTagName('name')->item(0)->value) ? 
+                $input->getElementsByTagName('name')->item(0)->value) ?
                 $input->getElementsByTagName('name')->item(0)->value : null;
             $results['link'] = isset(
-                   $input->getElementsByTagName('link')->item(0)->value) ? 
+                   $input->getElementsByTagName('link')->item(0)->value) ?
                    $input->getElementsByTagName('link')->item(0)->value : null;
-            if (empty($results['link']) and 
+            if (empty($results['link']) && 
                 $input->attributes->getNamedItem('resource')) {
                 $results['link'] = $input->attributes->getNamedItem('resource')->nodeValue;
             }
@@ -251,7 +251,7 @@ class XML_Feed_Parser_RSS11 extends XML_Feed_Parser_Type
         }
         return false;
     }
-    
+
     /**
      * Retrieve a link
      *


### PR DESCRIPTION
Good morning.

I replaced the logical operators in the source code. The reason for this is simple: for example, the and operator does not have the same precedence as &&. Same goes with or and ||. This could lead to unexpected behavior and carries a bug risk so it is best to replace them.

Thank you. 
