### PR TITLE
[-] CORE: Fix remaining antislash when using $this->l()

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -161,11 +161,11 @@ class TranslateCore
         $cache_key = $name.'|'.$string.'|'.$source.'|'.(int)$js;
 
         if (!isset($lang_cache[$cache_key])) {
-            if ($_MODULES == null) {
+            if ($_MODULES === null) {
                 if ($sprintf !== null) {
                     $string = Translate::checkAndReplaceArgs($string, $sprintf);
                 }
-                return str_replace('"', '&quot;', $string);
+                return stripslashes(str_replace('"', '&quot;', $string));
             }
 
             $current_key = strtolower('<{'.$name.'}'._THEME_NAME_.'>'.$source).'_'.$key;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project!
This text is a template text for your GitHub pull request description. Click the "Preview" button to see how it displays.

Please provide a general summary of your changes in the title field above, following this naming convention:
"[<type>] <category> : <short description>".

<type> can be:
* [-] for a bug fix.
* [*] for an improvement.
* [+] for a new feature.

<category> can be:
* FO : Related to the Front Office. Default theme (images, CSS, JavaScript, etc.), 'front' controllers, etc.
* BO : Related to the Back Office. BO theme, 'admin' controllers, images, CSS, JavaScript, etc.
* CORE : Related to the core of the software itself Classes, controllers, etc.
* MO : Related to modules. Please specify the module's name in the content of commit message.

Sample title: "[-] FO : Fix cart warning for IE9."

IMPORTANT: Your commits' names MUST also follow this convention. For more details, please read http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message

Guidelines:
* PrestaShop 1.7 development happens on the 'develop' branch
* PrestaShop 1.6 development happens on the '1.6.1.x' branch -- and only accept bugfixes, not improvements/new features.
* Don't target the 'master' branch!
* Make sure your local branch is up to date before commiting your changes!
* Your code MUST respect the PSR-2 Coding Style: http://doc.prestashop.com/display/PS16/Coding+Standards !
* Use 'git rebase' (in the command line) to squash/fixup unnecessary commits into only one commit, or to remove "Merge branch XXX:" commits.
-->
## Description

When a module does not include any translation for the current lang, and you want to translate a string containing simple quotes, it will add antislashes.
## Steps to Test this Fix

<!--
Describe the exact steps you've done to test that the code works. Remove the unecessary steps below :)
-->
1. Install a module that does not contains any translation for the current employee lang (module & theme)
2. Into the getContent() method, just translate a string containing simple quote like this:

`$this->l('Product\'s categories');`
- Expected : Product's categories
- Result : Product\'s categories
