### PR TITLE
// Fix module sort by name

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -282,7 +282,7 @@ var AdminModuleController = function () {
                 var uniqueID = '';
                 $.each(dataAttr, function (index, value) {
                     if (uniqueID !== '') {
-                        uniqueID += '#'; // Explode separator
+                        uniqueID += ' #'; // Explode separator
                     }
                     uniqueID += selectorObject.attr(value);
                 });
@@ -911,7 +911,7 @@ var AdminModuleController = function () {
                 var uniqueID = '';
                 $.each(dataAttr, function (index, value) {
                     if (uniqueID !== '') {
-                        uniqueID += '#'; // Explode separator
+                        uniqueID += ' #'; // Explode separator
                     }
                     uniqueID += selectorObject.attr(value);
                 });


### PR DESCRIPTION
## Description

When you had two modules with similar names like "Bloc liens permanents" and "Bloc liens", "Bloc liens permanents" was displayed first whereas it should be the other way.

@tchauviere can you look at this it this is okay for you ?
