### PR TITLE
[-] BO: ThemeManager on theme upload works as expected

### DIFF
--- a/admin-dev/themes/default/template/helpers/uploader/simple.tpl
+++ b/admin-dev/themes/default/template/helpers/uploader/simple.tpl
@@ -61,7 +61,7 @@
 		<input id="{$id|escape:'html':'UTF-8'}" type="file" name="{$name|escape:'html':'UTF-8'}{if isset ($multiple) && $multiple}[]{/if}"{if isset($multiple) && $multiple} multiple="multiple"{/if} class="hide" />
 		<div class="dummyfile input-group">
 			<span class="input-group-addon"><i class="icon-file"></i></span>
-			<input id="{$id|escape:'html':'UTF-8'}-name" type="text" name="filename" readonly />
+			<input id="{$id|escape:'html':'UTF-8'}-name" type="text" name="{$name|escape:'html':'UTF-8'}" readonly />
 			<span class="input-group-btn">
 				<button id="{$id|escape:'html':'UTF-8'}-selectbutton" type="button" name="submitAddAttachments" class="btn btn-default">
 					<i class="icon-folder-open"></i> {if isset($multiple) && $multiple}{l s='Add files'}{else}{l s='Add file'}{/if}

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1923,6 +1923,34 @@ class ToolsCore
         }
     }
 
