### PR TITLE
Fix fatal error on classes/stock/StockAvailable.php

### DIFF
--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -130,6 +130,7 @@ class StockManager
             // The product is not a pack
             $stockAvailable->quantity = $stockAvailable->quantity + $delta_quantity;
             $stockAvailable->id_product = (int)$product->id;
+            $stockAvailable->id_product_attribute = (int)$id_product_attribute;
             $stockAvailable->update();
 
             // Decrease case only: the stock of linked packs should be decreased too.


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Inspired by this thread: https://www.prestashop.com/forums/topic/483630-bug-161-1-1612-classesstockstockavailablephp/ <br /><br />When the classes/stock/StockAvailable.php is left as is some products would cause the payment window to hang and the page will never redirect. I turned on developer mode to get this error. <br /><br />`Fatal error: Uncaught exception 'PrestaShopException' with message 'Property StockAvailable-id_product_attribute is empty'`<br /><br />See #5242 for the `1.6.1.x` PR of this commit.<br />Also, see #4545 for a first PR attempting to fix this. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-6890 |
