### PR TITLE
[+] FO : Adds extra exculed keys for canonicalRedirection

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -112,6 +112,9 @@ class FrontControllerCore extends Controller
     /** @var bool If true, forces display to maintenance page. */
     protected $maintenance = false;
 
+    /** @var string[] Adds excluded $_GET keys for redirection */
+    protected $redirectionExtraExcludedKeys = array();
+
     /** @var bool If false, does not build left page column content and hides it. */
     public $display_column_left = true;
 
@@ -767,6 +770,7 @@ class FrontControllerCore extends Controller
                 }
             }
             $excluded_key = array('isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms');
+            $excluded_key = array_merge($excluded_key, $this->redirectionExtraExcludedKeys);
             foreach ($_GET as $key => $value) {
                 if (!in_array($key, $excluded_key) && Validate::isUrl($key) && Validate::isUrl($value)) {
                     $params[Tools::safeOutput($key)] = Tools::safeOutput($value);


### PR DESCRIPTION
## Description

The goal of this PR is to allow to add extra `excluded_keys` for canonical redirection.

This will be useful for modules' front controllers with custom routes definitions.
## Steps to Test this Fix

Let's take a concrete exemple. Here is my route configuration for my `artists` module:

``` php
public function hookModuleRoutes($params)
{
    return [
        'module-artists-artists' => [
            'controller' => 'artists',
            'rule' => 'artists',
            'keywords' => [],
            'params' => [
                'fc' => 'module',
                'module' => 'artists',
            ],
        ],
        'module-artists-artist' => [
            'controller' => 'artist',
            'rule' => 'artists/a-{id_artist}-{rewrite}',
            'keywords' => [
                'id_artist' => ['regexp' => '[0-9]+', 'param' => 'id_artist'],
                'rewrite' => ['regexp' => '[_a-zA-Z0-9\pL\pS-]*', 'param' => 'rewrite'],
            ],
            'params' => [
                'fc' => 'module',
                'module' => 'artists',
                'controller' => 'artist',
            ],
        ]
    ];
}
```

The route `module-artists-artist` has `id_artist` and `rewrite` parameters.

Here is my `ArtistsArtistController` from module with `canonicalRedirection` implement:

``` php
class ArtistsArtistModuleFrontController extends ModuleFrontControllerCore
{
    /**
     * @var Artist
     */
    private $artist;

    public function canonicalRedirection($canonical_url = '')
    {
        if (Tools::getValue('live_edit')) {
            return;
        }
        if (Validate::isLoadedObject($this->artist)) {
            parent::canonicalRedirection(
                $this->context->link->getModuleLink('artists', 'artist', [
                    'id_artist' => $this->artist->id,
                    'rewrite' => $this->artist->link_rewrite,
                ])
            );
        }
    }
}
```

Imagine the artist `42` with rewrite `joe`, the canonical url would be: `a-42-joe`.

With the actual code, if I try to get `/a-42-not-the-good-rewrite`, I will be redirected to `/a-42-joe?id_artist=42&rewrite=joe&module=artists`. Pretty ugly, isn't it?

With my PR's code, I just have to add the following:

``` php
class ArtistsArtistModuleFrontController extends ModuleFrontControllerCore
{
    protected $redirectionExtraExcludedKeys = ['module', 'id_artist', 'rewrite'];

    // Stuff...
}
```

And my problem is solved.

I opened this PR on `develop` as a new feature, but if you are OK to accept it on 1.6, I'll be glad to rebase my work on it!
