### PR TITLE
// Display a warning when no payment method is available

### DIFF
--- a/controllers/admin/AdminPaymentPreferencesController.php
+++ b/controllers/admin/AdminPaymentPreferencesController.php
@@ -24,6 +24,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
+
 class AdminPaymentPreferencesControllerCore extends AdminController
 {
     public $payment_modules = array();
@@ -37,9 +39,12 @@ class AdminPaymentPreferencesControllerCore extends AdminController
 
         /* Get all modules then select only payment ones */
         $modules = Module::getModulesOnDisk(true);
+        $moduleManagerBuilder = new ModuleManagerBuilder();
+        $moduleRepository = $moduleManagerBuilder->buildRepository();
 
         foreach ($modules as $module) {
-            if ($module->tab == 'payments_gateways') {
+            $addonModule = $moduleRepository->getModule($module->name);
+            if ($addonModule->attributes->get('parent_class') == 'PaymentModule') {
                 if ($module->id) {
                     if (!get_class($module) == 'SimpleXMLElement') {
                         $module->country = array();

--- a/themes/classic/templates/checkout/delivery-step.tpl
+++ b/themes/classic/templates/checkout/delivery-step.tpl
@@ -69,7 +69,7 @@
         </button>
       </form>
     {else}
-      <p class="warning">{l s='Unfortunately, there are no carriers available for your delivery address.'}</p>
+      <p class="alert alert-danger">{l s='Unfortunately, there are no carriers available for your delivery address.'}</p>
     {/if}
   </div>
 

--- a/themes/classic/templates/checkout/payment-step.tpl
+++ b/themes/classic/templates/checkout/payment-step.tpl
@@ -57,6 +57,8 @@
           {/if}
         </div>
       {/foreach}
+    {foreachelse}
+      <p class="alert alert-danger">{l s='Unfortunately, there are no payment method available.'}</p>
     {/foreach}
   </div>
 


### PR DESCRIPTION
## Description

When no payment module is available, a warning message is now displayed.
Also, the same style has been applied to the warning message displayed when no carrier is available.

By implementing this, I've run through the an error on `AdminPaymentPreferences` so I've used the `ModuleRepository` in the controller.
## Forge Ticket (optional)

http://forge.prestashop.com/browse/BOOM-344

Don't forget this PR too https://github.com/PrestaShop/StarterTheme/pull/51
