### PR TITLE
Category name can now be a single character

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
+++ b/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
@@ -81,7 +81,7 @@ class SimpleCategory extends CommonAbstractType
             'attr' => ['placeholder' => $this->translator->trans('Category name', [], 'AdminCategories'), 'class' => 'ajax'],
             'constraints' => $options['ajax'] ? [] : array(
                 new Assert\NotBlank(),
-                new Assert\Length(array('min' => 3))
+                new Assert\Length(array('min' => 1))
             )
         ))
         ->add('id_parent', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Prestashop 1.7 (alpha 3) - This PR fixes the minimum length of category name to 1 when creating one on product page. This will allow to set a one-character category name (one chinese character for example) |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-388 |
| How to test? | On product page, try to add a new category and insert a category name with a length between 1 and 3 characters. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

…BOOM-388)
