### PR TITLE
[-] BO : display condition should be false by default

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -184,7 +184,7 @@ class ProductCore extends ObjectModel
     public $available_date = '0000-00-00';
 
     /** @var bool Will the condition select should be visible for this product ? */
-    public $show_condition = true;
+    public $show_condition = false;
 
     /** @var string Enumerated (enum) product condition (new, used, refurbished) */
     public $condition;


### PR DESCRIPTION
## Steps to Test this Fix
1. Step 1.
   Create a new Product
2. Step 2.
   In "Options" tab, the "Display condition on product page" should be unchecked.

![boom346](https://cloud.githubusercontent.com/assets/1247388/13922402/6605915a-ef7c-11e5-982f-f558265c6869.png)
## Forge Ticket (optional)

http://forge.prestashop.com/browse/BOOM-346
