### PR TITLE
[-] BO : Remove redundant declaration of $start in AdminController::getList

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3070,7 +3070,6 @@ class AdminControllerCore extends Controller
         }
 
         /* Determine offset from current page */
-        $start = 0;
         if ((int)Tools::getValue('submitFilter'.$this->list_id)) {
             $start = ((int)Tools::getValue('submitFilter'.$this->list_id) - 1) * $limit;
         } elseif (empty($start) && isset($this->context->cookie->{$this->list_id.'_start'}) && Tools::isSubmit('export'.$this->table)) {


### PR DESCRIPTION
Redeclaration of $start within the getList method is redundant and makes the $start argument passed to the method unusable : 

```
public function getList($id_lang, $order_by = null, $order_way = null, $start = 0, $limit = null, $id_lang_shop = false){

...

$start = 0

//Code using $start
... 

}
```
