### PR TITLE
[*] Project : Add customization price and weight impact, separate products in cart by customizations

### DIFF
--- a/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
@@ -94,7 +94,7 @@
 				</thead>
 				<tbody>
 				{foreach from=$products item='product'}
-					{if isset($customized_datas[$product.id_product][$product.id_product_attribute][$product.id_address_delivery])}
+					{if $product['customizedDatas']}
 						<tr>
 							<td>{$product.image}</td>
 							<td><a href="{$link->getAdminLink('AdminProducts', true, ['id_product' => $product.id_product, 'updateproduct' => 1])|escape:'html':'UTF-8'}">
@@ -108,38 +108,42 @@
 							<td class="text-center">{$product.qty_in_stock}</td>
 							<td class="text-right">{displayWtPriceWithCurrency price=$product.total_customization_wt currency=$currency}</td>
 						</tr>
-						{foreach from=$customized_datas[$product.id_product][$product.id_product_attribute][$product.id_address_delivery] item='customization'}
-						<tr>
-							<td colspan="2">
-							{foreach from=$customization.datas key='type' item='datas'}
-								{if $type == constant('Product::CUSTOMIZE_FILE')}
-									<ul style="margin: 0; padding: 0; list-style-type: none;">
-									{foreach from=$datas key='index' item='data'}
-											<li style="display: inline; margin: 2px;">
-												<a href="displayImage.php?img={$data.value}&name={$order->id|intval}-file{$index}" class="_blank">
-												<img src="{$pic_dir}{$data.value}_small" alt="" /></a>
-											</li>
-									{/foreach}
-									</ul>
-								{elseif $type == constant('Product::CUSTOMIZE_TEXTFIELD')}
-									<div class="form-horizontal">
-										{foreach from=$datas key='index' item='data'}
-											<div class="form-group">
-												<span class="control-label col-lg-3"><strong>{if $data.name}{$data.name}{else}{l s='Text #'}{$index}{/if}</strong></span>
-												<div class="col-lg-9">
-													<p class="form-control-static">{$data.value}</p>
-												</div>
-											</div>
-										{/foreach}
-									</div>
-								{/if}
-							{/foreach}
-							</td>
-							<td></td>
-							<td class="text-center">{$customization.quantity}</td>
-							<td></td>
-							<td></td>
-						</tr>
+
+                        {foreach $product['customizedDatas'] as $customizationPerAddress}
+                            {foreach $customizationPerAddress as $customization}
+						    {if count($customizationPerAddress) == 1 && ((int)$customization.id_customization != (int)$product.id_customization)}{continue}{/if}
+						    <tr>
+							    <td colspan="2">
+							    {foreach from=$customization.datas key='type' item='datas'}
+								    {if $type == constant('Product::CUSTOMIZE_FILE')}
+									    <ul style="margin: 0; padding: 0; list-style-type: none;">
+									    {foreach from=$datas key='index' item='data'}
+											    <li style="display: inline; margin: 2px;">
+												    <a href="displayImage.php?img={$data.value}&name={$order->id|intval}-file{$index}" class="_blank">
+												    <img src="{$pic_dir}{$data.value}_small" alt="" /></a>
+											    </li>
+									    {/foreach}
+									    </ul>
+								    {elseif $type == constant('Product::CUSTOMIZE_TEXTFIELD')}
+									    <div class="form-horizontal">
+										    {foreach from=$datas key='index' item='data'}
+											    <div class="form-group">
+												    <span class="control-label col-lg-3"><strong>{if $data.name}{$data.name}{else}{l s='Text #'}{$index}{/if}</strong></span>
+												    <div class="col-lg-9">
+													    <p class="form-control-static">{$data.value}</p>
+												    </div>
+											    </div>
+										    {/foreach}
+									    </div>
+								    {/if}
+							    {/foreach}
+							    </td>
+							    <td></td>
+							    <td class="text-center">{$customization.quantity}</td>
+							    <td></td>
+							    <td></td>
+						    </tr>
+                            {/foreach}
 						{/foreach}
 					{/if}
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -544,7 +544,7 @@ class CartCore extends ObjectModel
         $sql->orderBy('cp.`date_add`, cp.`id_product`, cp.`id_product_attribute` ASC');
 
         if (Customization::isFeatureActive()) {
-            $sql->select('cu.`id_customization` AS customization_id, cu.`quantity` AS customization_quantity');
+            $sql->select('cu.`id_customization`, cu.`quantity` AS customization_quantity');
             $sql->leftJoin(
                 'customization',
                 'cu',

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1388,17 +1388,6 @@ class CartCore extends ObjectModel
                 WHERE `id_customization` = '.(int)$id_customization
             );
 
-            if ($result) {
-                $result &= Db::getInstance()->execute(
-                    'UPDATE `'._DB_PREFIX_.'cart_product`
-                    SET `quantity` = `quantity` - '.(int)$customization['quantity'].'
-                    WHERE `id_cart` = '.(int)$this->id.'
-                    AND `id_product` = '.(int)$id_product.
-                    ((int)$id_product_attribute ? ' AND `id_product_attribute` = '.(int)$id_product_attribute : '').'
-                    AND `id_address_delivery` = '.(int)$id_address_delivery
-                );
-            }
-
             if (!$result) {
                 return false;
             }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -499,13 +499,13 @@ class CartCore extends ObjectModel
         $sql = new DbQuery();
 
         // Build SELECT
-        $sql->select('cp.`id_product_attribute`, cp.`id_product`, cp.`quantity` AS cart_quantity, cp.id_shop, pl.`name`, p.`is_virtual`,
+        $sql->select('cp.`id_product_attribute`, cp.`id_product`, cp.`quantity` AS cart_quantity, cp.id_shop, cp.`id_customization`, pl.`name`, p.`is_virtual`,
                         pl.`description_short`, pl.`available_now`, pl.`available_later`, product_shop.`id_category_default`, p.`id_supplier`,
                         p.`id_manufacturer`, product_shop.`on_sale`, product_shop.`ecotax`, product_shop.`additional_shipping_cost`,
                         product_shop.`available_for_order`, product_shop.`price`, product_shop.`active`, product_shop.`unity`, product_shop.`unit_price_ratio`,
                         stock.`quantity` AS quantity_available, p.`width`, p.`height`, p.`depth`, stock.`out_of_stock`, p.`weight`,
                         p.`date_add`, p.`date_upd`, IFNULL(stock.quantity, 0) as quantity, pl.`link_rewrite`, cl.`link_rewrite` AS category,
-                        CONCAT(LPAD(cp.`id_product`, 10, 0), LPAD(IFNULL(cp.`id_product_attribute`, 0), 10, 0), IFNULL(cp.`id_address_delivery`, 0)) AS unique_id, cp.id_address_delivery,
+                        CONCAT(LPAD(cp.`id_product`, 10, 0), LPAD(IFNULL(cp.`id_product_attribute`, 0), 10, 0), IFNULL(cp.`id_address_delivery`, 0), IFNULL(cp.`id_customization`, 0)) AS unique_id, cp.id_address_delivery,
                         product_shop.advanced_stock_management, ps.product_supplier_reference supplier_reference');
 
         // Build FROM
@@ -544,13 +544,13 @@ class CartCore extends ObjectModel
         $sql->orderBy('cp.`date_add`, cp.`id_product`, cp.`id_product_attribute` ASC');
 
         if (Customization::isFeatureActive()) {
-            $sql->select('cu.`id_customization`, cu.`quantity` AS customization_quantity');
+            $sql->select('cu.`id_customization` AS customization_id, cu.`quantity` AS customization_quantity');
             $sql->leftJoin(
                 'customization',
                 'cu',
-                'p.`id_product` = cu.`id_product` AND cp.`id_product_attribute` = cu.`id_product_attribute` AND cu.`id_cart` = '.(int)$this->id
+                'p.`id_product` = cu.`id_product` AND cp.`id_product_attribute` = cu.`id_product_attribute` AND cp.`id_customization` = cu.`id_customization` AND cu.`id_cart` = '.(int)$this->id
             );
-            $sql->groupBy('cp.`id_product_attribute`, cp.`id_product`, cp.`id_shop`');
+            $sql->groupBy('cp.`id_product_attribute`, cp.`id_product`, cp.`id_shop`, cp.`id_customization`');
         } else {
             $sql->select('NULL AS customization_quantity, NULL AS id_customization');
         }
@@ -621,8 +621,14 @@ class CartCore extends ObjectModel
             // for compatibility with 1.2 themes
             $row['quantity'] = (int)$row['cart_quantity'];
 
+            // get the customization weight impact
+            $customization_weight = Customization::getCustomizationWeight($row['id_customization']);
+
             if (isset($row['id_product_attribute']) && (int)$row['id_product_attribute'] && isset($row['weight_attribute'])) {
+                $row['weight_attribute'] += $customization_weight;
                 $row['weight'] = (float)$row['weight_attribute'];
+            } else {
+                $row['weight'] += $customization_weight;
             }
 
             if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_invoice') {
@@ -658,7 +664,9 @@ class CartCore extends ObjectModel
                 $specific_price_output,
                 true,
                 true,
-                $cart_shop_context
+                $cart_shop_context,
+                true,
+                $row['id_customization']
             );
 
             $row['price_with_reduction'] = Product::getPriceStatic(
@@ -677,7 +685,9 @@ class CartCore extends ObjectModel
                 $specific_price_output,
                 true,
                 true,
-                $cart_shop_context
+                $cart_shop_context,
+                true,
+                $row['id_customization']
             );
 
             $row['price'] = $row['price_with_reduction_without_tax'] = Product::getPriceStatic(
@@ -696,7 +706,9 @@ class CartCore extends ObjectModel
                 $specific_price_output,
                 true,
                 true,
-                $cart_shop_context
+                $cart_shop_context,
+                true,
+                $row['id_customization']
             );
 
             switch (Configuration::get('PS_ROUND_TYPE')) {
@@ -900,6 +912,7 @@ class CartCore extends ObjectModel
         $sql .= '
             WHERE cp.`id_product` = '.(int)$id_product.'
             AND cp.`id_product_attribute` = '.(int)$id_product_attribute.'
+            AND cp.`id_customization` = '.(int)$id_customization.'
             AND cp.`id_cart` = '.(int)$this->id;
         if (Configuration::get('PS_ALLOW_MULTISHIPPING') && $this->isMultiAddressDelivery()) {
             $sql .= ' AND cp.`id_address_delivery` = '.(int)$id_address_delivery;
@@ -1041,6 +1054,7 @@ class CartCore extends ObjectModel
                         'UPDATE `'._DB_PREFIX_.'cart_product`
                         SET `quantity` = `quantity` '.$qty.'
                         WHERE `id_product` = '.(int)$id_product.
+                        ' AND `id_customization` = '.(int)$id_customization.
                         (!empty($id_product_attribute) ? ' AND `id_product_attribute` = '.(int)$id_product_attribute : '').'
                         AND `id_cart` = '.(int)$this->id.(Configuration::get('PS_ALLOW_MULTISHIPPING') && $this->isMultiAddressDelivery() ? ' AND `id_address_delivery` = '.(int)$id_address_delivery : '').'
                         LIMIT 1'
@@ -1078,7 +1092,8 @@ class CartCore extends ObjectModel
                     'id_address_delivery' =>    (int)$id_address_delivery,
                     'id_shop' =>                $shop->id,
                     'quantity' =>                (int)$quantity,
-                    'date_add' =>                date('Y-m-d H:i:s')
+                    'date_add' =>                date('Y-m-d H:i:s'),
+                    'id_customization' =>       (int)$id_customization
                 ));
 
                 if (!$result_add) {
@@ -1142,6 +1157,7 @@ class CartCore extends ObjectModel
                     UPDATE `'._DB_PREFIX_.'customization`
                     SET
                         `quantity` = `quantity` '.($operator == 'up' ? '+ ' : '- ').(int)$quantity.',
+                        `id_product_attribute` = '.(int)$id_product_attribute.',
                         `id_address_delivery` = '.(int)$id_address_delivery.',
                         `in_cart` = 1
                     WHERE `id_customization` = '.(int)$id_customization);
@@ -1149,6 +1165,7 @@ class CartCore extends ObjectModel
                 Db::getInstance()->execute('
                     UPDATE `'._DB_PREFIX_.'customization`
                     SET `id_address_delivery` = '.(int)$id_address_delivery.',
+                    `id_product_attribute` = '.(int)$id_product_attribute.',
                     `in_cart` = 1
                     WHERE `id_customization` = '.(int)$id_customization);
             }
@@ -1276,6 +1293,7 @@ class CartCore extends ObjectModel
                 'SELECT `quantity`
                 FROM `'._DB_PREFIX_.'cart_product`
                 WHERE `id_product` = '.(int)$id_product.'
+                AND `id_customization` = '.(int)$id_customization.'
                 AND `id_cart` = '.(int)$this->id.'
                 AND `id_product_attribute` = '.(int)$id_product_attribute
             );
@@ -1285,16 +1303,13 @@ class CartCore extends ObjectModel
             FROM `'._DB_PREFIX_.'customization`
             WHERE `id_cart` = '.(int)$this->id.'
             AND `id_product` = '.(int)$id_product.'
+            AND `id_customization` = '.(int)$id_customization.'
             AND `id_product_attribute` = '.(int)$id_product_attribute.'
             '.((int)$id_address_delivery ? 'AND `id_address_delivery` = '.(int)$id_address_delivery : ''));
 
             if (!$this->_deleteCustomization((int)$id_customization, (int)$id_product, (int)$id_product_attribute, (int)$id_address_delivery)) {
                 return false;
             }
-
-            // refresh cache of self::_products
-            $this->_products = $this->getProducts(true);
-            return ($customization_quantity == $product_total_quantity && $this->deleteProduct((int)$id_product, (int)$id_product_attribute, null, (int)$id_address_delivery));
         }
 
         /* Get customization quantity */
@@ -1303,6 +1318,7 @@ class CartCore extends ObjectModel
             FROM `'._DB_PREFIX_.'customization`
             WHERE `id_cart` = '.(int)$this->id.'
             AND `id_product` = '.(int)$id_product.'
+            AND `id_customization` = '.(int)$id_customization.'
             AND `id_product_attribute` = '.(int)$id_product_attribute);
 
         if ($result === false) {
@@ -1315,7 +1331,8 @@ class CartCore extends ObjectModel
                 'UPDATE `'._DB_PREFIX_.'cart_product`
                 SET `quantity` = '.(int)$result['quantity'].'
                 WHERE `id_cart` = '.(int)$this->id.'
-                AND `id_product` = '.(int)$id_product.
+                AND `id_product` = '.(int)$id_product.'
+                AND `id_customization` = '.(int)$id_customization.
                 ($id_product_attribute != null ? ' AND `id_product_attribute` = '.(int)$id_product_attribute : '')
             );
         }
