### PR TITLE
[*] CORE : Add redis cache + pipelining + cluster

### DIFF
--- a/admin-dev/themes/default/template/controllers/performance/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/performance/helpers/form/form.tpl
@@ -88,12 +88,12 @@
 					</div>
 					<div class="form-group">
 						<div class="col-lg-9 col-lg-push-3">
-							<input type="submit" value="{l s='Add Server'}" name="submitAddServer" class="btn btn-default" />
+							<input type="submit" value="{l s='Add Server'}" name="submitAddMemcachedServer" class="btn btn-default" />
 							<input type="button" value="{l s='Test Server'}" id="testMemcachedServer" class="btn btn-default" />
 	                	</div>
 					</div>
 			</div>
-			{if $servers}
+			{if isset($memcached_servers) && $memcached_servers}
 			<div class="form-group">
 				<table class="table">
 					<thead>
@@ -106,7 +106,7 @@
 						</tr>
 					</thead>
 					<tbody>
-				{foreach $servers AS $server}
+				{foreach $memcached_servers AS $server}
 					<tr>
 						<td>{$server.id_memcached_server}</td>
 						<td>{$server.ip}</td>
@@ -123,6 +123,79 @@
 			{/if}
 		</div>
 	{/if}
+	{if $key == 'redisServers'}
+		<div id="redisServers">
+			<div class="form-group">
+				<div class="col-lg-9 col-lg-push-3">
+					<button id="addRedisServer" class="btn btn-default" type="button" >
+						<i class="icon-plus-sign-alt"></i>&nbsp;{l s='Add server'}
+					</button>
+				</div>
+			</div>
+			<div id="formRedisServer" style="display:none;">
+				<div class="form-group">
+					<label class="control-label col-lg-3">{l s='IP Address'} </label>
+					<div class="col-lg-9">
+						<input class="form-control" type="text" name="redisIp" value="127.0.0.1" />
+					</div>
+				</div>
+				<div class="form-group">
+					<label class="control-label col-lg-3">{l s='Port'} </label>
+					<div class="col-lg-9">
+						<input class="form-control" type="text" name="redisPort" value="6379" />
+					</div>
+				</div>
+				<div class="form-group">
+					<label class="control-label col-lg-3">{l s='Auth'} </label>
+					<div class="col-lg-9">
+						<input class="form-control" type="text" name="redisAuth" value="" />
+					</div>
+				</div>
+				<div class="form-group">
+					<label class="control-label col-lg-3">{l s='Database ID'} </label>
+					<div class="col-lg-9">
+						<input class="form-control" type="text" name="redisDb" value="0" />
+					</div>
+				</div>
+				<div class="form-group">
+					<div class="col-lg-9 col-lg-push-3">
+						<input type="submit" value="{l s='Add Server'}" name="submitAddRedisServer" class="btn btn-default" />
+						<input type="button" value="{l s='Test Server'}" id="testRedisServer" class="btn btn-default" />
+					</div>
+				</div>
+			</div>
+			{if isset($redis_servers) && $redis_servers}
+				<div class="form-group">
+					<table class="table">
+						<thead>
+						<tr>
+							<th class="fixed-width-xs"><span class="title_box">{l s='ID'}</span></th>
+							<th><span class="title_box">{l s='IP address'}</span></th>
+							<th class="fixed-width-xs"><span class="title_box">{l s='Port'}</span></th>
+							<th class="fixed-width-xs"><span class="title_box">{l s='Auth'}</span></th>
+							<th class="fixed-width-xs"><span class="title_box">{l s='Db'}</span></th>
+							<th>&nbsp;</th>
+						</tr>
+						</thead>
+						<tbody>
+						{foreach $redis_servers AS $server}
+							<tr>
+								<td>{$server.id_redis_server}</td>
+								<td>{$server.ip}</td>
+								<td>{$server.port}</td>
+								<td>{$server.auth}</td>
+								<td>{$server.db}</td>
+								<td>
+									<a class="btn btn-default" href="{$currentIndex|escape:'html':'UTF-8'}&amp;token={$token|escape:'html':'UTF-8'}&amp;deleteRedisServer={$server.id_redis_server}" onclick="if (!confirm('{l s='Do you really want to remove the server %s:%s' sprintf=[$server.ip, $server.port] js=1}')) return false;"><i class="icon-minus-sign-alt"></i> {l s='Remove'}</a>
+								</td>
+							</tr>
+						{/foreach}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</div>
+	{/if}
 {/block}
 
 {block name="script"}
