### PR TITLE
// Fix hook called twice

### DIFF
--- a/themes/classic/templates/checkout/cart.tpl
+++ b/themes/classic/templates/checkout/cart.tpl
@@ -28,7 +28,7 @@
 
         <!-- shipping informations -->
         <div>
-          {hook h='displayShoppingCart'}
+          {hook h='displayShoppingCartFooter'}
         </div>
       </div>
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The hook displayShoppingCart was called twice and displayShoppingCartFooter was forgotten |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |

**StarterTheme PR https://github.com/PrestaShop/StarterTheme/pull/58**
