### PR TITLE
// CORE : ModuleRepository must keep in cache a broken module too

### DIFF
--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -272,11 +272,10 @@ class ModuleRepository implements ModuleRepositoryInterface
                 'is_valid' => 0,
                 'version' => null,
             ];
+            $main_class_attributes = [];
 
             if ($this->moduleProvider->isModuleMainClassValid($name)) {
                 require_once $php_file_path;
-
-                $main_class_attributes = [];
 
                 // We load the main class of the module, and get its properties
                 $tmp_module = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get($name);
@@ -293,13 +292,13 @@ class ModuleRepository implements ModuleRepositoryInterface
                 $disk['is_valid'] = 1;
                 $disk['version'] = $tmp_module->version;
 
-                $this->cache[$name]['attributes'] = $main_class_attributes;
-                $this->cache[$name]['disk']       = $disk;
-
                 $attributes = array_merge($attributes, $main_class_attributes);
             } else {
-                $attributes['warning'] = 'Invalid module class';
+                $main_class_attributes['warning'] = 'Invalid module class';
             }
+
+            $this->cache[$name]['attributes'] = $main_class_attributes;
+            $this->cache[$name]['disk']       = $disk;
         }
 
         foreach (['logo.png', 'logo.gif'] as $logo) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When a module main class is invalid, the error is properly blocked by the ModuleRepository. However, if the test is made a second time on the SAME module, the require_once is not executed and PHP returns directly true. |
| Type? | bug fix |
| Category? | CORE |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | Use a module which has an non-existing file for require_once and add it to your modules `folder/`. Then, go to the tab "Notifications" of the module page, and now no error should be displayed. |

It's dangerous to go alone ! Take the following module to see the error fixed:
:open_file_folder:  [test_wrong_require.zip](https://github.com/PrestaShop/PrestaShop/files/223881/test_wrong_require.zip)
