### PR TITLE
Cast properties of specific price to number

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -459,7 +459,12 @@ class ProductControllerCore extends FrontController
                 if (!isset($combination_prices_set[(int)$row['id_product_attribute']])) {
                     Product::getPriceStatic((int)$this->product->id, false, $row['id_product_attribute'], 6, null, false, true, 1, false, null, null, null, $combination_specific_price);
                     $combination_prices_set[(int)$row['id_product_attribute']] = true;
-                    $combinations[$row['id_product_attribute']]['specific_price'] = $combination_specific_price;
+                    $combinations[$row['id_product_attribute']]['specific_price'] = array_merge($combination_specific_price, array(
+                        'price' => (float)$combination_specific_price['price'],
+                        'reduction' => (float)$combination_specific_price['reduction'],
+                        'reduction_tax' => (float)$combination_specific_price['reduction_tax'],
+                        'score' => (int)$combination_specific_price['score'],
+                    ));
                 }
                 $combinations[$row['id_product_attribute']]['ecotax'] = (float)$row['ecotax'];
                 $combinations[$row['id_product_attribute']]['weight'] = (float)$row['weight'];


### PR DESCRIPTION
cf #5017 

Hi !

In some commercial template, there is a round on specific price in js, like : 

``` js
combination.specific_price.price.toFixed(2)
```

but `price` property is currently a string and schould be casted to float. This thrown a fatal js error and next it's not possible to change correclty prices by combination.

![image](https://cloud.githubusercontent.com/assets/4578773/13070127/3dbbfac0-d48a-11e5-9545-ff49267e0567.png)

To fix it, I propose to cast `price` and other properties of specific price to number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5023)
<!-- Reviewable:end -->