@@ -1324,7 +1341,8 @@ class CartCore extends ObjectModel
         $result = Db::getInstance()->execute('
         DELETE FROM `'._DB_PREFIX_.'cart_product`
         WHERE `id_product` = '.(int)$id_product.'
-        '.(!is_null($id_product_attribute) ? ' AND `id_product_attribute` = '.(int)$id_product_attribute : '').'
+        AND `id_customization` = '.(int)$id_customization.
+        (!is_null($id_product_attribute) ? ' AND `id_product_attribute` = '.(int)$id_product_attribute : '').'
         AND `id_cart` = '.(int)$this->id.'
         '.((int)$id_address_delivery ? 'AND `id_address_delivery` = '.(int)$id_address_delivery : ''));
 
@@ -1560,7 +1578,9 @@ class CartCore extends ObjectModel
                 $null,
                 $ps_use_ecotax,
                 true,
-                $virtual_context
+                $virtual_context,
+                true,
+                (int)$product['id_customization']
             );
 
             $address = $address_factory->findOrCreate($id_address, true);
@@ -3092,7 +3112,12 @@ class CartCore extends ObjectModel
             WHERE (cp.`id_product_attribute` IS NULL OR cp.`id_product_attribute` = 0)
             AND cp.`id_cart` = '.(int)$this->id);
 
