### PR TITLE
[-] Project: delete cache files on reinstallation

### DIFF
--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -93,6 +93,8 @@ class InstallControllerConsoleProcess extends InstallControllerConsole
 
     public function process()
     {
+        /* avoid exceptions on re-installation */
+        $this->clearConfigXML() && $this->clearConfigThemes();
         $steps = explode(',', $this->datas->step);
         if (in_array('all', $steps)) {
             $steps = array('database','fixtures','theme','modules','addons_modules');
@@ -289,5 +291,26 @@ class InstallControllerConsoleProcess extends InstallControllerConsole
     {
         $this->initializeContext();
         return $this->model_install->installTheme();
+    }
+
+    private function clearConfigXML()
+    {
+        $cacheFiles = glob(_PS_ROOT_DIR_.'/config/xml');
+        $excludes = ['.htaccess', 'index.php'];
+        foreach($cacheFiles as $file) {
+            if (is_file($file) && !in_array($file, $excludes)) {
+                unlink($file);
+            }
+        }
+    }
+
+    private function clearConfigThemes()
+    {
+        $cacheFiles = glob(_PS_ROOT_DIR_.'/config/themes');
+        foreach($cacheFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
     }
 }

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -75,6 +75,9 @@ class InstallControllerHttpProcess extends InstallControllerHttp
 
     public function process()
     {
+        /* avoid exceptions on re-installation */
+        $this->clearConfigXML() && $this->clearConfigThemes();
+
         if (file_exists(_PS_ROOT_DIR_.'/'.self::SETTINGS_FILE)) {
             require_once _PS_ROOT_DIR_.'/'.self::SETTINGS_FILE;
         }
@@ -367,5 +370,26 @@ class InstallControllerHttpProcess extends InstallControllerHttp
         $this->process_steps[] = array('key' => 'installTheme', 'lang' => $this->l('Install theme'));
 
         $this->displayTemplate('process');
+    }
+
+    private function clearConfigXML()
+    {
+        $cacheFiles = glob(_PS_ROOT_DIR_.'/config/xml');
+        $excludes = ['.htaccess', 'index.php'];
+        foreach($cacheFiles as $file) {
+            if (is_file($file) && !in_array($file, $excludes)) {
+                unlink($file);
+            }
+        }
+    }
+
+    private function clearConfigThemes()
+    {
+        $cacheFiles = glob(_PS_ROOT_DIR_.'/config/themes');
+        foreach($cacheFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

I noticed that our cache system is very agressive and could create some weird exceptions when we re-install PrestaShop. This is why I suggest to check for and remove all "legacy" cache files when installation process starts.
## Steps to Test this Fix
1. Step 1.
   Install PrestaShop, change theme, tabs position, etc...
2. Step 2.
   Re-install PrestaShop and try to access BO. without this patch => exception, with this patch => OK
