### PR TITLE
[-] BO: Themes / fix broken preview link

### DIFF
--- a/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
@@ -57,7 +57,7 @@
 											</div>
 										</div>
 									</div>
-									<img class="center-block img-thumbnail" src="{$theme->get('preview')}" alt="{$theme->getName()}" />
+									<img class="center-block img-thumbnail" src="{$base_url}{$theme->get('preview')}" alt="{$theme->getName()}" />
 								</div>
 							</div>
 						</div>
@@ -80,7 +80,7 @@
 
 			<div class="col-md-3">
 				<a href="{$base_url}" class="_blank">
-					<img class="center-block img-thumbnail" src="{$cur_theme->get('preview')}" alt="{$cur_theme->getName()}" />
+					<img class="center-block img-thumbnail" src="{$base_url}{$cur_theme->get('preview')}" alt="{$cur_theme->getName()}" />
 				</a>
 			</div>
 


### PR DESCRIPTION
## Description

On 1.7.0.0-alpha.3.0, links to preview of a theme are broken.
## Steps to Test this Fix
1. Instal 1.7.0.0-alpha.3.0.
2. Go to Design / Themes.