-            self::$_totalWeight[$this->id] = round((float)$weight_product_with_attribute + (float)$weight_product_without_attribute, 6);
+            $weight_cart_customizations = Db::getInstance()->getValue('
+            SELECT SUM(cd.`weight` * c.`quantity`) FROM `'._DB_PREFIX_.'customization` c
+            LEFT JOIN `'._DB_PREFIX_.'customized_data` cd ON (c.`id_customization` = cd.`id_customization`)
+            WHERE c.`in_cart` = 1 AND c.`id_cart` = '.(int)$this->id);
+
+            self::$_totalWeight[$this->id] = round((float)$weight_product_with_attribute + (float)$weight_product_without_attribute + (float)$weight_cart_customizations, 6);
         }
 
         return self::$_totalWeight[$this->id];
@@ -3527,32 +3552,7 @@ class CartCore extends ObjectModel
 
         $id_address_delivery = Configuration::get('PS_ALLOW_MULTISHIPPING') ? $cart->id_address_delivery : 0;
 
-        foreach ($products as $product) {
-            if ($id_address_delivery) {
-                if (Customer::customerHasAddress((int)$cart->id_customer, $product['id_address_delivery'])) {
-                    $id_address_delivery = $product['id_address_delivery'];
-                }
-            }
-
-            foreach ($product_gift as $gift) {
-                if (isset($gift['gift_product']) && isset($gift['gift_product_attribute']) && (int)$gift['gift_product'] == (int)$product['id_product'] && (int)$gift['gift_product_attribute'] == (int)$product['id_product_attribute']) {
-                    $product['quantity'] = (int)$product['quantity'] - 1;
-                }
-            }
-
-            $success &= $cart->updateQty(
-                (int)$product['quantity'],
-                (int)$product['id_product'],
-                (int)$product['id_product_attribute'],
-                null,
-                'up',
-                (int)$id_address_delivery,
-                new Shop((int)$cart->id_shop),
-                false
-            );
-        }
-
-        // Customized products
+        // Customized products: duplicate customizations before products so that we get new id_customizations
         $customs = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
             'SELECT *
             FROM '._DB_PREFIX_.'customization c
@@ -3577,7 +3577,7 @@ class CartCore extends ObjectModel
         foreach ($customs_by_id as $customization_id => $val) {
             Db::getInstance()->execute(
                 'INSERT INTO `'._DB_PREFIX_.'customization` (id_cart, id_product_attribute, id_product, `id_address_delivery`, quantity, `quantity_refunded`, `quantity_returned`, `in_cart`)
-                VALUES('.(int)$cart->id.', '.(int)$val['id_product_attribute'].', '.(int)$val['id_product'].', '.(int)$id_address_delivery.', '.(int)$val['quantity'].', 0, 0, 1)'
+                VALUES('.(int)$cart->id.', '.(int)$val['id_product_attribute'].', '.(int)$val['id_product'].', '.(int)$id_address_delivery.', 0, 0, 0, 1)'
             );
             $custom_ids[$customization_id] = Db::getInstance(_PS_USE_SQL_SLAVE_)->Insert_ID();
         }
@@ -3585,7 +3585,7 @@ class CartCore extends ObjectModel
         // Insert customized_data
         if (count($customs)) {
             $first = true;
-            $sql_custom_data = 'INSERT INTO '._DB_PREFIX_.'customized_data (`id_customization`, `type`, `index`, `value`) VALUES ';
+            $sql_custom_data = 'INSERT INTO '._DB_PREFIX_.'customized_data (`id_customization`, `type`, `index`, `value`, `id_module`, `price`, `weight`) VALUES ';
             foreach ($customs as $custom) {
                 if (!$first) {
                     $sql_custom_data .= ',';
@@ -3602,9 +3602,38 @@ class CartCore extends ObjectModel
                 }
 
                 $sql_custom_data .= '('.(int)$custom_ids[$custom['id_customization']].', '.(int)$custom['type'].', '.
-                    (int)$custom['index'].', \''.pSQL($customized_value).'\')';
+                    (int)$custom['index'].', \''.pSQL($customized_value).'\', '.
+                    (int)$custom['id_module'].', '.(float)$custom['price'].', '.(float)$custom['weight'].')';
             }
             Db::getInstance()->execute($sql_custom_data);
+        }
+
+        foreach ($products as $product) {
+            if ($id_address_delivery) {
+                if (Customer::customerHasAddress((int)$cart->id_customer, $product['id_address_delivery'])) {
+                    $id_address_delivery = $product['id_address_delivery'];
+                }
+            }
+
+            foreach ($product_gift as $gift) {
+                if (isset($gift['gift_product']) && isset($gift['gift_product_attribute']) && (int)$gift['gift_product'] == (int)$product['id_product'] && (int)$gift['gift_product_attribute'] == (int)$product['id_product_attribute']) {
+                    $product['quantity'] = (int)$product['quantity'] - 1;
+                }
+            }
+
+            $id_customization = (int)$product['id_customization'];
+
+            $success &= $cart->updateQty(
+                (int)$product['quantity'],
+                (int)$product['id_product'],
+                (int)$product['id_product_attribute'],
+                isset($custom_ids[$id_customization]) ? (int)$custom_ids[$id_customization] : 0,
+                'up',
+                (int)$id_address_delivery,
+                new Shop((int)$cart->id_shop),
+                false,
+                false
+            );
         }
 
         return array('cart' => $cart, 'success' => $success);
@@ -3702,6 +3731,16 @@ class CartCore extends ObjectModel
         Db::getInstance()->execute($sql);
 
         return true;
+    }
+
+    public function setProductCustomizedDatas(&$product, $customized_datas)
+    {
+        $product['customizedDatas'] = null;
+        if (isset($customized_datas[$product['id_product']][$product['id_product_attribute']])) {
+            $product['customizedDatas'] = $customized_datas[$product['id_product']][$product['id_product_attribute']];
+        } else {
+            $product['customizationQuantityTotal'] = 0;
+        }
     }
 
     public function duplicateProduct(

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3572,12 +3572,21 @@ class CartCore extends ObjectModel
             }
         }
 
+        // Backward compatibility: if true set customizations quantity to 0, they will be updated in Cart::_updateCustomizationQuantity
+        $new_customization_method = (int)Db::getInstance()->getValue('
+                SELECT COUNT(`id_customization`) FROM `'._DB_PREFIX_.'cart_product`
+                WHERE `id_cart` = '.(int)$this->id.
+                ' AND `id_customization` != 0') > 0;
+
         // Insert new customizations
         $custom_ids = array();
         foreach ($customs_by_id as $customization_id => $val) {
+            if ($new_customization_method) {
+                $val['quantity'] = 0;
+            }
             Db::getInstance()->execute(
                 'INSERT INTO `'._DB_PREFIX_.'customization` (id_cart, id_product_attribute, id_product, `id_address_delivery`, quantity, `quantity_refunded`, `quantity_returned`, `in_cart`)
-                VALUES('.(int)$cart->id.', '.(int)$val['id_product_attribute'].', '.(int)$val['id_product'].', '.(int)$id_address_delivery.', 0, 0, 0, 1)'
+                VALUES('.(int)$cart->id.', '.(int)$val['id_product_attribute'].', '.(int)$val['id_product'].', '.(int)$id_address_delivery.', '.(int)$val['quantity'].', 0, 0, 1)'
             );
             $custom_ids[$customization_id] = Db::getInstance(_PS_USE_SQL_SLAVE_)->Insert_ID();
         }

