### PR TITLE
// Display tax in shopping cart by default

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -249,7 +249,7 @@
     <value>id_shop;id_currency;id_country;id_group</value>
   </configuration>
   <configuration id="PS_TAX_DISPLAY" name="PS_TAX_DISPLAY">
-    <value>0</value>
+    <value>1</value>
   </configuration>
   <configuration id="PS_SMARTY_FORCE_COMPILE" name="PS_SMARTY_FORCE_COMPILE">
     <value>1</value>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -95,3 +95,5 @@ DROP TABLE `PREFIX_scene_products`;
 DROP TABLE `PREFIX_scene_shop`;
 ALTER TABLE `PREFIX_image_type` DROP `scenes`;
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_SCENE_FEATURE_ACTIVE';
+
+UPDATE `PREFIX_configuration` SET `PS_TAX_DISPLAY` = '1';


### PR DESCRIPTION
## Description

By default, the taxes are not displayed on a separate line in the shopping cart.
This PR, enable the line by default.
## Steps to test this fix

Apply the fix and re-install your shop.
On the shopping cart, you'll have a line indicating the taxes.
## Forge Ticket (optional)

http://forge.prestashop.com/browse/BOOM-564
