### PR TITLE
[-] CORE : Fix cache dir for ModuleDataProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "php": ">=5.4",
     "symfony/symfony": "~2.8.0",
     "doctrine/dbal": "~2.5.3",
+    "doctrine/common": "~2.5.3",
     "doctrine/orm": "~2.5.3",
     "ext-zip": "*",
     "doctrine/doctrine-bundle": "1.5.2",

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -66,13 +66,10 @@ class AdminModuleDataProvider implements ModuleInterface
     public function __construct(\AppKernel $kernel = null, Router $router = null)
     {
         $this->catalog_modules  = [];
-        $this->cache_dir        = _PS_ROOT_DIR_.'cache/';
+        $this->cache_dir        = _PS_CACHE_DIR_;
 
         $this->kernel = $kernel;
         $this->router = $router;
-        if ($this->kernel) {
-            $this->cache_dir = $this->kernel->getCacheDir().'/modules/';
-        }
     }
 
     public function clearCatalogCache()


### PR DESCRIPTION
## Description

Fix the path of the cache directory for ModuleDataProvider.
A `/` was missing
