### PR TITLE
// Fix legacy context

### DIFF
--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -47,7 +47,7 @@ class LegacyContext
     {
         $legacyContext = OldContext::getContext();
 
-        if ($legacyContext && !empty($legacyContext->shop) && isset($legacyContext->employee)) {
+        if ($legacyContext && !empty($legacyContext->shop) && !isset($legacyContext->controller) && isset($legacyContext->employee)) {
             //init real legacy shop context
             $adminController = new \AdminControllerCore();
             $adminController->initShopContext();


### PR DESCRIPTION
## Description

The `LegacyContext` adapter was overriding the `controller`.
An error was occurring when you tried to add a new shop group in multistore context.
