### PR TITLE
Fixed parsing of files *.twig for translations

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1938,8 +1938,8 @@ class AdminTranslationsControllerCore extends AdminController
 
         //Parse SF2/Twig files
         $regexSf2Tpl = [
-            '/trans\(([\'\"])' . _PS_TRANS_PATTERN_ . '([\'\"])(,\s*?\{(.*)\})(,\s*?([\'\"])(.*)([\'\"]))?\)/Us',
-            '/transchoice\(([\'\"])' . _PS_TRANS_PATTERN_ . '([\'\"])(,\s*?(.*))(,\s*?\{(.*)\})(,\s*?([\'\"])(.*)([\'\"]))?\)/Us',
+            '/trans\(([\'\"])' . _PS_TRANS_PATTERN_ . '([\'\"])(,\s*?[\{\[](.*)[\}\]])(,\s*?([\'\"])(.*)([\'\"]))?\)/Us',
+            '/transchoice\(([\'\"])' . _PS_TRANS_PATTERN_ . '([\'\"])(,\s*?(.*))(,\s*?[\{\[](.*)[\}\]])(,\s*?([\'\"])(.*)([\'\"]))?\)/Us',
         ];
 
         foreach ($files_per_directory['tpl-sf2'] as $file) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The parser does not parse square quotes from files *.twig<br>eg:   `{{ trans('String', [], 'AdminProducts') }}`<br>[See regex](https://regex101.com/r/lZ6pB0/1) |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Just go to Admin > Translations and check everything displays fine |

![image](https://cloud.githubusercontent.com/assets/8409258/13567523/68238168-e464-11e5-93c0-d66dbe707200.png)
