### PR TITLE
[-] BO: fix $module_name not defined in import module

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -231,8 +231,10 @@ class ModuleController extends FrameworkBundleAdminController
                 array( 'Content-Type' => 'application/json' )
             );
         } catch (Exception $e) {
-            $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
-            $modulesProvider->removeModuleFromDisk($module_name);
+            if (isset($module_name)) {
+                $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
+                $modulesProvider->removeModuleFromDisk($module_name);
+            }
             return new JsonResponse(array(
                 'status' => false,
                 'msg' => $e->getMessage()),


### PR DESCRIPTION
## Description

When you upload a new module, if you have an error during the process, you reach the catch() of the importModuleAction() method.

If the error occurs before set the $module_name var, you will have an error here.
## Steps to Test this Fix
1. Go to module manager
2. Upload a module.
   - Pray to have an error before the $module_name is set and see the error.
3. Apply this commit.
4. See that error doesn't occurs anymore.
