### PR TITLE
[*] CORE : Improve CloudFlare support

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -367,6 +367,14 @@ class ToolsCore
         } else {
             $headers = $_SERVER;
         }
+        
+        // CloudFlare support
+        if (array_key_exists('CF-Connecting-IP', $headers)) {
+            // Validate IP address (IPv4/IPv6)
+            if (filter_var($headers['CF-Connecting-IP'], FILTER_VALIDATE_IP)) {
+                return $headers['CF-Connecting-IP'];
+            }
+        }
 
         if (array_key_exists('X-Forwarded-For', $headers)) {
             $_SERVER['HTTP_X_FORWARDED_FOR'] = $headers['X-Forwarded-For'];


### PR DESCRIPTION
### Improve CloudFlare support.

Some merchants have setups that require them to use the `X-Forwarded-For` header for their own reverse proxies and can no longer find the correct visitor IP.
If the header `CF-Connecting-IP` is set, we can be certain that CloudFlare is used as a reversed proxy and should use the corresponding visitor IP from the header if it's valid.
