### PR TITLE
Synchronize stock after adding a product via ajax to an order

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2133,6 +2133,8 @@ class AdminOrdersControllerCore extends AdminController
 
         // Save changes of order
         $order->update();
+    
+        StockAvailable::synchronize($product->id);
 
         // Update weight SUM
         $order_carrier = new OrderCarrier((int)$order->getIdOrderCarrier());


### PR DESCRIPTION
The product qty wasn't updated correctly after adding a product to an order via ajax.