@@ -131,13 +204,19 @@
 		if ($('input[name="caching_system"]:radio:checked').val() == 'CacheMemcache' || $('input[name="caching_system"]:radio:checked').val() == 'CacheMemcached') {
 			$('#memcachedServers').css('display', $('#cache_active_on').is(':checked') ? 'block' : 'none');
 			$('#ps_cache_fs_directory_depth').closest('.form-group').hide();
+			$('#redisServers').hide();
 		}
 		else if ($('input[name="caching_system"]:radio:checked').val() == 'CacheFs') {
 			$('#memcachedServers').hide();
+			$('#redisServers').hide();
 			$('#ps_cache_fs_directory_depth').closest('.form-group').css('display', $('#cache_active_on').is(':checked') ? 'block' : 'none');
-		}
-		else {
+		} else if ($('input[name="caching_system"]:radio:checked').val() == 'CacheRedis') {
+			$('#redisServers').css('display', $('#cache_active_on').is(':checked') ? 'block' : 'none');
+			$('#ps_cache_fs_directory_depth').closest('.form-group').hide();
 			$('#memcachedServers').hide();
+		} else {
+			$('#memcachedServers').hide();
+			$('#redisServers').hide();
 			$('#ps_cache_fs_directory_depth').closest('.form-group').hide();
 		}
 	}
