### PR TITLE
[-] BO : Fixed popup when previewing on Product page (#BOOM-451)

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1108,6 +1108,9 @@ var form = (function() {
 			target = false;
 		}
 		var data = $('input, textarea, select', elem).not(':input[type=button], :input[type=submit], :input[type=reset]').serialize();
+		if (target == '_blank' && redirect) {
+			var openBlank = window.open('about:blank', target, '');
+		}
 		$.ajax({
 			type: 'POST',
 			data: data,
@@ -1120,7 +1123,11 @@ var form = (function() {
 			success: function(response){
 				if (redirect) {
 					if (target) {
-						window.open(redirect, target);
+						if (target == '_blank') {
+							openBlank.location = redirect;
+						} else {
+							window.open(redirect, target);
+						}
 					} else {
 						window.location = redirect;
 					}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Prestashop 1.7 (alpha 3) - Firefox/Chrome. This PR fixes the blocked popup when previewing a product on product page. Browsers didn't considerate the clicking event as "trusted" because of ajax async. request |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-451 |
| How to test? | Create or edit an existing product. Then click the preview button. A new blank tab will open and redirect to the product page. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)
