### PR TITLE
[WIP] // FO:  Start with the address in the conversion funnel

### DIFF
--- a/classes/checkout/AbstractCheckoutStep.php
+++ b/classes/checkout/AbstractCheckoutStep.php
@@ -110,7 +110,6 @@ abstract class AbstractCheckoutStepCore implements CheckoutStepInterface
     public function isComplete()
     {
         return $this->step_is_complete;
-        ;
     }
 
     public function setCurrent($step_is_current)

--- a/classes/checkout/CheckoutProcess.php
+++ b/classes/checkout/CheckoutProcess.php
@@ -165,4 +165,15 @@ class CheckoutProcessCore implements RenderableInterface
             }
         }
     }
+
+    public function getStep($className)
+    {
+        foreach ($this->getSteps() as $step) {
+            if (is_a($step, $className)) {
+                return $step;
+            }
+        }
+
+        return null;
+    }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1294,6 +1294,7 @@ class FrontControllerCore extends Controller
         }
         $pages['register'] = $this->context->link->getPageLink('authentication', true, null, ['create_account' => '1']);
         $pages['order_login'] = $this->context->link->getPageLink('order', true, null, ['login' => '1']);
+        $pages['order'] = $this->context->link->getPageLink('order', true, null, ['state' => 'new']);
         $urls['pages'] = $pages;
 
         $urls['theme_assets'] = __PS_BASE_URI__ . 'themes/' . $this->context->shop->theme->getName() . '/assets/';

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -145,6 +145,7 @@ class OrderControllerCore extends FrontController
         if (!is_array($data)) {
             $data = [];
         }
+
         $process->restorePersistedData($data);
     }
 
@@ -182,6 +183,11 @@ class OrderControllerCore extends FrontController
         );
 
         $this->checkoutProcess->setNextStepReachable();
+        $step = $this->checkoutProcess->getStep('CheckoutAddressesStep');
+
+        if (Tools::getValue('state') && $step) {
+            $step->setCurrent(true);
+        }
 
         $this->checkoutProcess->markCurrentStep();
 


### PR DESCRIPTION
## Steps to Test this Fix
1. To connect, add a product, and get in the basket
2.  Checkout, and follow the purchase process
3.  At the time of validating the order, leaving the tunnel command
4. return in the basket, and remove this product
5. Add another product,
6. Back in the basket and then checkout.
7. get directly through payment, without asking me the address nor the carrier
## Forge Ticket (optional)

http://forge.prestashop.com/browse/BOOM-445