@@ -185,7 +264,7 @@
 					{
 						controller: 'adminperformance',
 						token: '{$token|escape:'html':'UTF-8'}',
-						action: 'test_server',
+						action: 'test_memcached_server',
 						sHost: host,
 						sPort: port,
 						type: type,
@@ -203,6 +282,52 @@
 							$('#formMemcachedServerStatus').show();
 							$('input:text[name=memcachedIp]').css('background', color);
 							$('input:text[name=memcachedPort]').css('background', color);
+						}
+					}
+				});
+			}
+			return false;
+		});
+
+		$('#addRedisServer').click(function() {
+			$('#formRedisServer').show();
+			return false;
+		});
+
+		$('#testRedisServer').click(function() {
+			var host = $('input:text[name=redisIp]').val();
+			var port = $('input:text[name=redisPort]').val();
+			var auth = $('input:text[name=redisAuth]').val();
+			var db   = $('input:text[name=redisDb]').val();
+			var type = $('input[name="caching_system"]:radio:checked').val() == 'redis';
+			if (host && port)
+			{
+				$.ajax({
+					url: 'index.php',
+					data:
+					{
+						controller: 'adminperformance',
+						token: '{$token|escape:'html':'UTF-8'}',
+						action: 'test_redis_server',
+						sHost: host,
+						sPort: port,
+						type: type,
+						ajax: true
+					},
+					context: document.body,
+					dataType: 'json',
+					context: this,
+					async: false,
+					success: function(data)
+					{
+						if (data && $.isArray(data))
+						{
+							var color = data[0] != 0 ? 'green' : 'red';
+							$('#formRedisServerStatus').show();
+							$('input:text[name=redisIp]').css('background', color);
+							$('input:text[name=redisPort]').css('background', color);
+							$('input:text[name=redisAuth]').css('background', color);
+							$('input:text[name=redisDb]').css('background', color);
 						}
 					}
 				});

--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2016 PrestaShop
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to http://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2015 PrestaShop SA
+ * @copyright 2007-2016 PrestaShop SA
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
@@ -243,8 +243,9 @@ abstract class CacheCore
     /**
      * Store a query in cache
      *
-     * @param string $query
-     * @param array $result
+     * @param string $query Query
+     * @param array $result Result
+     * @return bool Whether the query was successfully stored in cache
      */
     public function setQuery($query, $result)
     {
@@ -396,5 +397,41 @@ abstract class CacheCore
         } else {
             unset(Cache::$local[$key]);
         }
+    }
+
+    /**
+     * Can be implemented by caching systems that support pipelining
+     *
+     * Enable pipeline mode
+     *
+     * @return bool Whether pipeline could be started/enabled
+     */
+    public function pipeline()
+    {
+        return false;
+    }
+
+    /**
+     * Can be implemented by caching systems that support pipelining
+     *
+     * Execute the query
+     *
+     * @return bool Whether the query could be executed
+     */
+    public function exec()
+    {
+        return false;
+    }
+
+    /**
+     * Can be implemented by caching systems that support pipelining
+     *
+     * Cancel the current pipelined transaction -- nothing will be sent to redis
+     *
+     * @return bool Whether the transaction could be cancelled
+     */
+    public function discard()
+    {
+        return false;
     }
 }

--- a/classes/cache/CacheRedis.php
+++ b/classes/cache/CacheRedis.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * This class require a redis server and the Redis PECL extension
+ *
+ */
+class CacheRedis extends Cache
+{
+    /**
+     * @var RedisClient|RedisArray
+     */
+    protected $redis;
+
+    /**
+     * @var RedisParams
+     */
+    protected $_params = array();
+    protected $_servers = array();
+
+    /**
+     * @var bool Connection status
+     */
+    public $is_connected = false;
+
+    /**
+     * CachePhpRedis constructor.
+     */
+    public function __construct()
+    {
+        if (!extension_loaded('redis')) {
+            throw new PrestaShopException('Redis cache has been enabled, but the Redis extension is not available');
+        }
+        $this->connect();
+
+        if ($this->is_connected) {
+            $this->keys = @$this->redis->get(_COOKIE_IV_);
+            if (!is_array($this->keys)) {
+                $this->keys = array();
+            }
+        }
+    }
+
+    /**
+     * CachePhpRedis destructor.
+     */
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    /**
+     * Connect to redis server
+     *
+     * @return void
+     */
+    public function connect()
+    {
+        $this->is_connected = false;
+        $this->_servers = self::getRedisServers();
+
+        if (!$this->_servers) {
+            return;
+        } else {
+            if (count($this->_servers) > 1) {
+                // Multiple servers, set up redis array
+                $hosts = array();
+                foreach ($this->_servers as $server) {
+                    $hosts[] = $server['ip'].':'.$server['port'];
+                }
+                $this->redis = new RedisArray($hosts, array('pconnect' => true));
+                foreach ($this->_servers as $server) {
+                    $instance = $this->redis->_instance($server['ip'].':'.$server['port']);
+                    if (!empty($server['auth'])) {
+                        if (is_object($instance)) {
+                            if ($instance->auth($server['auth'])) {
+                                // We're connected as soon as authentication is successful
+                                $this->is_connected = true;
+                            }
+                        }
+                    } else {
+                        $ping = array_values($this->redis->ping());
+                        if(!empty($ping) && $ping[0] === '+PONG') {
+                            // We're connected if a connection without +AUTH receives a +PONG
+                            $this->is_connected = true;
+                        }
+                    }
+                }
+                if (!empty($this->_servers[0]['auth'])) {
+                    if (!($this->redis->auth($this->_servers[0]['auth']))) {
+                        return;
+                    }
+                }
+            } elseif (count($this->_servers) === 1) {
+                $this->redis = new Redis();
+                if ($this->redis->pconnect($this->_servers[0]['ip'], $this->_servers[0]['port'])) {
+                    $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+                    if (!empty($this->_servers[0]['auth'])) {
+                        if (!($this->redis->auth($this->_servers[0]['auth']))) {
+                            return;
+                        }
+                    }
+                    $this->redis->select($this->_servers[0]['db']);
+                    try {
+                        $this->redis->select($this->_servers[0]['db']);
+                    } catch (Exception $e) {
+                        $this->is_connected = false;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @see Cache::_set()
+     *
+     * @param string $key Cache key
+     * @param mixed $value Value
+     * @param int $ttl Time to live in cache
+     * @return bool Whether the value could be stored
+     */
+    protected function _set($key, $value, $ttl = 0)
+    {
+        // TODO: add TTL support
+        if (!$this->is_connected) {
+            return false;
+        }
+
+        if ((count($this->_servers) > 1)) {
+            $this->redis->set($key, $value);
+            if (!empty($ret) && is_array($ret) && $ret = array_values($ret)) {
+                return $ret[0];
+            }
+            return false;
+        }
+
+        return $this->redis->set($key, $value);
+    }
+
+    /**
+     * @see Cache::_get()
+     *
+     * @return bool Value
+     */
+    protected function _get($key)
+    {
+        if (!$this->is_connected) {
+            return false;
+        }
+
+        if ((count($this->_servers) > 1)) {
+            $ret = $this->redis->get($key);
+            if (!empty($ret) && is_array($ret) && $ret = array_values($ret)) {
+                return $ret[0];
+            }
+            return false;
+        }
+
+        return $this->redis->get($key);
+    }
+
+    /**
+     * @see Cache::_exists()
+     *
+     * @return bool Whether key exists
+     */
+    protected function _exists($key)
+    {
+        if (!$this->is_connected) {
+            return false;
+        }
+
+        if ((count($this->_servers) > 1)) {
+            $ret = $this->redis->exists($key);
+            if (!empty($ret) && is_array($ret) && $ret = array_values($ret)) {
+                return $ret[0];
+            }
+            return false;
+        }
+
+        return $this->redis->exists($key);
+    }
+
+    /**
+     * @see Cache::_delete()
+     *
+     * @return bool Whether key could be deleted
+     */
+    protected function _delete($key)
+    {
+        if (!$this->is_connected) {
+            return false;
+        }
+
+        if ((count($this->_servers) > 1)) {
+            $ret = array_values($this->redis->del($key));
+            if (!empty($ret) && is_array($ret) && $ret = array_values($ret)) {
+                return $ret[0];
+            }
+            return false;
+        }
+
+        return $this->redis->del($key);
+    }
+
+    /**
+     * @see Cache::_writeKeys()
+     *
+     * @return bool Whether keys could be written
+     */
+    protected function _writeKeys()
+    {
+        if (!$this->is_connected) {
+            return false;
+        }
+        $this->redis->set(_COOKIE_IV_, $this->keys);
+
+        return true;
+    }
+
+    /**
+     * @see Cache::flush()
+     *
+     * @return bool
+     */
+    public function flush()
+    {
+        if (!$this->is_connected) {
+            return false;
+        }
+
+        return (bool)$this->redis->flushDB();
+    }
+
+    /**
+     * Close connection to redis server
+     *
+     * @return bool Whether closed successfully
+     */
+    protected function close()
+    {
+        if (!$this->is_connected) {
+            return false;
+        }
+
+        // Don't close the connection, needs to be persistent across PHP-sessions
+        return true;
+    }
+
+    /**
+     * Enable pipelining
+     * Requires exec() in order to send data to redis
+     * because data is now being 'piped' over 1 connection
+     *
+     * @return bool Whether pipeline could be enabled
+     */
+    public function pipeline()
+    {
+        // Cannot enter multi mode if we are using a redis array
+        if (count($this->_servers()) > 1) {
+            return false;
+        }
+        return $this->redis->multi(Redis::PIPELINE);
+    }
+
+    /**
+     * Executes the query
+     *
+     * Do not use this when not in multi-mode
+     *
+     * @return bool Whether exec succeeded
+     */
+    public function exec()
+    {
+        return $this->redis->exec();
+    }
+
+    /**
+     * Add a redis server
+     *
+     * @param string $ip IP address or hostname
+     * @param int $port Port number
+     * @param string $auth Authentication key
+     * @param int $db Redis database ID
+     * @return bool Whether the server was successfully added
+     * @throws PrestaShopDatabaseException
+     */
+    public static function addServer($ip, $port, $auth, $db)
+    {
+        $sql = new DbQuery();
+        $sql->select('count(*)');
+        $sql->from('redis_servers');
+        $sql->where('`ip` = \''.pSQL($ip).'\'');
+        $sql->where('`port` = '.(int)$port);
+        $sql->where('`auth` = \''.pSQL($auth).'\'');
+        $sql->where('`db` = '.(int)$db);
+        if (Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql, false)) {
+            $context = Context::getContext();
+            $context->controller->errors[] =
+                Tools::displayError('Redis server has already been added');
+            return false;
+        }
+
+        return Db::getInstance()->insert(
+            'redis_servers',
+            array(
+                'ip' => pSQL($ip),
+                'port' => (int)$port,
+                'auth' => pSQL($auth),
+                'db' => (int)$db
+            ),
+            false,
+            false
+        );
+    }
+
+    /**
+     * Get list of redis server information
+     *
+     * @return array
+     */
+    public static function getRedisServers()
+    {
+        $sql = new DbQuery();
+        $sql->select('*');
+        $sql->from('redis_servers');
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql, true, false);
+    }
+
+    /**
+     * Delete a redis server
+     *
+     * @param int $id_server Server ID
+     * @return bool Whether the server was successfully deleted
+     */
+    public static function deleteServer($id_server)
+    {
+        return Db::getInstance()->delete(
+            'redis_servers',
+            '`id_redis_server` = '.(int)$id_server,
+            0,
+            false
+        );
+    }
+}

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -77,7 +77,7 @@ abstract class DbCore
      *
      * @var string
      */
-    protected $last_query;
+    public $last_query;
 
     /**
      * Store hash of the last executed query
@@ -459,6 +459,7 @@ abstract class DbCore
         if ($type == Db::ON_DUPLICATE_KEY) {
             $sql .= ' ON DUPLICATE KEY UPDATE '.substr($duplicate_key_stringified, 0, -1);
         }
+        $this->last_query = $sql;
 
         return (bool)$this->q($sql, $use_cache);
     }

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1951,6 +1951,14 @@ CREATE TABLE `PREFIX_memcached_servers` (
 `weight` INT(11) UNSIGNED NOT NULL
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 
+CREATE TABLE `PREFIX_redis_servers` (
+  `id_redis_server` INT(11) UNSIGNED PRIMARY KEY NOT NULL,
+  `ip` VARCHAR(46) NOT NULL,
+  `port` INT(11) UNSIGNED NOT NULL,
+  `auth` TEXT,
+  `db` INT(11) UNSIGNED NOT NULL
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+
 CREATE TABLE `PREFIX_product_country_tax` (
   `id_product` int(11) NOT NULL,
   `id_country` int(11) NOT NULL,
@@ -2583,3 +2591,4 @@ CREATE TABLE IF NOT EXISTS `PREFIX_cms_role_lang` (
   `name` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`id_cms_role`,`id_lang`, id_shop)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
+

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -98,4 +98,14 @@ DROP TABLE `PREFIX_scene_shop`;
 ALTER TABLE `PREFIX_image_type` DROP `scenes`;
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_SCENE_FEATURE_ACTIVE';
 
+
 UPDATE `PREFIX_configuration` SET value=1 WHERE name='PS_TAX_DISPLAY';
+
+/* Add redis cache */
+CREATE TABLE `PREFIX_redis_servers` (
+  `id_redis_server` INT(11) UNSIGNED PRIMARY KEY NOT NULL,
+  `ip` VARCHAR(46) NOT NULL,
+  `port` INT(11) UNSIGNED NOT NULL,
+  `auth` TEXT,
+  `db` INT(11) UNSIGNED NOT NULL
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;


### PR DESCRIPTION
## Description

Add redis cache support to PrestaShop.

Attempt to merge the redis cache module https://github.com/firstred/phprediscache into PrestaShop's core and make redis an out-of-the-box supported caching system.

This PR also tries to fully utilize redis by adding support for pipelining. This can save a lot of overhead when using caching over TCP. More info: http://redis.io/topics/pipelining
If a lot of keys need to be requested at once, then pipelining would be ideal to use. It can be used as follows:

``` php
$cache = Cache::getInstance();
$pipeling = false;
if ($cache->pipeline()) { 
    // pipeline supported
    $pipeline = true;
}
$results = array();
$results[] = $cache->get('key');
$results[] = $cache->get('key2');
...
$results[] = $cache->get('keyn');
if ($pipeline) {
    $results = $cache->exec();
}
```

If you enter multiple redis servers, then PrestaShop will automatically create a redis cluster and keys will be automatically distributed among the servers. More info: https://github.com/phpredis/phpredis/blob/develop/arrays.markdown

Furthermore, auth and database number are supported.
## Screenshot

![rediscache](https://cloud.githubusercontent.com/assets/6775736/14039155/c9d5c1a2-f259-11e5-887a-14026e507407.png)
## Steps to Test this Feature
1. Host multiple redis servers, with or without auth (`/etc/redis/redis.conf` => `requirepass`)
2. Enter server credentials
3. Check with `redis-cli` and `keys *` if database is actually filled
4. Use `xdebug` or stuff like `ddd` to check if PrestaShop uses the actual data from redis
