### PR TITLE
[+] FO: Change structure for module assets override

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1025,13 +1025,13 @@ class FrontControllerCore extends Controller
                     $file = $media;
                 }
                 if (strpos($file, __PS_BASE_URI__.'modules/') === 0) {
-                    $override_path = str_replace(__PS_BASE_URI__.'modules/', _PS_ROOT_DIR_.'/themes/'._THEME_NAME_.'/'.$type.'/modules/', $file, $different);
+                    $override_path = str_replace(__PS_BASE_URI__.'modules/', _PS_ROOT_DIR_.'/themes/'._THEME_NAME_.'/modules/', $file, $different);
                     if (strrpos($override_path, $type.'/'.basename($file)) !== false) {
                         $override_path_css = str_replace($type.'/'.basename($file), basename($file), $override_path, $different_css);
                     }
 
                     if ($different && @filemtime($override_path)) {
-                        $file = str_replace(__PS_BASE_URI__.'modules/', __PS_BASE_URI__.'themes/'._THEME_NAME_.'/'.$type.'/modules/', $file, $different);
+                        $file = str_replace(__PS_BASE_URI__.'modules/', __PS_BASE_URI__.'themes/'._THEME_NAME_.'/modules/', $file, $different);
                     } elseif ($different_css && @filemtime($override_path_css)) {
                         $file = $override_path_css;
                     }


### PR DESCRIPTION
Theme can override module assets (CSS and JS only) by placing a file at a specific location. I slightly change the location.
Since the theme assets have moved under the `assets/`, it had to be changed. I thought moving everything module-related under `modules` would make more sense. 

**BEFORE**

| Type | Original | Override |
| --: | --- | --- |
| JavaScript | /modules/MODULE_NAME/js/file.js | /themes/THEME_NAME/js/modules/MODULE_NAME/js/file.js |
| CSS | /modules/MODULE_NAME/css/style.css | /themes/THEME_NAME/css/modules/MODULE_NAME/css/style.css |
| JavaScript | /modules/MODULE_NAME/view.tpl | /themes/THEME_NAME/modules/MODULE_NAME/view.tpl |

**AFTER**

| Type | Original | Override |
| --: | --- | --- |
| JavaScript | /modules/MODULE_NAME/js/file.js | /themes/THEME_NAME/modules/MODULE_NAME/js/file.js |
| CSS | /modules/MODULE_NAME/css/style.css | /themes/THEME_NAME/modules/MODULE_NAME/css/style.css |
| JavaScript | /modules/MODULE_NAME/view.tpl | /themes/THEME_NAME/modules/MODULE_NAME/view.tpl |

Note: **css/** and **js/** have been removed between THEME_NAME/ and modules/
