### PR TITLE
[-] CORE : get nested categories alphabetically does not return all nested categories

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -584,21 +584,24 @@ class CategoryCore extends ObjectModel
 				'.($sql_limit != '' ? $sql_limit : '')
             );
 
-            $categories = array();
-            $buff = array();
-
             if (!isset($root_category)) {
                 $root_category = Category::getRootCategory()->id;
             }
 
-            foreach ($result as $row) {
-                $current = &$buff[$row['id_category']];
-                $current = $row;
+            $categories = array();
 
+            foreach ($result as $row) {
                 if ($row['id_category'] == $root_category) {
-                    $categories[$row['id_category']] = &$current;
+                    foreach ($row as $index => $value) {
+                        $categories[$row['id_category']][$index] = $value;
+                    }
                 } else {
-                    $buff[$row['id_parent']]['children'][$row['id_category']] = &$current;
+                    if (!isset($categories[$row['id_parent']])) {
+                        $categories[$row['id_parent']] = array(
+                            'children' => array()
+                        );
+                    }
+                    $categories[$row['id_parent']]['children'][$row['id_category']] = $row;
                 }
             }
 


### PR DESCRIPTION
All the details are given in this issue https://github.com/mikaelcom/PrestaShop/issues/1,

Except for the reason I fixed it this way: I do not know if there is a way using pointers such as it had been done before. All I know is that doing `foreach ($row as $index => $value) {` should not be called often so it seems to me it's not big deal having another `foreach` in the main `foreach`. I do not know too if performances are impacted by this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5109)
<!-- Reviewable:end -->
