### PR TITLE
[-] Installer : Fix install DB query

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -311,9 +311,9 @@ CREATE TABLE `PREFIX_cart_rule_shop` (
 CREATE TABLE `PREFIX_cart_product` (
   `id_cart` int(10) unsigned NOT NULL,
   `id_product` int(10) unsigned NOT NULL,
-  `id_address_delivery` int(10) UNSIGNED DEFAULT '0',
+  `id_address_delivery` int(10) unsigned NOT NULL DEFAULT '0',
   `id_shop` int(10) unsigned NOT NULL DEFAULT '1',
-  `id_product_attribute` int(10) unsigned NOT NULL,
+  `id_product_attribute` int(10) unsigned NOT NULL DEFAULT '0',
   `quantity` int(10) unsigned NOT NULL DEFAULT '0',
   `date_add` datetime NOT NULL,
   PRIMARY KEY (`id_cart`,`id_product`,`id_product_attribute`,`id_address_delivery`),


### PR DESCRIPTION
Applying this fix: https://github.com/PrestaShop/PrestaShop/commit/8134781f64053826c8c21402ef7d46bf6ca1bad4 from the branch `1.6.1.x` to the `develop` branch as well.

Including `NOT NULL` restriction, like the rest of the IDs have
