### PR TITLE
[-] CORE : PHP 5.4 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     sauce_connect: true
     firefox: latest
 php:
+  - 5.4
   - 5.5
   - 5.6
 

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -139,7 +139,7 @@ class ConfigurationTestCore
 
     public static function test_phpversion()
     {
-        return version_compare(substr(phpversion(), 0, 5), '5.5.0', '>=');
+        return version_compare(substr(phpversion(), 0, 5), '5.4.0', '>=');
     }
 
     public static function test_apache_mod_rewrite()
@@ -152,7 +152,7 @@ class ConfigurationTestCore
 
     public static function test_new_phpversion()
     {
-        return version_compare(substr(phpversion(), 0, 5), '5.5.0', '>=');
+        return version_compare(substr(phpversion(), 0, 5), '5.4.0', '>=');
     }
 
     public static function test_mysql_support()

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -114,8 +114,9 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
             // - user has clicked on "continue"
             // - there are delivery options
             // - the is a selected delivery option
+            $deliveryOptions = $this->getCheckoutSession()->getDeliveryOptions();
             $this->step_is_complete =
-                !empty($this->getCheckoutSession()->getDeliveryOptions()) && $this->getCheckoutSession()->getSelectedDeliveryOption()
+                !empty($deliveryOptions) && $this->getCheckoutSession()->getSelectedDeliveryOption()
             ;
         }
 

