### PR TITLE
[-] CORE: Bugfix order-address-advanced.tpl

### DIFF
--- a/themes/default-bootstrap/order-address-advanced.tpl
+++ b/themes/default-bootstrap/order-address-advanced.tpl
@@ -31,71 +31,84 @@
 {/foreach}
 <h2>{l s='Address(es) Details'}</h2>
 {if ((!empty($delivery_option) AND (!isset($isVirtualCart) || !$isVirtualCart)) OR $delivery->id OR $invoice->id)}
-    <div class="order_delivery clearfix row">
-        {if !isset($formattedAddresses) || (count($formattedAddresses.invoice) == 0 && count($formattedAddresses.delivery) == 0) || (count($formattedAddresses.invoice.formated) == 0 && count($formattedAddresses.delivery.formated) == 0)}
-            {if $delivery->id}
-                <div class="col-xs-12 col-sm-6"{if !$have_non_virtual_products} style="display: none;"{/if}>
-                    <ul id="delivery_address" class="address item box">
-                        <li><h3 class="page-subheading">{l s='Delivery address'}&nbsp;<span class="address_alias">({$delivery->alias})</span></h3></li>
-                        {if $delivery->company}<li class="address_company">{$delivery->company|escape:'html':'UTF-8'}</li>{/if}
-                        <li class="address_name">{$delivery->firstname|escape:'html':'UTF-8'} {$delivery->lastname|escape:'html':'UTF-8'}</li>
-                        <li class="address_address1">{$delivery->address1|escape:'html':'UTF-8'}</li>
-                        {if $delivery->address2}<li class="address_address2">{$delivery->address2|escape:'html':'UTF-8'}</li>{/if}
-                        <li class="address_city">{$delivery->postcode|escape:'html':'UTF-8'} {$delivery->city|escape:'html':'UTF-8'}</li>
-                        <li class="address_country">{$delivery->country|escape:'html':'UTF-8'} {if $delivery->id_state }({$delivery_state->name|escape:'html':'UTF-8'}){/if}</li>
-                    </ul>
-                </div>
-            {/if}
-            {if $invoice->id}
-                <div class="col-xs-12 col-sm-6">
-                    <ul id="invoice_address" class="address alternate_item box">
-                        <li><h3 class="page-subheading">{l s='Invoice address'}&nbsp;<span class="address_alias">({$invoice->alias})</span></h3></li>
-                        {if $invoice->company}<li class="address_company">{$invoice->company|escape:'html':'UTF-8'}</li>{/if}
-                        <li class="address_name">{$invoice->firstname|escape:'html':'UTF-8'} {$invoice->lastname|escape:'html':'UTF-8'}</li>
-                        <li class="address_address1">{$invoice->address1|escape:'html':'UTF-8'}</li>
-                        {if $invoice->address2}<li class="address_address2">{$invoice->address2|escape:'html':'UTF-8'}</li>{/if}
-                        <li class="address_city">{$invoice->postcode|escape:'html':'UTF-8'} {$invoice->city|escape:'html':'UTF-8'}</li>
-                        <li class="address_country">{$invoice->country|escape:'html':'UTF-8'} {if $invoice->id_state}({$invoice->name|escape:'html':'UTF-8'}){/if}</li>
-                    </ul>
-                </div>
-            {/if}
-        {else}
-            {foreach from=$formattedAddresses key=k item=address}
-                <div class="col-xs-12 col-sm-6"{if $k == 'delivery' && !$have_non_virtual_products} style="display: none;"{/if}>
-                    <ul class="address {if $address@last}last_item{elseif $address@first}first_item{/if} {if $address@index % 2}alternate_item{else}item{/if} box">
-                        <li>
-                            <h3 class="page-subheading">
-                                {if $k eq 'invoice'}
-                                    {l s='Invoice address'}
-                                {elseif $k eq 'delivery' && $delivery->id}
-                                    {l s='Delivery address'}
-                                {/if}
-                                {if isset($address.object.alias)}
-                                    <span class="address_alias">({$address.object.alias})</span>
-                                {/if}
-                            </h3>
-                        </li>
-                        {foreach $address.ordered as $pattern}
-                            {assign var=addressKey value=" "|explode:$pattern}
-                            {assign var=addedli value=false}
-                            {foreach from=$addressKey item=key name=foo}
-                                {$key_str = $key|regex_replace:AddressFormat::_CLEANING_REGEX_:""}
-                                {if isset($address.formated[$key_str]) && !empty($address.formated[$key_str])}
-                                    {if (!$addedli)}
-                                        {$addedli = true}
-                                        <li><span class="{if isset($addresses_style[$key_str])}{$addresses_style[$key_str]}{/if}">
-                                    {/if}
-                                    {$address.formated[$key_str]|escape:'html':'UTF-8'}
-                                {/if}
-                                {if ($smarty.foreach.foo.last && $addedli)}
-                                    </span></li>
-                                {/if}
-                            {/foreach}
-                        {/foreach}
-                    </ul>
-                </div>
-            {/foreach}
-        {/if}
-    </div>
+<div class="addresses clearfix">
+	<div class="row">
+		<div class="col-xs-12 col-sm-6">
+			<div class="address_delivery select form-group selector1">
+				<label for="id_address_delivery">{if $cart->isVirtualCart()}{l s='Choose a billing address:'}{else}{l s='Choose a delivery address:'}{/if}</label>
+				<select name="id_address_delivery" id="id_address_delivery" class="address_select form-control">
+					{foreach from=$addresses key=k item=address}
+						<option value="{$address.id_address|intval}"{if $address.id_address == $cart->id_address_delivery} selected="selected"{/if}>
+							{$address.alias|escape:'html':'UTF-8'}
+						</option>
+					{/foreach}
+				</select><span class="waitimage"></span>
+			</div>
+			<p class="checkbox addressesAreEquals"{if $cart->isVirtualCart()} style="display:none;"{/if}>
+				<input type="checkbox" name="same" id="addressesAreEquals" value="1"{if $cart->id_address_invoice == $cart->id_address_delivery || $addresses|@count == 1} checked="checked"{/if} />
+				<label for="addressesAreEquals">{l s='Use the delivery address as the billing address.'}</label>
+			</p>
+		</div>
+		<div class="col-xs-12 col-sm-6">
+			<div id="address_invoice_form" class="select form-group selector1"{if $cart->id_address_invoice == $cart->id_address_delivery} style="display: none;"{/if}>
+				{if $addresses|@count > 1}
+					<label for="id_address_invoice" class="strong">{l s='Choose a billing address:'}</label>
+					<select name="id_address_invoice" id="id_address_invoice" class="address_select form-control">
+					{section loop=$addresses step=-1 name=address}
+						<option value="{$addresses[address].id_address|intval}"{if $addresses[address].id_address == $cart->id_address_invoice && $cart->id_address_delivery != $cart->id_address_invoice} selected="selected"{/if}>
+							{$addresses[address].alias|escape:'html':'UTF-8'}
+						</option>
+					{/section}
+					</select><span class="waitimage"></span>
+				{else}
+					<a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1&select_address=1{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default">
+						<span>
+							{l s='Add a new address'}
+							<i class="icon-chevron-right right"></i>
+						</span>
+					</a>
+				{/if}
+			</div>
+		</div>
+	</div> <!-- end row -->
+	<div class="row">
+		<div class="col-xs-12 col-sm-6"{if $cart->isVirtualCart()} style="display:none;"{/if}>
+			<ul class="address item box" id="address_delivery">
+			</ul>
+		</div>
+		<div class="col-xs-12 col-sm-6">
+			<ul class="address alternate_item{if $cart->isVirtualCart()} full_width{/if} box" id="address_invoice">
+			</ul>
+		</div>
+	</div> <!-- end row -->
+	<p class="address_add submit">
+		<a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default">
+			<span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span>
+		</a>
+	</p>
+
+	<div id="ordermsg" class="form-group">
+			<label>{l s='If you would like to add a comment about your order, please write it in the field below.'}</label>
+			<textarea class="form-control" cols="60" rows="6" name="message">{if isset($oldMessage)}{$oldMessage}{/if}</textarea>
+	</div>
+
+</div> <!-- end addresses -->
+{strip}
+{capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
+{capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
+{addJsDef addressUrl=$smarty.capture.addressUrl}
+{capture}{'&multi-shipping=1'|urlencode}{/capture}
+{addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
+{capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
+{addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
+{addJsDef formatedAddressFieldsValuesList=$formatedAddressFieldsValuesList}
+{addJsDef opc=$opc|boolval}
+{capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
+{addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+{capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
+{addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+{capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
+{addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+{/strip}
 {/if}
 


### PR DESCRIPTION
There are no legal reasons given for disabling the normal opc feature for customers, to modify the invoice or delivery address or create a new one during checkout. The advanced checkout should have the same feature as the normal opc, just the *_sequence *_is mandatory!

In this context have a look into this patch too: https://github.com/PrestaShop/PrestaShop/pull/5392

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5404)
<!-- Reviewable:end -->