--- a/classes/Customization.php
+++ b/classes/Customization.php
@@ -121,6 +121,28 @@ class CustomizationCore extends ObjectModel
         return $customizations;
     }
 
+    public static function getCustomizationPrice($id_customization)
+    {
+        if (!(int)$id_customization) {
+            return 0;
+        }
+        return (float)Db::getInstance()->getValue('
+            SELECT SUM(`price`) FROM `'._DB_PREFIX_.'customized_data`
+            WHERE `id_customization` = '.(int)$id_customization
+        );
+    }
+
+    public static function getCustomizationWeight($id_customization)
+    {
+        if (!(int)$id_customization) {
+            return 0;
+        }
+        return (float)Db::getInstance()->getValue('
+            SELECT SUM(`weight`) FROM `'._DB_PREFIX_.'customized_data`
+            WHERE `id_customization` = '.(int)$id_customization
+        );
+    }
+
     public static function countCustomizationQuantityByProduct($customizations)
     {
         $total = array();

--- a/classes/CustomizationField.php
+++ b/classes/CustomizationField.php
@@ -32,6 +32,8 @@ class CustomizationFieldCore extends ObjectModel
     public $type;
     /** @var bool Field is required */
     public $required;
+    /** @var bool Field was added by a module */
+    public $is_module;
     /** @var string Label for customized field */
     public $name;
 
@@ -48,6 +50,7 @@ class CustomizationFieldCore extends ObjectModel
             'id_product' =>            array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
             'type' =>                array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
             'required' =>                array('type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => true),
+            'is_module' =>                array('type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => false),
 
             /* Lang fields */
             'name' =>                array('type' => self::TYPE_STRING, 'lang' => true, 'required' => true, 'size' => 255),

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -464,7 +464,7 @@ abstract class PaymentModuleCore extends Module
                             'customization' => array()
                         );
 
-                        $customized_datas = Product::getAllCustomizedDatas((int)$order->id_cart);
+                        $customized_datas = Product::getAllCustomizedDatas((int)$order->id_cart, null, true, null, (int)$product['id_customization']);
                         if (isset($customized_datas[$product['id_product']][$product['id_product_attribute']])) {
                             $product_var_tpl['customization'] = array();
                             foreach ($customized_datas[$product['id_product']][$product['id_product_attribute']][$order->id_address_delivery] as $customization) {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2774,7 +2774,7 @@ class ProductCore extends ObjectModel
     public static function getPriceStatic($id_product, $usetax = true, $id_product_attribute = null, $decimals = 6, $divisor = null,
         $only_reduc = false, $usereduc = true, $quantity = 1, $force_associated_tax = false, $id_customer = null, $id_cart = null,
         $id_address = null, &$specific_price_output = null, $with_ecotax = true, $use_group_reduction = true, Context $context = null,
-        $use_customer_price = true)
+        $use_customer_price = true, $id_customization = null)
     {
         if (!$context) {
             $context = Context::getContext();
@@ -2890,7 +2890,8 @@ class ProductCore extends ObjectModel
             $id_customer,
             $use_customer_price,
             $id_cart,
-            $cart_quantity
+            $cart_quantity,
+            $id_customization
         );
 
         return $return;
@@ -2924,7 +2925,7 @@ class ProductCore extends ObjectModel
      **/
     public static function priceCalculation($id_shop, $id_product, $id_product_attribute, $id_country, $id_state, $zipcode, $id_currency,
         $id_group, $quantity, $use_tax, $decimals, $only_reduc, $use_reduc, $with_ecotax, &$specific_price, $use_group_reduction,
-        $id_customer = 0, $use_customer_price = true, $id_cart = 0, $real_quantity = 0)
+        $id_customer = 0, $use_customer_price = true, $id_cart = 0, $real_quantity = 0, $id_customization = 0)
     {
         static $address = null;
         static $context = null;
@@ -2950,7 +2951,7 @@ class ProductCore extends ObjectModel
         }
 
         $cache_id = (int)$id_product.'-'.(int)$id_shop.'-'.(int)$id_currency.'-'.(int)$id_country.'-'.$id_state.'-'.$zipcode.'-'.(int)$id_group.
-            '-'.(int)$quantity.'-'.(int)$id_product_attribute.
+            '-'.(int)$quantity.'-'.(int)$id_product_attribute.'-'.(int)$id_customization.
             '-'.(int)$with_ecotax.'-'.(int)$id_customer.'-'.(int)$use_group_reduction.'-'.(int)$id_cart.'-'.(int)$real_quantity.
             '-'.($only_reduc?'1':'0').'-'.($use_reduc?'1':'0').'-'.($use_tax?'1':'0').'-'.(int)$decimals;
 
@@ -3032,6 +3033,11 @@ class ProductCore extends ObjectModel
             if ($id_product_attribute !== false) {
                 $price += $attribute_price;
             }
+        }
+
+        // Customization price
+        if ((int)$id_customization) {
+            $price += Customization::getCustomizationPrice($id_customization);
         }
 
         // Tax
@@ -4533,10 +4539,20 @@ class ProductCore extends ObjectModel
     ** Customization management
     */
 
-    public static function getAllCustomizedDatas($id_cart, $id_lang = null, $only_in_cart = true, $id_shop = null)
+    public static function getAllCustomizedDatas($id_cart, $id_lang = null, $only_in_cart = true, $id_shop = null, $id_customization = null)
     {
         if (!Customization::isFeatureActive()) {
             return false;
+        }
+
+        if ($id_customization === 0) {
+            // Backward compatibility: check if there are no products in cart with specific `id_customization` before returning false
+            $product_customizations = (int)Db::getInstance()->getValue('
+                SELECT COUNT(`id_customization`) FROM `'._DB_PREFIX_.'cart_product`
+                WHERE `id_cart` = '.(int)$id_cart.
+                ' AND `id_customization` != 0');
+            if ($product_customizations)
+                return false;
         }
 
         // No need to query if there isn't any real cart!
@@ -4553,13 +4569,14 @@ class ProductCore extends ObjectModel
 
         if (!$result = Db::getInstance()->executeS('
 			SELECT cd.`id_customization`, c.`id_address_delivery`, c.`id_product`, cfl.`id_customization_field`, c.`id_product_attribute`,
-				cd.`type`, cd.`index`, cd.`value`, cfl.`name`
+				cd.`type`, cd.`index`, cd.`value`, cd.`id_module`, cfl.`name`
 			FROM `'._DB_PREFIX_.'customized_data` cd
 			NATURAL JOIN `'._DB_PREFIX_.'customization` c
 			LEFT JOIN `'._DB_PREFIX_.'customization_field_lang` cfl ON (cfl.id_customization_field = cd.`index` AND id_lang = '.(int)$id_lang.
                 ($id_shop ? ' AND cfl.`id_shop` = '.$id_shop : '').')
 			WHERE c.`id_cart` = '.(int)$id_cart.
-            ($only_in_cart ? ' AND c.`in_cart` = 1' : '').'
+            ($only_in_cart ? ' AND c.`in_cart` = 1' : '').
+            ((int)$id_customization ? ' AND cd.`id_customization` = '.(int)$id_customization : '').'
 			ORDER BY `id_product`, `id_product_attribute`, `type`, `index`')) {
             return false;
         }
@@ -4567,14 +4584,20 @@ class ProductCore extends ObjectModel
         $customized_datas = array();
 
         foreach ($result as $row) {
+            if ((int)$row['id_module'] && (int)$row['type'] == Product::CUSTOMIZE_TEXTFIELD) {
+                // Hook displayCustomization: Call only the module in question
+                // When a module saves a customization programmatically, it should add its ID in the `id_module` column
+                $row['value'] = Hook::exec('displayCustomization', array('customization' => $row), (int)$row['id_module']);
+            }
             $customized_datas[(int)$row['id_product']][(int)$row['id_product_attribute']][(int)$row['id_address_delivery']][(int)$row['id_customization']]['datas'][(int)$row['type']][] = $row;
         }
 
         if (!$result = Db::getInstance()->executeS(
             'SELECT `id_product`, `id_product_attribute`, `id_customization`, `id_address_delivery`, `quantity`, `quantity_refunded`, `quantity_returned`
 			FROM `'._DB_PREFIX_.'customization`
-			WHERE `id_cart` = '.(int)$id_cart.($only_in_cart ? '
-			AND `in_cart` = 1' : ''))) {
+			WHERE `id_cart` = '.(int)$id_cart.
+			((int)$id_customization ? ' AND `id_customization` = '.(int)$id_customization : '').
+			($only_in_cart ? ' AND `in_cart` = 1' : ''))) {
             return false;
         }
 
@@ -4582,6 +4605,7 @@ class ProductCore extends ObjectModel
             $customized_datas[(int)$row['id_product']][(int)$row['id_product_attribute']][(int)$row['id_address_delivery']][(int)$row['id_customization']]['quantity'] = (int)$row['quantity'];
             $customized_datas[(int)$row['id_product']][(int)$row['id_product_attribute']][(int)$row['id_address_delivery']][(int)$row['id_customization']]['quantity_refunded'] = (int)$row['quantity_refunded'];
             $customized_datas[(int)$row['id_product']][(int)$row['id_product_attribute']][(int)$row['id_address_delivery']][(int)$row['id_customization']]['quantity_returned'] = (int)$row['quantity_returned'];
+			$customized_datas[(int)$row['id_product']][(int)$row['id_product_attribute']][(int)$row['id_address_delivery']][(int)$row['id_customization']]['id_customization'] = (int)$row['id_customization'];
         }
 
         return $customized_datas;
@@ -4620,6 +4644,9 @@ class ProductCore extends ObjectModel
                 }
                 if (isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery])) {
                     foreach ($customized_datas[$product_id][$product_attribute_id][$id_address_delivery] as $customization) {
+						if ((int)$product_update['id_customization'] && $customization['id_customization'] != $product_update['id_customization']) {
+							continue;
+                    	}
                         $customization_quantity += (int)$customization['quantity'];
                         $customization_quantity_refunded += (int)$customization['quantity_refunded'];
                         $customization_quantity_returned += (int)$customization['quantity_returned'];
@@ -4638,6 +4665,20 @@ class ProductCore extends ObjectModel
                 }
             }
         }
