### PR TITLE
[+] CORE: Remove many smarty variables

### DIFF
--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -2,23 +2,25 @@
 
 use Symfony\Component\Translation\TranslatorInterface;
 use PrestaShop\PrestaShop\Adapter\Product\PricePresenter;
-use PrestaShop\PrestaShop\Adapter\ObjectSerializer;
+use PrestaShop\PrestaShop\Adapter\ObjectPresenter;
 
 class DeliveryOptionsFinderCore
 {
     private $context;
+    private $objectPresenter;
     private $translator;
+    private $pricePresenter;
 
     public function __construct(
         Context $context,
         TranslatorInterface $translator,
-        ObjectSerializer $objectSerializer,
+        ObjectPresenter $objectPresenter,
         PricePresenter $pricePresenter
     ) {
-        $this->context = $context;
-        $this->objectSerializer = $objectSerializer;
-        $this->translator = $translator;
-        $this->pricePresenter = $pricePresenter;
+        $this->context         = $context;
+        $this->objectPresenter = $objectPresenter;
+        $this->translator      = $translator;
+        $this->pricePresenter  = $pricePresenter;
     }
 
     private function isFreeShipping($cart, array $carrier)
@@ -57,7 +59,7 @@ class DeliveryOptionsFinderCore
                 foreach ($carriers_list as $carriers) {
                     if (is_array($carriers)) {
                         foreach ($carriers as $carrier) {
-                            $carrier = array_merge($carrier, $this->objectSerializer->toArray($carrier['instance']));
+                            $carrier = array_merge($carrier, $this->objectPresenter->present($carrier['instance']));
                             $delay = $carrier['delay'][$this->context->language->id];
                             unset($carrier['instance'], $carrier['delay']);
                             $carrier['delay'] = $delay;

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1252,12 +1252,13 @@ class FrontControllerCore extends Controller
     public function getTemplateVarUrls()
     {
         $http = Tools::getCurrentUrlProtocolPrefix();
+        $base_url = $this->context->shop->getBaseURL(true, true);
 
         $urls = [
-            'base_url' => $this->context->shop->getBaseURL(true, true),
+            'base_url' => $base_url,
+            'current_url' => $base_url.$_SERVER['REQUEST_URI'],
         ];
 
-        /* StarterTheme: Are these URLs really useful ? */
         $assign_array = array(
             'img_ps_url'    => _PS_IMG_,
             'img_cat_url'   => _THEME_CAT_DIR_,

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -457,27 +457,20 @@ class FrontControllerCore extends Controller
 
     protected function assignGeneralPurposeVariables()
     {
-        $customer = $this->getTemplateVarCustomer();
-        $urls = $this->getTemplateVarUrls();
-
-        /**
-         * Template vars assignation
-         */
-        $this->context->smarty->assign([
+        $templateVars = [
             'currency' => $this->getTemplateVarCurrency(),
-            'customer' => $customer,
+            'customer' => $this->getTemplateVarCustomer(),
             'language' => $this->objectSerializer->toArray($this->context->language),
             'page' => $this->getTemplateVarPage(),
             'shop' => $this->getTemplateVarShop(),
-            'urls' => $urls,
+            'urls' => $this->getTemplateVarUrls(),
             'feature_active' => $this->getTemplateVarFeatureActive(),
             'field_required' => $this->context->customer->validateFieldsRequiredDatabase(),
             'breadcrumb' => $this->getBreadcrumb(),
-        ]);
-        Media::addJsDef(['prestashop' => [
-            'customer' => $customer,
-            'urls' => $urls,
-        ]]);
+        ];
+
+        $this->context->smarty->assign($templateVars);
+        Media::addJsDef(['prestashop' => $templateVars]);
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1471,6 +1471,10 @@ class FrontControllerCore extends Controller
         ];
 
         $body_classes = [
+            'lang-'.$this->context->language->iso_code,
+            'lang-'.($this->context->language->is_rtl) ? 'rtl' : 'ltr',
+            'country-'.$this->context->country->iso_code,
+            'currency-'.$this->context->currency->iso_code,
             $this->context->shop->theme->getLayoutNameForPage($this->php_self) => true,
             'page-'.$this->php_self => true,
         ];

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -481,22 +481,17 @@ class FrontControllerCore extends Controller
         $this->assignGeneralPurposeVariables();
         $this->process();
 
-
         if (!isset($this->context->cart)) {
             $this->context->cart = new Cart();
         }
 
         $this->context->smarty->assign(array(
             'HOOK_HEADER'       => Hook::exec('displayHeader'),
-            'HOOK_TOP'          => Hook::exec('displayTop'),
         ));
     }
 
     public function initFooter()
     {
-        $this->context->smarty->assign(array(
-            'HOOK_FOOTER'       => Hook::exec('displayFooter'),
-        ));
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1310,9 +1310,15 @@ class FrontControllerCore extends Controller
     public function getTemplateVarFeatureActive()
     {
         return [
-            'b2b' => (bool)Configuration::get('PS_B2B_ENABLE'),
-            'optin' => (bool)Configuration::get('PS_CUSTOMER_OPTIN'),
-            'newsletter' => Configuration::get('PS_CUSTOMER_NWSL') || (Module::isInstalled('blocknewsletter') && Module::getInstanceByName('blocknewsletter')->active),
+            'is_b2b' => (bool)Configuration::get('PS_B2B_ENABLE'),
+            'is_catalog' => (bool)Configuration::get('PS_CATALOG_MODE'),
+            'show_prices' => (Configuration::get('PS_CATALOG_MODE')
+                            || (Group::isFeatureActive() && !(bool)Group::getCurrent()->show_prices)),
+            'opt_in' => [
+                'partner' => (bool)Configuration::get('PS_CUSTOMER_OPTIN'),
+                'newsletter' => (Configuration::get('PS_CUSTOMER_NWSL')
+                                || (Module::isInstalled('blocknewsletter') && Module::getInstanceByName('blocknewsletter')->active)),
+            ],
         ];
     }
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -27,7 +27,7 @@
 use PrestaShop\PrestaShop\Adapter\Translator;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Cart\CartPresenter;
-use PrestaShop\PrestaShop\Adapter\ObjectSerializer;
+use PrestaShop\PrestaShop\Adapter\ObjectPresenter;
 use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 
 class FrontControllerCore extends Controller
@@ -139,7 +139,7 @@ class FrontControllerCore extends Controller
     /**
      * @var object ObjectSerializer
      */
-    public $objectSerializer;
+    public $objectPresenter;
 
     /**
      * @var object CartPresenter
@@ -171,8 +171,8 @@ class FrontControllerCore extends Controller
             $useSSL = $this->ssl;
         }
 
-        $this->objectSerializer = new ObjectSerializer();
-        $this->cart_presenter = new CartPresenter;
+        $this->objectPresenter = new ObjectPresenter();
+        $this->cart_presenter  = new CartPresenter;
     }
 
     /**
@@ -460,7 +460,7 @@ class FrontControllerCore extends Controller
         $templateVars = [
             'currency' => $this->getTemplateVarCurrency(),
             'customer' => $this->getTemplateVarCustomer(),
-            'language' => $this->objectSerializer->toArray($this->context->language),
+            'language' => $this->objectPresenter->present($this->context->language),
             'page' => $this->getTemplateVarPage(),
             'shop' => $this->getTemplateVarShop(),
             'urls' => $this->getTemplateVarUrls(),
@@ -1330,9 +1330,9 @@ class FrontControllerCore extends Controller
     public function getTemplateVarCustomer($customer = null)
     {
         if (Validate::isLoadedObject($customer)) {
-            $cust = $this->objectSerializer->toArray($customer);
+            $cust = $this->objectPresenter->present($customer);
         } else {
-            $cust = $this->objectSerializer->toArray($this->context->customer);
+            $cust = $this->objectPresenter->present($this->context->customer);
         }
 
         unset($cust['secure_key']);
@@ -1343,10 +1343,10 @@ class FrontControllerCore extends Controller
 
         $cust['is_logged'] = $this->context->customer->isLogged(true);
 
-        $cust['gender'] = $this->objectSerializer->toArray(new Gender($cust['id_gender']));
+        $cust['gender'] = $this->objectPresenter->present(new Gender($cust['id_gender']));
         unset($cust['id_gender']);
 
-        $cust['risk'] = $this->objectSerializer->toArray(new Risk($cust['id_risk']));
+        $cust['risk'] = $this->objectPresenter->present(new Risk($cust['id_risk']));
         unset($cust['id_risk']);
 
         $addresses = $this->context->customer->getSimpleAddresses();

--- a/classes/proxy/LinkProxy.php
+++ b/classes/proxy/LinkProxy.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author     PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2015 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+class LinkProxyCore
+{
+    private $link;
+
+    public function __construct(Link $link)
+    {
+        $this->link = $link;
+    }
+
+    public function getPageLink($controller, $ssl = null, $id_lang = null, $request = null, $request_url_encode = false, $id_shop = null, $relative_protocol = false)
+    {
+        return $this->link->getPageLink($controller, $ssl, $id_lang, $request, $request_url_encode, $id_shop, $relative_protocol);
+    }
+
+    public function getProductLink($product, $alias = null, $category = null, $ean13 = null, $id_lang = null, $id_shop = null, $ipa = 0, $force_routes = false, $relative_protocol = false, $add_anchor = false, $extra_params = [])
+    {
+        return $this->link->getProductLink($product, $alias, $category, $ean13, $id_lang, $id_shop, $ipa, $force_routes, $relative_protocol, $add_anchor, $extra_params);
+    }
+}

--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -108,7 +108,7 @@ class CategoryControllerCore extends ProductListingFrontController
 
     protected function getTemplateVarCategory()
     {
-        $category = $this->objectSerializer->toArray($this->category);
+        $category = $this->objectPresenter->present($this->category);
         $category['image'] = $this->getImage(
             $this->category,
             $this->category->id_image

--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -91,7 +91,7 @@ class CmsControllerCore extends FrontController
 
         if ($this->assignCase == 1) {
             $this->context->smarty->assign(array(
-                'cms' => $this->objectSerializer->toArray($this->cms),
+                'cms' => $this->objectPresenter->present($this->cms),
             ));
 
             if ($this->cms->indexation == 0) {
@@ -161,7 +161,7 @@ class CmsControllerCore extends FrontController
     {
         $categoryCms = [];
 
-        $categoryCms['cms_category'] = $this->objectSerializer->toArray($this->cms_category);
+        $categoryCms['cms_category'] = $this->objectPresenter->present($this->cms_category);
         $categoryCms['sub_categories'] = [];
         $categoryCms['cms_pages'] = [];
 

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -64,7 +64,7 @@ class OrderControllerCore extends FrontController
         $deliveryOptionsFinder = new DeliveryOptionsFinder(
             $this->context,
             $this->getTranslator(),
-            $this->objectSerializer,
+            $this->objectPresenter,
             new PricePresenter
         );
 

--- a/controllers/front/OrderReturnController.php
+++ b/controllers/front/OrderReturnController.php
@@ -94,7 +94,7 @@ class OrderReturnControllerCore extends FrontController
 
     public function getTemplateVarOrderReturn($order_return)
     {
-        $order_return = $this->objectSerializer->toArray($order_return);
+        $order_return = $this->objectPresenter->present($order_return);
 
         $order_return['return_number'] = sprintf('%06d', $order_return['id']);
         $order_return['return_date'] = Tools::displayDate($order_return['date_add'], null, false);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -774,7 +774,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     public function getTemplateVarProduct()
     {
-        $product = $this->objectSerializer->toArray($this->product);
+        $product = $this->objectPresenter->present($this->product);
         $product['id_product'] = (int)$this->product->id;
         $product['out_of_stock'] = (int)$this->product->out_of_stock;
         $product['new'] = (int)$this->product->new;

--- a/src/Adapter/ObjectPresenter.php
+++ b/src/Adapter/ObjectPresenter.php
@@ -26,9 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Adapter;
 
-class ObjectSerializer
+class ObjectPresenter
 {
-    public function toArray($object)
+    public function present($object)
     {
         $arr = array();
 

--- a/src/Adapter/Order/OrderPresenter.php
+++ b/src/Adapter/Order/OrderPresenter.php
@@ -3,7 +3,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
 use PrestaShop\PrestaShop\Adapter\Cart\CartPresenter;
-use PrestaShop\PrestaShop\Adapter\ObjectSerializer;
+use PrestaShop\PrestaShop\Adapter\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PricePresenter;
 use PrestaShop\PrestaShop\Adapter\Translator;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
@@ -24,17 +24,20 @@ class OrderPresenter
 {
     /* @var CartPresenter */
     private $cartPresenter;
-    /* @var ObjectSerializer */
-    private $objectSerializer;
+
+    /* @var ObjectPresenter */
+    private $objectPresenter;
+
     /* @var PricePresenter */
     private $pricePresenter;
+
     /* @var Translator */
     private $translator;
 
     public function __construct()
     {
         $this->cartPresenter = new CartPresenter();
-        $this->objectSerializer = new ObjectSerializer();
+        $this->objectPresenter = new ObjectPresenter();
         $this->pricePresenter = new PricePresenter();
         $this->translator = new Translator(new LegacyContext());
     }
@@ -265,7 +268,7 @@ class OrderPresenter
     public function getCarrier(Order $order)
     {
         $carrier = new Carrier((int) $order->id_carrier, (int) $order->id_lang);
-        $orderCarrier = $this->objectSerializer->toArray($carrier);
+        $orderCarrier = $this->objectPresenter->present($carrier);
         $orderCarrier['name'] = ($carrier->name == '0') ? Configuration::get('PS_SHOP_NAME') : $carrier->name;
 
         return $orderCarrier;
@@ -287,11 +290,11 @@ class OrderPresenter
         $addressInvoice = new Address((int) $order->id_address_invoice);
 
         if (!$order->isVirtual()) {
-            $orderAddresses['delivery'] = $this->objectSerializer->toArray($addressDelivery);
+            $orderAddresses['delivery'] = $this->objectPresenter->present($addressDelivery);
             $orderAddresses['delivery']['formatted'] = AddressFormat::generateAddress($addressDelivery, array(), '<br />');
         }
 
-        $orderAddresses['invoice'] = $this->objectSerializer->toArray($addressInvoice);
+        $orderAddresses['invoice'] = $this->objectPresenter->present($addressInvoice);
         $orderAddresses['invoice']['formatted'] = AddressFormat::generateAddress($addressInvoice, array(), '<br />');
 
         return $orderAddresses;

--- a/src/Core/Foundation/Templating/PresentationSettingsInterface.php
+++ b/src/Core/Foundation/Templating/PresentationSettingsInterface.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2015 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Core\Foundation\Templating;
+
+interface PresentationSettingsInterface
+{
+
+}

--- a/src/Core/Foundation/Templating/PresenterInterface.php
+++ b/src/Core/Foundation/Templating/PresenterInterface.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2015 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Core\Foundation\Templating;
+
+interface PresenterInterface
+{
+    public function preset(ObjectModel $object); // must return an array
+    public function setSettings(PresentationSettingsInterface $settings);
+}

--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -6,7 +6,7 @@
 
 {block name='head' append}
   <meta property="og:type" content="product" />
-  <meta property="og:url" content="{$request}" />
+  <meta property="og:url" content="{$urls.current_url}" />
   <meta property="og:title" content="{$page.title}" />
   <meta property="og:site_name" content="{$shop.name}" />
   <meta property="og:description" content="{$page.description}" />


### PR DESCRIPTION
## Description

A lot of variable were still passed to Smarty, because we have a StarterTheme and many presenter, they shouldn't be used anymore.
## Steps to Test this Fix

There isn't step to reproduce but you can test _Classic_ and/or _StarterTheme_ and your moduleto make sure it doesn't break anything.
To be fair, it probably does since `objectSerializer` has been renamed.
