### PR TITLE
// Remove data from ProductController and related templates

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4428,6 +4428,8 @@ class ProductCore extends ObjectModel
 
         $row = Product::getTaxesInformations($row, $context);
 
+        $row['ecotax_rate'] = (float)Tax::getProductEcotaxRate($context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
+
         Hook::exec('actionGetProductPropertiesAfter', [
             'id_lang'   => $id_lang,
             'product'   => $row,

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -352,11 +352,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $id_group = (int)Group::getCurrent()->id;
         $id_country = $id_customer ? (int)Customer::getCurrentCountry($id_customer) : (int)Tools::getCountry();
 
-        $group_reduction = GroupReduction::getValueForProduct($this->product->id, $id_group);
-        if ($group_reduction === false) {
-            $group_reduction = Group::getReduction((int)$this->context->cookie->id_customer) / 100;
-        }
-
         // Tax
         $tax = (float)$this->product->getTaxesRate(new Address((int)$this->context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}));
         $this->context->smarty->assign('tax_rate', $tax);
@@ -390,7 +385,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $this->quantity_discounts = $this->formatQuantityDiscounts($quantity_discounts, $product_price, (float)$tax, $this->product->ecotax);
 
         $this->context->smarty->assign(array(
-            'group_reduction' => $group_reduction,
             'no_tax' => Tax::excludeTaxeOption() || !$this->product->getTaxesRate($address),
             'tax_enabled' => Configuration::get('PS_TAX') && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'),
             'customer_group_without_tax' => Group::getPriceDisplayMethod($this->context->customer->id_default_group),
@@ -784,6 +778,13 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         );
         $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->l('Items') : $this->l('Item');
         $product_full['quantity_discounts'] = $this->quantity_discounts;
+
+
+        $group_reduction = GroupReduction::getValueForProduct($this->product->id, (int)Group::getCurrent()->id);
+        if ($group_reduction === false) {
+            $group_reduction = Group::getReduction((int)$this->context->cookie->id_customer) / 100;
+        }
+        $product_full['customer_group_discount'] = $group_reduction;
 
         $presenter = $this->getProductPresenter();
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -41,6 +41,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /** @var Category */
     protected $category;
 
+    private $quantity_discounts;
+
     public function canonicalRedirection($canonical_url = '')
     {
         $id_product_attribute = Tools::getValue('id_product_attribute');
@@ -385,8 +387,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         $product_price = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, false);
         $address = new Address($this->context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
+        $this->quantity_discounts = $this->formatQuantityDiscounts($quantity_discounts, $product_price, (float)$tax, $this->product->ecotax);
+
         $this->context->smarty->assign(array(
-            'quantity_discounts' => $this->formatQuantityDiscounts($quantity_discounts, $product_price, (float)$tax, $this->product->ecotax),
             'group_reduction' => $group_reduction,
             'no_tax' => Tax::excludeTaxeOption() || !$this->product->getTaxesRate($address),
             'tax_enabled' => Configuration::get('PS_TAX') && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'),
@@ -780,6 +783,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             && !Configuration::get('PS_CATALOG_MODE')
         );
         $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->l('Items') : $this->l('Item');
+        $product_full['quantity_discounts'] = $this->quantity_discounts;
 
         $presenter = $this->getProductPresenter();
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -295,14 +295,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'priceDisplay' => $priceDisplay,
                 'productPrice' => $productPrice,
                 'productPriceWithoutReduction' => $productPriceWithoutReduction,
-                'display_quantities' => ((bool)Configuration::get('PS_DISPLAY_QTIES') && (bool)Configuration::get('PS_STOCK_MANAGEMENT') && $this->product->quantity > 0 && (bool)$this->product->available_for_order && !(Configuration::get('PS_CATALOG_MODE'))) ? true : false,
                 'customizationFields' => $customization_fields,
                 'id_customization' => empty($customization_datas) ? null : $customization_datas[0]['id_customization'],
                 'accessories' => $accessories,
                 'product' => $product_for_template,
                 'displayUnitPrice' => (!empty($this->product->unity) && $this->product->unit_price_ratio > 0.000000) ? true : false,
                 'unit_price' => ($this->product->unit_price_ratio > 0) ? ($productPrice / $this->product->unit_price_ratio) : 0,
-                'quantity_label' => ($product_for_template['quantity'] > 1) ? $this->l('Items') : $this->l('Item'),
                 'product_manufacturer' => new Manufacturer((int)$this->product->id_manufacturer, $this->context->language->id),
                 'last_qties' =>  (int)Configuration::get('PS_LAST_QTIES'),
                 'display_taxes_label' => true,
@@ -785,6 +783,14 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product_full = Product::getProductProperties($this->context->language->id, $product, $this->context);
 
         $product_full = $this->addProductCustomizationData($product_full);
+
+        $product_full['show_quantities'] = (bool)(
+            Configuration::get('PS_DISPLAY_QTIES')
+            && Configuration::get('PS_STOCK_MANAGEMENT')
+            && $this->product->quantity > 0
+            && $this->product->available_for_order
+            && !Configuration::get('PS_CATALOG_MODE'));
+        $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->l('Items') : $this->l('Item');
 
         $presenter = $this->getProductPresenter();
 

--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -81,6 +81,7 @@ class CartPresenter implements PresenterInterface
             $rawProduct['id_product_attribute']
         );
 
+        $rawProduct['ecotax_rate'] = '';
         $rawProduct['specific_prices'] = '';
         $rawProduct['customizable'] = '';
         $rawProduct['online_only'] = '';

--- a/src/Core/Product/ProductPresenterAbstract.php
+++ b/src/Core/Product/ProductPresenterAbstract.php
@@ -121,6 +121,16 @@ abstract class ProductPresenterAbstract
         return $presentedProduct;
     }
 
+    private function addQuantityDiscountInformation(
+        array $presentedProduct,
+        array $product
+    ) {
+        $presentedProduct['quantity_discounts'] =
+            (isset($product['quantity_discounts'])) ? $product['quantity_discounts'] : [];
+
+        return $presentedProduct;
+    }
+
     private function shouldShowAddToCartButton(
         ProductPresentationSettings $settings,
         array $product
@@ -414,6 +424,11 @@ abstract class ProductPresenterAbstract
                 $product
             );
         }
+
+        $presentedProduct = $this->addQuantityDiscountInformation(
+            $presentedProduct,
+            $product
+        );
 
         return $presentedProduct;
     }

--- a/src/Core/Product/ProductPresenterAbstract.php
+++ b/src/Core/Product/ProductPresenterAbstract.php
@@ -108,6 +108,19 @@ abstract class ProductPresenterAbstract
         return $presentedProduct;
     }
 