+    }
+
+    /*
+    ** Add customization price for a single product
+    */
+    public static function addProductCustomizationPrice(&$product, &$customized_datas)
+    {
+        if (!$customized_datas) {
+            return;
+        }
+
+        $products = [$product];
+        self::addCustomizationPrice($products, $customized_datas);
+        $product = $products[0];
     }
 
     /*
@@ -4832,12 +4873,18 @@ class ProductCore extends ObjectModel
             $id_shop = (int)Context::getContext()->shop->id;
         }
 
+        // Hide the modules fields in the front-office
+        // When a module adds a customization programmatically, it should set the `is_module` to 1
+        $context = Context::getContext();
+        $front = isset($context->controller->controller_type) && in_array($context->controller->controller_type, array('front'));
+
         if (!$result = Db::getInstance()->executeS('
 			SELECT cf.`id_customization_field`, cf.`type`, cf.`required`, cfl.`name`, cfl.`id_lang`
 			FROM `'._DB_PREFIX_.'customization_field` cf
 			NATURAL JOIN `'._DB_PREFIX_.'customization_field_lang` cfl
 			WHERE cf.`id_product` = '.(int)$this->id.($id_lang ? ' AND cfl.`id_lang` = '.(int)$id_lang : '').
-                ($id_shop ? ' AND cfl.`id_shop` = '.$id_shop : '').'
+                ($id_shop ? ' AND cfl.`id_shop` = '.$id_shop : '').
+                ($front ? ' AND !cf.`is_module`' : '').'
 			ORDER BY cf.`id_customization_field`')) {
             return false;
         }

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -601,8 +601,6 @@ class OrderCore extends ObjectModel
             $products = $this->getProductsDetail();
         }
 
-        $customized_datas = Product::getAllCustomizedDatas($this->id_cart);
-
         $result_array = array();
         foreach ($products as $row) {
             // Change qty if selected
@@ -624,6 +622,8 @@ class OrderCore extends ObjectModel
             // Backward compatibility 1.4 -> 1.5
             $this->setProductPrices($row);
 
+			$customized_datas = Product::getAllCustomizedDatas($this->id_cart, null, true, null, (int)$row['id_customization']);
+
             $this->setProductCustomizedDatas($row, $customized_datas);
 
             // Add information for virtual product
@@ -635,12 +635,12 @@ class OrderCore extends ObjectModel
 
             $row['id_address_delivery'] = $this->id_address_delivery;
 
+            if ($customized_datas) {
+	            Product::addProductCustomizationPrice($row, $customized_datas);
+	        }
+
             /* Stock product */
             $result_array[(int)$row['id_order_detail']] = $row;
-        }
-
-        if ($customized_datas) {
-            Product::addCustomizationPrice($result_array, $customized_datas);
         }
 
         return $result_array;

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -44,6 +44,9 @@ class OrderDetailCore extends ObjectModel
     /** @var int */
     public $product_attribute_id;
 
+    /** @var int */
+    public $id_customization;
+
     /** @var string */
     public $product_name;
 
@@ -174,6 +177,7 @@ class OrderDetailCore extends ObjectModel
             'id_shop' =>                array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
             'product_id' =>                array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId'),
             'product_attribute_id' =>        array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId'),
+            'id_customization' =>        array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId'),
             'product_name' =>                array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true),
             'product_quantity' =>            array('type' => self::TYPE_INT, 'validate' => 'isInt', 'required' => true),
             'product_quantity_in_stock' =>    array('type' => self::TYPE_INT, 'validate' => 'isInt'),
@@ -650,6 +654,7 @@ class OrderDetailCore extends ObjectModel
 
         $this->product_id = (int)$product['id_product'];
         $this->product_attribute_id = $product['id_product_attribute'] ? (int)$product['id_product_attribute'] : 0;
+        $this->id_customization = $product['id_customization'] ? (int)$product['id_customization'] : 0;
         $this->product_name = $product['name'].
             ((isset($product['attributes']) && $product['attributes'] != null) ?
                 ' - '.$product['attributes'] : '');

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -173,7 +173,6 @@ class OrderInvoiceCore extends ObjectModel
         }
 
         $order = new Order($this->id_order);
-        $customized_datas = Product::getAllCustomizedDatas($order->id_cart);
 
         $result_array = array();
         foreach ($products as $row) {
@@ -192,6 +191,8 @@ class OrderInvoiceCore extends ObjectModel
 
             $this->setProductImageInformations($row);
             $this->setProductCurrentStock($row);
+
+            $customized_datas = Product::getAllCustomizedDatas($order->id_cart, null, true, null, (int)$row['id_customization']);
             $this->setProductCustomizedDatas($row, $customized_datas);
 
             // Add information for virtual product
@@ -236,12 +237,11 @@ class OrderInvoiceCore extends ObjectModel
             $row['total_price_tax_excl_including_ecotax'] = $row['total_price_tax_excl'];
             $row['total_price_tax_incl_including_ecotax'] = $row['total_price_tax_incl'];
 
+            if ($customized_datas) {
+                Product::addProductCustomizationPrice($row, $customized_datas);
+            }
             /* Stock product */
             $result_array[(int)$row['id_order_detail']] = $row;
-        }
-
-        if ($customized_datas) {
-            Product::addCustomizationPrice($result_array, $customized_datas);
         }
 
         return $result_array;

