### PR TITLE
[+] CORE : Module page tooltips and theme modules (BOOM 76 & BOOM 582)

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -439,6 +439,7 @@ var AdminModuleController = function () {
                         $(element.selector).append(element.content);
                     });
                     $(requiredSelectorCombination).fadeIn(800);
+                    $('[data-toggle="popover"]').popover();
                 });
             } else {
                 $(_this.placeholderGlobalSelector).fadeOut(800, function(){

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -35,6 +35,10 @@ services:
     # ADAPTERS (prestashop.adapter.*)
 
     # Legacy context service, transitional
+    prestashop.adapter.legacy.configuration:
+        class: PrestaShop\PrestaShop\Adapter\Configuration
+        arguments: ["@=service('prestashop.adapter.legacy.context').getContext().shop"]
+
     prestashop.adapter.legacy.context:
         class: PrestaShop\PrestaShop\Adapter\LegacyContext
 
@@ -175,6 +179,10 @@ services:
             - @prestashop.adapter.data_provider.module
             - @prestashop.core.module.updater
             - @prestashop.adapter.legacy.logger
+            
+    prestashop.core.admin.theme.repository:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository
+        arguments: ["@prestashop.adapter.legacy.configuration", "@=service('prestashop.adapter.legacy.context').getContext().shop"]
 
     # Managers
     prestashop.adapter.image_manager:

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
@@ -4,6 +4,10 @@
         <div class="col-lg-6">
             <div class="module-sorting-search-wording">
                 <span class="module-search-result-wording">{{ totalModules }} modules and services selected for you</span>
+                <span class="help-box" data-toggle="popover"
+                    data-title="{{ trans("Selection", {}, 'AdminModules') }}"
+                    data-content="{{ trans("Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules.", {}, 'AdminModules') }}">
+                </span>
             </div>
             <p class="module-addons-search">
                 <a class='module-addons-search-link' href="#">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -78,13 +78,13 @@
 		<hr class="top-menu-separator">
 
 		<div class="module-short-list">
-			<span class="module-search-result-wording">{{[]|length}} theme modules</span>
+			<span class="module-search-result-wording">{{modules.theme_bundle|length}} theme modules</span>
                            <span class="help-box" data-toggle="popover"
                                 data-title="{{ trans("Theme modules", {}, 'AdminModules') }}"
                                 data-content="{{ trans("Each theme you install will come with its own set of modules. You’ll find here all the modules related to your active theme.", {}, 'AdminModules') }}">
                            </span>
 		</div>
-		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : [], 'display_type' : 'list', 'origin' : 'manage'  } %}
+		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.theme_bundle, 'display_type' : 'list', 'origin' : 'manage'  } %}
         </div>
     </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -57,13 +57,21 @@
             {# Actual Page Content #}
 		<div class="module-short-list">
 			<span class="module-search-result-wording">{{modules.modules|length}} installed modules</span>
-		</div>
+                           <span class="help-box" data-toggle="popover"
+                                data-title="{{ trans("Installed modules", {}, 'AdminModules') }}"
+                                data-content="{{ trans("These are all the modules you’ve added to your shop, either by buying it from PrestaShop Addons, or by uploading it directly.", {}, 'AdminModules') }}">
+                           </span>
+                   </div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.modules, 'display_type' : 'list', 'origin' : 'manage'  } %}
 
 		<hr class="top-menu-separator">
 
 		<div class="module-short-list">
 			<span class="module-search-result-wording">{{modules.native_modules|length}} built-in modules</span>
+                           <span class="help-box" data-toggle="popover"
+                                 data-title="{{ trans("Built-in modules", {}, 'AdminModules') }}"
+                                data-content="{{ trans("These modules from PrestaShop are preinstalled when you set-up your shop. They cover the basics of e-commerce and comes for free.", {}, 'AdminModules') }}">
+                           </span>
 		</div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.native_modules, 'display_type' : 'list', 'origin' : 'manage'  } %}
 
@@ -71,6 +79,10 @@
 
 		<div class="module-short-list">
 			<span class="module-search-result-wording">{{[]|length}} theme modules</span>
+                           <span class="help-box" data-toggle="popover"
+                                data-title="{{ trans("Theme modules", {}, 'AdminModules') }}"
+                                data-content="{{ trans("Each theme you install will come with its own set of modules. You’ll find here all the modules related to your active theme.", {}, 'AdminModules') }}">
+                           </span>
 		</div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : [], 'display_type' : 'list', 'origin' : 'manage'  } %}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -27,13 +27,21 @@
         <div class="col-lg-10 col-lg-offset-1">
 
             <div class="module-short-list">
-                <span class="module-search-result-wording">{{modules.to_configure|length}} modules to configure</span>
+                <span class="module-search-result-wording">{{modules.to_configure|length}} modules to configure</span> 
+                <span class="help-box" data-toggle="popover"
+                      data-title="{{ trans("Modules to configure", {}, 'AdminModules') }}"
+                      data-content="{{ trans("These modules require your attention: you need to take some action to ensure they are fully operational.", {}, 'AdminModules') }}">
+                </span>
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_configure.html.twig' with { 'modules' : modules.to_configure, 'display_type' : 'list'  } %}
 
             <hr class="top-menu-separator">
             <div class="module-short-list">
                 <span class="module-search-result-wording">{{modules.to_update|length}} modules to update</span>
+                <span class="help-box" data-toggle="popover"
+                      data-title="{{ trans("Modules to update", {}, 'AdminModules') }}"
+                      data-content="{{ trans("Update these modules to enjoy their latest versions.", {}, 'AdminModules') }}">
+                </span>
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_update.html.twig' with { 'modules' : modules.to_update, 'display_type' : 'list' } %}
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Add tooltips on the 3 modules page tabs AND display modules related to the current theme in the proper panel |
| Type? | improvement |
| Category? | CORE |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-582](http://forge.prestashop.com/browse/BOOM-582) AND [BOOM-76](http://forge.prestashop.com/browse/BOOM-76) |
| How to test? | Get the PR and see the tooltips and the third part of the "Installed modules" fulfilled, that's all. |
