### PR TITLE
[*] BO : improvement on adding ip on maintenance

### DIFF
--- a/classes/helper/HelperOptions.php
+++ b/classes/helper/HelperOptions.php
@@ -178,16 +178,19 @@ class HelperOptionsCore extends Helper
                 // @todo move this
                 if ($field['type'] == 'maintenance_ip') {
                     $field['script_ip'] = '
-						<script type="text/javascript">
-							function addRemoteAddr()
-							{
-								var length = $(\'input[name=PS_MAINTENANCE_IP]\').attr(\'value\').length;
-								if (length > 0)
-									$(\'input[name=PS_MAINTENANCE_IP]\').attr(\'value\',$(\'input[name=PS_MAINTENANCE_IP]\').attr(\'value\') +\','.Tools::getRemoteAddr().'\');
-								else
-									$(\'input[name=PS_MAINTENANCE_IP]\').attr(\'value\',\''.Tools::getRemoteAddr().'\');
-							}
-						</script>';
+                        <script type="text/javascript">
+                            function addRemoteAddr()
+                            {
+                                var length = $(\'input[name=PS_MAINTENANCE_IP]\').attr(\'value\').length;
+                                if (length > 0) {
+                                    if ($(\'input[name=PS_MAINTENANCE_IP]\').attr(\'value\').indexOf(\''.Tools::getRemoteAddr().'\') < 0) {
+                                        $(\'input[name=PS_MAINTENANCE_IP]\').attr(\'value\',$(\'input[name=PS_MAINTENANCE_IP]\').attr(\'value\') +\','.Tools::getRemoteAddr().'\');
+                                    }
+                                } else {
+                                    $(\'input[name=PS_MAINTENANCE_IP]\').attr(\'value\',\''.Tools::getRemoteAddr().'\');
+                                }
+                            }
+                        </script>';
                     $field['link_remove_ip'] = '<button type="button" class="btn btn-default" onclick="addRemoteAddr();"><i class="icon-plus"></i> '.$this->l('Add my IP', 'Helper').'</button>';
                 }
 


### PR DESCRIPTION
## Description

Rework of https://github.com/PrestaShop/PrestaShop/pull/4428 to make it PSR-2 compliant (cherry picked from commit 708e743760510169946b616de56d39bb646a7e0d).
It avoids IP address duplication in the maintenance IP field.
## Steps to Test this Fix
1. Apply the fix.
2. Try to click on `Add my IP` when your IP address is already in the field.
