### PR TITLE
[-] CORE : Fix bug when X-Forwarded-Host HTTP header has more than one host

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -287,7 +287,12 @@ class ToolsCore
      */
     public static function getHttpHost($http = false, $entities = false, $ignore_port = false)
     {
-        $host = (isset($_SERVER['HTTP_X_FORWARDED_HOST']) ? $_SERVER['HTTP_X_FORWARDED_HOST'] : $_SERVER['HTTP_HOST']);
+        if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+            $host = trim(array_pop(explode(',', $_SERVER['HTTP_X_FORWARDED_HOST'])));
+        }
+        else {
+            $host = $_SERVER['HTTP_HOST'];
+        }
         if ($ignore_port && $pos = strpos($host, ':')) {
             $host = substr($host, 0, $pos);
         }


### PR DESCRIPTION
The HTTP header X-Forwarded-Host is not a standard header but come conventions are used by servers. For instance, Apache can include more than one host in this header.

See. https://httpd.apache.org/docs/current/en/mod/mod_proxy.html#x-headers

"Be careful when using these headers on the origin server, since they will contain more than one (comma-separated) value if the original request already contained one of these headers"

This fix allow multiple values in X-Forwarded-Host header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5260)
<!-- Reviewable:end -->
