### PR TITLE
Select not ordered cart directly in SQL instead of excluding ordered cart in PHP

### DIFF
--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -735,15 +735,16 @@ class AdminCartsControllerCore extends AdminController
     public function displayAjaxSearchCarts()
     {
         $id_customer = (int)Tools::getValue('id_customer');
-        $carts = Cart::getCustomerCarts((int)$id_customer);
+        $carts = Cart::getCustomerCarts((int)$id_customer, false);
         $orders = Order::getCustomerOrders((int)$id_customer);
         $customer = new Customer((int)$id_customer);
 
         if (count($carts)) {
             foreach ($carts as $key => &$cart) {
                 $cart_obj = new Cart((int)$cart['id_cart']);
-                if ($cart['id_cart'] == $this->context->cart->id || !Validate::isLoadedObject($cart_obj) || $cart_obj->OrderExists()) {
+                if ($cart['id_cart'] == $this->context->cart->id) {
                     unset($carts[$key]);
+                    continue;
                 }
                 $currency = new Currency((int)$cart['id_currency']);
                 $cart['total_price'] = Tools::displayPrice($cart_obj->getOrderTotal(), $currency);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  |When adding an order manually, carts and order are loaded for the selected customer. Instead of loading all carts, and then excluding in PHP those who was ordered, it is much more efficient to not load them in the first place in SQL. When a customer have hundreds of orders this change reduce the loading time from 40~ secondes to 2 secondes on a litle server.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | In back office > Carts try to display User orders with a lot of orders in develop and in this branch.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5102)
<!-- Reviewable:end -->
