### PR TITLE
[*] CORE : Toggle birthdate field with one click

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1597,6 +1597,7 @@ class FrontControllerCore extends Controller
         $formatter
             ->setAskForNewsletter(Configuration::get('PS_CUSTOMER_NWSL'))
             ->setAskForPartnerOptin(Configuration::get('PS_CUSTOMER_OPTIN'))
+            ->setAskForBirthdate(Configuration::get('PS_CUSTOMER_BIRTHDATE'))
         ;
 
         return $formatter;

--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -92,6 +92,13 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
+                    'PS_CUSTOMER_BIRTHDATE' => array(
+                        'title' => $this->l('Ask for birthdate'),
+                        'hint' => $this->l('Display or not the birthdate field.'),
+                        'validation' => 'isBool',
+                        'cast' => 'intval',
+                        'type' => 'bool'
+                    ),
                     'PS_CUSTOMER_NWSL' => array(
                         'title' => $this->l('Enable newsletter registration'),
                         'hint' => $this->l('Display or not the newsletter registration tick box.'),

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -817,6 +817,9 @@ Country</value>
   <configuration id="PS_CUSTOMER_OPTIN" name="PS_CUSTOMER_OPTIN">
     <value>1</value>
   </configuration>
+  <configuration id="PS_CUSTOMER_BIRTHDATE" name="PS_CUSTOMER_BIRTHDATE">
+    <value>1</value>
+  </configuration>
   <configuration id="PS_PACK_STOCK_TYPE" name="PS_PACK_STOCK_TYPE">
     <value>0</value>
   </configuration>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -25,6 +25,8 @@ ALTER TABLE `PREFIX_customer` CHANGE COLUMN `passwd` `passwd` varchar(255) NOT N
 
 INSERT INTO `PREFIX_configuration` (`id_configuration` ,`id_shop_group` ,`id_shop` ,`name` ,`value` ,`date_add` ,`date_upd`) VALUES (NULL , NULL , NULL , 'PS_ACTIVE_CRONJOB_EXCHANGE_RATE', '0', '0000-00-00 00:00:00', '0000-00-00 00:00:00');
 
+INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_CUSTOMER_BIRTHDATE', 1, NOW(), NOW());
+
 ALTER TABLE `PREFIX_customer` CHANGE COLUMN `firstname` `firstname` varchar(255) NOT NULL;
 ALTER TABLE `PREFIX_customer` CHANGE COLUMN `lastname` `lastname` varchar(255) NOT NULL;
 


### PR DESCRIPTION
## Description

Simply toggle the birthdate field on the customer registration form with one click.

![customerfields](https://cloud.githubusercontent.com/assets/6775736/14413135/b56ae416-ff71-11e5-8128-3516d4102fb0.png)
![createaccountbirthdate](https://cloud.githubusercontent.com/assets/6775736/14413134/b567b840-ff71-11e5-8916-4af8d14aa392.png)
