### PR TITLE
[-] BO : use module list according to customer/employee language

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -27,13 +27,11 @@
 namespace PrestaShop\PrestaShop\Adapter\Module;
 
 use PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider;
-use PrestaShop\PrestaShop\Adapter\Admin\AbstractAdminQueryBuilder;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterOrigin;
 use PrestaShopBundle\Service\DataProvider\Admin\ModuleInterface;
 use Symfony\Component\Config\ConfigCacheFactory;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Routing\Router;
-use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 
 /**
  * Data provider for new Architecture, about Module object model.
@@ -46,12 +44,12 @@ use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 class AdminModuleDataProvider implements ModuleInterface
 {
     const _CACHEFILE_CATEGORIES_ = 'catalog_categories.json';
-    const _CACHEFILE_MODULES_ = 'catalog_modules.json';
+    const _CACHEFILE_MODULES_ = '_catalog_modules.json';
 
     /* Cache for One Day */
     const _DAY_IN_SECONDS_ = 86400;
 
-    private $kernel;
+    private $languageISO;
     /**
      * @var Router
      */
@@ -63,18 +61,18 @@ class AdminModuleDataProvider implements ModuleInterface
     protected $catalog_modules;
     protected $catalog_modules_names;
 
-    public function __construct(\AppKernel $kernel = null, Router $router = null)
+    public function __construct($languageISO, Router $router = null)
     {
         $this->catalog_modules  = [];
         $this->cache_dir        = _PS_CACHE_DIR_;
 
-        $this->kernel = $kernel;
+        $this->languageISO = $languageISO;
         $this->router = $router;
     }
 
     public function clearCatalogCache()
     {
-        $this->clearCache([self::_CACHEFILE_CATEGORIES_, self::_CACHEFILE_MODULES_]);
+        $this->clearCache([self::_CACHEFILE_CATEGORIES_, $this->languageISO.self::_CACHEFILE_MODULES_]);
         $this->catalog_modules         = [];
     }
 
