### PR TITLE
[-]IN: Fix creation directory on some servers

### DIFF
--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -328,7 +328,7 @@ class ThemeManager implements AddonManagerInterface
     {
         $jsonConfigFolder = $this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$theme->getName();
         if (!file_exists($jsonConfigFolder) && !is_dir($jsonConfigFolder)) {
-            mkdir($jsonConfigFolder);
+            mkdir($jsonConfigFolder, 0777, true);
         }
 
         file_put_contents(


### PR DESCRIPTION
## Description

Some shared servers have a configuration blocking on a folder creation without the recursive parameter when the full path is sent.

This will fix this problem.
