### PR TITLE
[-] CORE : Fix id_order ambiguous search

### DIFF
--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -43,7 +43,7 @@ class AdminReturnControllerCore extends AdminController
 
         $this->fields_list = array(
             'id_order_return' => array('title' => $this->l('ID'), 'align' => 'center', 'width' => 25),
-            'id_order' => array('title' => $this->l('Order ID'), 'width' => 100, 'align' => 'center', 'filter_key'=>'a!id_order'),
+            'id_order' => array('title' => $this->l('Order ID'), 'width' => 100, 'align' => 'center', 'filter_key'=>'a!id_order', 'havingFilter' => true),
             'name' => array('title' => $this->l('Status'),'color' => 'color', 'width' => 'auto', 'align' => 'left'),
             'date_add' => array('title' => $this->l('Date issued'), 'width' => 150, 'type' => 'date', 'align' => 'right', 'filter_key'=>'a!date_add'),
         );


### PR DESCRIPTION
Permet d'éviter, dans un environnement strict, une erreur SQL de type "Column 'id_order' in where clause is ambiguous" au moment de rechercher un Retour produits à partir de l'ID d'une commande (le 'filter_key'=>'a!id_order' ne suffisant pas à régler ce problème).

Fix the id_order ambiguous search in strict environment