@@ -297,7 +295,7 @@ class AdminModuleDataProvider implements ModuleInterface
 
     protected function loadCatalogData()
     {
-        $this->catalog_modules    = $this->getModuleCache(self::_CACHEFILE_MODULES_);
+        $this->catalog_modules    = $this->getModuleCache($this->languageISO.self::_CACHEFILE_MODULES_);
 
         if (!$this->catalog_modules) {
             $addons_provider = new AddonsDataProvider();
@@ -330,7 +328,7 @@ class AdminModuleDataProvider implements ModuleInterface
                 }
 
                 $this->catalog_modules    = $this->convertJsonForNewCatalog($jsons);
-                $this->registerModuleCache(self::_CACHEFILE_MODULES_, $this->catalog_modules);
+                $this->registerModuleCache($this->languageISO.self::_CACHEFILE_MODULES_, $this->catalog_modules);
             } catch (\Exception $e) {
                 if (! $this->fallbackOnCatalogCache()) {
                     $this->catalog_modules = [];

--- a/src/Adapter/Module/ModuleDataUpdater.php
+++ b/src/Adapter/Module/ModuleDataUpdater.php
@@ -44,9 +44,9 @@ class ModuleDataUpdater
     {
         // Note : Data caching should be handled by the addons data provider
         // Check if the module can be downloaded from addons
-        foreach ($this->admin_module_provider->getCatalogModules(['name' => $name]) as $catalog_module) {
+        foreach ($this->adminModuleDataProvider->getCatalogModules(['name' => $name]) as $catalog_module) {
             if ($catalog_module->name == $name && in_array($catalog_module->origin, ['native', 'native_all', 'partner', 'customer'])) {
-                return $this->addons_provider->downloadModule($catalog_module->id);
+                return $this->addonsDataProvider->downloadModule($catalog_module->id);
             }
         }
 

--- a/src/Adapter/Module/ModuleDataUpdater.php
+++ b/src/Adapter/Module/ModuleDataUpdater.php
@@ -31,17 +31,22 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class ModuleDataUpdater
 {
+    private $addonsDataProvider;
+    private $adminModuleDataProvider;
+
+    public function __construct(AddonsDataProvider $addonsDataProvider, AdminModuleDataProvider $adminModuleDataProvider)
+    {
+        $this->addonsDataProvider = $addonsDataProvider;
+        $this->adminModuleDataProvider = $adminModuleDataProvider;
+    }
 
     public function setModuleOnDiskFromAddons($name)
     {
         // Note : Data caching should be handled by the addons data provider
-
-        $addons_provider = new AddonsDataProvider();
-        $admin_module_provider = new AdminModuleDataProvider();
         // Check if the module can be downloaded from addons
-        foreach ($admin_module_provider->getCatalogModules(['name' => $name]) as $catalog_module) {
+        foreach ($this->admin_module_provider->getCatalogModules(['name' => $name]) as $catalog_module) {
             if ($catalog_module->name == $name && in_array($catalog_module->origin, ['native', 'native_all', 'partner', 'customer'])) {
-                return $addons_provider->downloadModule($catalog_module->id);
+                return $this->addons_provider->downloadModule($catalog_module->id);
             }
         }
 

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -62,7 +62,7 @@ services:
     prestashop.adapter.admin.data_provider.module:
         class: PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider
         arguments:
-             - "@kernel"
+             - "@=service('prestashop.adapter.legacy.context').getEmployeeLanguageIso()"
              - "@router"
         decorates: prestashop.core.admin.data_provider.module_interface
         public: false
@@ -91,3 +91,4 @@ services:
             - "@prestashop.adapter.translator"
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -101,6 +101,9 @@ services:
     prestashop.adapter.data_provider.customer:
         class: PrestaShop\PrestaShop\Adapter\Customer\CustomerDataProvider
 
+    prestashop.adapter.data_provider.addon:
+        class: PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider
+
     prestashop.adapter.stock_manager:
         class: PrestaShop\PrestaShop\Adapter\StockManager
         decorates: prestashop.core.data_provider.stock_interface
@@ -118,11 +121,6 @@ services:
 
     prestashop.adapter.tools:
         class: PrestaShop\PrestaShop\Adapter\Tools
-
-    prestashop.adapter.image_manager:
-        class: PrestaShop\PrestaShop\Adapter\ImageManager
-        arguments: ["@prestashop.adapter.legacy.context"]
-
 
     #TWIG EXTENSIONS
     prestashop.twig.extension.translation:
@@ -152,3 +150,33 @@ services:
         class: PrestaShopBundle\Twig\DataFormatterExtension
         tags:
             - { name: twig.extension }
+
+    # Updaters
+    prestashop.core.module.updater:
+        class: PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater
+        arguments:
+            - @prestashop.adapter.data_provider.addon
+            - @prestashop.adapter.admin.data_provider.module
+
+    # Repositories
+    prestashop.core.admin.module.repository:
+        class: PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository
+        arguments:
+            - @prestashop.adapter.admin.data_provider.module
+            - @prestashop.adapter.data_provider.module
+            - @prestashop.core.module.updater
+            - @prestashop.core.module.updater
+
+    # Managers
+    prestashop.adapter.image_manager:
+        class: PrestaShop\PrestaShop\Adapter\ImageManager
+        arguments: ["@prestashop.adapter.legacy.context"]
+
+    prestashop.module.manager:
+        class: PrestaShop\PrestaShop\Core\Addon\Module\ModuleManager
+        arguments:
+            - @prestashop.adapter.admin.data_provider.module
+            - @prestashop.adapter.data_provider.module
+            - @prestashop.core.module.updater
+            - @prestashop.core.admin.module.repository
+            - "@=service('prestashop.adapter.legacy.context').getContext().employee"

--- a/tests/Unit/Adapter/Module/AdminModuleDataProviderTest.php
+++ b/tests/Unit/Adapter/Module/AdminModuleDataProviderTest.php
@@ -62,7 +62,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
 
         // We try to load the Addons catalog. If it fails, we skip the tests of this file.
         try {
-            $dataProvider = new AdminModuleDataProvider($this->sfKernel, $this->sfRouter);
+            $dataProvider = new AdminModuleDataProvider($this->context->language->iso_code, $this->sfRouter);
             $dataProvider->getCatalogModules();
         } catch (\Exception $e) {
             if ($e->getMessage() == 'Data from PrestaShop Addons is invalid, and cannot fallback on cache') {
@@ -73,7 +73,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
 
     public function test_modules_in_catalog()
     {
-        $dataProvider = new AdminModuleDataProvider($this->sfKernel, $this->sfRouter);
+        $dataProvider = new AdminModuleDataProvider($this->context->language->iso_code, $this->sfRouter);
 
         $modules = $dataProvider->getCatalogModules();
 
@@ -81,9 +81,10 @@ class AdminModuleDataProviderTest extends UnitTestCase
     }
 
     // To be moved and adapted in the module repository
-    /*public function test_modules_in_categories_can_be_found_in_module_list()
+    public function test_modules_in_categories_can_be_found_in_module_list()
     {
-        $dataProvider = new AdminModuleDataProvider($this->sfKernel, $this->sfRouter);
+        $this->markTestSkipped('Test `test_modules_in_categories_can_be_found_in_module_list` should not be commented.');
+        $dataProvider = new AdminModuleDataProvider($this->context->language->iso_code, $this->sfRouter);
 
         $modules = $dataProvider->getCatalogModules();
         $categories = $dataProvider->getCatalogCategories();
@@ -97,7 +98,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
                 foreach ($modules as $module) {
                     if ($module->id == $moduleId) {
                         // The IDs given are related to a module in the list
-                        //$this->assertContains($moduleId, $moduleIds);
+                        $this->assertContains($moduleId, $moduleIds);
 
                         // We also check that the module has also a ref to the current category we test
                         $this->assertTrue(in_array($category->refMenu, $module->refs));
@@ -108,11 +109,11 @@ class AdminModuleDataProviderTest extends UnitTestCase
                 $this->fail('Module with the ID "'. $moduleId .'" not found.');
             }
         }
-    }*/
+    }
 
     public function test_no_results()
     {
-        $dataProvider = new AdminModuleDataProvider($this->sfKernel, $this->sfRouter);
+        $dataProvider = new AdminModuleDataProvider($this->context->language->iso_code, $this->sfRouter);
 
         $filters = ['search' => 'doge'];
         $modules = $dataProvider->getCatalogModules($filters);
@@ -122,7 +123,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
 
     public function test_unknown_filter_criteria()
     {
-        $dataProvider = new AdminModuleDataProvider($this->sfKernel, $this->sfRouter);
+        $dataProvider = new AdminModuleDataProvider($this->context->language->iso_code, $this->sfRouter);
 
         // An unexpected critera should have no effect on the module list
         $filters = ['random_filter' => 'doge'];
@@ -135,7 +136,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
 
     public function test_specific_module_search()
     {
-        $dataProvider = new AdminModuleDataProvider($this->sfKernel, $this->sfRouter);
+        $dataProvider = new AdminModuleDataProvider($this->context->language->iso_code, $this->sfRouter);
 
         // An unexpected critera should have no effect on the module list
         $filters = ['search' => 'ganalytics'];
@@ -146,7 +147,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
 
     public function test_specific_module_search_2_results()
     {
-        $dataProvider = new AdminModuleDataProvider($this->sfKernel, $this->sfRouter);
+        $dataProvider = new AdminModuleDataProvider($this->context->language->iso_code, $this->sfRouter);
 
         // An unexpected critera should have no effect on the module list
         $filters = ['search' => 'ganalytics gapi'];
@@ -157,8 +158,8 @@ class AdminModuleDataProviderTest extends UnitTestCase
 
     public function test_only_one_call_to_addons_and_same_result()
     {
-        $dataProvider = new AdminModuleDataProvider($this->sfKernel, $this->sfRouter);
-        $mock = $this->getMock('PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider', ['convertJsonForNewCatalog'], ['kernel' => $this->sfKernel, 'router' => $this->sfRouter]);
+        $dataProvider = new AdminModuleDataProvider($this->context->language->iso_code, $this->sfRouter);
+        $mock = $this->getMock('PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider', ['convertJsonForNewCatalog'], ['languageISO' => $this->context->language->iso_code, 'router' => $this->sfRouter]);
         $mock->expects($this->once())->method('convertJsonForNewCatalog')->will($this->returnValue($dataProvider->getCatalogModules()));
 
         $mock->clearCatalogCache();
@@ -171,7 +172,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
 
     public function test_product_type_correct()
     {
-        $dataProvider = new AdminModuleDataProvider($this->sfKernel, $this->sfRouter);
+        $dataProvider = new AdminModuleDataProvider($this->context->language->iso_code, $this->sfRouter);
 
         $modules = $dataProvider->getCatalogModules();
         $possible_values = ['module', 'service', 'theme'];


### PR DESCRIPTION
## Description

The module list and categories are stored in cache to avoid multiple calls to addons website.
But if you change your language preferences, or if you have multiple employees with differents languages, you can't have a consistent display for each one of them.

This is why the module list and categories should be displayed according to the selected employee language.

This contribution allows and set up a multiple files cache for modules: you have data stored by language now.
## Steps to Test this Fix

Step 1
Access the module list

Step 2
Change language in employee preferences

Step 3
Come back to the module list page
## Forge issue

http://forge.prestashop.com/browse/BOOM-156
