### PR TITLE
[-] BO : product description can be saved when empty

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -86,6 +86,7 @@ class ProductInformation extends CommonAbstractType
      * {@inheritdoc}
      *
      * Builds form
+     *
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -137,7 +138,7 @@ class ProductInformation extends CommonAbstractType
             'required' => false
         ))
         ->add('description_short', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType',
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType', // https://github.com/symfony/symfony/issues/5906
             'options' => [
                 'attr' => array('class' => 'autoload_rte'),
                 'constraints' => array(

--- a/src/PrestaShopBundle/Form/Admin/Type/TextareaEmptyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextareaEmptyType.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\DataTransformerInterface;
+
+
+class TextareaEmptyType extends AbstractTypeExtension implements DataTransformerInterface
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer($this);
+    }
+
+    public function getExtendedType()
+    {
+        return 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
+    }
+
+    public function transform($data)
+    {
+        return $data;
+    }
+
+    public function reverseTransform($data)
+    {
+        return empty($data) ? '' : $data;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/admin/services-form.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services-form.yml
@@ -173,3 +173,7 @@ services:
             - "@prestashop.adapter.data_provider.customer"
         tags:
             - { name: form.type }
+    form.type.extension.textarea:
+            class: PrestaShopBundle\Form\Admin\Type\TextareaEmptyType
+            tags:
+                - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\TextareaType }


### PR DESCRIPTION
## Description

At this moment, we cant empty short description in Product form edition: if a value already have been provided, the Form handler from Symfony was unable to manage empty values.

More information here https://github.com/symfony/symfony/issues/5906, this is a workaround as this bug wont probably be fixed in Symfony 2 and is not fixed yet in Symfony 3.
## Steps to Test this Fix
1. Step 1.
   Edit a product that already have a short description, and empty the textarea field.
2. Step 2.
   Save
3. Step 3.
   Enjoy the empty field.
## Forge Ticket (optional)

Fixes ticket http://forge.prestashop.com/browse/BOOM-372
