### PR TITLE
[-] PDF : Fix generation of PDF files

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -232,4 +232,14 @@ abstract class HTMLTemplateCore
             Shop::setContext(Shop::CONTEXT_SHOP, (int)$this->shop->id);
         }
     }
+    
+    /**
+     * Returns the template's HTML pagination block
+     *
+     * @return string HTML pagination block
+     */
+    public function getPagination()
+    {
+        return $this->smarty->fetch($this->getTemplate('pagination'));
+    }
 }

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -503,14 +503,4 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             date('Y', strtotime($this->order_invoice->date_add))
         ).'.pdf';
     }
-
-    /**
-     * Returns the template's HTML pagination block
-     *
-     * @return string HTML pagination block
-     */
-    public function getPagination()
-    {
-        return $this->smarty->fetch($this->getTemplate('pagination'));
-    }
 }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | PDF templates can have pagination, but it hasn't been implemented for every PDF type, causing issues with PDF generation. |
| Type? | bug fix |
| Category? | PDF |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7938 |
| How to test? | Generate PDF for order return, delivery slip, invoice with lots of info, thereby causing pagination to happen. |
