### PR TITLE
Use per shop product visibiliy

### DIFF
--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -122,7 +122,7 @@ class ProductSaleCore
 
         $sql .= '
 				WHERE product_shop.`active` = 1
-					AND p.`visibility` != \'none\'';
+					AND product_shop.`visibility` != \'none\'';
 
         if (Group::isFeatureActive()) {
             $groups = FrontController::getCurrentCustomerGroups();


### PR DESCRIPTION
Visibility is set per shop and not global so the following code/query :

```
WHERE product_shop.`active` = 1
AND p.`visibility` != \'none\'';
```

Needs to be:

```
WHERE product_shop.`active` = 1
AND product_shop.`visibility` != \'none\'';
```

Feel free to comment :)
