### PR TITLE
[-] CORE : Fix fatal error on classes/stock/StockAvailable.php (1.6)

### DIFF
--- a/Core/Business/Stock/Core_Business_Stock_StockManager.php
+++ b/Core/Business/Stock/Core_Business_Stock_StockManager.php
@@ -125,6 +125,7 @@ class Core_Business_Stock_StockManager
             // The product is not a pack
             $stockAvailable->quantity = $stockAvailable->quantity + $delta_quantity;
             $stockAvailable->id_product = (int)$product->id;
+            $stockAvailable->id_product_attribute = (int)$id_product_attribute;
             $stockAvailable->update();
 
             // Decrease case only: the stock of linked packs should be decreased too.


### PR DESCRIPTION
## Description

Inspired by this thread: https://www.prestashop.com/forums/topic/483630-bug-161-1-1612-classesstockstockavailablephp/

> When the classes/stock/StockAvailable.php is left as is some products would cause the payment window to hang and the page will never redirect. I turned on developer mode to get this error. 
> 
> `Fatal error: Uncaught exception 'PrestaShopException' with message 'Property StockAvailable->id_product_attribute is empty'`

See #5241  for the `develop` PR of this commit.
Also, see #4545 for a first PR attempting to fix this.
## Forge Ticket (optional)

Fixes http://forge.prestashop.com/browse/PSCSX-6890
