### PR TITLE
[*] TR : Better spelling of Dutch tab names

### DIFF
--- a/install-dev/langs/nl/data/tab.xml
+++ b/install-dev/langs/nl/data/tab.xml
@@ -6,9 +6,9 @@
   <tab id="Addresses" name="Adressen"/>
   <tab id="Administration" name="Administratie"/>
   <tab id="AdminModulesSf" name="Modulecatalogus" />
-  <tab id="Advanced_Parameters" name="Geavanceerde Instellingen"/>
+  <tab id="Advanced_Parameters" name="Geavanceerde instellingen"/>
   <tab id="Attachments" name="Bijlagen"/>
-  <tab id="Attributes_and_features" name="Attributes &amp; Features" />
+  <tab id="Attributes_and_features" name="Attributen &amp; kenmerken" />
   <tab id="Attributes_and_Values" name="Productattributen"/>
   <tab id="Carriers" name="Vervoerders"/>
   <tab id="CarrierWizard" name="Vervoerder"/>
@@ -46,7 +46,7 @@
   <tab id="Groups" name="Groepen"/>
   <tab id="Image_Settings" name="Afbeeldingsinstellingen" />
   <tab id="Images" name="Afbeeldingen"/>
-  <tab id="Information" name="Information" />
+  <tab id="Information" name="Informatie" />
   <tab id="Instant_Stock_Status" name="Huidige voorraadstatus"/>
   <tab id="International" name="Internationaal" />
   <tab id="Invoices" name="Facturen"/>
@@ -63,7 +63,7 @@
   <tab id="Marketing" name="Marketing"/>
   <tab id="Menus" name="Menu's"/>
   <tab id="Merchandise_Returns" name="Retourzendingen"/>
-  <tab id="Modules_1" name="Modules en Services"/>
+  <tab id="Modules_1" name="Modules en services"/>
   <tab id="Modules" name="Modules"/>
   <tab id="Monitoring" name="Monitoring"/>
   <tab id="Multistore" name="Multistore"/>
@@ -96,8 +96,8 @@
   <tab id="SEO_URLs" name="SEO &amp; URL's"/>
   <tab id="Shipping_1" name="Instellingen"/>
   <tab id="Shipping" name="Verzending"/>
-  <tab id="Shop_parameters" name="Shop Parameters" />
-  <tab id="Shop_URLs" name="Winkel-URLs"/>
+  <tab id="Shop_parameters" name="Winkelinstellingen" />
+  <tab id="Shop_URLs" name="Winkel-URL's"/>
   <tab id="Shopping_Carts" name="Winkelwagens"/>
   <tab id="Shops" name="Winkels"/>
   <tab id="SQL_Manager" name="SQL-beheer"/>


### PR DESCRIPTION
A few extra translated tabs.

Some words no longer have capitals. Capitalization of titles is usually avoided in Dutch.
