### PR TITLE
[*] FO : Checkout & Shopping-Cart when empty cart

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -73,12 +73,21 @@ class CartControllerCore extends FrontController
         parent::initContent();
 
         $presenter = new CartPresenter;
+        $presented_cart = $presenter->present($this->context->cart);
+
         $this->context->smarty->assign([
-            'cart' => $presenter->present($this->context->cart),
+            'cart' => $presented_cart,
             'static_token' => Tools::getToken(false),
         ]);
 
-        $this->setTemplate('checkout/cart.tpl');
+        if (count($presented_cart['products']) > 0) {
+            $this->setTemplate('checkout/cart.tpl');
+        } else {
+            $this->context->smarty->assign([
+                'allProductsLink' => $this->context->link->getCategoryLink(Configuration::get('PS_HOME_CATEGORY')),
+            ]);
+            $this->setTemplate('checkout/cart-empty.tpl');
+        }
     }
 
     public function displayAjaxUpdate()
@@ -98,6 +107,7 @@ class CartControllerCore extends FrontController
             ]));
         }
     }
+
 
     public function displayAjaxRefresh()
     {

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -171,6 +171,12 @@ class OrderControllerCore extends FrontController
 
         parent::initContent();
 
+        $presentedCart = $this->cart_presenter->present($this->context->cart);
+
+        if (count($presentedCart['products']) <= 0) {
+            Tools::redirect('index.php?controller=cart');
+        }
+
         $this->restorePersistedData($this->checkoutProcess);
         $this->checkoutProcess->handleRequest(
             Tools::getAllValues()
@@ -192,9 +198,7 @@ class OrderControllerCore extends FrontController
 
         $this->context->smarty->assign([
             'checkout_process'  => new RenderableProxy($this->checkoutProcess),
-            'cart'              => $this->cart_presenter->present(
-                                        $this->context->cart
-                                    )
+            'cart'              => $presentedCart
         ]);
         $this->setTemplate('checkout/checkout.tpl');
     }

--- a/themes/classic/templates/checkout/cart-empty.tpl
+++ b/themes/classic/templates/checkout/cart-empty.tpl
@@ -1,0 +1,10 @@
+{extends file=$layout}
+
+{block name='content'}
+
+  <section id="main" class="card text-xs-center">
+    <div class="card-block"><h1 class="display-4 card-title">{l s='Oh no! Your shopping cart is empty'}</h1></div>
+    <a class="btn btn-primary" href="{$allProductsLink}">{l s='Add some products'}</a>
+  </section>
+
+{/block}


### PR DESCRIPTION
## Description

Currently, you can access to the checkout process even if you don't have any products in your cart.
This PR prevent this and change the shopping-cart layout to offer the possibility to browse the catalog.
## Steps to Test this Fix
1. Try to access to your-sho-url/index.php?controller=order
2. You should be redirected to the shopping cart
3. It should displays this 

![capture d ecran 2016-03-08 a 18 28 03](https://cloud.githubusercontent.com/assets/2203436/13609938/863b5188-e55b-11e5-904f-28a686903dc8.png)

Do not forget this related PR https://github.com/PrestaShop/StarterTheme/pull/47
