### PR TITLE
[-]BO: Fix some number formats on product page

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -74,7 +74,7 @@ class ProductShipping extends CommonAbstractType
             'label' => $this->translator->trans('Width', [], 'AdminProducts'),
             'constraints' => array(
                 new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
+                new Assert\Type(array('type' => 'numeric'))
             )
         ))
         ->add('height', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
@@ -82,7 +82,7 @@ class ProductShipping extends CommonAbstractType
             'label' => $this->translator->trans('Height', [], 'AdminProducts'),
             'constraints' => array(
                 new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
+                new Assert\Type(array('type' => 'numeric'))
             )
         ))
         ->add('depth', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
@@ -90,7 +90,7 @@ class ProductShipping extends CommonAbstractType
             'label' => $this->translator->trans('Depth', [], 'AdminProducts'),
             'constraints' => array(
                 new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
+                new Assert\Type(array('type' => 'numeric'))
             )
         ))
         ->add('weight', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
@@ -98,7 +98,7 @@ class ProductShipping extends CommonAbstractType
             'label' => $this->translator->trans('Weight', [], 'AdminProducts'),
             'constraints' => array(
                 new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
+                new Assert\Type(array('type' => 'numeric'))
             )
         ))
         ->add('additional_shipping_cost', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
@@ -65,7 +65,7 @@ class ProductSupplierCombination extends CommonAbstractType
             'required' => false,
             'label' => null
         ))
-        ->add('product_price', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
+        ->add('product_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'constraints' => array(
                 new Assert\NotBlank(),

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-supplier-combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-supplier-combination.html.twig
@@ -21,12 +21,12 @@
         {{ form_errors(form[collectionName]) }}
         <table class="table table-striped">
           <thead>
-          <tr>
-            <th>{{ trans('Product name', {}, 'AdminProducts') }}</th>
-            <th>{{ trans('Supplier reference', {}, 'AdminProducts') }}</th>
-            <th>{{ trans('Unit price tax excluded', {}, 'AdminProducts') }}</th>
-            <th>{{ trans('Unit price currency', {}, 'AdminProducts') }}</th>
-          </tr>
+            <tr>
+              <th width="40%">{{ trans('Product name', {}, 'AdminProducts') }}</th>
+              <th width="20%">{{ trans('Supplier reference', {}, 'AdminProducts') }}</th>
+              <th width="20%">{{ trans('Unit price tax excluded', {}, 'AdminProducts') }}</th>
+              <th width="20%">{{ trans('Unit price currency', {}, 'AdminProducts') }}</th>
+            </tr>
           </thead>
           <tbody>
           {% for supplier_combination in form[collectionName] %}


### PR DESCRIPTION
## Description

Fix the wrong number format on product sizes & supplier prices.
## Steps to Test this Fix
- Create or Edit a product
- Try to save with a product size to 0
- The product should be saved
## Forge Ticket (optional)

http://forge.prestashop.com/browse/BOOM-491
