### PR TITLE
[-] BO : Fixed notice Undefined index: medium

### DIFF
--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -556,7 +556,7 @@ class AdminCategoriesControllerCore extends AdminController
                     'display_image' => true,
                     'image' => $thumb_url ? $thumb_url : false,
                     'size' => $thumb_size,
-                    'format' => $format['medium']
+                    'format' => isset($format['medium']) ?: $format['category']
                 ),
                 array(
                     'type' => 'file',


### PR DESCRIPTION
## Description

The 'thumb' form field was trying to use the undefined offset 'medium' in $format. It is defined in 'category' instead.
## Steps to Test this Fix
1. Navigate to category edit page.
   - The notice does not appear.
## Forge Ticket (optional)

Fixes ticket http://forge.prestashop.com/browse/BOOM-461