+    /**
+     * Create a local file from url
+     * required because ZipArchive is unable to extract from remote files.
+     * @param string $url the remote location
+     * @return bool|string false if failure, else the local filename
+     */
+    public static function createFileFromUrl($url)
+    {
+        $remoteFile = fopen($url, "r");
+        if (!$remoteFile) {
+            return false;
+        }
+        $localFile = fopen(basename(url), "w");
+        if (!$localFile) {
+            return false;
+        }
+
+        while (!feof($remoteFile)) {
+            $data = fread($remoteFile, 1024);
+            fwrite($localFile, $data, 1024);
+        }
+
+        fclose($remoteFile);
+        fclose($localFile);
+
+        return basename($url);
+    }
+
     public static function simplexml_load_file($url, $class_name = null)
     {
         $cache_id = 'Tools::simplexml_load_file'.$url;

--- a/src/Core/Shop/ImageUploader.php
+++ b/src/Core/Shop/ImageUploader.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Shop;
+
+use Configuration;
+use ImageManager;
+use PrestaShopException;
+use Shop;
+use Tools;
+
+/**
+ * Class LogoUploader used to manage upload of Shop logos and favicon
+ *
+ * @package PrestaShop\PrestaShop\Core\Shop
+ */
+class LogoUploader
+{
+    /* @var $shop the shop */
+    private $shop;
+
+    public function __construct(Shop $shop)
+    {
+        $this->shop = $shop;
+    }
+
+    public function updateHeader()
+    {
+        $this->update('PS_LOGO', 'logo');
+    }
+
+    public function updateMail()
+    {
+        $this->update('PS_LOGO_MAIL', 'logo_mail');
+    }
+
+    public function updateInvoice()
+    {
+        $this->update('PS_LOGO_INVOICE', 'logo_invoice');
+    }
+
+    public function updateFavicon()
+    {
+        $shopId = (int) $this->shop->id;
+        if ($shopId == Configuration::get('PS_SHOP_DEFAULT')) {
+            $this->uploadIco('PS_FAVICON', _PS_IMG_DIR_.'favicon.ico');
+        }
+        if ($this->uploadIco('PS_FAVICON', _PS_IMG_DIR_.'favicon-'.$shopId.'.ico')) {
+            Configuration::updateValue('PS_FAVICON', 'favicon-'.$shopId.'.ico');
+        }
+
+        Configuration::updateGlobalValue('PS_FAVICON', 'favicon.ico');
+    }
+
+    /**
+     * Generic function which allows logo upload
+     *
+     * @param $fieldName
+     * @param $logoPrefix
+     * @param $files[] the array of files to avoid use $_POST
+     *
+     * @return bool
+     * @throws PrestaShopException in case of upload failure
+     */
+    public function update($fieldName, $logoPrefix, array $files = [])
+    {
+        $files = empty($files) ? $_FILES : $files;
+
+        if (isset($files[$fieldName]['tmp_name'], $files[$fieldName]['tmp_name'], $files[$fieldName]['size'])) {
+            if ($error = ImageManager::validateUpload($files[$fieldName], Tools::getMaxUploadSize())) {
+                throw new PrestaShopException($error);
+            }
+            $tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS');
+
+            if (!$tmpName || !move_uploaded_file($files[$fieldName]['tmp_name'], $tmpName)) {
+                throw new PrestaShopException(sprintf('%Upload of temporary file to %s has failed.', $tmpName));
+            }
+
+            $fileExtension = ($fieldName == 'PS_STORES_ICON') ? '.gif' : '.jpg';
+            $logoName = $this->getLogoName($logoPrefix, $fileExtension);
+
+            if ($fieldName == 'PS_STORES_ICON') {
+                if (!@ImageManager::resize($tmpName, _PS_IMG_DIR_.$logoName, null, null, 'gif', true)) {
+                    throw new PrestaShopException(sprintf('An error occurred while attempting to copy shop icon %s.', $logoName));
+                }
+            } else {
+                if (!@ImageManager::resize($tmpName, _PS_IMG_DIR_.$logoName)) {
+                    throw new PrestaShopException(sprintf('An error occurred while attempting to copy shop logo %s.', $logoName));
+                }
+            }
+
+            $idShop = $this->shop->id;
+            $idShopGroup = null;
+
+            if (!count($this->errors) && @filemtime(_PS_IMG_DIR_.Configuration::get($fieldName))) {
+                if (Shop::isFeatureActive()) {
+                    $this->updateInMultiShopContext($idShop, $idShopGroup, $fieldName);
+                } else {
+                    @unlink(_PS_IMG_DIR_.Configuration::get($fieldName));
+                }
+            }
+
+            Configuration::updateValue($fieldName, $logoName, false, $idShopGroup, $idShop);
+            unlink($tmpName);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function updateInMultiShopContext(&$idShop, &$idShopGroup, $fieldName)
+    {
+        if (Shop::getContext() == Shop::CONTEXT_SHOP) {
+            $idShop = Shop::getContextShopID();
+            $idShopGroup = Shop::getContextShopGroupID();
+            Shop::setContext(Shop::CONTEXT_ALL);
+            $logoAll = Configuration::get($fieldName);
+            Shop::setContext(Shop::CONTEXT_GROUP);
+            $logoGroup = Configuration::get($fieldName);
+            Shop::setContext(Shop::CONTEXT_SHOP);
+            $logoShop = Configuration::get($fieldName);
+            if ($logoAll != $logoShop && $logoGroup != $logoShop && $logoShop != false) {
+                @unlink(_PS_IMG_DIR_.Configuration::get($fieldName));
+            }
+        } elseif (Shop::getContext() == Shop::CONTEXT_GROUP) {
+            $idShopGroup = Shop::getContextShopGroupID();
+            Shop::setContext(Shop::CONTEXT_ALL);
+            $logoAll = Configuration::get($fieldName);
+            Shop::setContext(Shop::CONTEXT_GROUP);
+            if ($logoAll != Configuration::get($fieldName)) {
+                @unlink(_PS_IMG_DIR_.Configuration::get($fieldName));
+            }
+        }
+    }
+
+    public function uploadIco($name, $destination, $files = [])
+    {
+        $files = empty($files) ? $_FILES : $files;
+
+        if (isset($files[$name]['tmp_name']) && !empty($files[$name]['tmp_name'])) {
+            if ($error = ImageManager::validateIconUpload($files[$name])) {
+                throw new PrestaShopException(self::NOTICE.$error);
+            } elseif (!copy($_FILES[$name]['tmp_name'], $destination)) {
+                throw new PrestaShopException(sprintf(Tools::displayError('An error occurred while uploading the favicon: cannot copy file "%s" to folder "%s".'), $files[$name]['tmp_name'], $destination));
+            }
+        }
+
+        return !count($this->errors);
+    }
+
+    private function getLogoName($logoPrefix, $fileExtension)
+    {
+        $shopId = $this->shop->id;
+        $shopName = $this->shop->name;
+
+        $logoName = Tools::link_rewrite($shopName)
+            .'-'
+            .$logoPrefix
+            .'-'
+            .(int)Configuration::get('PS_IMG_UPDATE_TIME')
+            .(int)$shopId.$fileExtension
+        ;
+
+        if ($this->shop->getContext() == Shop::CONTEXT_ALL
+            || $shopId == 0
+            || Shop::isFeatureActive() == false
+        ) {
+            $logoName = Tools::link_rewrite($shopName)
+                . '-'
+                . $logoPrefix.'-'.(int)Configuration::get('PS_IMG_UPDATE_TIME').$fileExtension
+            ;
+        }
+
+        return $logoName;
+    }
+}


### PR DESCRIPTION
Hi,

the configuration wasnt properly loaded from YAML parser, I've fixed this behavior.

Also, there was an issue with the theme upload from an url, `ZipArchive->open()` is unable to deal with remote files, this is why I've created a new function to create a temporary local file.

When we used to download the zip file, this archive wasn't deleted after theme installation: this is now done.

Also, I've fixed logo/favicon upload and move the business logic in his own classes (sorry for non atomic commit).

Mickaël
