### PR TITLE
Override admin and front controllers of modules

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -290,7 +290,12 @@ class DispatcherCore
                     $controllers = Dispatcher::getControllers(_PS_MODULE_DIR_.$module_name.'/controllers/front/');
                     if (isset($controllers[strtolower($this->controller)])) {
                         include_once(_PS_MODULE_DIR_.$module_name.'/controllers/front/'.$this->controller.'.php');
-                        $controller_class = $module_name.$this->controller.'ModuleFrontController';
+                        if (file_exists(_PS_OVERRIDE_DIR_ . 'modules/' . $module_name . '/controllers/front/' . $this->controller . '.php')) {
+                            include_once(_PS_OVERRIDE_DIR_ . 'modules/' . $module_name . '/controllers/front/' . $this->controller . '.php');
+                            $controller_class = $module_name . $this->controller . 'ModuleFrontControllerOverride';
+                        } else {
+                            $controller_class = $module_name . $this->controller . 'ModuleFrontController';
+                        }
                     }
                 }
                 $params_hook_action_dispatcher = array('controller_type' => self::FC_FRONT, 'controller_class' => $controller_class, 'is_module' => 1);
@@ -316,7 +321,12 @@ class DispatcherCore
                         } else {
                             // Controllers in modules can be named AdminXXX.php or AdminXXXController.php
                             include_once(_PS_MODULE_DIR_.$tab->module.'/controllers/admin/'.$controllers[strtolower($this->controller)].'.php');
-                            $controller_class = $controllers[strtolower($this->controller)].(strpos($controllers[strtolower($this->controller)], 'Controller') ? '' : 'Controller');
+                            if (file_exists(_PS_OVERRIDE_DIR_ . 'modules/' . $tab->module . '/controllers/admin/' . $controllers[strtolower($this->controller)] . '.php')) {
+                                include_once(_PS_OVERRIDE_DIR_ . 'modules/' . $tab->module . '/controllers/admin/' . $controllers[strtolower($this->controller)] . '.php');
+                                $controller_class = $controllers[strtolower($this->controller)] . (strpos($controllers[strtolower($this->controller)], 'Controller') ? 'Override' : 'ControllerOverride');
+                            } else {
+                                $controller_class = $controllers[strtolower($this->controller)] . (strpos($controllers[strtolower($this->controller)], 'Controller') ? '' : 'Controller');
+                            }
                         }
                     }
                     $params_hook_action_dispatcher = array('controller_type' => self::FC_ADMIN, 'controller_class' => $controller_class, 'is_module' => 1);

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -394,6 +394,9 @@ class AdminControllerCore extends Controller
 
         $this->controller_type = 'admin';
         $this->controller_name = !empty($forceControllerName) ? $forceControllerName : get_class($this);
+        if (strpos($this->controller_name, 'ControllerOverride')) {
+            $this->controller_name = substr($this->controller_name, 0, -18);
+        }
         if (strpos($this->controller_name, 'Controller')) {
             $this->controller_name = substr($this->controller_name, 0, -10);
         }


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This feature allows to override ModuleAdminController and ModuleFrontController by adding it in /override/modules/controller/admin or /override/modules/controller/front
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |




This feature allows to override ModuleAdminController and ModuleFrontController by adding it in /override/modules/controller/admin or /override/modules/controller/front

The new file should contain the ModuleAdminController or ModuleFrontController class extending the name with an "Override" suffix and extending the ModuleAdminController's or ModuleFrontControllerr's name to be its child.

Example:

```
override/modules/productscomment/controllers/front/default.php

class ProductCommentsDefaultModuleFrontControllerOverride extends ProductCommentsDefaultModuleFrontController {
    ..............
}
```
