### PR TITLE
[-] CORE : Fix shipping tax when proportionate is enabled in AEU

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1322,7 +1322,7 @@ class OrderCore extends ObjectModel
 
         $address = new Address((int)$this->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
         $carrier = new Carrier((int)$this->id_carrier);
-        $tax_calculator = $carrier->getTaxCalculator($address);
+        $tax_calculator = (Configuration::get('PS_ATCP_SHIPWRAP')) ? \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('AverageTaxOfProductsTaxCalculator')->setIdOrder($this->id) : $carrier->getTaxCalculator($address);
         $order_invoice->total_discount_tax_excl = $this->total_discounts_tax_excl;
         $order_invoice->total_discount_tax_incl = $this->total_discounts_tax_incl;
         $order_invoice->total_paid_tax_excl = $this->total_paid_tax_excl;


### PR DESCRIPTION
## Description

There is a flaw in the way proportionate tax feature works in Advanced EU Compliance. When the proportionate tax feature for shipping is activated:
- if the input field of shipping tax of the carrier was set to 0, then the proportionate tax is computed correctly BUT it is not shown on the invoice
- if the input field of shipping tax of the carrier was set to a value different from 0, then tax is not computed correctly BUT shown on the invoice
## Steps to Test this Fix
1. Set the tax rate to 0 for your carrier
2. Set `PS_ATCP_SHIPWRAP` to `1` in the `ps_configuration` table.
3. Make an order and get the invoice.
   The tax rate for the shipping should be the average tax rate of your cart.
4. Set the tax to 10% for example for your carrier
5. Set `PS_ATCP_SHIPWRAP` to `1` in the `ps_configuration` table.
6. Make an order and get the invoice.
   The tax rate for the shipping should be the average tax rate of your cart and **NOT** 10%.
## Forge Ticket

http://forge.prestashop.com/browse/BOOM-202
