### PR TITLE
// removed call from external api in integration tests

### DIFF
--- a/tests/selenium/helpers/random-user.js
+++ b/tests/selenium/helpers/random-user.js
@@ -1,36 +1,19 @@
-import request from 'request';
+var faker = require('faker');
 
 export function getRandomUser () {
   const defaultUser = {
     name: {
-      first: "Example",
-      last: "User",
+      first: faker.name.firstName(),
+      last: faker.name.lastName(),
     },
-    email: `user${Date.now()}@example.com`,
+    email: faker.internet.email(),
     location: {
-      street: "777, Main Street",
-      city: "FileSystem"
+      street: faker.address.streetAddress(),
+      city: faker.address.city()
     }
   };
 
   return new Promise((resolve, reject) => {
-
-    setTimeout(() => resolve(defaultUser), 2000);
-
-    request.get({
-      url: 'https://randomuser.me/api/',
-      json: true
-    }, (error, response, body) => {
-      if (error) {
-          resolve(defaultUser);
-      } else if (body.results) {
-        const user = body.results[0].user;
-        // sometimes we get weird e-mails from the API
-        user.email = user.email.replace(/[^a-z@.]/g, '_');
-        resolve(user);
-      } else {
-        resolve(defaultUser);
-      }
-    });
+    resolve(defaultUser);
   });
 }

--- a/tests/selenium/package.json
+++ b/tests/selenium/package.json
@@ -16,6 +16,7 @@
     "babel-register": "^6.3.13",
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
+    "faker": "^3.1.0",
     "mocha": "^2.4.5",
     "q": "^1.4.1",
     "request": "^2.67.0",


### PR DESCRIPTION
this fix actuals tests that broke because the external service in charge of generate a random user sounds broken.

Let's use `faker` node module instead :)
