### PR TITLE
[*] BO : Module page enhance list view display mode

### DIFF
--- a/admin-dev/themes/default/css/bundle/module/module.css
+++ b/admin-dev/themes/default/css/bundle/module/module.css
@@ -166,8 +166,9 @@
  */
 .module-item-list {
     background-color: white;
-    max-height: 50px;
-    height: 50px;
+    max-height: 70px;
+    height: 70px;
+    padding-top:10px
  }
  .module-item-list:nth-child(even) {
      background-color: #f5f8f9 !important;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | When viewing BO modules page in list mode, the modules are jumbled, needing more space and some padding. This change cleans it up nicely and makes it much easier to read. First try with git. |
| Type? | Improvement |
| Category? | BO |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | None |
| How to test? | Just look at the modules page in list view before this change. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
