### PR TITLE
[+] FO : Add display after carrier list hook

### DIFF
--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -138,6 +138,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
             $extraParams,
             [
                 'hookDisplayBeforeCarrier'  => Hook::exec('displayBeforeCarrier', array('cart' => $this->getCheckoutSession()->getCart())),
+                'hookDisplayAfterCarrier'  => Hook::exec('displayAfterCarrier', array('cart' => $this->getCheckoutSession()->getCart())),
                 'id_address'            => $this->getCheckoutSession()->getIdAddressDelivery(),
                 'delivery_options'      => $this->getCheckoutSession()->getDeliveryOptions(),
                 'delivery_option'       => $this->getCheckoutSession()->getSelectedDeliveryOption(),

--- a/themes/classic/templates/checkout/delivery-step.tpl
+++ b/themes/classic/templates/checkout/delivery-step.tpl
@@ -73,5 +73,9 @@
     {/if}
   </div>
 
+  <div id="hook-display-after-carrier">
+    {$hookDisplayAfterCarrier nofilter}
+  </div>
+
   <div id="extra_carrier"></div>
 {/block}


### PR DESCRIPTION
## Description

Add a hook to display information after the carrier list
## Steps to Test this Fix

Step 1. Create a new module
Step 2. Hook some HTML to `displayAfterCarrier`
Step 3. Check if output is shown
