### PR TITLE
Fix webservice unit_price_ratio set to 0

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5844,6 +5844,9 @@ class ProductCore extends ObjectModel
 
     public function updateWs($null_values = false)
     {
+        $this->price = Product::getPriceStatic((int)$this->id, false, null, 6, null, false, true, 1, false, null, null, null, $this->specificPrice);
+        $this->unit_price = ($this->unit_price_ratio != 0  ? $this->price / $this->unit_price_ratio : 0);
+        
         $success = parent::update($null_values);
         if ($success && Configuration::get('PS_SEARCH_INDEXATION')) {
             Search::indexation(false, $this->id);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix webservice unit_price_ratio set to 0
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | -

Product class contains associated tables (manufacturer, supplier, categories, etc). In the core ObjectModel when class that have associated tables is updated it loads fields and merges them with Shop specific fields.
=> file `classes/ObjectModel.php` line 250

ObjectModel is abstract, inherited by original classes like Product.

In Product class there is method `getFieldsShop()` line 517
This method checks if there are update fields. In your test case there are no update fields because you pass same data as original Product record so it goes to line 521:

```
$fields['unit_price_ratio'] = (float)$this->unit_price > 0 ? $this->price / $this->unit_price : 0;
```

But `$this->unit_price` is NULL in webservice call because this property is set in Product's `__constructor()` (line 500) ONLY id second parameter of constructor is true (`$full = true`)

However in `classes/webservice/WebserviceRequest.php` line 1408 the constructor is called with only 1 parameter, the record id: 

```
$object = new $this->resourceConfiguration['retrieveData']['className']((int)$attributes->id);
```

$full is false by default and unit_price is 0 so unit_price_ratio is also 0.

I used part of the code (2 lines) located in Product's `__construct()` and added these 2 lines in `updateWS()`. This guarantees that the change is executed only on webservice update. The 2 lines are:

```
$this->price = Product::getPriceStatic((int)$this->id, false, null, 6, null, false, true, 1, false, null, null, null, $this->specificPrice);
$this->unit_price = ($this->unit_price_ratio != 0  ? $this->price / $this->unit_price_ratio : 0);
```

These 2 lines are added in `classes/Product.php` in `public function updateWs()` after line 5847

unit_price is a calculated field, it does not exist in db. But it is calculated only if Product record is loaded with `$full=true` in `__construct()` method.
Later in the update process, the code checks if no unit_price set, then unit_price_ratio is set to 0.
