### PR TITLE
[-] BO: Fix AdminCarrierWizard variables when SHIPPING_METHOD_FREE

### DIFF
--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -501,10 +501,12 @@ class AdminCarrierWizardControllerCore extends AdminController
         }
 
         if ($shipping_method == Carrier::SHIPPING_METHOD_FREE) {
-            $range_obj = $carrier->getRangeObject($carrier->shipping_method);
+            $tmp_range = array();
             $price_by_range = array();
         } else {
             $range_obj = $carrier->getRangeObject();
+            // Just to be safe check if the object is not empty
+            $tmp_range = $range_obj ? $range_obj->getRanges((int)$carrier->id) : array();
             $price_by_range = Carrier::getDeliveryPriceByRanges($range_table, (int)$carrier->id);
         }
 
@@ -512,13 +514,10 @@ class AdminCarrierWizardControllerCore extends AdminController
             $tpl_vars['price_by_range'][$price['id_'.$range_table]][$price['id_zone']] = $price['price'];
         }
 
-        $tmp_range = $range_obj->getRanges((int)$carrier->id);
         $tpl_vars['ranges'] = array();
-        if ($shipping_method != Carrier::SHIPPING_METHOD_FREE) {
-            foreach ($tmp_range as $id => $range) {
-                $tpl_vars['ranges'][$range['id_'.$range_table]] = $range;
-                $tpl_vars['ranges'][$range['id_'.$range_table]]['id_range'] = $range['id_'.$range_table];
-            }
+        foreach ($tmp_range as $id => $range) {
+            $tpl_vars['ranges'][$range['id_'.$range_table]] = $range;
+            $tpl_vars['ranges'][$range['id_'.$range_table]]['id_range'] = $range['id_'.$range_table];
         }
 
         // init blank range


### PR DESCRIPTION
## Description

`AdminCarrierWizard` tries to collect variables for rendering the ranges:
when carrier has `Carrier::SHIPPING_METHOD_FREE` as `shipping_method` field,
the wizard fails because Line 504 returns `false` and then Line 515 tries to call method on `false`.

When you create a new free carrier using wizard, the constant is `SHIPPING_METHOD_DEFAULT`, but it returns `SHIPPING_METHOD_FREE` when using `Carrier::getShippingMethod` since the carrier has `is_free=1`.
I tried to create a new carrier using a custom module and inserted `SHIPPING_METHOD_FREE` as `shipping_method`. Don't know if that's not I were supposed to do it, but the logic is very convoluted. 
## Steps to Test this Fix
1. Change `shipping_method` in database to `3` (`SHIPPING_METHOD_FREE`).
2. Try to open carrier edit page, there should be an error.
   - Check the PHP error logs to confirm that I described the PHP error correctly
3. Apply the fix and check again.
   - This fix is just a basic code refactor, to avoid calling method on null objects
## Forge Ticket

Couldn't find any related tickets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5219)
<!-- Reviewable:end -->
