### PR TITLE
[-] Project : check for rights on Module installation

### DIFF
--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -82,11 +82,13 @@ class ModuleManager implements AddonManagerInterface
      */
     public function install($name)
     {
-        // TODO : Fix for CLI install : No employee here
-        // if (!$this->employee->can('add', 'AdminModules')) {
-        //     throw new Exception('You are not allowed to install a module');
-        // }
-
+        // in CLI mode, there is no employee set up
+        if (php_sapi_name() !== 'cli') {
+            if (!$this->employee->can('add', 'AdminModules')) {
+                throw new Exception('You are not allowed to install a module');
+            }
+        }
+        
         if ($this->moduleProvider->isInstalled($name)) {
             throw new Exception(sprintf('The module %s is already installed', $name));
         }


### PR DESCRIPTION
## Description

We can install modules in CLI mode, but in this context we have no employee set up.

This fix is done in order to re-allow the check on employee rights to install modules if we are in "Back Office" context.
## Steps to Test this Fix
1. Step 1.
   Try to install a module without rights to do it.
