### PR TITLE
Fix warning when duplicating products

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -339,8 +339,10 @@ class ImageCore extends ObjectModel
                         copy(_PS_PROD_IMG_DIR_.$image_old->getExistingImgPath().'-'.$image_type['name'].'.jpg',
                         $new_path.'-'.$image_type['name'].'.jpg');
                         if (Configuration::get('WATERMARK_HASH')) {
-                            copy(_PS_PROD_IMG_DIR_.$image_old->getExistingImgPath().'-'.$image_type['name'].'-'.Configuration::get('WATERMARK_HASH').'.jpg',
-                            $new_path.'-'.$image_type['name'].'-'.Configuration::get('WATERMARK_HASH').'.jpg');
+                            $old_image_path = _PS_PROD_IMG_DIR_.$image_old->getExistingImgPath().'-'.$image_type['name'].'-'.Configuration::get('WATERMARK_HASH').'.jpg';
+                            if (file_exists($old_image_path)) {
+                                copy($old_image_path, $new_path.'-'.$image_type['name'].'-'.Configuration::get('WATERMARK_HASH').'.jpg');
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When cloning a product and image watermarking is on, but the product being copied didn't have its images already watermarked (maybe it wasn't run retroactively) there would be a warning for trying to copy the watermark images that aren't there. |
| Type? | bug fix |
| Category? | Core |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | no |
| How to test? | <ol><li>Create a product and add an image</li><li>turn on watermarking (without regenerating images)</li><li>clone the product.</li></ol> You'll see some warnings being logged. |