--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -43,8 +43,11 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
         $this->order = new Order((int)$order_slip->id_order);
 
         $products = OrderSlip::getOrdersSlipProducts($this->order_slip->id, $this->order);
-        $customized_datas = Product::getAllCustomizedDatas((int)$this->order->id_cart);
-        Product::addCustomizationPrice($products, $customized_datas);
+
+        foreach ($products as $product) {
+            $customized_datas = Product::getAllCustomizedDatas($this->id_cart, null, true, null, (int)$product['id_customization']);
+            Product::addProductCustomizationPrice($product, $customized_datas);
+        }
 
         $this->order->products = $products;
         $this->smarty = $smarty;

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -213,8 +213,6 @@ class AdminCartsControllerCore extends AdminController
         $this->context->customer = $customer;
         $this->toolbar_title = sprintf($this->l('Cart #%06d'), $this->context->cart->id);
         $products = $cart->getProducts();
-        $customized_datas = Product::getAllCustomizedDatas((int)$cart->id);
-        Product::addCustomizationPrice($products, $customized_datas);
         $summary = $cart->getSummaryDetails();
 
         /* Display order information */
@@ -261,6 +259,12 @@ class AdminCartsControllerCore extends AdminController
 
             $image_product = new Image($image['id_image']);
             $product['image'] = (isset($image['id_image']) ? ImageManager::thumbnail(_PS_IMG_DIR_.'p/'.$image_product->getExistingImgPath().'.jpg', 'product_mini_'.(int)$product['id_product'].(isset($product['id_product_attribute']) ? '_'.(int)$product['id_product_attribute'] : '').'.jpg', 45, 'jpg') : '--');
+
+            $customized_datas = Product::getAllCustomizedDatas($this->context->cart->id, null, true, null, (int)$product['id_customization']);
+            $this->context->cart->setProductCustomizedDatas($product, $customized_datas);
+            if ($customized_datas) {
+                Product::addProductCustomizationPrice($product, $customized_datas);
+            }
         }
 
         $helper = new HelperKpi();
@@ -286,7 +290,6 @@ class AdminCartsControllerCore extends AdminController
             'total_wrapping' => $total_wrapping,
             'total_price' => $total_price,
             'total_shipping' => $total_shipping,
-            'customized_datas' => $customized_datas,
             'tax_calculation_method' => $tax_calculation_method
         );
 
@@ -667,7 +670,7 @@ class AdminCartsControllerCore extends AdminController
                 if (!isset($product['attributes_small'])) {
                     $product['attributes_small'] = '';
                 }
-                $product['customized_datas'] = Product::getAllCustomizedDatas((int)$this->context->cart->id, null, true);
+                $product['customized_datas'] = Product::getAllCustomizedDatas((int)$this->context->cart->id, null, true, null, (int)$product['id_customization']);
             }
         }
         if (count($summary['discounts'])) {

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -101,7 +101,7 @@ class CartControllerCore extends FrontController
         } else {
             $this->ajaxDie(Tools::jsonEncode([
                 'hasError' => true,
-                'errors' => [$this->l('Something went wrong during cart update')],
+                'errors' => $this->errors,
             ]));
         }
     }
