### PR TITLE
Fix admin email translations

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -118,6 +118,8 @@
 							var rte_mail_config = {};
 							rte_mail_config['editor_selector'] = 'rte-mail-' + rte_mail_selector;
 							rte_mail_config['height'] = '500px';
+							// We want the default plugins + 'fullpage' plugin for HTML emails
+							rte_mail_config['plugins'] = "colorpicker link image paste pagebreak table contextmenu filemanager table code media autoresize textcolor anchor fullpage";
 							// move controls to active panel
 							$('#translation_mails-control-actions').appendTo($(this).find('.panel-collapse.in'));
 							// when user first open email

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1568,17 +1568,7 @@ class AdminTranslationsControllerCore extends AdminController
 
     protected function getMailPattern()
     {
-        // Let the indentation like it.
-        return '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/1999/REC-html401-19991224/strict.dtd">
-<html>
-<head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>#title</title>
-</head>
-<body>
-    #content
-</body>
-</html>';
+        Tools::displayAsDeprecated('Email pattern is no longer used, emails are always saved like they are.');
     }
 
     /**
@@ -1641,13 +1631,13 @@ class AdminTranslationsControllerCore extends AdminController
                         if (Tools::getValue('title_'.$group_name.'_'.$mail_name)) {
                             $title = Tools::getValue('title_'.$group_name.'_'.$mail_name);
                         }
-                        $string_mail = $this->getMailPattern();
-                        $content = str_replace(array('#title', '#content'), array($title, $content), $string_mail);
 
                         // Magic Quotes shall... not.. PASS!
                         if (_PS_MAGIC_QUOTES_GPC_) {
                             $content = stripslashes($content);
                         }
+
+                        $content = preg_replace('/<title>.*<\/title>/', '<title>'.$title.'</title>', $content);
                     }
 
                     if (Validate::isCleanHTML($content)) {
@@ -1658,7 +1648,7 @@ class AdminTranslationsControllerCore extends AdminController
                         if (!file_exists($path) && !mkdir($path, 0777, true)) {
                             throw new PrestaShopException(sprintf(Tools::displayError('Directory "%s" cannot be created'), dirname($path)));
                         }
-                        file_put_contents($path.$mail_name.'.'.$type_content, Tools::purifyHTML($content, array('{', '}'), true));
+                        file_put_contents($path.$mail_name.'.'.$type_content, $content);
                     } else {
                         throw new PrestaShopException(Tools::displayError('Your HTML email templates cannot contain JavaScript code.'));
                     }
@@ -2486,11 +2476,6 @@ class AdminTranslationsControllerCore extends AdminController
                 $title[$language] = substr($content[$language], 0, stripos($content[$language], '<body'));
                 preg_match('#<title>([^<]+)</title>#Ui', $title[$language], $matches);
                 $title[$language] = empty($matches[1])?'':$matches[1];
-                // The 2 lines below allow to exlude <body> tag from the content.
-                // This allow to exclude body tag even if attributs are setted.
-                $content[$language] = substr($content[$language], stripos($content[$language], '<body') + 5);
-                $content[$language] = substr($content[$language], stripos($content[$language], '>') + 1);
-                $content[$language] = substr($content[$language], 0, stripos($content[$language], '</body>'));
             }
         }
         $content[$lang] = (isset($content[$lang]) ? Tools::htmlentitiesUTF8(stripslashes($content[$lang])) : '');

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2469,7 +2469,6 @@ class AdminTranslationsControllerCore extends AdminController
 
     protected function cleanMailContent(&$content, $lang, &$title)
     {
-        // Because TinyMCE don't work correctly with <DOCTYPE>, <html> and <body> tags
         if (stripos($content[$lang], '<body')) {
             $array_lang = $lang != 'en' ? array('en', $lang) : array($lang);
             foreach ($array_lang as $language) {

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1569,6 +1569,17 @@ class AdminTranslationsControllerCore extends AdminController
     protected function getMailPattern()
     {
         Tools::displayAsDeprecated('Email pattern is no longer used, emails are always saved like they are.');
+        // Let the indentation like it.
+        return '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/1999/REC-html401-19991224/strict.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>#title</title>
+</head>
+<body>
+    #content
+</body>
+</html>';
     }
 
     /**


### PR DESCRIPTION
This is a major bug, I don't why anyone hasn't fixed this yet.

What doesn't work:
- `cleanMailContent` butchers the HTML before outputting it to admin forms: only the contents of the `<body>` is left;
- TinyMCE doesn't allow full HTML, it would butcher the full HTML too.
- Submitted translations are butchered, we lost `<head>` tag (which contains `<style>` block) and the `<body style="*"` attribute, which contains email width.
- When we are processing the email, we wrap the email with HTML document tags again by calling `getMailPattern`.
- Just before putting the HTML to file, the HTML is butchered again by `Tools::purifyHTML`.

Same description can be found here:
- https://gist.github.com/gskema/d3f62431965dbb5c8cdb04da97c9dc77

What this PR fixes:
- HTML isn't butchered anymore before outputting it to admin form. Removed functions in `cleanMailContent`.
- TinyMCE doesn't butcher the full HTML that we managed to output because it now includes `fullpage` plugin.
- When we process the submitted HTML (now full HTML document), we no longer need `getMailPattern` (deprecated).
- We only need to insert the `title` text since it's entered using a separate field. Tip: you could edit these fields by adding `fullpage` plugin to TinyMCE toolbar!
- When we are ready to save with `file_put_contents`, we don't use `Tools::purifyHTML` -> our HTML doesn't get butchered. But you will say that we need to escape the input! Well, we already check if the HTML is secure with `Validate::isCleanHTML`.

**Does this affect 1.7** ? Yes

**Should you include this to 1.7 and 1.6.1.5** ? Yes, absolutely definitely please

Someone didn't believe that full HTML was possible with TinyMCE, see the highlighted line:

https://github.com/PrestaShop/PrestaShop/pull/5333/files#diff-b06d30a34002e19b65a408bbb0d4d82bL2482
