### PR TITLE
[-] BO: Duplicated payments

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -321,10 +321,8 @@ class OrderHistoryCore extends ObjectModel
         $order->valid = $new_os->logable;
         $order->update();
 
-        if ($new_os->invoice && !$order->invoice_number) {
+        if (($new_os->invoice && !$order->invoice_number) || ($new_os->delivery && !$order->delivery_number)) {
             $order->setInvoice($use_existing_payment);
-        } elseif ($new_os->delivery && !$order->delivery_number) {
-            $order->setDeliverySlip();
         }
 
         // set orders as paid


### PR DESCRIPTION
This error only happens when the orders status workflow is altered to invoice AFTER sending (useful in COD payment method)
In this scenario, as a sent order needs an invoice to set the delivery slip number and delivery date, an invoice is created in this part of the code.

This modifications to **changeIdOrderState** doesn't affect the normal behaviour where invoices are generated first. Here is why:
- the method **setDeliverySlip()** generates an invoice, set delivery date and set delivery number IF there are no invoices.
- This invoice generation doesn't check for previous payments, so a new payment is added <--- here is the problem
- the method **setInvoice($use_existing_payment)** generate an invoice and check for previous payments, so no duplicate payment is generated, but doesn't add the delivery number and delivery date. It doesn't matter: latter in the same function **changeIdOrderState** there is a call to **setDelivery()**, which does exactly those things.

there were various ways to solve this:
- use a different way to store delivery slips (and not using an invoice for that)
- if an invoice is needed before sending, force payment method's statuses to always invoice.
- this PR :)

Note: after doing this PR, looks like there is no other call $order->setDeliverySlip() in the whole project, so it might be deleted...
