### PR TITLE
[-]BO: Fix Add customization button on product page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -882,7 +882,7 @@
                               </li>
                             {% endfor %}
                           </ul>
-                          <a href="#" class="btn btn-action">
+                          <a href="#" class="btn btn-action add">
                             <i class="material-icons">add</i>
                             {{ trans('Add a customization field', {}, 'AdminProducts') }}
                           </a>


### PR DESCRIPTION
## Description

Fix the non working customization button add on the product page.
## Steps to Test this Fix

Create a product and go to tab option, then try to add a customization field.
