### PR TITLE
[*] BO Shop Link Change

### DIFF
--- a/admin-dev/themes/new-theme/template/components/layout/shop_list.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/shop_list.tpl
@@ -15,6 +15,6 @@
   </div>
 {else}
   <div class="shop-list">
-    <a class="link" href="{if isset($base_url_tc)}{$base_url_tc|escape:'html':'UTF-8'}{else}{$base_url|escape:'html':'UTF-8'}{/if}">{$shop_name}</a>
+    <a class="link" target="_blank" href="{if isset($base_url_tc)}{$base_url_tc|escape:'html':'UTF-8'}{else}{$base_url|escape:'html':'UTF-8'}{/if}">{$shop_name}</a>
   </div>
 {/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | Shop link opens in current widow this change corrects this |
| Type? | [*] |
| Category? | BO |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | None |
| How to test? | After Fresh install click shop link inheader of page. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

The BO shop link will open when clicked in the same window this change will correct this and open in a new tab.
This I believe is for Multi-Shop.
