### PR TITLE
[-] BO : Fix non-refreshing notifications when cache activated

### DIFF
--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -47,7 +47,7 @@ class NotificationCore
         $employee_infos = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
 		SELECT id_last_order, id_last_customer_message, id_last_customer
 		FROM `'._DB_PREFIX_.'employee`
-		WHERE `id_employee` = '.(int)$cookie->id_employee);
+		WHERE `id_employee` = '.(int)$cookie->id_employee, false);
 
         foreach ($this->types as $type) {
             $notifications[$type] = Notification::getLastElementsIdsByType($type, $employee_infos['id_last_'.$type]);


### PR DESCRIPTION
## Description

When cache (memcached, apc, xcache, filesystem) is activated, the "new order", "new customer" and "new customer message" notifications do not refresh anymore. Clicking on them does not reset the counter. 
This is due to the employee_infos request being cached. It is fixed by adding the argument $cache = false to the getRow call (defaults to true). 
## Steps to Test this Fix

In the back-office
1. Activate cache system in advanced preferences > performances.
2. Create a new order, a notification should appear in top bar
3. Click on the notification to make it disappear
4. Refresh your page : notification should have disappeared

Before bugfix : notification comes back to previous state. 
