### PR TITLE
Added template name in error when no template found for module

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2172,7 +2172,7 @@ abstract class ModuleCore
     public function display($file, $template, $cache_id = null, $compile_id = null)
     {
         if (($overloaded = Module::_isTemplateOverloadedStatic(basename($file, '.php'), $template)) === null) {
-            return Tools::displayError('No template found for module').' '.basename($file, '.php');
+            return Tools::displayError('No template found for module').' '.basename($file, '.php').(_PS_MODE_DEV_ ? ' ('.$template.')' : '');
         } else {
             $this->smarty->assign(array(
                 'module_dir' =>    __PS_BASE_URI__.'modules/'.basename($file, '.php').'/',


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When a template for a module isn't found, it will display the template name into the error with DEV mode enabled. |
| Type? | improvement |
| Category? | CORE |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Checkout this and remove a template file of a module. |