@@ -283,7 +283,9 @@ class CartControllerCore extends FrontController
 
         if (is_array($cart_products)) {
             foreach ($cart_products as $cart_product) {
-                if ((!isset($this->id_product_attribute) || $cart_product['id_product_attribute'] == $this->id_product_attribute) &&
+                if ((!isset($this->id_product_attribute) ||
+                    ($cart_product['id_product_attribute'] == $this->id_product_attribute &&
+                    $cart_product['id_customization'] == $this->customization_id)) &&
                     (isset($this->id_product) && $cart_product['id_product'] == $this->id_product)) {
                     $qty_to_check = $cart_product['cart_quantity'];
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -831,62 +831,69 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 true
             );
 
+            $id_customization = 0;
             foreach ($already_customized as $customization) {
+                $id_customization = $customization['id_customization'];
                 $customized_data[$customization['index']] = $customization;
             }
 
-            foreach ($this->product->getCustomizationFields($this->context->language->id) as $customization_field) {
-                // 'id_customization_field' maps to what is called 'index'
-                // in what Product::getProductCustomization() returns
-                $key = $customization_field['id_customization_field'];
+            $customization_fields = $this->product->getCustomizationFields($this->context->language->id);
+            if (is_array($customization_fields)) {
+                foreach ($customization_fields as $customization_field) {
+                    // 'id_customization_field' maps to what is called 'index'
+                    // in what Product::getProductCustomization() returns
+                    $key = $customization_field['id_customization_field'];
 
-                $field['label'] = $customization_field['name'];
-                $field['id_customization_field'] = $customization_field['id_customization_field'];
-                $field['required'] = $customization_field['required'];
+                    $field['label'] = $customization_field['name'];
+                    $field['id_customization_field'] = $customization_field['id_customization_field'];
+                    $field['required'] = $customization_field['required'];
 
-                switch ($customization_field['type']) {
-                    case Product::CUSTOMIZE_FILE:
-                        $field['type'] = 'image';
-                        $field['image'] = null;
-                        $field['input_name'] = 'file' . $customization_field['id_customization_field'];
-                        break;
-                    case Product::CUSTOMIZE_TEXTFIELD:
-                        $field['type'] = 'text';
-                        $field['text'] = '';
-                        $field['input_name'] = 'textField' . $customization_field['id_customization_field'];
-                        break;
-                    default:
-                        $field['type'] = null;
-                }
-
-                if (array_key_exists($key, $customized_data)) {
-                    $data = $customized_data[$key];
-                    $field['is_customized'] = true;
                     switch ($customization_field['type']) {
                         case Product::CUSTOMIZE_FILE:
-                            $imageRetriever = new ImageRetriever($this->context->link);
-                            $field['image'] = $imageRetriever->getCustomizationImage(
-                                $data['value']
-                            );
-                            $field['remove_image_url'] = $this->context->link->getProductDeletePictureLink(
-                                $product_full,
-                                $customization_field['id_customization_field']
-                            );
+                            $field['type'] = 'image';
+                            $field['image'] = null;
+                            $field['input_name'] = 'file' . $customization_field['id_customization_field'];
                             break;
                         case Product::CUSTOMIZE_TEXTFIELD:
-                            $field['text'] = $data['value'];
+                            $field['type'] = 'text';
+                            $field['text'] = '';
+                            $field['input_name'] = 'textField' . $customization_field['id_customization_field'];
                             break;
+                        default:
+                            $field['type'] = null;
                     }
-                } else {
-                    $field['is_customized'] = false;
-                }
 
-                $customizationData['fields'][] = $field;
+                    if (array_key_exists($key, $customized_data)) {
+                        $data = $customized_data[$key];
+                        $field['is_customized'] = true;
+                        switch ($customization_field['type']) {
+                            case Product::CUSTOMIZE_FILE:
+                                $imageRetriever = new ImageRetriever($this->context->link);
+                                $field['image'] = $imageRetriever->getCustomizationImage(
+                                    $data['value']
+                                );
+                                $field['remove_image_url'] = $this->context->link->getProductDeletePictureLink(
+                                    $product_full,
+                                    $customization_field['id_customization_field']
+                                );
+                                break;
+                            case Product::CUSTOMIZE_TEXTFIELD:
+                                $field['text'] = $data['value'];
+                                break;
+                        }
+                    } else {
+                        $field['is_customized'] = false;
+                    }
+
+                    $customizationData['fields'][] = $field;
+                }
             }
             $product_full['customizations'] = $customizationData;
+            $product_full['id_customization'] = $id_customization;
             $product_full['is_customizable'] = true;
         } else {
             $product_full['customizations'] = [];
+            $product_full['id_customization'] = 0;
             $product_full['is_customizable'] = false;
         }
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -314,9 +314,10 @@ CREATE TABLE `PREFIX_cart_product` (
   `id_address_delivery` int(10) unsigned NOT NULL DEFAULT '0',
   `id_shop` int(10) unsigned NOT NULL DEFAULT '1',
   `id_product_attribute` int(10) unsigned NOT NULL DEFAULT '0',
+  `id_customization` int(10) unsigned NOT NULL DEFAULT '0',
   `quantity` int(10) unsigned NOT NULL DEFAULT '0',
   `date_add` datetime NOT NULL,
-  PRIMARY KEY (`id_cart`,`id_product`,`id_product_attribute`,`id_address_delivery`),
+  PRIMARY KEY (`id_cart`,`id_product`,`id_product_attribute`,`id_customization`,`id_address_delivery`),
   KEY `id_product_attribute` (`id_product_attribute`),
   KEY `id_cart_order` (`id_cart`, `date_add`, `id_product`, `id_product_attribute`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
@@ -675,6 +676,7 @@ CREATE TABLE `PREFIX_customization_field` (
   `id_product` int(10) unsigned NOT NULL,
   `type` tinyint(1) NOT NULL,
   `required` tinyint(1) NOT NULL,
+  `is_module` TINYINT(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_customization_field`),
   KEY `id_product` (`id_product`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
@@ -692,6 +694,9 @@ CREATE TABLE `PREFIX_customized_data` (
   `type` tinyint(1) NOT NULL,
   `index` int(3) NOT NULL,
   `value` varchar(255) NOT NULL,
+  `id_module` int(10) NOT NULL DEFAULT '0',
+  `price` decimal(20,6) NOT NULL DEFAULT '0',
+  `weight` decimal(20,6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_customization`,`type`,`index`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 
@@ -1193,6 +1198,7 @@ CREATE TABLE `PREFIX_order_detail` (
   `id_shop` int(11) unsigned NOT NULL,
   `product_id` int(10) unsigned NOT NULL,
   `product_attribute_id` int(10) unsigned DEFAULT NULL,
+  `id_customization` int(10) unsigned DEFAULT 0,
   `product_name` varchar(255) NOT NULL,
   `product_quantity` int(10) unsigned NOT NULL DEFAULT '0',
   `product_quantity_in_stock` int(10) NOT NULL DEFAULT '0',

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -101,3 +101,9 @@ DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_SCENE_FEATURE_ACTIVE';
 UPDATE `PREFIX_configuration` SET value=1 WHERE name='PS_TAX_DISPLAY';
 
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_ADMINREFRESH_NOTIFICATION';
+
+ALTER TABLE `PREFIX_cart_product` ADD `id_customization` INT(10) NOT NULL DEFAULT '0' AFTER `id_product_attribute`;
+ALTER TABLE `PREFIX_cart_product` DROP PRIMARY KEY, ADD PRIMARY KEY (`id_cart`, `id_product`, `id_product_attribute`, `id_customization`, `id_address_delivery`);
+ALTER TABLE `PREFIX_order_detail` ADD `id_customization` INT(10) NULL DEFAULT '0' AFTER `product_attribute_id`;
+ALTER TABLE `PREFIX_customized_data` ADD `id_module` INT(10) NOT NULL DEFAULT '0', ADD `price` DECIMAL(20,6) NOT NULL DEFAULT '0', ADD `weight` DECIMAL(20,6) NOT NULL DEFAULT '0';
+ALTER TABLE `PREFIX_customization_field` ADD `is_module` TINYINT(1) NOT NULL DEFAULT '0' ;

--- a/pdf/invoice.product-tab.tpl
+++ b/pdf/invoice.product-tab.tpl
@@ -112,7 +112,7 @@
 										<td style="width: 30%;">
 											{$customization_infos.name|string_format:{l s='%s:' pdf='true'}}
 										</td>
-										<td>{$customization_infos.value}</td>
+										<td>{if (int)$customization_infos.id_module}{$customization_infos.value nofilter}{else}{$customization_infos.value}{/if}</td>
 									</tr>
 								{/foreach}
 							</table>

--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -113,16 +113,15 @@ class CartPresenter implements PresenterInterface
 
     public function addCustomizedData(array $products, Cart $cart)
     {
-        $data = Product::getAllCustomizedDatas($cart->id);
-
-        if (!$data) {
-            $data = [];
-        }
-
-        return array_map(function (array $product) use ($data) {
+        return array_map(function (array $product) use ($cart) {
 
             $product['customizations'] = [];
 
+            $data = Product::getAllCustomizedDatas($cart->id, null, true, null, (int)$product['id_customization']);
+
+            if (!$data) {
+                $data = [];
+            }
             $id_product = (int) $product['id_product'];
             $id_product_attribute = (int) $product['id_product_attribute'];
             if (array_key_exists($id_product, $data)) {
@@ -135,11 +134,10 @@ class CartPresenter implements PresenterInterface
                                     'fields' => [],
                                     'id_customization' => null,
                                 ];
-                                $product['up_quantity_url'] = [];
-                                $product['down_quantity_url'] = [];
+
                                 foreach ($customization['datas'] as $byType) {
-                                    $field = [];
                                     foreach ($byType as $data) {
+                                        $field = [];
                                         switch ($data['type']) {
                                             case Product::CUSTOMIZE_FILE:
                                                 $field['type'] = 'image';
@@ -155,12 +153,23 @@ class CartPresenter implements PresenterInterface
                                                 $field['type'] = null;
                                         }
                                         $field['label'] = $data['name'];
+                                        $field['id_module'] = $data['id_module'];
                                         $presentedCustomization['id_customization'] = $data['id_customization'];
+                                        $presentedCustomization['fields'][] = $field;
                                     }
-                                    $presentedCustomization['fields'][] = $field;
                                 }
 
-                                $presentedCustomization['remove_from_cart_url'] = $this->link->getRemoveFromCartURL(
+                                $product['up_quantity_url'] = $this->link->getUpQuantityCartURL(
+                                    $product['id_product'],
+                                    $product['id_product_attribute'],
+                                    $presentedCustomization['id_customization']
+                                );
+                                $product['down_quantity_url'] = $this->link->getDownQuantityCartURL(
+                                    $product['id_product'],
+                                    $product['id_product_attribute'],
+                                    $presentedCustomization['id_customization']
+                                );
+                                $product['remove_from_cart_url'] = $this->link->getRemoveFromCartURL(
                                     $product['id_product'],
                                     $product['id_product_attribute'],
                                     $presentedCustomization['id_customization']
@@ -173,6 +182,12 @@ class CartPresenter implements PresenterInterface
                                 );
 
                                 $presentedCustomization['down_quantity_url'] = $this->link->getDownQuantityCartURL(
+                                    $product['id_product'],
+                                    $product['id_product_attribute'],
+                                    $presentedCustomization['id_customization']
+                                );
+
+                                $presentedCustomization['remove_from_cart_url'] = $this->link->getRemoveFromCartURL(
                                     $product['id_product'],
                                     $product['id_product_attribute'],
                                     $presentedCustomization['id_customization']

--- a/src/Adapter/Product/PriceCalculator.php
+++ b/src/Adapter/Product/PriceCalculator.php
@@ -44,9 +44,10 @@ class PriceCalculator
         $with_ecotax = true,
         $use_group_reduction = true,
         \ContextCore $context = null,
-        $use_customer_price = true
+        $use_customer_price = true,
+        $id_customization = null
     ) {
-        return \ProductCore::getPriceStatic(
+        return \Product::getPriceStatic(
             $id_product,
             $usetax,
             $id_product_attribute,
@@ -63,7 +64,8 @@ class PriceCalculator
             $with_ecotax,
             $use_group_reduction,
             $context,
-            $use_customer_price
+            $use_customer_price,
+            $id_customization
         );
     }
 }

--- a/tests/Unit/classes/CartTest.php
+++ b/tests/Unit/classes/CartTest.php
@@ -61,6 +61,7 @@ class FakeProductPriceCalculator
             'id_shop' => null,
             'id_product' => $id,
             'id_product_attribute' => $id,
+            'id_customization' => 0,
             'cart_quantity' => $product->quantity,
             'price' => $product->price
         );

--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -62,7 +62,7 @@
               <div id="product-description-short" itemprop="description">{$product.description_short nofilter}</div>
             {/block}
 
-            {if $product.is_customizable}
+            {if $product.is_customizable && count($product.customizations.fields)}
               {block name='product_customization'}
                 {include file="catalog/_partials/product-customization.tpl" customizations=$product.customizations}
               {/block}
@@ -73,6 +73,7 @@
                 <form action="{$urls.pages.cart}" method="post" id="add-to-cart-or-refresh">
                   <input type="hidden" name="token" value="{$static_token}">
                   <input type="hidden" name="id_product" value="{$product.id}" id="product_page_product_id">
+                  <input type="hidden" name="id_customization" value="{$product.id_customization}" id="product_customization_id" />
 
                   {block name='product_variants'}
                     {include file='catalog/_partials/product-variants.tpl'}

--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -55,6 +55,7 @@
               data-link-action            = "delete-from-cart"
               data-id-product             = "{$product.id_product|escape:'javascript'}"
               data-id-product-attribute   = "{$product.id_product_attribute|escape:'javascript'}"
+              data-id-customization   	  = "{$product.id_customization|escape:'javascript'}"
           >
             <i class="material-icons pull-xs-left">delete</i>
           </a>
@@ -65,16 +66,22 @@
           <ul>
             {foreach from=$product.customizations item="customization"}
               <li>
-                {if $customization.down_quantity_url}<a href="{$customization.down_quantity_url}" data-link-action="update-quantity">-</a>{/if}
-                <span class="product-quantity">{$customization.quantity}</span>
-                {if $customization.up_quantity_url}<a href="{$customization.up_quantity_url}" data-link-action="update-quantity">+</a>{/if}
-                <a href="{$customization.remove_from_cart_url}" class="remove-from-cart" rel="nofollow">{l s='Remove'}</a>
+                {if count($product.customizations) > 1}
+                    {if $customization.down_quantity_url}<a href="{$customization.down_quantity_url}" data-link-action="update-quantity">-</a>{/if}
+                    <span class="product-quantity">{$customization.quantity}</span>
+                    {if $customization.up_quantity_url}<a href="{$customization.up_quantity_url}" data-link-action="update-quantity">+</a>{/if}
+                    <a href="{$customization.remove_from_cart_url}" class="remove-from-cart" rel="nofollow">{l s='Remove'}</a>
+                {/if}
                 <ul>
                   {foreach from=$customization.fields item="field"}
                     <li>
                       <label>{$field.label}</label>
                       {if $field.type == 'text'}
-                        <span>{$field.text}</span>
+                        {if (int)$field.id_module}
+                          <span>{$field.text nofilter}</span>
+                        {else}
+                          <span>{$field.text}</span>
+                        {/if}
                       {else if $field.type == 'image'}
                         <img src="{$field.image.small.url}">
                       {/if}

--- a/themes/classic/templates/checkout/order-confirmation.tpl
+++ b/themes/classic/templates/checkout/order-confirmation.tpl
@@ -46,7 +46,11 @@
                                                         <li>
                                                             <label>{$field.label}</label>
                                                             {if $field.type == 'text'}
-                                                                <span>{$field.text}</span>
+                                                                {if (int)$field.id_module}
+                                                                    <span>{$field.text nofilter}</span>
+                                                                {else}
+                                                                    <span>{$field.text}</span>
+                                                                {/if}
                                                             {else if $field.type == 'image'}
                                                                 <img src="{$field.image.small.url}">
                                                             {/if}

--- a/themes/classic/templates/customer/_partials/order-detail-no-return.tpl
+++ b/themes/classic/templates/customer/_partials/order-detail-no-return.tpl
@@ -28,7 +28,7 @@
                 {if $field.type == 'image'}
                   <li><img src="{$field.image.small.url}" alt=""></li>
                 {elseif $field.type == 'text'}
-                  <li>{$field.label} : {$field.text}</li>
+                  <li>{$field.label} : {if (int)$field.id_module}{$field.text nofilter}{else}{$field.text}{/if}</li>
                 {/if}
               {/foreach}
             </ul>

--- a/themes/classic/templates/customer/_partials/order-detail-return.tpl
+++ b/themes/classic/templates/customer/_partials/order-detail-return.tpl
@@ -55,7 +55,7 @@
                   {if $field.type == 'image'}
                     <li><img src="{$field.image.small.url}" alt=""></li>
                   {elseif $field.type == 'text'}
-                    <li>{$field.label} : {$field.text}</li>
+                    <li>{$field.label} : {if (int)$field.id_module}{$field.text nofilter}{else}{$field.text}{/if}</li>
                   {/if}
                 {/foreach}
               </ul>

--- a/themes/classic/templates/customer/order-return.tpl
+++ b/themes/classic/templates/customer/order-return.tpl
@@ -37,7 +37,7 @@
                         {if $field.type == 'image'}
                           <li><img src="{$field.image.small.url}" alt=""></li>
                         {elseif $field.type == 'text'}
-                          <li>{$field.label} : {$field.text}</li>
+                          <li>{$field.label} : {if (int)$field.id_module}{$field.text nofilter}{else}{$field.text}{/if}</li>
                         {/if}
                       {/foreach}
                     </ul>


### PR DESCRIPTION
## Description

Add customization price and weight impact similarly to combinations
Separate products in cart by customizations as well as combinations so that each customization can have its own line and thus quantity, price and weight
This allows modules to easily add extra data to the cart and influence the cost and shipping fees when needed
## Steps to test this Improvement
1. Apply the upgrade code if it's not a new install
   https://gist.github.com/unlocomqx/489784305d3f807404387b120f5a21ab
2. Create a text customization field on a test product
3. Save a customization in the product page and add to cart
4. Save a second customization and add to cart

The customizations will be each on a separate line (screenshots in the Forge link below)
They will be also separated in the backoffice order, invoice & emails etc

Module scénario:
5. In the table `customized_data`, add a price and weight impact to the customizations values you entered previously
This will influence the cost in cart in terms of pricing and shipping fees
1. In the table `customization_field`, set the column `is_module` to 1 to simulate a module field
   This will hide the field in the front office and make it sort of exclusive to the module which added it
   The module can then set the value of the input:hidden#product_customization_id via JS when module data is saved in the product page
2. To test the 'displayCustomization' hook, install the demo module
   https://www.dropbox.com/s/87wqjissj278ssf/customizer-demo.zip?dl=0
   Check the module ID in the `module` table , then set the column `id_module` in `customized_data` to the ID of the demo module
   Now the module can receive the value of the customization and return the desired display
   The value would be an ID of a row in the module custom table, it will then query the data, fetch a tpl for example and return the corresponding content
   Only one module will be called for a `customized_data` row and that's based on `id_module` (if not set to 0)
3. Test the reorder process after finalizing the first order

The code takes into account backward compatibility so if you have previous orders with customized data, they will be correctly displayed
The code also adds optional parameters to some core methods without creating a conflict

Module dev:
- The module creates a customization field for the product in question and sets `is_module` to 1
- It displays its interface in the product page and when the client saves the data, the module saves the customization values including `id_module`, `price` and `weight`
- The module hooks to 'displayCustomization' and displays its own data in cart, order, invoice etc
## Forge Ticket

Forge: http://forge.prestashop.com/browse/BOOM-535
Forum: https://www.prestashop.com/forums/topic/516960-cart-customizations-in-prestashop-1
