### PR TITLE
[-] CORE : Force POST method for payment options

### DIFF
--- a/classes/checkout/PaymentOptionsFinder.php
+++ b/classes/checkout/PaymentOptionsFinder.php
@@ -54,9 +54,6 @@ class PaymentOptionsFinderCore
                     );
                 }
 
-                if (!$formattedOption['method']) {
-                    $formattedOption['method'] = 'GET';
-                }
                 return $formattedOption;
             }, $options);
         }, $this->getPaymentOptions());

--- a/src/Core/Payment/PaymentOption.php
+++ b/src/Core/Payment/PaymentOption.php
@@ -68,13 +68,6 @@ class PaymentOption
     private $action;
 
     /**
-     * The HTTP method to use when sending the request to $action,
-     * i.e. "GET" or "POST".
-     * @var string
-     */
-    private $method;
-
-    /**
      * An associative array of additional parameters to use when sending
      * the request to $action,
      * e.g. if  $action is "http://payment-provider.example.com/process",
@@ -195,17 +188,6 @@ class PaymentOption
         return $this;
     }
 
-    public function getMethod()
-    {
-        return $this->method;
-    }
-
-    public function setMethod($method)
-    {
-        $this->method = $method;
-        return $this;
-    }
-
     /**
      * Return inputs contained in this payment option
      * @return mixed
@@ -271,7 +253,6 @@ class PaymentOption
         return [
             'action' => $this->action,
             'form' => $this->form,
-            'method' => $this->method,
             'inputs' => $this->inputs,
             'logo' => $this->logo,
             'additionalInformation' => $this->additionalInformation,
@@ -318,8 +299,7 @@ class PaymentOption
                       ->setAction($option['action'])
                       ->setForm($option['form'])
                       ->setInputs($option['inputs'])
-                      ->setLogo($option['logo'])
-                      ->setMethod($option['method']);
+                      ->setLogo($option['logo']);
 
             $newOptions[] = $newOption;
         }

--- a/tests/Unit/Core/Payment/Core_Payment_PaymentOptionTest.php
+++ b/tests/Unit/Core/Payment/Core_Payment_PaymentOptionTest.php
@@ -38,7 +38,6 @@ class Core_Payment_PaymentOptionTest extends UnitTestCase
             ->setCallToActionText('Pay by bankwire')
             ->setLogo('http://example.com/logo.png')
             ->setAction('http://example.com/submit')
-            ->setMethod('POST')
             ->setForm(null)
             ->setInputs(array('key' => 42))
         ;
@@ -47,7 +46,6 @@ class Core_Payment_PaymentOptionTest extends UnitTestCase
             'cta_text'  => 'Pay by bankwire',
             'logo'      => 'http://example.com/logo.png',
             'action'    => 'http://example.com/submit',
-            'method'    => 'POST',
             'form'      => null,
             'inputs'    => array('key' => 42)
         );
@@ -65,7 +63,6 @@ class Core_Payment_PaymentOptionTest extends UnitTestCase
             ->setCallToActionText('Pay by bankwire')
             ->setLogo('http://example.com/logo.png')
             ->setAction('http://example.com/submit')
-            ->setMethod('POST')
             ->setForm(null)
             ->setInputs(array('key' => 42))
         ;
@@ -74,7 +71,6 @@ class Core_Payment_PaymentOptionTest extends UnitTestCase
             'cta_text'  => 'Pay by bankwire',
             'logo'      => 'http://example.com/logo.png',
             'action'    => 'http://example.com/submit',
-            'method'    => 'POST',
             'form'      => null,
             'inputs'    => array('key' => 42)
         );

--- a/themes/classic/templates/checkout/payment-step.tpl
+++ b/themes/classic/templates/checkout/payment-step.tpl
@@ -48,7 +48,7 @@
           {if $option.form}
             {$option.form nofilter}
           {else}
-            <form id="payment-form" method="{$option.method}" action="{$option.action}">
+            <form id="payment-form" method="POST" action="{$option.action nofilter}">
               {foreach from=$option.inputs item=input}
                 <input type="{$input.type}" name="{$input.name}" value="{$input.value}">
               {/foreach}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR meant to always use POST to submit payment form. Indeed, you can't use GET method when you disable friendly urls |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-471 |
| How to test? | Disable URL rewriting and try to process an order |
