### PR TITLE
[+] FO : Use hreflang attribute for SEO

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -462,6 +462,7 @@ class FrontControllerCore extends Controller
             'currency' => $this->getTemplateVarCurrency(),
             'customer' => $this->getTemplateVarCustomer(),
             'language' => $this->objectPresenter->present($this->context->language),
+            'languages' => Language::getLanguages(true, $this->context->shop->id),
             'page' => $this->getTemplateVarPage(),
             'shop' => $this->getTemplateVarShop(),
             'urls' => $this->getTemplateVarUrls(),

--- a/themes/classic/templates/_partials/head.tpl
+++ b/themes/classic/templates/_partials/head.tpl
@@ -8,6 +8,11 @@
   {if $page.canonical}
     <link rel="canonical" href="{$page.canonical}">
   {/if}
+
+  {foreach from=$languages item=language_item}
+    <link rel="alternate" href="{$link->getLanguageLink($language_item.id_lang)}" hreflang="{$language_item.iso_code}" />
+  {/foreach}
+  <link rel="alternate" href="{$link->getXDefaultLink()}" hreflang="x-default" />
 {/block}
 
 <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | According to [Google Webmaster documentation](https://support.google.com/webmasters/answer/189077?hl=en), a multi-language website must use `hreflang` attribute on document `head` for better SEO results. |
| Type? | new feature |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Just setup a multi-language instance and see the result |

Result example (with `FR` as default language):

``` html
  <link rel="alternate" href="http://localhost:9000/en/content/3-terms-and-conditions-of-use" hreflang="en">
  <link rel="alternate" href="http://localhost:9000/fr/content/3-conditions-utilisation" hreflang="fr">
  <link rel="alternate" href="http://localhost:9000/content/3-conditions-utilisation" hreflang="x-default">
```
