### PR TITLE
[-] BO : Fix theme preview

### DIFF
--- a/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
@@ -57,7 +57,7 @@
 											</div>
 										</div>
 									</div>
-									<img class="center-block img-thumbnail" src="{$base_url}{$theme->get('preview')}" alt="{$theme->getName()}" />
+									<img class="center-block img-thumbnail" src="{$theme->get('preview')}" alt="{$theme->getName()}" />
 								</div>
 							</div>
 						</div>
@@ -80,7 +80,7 @@
 
 			<div class="col-md-3">
 				<a href="{$base_url}" class="_blank">
-					<img class="center-block img-thumbnail" src="{$base_url}{$cur_theme->get('preview')}" alt="{$cur_theme->getName()}" />
+					<img class="center-block img-thumbnail" src="{$cur_theme->get('preview')}" alt="{$cur_theme->getName()}" />
 				</a>
 			</div>
 

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -35,7 +35,7 @@ class Theme implements AddonInterface
     public function __construct(array $attributes)
     {
         $attributes['directory'] = rtrim($attributes['directory'], '/') . '/';
-        $attributes['preview'] = '/themes/'.$attributes['name'].'/preview.png';
+        $attributes['preview'] = $attributes['physical_uri'].'/themes/'.$attributes['name'].'/preview.png';
 
         $this->attributes = new ArrayFinder($attributes);
     }

--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -62,6 +62,7 @@ class ThemeRepository implements AddonRepositoryInterface
         }
 
         $data['directory'] = $dir;
+        $data['physical_uri'] = $this->shop->physical_uri;
 
         return new Theme($data);
     }

--- a/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
@@ -76,6 +76,7 @@ class ThemeValidatorTest extends \PHPUnit_Framework_TestCase
 
         $config = (new Parser())->parse(file_get_contents($themeConfigFile));
         $config['directory'] = $themeDir;
+        $config['physical_uri'] = '/prestashop.unit.test';
 
         $theme = new Theme($config);
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When you installed PrestaShop not in the root directory, the theme thumbnail was not displayed in "Design" > "Theme" |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Install PrestaShop in a subfolder and go to "Design" > "Theme". You should now see the themes thumbnails |
