### PR TITLE
// Make tests less dependants from addons website

### DIFF
--- a/src/Adapter/Addons/AddonsDataProvider.php
+++ b/src/Adapter/Addons/AddonsDataProvider.php
@@ -228,7 +228,7 @@ class AddonsDataProvider implements AddonsInterface
 
     /**
      * Check if a request has already failed
-     * @return bool 
+     * @return bool
      */
     public function isAddonsUp()
     {

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -64,6 +64,7 @@ services:
         arguments:
              - "@=service('prestashop.adapter.legacy.context').getEmployeeLanguageIso()"
              - "@router"
+             - "@prestashop.adapter.data_provider.addon"
         decorates: prestashop.core.admin.data_provider.module_interface
         public: false
     prestashop.adapter.admin.controller.attribute_generator:

--- a/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
@@ -82,9 +82,15 @@ class ModuleRepositoryTest extends UnitTestCase
             ->method('isModuleMainClassValid')
             ->willReturn(true);
 
+        $this->setupSfKernel();
+        $this->sfRouter = $this->sfKernel->getContainer()->get('router');
+
+        $this->addonsDataProviderS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider')
+            ->getMock();
+
         $this->adminModuleDataProviderStub = $this->getMock('PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider',
             ['getCatalogModulesNames'],
-            ['en']
+            ['en', $this->sfRouter, $this->addonsDataProviderS]
         );
 
         $this->adminModuleDataProviderStub
@@ -97,7 +103,11 @@ class ModuleRepositoryTest extends UnitTestCase
             [
                 $this->adminModuleDataProviderStub,
                 $this->moduleDataProviderStub,
-                new ModuleDataUpdater(new AddonsDataProvider(), new AdminModuleDataProvider('en')),
+                new ModuleDataUpdater(new AddonsDataProvider(), new AdminModuleDataProvider(
+                    'en',
+                    $this->sfRouter,
+                    $this->addonsDataProviderS
+                )),
                 new FakeLogger()
             ]
         );


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Don't depends on Addons website to launch modules tests |
| Type? | improvements |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Nope but fixes actual test broken cause of Addons api ;) |
| How to test? | clone the repository, launch the tests or ... look at Travis report |

![yolo](https://cloud.githubusercontent.com/assets/1247388/14531079/228e7084-025c-11e6-9a88-9db44933ebee.gif)
