### PR TITLE
[-] FO : Fix incorrect cart rules list in case of country restriction (PSCSX-7873)

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -368,10 +368,14 @@ class CartRuleCore extends ObjectModel
                             WHERE crc.id_cart_rule = '.(int)$cart_rule['id_cart_rule'].'
                             AND crc.id_country = '.(int)$country['id_country']);
                         if ($id_cart_rule) {
-                            $result[$id_cart_rule] = $result_bak[$key];
+                            $result[] = $result_bak[$key];
+                            break;
                         }
                     }
                 }
+            }
+            else {
+                $result[] = $result_bak[$key];
             }
         }
 


### PR DESCRIPTION
Partly fixes http://forge.prestashop.com/browse/PSCSX-7873 (point 2)

To reproduce: create some highlighted cart rules, restrict some to specific countries, make an order => available cart rules list is not complete.
