### PR TITLE
[*] FO : Revert change on "display_tax_label" forced to true

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -296,7 +296,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'unit_price' => ($this->product->unit_price_ratio > 0) ? ($productPrice / $this->product->unit_price_ratio) : 0,
                 'product_manufacturer' => new Manufacturer((int)$this->product->id_manufacturer, $this->context->language->id),
                 'last_qties' =>  (int)Configuration::get('PS_LAST_QTIES'),
-                'display_taxes_label' => true,
+                'display_taxes_label' => (Module::isEnabled('ps_legalcompliance')
+                                          && (bool)Configuration::get('AEUC_LABEL_TAX_INC_EXC'))
+                                         || $this->context->country->display_tax_label,
                 'display_discount_price' => Configuration::get('PS_DISPLAY_DISCOUNT_PRICE')
             ));
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Revert a change that was forcing the display of tax label on product page |
| Type? | revert |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | None |
| How to test? | Disable tax for a given country and check if its displayed or not |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
