### PR TITLE
Prevent PHP Warning in Tools class

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1242,13 +1242,13 @@ class ToolsCore
         if ($has_mb_strtolower === null) {
             $has_mb_strtolower = function_exists('mb_strtolower');
         }
+        
+        if (!is_string($str)) {
+            return false;
+        }
 
         if (isset($array_str[$str])) {
             return $array_str[$str];
-        }
-
-        if (!is_string($str)) {
-            return false;
         }
 
         if ($str == '') {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | fix PHP Warning:  Illegal offset type in isset or empty in Tools.php |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
