### PR TITLE
[-] CORE : Missing variable in CartPresenter

### DIFF
--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -87,12 +87,12 @@ class CartPresenter
         $rawProduct['new'] = '';
         $rawProduct['pack'] = '';
 
-        $rawProduct['price'] = $this->pricePresenter->convertAndFormat(
-            $this->includeTaxes() ?
-            $rawProduct['price_wt'] :
-            $rawProduct['price']
-        );
-
+        if($this->includeTaxes()) {
+            $rawProduct['price'] = $this->pricePresenter->convertAndFormat($rawProduct['price_wt']);
+        } else {
+            $rawProduct['price'] = $rawProduct['price_tax_exc'] = $this->pricePresenter->convertAndFormat($rawProduct['price']);
+        }
+        
         $rawProduct['total'] = $this->pricePresenter->convertAndFormat(
             $this->includeTaxes() ?
             $rawProduct['total_wt'] :


### PR DESCRIPTION
Variable `$product['price_tax_exc']` is required in ProductPresenter
