### PR TITLE
[+] CORE : Add logger on module class checks

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -24,6 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
@@ -333,7 +334,7 @@ abstract class ModuleCore
         }
 
         // Check if module is installed
-        $result = (new ModuleDataProvider())->isInstalled($this->name);
+        $result = (new ModuleDataProvider(new LegacyLogger()))->isInstalled($this->name);
         if ($result) {
             $this->_errors[] = Tools::displayError('This module has already been installed.');
             return false;

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -55,9 +55,10 @@ class ModuleManagerBuilder
         } else {
             $addonsDataProvider = new AddonsDataProvider();
             $adminModuleDataProvider = new AdminModuleDataProvider($this->getLanguageIso(), $this->getSymfonyRouter(), $addonsDataProvider);
+            $legacyLogger = new LegacyLogger();
 
             return new ModuleManager($adminModuleDataProvider,
-                new ModuleDataProvider(),
+                new ModuleDataProvider($legacyLogger),
                 new ModuleDataUpdater($addonsDataProvider, $adminModuleDataProvider),
                 $this->buildRepository(),
                 \Context::getContext()->employee);
@@ -78,12 +79,13 @@ class ModuleManagerBuilder
             } else {
                 $addonsDataProvider = new AddonsDataProvider();
                 $adminModuleDataProvider = new AdminModuleDataProvider($this->getLanguageIso(), $this->getSymfonyRouter(), $addonsDataProvider);
+                $legacyLogger = new LegacyLogger();
 
                 self::$modulesRepository = new ModuleRepository(
                     $adminModuleDataProvider,
-                    new ModuleDataProvider(),
+                    new ModuleDataProvider($legacyLogger),
                     new ModuleDataUpdater($addonsDataProvider, $adminModuleDataProvider),
-                    new LegacyLogger()
+                    $legacyLogger
                 );
             }
         }

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -114,6 +114,7 @@ services:
 
     prestashop.adapter.data_provider.module:
         class: PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider
+        arguments: ["@prestashop.adapter.legacy.logger"]
 
     # Presenters
     prestashop.adapter.presenter.module:


### PR DESCRIPTION
This PR follows-up https://github.com/PrestaShop/PrestaShop/pull/5397.

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | If case of error during the module main class check, add an entry in the logger |
| Type? | improvement |
| Category? | CORE |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | Get a module which has an incorrect `require_once` in its main class. When you reach the new module catalog, an entry should be added in the log and the shop should not be impacted by this issue. |
