### PR TITLE
[*] CORE : Remove unused variable and use product minimal quantity

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4293,9 +4293,9 @@ class ProductCore extends ObjectModel
 
         if (isset($row['quantity_wanted'])) {
             // 'quantity_wanted' may very well be zero even if set
-            $quantity = max(1, (int)$row['quantity_wanted']);
+            $quantity = max((int)$row['minimal_quantity'], (int)$row['quantity_wanted']);
         } else {
-            $quantity = 1;
+            $quantity = (int)$row['minimal_quantity'];
         }
 
         $row['price_tax_exc'] = Product::getPriceStatic(

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -16,7 +16,6 @@ class ProductPresenter
     private $imageRetriever;
     private $link;
     private $pricePresenter;
-    private $productPriceCalculator;
     private $productColorsRetriever;
     private $translator;
 
@@ -30,7 +29,6 @@ class ProductPresenter
         $this->imageRetriever = $imageRetriever;
         $this->link = $link;
         $this->pricePresenter = $pricePresenter;
-        $this->productPriceCalculator = new PriceCalculator();
         $this->productColorsRetriever = $productColorsRetriever;
         $this->translator = $translator;
     }


### PR DESCRIPTION
## Description

The variable `productPriceCalculator` is not used anymore in the `ProductPresenter`, so I removed it.
Also, we have to use `minimal_quantity` set in the back-office to calculate the price and to prevent customers to order less than the merchant defined in the BO.