+    private function addEcotaxInformation(
+        array $presentedProduct,
+        array $product
+    ) {
+        $presentedProduct['ecotax'] = [
+            'value' => $this->priceFormatter->format($product['ecotax']),
+            'amount' => $product['ecotax'],
+            'rate' => $product['ecotax_rate'],
+        ];
+
+        return $presentedProduct;
+    }
+
     private function shouldShowAddToCartButton(
         ProductPresentationSettings $settings,
         array $product
@@ -394,6 +407,13 @@ abstract class ProductPresenterAbstract
             $settings,
             $product
         );
+
+        if (isset($product['ecotax'])) {
+            $presentedProduct = $this->addEcotaxInformation(
+                $presentedProduct,
+                $product
+            );
+        }
 
         return $presentedProduct;
     }

--- a/themes/classic/templates/catalog/_partials/product-details.tpl
+++ b/themes/classic/templates/catalog/_partials/product-details.tpl
@@ -8,10 +8,10 @@
     {/if}
     {/block}
     {block name='product_quantities'}
-      {if $display_quantities}
+      {if $product.show_quantities}
         <div class="product-quantities">
           <label class="label">{l s='In stock'}</label>
-          <span>{$product.quantity} {$quantity_label}</span>
+          <span>{$product.quantity} {$product.quantity_label}</span>
         </div>
       {/if}
     {/block}

--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -39,8 +39,8 @@
     {/block}
 
     {block name='product_ecotax'}
-      {if $displayEcotax}
-        <p class="price-ecotax">{l s='Including %s for ecotax' sprintf=$ecotax}
+      {if $product.ecotax}
+        <p class="price-ecotax">{l s='Including %s for ecotax' sprintf=$product.ecotax.value}
           {if $product.has_discount}
             {l s='(not impacted by the discount)'}
           {/if}

--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -95,7 +95,7 @@
                   {/block}
 
                   {block name='product_discounts'}
-                    {if $quantity_discounts}
+                    {if $product.quantity_discounts}
                       <section class="product-discounts">
                         <h3 class="h6 product-discounts-title">{l s='Volume discounts'}</h3>
                         <table class="table-product-discounts">
@@ -107,7 +107,7 @@
                             </tr>
                           </thead>
                           <tbody>
-                            {foreach from=$quantity_discounts item='quantity_discount' name='quantity_discounts'}
+                            {foreach from=$product.quantity_discounts item='quantity_discount' name='quantity_discounts'}
                               <tr data-discount-type="{$quantity_discount.reduction_type}" data-discount="{$quantity_discount.real_value}" data-discount-quantity="{$quantity_discount.quantity}">
                                 <td>{$quantity_discount.quantity}</td>
                                 <td>{$quantity_discount.discount}</td>


### PR DESCRIPTION
Removed global smarty data and assigned them to `$product`.

Ex: $ecotax became $product.ecotax
