### PR TITLE
[-] FO : Fix CSS 404 when using subdirectory

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -500,7 +500,7 @@ class MediaCore
         $compressed_css_files_infos = array();
         $protocol_link = Tools::getCurrentUrlProtocolPrefix();
         //if cache_path not specified, set curent theme cache folder
-        $cache_path = $cache_path ? $cache_path : _PS_THEME_DIR_.'cache'.DIRECTORY_SEPARATOR;
+        $cache_path = $cache_path ? $cache_path : _PS_THEME_DIR_.'cache/';
         $css_split_need_refresh = false;
 
         // group css files by media
@@ -594,7 +594,7 @@ class MediaCore
         // rebuild the original css_files array
         $css_files = array();
         foreach ($compressed_css_files as $media => $filename) {
-            $url = str_replace(_PS_ROOT_DIR_, '', $filename);
+            $url = str_replace(_PS_THEME_DIR_, _THEMES_DIR_._THEME_NAME_.'/', $filename);
             $css_files[$protocol_link.Tools::getMediaServer($url).$url] = $media;
         }
 
@@ -604,7 +604,7 @@ class MediaCore
         if (!preg_match('/(?i)msie [1-9]/', $_SERVER['HTTP_USER_AGENT'])) {
             return $compiled_css;
         }
-		$splitted_css = self::ieCssSplitter($compiled_css, $cache_path.'ie9', $css_split_need_refresh);
+        $splitted_css = self::ieCssSplitter($compiled_css, $cache_path.'ie9', $css_split_need_refresh);
 
         return array_merge($splitted_css, $compiled_css);
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | A lot of users reported, after upgrading to 1.6.1.5, that styling is lost when hosting PrestaShop in a subdirectory. This PR fixes the CSS issues as reported in this topic: https://www.prestashop.com/forums/topic/520452-update-from-1614-to-1615/ |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | unknown |
| How to test? | Install PrestaShop in a subdirectory, enable CCC for CSS. It should be working again after this PR. |
