### PR TITLE
[-] CORE: Always add combo price to base price in price calculation

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3024,6 +3024,9 @@ class ProductCore extends ObjectModel
         } else {
             $price = (float)$specific_price['price'];
         }
+
+        // @TODO FIXME $specific_price['id_currency'] is "0", but we use integer comparisons below: $specific_price['id_currency'] ??
+
         // convert only if the specific price is in the default currency (id_currency = 0)
         if (!$specific_price || !($specific_price['price'] >= 0 && $specific_price['id_currency'])) {
             $price = Tools::convertPrice($price, $id_currency);
@@ -3032,6 +3035,7 @@ class ProductCore extends ObjectModel
             }
         }
 
+     
         // Attribute price
         if (is_array($result)) {
             $attribute_price = Tools::convertPrice($result['attribute_price'] !== null ? (float)$result['attribute_price'] : 0, $id_currency);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3033,7 +3033,7 @@ class ProductCore extends ObjectModel
         }
 
         // Attribute price
-        if (is_array($result) && (!$specific_price || !$specific_price['id_product_attribute'] || $specific_price['price'] < 0)) {
+        if (is_array($result)) {
             $attribute_price = Tools::convertPrice($result['attribute_price'] !== null ? (float)$result['attribute_price'] : 0, $id_currency);
             // If you want the default combination, please use NULL value instead
             if ($id_product_attribute !== false) {


### PR DESCRIPTION
## Description

Environment:
- Cache is turned off
- Product with combinations
- Product has a base price of 0
- Product attributes have their prices, which are used as full price (therefore base price is 0)

Steps to reproduce bug:
- We enter a specific price for a specific combination (using Product Edit form > Prices), for the default combination
- We look at category products, we see that product with specific price has a price of 0
- We look inside the product page, the prices are correct. That's because the prices are recalculated using JS :cry:
- We add the product to cart, the price is 0! :warning: 
## Pull Request

The goal of this PR is to point out the problem. The price calculation is too complex for me to understand all the outcome cases.

I can tell that the bug appear in
[0eecc7a3dbbace04216a84529bcefe4b0fd59f1f](https://github.com/PrestaShop/PrestaShop/commit/0eecc7a3dbbace04216a84529bcefe4b0fd59f1f)

How does the bug work?

First:
- [Product.php#L3031](https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/Product.php#L3031) this line sets the `$specific_price['price'] = 0;`
- [Product.php#L3036](https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/Product.php#L3036) in this line we check for some things (I have no idea why), but the `$specific_price['price'] < 0` part is intended to check if the `$specific_price['price'] < "-1.000000"` (yes the value is string, another possible bug)

My solution: delete the conditional, because in my understanding the **attribute price** should always be added to base price.

**Bonus**:
- [Product.php#L3028](https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/Product.php#L3028)
- [Product.php#L3086](https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/Product.php#L3086)

`$specific_price['id_currency']` is supposed to be an integer and we mean it to use it like that here (I assume). For example, `!0 ~ true`. However, the values in `$specific_price` are all **strings**!. I added a TODO in case some of you decide to fix it :cry: 
## Other branches

Does this concern `dev` branch (1.7)?

Possibly, since I understand that 0eecc7a3dbbace04216a84529bcefe4b0fd59f1f has not been cherry-picked to `dev` yet, but if you do, then you introduce this bug.
## Forge Ticket (optional)

There may be some tickets related to this bugs.
May be related:
- [stackoverflow/36308902](http://stackoverflow.com/questions/36308902/prestashop-combinations-doesnt-play-well-with-specific-prices)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5277)
<!-- Reviewable:end -->
