### PR TITLE
[~] Core: remove "autoExecuteWithNullValues" method

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -355,22 +355,6 @@ abstract class DbCore
     }
 
     /**
-     * Filter SQL query within a blacklist
-     *
-     * @param string $table Table where insert/update data
-     * @param array $values Data to insert/update
-     * @param string $type INSERT or UPDATE
-     * @param string $where WHERE clause, only for UPDATE (optional)
-     * @param int $limit LIMIT clause (optional)
-     * @return bool
-     * @throws PrestaShopDatabaseException
-     */
-    public function autoExecuteWithNullValues($table, $values, $type, $where = '', $limit = 0)
-    {
-        return $this->autoExecute($table, $values, $type, $where, $limit, 0, true);
-    }
-
-    /**
      * Execute a query and get result resource
      *
      * @param string|DbQuery $sql


### PR DESCRIPTION
## Description

See: https://github.com/PrestaShop/PrestaShop/commit/93f7696f0287d5bb5d9ccdf11f77935e5412e59d

Since the method "autoExecute" was deleted, this one can handle the call inside. 
There is no call of "autoExecute" inside the core project.
