### PR TITLE
[-] FO : Fix loyalty to work in 1.6.1.4 (and probably earlier 1.6.1.x

### DIFF
--- a/themes/default-bootstrap/modules/loyalty/views/templates/hook/product.tpl
+++ b/themes/default-bootstrap/modules/loyalty/views/templates/hook/product.tpl
@@ -22,12 +22,56 @@
 *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 *}
+<script type="text/javascript">
+var point_rate = {$point_rate};
+var point_value = {$point_value};
+var points_in_cart = {$points_in_cart};
+var none_award = {$none_award};
+
+$(document).ready(function() {
+	// Force color "button" to fire event change
+	$('#color_to_pick_list').click(function() {
+		$('#color_pick_hidden').triggerHandler('change');
+	});
+
+	// Catch all attribute changeent of the product
+	$('.product_attributes input, .product_attributes select').change(function() {
+		if (typeof(productPrice) == 'undefined' || typeof(productPriceWithoutReduction) == 'undefined')
+			return;
+		
+		var points = {$points};
+		var total_points = points_in_cart + points;
+		var voucher = total_points * point_value;
+		if (!none_award && productPriceWithoutReduction != productPrice) {
+			$('#loyalty').html("{l s='No reward points for this product because there\'s already a discount.' mod='loyalty'}");
+		} else if (!points) {
+			$('#loyalty').html("{l s='No reward points for this product.' mod='loyalty'}");
+		} else {
+			var content = "{l s='By buying this product you can collect up to' mod='loyalty'} <b><span id=\"loyalty_points\">"+points+'</span> ';
+			if (points > 1)
+				content += "{l s='loyalty points' mod='loyalty'}</b>. ";
+			else
+				content += "{l s='loyalty point' mod='loyalty'}</b>. ";
+			
+			content += "{l s='Your cart will total' mod='loyalty'} <b><span id=\"total_loyalty_points\">"+total_points+'</span> ';
+			if (total_points > 1)
+				content += "{l s='points' mod='loyalty'}";
+			else
+				content += "{l s='point' mod='loyalty'}";
+			
+			content += "</b> {l s='that can be converted into a voucher of' mod='loyalty'} ";
+			content += '<span id="loyalty_price">'+formatCurrency(voucher, currencyFormat, currencySign, currencyBlank)+'</span>.';
+			$('#loyalty').html(content);
+		}
+	});
+});
+</script>
 <p id="loyalty" class="align_justify">
 	{if $points}
 		{l s='By buying this product you can collect up to' mod='loyalty'} <b><span id="loyalty_points">{$points}</span> 
 		{if $points > 1}{l s='loyalty points' mod='loyalty'}{else}{l s='loyalty point' mod='loyalty'}{/if}</b>. 
 		{l s='Your cart will total' mod='loyalty'} <b><span id="total_loyalty_points">{$total_points}</span> 
-		{if $total_points > 1}{l s='loyalty points' mod='loyalty'}{else}{l s='loyalty point' mod='loyalty'}{/if}</b> {l s='that can be converted into a voucher of' mod='loyalty'} 
+		{if $total_points > 1}{l s='points' mod='loyalty'}{else}{l s='point' mod='loyalty'}{/if}</b> {l s='that can be converted into a voucher of' mod='loyalty'} 
 		<span id="loyalty_price">{convertPrice price=$voucher}</span>.
 	{else}
 		{if isset($no_pts_discounted) && $no_pts_discounted == 1}
@@ -38,15 +82,3 @@
 	{/if}
 </p>
 <br class="clear" />
-{addJsDef point_rate=$point_rate}
-{addJsDef point_value=$point_value}
-{addJsDef points_in_cart=$points_in_cart}
-{addJsDef none_award=$none_award}
-
-{addJsDefL name=loyalty_willcollect}{l s='By buying this product you can collect up to' mod='loyalty' js=1}{/addJsDefL}
-{addJsDefL name=loyalty_already}{l s='No reward points for this product because there\'s already a discount.' mod='loyalty' js=1}{/addJsDefL}
-{addJsDefL name=loyalty_nopoints}{l s='No reward points for this product.' mod='loyalty' js=1}{/addJsDefL}
-{addJsDefL name=loyalty_points}{l s='loyalty points' mod='loyalty' js=1}{/addJsDefL}
-{addJsDefL name=loyalty_point}{l s='loyalty point' mod='loyalty' js=1}{/addJsDefL}
-{addJsDefL name=loyalty_total}{l s='Your cart will total' mod='loyalty' js=1}{/addJsDefL}
-{addJsDefL name=loyalty_converted}{l s='that can be converted into a voucher of' mod='loyalty' js=1}{/addJsDefL}


### PR DESCRIPTION
## Description

Default bootstrap loyalty files needed updating to work. Noticed it was not working in 1.6.1.4. The module must have gotten ahead of the theme module files.
## Steps to Test this Fix

1) Install 1.6.1.4 with default-bootstrap.
2) Notice loyalty does not work in the product page (says no points)
3) Replace file from the main module folder (/modules/loyalty) into default-bootstrap
4) Notice it works.
## Forge Ticket (optional)

none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5128)
<!-- Reviewable:end -->