--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -110,14 +110,15 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
      */
     protected function renderFacets(ProductSearchResult $result)
     {
+        $facetCollection = $result->getFacetCollection();
         // not all search providers generate menus
-        if (empty($result->getFacetCollection())) {
+        if (empty($facetCollection)) {
             return '';
         }
 
         $facetsVar = array_map(
             [$this, 'prepareFacetForTemplate'],
-            $result->getFacetCollection()->getFacets()
+            $facetCollection->getFacets()
         );
 
         $activeFilters = [];
@@ -145,14 +146,15 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
      */
     protected function renderActiveFilters(ProductSearchResult $result)
     {
+        $facetCollection = $result->getFacetCollection();
         // not all search providers generate menus
-        if (empty($result->getFacetCollection())) {
+        if (empty($facetCollection)) {
             return '';
         }
 
         $facetsVar = array_map(
             [$this, 'prepareFacetForTemplate'],
-            $result->getFacetCollection()->getFacets()
+            $facetCollection->getFacets()
         );
 
         $activeFilters = [];

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
   "require": {
     "php": ">=5.4",
     "symfony/symfony": "~2.8.0",
-    "doctrine/dbal": "~2.5.0",
-    "doctrine/orm": "~2.5.0",
+    "doctrine/dbal": "~2.5.3",
+    "doctrine/orm": "~2.5.3",
     "ext-zip": "*",
     "doctrine/doctrine-bundle": "1.5.2",
     "symfony/swiftmailer-bundle": "2.3.8",

--- a/controllers/admin/AdminInformationController.php
+++ b/controllers/admin/AdminInformationController.php
@@ -127,7 +127,7 @@ class AdminInformationControllerCore extends AdminController
             'fopen' => $this->l('Allow the PHP fopen() function on your server.'),
             'gz' => $this->l('Enable GZIP compression on your server.'),
             'files' => $this->l('Some PrestaShop files are missing from your server.'),
-            'new_phpversion' => sprintf($this->l('You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!'), phpversion()),
+            'new_phpversion' => sprintf($this->l('You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!'), phpversion()),
             'apache_mod_rewrite' => $this->l('Enable the Apache mod_rewrite module')
         );
 

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -255,16 +255,16 @@ class AdminThemesControllerCore extends AdminController
             Configuration::updateValue('PS_IMG_UPDATE_TIME', time());
 
             try {
-                if (!empty(Tools::getValue('PS_LOGO'))) {
+                if (Tools::getValue('PS_LOGO')) {
                     $this->logo_uploader->updateHeader();
                 }
-                if (!empty(Tools::getValue('PS_LOGO_MAIL'))) {
+                if (Tools::getValue('PS_LOGO_MAIL')) {
                     $this->logo_uploader->updateMail();
                 }
-                if (!empty(Tools::getValue('PS_LOGO_INVOICE'))) {
+                if (Tools::getValue('PS_LOGO_INVOICE')) {
                     $this->logo_uploader->updateInvoice();
                 }
-                if (!empty(Tools::getValue('PS_FAVICON'))) {
+                if (Tools::getValue('PS_FAVICON')) {
                     $this->logo_uploader->updateFavicon();
                     $this->redirect_after = self::$currentIndex.'&token='.$this->token;
                 }

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -90,7 +90,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp
                     'title' => $this->l('Required PHP parameters'),
                     'success' => 1,
                     'checks' => array(
-                        'phpversion' => $this->l('PHP 5.5 or later is not enabled'),
+                        'phpversion' => $this->l('PHP 5.4 or later is not enabled'),
                         'upload' => $this->l('Cannot upload files'),
                         'system' => $this->l('Cannot create new files and folders'),
                         'gd' => $this->l('GD library is not installed'),
@@ -136,7 +136,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp
                     'title' => $this->l('Recommended PHP parameters'),
                     'success' => $this->tests['optional']['success'],
                     'checks' => array(
-                        'new_phpversion' => sprintf($this->l('You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!'), phpversion()),
+                        'new_phpversion' => sprintf($this->l('You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!'), phpversion()),
                         'fopen' => $this->l('Cannot open external URLs'),
                         'gz' => $this->l('GZIP compression is not activated'),
                         'mcrypt' => $this->l('Mcrypt extension is not enabled'),

--- a/install-dev/langs/bg/install.php
+++ b/install-dev/langs/bg/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Права на файлове и папки',
         'Recursive write permissions for %1$s user on %2$s' => 'Рекурсивни права за писане за потребител %1$s на %2$s',
         'Recommended PHP parameters' => 'Препоръчвани PHP параметри',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Вие имате инсталиран PHP версия %s. Скоро минималната поддържана версия от PrestaShop ще бъде PHP 5.5. За нормалната работа в бъдеще, препоръчваме да обновите версията си до PHP 5.5 сега!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Вие имате инсталиран PHP версия %s. Скоро минималната поддържана версия от PrestaShop ще бъде PHP 5.4. За нормалната работа в бъдеще, препоръчваме да обновите версията си до PHP 5.4 сега!',
         'Cannot open external URLs' => 'Невъзможни за отваряне външни адреси (URL)',
         'GZIP compression is not activated' => 'GZIP компресията не е активирана',
         'Mcrypt extension is not enabled' => 'Разширението Mcrypt не е разрешено',

--- a/install-dev/langs/bn/install.php
+++ b/install-dev/langs/bn/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'ফাইল এবং ফোল্ডার অনুমতি',
         'Recursive write permissions for %1$s user on %2$s' => ' %1$s ব্যভারকারির %2$s এর জন্য রিকারসিভ রাইট অনুমতি  ',
         'Recommended PHP parameters' => 'প্রস্তাবিত পিএইচপি পরামিতি',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => 'বাহ্যিক URL-খোলা যাচ্ছে না',
         'GZIP compression is not activated' => 'Gzip কম্প্রেশন সক্রিয় করা নেই',
         'Mcrypt extension is not enabled' => 'Mcrypt এক্সটেনশন সক্রিয় করা নেই',

--- a/install-dev/langs/br/install.php
+++ b/install-dev/langs/br/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Permissões em arquivos e pastas',
         'Recursive write permissions for %1$s user on %2$s' => 'Permissões de gravação recursivas para usuário %1$s em %2$s',
         'Recommended PHP parameters' => 'Parâmetros PHP recomendados',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Você está usando a versão do PHP %s. Em breve, a última versão suportada pelo PrestaShop será a 5.5. Para garantir que a sua loja estará pronta para futuras atualizações, recomendamos atualizar para a versão 5.5 agora!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Você está usando a versão do PHP %s. Em breve, a última versão suportada pelo PrestaShop será a 5.4. Para garantir que a sua loja estará pronta para futuras atualizações, recomendamos atualizar para a versão 5.4 agora!',
         'Cannot open external URLs' => 'Não é possível abrir URLs externas',
         'GZIP compression is not activated' => 'Compressão GZIP não está ativada',
         'Mcrypt extension is not enabled' => 'Extensão Mcrypt não está habilitada',

--- a/install-dev/langs/ca/install.php
+++ b/install-dev/langs/ca/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Permisos de fitxers i carpetes',
         'Recursive write permissions for %1$s user on %2$s' => 'Permisos recursius d\'escriptura per a l\'usuari  %1$s a %2$s',
         'Recommended PHP parameters' => 'Paràmetres PHP recomanats',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => 'No es poden obrir URL externs',
         'GZIP compression is not activated' => 'La compressió GZIP no està activada',
         'Mcrypt extension is not enabled' => 'L\'extensió Mcrypt no està activada',

--- a/install-dev/langs/cs/install.php
+++ b/install-dev/langs/cs/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Práva k souborům a složkám',
         'Recursive write permissions for %1$s user on %2$s' => 'Rekurzivní práva k zápisu pro %1$s použité na %2$s',
         'Recommended PHP parameters' => 'Doporučené parametry PHP',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Používáte verzi PHP %s. Prosím aktualizujte na verzi PHP 5.5 nyní!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Používáte verzi PHP %s. Prosím aktualizujte na verzi PHP 5.4 nyní!',
         'Cannot open external URLs' => 'Není možné otevřít externí URL adresy',
         'GZIP compression is not activated' => 'GZIP komprese není aktivní',
         'Mcrypt extension is not enabled' => 'Mcrypt rozšíření není povoleno',

--- a/install-dev/langs/en/install.php
+++ b/install-dev/langs/en/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Permissions on files and folders',
         'Recursive write permissions for %1$s user on %2$s' => 'Recursive write permissions for %1$s user on %2$s',
         'Recommended PHP parameters' => 'Recommended PHP parameters',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => 'Cannot open external URLs',
         'GZIP compression is not activated' => 'GZIP compression is not activated',
         'Mcrypt extension is not enabled' => 'Mcrypt extension is not enabled',

--- a/install-dev/langs/es/install.php
+++ b/install-dev/langs/es/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Permisos de archivos y carpetas',
         'Recursive write permissions for %1$s user on %2$s' => 'Permisos recursivos de escritura para el usuario %1$s en %2$s',
         'Recommended PHP parameters' => 'Parámetros PHP recomendados',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Está usando la versión %s de PHP. Pronto la última versión de PHP soportada por PrestaShop será la 5.5. ¡Para garantizar que esté preparado para el futuro actualice a PHP 5.5 ahora!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Está usando la versión %s de PHP. Pronto la última versión de PHP soportada por PrestaShop será la 5.4. ¡Para garantizar que esté preparado para el futuro actualice a PHP 5.4 ahora!',
         'Cannot open external URLs' => 'No se pueden abrir URLs externas',
         'GZIP compression is not activated' => 'La compresión GZIP no está activada',
         'Mcrypt extension is not enabled' => 'La extensión Mcrypt no está habilitada',

--- a/install-dev/langs/fa/install.php
+++ b/install-dev/langs/fa/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'دسترسی به فایل‌ها و پوشه‌ها',
         'Recursive write permissions for %1$s user on %2$s' => 'اجازه های نوشتن بازگشتی برای %1$s تعداد کاربر در %2$s',
         'Recommended PHP parameters' => 'پارامترهای توصیه شده‌ی PHP',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'شما از ویرایش %s PHP استفاده می‌کنید. به زودی آخرین ویرایش PHP پشتبانی شده توسط پرستاشاپ PHP 5.5 خواهد بود. برای اطمینان از این که برای آینده آماده‌ باشید، پیشنهاد می کنیم همین حالا به PHP 5.5 ارتقا دهید!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'شما از ویرایش %s PHP استفاده می‌کنید. به زودی آخرین ویرایش PHP پشتبانی شده توسط پرستاشاپ PHP 5.4 خواهد بود. برای اطمینان از این که برای آینده آماده‌ باشید، پیشنهاد می کنیم همین حالا به PHP 5.4 ارتقا دهید!',
         'Cannot open external URLs' => 'نمی‌توان لینک‌های خارجی را باز کرد',
         'GZIP compression is not activated' => 'فشرده سازی GZIP فعال نیست',
         'Mcrypt extension is not enabled' => 'افزونه Mcrypt فعال نیست',

--- a/install-dev/langs/fr/install.php
+++ b/install-dev/langs/fr/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Permissions d\'accès sur les fichiers et dossiers',
         'Recursive write permissions for %1$s user on %2$s' => 'Droits récursifs en écriture pour l\'utilisateur %1$s sur le dossier %2$s',
         'Recommended PHP parameters' => 'Configuration PHP recommandée',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Vous utilisez la version %s de PHP. PrestaShop ne supportera bientôt plus les versions PHP antérieures à 5.5. Pour anticiper ce changement, nous vous recommandons d\'effectuer une mise à jour vers PHP 5.5 dès maintenant !',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Vous utilisez la version %s de PHP. PrestaShop ne supportera bientôt plus les versions PHP antérieures à 5.4. Pour anticiper ce changement, nous vous recommandons d\'effectuer une mise à jour vers PHP 5.4 dès maintenant !',
         'Cannot open external URLs' => 'Impossible d\'ouvrir des URL externes',
         'GZIP compression is not activated' => 'La compression GZIP n\'est pas activée',
         'Mcrypt extension is not enabled' => 'L\'extension Mcrypt n\'est pas activée',

--- a/install-dev/langs/he/install.php
+++ b/install-dev/langs/he/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'הרשאות קבצים וספריות',
         'Recursive write permissions for %1$s user on %2$s' => 'הרשאות כתיבה רקורסיביות עבור המשתמש %1$s ב %2$s',
         'Recommended PHP parameters' => 'פרמטרי PHP מומלצים',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => 'אין אפשרות לפתוח קישורים חיצוניים',
         'GZIP compression is not activated' => 'דחיסת GZIP לא מופעלת',
         'Mcrypt extension is not enabled' => 'ההרחבה Mcrypt לא מופעלת',

--- a/install-dev/langs/hr/install.php
+++ b/install-dev/langs/hr/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Dozvole na datoteke i mape',
         'Recursive write permissions for %1$s user on %2$s' => 'Rekurzivna dozvola pisanja za %1$s korisnika na %2$s',
         'Recommended PHP parameters' => 'Preporučeni PHP parametri',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Vi koristite PHP inačicu %s . Uskoro, najnovija verzija PHP podržana od PrestaShopa će biti PHP 5.5. Da biste bili sigurni da ste spremni za budućnost, preporučujemo vam da nadogradite PHP 5.5 sada!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Vi koristite PHP inačicu %s . Uskoro, najnovija verzija PHP podržana od PrestaShopa će biti PHP 5.4. Da biste bili sigurni da ste spremni za budućnost, preporučujemo vam da nadogradite PHP 5.4 sada!',
         'Cannot open external URLs' => 'Ne mogu otvoriti vanjske URL-ove',
         'GZIP compression is not activated' => 'GZIP kompresija nije aktivirana',
         'Mcrypt extension is not enabled' => 'Mcrypt ekstenzija nije uključena',

--- a/install-dev/langs/hu/install.php
+++ b/install-dev/langs/hu/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Jogosultság a mappákon és fájlokon',
         'Recursive write permissions for %1$s user on %2$s' => 'Rekurzív írási engedély %1$s felhasználóhoz %2$s helyen',
         'Recommended PHP parameters' => 'Javasolt PHP paraméterek',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => 'Nem nyithatóak meg külső URL-ek',
         'GZIP compression is not activated' => 'GZIP tömörítés nem aktív',
         'Mcrypt extension is not enabled' => 'Mcrypt kiterjesztés nem bekapcsolt',

--- a/install-dev/langs/id/install.php
+++ b/install-dev/langs/id/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Hak akses pada file dan direktori',
         'Recursive write permissions for %1$s user on %2$s' => 'Hak tulis rekursif untuk %1$s user pada %2$s',
         'Recommended PHP parameters' => 'Parameter PHP yang direkomendasikan',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Anda menggunakan PHP versi %s. Nantinya, versi PHP yang akan digunakan oleh PrestaShop adalah PHP 5.5. Saat itu pastikan server Anda telah siap, kami sarankan untuk segera melakukan upgrade ke PHP 5.5 sekarang juga!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Anda menggunakan PHP versi %s. Nantinya, versi PHP yang akan digunakan oleh PrestaShop adalah PHP 5.4. Saat itu pastikan server Anda telah siap, kami sarankan untuk segera melakukan upgrade ke PHP 5.4 sekarang juga!',
         'Cannot open external URLs' => 'Tidak dapat membuka URL lain, akses diblok.',
         'PHP register_globals option is enabled' => 'Opsi PHP register_globals aktif',
         'GZIP compression is not activated' => 'Kompresi GZIP tidak aktif',

--- a/install-dev/langs/it/install.php
+++ b/install-dev/langs/it/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Permessi su file e cartelle',
         'Recursive write permissions for %1$s user on %2$s' => 'Permessi di scrittura per l\'utente %1$s su %2$s',
         'Recommended PHP parameters' => 'Configurazioni PHP raccomandate',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Stai utilizzando la versione %s di PHP. Presto, l\'ultima versione supportata da PrestaShop sarà PHP 5.5. Per essere certo di essere pronto per il futuro, ci raccomandiamo di aggiornare adesso a PHP 5.5!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Stai utilizzando la versione %s di PHP. Presto, l\'ultima versione supportata da PrestaShop sarà PHP 5.4. Per essere certo di essere pronto per il futuro, ci raccomandiamo di aggiornare adesso a PHP 5.4!',
         'Cannot open external URLs' => 'Impossibile aprire URL esterne',
         'GZIP compression is not activated' => 'La compressione GZIP non è attiva',
         'Mcrypt extension is not enabled' => 'L\'estensione Mcrypt non è attiva',

--- a/install-dev/langs/lt/install.php
+++ b/install-dev/langs/lt/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Failų ir katalogų leidimai',
         'Recursive write permissions for %1$s user on %2$s' => 'Rekursiniai rašymo leidimai  %1$s vartotojui %2$s',
         'Recommended PHP parameters' => 'Rekomenduojami PHP parametrai',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Jūs naudojate  PHP %s versiją. Greitai, paskutinė PrestaShop palaikoma PHP versija bus PHP 5.5. Kad būtumėte pasiruošę ateičiai, siūlome jums atsinaujinti iki PHP 5.5 dabar!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Jūs naudojate  PHP %s versiją. Greitai, paskutinė PrestaShop palaikoma PHP versija bus PHP 5.4. Kad būtumėte pasiruošę ateičiai, siūlome jums atsinaujinti iki PHP 5.4 dabar!',
         'Cannot open external URLs' => 'Nepavyko atidaryti išorinio URL',
         'GZIP compression is not activated' => 'GZIP suspaudimas neaktyvuotas',
         'Mcrypt extension is not enabled' => 'Mcrypt plėtinys neįjungtas',

--- a/install-dev/langs/mk/install.php
+++ b/install-dev/langs/mk/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'дозволи на датотеки и директориуми',
         'Recursive write permissions for %1$s user on %2$s' => 'рекурзивни дозволи за запис за %1$s корисник на %2$s',
         'Recommended PHP parameters' => 'Препорачува параметри',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => 'неможе да се отвори надворешна врска кон URLs',
         'GZIP compression is not activated' => 'GZIP компресија не е активирана',
         'Mcrypt extension is not enabled' => 'Mcrypt екстензии не се овозможени',

--- a/install-dev/langs/nl/install.php
+++ b/install-dev/langs/nl/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Rechten van bestanden en folders',
         'Recursive write permissions for %1$s user on %2$s' => 'Recursieve schrijfrechten voor %1$s gebruiker op %2$s',
         'Recommended PHP parameters' => 'PHP parameters',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'U maakt gebruik van PHP versie %s. Binnenkort zal PHP 5.5 de nieuwste PHP versie ondersteund zijn door PrestaShop. Om ervoor te zorgen dat je klaar bent voor de toekomst, raden wij u aan nu upgraden naar PHP 5.5!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'U maakt gebruik van PHP versie %s. Binnenkort zal PHP 5.4 de nieuwste PHP versie ondersteund zijn door PrestaShop. Om ervoor te zorgen dat je klaar bent voor de toekomst, raden wij u aan nu upgraden naar PHP 5.4!',
         'Cannot open external URLs' => 'Kan externe URLs niet openen',
         'GZIP compression is not activated' => 'GZIP compressie is niet geactiveerd',
         'Mcrypt extension is not enabled' => 'Mcrypt extensie is niet geactiveerd',

--- a/install-dev/langs/no/install.php
+++ b/install-dev/langs/no/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Rettigheter på filer og mapper',
         'Recursive write permissions for %1$s user on %2$s' => 'Rekursive skrivetillganger for brukeren %1$s på %2$s',
         'Recommended PHP parameters' => 'Anbefalte PHP-parametere',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Du bruker PHP versjon %s. Snart vil siste versjon som støttes av PrestaShop være PHP 5.5. for å være sikker på at du er klar for fremtiden anbefaler vi at du oppgraderer til PHP 5.5 nå!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Du bruker PHP versjon %s. Snart vil siste versjon som støttes av PrestaShop være PHP 5.4. for å være sikker på at du er klar for fremtiden anbefaler vi at du oppgraderer til PHP 5.4 nå!',
         'Cannot open external URLs' => 'Kan ikke åpne eksterne URL\'er',
         'GZIP compression is not activated' => 'GZIP-komprimering er ikke aktivert',
         'Mcrypt extension is not enabled' => 'Mcrypt-utvidelse er ikke aktivert',

--- a/install-dev/langs/pl/install.php
+++ b/install-dev/langs/pl/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Uprawnienia do plików i folderów',
         'Recursive write permissions for %1$s user on %2$s' => 'Rekurencyjne prawa zapisu dla %1$s użytkownika na %2$s',
         'Recommended PHP parameters' => 'Zalecane parametry PHP',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => 'Nie można otworzyć zewnętrznych adresów URL ',
         'GZIP compression is not activated' => 'Kompresja GZIP nie jest włączona',
         'Mcrypt extension is not enabled' => 'Rozszerzenie Mcrypt nie jest włączone',

--- a/install-dev/langs/pt/install.php
+++ b/install-dev/langs/pt/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Permissões de ficheiros e pastas',
         'Recursive write permissions for %1$s user on %2$s' => 'Permissões de escrita recursivas para o utilizador %1$s em %2$s',
         'Recommended PHP parameters' => 'Parâmetros PHP recomendados',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Está a usar a versão %s do PHP. Brevemente a última versão suportada será a 5.5. Para ter a certeza que a sua loja estará preparada para futuras atualizações, recomendamos atualizar o PHP para a versão 5.5.',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Está a usar a versão %s do PHP. Brevemente a última versão suportada será a 5.4. Para ter a certeza que a sua loja estará preparada para futuras atualizações, recomendamos atualizar o PHP para a versão 5.4.',
         'Cannot open external URLs' => 'Não é possível abrir URLs externos',
         'GZIP compression is not activated' => 'A compressão GZIP não está activa',
         'Mcrypt extension is not enabled' => 'A extensão Mcrypt não está activa',

--- a/install-dev/langs/qc/install.php
+++ b/install-dev/langs/qc/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Permissions d\'accès sur les fichiers et dossiers',
         'Recursive write permissions for %1$s user on %2$s' => 'Droits récursifs en écriture pour l\'utilisateur %1$s sur le dossier %2$s',
         'Recommended PHP parameters' => 'Configuration PHP recommandée',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Vous utilisez la version %s de PHP. PrestaShop ne supportera bientôt plus les versions PHP antérieures à 5.5. Pour anticiper ce changement, nous vous recommandons d\'effectuer une mise à jour vers PHP 5.5 dès maintenant !',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Vous utilisez la version %s de PHP. PrestaShop ne supportera bientôt plus les versions PHP antérieures à 5.4. Pour anticiper ce changement, nous vous recommandons d\'effectuer une mise à jour vers PHP 5.4 dès maintenant !',
         'Cannot open external URLs' => 'Impossible d\'ouvrir des URL externes',
         'GZIP compression is not activated' => 'La compression GZIP n\'est pas activée',
         'Mcrypt extension is not enabled' => 'L\'extension Mcrypt n\'est pas activée',

--- a/install-dev/langs/ro/install.php
+++ b/install-dev/langs/ro/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Permisiuni pe fișiere și foldere',
         'Recursive write permissions for %1$s user on %2$s' => 'Permisiuni de scriere recursivă pentru %1$s  utilizator de pe %2$s',
         'Recommended PHP parameters' => 'Parametri PHP recomandați',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => 'Nu se pot deschide URL-uri externe',
         'GZIP compression is not activated' => 'Reducerea GZIP nu este activată',
         'Mcrypt extension is not enabled' => 'Extensia Mcrypt nu este activă',

--- a/install-dev/langs/ru/install.php
+++ b/install-dev/langs/ru/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Разрешения на файлы и папки',
         'Recursive write permissions for %1$s user on %2$s' => 'Рекурсивно права на запись для пользователя %1$s на %2$s',
         'Recommended PHP parameters' => 'Рекомендуемые параметры PHP',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'У вас установлен РНР версии %s. Скоро минимальной поддерживаемой PrestaShop версией будет РНР 5.5. Для нормальной рабты в будущем рекомендуем обновить ваш РНР до этой версии сейчас!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'У вас установлен РНР версии %s. Скоро минимальной поддерживаемой PrestaShop версией будет РНР 5.4. Для нормальной рабты в будущем рекомендуем обновить ваш РНР до этой версии сейчас!',
         'Cannot open external URLs' => 'Невозможно переходить на внешние URLs',
         'GZIP compression is not activated' => 'Сжатие GZIP не активировано',
         'Mcrypt extension is not enabled' => 'Расширение mcrypt  не активировано',

--- a/install-dev/langs/si/install.php
+++ b/install-dev/langs/si/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Dovoljenja za datoteke in mape',
         'Recursive write permissions for %1$s user on %2$s' => 'Rekurzivna dovoljenja zapisa za %1$s uporabnika na %2$s',
         'Recommended PHP parameters' => 'Priporočeni PHP parametri',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Uporabljate PHP verzijo %s . Kmalu bo zadnja PHP verzija podprta od PrestaShop  PHP 5.5. Da boste priprvaljeni za prihodnost, vam priporočamo, da sedaj posodobite na PHP 5.5 verzijo!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Uporabljate PHP verzijo %s . Kmalu bo zadnja PHP verzija podprta od PrestaShop  PHP 5.4. Da boste priprvaljeni za prihodnost, vam priporočamo, da sedaj posodobite na PHP 5.4 verzijo!',
         'Cannot open external URLs' => 'Ne morem odpreti zunanjih URL-jev',
         'GZIP compression is not activated' => 'GZIP compression ni aktivirana',
         'Mcrypt extension is not enabled' => 'Mcrypt ni omogočen',

--- a/install-dev/langs/sr/install.php
+++ b/install-dev/langs/sr/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Dozvole na fajlovima  folderima',
         'Recursive write permissions for %1$s user on %2$s' => 'Rekurzivne dozvole pisanja za %1$s korisnika  na %2$s',
         'Recommended PHP parameters' => 'Preporučljivi PHP parametri',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => 'Eksterni linkovi se ne mogu otvoriti',
         'GZIP compression is not activated' => 'GZIP kompresija nije aktivirana',
         'Mcrypt extension is not enabled' => 'Mcrypt ekstenzija nije uključena',

--- a/install-dev/langs/sv/install.php
+++ b/install-dev/langs/sv/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => 'Rättigheter till filer och kataloger',
         'Recursive write permissions for %1$s user on %2$s' => 'Rekursiva skrivrättigheter för användare %1$s till %2$s',
         'Recommended PHP parameters' => 'Rekommenderade PHP-inställningar',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'Du använder PHP version %s. Snart så kommer den senaste versionen som stöds av PrestaShop att vara 5.5. Se till att uppgradera till version 5.5 för att vara redo för framtiden!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'Du använder PHP version %s. Snart så kommer den senaste versionen som stöds av PrestaShop att vara 5.4. Se till att uppgradera till version 5.4 för att vara redo för framtiden!',
         'Cannot open external URLs' => 'Kan inte öppna externa URLer',
         'PHP register_globals option is enabled' => 'PHP-inställningen register_globals är aktiverad',
         'GZIP compression is not activated' => 'GZIP-komprimering är inte aktiverad',

--- a/install-dev/langs/tw/install.php
+++ b/install-dev/langs/tw/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => '文件和文件夾的​​權限',
         'Recursive write permissions for %1$s user on %2$s' => '％1$s 在 ％2$s 的用戶遞歸寫權限',
         'Recommended PHP parameters' => '推薦PHP參數',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => '無法開啟外部網址',
         'GZIP compression is not activated' => '沒有啟用 GZIP 壓縮',
         'Mcrypt extension is not enabled' => '沒有啟用 Mcrypt 外掛',

--- a/install-dev/langs/zh/install.php
+++ b/install-dev/langs/zh/install.php
@@ -70,7 +70,7 @@ return array(
         'Permissions on files and folders' => '文件和文件夹的权限',
         'Recursive write permissions for %1$s user on %2$s' => 'Recursive write permissions for %1$s user on %2$s',
         'Recommended PHP parameters' => 'Recommended PHP parameters',
-        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.5. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.5 now!',
+        'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!' => 'You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!',
         'Cannot open external URLs' => '无法打开外部链接',
         'GZIP compression is not activated' => 'GZIP压缩未激活',
         'Mcrypt extension is not enabled' => 'Mcrypt扩展未启用',

--- a/src/PrestaShopBundle/Controller/Admin/AttachementProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AttachementProductController.php
@@ -57,7 +57,7 @@ class AttachementProductController extends FrameworkBundleAdminController
         }
 
         $form = $this->createForm(
-            \PrestaShopBundle\Form\Admin\Product\ProductAttachement::class,
+            'PrestaShopBundle\Form\Admin\Product\ProductAttachement',
             null,
             array('csrf_protection' => false)
         );

--- a/src/PrestaShopBundle/Controller/Admin/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AttributeController.php
@@ -150,7 +150,7 @@ class AttributeController extends FrameworkBundleAdminController
             $attribute = $product->getAttributeCombinationsById($combinationId, $locales[0]['id_lang']);
 
             $form = $this->createForm(
-                \PrestaShopBundle\Form\Admin\Product\ProductCombination::class,
+                'PrestaShopBundle\Form\Admin\Product\ProductCombination',
                 $modelMapper->getFormCombination($attribute[0])
             );
 

--- a/src/PrestaShopBundle/Controller/Admin/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CategoryController.php
@@ -49,7 +49,7 @@ class CategoryController extends FrameworkBundleAdminController
         $currentIdShop = $shopContext->getContextShopID();
 
         $form = $this->createFormBuilder()
-            ->add('category', \PrestaShopBundle\Form\Admin\Category\SimpleCategory::class)
+            ->add('category', 'PrestaShopBundle\Form\Admin\Category\SimpleCategory')
             ->getForm();
 
         $form->handleRequest($request);

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -167,7 +167,7 @@ class ProductController extends FrameworkBundleAdminController
 
             // Category tree
             $categories = $this->createForm(
-                \PrestaShopBundle\Form\Admin\Type\ChoiceCategoriesTreeType::class,
+                'PrestaShopBundle\Form\Admin\Type\ChoiceCategoriesTreeType',
                 null,
                 array(
                     'label' => $translator->trans('Categories', array(), 'AdminProducts'),
@@ -374,13 +374,13 @@ class ProductController extends FrameworkBundleAdminController
         $adminProductWrapper = $this->container->get('prestashop.adapter.admin.wrapper.product');
 
         $form = $this->createFormBuilder($modelMapper->getFormData())
-            ->add('id_product', FormType\HiddenType::class)
-            ->add('step1', \PrestaShopBundle\Form\Admin\Product\ProductInformation::class)
-            ->add('step2', \PrestaShopBundle\Form\Admin\Product\ProductPrice::class)
-            ->add('step3', \PrestaShopBundle\Form\Admin\Product\ProductQuantity::class)
-            ->add('step4', \PrestaShopBundle\Form\Admin\Product\ProductShipping::class)
-            ->add('step5', \PrestaShopBundle\Form\Admin\Product\ProductSeo::class)
-            ->add('step6', \PrestaShopBundle\Form\Admin\Product\ProductOptions::class)
+            ->add('id_product', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
+            ->add('step1', 'PrestaShopBundle\Form\Admin\Product\ProductInformation')
+            ->add('step2', 'PrestaShopBundle\Form\Admin\Product\ProductPrice')
+            ->add('step3', 'PrestaShopBundle\Form\Admin\Product\ProductQuantity')
+            ->add('step4', 'PrestaShopBundle\Form\Admin\Product\ProductShipping')
+            ->add('step5', 'PrestaShopBundle\Form\Admin\Product\ProductSeo')
+            ->add('step6', 'PrestaShopBundle\Form\Admin\Product\ProductOptions')
             ->getForm();
 
         $form->handleRequest($request);
@@ -809,13 +809,13 @@ class ProductController extends FrameworkBundleAdminController
         );
 
         $form = $this->createFormBuilder($modelMapper->getFormData())
-            ->add('id_product', FormType\HiddenType::class)
-            ->add('step1', \PrestaShopBundle\Form\Admin\Product\ProductInformation::class)
-            ->add('step2', \PrestaShopBundle\Form\Admin\Product\ProductPrice::class)
-            ->add('step3', \PrestaShopBundle\Form\Admin\Product\ProductQuantity::class)
-            ->add('step4', \PrestaShopBundle\Form\Admin\Product\ProductShipping::class)
-            ->add('step5', \PrestaShopBundle\Form\Admin\Product\ProductSeo::class)
-            ->add('step6', \PrestaShopBundle\Form\Admin\Product\ProductOptions::class)
+            ->add('id_product', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
+            ->add('step1', 'PrestaShopBundle\Form\Admin\Product\ProductInformation')
+            ->add('step2', 'PrestaShopBundle\Form\Admin\Product\ProductPrice')
+            ->add('step3', 'PrestaShopBundle\Form\Admin\Product\ProductQuantity')
+            ->add('step4', 'PrestaShopBundle\Form\Admin\Product\ProductShipping')
+            ->add('step5', 'PrestaShopBundle\Form\Admin\Product\ProductSeo')
+            ->add('step6', 'PrestaShopBundle\Form\Admin\Product\ProductOptions')
             ->getForm();
 
         return $this->render('PrestaShopBundle:Admin/Common/_partials:_form_field.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
@@ -57,7 +57,7 @@ class ProductImageController extends FrameworkBundleAdminController
         }
 
         $form = $this->createFormBuilder(null, array('csrf_protection' => false))
-            ->add('file', FormType\FileType::class, array(
+            ->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType', array(
                 'error_bubbling' => true,
                 'constraints' => [
                     new Assert\NotNull(array('message' => $translator->trans('Please select a file', [], 'AdminProducts'))),
@@ -127,15 +127,15 @@ class ProductImageController extends FrameworkBundleAdminController
         $image = $productAdapter->getImage((int)$idImage);
 
         $form = $this->container->get('form.factory')->createNamedBuilder('form_image', 'form', $image, array('csrf_protection' => false))
-            ->add('legend', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-                'type' => FormType\TextType::class,
+            ->add('legend', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+                'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
                 'options' => [],
                 'locales' => $locales,
                 'hideTabs' => true,
                 'label' => $translator->trans('Legend', [], 'AdminProducts'),
                 'required' => false,
             ))
-            ->add('cover', FormType\CheckboxType::class, array(
+            ->add('cover', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                 'label'    => $translator->trans('Choose as cover image', [], 'AdminProducts'),
                 'required' => false,
             ))

--- a/src/PrestaShopBundle/Controller/Admin/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/SupplierController.php
@@ -91,8 +91,8 @@ class SupplierController extends FrameworkBundleAdminController
                 continue;
             }
 
-            $simpleSubForm->add('supplier_combination_'.$idSupplier, FormType\CollectionType::class, array(
-                'entry_type' =>  \PrestaShopBundle\Form\Admin\Product\ProductSupplierCombination::class,
+            $simpleSubForm->add('supplier_combination_'.$idSupplier, 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+                'entry_type' => 'PrestaShopBundle\Form\Admin\Product\ProductSupplierCombination',
                 'entry_options'  => array(
                     'id_supplier' => $idSupplier,
                 ),

--- a/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
@@ -57,7 +57,7 @@ class VirtualProductController extends FrameworkBundleAdminController
         }
 
         $form = $this->createForm(
-            \PrestaShopBundle\Form\Admin\Product\ProductVirtual::class,
+           'PrestaShopBundle\Form\Admin\Product\ProductVirtual',
             null,
             array('csrf_protection' => false)
         );

--- a/src/PrestaShopBundle/Controller/Admin/WarehouseController.php
+++ b/src/PrestaShopBundle/Controller/Admin/WarehouseController.php
@@ -73,8 +73,8 @@ class WarehouseController extends FrameworkBundleAdminController
         $simpleSubForm = $form->create('step4', 'form');
 
         foreach ($warehouses as $warehouse) {
-            $simpleSubForm->add('warehouse_combination_'.$warehouse['id_warehouse'], FormType\CollectionType::class, array(
-                'entry_type' => \PrestaShopBundle\Form\Admin\Product\ProductWarehouseCombination::class,
+            $simpleSubForm->add('warehouse_combination_'.$warehouse['id_warehouse'], 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+                'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductWarehouseCombination',
                 'entry_options' => array(
                     'id_warehouse' => $warehouse['id_warehouse'],
                 ),

--- a/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
+++ b/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
@@ -75,7 +75,7 @@ class SimpleCategory extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', FormType\TextType::class, array(
+        $builder->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'label' => $this->translator->trans('Name', [], 'AdminCategories'),
             'required' => false,
             'attr' => ['placeholder' => $this->translator->trans('Category name', [], 'AdminCategories'), 'class' => 'ajax'],
@@ -84,7 +84,7 @@ class SimpleCategory extends CommonAbstractType
                 new Assert\Length(array('min' => 3))
             )
         ))
-        ->add('id_parent', FormType\ChoiceType::class, array(
+        ->add('id_parent', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' => $this->categories,
             'choices_as_values' => true,
             'required' => true,

--- a/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
+++ b/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
@@ -68,7 +68,7 @@ class ProductFeature extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('feature', FormType\ChoiceType::class, array(
+        $builder->add('feature', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label' => $this->translator->trans('Feature', [], 'AdminProducts'),
             'choices' =>  $this->features,
             'choices_as_values' => true,
@@ -78,14 +78,14 @@ class ProductFeature extends CommonAbstractType
                 'class' => 'feature-selector',
             )
         ))
-        ->add('value', FormType\ChoiceType::class, array(
+        ->add('value', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label' => $this->translator->trans('Pre-defined value', [], 'AdminProducts'),
             'required' =>  false,
             'choices_as_values' => true,
             'attr' => array('class' => 'feature-value-selector')
         ))
-        ->add('custom_value', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-            'type' => FormType\TextType::class,
+        ->add('custom_value', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [],
             'locales' => $this->locales,
             'hideTabs' => true,
@@ -107,7 +107,7 @@ class ProductFeature extends CommonAbstractType
                 'value'
             );
 
-            $form->add('value', FormType\ChoiceType::class, array(
+            $form->add('value', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'label' => $this->translator->trans('Pre-defined value', [], 'AdminProducts'),
                 'choices' => $choices,
                 'choices_as_values' => true,
@@ -131,7 +131,7 @@ class ProductFeature extends CommonAbstractType
                 'value'
             );
 
-            $form->add('value', FormType\ChoiceType::class, array(
+            $form->add('value', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'label' => $this->translator->trans('Pre-defined value', [], 'AdminProducts'),
                 'required' =>  false,
                 'attr' => array('class' => 'feature-value-selector'),

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductAttachement.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductAttachement.php
@@ -61,7 +61,7 @@ class ProductAttachement extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('file', FormType\FileType::class, array(
+        $builder->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType', array(
             'required' => false,
             'label' => $this->translator->trans('File', [], 'AdminProducts'),
             'constraints' => array(
@@ -69,7 +69,7 @@ class ProductAttachement extends CommonAbstractType
                 new Assert\File(array('maxSize' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE').'M')),
             )
         ))
-        ->add('name', FormType\TextType::class, array(
+        ->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'label' =>  $this->translator->trans('Filename', [], 'AdminProducts'),
             'attr' =>  ['placeholder' => $this->translator->trans('Title', [], 'AdminProducts')],
             'constraints' => array(
@@ -77,11 +77,11 @@ class ProductAttachement extends CommonAbstractType
                 new Assert\Length(array('min' => 2))
             )
         ))
-        ->add('description', FormType\TextType::class, array(
+        ->add('description', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'label' =>  $this->translator->trans('Description', [], 'AdminProducts'),
             'attr' =>  ['placeholder' => $this->translator->trans('Description', [], 'AdminProducts')],
         ))
-        ->add('add', FormType\ButtonType::class, array(
+        ->add('add', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
             'label' =>  $this->translator->trans('Add', [], 'AdminProducts'),
             'attr' =>  ['class' => 'btn-primary-outline pull-right']
         ));
@@ -92,8 +92,8 @@ class ProductAttachement extends CommonAbstractType
             //if this partial form is submit from a parent form, disable it
             if ($form->getParent()) {
                 $event->setData([]);
-                $form->add('file', FormType\FileType::class, array('mapped' => false));
-                $form->add('name', FormType\TextType::class, array('mapped' => false));
+                $form->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType', array('mapped' => false));
+                $form->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('mapped' => false));
             }
         });
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -63,14 +63,14 @@ class ProductCombination extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('id_product_attribute', FormType\HiddenType::class, array(
+        $builder->add('id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\HiddenType', array(
             'required' => false,
         ))
-        ->add('attribute_reference', FormType\TextType::class, array(
+        ->add('attribute_reference', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'label' => $this->translator->trans('Reference', [], 'AdminProducts')
         ))
-        ->add('attribute_ean13', FormType\TextType::class, array(
+        ->add('attribute_ean13', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'error_bubbling' => true,
             'label' => $this->translator->trans('EAN-13 or JAN barcode', [], 'AdminProducts'),
@@ -78,36 +78,36 @@ class ProductCombination extends CommonAbstractType
                 new Assert\Regex("/^[0-9]{0,13}$/"),
             )
         ))
-        ->add('attribute_isbn', FormType\TextType::class, array(
+        ->add('attribute_isbn', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'label' => $this->translator->trans('ISBN code', [], 'AdminProducts')
         ))
-        ->add('attribute_upc', FormType\TextType::class, array(
+        ->add('attribute_upc', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'label' => $this->translator->trans('UPC barcode', [], 'AdminProducts'),
             'constraints' => array(
                 new Assert\Regex("/^[0-9]{0,12}$/"),
             )
         ))
-        ->add('attribute_wholesale_price', FormType\MoneyType::class, array(
+        ->add('attribute_wholesale_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Cost price', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
         ))
-        ->add('attribute_price', FormType\MoneyType::class, array(
+        ->add('attribute_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Impact on price (tax excl.)', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
             'attr' => ['class' => 'attribute_priceTE']
         ))
-        ->add('attribute_priceTI', FormType\MoneyType::class, array(
+        ->add('attribute_priceTI', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'mapped' => false,
             'label' => $this->translator->trans('Impact on price (tax incl.)', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
             'attr' => ['class' => 'attribute_priceTI']
         ))
-        ->add('attribute_ecotax', FormType\MoneyType::class, array(
+        ->add('attribute_ecotax', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Ecotax', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
@@ -116,16 +116,16 @@ class ProductCombination extends CommonAbstractType
                 new Assert\Type(array('type' => 'float'))
             )
         ))
-        ->add('attribute_weight', FormType\NumberType::class, array(
+        ->add('attribute_weight', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'label' => $this->translator->trans('Impact on weight', [], 'AdminProducts')
         ))
-        ->add('attribute_unity', FormType\MoneyType::class, array(
+        ->add('attribute_unity', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Impact on unit price', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
         ))
-        ->add('attribute_minimal_quantity', FormType\NumberType::class, array(
+        ->add('attribute_minimal_quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'label' => $this->translator->trans('Minimum quantity', [], 'AdminProducts'),
             'constraints' => array(
@@ -133,16 +133,16 @@ class ProductCombination extends CommonAbstractType
                 new Assert\Type(array('type' => 'numeric')),
             )
         ))
-        ->add('available_date_attribute', PsFormType\DatePickerType::class, array(
+        ->add('available_date_attribute', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
             'required' => false,
             'label' => $this->translator->trans('Availability date', [], 'AdminProducts'),
             'attr' => ['class' => 'date', 'placeholder' => 'YYYY-MM-DD']
         ))
-        ->add('attribute_default', FormType\CheckboxType::class, array(
+        ->add('attribute_default', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
             'label'    => $this->translator->trans('Set as default combination', [], 'AdminProducts'),
             'required' => false,
         ))
-        ->add('attribute_quantity', FormType\NumberType::class, array(
+        ->add('attribute_quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => true,
             'label' => $this->translator->trans('Quantity', [], 'AdminProducts'),
             'constraints' => array(
@@ -150,7 +150,7 @@ class ProductCombination extends CommonAbstractType
                 new Assert\Type(array('type' => 'numeric')),
             )
         ))
-        ->add('id_image_attr', FormType\ChoiceType::class, array(
+        ->add('id_image_attr', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices'  => array(),
             'choices_as_values' => true,
             'required' => false,
@@ -171,7 +171,7 @@ class ProductCombination extends CommonAbstractType
                 }
             }
 
-            $form->add('id_image_attr', FormType\ChoiceType::class, array(
+            $form->add('id_image_attr', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices' => $choices,
                 'required' => false,
                 'expanded' => true,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
@@ -57,8 +57,8 @@ class ProductCustomField extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('label', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-            'type' => FormType\TextType::class,
+        $builder->add('label', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [ 'constraints' => array(
                 new Assert\NotBlank(),
                 new Assert\Length(array('min' => 2))
@@ -67,7 +67,7 @@ class ProductCustomField extends CommonAbstractType
             'hideTabs' => true,
             'label' => $this->translator->trans('Label', [], 'AdminProducts')
         ))
-        ->add('type', FormType\ChoiceType::class, array(
+        ->add('type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label' => $this->translator->trans('Type', [], 'AdminProducts'),
             'choices'  => array(
                 $this->translator->trans('Text', [], 'AdminProducts') => 1,
@@ -75,7 +75,7 @@ class ProductCustomField extends CommonAbstractType
             ),
             'choices_as_values' => true,
             'required' =>  true
-        ))->add('require', FormType\CheckboxType::class, array(
+        ))->add('require', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
             'label'    => $this->translator->trans('Required', [], 'AdminProducts'),
             'required' => false,
         ));

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -89,7 +89,7 @@ class ProductInformation extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('type_product', FormType\ChoiceType::class, array(
+        $builder->add('type_product', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices'  => array(
                 $this->translator->trans('Standard product', [], 'AdminProducts') => 0,
                 $this->translator->trans('Pack of existing products', [], 'AdminProducts') => 1,
@@ -99,7 +99,7 @@ class ProductInformation extends CommonAbstractType
             'label' =>  $this->translator->trans('Type', [], 'AdminProducts'),
             'required' => true,
         ))
-        ->add('inputPackItems', \PrestaShopBundle\Form\Admin\Type\TypeaheadProductPackCollectionType::class, array(
+        ->add('inputPackItems', 'PrestaShopBundle\Form\Admin\Type\TypeaheadProductPackCollectionType', array(
             'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&excludeVirtuals=1&limit=20&q=%QUERY',
             'mapping_value' => 'id',
             'mapping_name' => 'name',
@@ -108,8 +108,8 @@ class ProductInformation extends CommonAbstractType
             'required' => false,
             'label' => $this->translator->trans('Add product in your pack', [], 'AdminProducts'),
         ))
-        ->add('name', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-            'type' => FormType\TextType::class,
+        ->add('name', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [
                 'constraints' => array(
                     new Assert\NotBlank(),
@@ -120,8 +120,8 @@ class ProductInformation extends CommonAbstractType
             'hideTabs' => true,
             'label' => $this->translator->trans('Name', [], 'AdminProducts')
         ))
-        ->add('description', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-            'type' => FormType\TextareaType::class,
+        ->add('description', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType',
             'options' => [
                 'attr' => array('class' => 'autoload_rte'),
                 'required' => false
@@ -131,8 +131,8 @@ class ProductInformation extends CommonAbstractType
             'label' =>  $this->translator->trans('Description', [], 'AdminProducts'),
             'required' => false
         ))
-        ->add('description_short', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-            'type' => FormType\TextareaType::class,
+        ->add('description_short', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType',
             'options' => [
                 'attr' => array('class' => 'autoload_rte'),
                 'constraints' => array(
@@ -157,13 +157,13 @@ class ProductInformation extends CommonAbstractType
         ))
 
         //FEATURES & ATTRIBUTES
-        ->add('features', FormType\CollectionType::class, array(
-            'entry_type' => \PrestaShopBundle\Form\Admin\Feature\ProductFeature::class,
+        ->add('features', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+            'entry_type' =>'PrestaShopBundle\Form\Admin\Feature\ProductFeature',
             'prototype' => true,
             'allow_add' => true,
             'allow_delete' => true
         ))
-        ->add('id_manufacturer', FormType\ChoiceType::class, array(
+        ->add('id_manufacturer', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' => $this->manufacturers,
             'choices_as_values' => true,
             'required' => false,
@@ -171,11 +171,11 @@ class ProductInformation extends CommonAbstractType
         ))
 
         //RIGHT COL
-        ->add('active', FormType\CheckboxType::class, array(
+        ->add('active', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
             'label' => $this->translator->trans('Enabled', [], 'AdminProducts'),
             'required' => false,
         ))
-        ->add('price_shortcut', FormType\MoneyType::class, array(
+        ->add('price_shortcut', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Pre-tax retail price', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
@@ -185,13 +185,13 @@ class ProductInformation extends CommonAbstractType
             ),
             'attr' => []
         ))
-        ->add('price_ttc_shortcut', FormType\MoneyType::class, array(
+        ->add('price_ttc_shortcut', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Retail price with tax', [], 'AdminProducts'),
             'mapped' => false,
             'currency' => $this->currency->iso_code,
         ))
-        ->add('qty_0_shortcut', FormType\NumberType::class, array(
+        ->add('qty_0_shortcut', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'label' => $this->translator->trans('Quantity', [], 'AdminProducts'),
             'constraints' => array(
@@ -199,19 +199,19 @@ class ProductInformation extends CommonAbstractType
                 new Assert\Type(array('type' => 'numeric'))
             )
         ))
-        ->add('categories', \PrestaShopBundle\Form\Admin\Type\ChoiceCategoriesTreeType::class, array(
+        ->add('categories', 'PrestaShopBundle\Form\Admin\Type\ChoiceCategoriesTreeType', array(
             'label' => $this->translator->trans('Associated categories', [], 'AdminProducts'),
             'list' => $this->nested_categories,
             'valid_list' => $this->categories,
             'multiple' => true,
         ))
-        ->add('id_category_default', FormType\ChoiceType::class, array(
+        ->add('id_category_default', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->categories,
             'choices_as_values' => true,
             'required' =>  true,
             'label' => $this->translator->trans('Default category', [], 'AdminProducts')
         ))
-        ->add('new_category', \PrestaShopBundle\Form\Admin\Category\SimpleCategory::class, array(
+        ->add('new_category', 'PrestaShopBundle\Form\Admin\Category\SimpleCategory', array(
             'ajax' => true,
             'required' => false,
             'mapped' => false,
@@ -219,7 +219,7 @@ class ProductInformation extends CommonAbstractType
             'label' => $this->translator->trans('Add a new category', [], 'AdminProducts'),
             'attr' => ['data-action' => $this->router->generate('admin_category_simple_add_form')]
         ))
-        ->add('related_products', \PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType::class, array(
+        ->add('related_products', 'PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType', array(
             'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
             'mapping_value' => 'id',
             'mapping_name' => 'name',

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
@@ -84,7 +84,7 @@ class ProductOptions extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('visibility', FormType\ChoiceType::class, array(
+        $builder->add('visibility', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices'  => array(
                 $this->translator->trans('Everywhere', [], 'AdminProducts') => 'both',
                 $this->translator->trans('Catalog only', [], 'AdminProducts') => 'catalog',
@@ -95,8 +95,8 @@ class ProductOptions extends CommonAbstractType
             'required' => true,
             'label' => $this->translator->trans('Visibility', [], 'AdminProducts'),
         ))
-        ->add('tags', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-            'type' => FormType\TextType::class,
+        ->add('tags', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [
                 'attr' => [
                     'class' => 'tokenfield',
@@ -107,28 +107,28 @@ class ProductOptions extends CommonAbstractType
             'label' => $this->translator->trans('Tags...', [], 'AdminProducts')
         ))
         ->add(
-            $builder->create('display_options', FormType\FormType::class, array('required' => false, 'label' => $this->translator->trans('Display options', [], 'AdminProducts')))
-                ->add('available_for_order', FormType\CheckboxType::class, array(
+            $builder->create('display_options', 'Symfony\Component\Form\Extension\Core\Type\FormType', array('required' => false, 'label' => $this->translator->trans('Display options', [], 'AdminProducts')))
+                ->add('available_for_order', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                     'label'    => $this->translator->trans('Available for order', [], 'AdminProducts'),
                     'required' => false,
                 ))
-                ->add('show_price', FormType\CheckboxType::class, array(
+                ->add('show_price', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                     'label'    => $this->translator->trans('Show price', [], 'AdminProducts'),
                     'required' => false,
                 ))
-                ->add('online_only', FormType\CheckboxType::class, array(
+                ->add('online_only', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                     'label'    => $this->translator->trans('Online only (not sold in your retail store)', [], 'AdminProducts'),
                     'required' => false,
                 ))
         )
-        ->add('upc', FormType\TextType::class, array(
+        ->add('upc', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'label' => $this->translator->trans('UPC barcode', [], 'AdminProducts'),
             'constraints' => array(
                 new Assert\Regex("/^[0-9]{0,12}$/"),
             )
         ))
-        ->add('ean13', FormType\TextType::class, array(
+        ->add('ean13', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'error_bubbling' => true,
             'label' => $this->translator->trans('EAN-13 or JAN barcode', [], 'AdminProducts'),
@@ -136,19 +136,19 @@ class ProductOptions extends CommonAbstractType
                 new Assert\Regex("/^[0-9]{0,13}$/"),
             )
         ))
-        ->add('isbn', FormType\TextType::class, array(
+        ->add('isbn', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'label' => $this->translator->trans('ISBN code', [], 'AdminProducts')
         ))
-        ->add('reference', FormType\TextType::class, array(
+        ->add('reference', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'label' => $this->translator->trans('Reference', [], 'AdminProducts')
         ))
-        ->add('show_condition', FormType\CheckboxType::class, array(
+        ->add('show_condition', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
             'required' => false,
             'label' => $this->translator->trans('Display condition on product page', [], 'AdminProducts'),
         ))
-        ->add('condition', FormType\ChoiceType::class, array(
+        ->add('condition', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices'  => array(
                  $this->translator->trans('New', [], 'AdminProducts') => 'new',
                  $this->translator->trans('Used', [], 'AdminProducts') => 'used',
@@ -158,7 +158,7 @@ class ProductOptions extends CommonAbstractType
             'required' => true,
             'label' => $this->translator->trans('Condition', [], 'AdminProducts')
         ))
-        ->add('suppliers', FormType\ChoiceType::class, array(
+        ->add('suppliers', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->suppliers,
             'choices_as_values' => true,
             'expanded' =>  true,
@@ -166,7 +166,7 @@ class ProductOptions extends CommonAbstractType
             'required' =>  false,
             'label' => $this->translator->trans('Suppliers', [], 'AdminProducts')
         ))
-        ->add('default_supplier', FormType\ChoiceType::class, array(
+        ->add('default_supplier', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->suppliers,
             'choices_as_values' => true,
             'required' =>  true,
@@ -174,8 +174,8 @@ class ProductOptions extends CommonAbstractType
         ));
 
         foreach ($this->suppliers as $supplier => $id) {
-            $builder->add('supplier_combination_'.$id, FormType\CollectionType::class, array(
-                'entry_type' => \PrestaShopBundle\Form\Admin\Product\ProductSupplierCombination::class,
+            $builder->add('supplier_combination_'.$id, 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+                'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductSupplierCombination',
                 'entry_options'  => array(
                     'id_supplier' => $id,
                 ),
@@ -186,8 +186,8 @@ class ProductOptions extends CommonAbstractType
             ));
         }
 
-        $builder->add('custom_fields', FormType\CollectionType::class, array(
-            'entry_type' => \PrestaShopBundle\Form\Admin\Product\ProductCustomField::class,
+        $builder->add('custom_fields', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+            'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductCustomField',
             'label' => $this->translator->trans('Customization', [], 'AdminProducts'),
             'prototype' => true,
             'allow_add' => true,
@@ -195,14 +195,14 @@ class ProductOptions extends CommonAbstractType
         ));
 
         //Add product attachment form
-        $builder->add('attachment_product', \PrestaShopBundle\Form\Admin\Product\ProductAttachement::class, array(
+        $builder->add('attachment_product', 'PrestaShopBundle\Form\Admin\Product\ProductAttachement', array(
             'required' => false,
             'label' => $this->translator->trans('Attachment', [], 'AdminProducts'),
             'attr' => ['data-action' => $this->router->generate('admin_product_attachement_add_action')]
         ));
 
         //Add attachment selectors
-        $builder->add('attachments', FormType\ChoiceType::class, array(
+        $builder->add('attachments', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'expanded'  => true,
             'multiple'  => true,
             'choices'  => $this->attachmentList,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -80,7 +80,7 @@ class ProductPrice extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('price', FormType\MoneyType::class, array(
+        $builder->add('price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Pre-tax retail price', [], 'AdminProducts'),
             'attr' => ['data-display-price-precision' => $this->configuration->get('_PS_PRICE_DISPLAY_PRECISION_')],
@@ -90,13 +90,13 @@ class ProductPrice extends CommonAbstractType
                 new Assert\Type(array('type' => 'float'))
             )
         ))
-        ->add('price_ttc', FormType\MoneyType::class, array(
+        ->add('price_ttc', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'mapped' => false,
             'label' => $this->translator->trans('Retail price with tax', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
         ))
-        ->add('ecotax', FormType\MoneyType::class, array(
+        ->add('ecotax', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Ecotax (tax incl.)', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
@@ -106,7 +106,7 @@ class ProductPrice extends CommonAbstractType
             ),
             'attr' => ['data-eco-tax-rate' => $this->eco_tax_rate],
         ))
-        ->add('id_tax_rules_group', FormType\ChoiceType::class, array(
+        ->add('id_tax_rules_group', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->tax_rules,
             'required' => true,
             'choices_as_values' => true,
@@ -118,26 +118,26 @@ class ProductPrice extends CommonAbstractType
             },
             'label' => $this->translator->trans('Tax rule', [], 'AdminProducts'),
         ))
-        ->add('on_sale', FormType\CheckboxType::class, array(
+        ->add('on_sale', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
             'required' => false,
             'label' => $this->translator->trans('Display the "sale!" flag on the product page, and in the text found within the product listing.', [], 'AdminProducts'),
         ))
-        ->add('wholesale_price', FormType\MoneyType::class, array(
+        ->add('wholesale_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Price - Tax excluded', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
         ))
-        ->add('unit_price', FormType\MoneyType::class, array(
+        ->add('unit_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Unit price', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
         ))
-        ->add('unity', FormType\TextType::class, array(
+        ->add('unity', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'attr' => ['placeholder' => $this->translator->trans('Per kilo, per litre', [], 'AdminProducts')]
         ))
-        ->add('specific_price', \PrestaShopBundle\Form\Admin\Product\ProductSpecificPrice::class)
-        ->add('specificPricePriorityToAll', FormType\CheckboxType::class, array(
+        ->add('specific_price', 'PrestaShopBundle\Form\Admin\Product\ProductSpecificPrice')
+        ->add('specificPricePriorityToAll', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
             'required' => false,
             'label' => $this->translator->trans('Apply to all products', [], 'AdminProducts'),
         ));
@@ -151,7 +151,7 @@ class ProductPrice extends CommonAbstractType
         ];
 
         for ($i=0; $i < count($specificPricePriorityChoices); $i++) {
-            $builder->add('specificPricePriority_'.$i, FormType\ChoiceType::class, array(
+            $builder->add('specificPricePriority_'.$i, 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices' => $specificPricePriorityChoices,
                 'choices_as_values' => true,
                 'required' => true

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -65,7 +65,7 @@ class ProductQuantity extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('attributes', FormType\TextType::class, array(
+        $builder->add('attributes', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'attr' =>  [
                 'class' => 'tokenfield',
                 'data-limit' => 20,
@@ -76,12 +76,12 @@ class ProductQuantity extends CommonAbstractType
             ],
             'label' =>  $this->translator->trans('Create combinations', [], 'AdminProducts')
             ))
-            ->add('advanced_stock_management', FormType\CheckboxType::class, array(
+            ->add('advanced_stock_management', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                 'required' => false,
                 'label' => $this->translator->trans('I want to use the advanced stock management system for this product.', [], 'AdminProducts'),
             ))
-            ->add('pack_stock_type', FormType\ChoiceType::class, ['choices_as_values' => true, ]) //see eventListener for details
-            ->add('depends_on_stock', FormType\ChoiceType::class, array(
+            ->add('pack_stock_type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', ['choices_as_values' => true, ]) //see eventListener for details
+            ->add('depends_on_stock', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
                     $this->translator->trans('The available quantities for the current product and its combinations are based on the stock in your warehouse (using the advanced stock management system). ', [], 'AdminProducts') => 1,
                     $this->translator->trans('I want to specify available quantities manually.', [], 'AdminProducts') => 0,
@@ -91,7 +91,7 @@ class ProductQuantity extends CommonAbstractType
                 'required' => true,
                 'multiple' => false,
             ))
-            ->add('qty_0', FormType\NumberType::class, array(
+            ->add('qty_0', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
                 'required' => true,
                 'label' => $this->translator->trans('Quantity', [], 'AdminProducts'),
                 'constraints' => array(
@@ -99,13 +99,13 @@ class ProductQuantity extends CommonAbstractType
                     new Assert\Type(array('type' => 'numeric')),
                 ),
             ))
-            ->add('combinations', FormType\CollectionType::class, array(
-                'entry_type' => \PrestaShopBundle\Form\Admin\Product\ProductCombination::class,
+            ->add('combinations', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+                'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductCombination',
                 'allow_add' => true,
                 'allow_delete' => true
             ))
-            ->add('out_of_stock', FormType\ChoiceType::class, ['choices_as_values' => true, ]) //see eventListener for details
-            ->add('minimal_quantity', FormType\NumberType::class, array(
+            ->add('out_of_stock', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', ['choices_as_values' => true, ]) //see eventListener for details
+            ->add('minimal_quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
                 'required' => true,
                 'label' => $this->translator->trans('Minimum quantity', [], 'AdminProducts'),
                 'constraints' => array(
@@ -113,26 +113,26 @@ class ProductQuantity extends CommonAbstractType
                     new Assert\Type(array('type' => 'numeric')),
                 ),
             ))
-            ->add('available_now', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-                'type' => FormType\TextType::class,
+            ->add('available_now', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+                'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
                 'options' => [],
                 'locales' => $this->locales,
                 'hideTabs' => true,
                 'label' =>  $this->translator->trans('Displayed text when in-stock', [], 'AdminProducts')
             ))
-            ->add('available_later', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-                'type' => FormType\TextType::class,
+            ->add('available_later', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+                'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
                 'options' => [],
                 'locales' => $this->locales,
                 'hideTabs' => true,
                 'label' =>  $this->translator->trans('Displayed text when out of stock', [], 'AdminProducts')
             ))
-            ->add('available_date', PsFormType\DatePickerType::class, array(
+            ->add('available_date', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
                 'required' => false,
                 'label' => $this->translator->trans('Availability date:', [], 'AdminProducts'),
                 'attr' => ['placeholder' => 'YYYY-MM-DD']
             ))
-            ->add('virtual_product', \PrestaShopBundle\Form\Admin\Product\ProductVirtual::class, array(
+            ->add('virtual_product', 'PrestaShopBundle\Form\Admin\Product\ProductVirtual', array(
                 'required' => false,
                 'label' => $this->translator->trans('Does this product have an associated file?', [], 'AdminProducts'),
             ));
@@ -147,7 +147,7 @@ class ProductQuantity extends CommonAbstractType
                 $this->translator->trans('Deny', [], 'AdminProducts');
             $defaultChoiceLabel .= ')';
 
-            $form->add('out_of_stock', FormType\ChoiceType::class, array(
+            $form->add('out_of_stock', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
                     $this->translator->trans('Deny', [], 'AdminProducts') => '0',
                     $this->translator->trans('Allow', [], 'AdminProducts') => '1',
@@ -171,7 +171,7 @@ class ProductQuantity extends CommonAbstractType
                 $defaultChoiceLabel .= $this->translator->trans('Decrement both.', [], 'AdminProducts');
             }
 
-            $form->add('pack_stock_type', FormType\ChoiceType::class, array(
+            $form->add('pack_stock_type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
                     $this->translator->trans('Decrement pack only.', [], 'AdminProducts') => '0',
                     $this->translator->trans('Decrement products in pack only.', [], 'AdminProducts') => '1',

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
@@ -57,8 +57,8 @@ class ProductSeo extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('meta_title', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-            'type' => FormType\TextType::class,
+        $builder->add('meta_title', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [
                 'attr' => ['placeholder' => $this->translator->trans('To have a different title from the product name, enter it here.', [], 'AdminProducts')],
                 'required' => false
@@ -68,8 +68,8 @@ class ProductSeo extends CommonAbstractType
             'label' => $this->translator->trans('Meta title', [], 'AdminProducts'),
             'required' => false
         ))
-        ->add('meta_description', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-            'type' => FormType\TextType::class,
+        ->add('meta_description', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [
                 'attr' => ['placeholder' => $this->translator->trans('To have a different description than your product summary, enter it here.', [], 'AdminProducts')],
                 'required' => false
@@ -79,14 +79,14 @@ class ProductSeo extends CommonAbstractType
             'label' => $this->translator->trans('Meta description', [], 'AdminProducts'),
             'required' => false
         ))
-        ->add('link_rewrite', \PrestaShopBundle\Form\Admin\Type\TranslateType::class, array(
-            'type' => FormType\TextType::class,
+        ->add('link_rewrite', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [],
             'locales' => $this->locales,
             'hideTabs' => true,
             'label' => $this->translator->trans('Friendly URL', [], 'AdminProducts'),
         ))
-        ->add('redirect_type', FormType\ChoiceType::class, array(
+        ->add('redirect_type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices'  => array(
                 $this->translator->trans('No redirect (404)', [], 'AdminProducts') => '404',
                 $this->translator->trans('Catalog Redirected permanently (301)', [], 'AdminProducts') => '301',
@@ -96,7 +96,7 @@ class ProductSeo extends CommonAbstractType
             'required' => true,
             'label' => $this->translator->trans('Redirection when offline', [], 'AdminProducts'),
         ))
-        ->add('id_product_redirected', \PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType::class, array(
+        ->add('id_product_redirected', 'PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType', array(
             'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
             'mapping_value' => 'id',
             'mapping_name' => 'name',

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -69,7 +69,7 @@ class ProductShipping extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('width', FormType\NumberType::class, array(
+        $builder->add('width', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'label' => $this->translator->trans('Width', [], 'AdminProducts'),
             'constraints' => array(
@@ -77,7 +77,7 @@ class ProductShipping extends CommonAbstractType
                 new Assert\Type(array('type' => 'float'))
             )
         ))
-        ->add('height', FormType\NumberType::class, array(
+        ->add('height', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'label' => $this->translator->trans('Height', [], 'AdminProducts'),
             'constraints' => array(
@@ -85,7 +85,7 @@ class ProductShipping extends CommonAbstractType
                 new Assert\Type(array('type' => 'float'))
             )
         ))
-        ->add('depth', FormType\NumberType::class, array(
+        ->add('depth', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'label' => $this->translator->trans('Depth', [], 'AdminProducts'),
             'constraints' => array(
@@ -93,7 +93,7 @@ class ProductShipping extends CommonAbstractType
                 new Assert\Type(array('type' => 'float'))
             )
         ))
-        ->add('weight', FormType\NumberType::class, array(
+        ->add('weight', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'label' => $this->translator->trans('Weight', [], 'AdminProducts'),
             'constraints' => array(
@@ -101,7 +101,7 @@ class ProductShipping extends CommonAbstractType
                 new Assert\Type(array('type' => 'float'))
             )
         ))
-        ->add('additional_shipping_cost', FormType\MoneyType::class, array(
+        ->add('additional_shipping_cost', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Shipping fees', [], 'AdminProducts'),
             'currency' => $this->currency->iso_code,
@@ -110,7 +110,7 @@ class ProductShipping extends CommonAbstractType
                 new Assert\Type(array('type' => 'float'))
             )
         ))
-        ->add('selectedCarriers', FormType\ChoiceType::class, array(
+        ->add('selectedCarriers', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->carriersChoices,
             'choices_as_values' => true,
             'expanded' =>  true,
@@ -120,8 +120,8 @@ class ProductShipping extends CommonAbstractType
         ));
 
         foreach ($this->warehouses as $warehouse) {
-            $builder->add('warehouse_combination_'.$warehouse['id_warehouse'], FormType\CollectionType::class, array(
-                'entry_type' => \PrestaShopBundle\Form\Admin\Product\ProductWarehouseCombination::class,
+            $builder->add('warehouse_combination_'.$warehouse['id_warehouse'], 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+                'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductWarehouseCombination',
                 'entry_options' => array(
                     'id_warehouse' => $warehouse['id_warehouse'],
                 ),

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -82,11 +82,11 @@ class ProductSpecificPrice extends CommonAbstractType
         //If context multi-shop, hide shop selector
         //Else show selector
         if (count($this->shops) == 1) {
-            $builder->add('sp_id_shop', FormType\HiddenType::class, array(
+            $builder->add('sp_id_shop', 'Symfony\Component\Form\Extension\Core\Type\HiddenType', array(
                 'required' =>  false,
             ));
         } else {
-            $builder->add('sp_id_shop', FormType\ChoiceType::class, array(
+            $builder->add('sp_id_shop', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices' =>  $this->shops,
                 'choices_as_values' => true,
                 'required' =>  false,
@@ -95,28 +95,28 @@ class ProductSpecificPrice extends CommonAbstractType
             ));
         }
 
-        $builder->add('sp_id_currency', FormType\ChoiceType::class, array(
+        $builder->add('sp_id_currency', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->currencies,
             'choices_as_values' => true,
             'required' =>  false,
             'label' =>  false,
             'placeholder' =>  $this->translator->trans('All currencies', [], 'AdminProducts'),
         ))
-        ->add('sp_id_country', FormType\ChoiceType::class, array(
+        ->add('sp_id_country', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->countries,
             'choices_as_values' => true,
             'required' =>  false,
             'label' =>  false,
             'placeholder' => $this->translator->trans('All countries', [], 'AdminProducts'),
         ))
-        ->add('sp_id_group', FormType\ChoiceType::class, array(
+        ->add('sp_id_group', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->groups,
             'choices_as_values' => true,
             'required' =>  false,
             'label' =>  false,
             'placeholder' => $this->translator->trans('All groups', [], 'AdminProducts'),
         ))
-        ->add('sp_id_customer', \PrestaShopBundle\Form\Admin\Type\TypeaheadCustomerCollectionType::class, array(
+        ->add('sp_id_customer', 'PrestaShopBundle\Form\Admin\Type\TypeaheadCustomerCollectionType', array(
             'remote_url' => $this->context->getAdminLink('AdminCustomers', true).'&sf2=1&ajax=1&tab=AdminCustomers&action=searchCustomers&customer_search=%QUERY',
             'mapping_value' => 'id_customer',
             'mapping_name' => 'fullname_and_email',
@@ -126,7 +126,7 @@ class ProductSpecificPrice extends CommonAbstractType
             'required' => false,
             'label' => $this->translator->trans('Add customer', [], 'AdminProducts'),
         ))
-        ->add('sp_id_product_attribute', FormType\ChoiceType::class, array(
+        ->add('sp_id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  [],
             'choices_as_values' => true,
             'required' =>  false,
@@ -134,17 +134,17 @@ class ProductSpecificPrice extends CommonAbstractType
             'label' => $this->translator->trans('Combination', [], 'AdminProducts'),
             'attr' => ['data-action' =>  $this->router->generate('admin_get_product_combinations')],
         ))
-        ->add('sp_from', PsFormType\DatePickerType::class, array(
+        ->add('sp_from', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
             'required' => false,
             'label' => $this->translator->trans('Available from', [], 'AdminProducts'),
             'attr' => ['placeholder' => 'YYYY-MM-DD HH:II']
         ))
-        ->add('sp_to', PsFormType\DatePickerType::class, array(
+        ->add('sp_to', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
             'required' => false,
             'label' => $this->translator->trans('to', [], 'AdminProducts'),
             'attr' => ['placeholder' => 'YYYY-MM-DD HH:II']
         ))
-        ->add('sp_from_quantity', FormType\NumberType::class, array(
+        ->add('sp_from_quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'label' => $this->translator->trans('Starting at', [], 'AdminProducts'),
             'constraints' => array(
@@ -152,22 +152,22 @@ class ProductSpecificPrice extends CommonAbstractType
                 new Assert\Type(array('type' => 'numeric')),
             )
         ))
-        ->add('sp_price', FormType\MoneyType::class, array(
+        ->add('sp_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Product price (tax excl.)', [], 'AdminProducts'),
             'attr' => ['class' => 'price'],
             'currency' => $this->currency->iso_code,
         ))
-        ->add('leave_bprice', FormType\CheckboxType::class, array(
+        ->add('leave_bprice', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
             'label'    => $this->translator->trans('Leave base price:', [], 'AdminProducts'),
             'required' => false,
         ))
-        ->add('sp_reduction', FormType\MoneyType::class, array(
+        ->add('sp_reduction', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'label' => $this->translator->trans('Reduction', [], 'AdminProducts'),
             'required' => false,
             'currency' => $this->currency->iso_code,
         ))
-        ->add('sp_reduction_type', FormType\ChoiceType::class, array(
+        ->add('sp_reduction_type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label' => $this->translator->trans('Reduction type', [], 'AdminProducts'),
             'choices'  => array(
                 '€' => 'amount',
@@ -176,7 +176,7 @@ class ProductSpecificPrice extends CommonAbstractType
             'choices_as_values' => true,
             'required' => true,
         ))
-        ->add('sp_reduction_tax', FormType\ChoiceType::class, array(
+        ->add('sp_reduction_tax', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label' => $this->translator->trans('Reduction tax', [], 'AdminProducts'),
             'choices'  => array(
                 $this->translator->trans('Tax excluded', [], 'AdminProducts') => '0',
@@ -185,11 +185,11 @@ class ProductSpecificPrice extends CommonAbstractType
             'choices_as_values' => true,
             'required' => true,
         ))
-        ->add('save', FormType\ButtonType::class, array(
+        ->add('save', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
             'label' => $this->translator->trans('Done', [], 'AdminProducts'),
             'attr' => array('class' => 'btn-primary-outline js-save'),
         ))
-        ->add('cancel', FormType\ButtonType::class, array(
+        ->add('cancel', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
             'label' => $this->translator->trans('Cancel', [], 'AdminProducts'),
             'attr' => array('class' => 'btn-default-outline js-cancel'),
         ));
@@ -203,7 +203,7 @@ class ProductSpecificPrice extends CommonAbstractType
             }
 
             //bypass SF validation, define submitted value in choice list
-            $form->add('sp_id_product_attribute', FormType\ChoiceType::class, array(
+            $form->add('sp_id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices' =>  [$data['sp_id_product_attribute'] => ''],
                 'choices_as_values' => true,
                 'required' =>  false,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
@@ -61,25 +61,25 @@ class ProductSupplierCombination extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('supplier_reference', FormType\TextType::class, array(
+        $builder->add('supplier_reference', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'label' => null
         ))
-        ->add('product_price', FormType\NumberType::class, array(
+        ->add('product_price', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'constraints' => array(
                 new Assert\NotBlank(),
                 new Assert\Type(array('type' => 'float'))
             )
         ))
-        ->add('product_price_currency', FormType\ChoiceType::class, array(
+        ->add('product_price_currency', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices'  => $this->formatDataChoicesList($this->currencyAdapter->getCurrencies(), 'id_currency'),
             'choices_as_values' => true,
             'required' => true,
         ))
-        ->add('id_product_attribute', FormType\HiddenType::class)
-        ->add('product_id', FormType\HiddenType::class)
-        ->add('supplier_id', FormType\HiddenType::class);
+        ->add('id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
+        ->add('product_id', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
+        ->add('supplier_id', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
 
         //set default minimal values for collection prototype
         $builder->setData([

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
@@ -62,7 +62,7 @@ class ProductVirtual extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('is_virtual_file', FormType\ChoiceType::class, array(
+        $builder->add('is_virtual_file', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices'  => array(
                 $this->translator->trans('Yes', [], 'AdminProducts') => 1,
                 $this->translator->trans('No', [], 'AdminProducts') => 0,
@@ -72,39 +72,39 @@ class ProductVirtual extends CommonAbstractType
             'required' => true,
             'multiple' => false,
         ))
-        ->add('file', FormType\FileType::class, array(
+        ->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType', array(
             'required' => false,
             'label' => $this->translator->trans('File', [], 'AdminProducts'),
             'constraints' => array(
                 new Assert\File(array('maxSize' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE').'M')),
             )
         ))
-        ->add('name', FormType\TextType::class, array(
+        ->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'label'    => $this->translator->trans('Filename', [], 'AdminProducts'),
             'constraints' => array(
                 new Assert\NotBlank(),
             ),
         ))
-        ->add('nb_downloadable', FormType\NumberType::class, array(
+        ->add('nb_downloadable', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'label'    => $this->translator->trans('Number of allowed downloads', [], 'AdminProducts'),
             'required' => false,
             'constraints' => array(
                 new Assert\Type(array('type' => 'numeric')),
             ),
         ))
-        ->add('expiration_date', PsFormType\DatePickerType::class, array(
+        ->add('expiration_date', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
             'label'    => $this->translator->trans('Expiration date', [], 'AdminProducts'),
             'required' => false,
             'attr' => ['placeholder' => 'YYYY-MM-DD']
         ))
-        ->add('nb_days', FormType\NumberType::class, array(
+        ->add('nb_days', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'label'    => $this->translator->trans('Number of days', [], 'AdminProducts'),
             'required' => false,
             'constraints' => array(
                 new Assert\Type(array('type' => 'numeric')),
             )
         ))
-        ->add('save', FormType\ButtonType::class, array(
+        ->add('save', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
             'label' => $this->translator->trans('Save', [], 'AdminProducts'),
             'attr' => ['class' => 'btn-primary pull-right']
         ));
@@ -116,10 +116,10 @@ class ProductVirtual extends CommonAbstractType
             //if this partial form is submit from a parent form, disable it
             if ($form->getParent()) {
                 $event->setData([]);
-                $form->add('name', FormType\TextType::class, array('mapped' => false));
+                $form->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('mapped' => false));
             } elseif ($data['is_virtual_file'] == 0) {
                 //disable name mapping when is virtual not defined to yes
-                $form->add('name', FormType\TextType::class, array('mapped' => false));
+                $form->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('mapped' => false));
             }
         });
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php
@@ -58,14 +58,14 @@ class ProductWarehouseCombination extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('activated', FormType\CheckboxType::class, array(
+        $builder->add('activated', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
             'required' => false,
             'label' => $this->translator->trans('Stored', [], 'AdminProducts')
         ))
-        ->add('id_product_attribute', FormType\HiddenType::class)
-        ->add('product_id', FormType\HiddenType::class)
-        ->add('warehouse_id', FormType\HiddenType::class)
-        ->add('location', FormType\TextType::class, array(
+        ->add('id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
+        ->add('product_id', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
+        ->add('warehouse_id', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
+        ->add('location', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,
             'label' => $this->translator->trans('Location (optional)', [], 'AdminProducts')
         ));

--- a/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
@@ -60,7 +60,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('tree', FormType\ChoiceType::class, array(
+        $builder->add('tree', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label' => false,
             'choices' => $options['valid_list'],
             'choices_as_values' => true,

--- a/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
@@ -38,7 +38,7 @@ class DatePickerType extends AbstractType
      */
     public function getParent()
     {
-        return \Symfony\Component\Form\Extension\Core\Type\TextType::class;
+        return'Symfony\Component\Form\Extension\Core\Type\TextType';
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
@@ -94,8 +94,8 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('data', \Symfony\Component\Form\Extension\Core\Type\CollectionType::class, array(
-            'entry_type' => \Symfony\Component\Form\Extension\Core\Type\HiddenType::class,
+        $builder->add('data', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+            'entry_type' =>'Symfony\Component\Form\Extension\Core\Type\HiddenType',
             'allow_add' => true,
             'allow_delete' => true,
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -95,8 +95,8 @@ class TypeaheadProductCollectionType extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('data', \Symfony\Component\Form\Extension\Core\Type\CollectionType::class, array(
-            'entry_type' => \Symfony\Component\Form\Extension\Core\Type\HiddenType::class,
+        $builder->add('data', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+            'entry_type' =>'Symfony\Component\Form\Extension\Core\Type\HiddenType',
             'allow_add' => true,
             'allow_delete' => true,
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductPackCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductPackCollectionType.php
@@ -74,8 +74,8 @@ class TypeaheadProductPackCollectionType extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('data', \Symfony\Component\Form\Extension\Core\Type\CollectionType::class, array(
-            'entry_type' => \Symfony\Component\Form\Extension\Core\Type\HiddenType::class,
+        $builder->add('data', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+            'entry_type' =>'Symfony\Component\Form\Extension\Core\Type\HiddenType',
             'allow_add' => true,
             'allow_delete' => true,
             'label' => false,

--- a/tests/selenium/prepare-shop.php
+++ b/tests/selenium/prepare-shop.php
@@ -70,7 +70,6 @@ function hookModule($moduleName, $hookName)
 }
 
 // disableModule('blocklayered');
-disableModule('cheque'); // not yet working
 
 // We need a customizable product: we add a single required text field to the product with id 1.
 


### PR DESCRIPTION
## Description

This PR meant to make PretaShop 1.7 running on PHP 5.4.
## Steps to Test this Fix

Install PrestaShop 1.7 with PHP 5.4 and browse :wink:
