### PR TITLE
[-] BO : Fix backoffice order with deleted address

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -1042,13 +1042,11 @@
 				delivery_address_edit_link = "{$link->getAdminLink('AdminAddresses')}&id_address="+this.id_address+"&updateaddress&realedit=1&liteDisplaying=1&submitFormAjax=1#";
 			}
 			
-			if(address_invoice_detail == '')
-			{
+			if(address_invoice_detail == '') {
 				address_invoice_detail = this.formated_address;
 			}
-			
-			if(address_delivery_detail == '')
-			{
+
+			if(address_delivery_detail == '') {
 				address_delivery_detail = this.formated_address;
 			}
 

--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -1041,6 +1041,16 @@
 				address_delivery_detail = this.formated_address;
 				delivery_address_edit_link = "{$link->getAdminLink('AdminAddresses')}&id_address="+this.id_address+"&updateaddress&realedit=1&liteDisplaying=1&submitFormAjax=1#";
 			}
+			
+			if(address_invoice_detail == '')
+			{
+				address_invoice_detail = this.formated_address;
+			}
+			
+			if(address_delivery_detail == '')
+			{
+				address_delivery_detail = this.formated_address;
+			}
 
 			addresses_delivery_options += '<option value="'+this.id_address+'" '+(this.id_address == id_address_delivery ? 'selected="selected"' : '')+'>'+this.alias+'</option>';
 			addresses_invoice_options += '<option value="'+this.id_address+'" '+(this.id_address == id_address_invoice ? 'selected="selected"' : '')+'>'+this.alias+'</option>';


### PR DESCRIPTION
If you want to add an order via backoffice and you have chosen an existing customer, his carts and orders are loaded. But if the address of the cart is not existing anymore (marked as deleted), there is no chance to edit it. This code change makes sure, that an existing backup address is loaded properly.
