### PR TITLE
Avoid the deletion of still used address in order history

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -11,7 +11,6 @@ use Symfony\Component\Translation\TranslatorInterface;
  * I *think* this is not necessary now because the invoicing thing
  * does its own historization. But this should be checked more thoroughly.
  */
-
 class CustomerAddressFormCore extends AbstractForm
 {
     private $language;
@@ -135,15 +134,16 @@ class CustomerAddressFormCore extends AbstractForm
 
         $this->setValue('token', $this->persister->getToken());
 
-        return [
-            'action'    => $this->action,
-            'errors'    => $this->getErrors(),
+        return array(
+            'id_address' => (isset($this->address->id)) ? $this->address->id : 0,
+            'action' => $this->action,
+            'errors' => $this->getErrors(),
             'formFields' => array_map(
                 function (FormField $item) {
                     return $item->toArray();
                 },
                 $this->formFields
-            )
-        ];
+            ),
+        );
     }
 }

--- a/classes/form/CustomerAddressPersister.php
+++ b/classes/form/CustomerAddressPersister.php
@@ -41,6 +41,13 @@ class CustomerAddressPersisterCore
 
         $address->id_customer = $this->customer->id;
 
+        if ($address->isUsed()) {
+            $old_address = new Address($address->id);
+            $address->id = $address->id_address = null;
+
+            return $address->save() && $old_address->delete();
+        }
+
         return $address->save();
     }
 

--- a/tests/Selenium/specs/customer/addresses.js
+++ b/tests/Selenium/specs/customer/addresses.js
@@ -1,7 +1,7 @@
 /* global describe, it, browser, before, after */
 
 var fixtures = require('../../fixtures');
-var _        = require('underscore');
+var _ = require('underscore');
 
 describe('Customer account: Addresses', function () {
 
@@ -27,27 +27,7 @@ describe('Customer account: Addresses', function () {
         .then(function (elements) {
           initialAddressesCount = elements.value.length;
           initialAddressesCount.should.be.greaterThan(0);
-        })
-      ;
-    });
-
-    it('should allow customer to edit it', function () {
-      var addressAlias = 'Edit address '+_.now();
-
-      return browser
-        .element('a[data-link-action="edit-address"]')
-        .click()
-        .pause(500)
-        .setValue('.address-form input[name=alias]', addressAlias)
-        .submitForm('.address-form form')
-        .element('a[data-link-action="edit-address"]')
-        .click()
-        .pause(500)
-        .getValue('.address-form input[name=alias]')
-        .then(function (value) {
-          value.should.equals(addressAlias);
-        })
-      ;
+        });
     });
 
     var idAddressCreated = 0;
@@ -61,7 +41,6 @@ describe('Customer account: Addresses', function () {
         })
         .element('a[data-link-action="add-address"]')
         .click()
-        .pause(500)
         .setValue('.address-form input[name=firstname]', 'Yolo')
         .setValue('.address-form input[name=lastname]', 'Really')
         .setValue('.address-form input[name=address1]', '12 rue d\'Amsterdam')
@@ -91,15 +70,30 @@ describe('Customer account: Addresses', function () {
         });
     });
 
+    it('should allow customer to edit it', function () {
+      const addressAlias = 'Edit address '+_.now();
+
+      return browser
+        .element('#address-'+idAddressCreated+' a[data-link-action="edit-address"]')
+        .click()
+        .setValue('.address-form input[name=alias]', addressAlias)
+        .submitForm('.address-form form')
+        .element('#address-'+idAddressCreated+' a[data-link-action="edit-address"]')
+        .click()
+        .getValue('.address-form input[name=alias]')
+        .then(function (value) {
+          value.should.equals(addressAlias);
+        });
+    });
+
     it('should allow customer to delete an address', function () {
       return browser
+        .url(fixtures.urls.myAddresses)
         .click('#address-'+idAddressCreated+' a[data-link-action="delete-address"]')
-        .pause(500)
         .isExisting('article#address-'+idAddressCreated)
         .then(function (isExisting) {
           isExisting.should.be.false;
-        })
-      ;
+        });
     });
 
   });

--- a/themes/classic/templates/customer/_partials/address-form.tpl
+++ b/themes/classic/templates/customer/_partials/address-form.tpl
@@ -1,6 +1,6 @@
 {include file='_partials/form-errors.tpl' errors=$errors['']}
 
-<form method="POST" action="{$action}">
+<form method="POST" action="{$action}" data-id-address="{$id_address}">
   <section class="form-fields">
     {block name='form_fields'}
       {foreach from=$formFields item="field"}


### PR DESCRIPTION
Until this PR is merged, if a customer edit an address, all order with this address will be affected. (bug introduce between 1.6 and 1.7)

This PR fixes this.
