### PR TITLE
[*] CORE : Link carriers to payment methods

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -217,7 +217,8 @@ class CarrierCore extends ObjectModel
         }
         Carrier::cleanPositions();
         return (Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'cart_rule_carrier WHERE id_carrier = '.(int)$this->id) &&
-                    $this->deleteTaxRulesGroup(Shop::getShops(true, null, true)));
+                Db::getInstance()->delete('module_carrier', 'id_reference = '.(int)$this->id_reference) &&
+                $this->deleteTaxRulesGroup(Shop::getShops(true, null, true)));
     }
 
     /**

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -187,7 +187,11 @@ class CurrencyCore extends ObjectModel
             Configuration::updateValue('PS_CURRENCY_DEFAULT', $result['id_currency']);
         }
         $this->deleted = 1;
-        return $this->update();
+
+        // Remove currency restrictions
+        $res = Db::getInstance()->delete('module_currency', 'id_currency = '.(int)$this->id);
+
+        return $res && $this->update();
     }
 
     /**

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -200,7 +200,10 @@ class GroupCore extends ObjectModel
 						'.(int)Configuration::get('PS_CUSTOMER_GROUP').')
 				WHERE `id_default_group` = '.(int)$this->id);
 
-            return true;
+            // Remove group restrictions
+            $res = Db::getInstance()->delete('module_group', 'id_group = '.(int)$this->id);
+
+            return $res;
         }
         return false;
     }

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2016 PrestaShop
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to http://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2015 PrestaShop SA
+ * @copyright 2007-2016 PrestaShop SA
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
@@ -430,7 +430,7 @@ class HookCore extends ObjectModel
     {
         $context = Context::getContext();
         $cache_id = 'hook_module_exec_list_'.(isset($context->shop->id) ? '_'.$context->shop->id : '').((isset($context->customer)) ? '_'.$context->customer->id : '');
-        if (!Cache::isStored($cache_id) || $hook_name == 'displayPayment' || $hook_name == 'displayBackOfficeHeader') {
+        if (!Cache::isStored($cache_id) || $hook_name == 'displayPayment' || $hook_name == 'displayPaymentEU' || $hook_name == 'paymentOptions' || $hook_name == 'displayBackOfficeHeader') {
             $frontend = true;
             $groups = array();
             $use_groups = Group::isFeatureActive();
@@ -459,20 +459,26 @@ class HookCore extends ObjectModel
             }
             $sql->innerJoin('hook_module', 'hm', 'hm.`id_module` = m.`id_module`');
             $sql->innerJoin('hook', 'h', 'hm.`id_hook` = h.`id_hook`');
-            if ($hook_name != 'displayPayment' && $hook_name != 'displayPaymentEU') {
-                $sql->where('h.name != "displayPayment" AND h.name != "displayPaymentEU"');
+            if ($hook_name != 'paymentOptions') {
+                $sql->where('h.`name` != "paymentOptions"');
             }
             // For payment modules, we check that they are available in the contextual country
             elseif ($frontend) {
                 if (Validate::isLoadedObject($context->country)) {
-                    $sql->where('((h.name = "displayPayment" OR h.name = "displayPaymentEU") AND (SELECT id_country FROM '._DB_PREFIX_.'module_country mc WHERE mc.id_module = m.id_module AND id_country = '.(int)$context->country->id.' AND id_shop = '.(int)$context->shop->id.' LIMIT 1) = '.(int)$context->country->id.')');
+                    $sql->where('((h.`name` = "displayPayment" OR h.`name` = "displayPaymentEU" OR h.`name` = "paymentOptions")AND (SELECT `id_country` FROM `'._DB_PREFIX_.'module_country` mc WHERE mc.`id_module` = m.`id_module` AND `id_country` = '.(int)$context->country->id.' AND `id_shop` = '.(int)$context->shop->id.' LIMIT 1) = '.(int)$context->country->id.')');
                 }
                 if (Validate::isLoadedObject($context->currency)) {
-                    $sql->where('((h.name = "displayPayment" OR h.name = "displayPaymentEU") AND (SELECT id_currency FROM '._DB_PREFIX_.'module_currency mcr WHERE mcr.id_module = m.id_module AND id_currency IN ('.(int)$context->currency->id.', -1, -2) LIMIT 1) IN ('.(int)$context->currency->id.', -1, -2))');
+                    $sql->where('((h.`name` = "displayPayment" OR h.`name` = "displayPaymentEU" OR h.`name` = "paymentOptions") AND (SELECT `id_currency` FROM `'._DB_PREFIX_.'module_currency` mcr WHERE mcr.`id_module` = m.`id_module` AND `id_currency` IN ('.(int)$context->currency->id.', -1, -2) LIMIT 1) IN ('.(int)$context->currency->id.', -1, -2))');
+                }
+                if (Validate::isLoadedObject($context->cart)) {
+                    $carrier = new Carrier($context->cart->id_carrier);
+                    if (Validate::isLoadedObject($carrier)) {
+                        $sql->where('((h.`name` = "displayPayment" OR h.`name` = "displayPaymentEU" OR h.`name` = "paymentOptions") AND (SELECT `id_reference` FROM `'._DB_PREFIX_.'module_carrier` mcar WHERE mcar.`id_module` = m.`id_module` AND `id_reference` = '.(int)$carrier->id_reference.' AND `id_shop` = '.(int)$context->shop->id.' LIMIT 1) = '.(int)$carrier->id_reference.')');
+                    }
                 }
             }
             if (Validate::isLoadedObject($context->shop)) {
-                $sql->where('hm.id_shop = '.(int)$context->shop->id);
+                $sql->where('hm.`id_shop` = '.(int)$context->shop->id);
             }
 
             if ($frontend) {
@@ -504,7 +510,7 @@ class HookCore extends ObjectModel
                     );
                 }
             }
-            if ($hook_name != 'displayPayment' && $hook_name != 'displayBackOfficeHeader') {
+            if ($hook_name != 'displayPayment' && $hook_name != 'displayPaymentEU' && $hook_name != 'paymentOptions' && $hook_name != 'displayBackOfficeHeader') {
                 Cache::store($cache_id, $list);
                 // @todo remove this in 1.6, we keep it in 1.5 for backward compatibility
                 self::$_hook_modules_cache_exec = $list;

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -278,6 +278,18 @@ class ShopCore extends ObjectModel
         // Remove urls
         $res &= Db::getInstance()->delete('shop_url', 'id_shop = '.(int)$this->id);
 
+        // Remove currency restrictions
+        $res &= Db::getInstance()->delete('module_currency', 'id_shop = '.(int)$this->id);
+
+        // Remove group restrictions
+        $res &= Db::getInstance()->delete('module_group', 'id_shop = '.(int)$this->id);
+
+        // Remove country restrictions
+        $res &= Db::getInstance()->delete('module_country', 'id_shop = '.(int)$this->id);
+
+        // Remove carrier restrictions
+        $res &= Db::getInstance()->delete('module_carrier', 'id_shop = '.(int)$this->id);
+
         Shop::cacheShops(true);
 
         return $res;

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1025,6 +1025,12 @@ CREATE TABLE `PREFIX_module_group` (
   PRIMARY KEY (`id_module`,`id_shop`, `id_group`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 
+CREATE TABLE `PREFIX_module_carrier` (
+  `id_module`INT(10) unsigned NOT NULL,
+  `id_shop`INT(11) unsigned NOT NULL DEFAULT '1',
+  `id_reference` INT(11) NOT NULL
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+
 CREATE TABLE `PREFIX_module_history` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `id_employee` int(10) unsigned NOT NULL,

--- a/install-dev/upgrade/php/select_current_payment_modules.php
+++ b/install-dev/upgrade/php/select_current_payment_modules.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Select all current payment modules for the carrier restriction
+ */
+function select_current_payment_modules()
+{
+    $shops = Db::getInstance()->executeS('
+			SELECT `id_shop`
+			FROM `'._DB_PREFIX_.'shop`'
+    );
+    $carriers = Db::getInstance()->executeS('
+			SELECT DISTINCT `id_reference`
+			FROM `'._DB_PREFIX_.'carrier`
+			WHERE `active` = 1
+			AND `deleted` = 0'
+    );
+    $modules = Db::getInstance()->executeS('
+			SELECT m.`id_module`
+			FROM `'._DB_PREFIX_.'module` m
+			LEFT JOIN `'._DB_PREFIX_.'hook_module` hm ON hm.`id_module` = m.`id_module`
+			LEFT JOIN `'._DB_PREFIX_.'hook` h ON hm.`id_hook` = h.`id_hook`
+			WHERE h.`name` = \'displayPayment\' OR h.`name` = \'displayPaymentEU\' OR h.`name` = \'paymentOptions\''
+    );
+
+    foreach ($shops as $shop) {
+        foreach ($carriers as $carrier) {
+            foreach ($modules as $module) {
+                Db::getInstance()->insert(
+                    'module_carrier',
+                    array(
+                        'id_reference' => (int)$carrier['id_reference'],
+                        'id_module' => (int)$module['id_module'],
+                        'id_shop' => (int)$shop['id_shop']
+                    ),
+                    false,
+                    false,
+                    Db::INSERT_IGNORE
+                );
+            }
+        }
+    }
+}

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -45,6 +45,13 @@ CREATE TABLE `PREFIX_module_history` (
   UNIQUE KEY `id_employee` (`id_employee`,`id_module`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
+CREATE TABLE `PREFIX_module_carrier` (
+  `id_module`INT(10) unsigned NOT NULL,
+  `id_shop`INT(11) unsigned NOT NULL DEFAULT '1',
+  `id_reference` INT(11) NOT NULL
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+/* PHP:select_current_payment_modules(); */;
+
 
 ALTER TABLE `PREFIX_product` ADD `show_condition` TINYINT(1) NOT NULL DEFAULT '0' AFTER `available_date`;
 ALTER TABLE `PREFIX_product_shop` ADD `show_condition` TINYINT(1) NOT NULL DEFAULT '0' AFTER `available_date`;


### PR DESCRIPTION
## Description
### Link carriers to payments.

There have been several modules to achieve this functionality, but the best way to do so seems to be providing this functionality from the core. It saves a lot of (unnecessary) overrides.
## TODO
- [x] Provide configuration page
- [x] Create table `PREFIX_module_carrier` at install
- [x] Create table `PREFIX_module_carrier` at upgrade from 1.6 to 1.7
- [x] Check all modules at upgrade from 1.6 to 1.7 
- [x] Check all carriers at payment module install
- [x] Remove payment module from DB table `PREFIX_module_carrier` when uninstalled
- [x] Remove carrier from DB table `PREFIX_module_carrier` when deleted
- [x] Remove currency from DB table `PREFIX_module_currency` when deleted
- [x] Remove customer group from DB table `PREFIX_module_group` when deleted
- [x] Remove shop from DB table `PREFIX_module_currency`, `PREFIX_module_country`, `PREFIX_module_group` and `PREFIX_module_carrier` when deleted
- [x] Prevent payment method from being shown
- [x] Fix typo: IN which -> FOR which
## Screenshot

![carrierrestrictions](https://cloud.githubusercontent.com/assets/6775736/13971381/1ce1251a-f090-11e5-9df7-2956c9de6f9b.png)
## Steps to Test this Fix
- Add payment modules; all carriers should be checked
- Upgrade to or install PS 1.7; all carriers/payment methods should be checked
- Change options and see if payment methods are hidden or shown
## Requirements

Requires #5243 to be applied first
