### PR TITLE
[*] FO Cart Summary Change

### DIFF
--- a/themes/classic/assets/css/theme.css
+++ b/themes/classic/assets/css/theme.css
@@ -5208,6 +5208,7 @@ body#checkout {
       margin-left: 14.375em; }
   body#checkout .products,
   body#checkout .shipping,
+  body#checkout .discount,
   body#checkout .cart-summary-totals {
     margin-top: 1.25em; }
   body#checkout .cart-summary-totals .label,
@@ -5221,6 +5222,7 @@ body#checkout {
       font-weight: normal;
       bottom: 0;
       font-size: 0.9375em; }
+  body#checkout .tax .label,	 
   body#checkout .shipping .label,
   body#checkout .discount .label,
   body#checkout .products .label {
@@ -6495,6 +6497,9 @@ li.product-label {
     padding-right: 0.9375rem; }
 
 /** CART BODY **/
+.cart-summary-title{
+  margin-bottom:20px; }
+
 .cart-grid-body > a.label {
   color: #414141;
   font-size: 1em; }

--- a/themes/classic/templates/checkout/_partials/cart-summary-totals.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary-totals.tpl
@@ -11,7 +11,7 @@
       {/foreach}
     </div>
   {/block}
-
+<hr/>
   {block name='cart_summary_totals'}
     <div class="cart-summary-totals">
       <span class="label">{$cart.total.label}</span>

--- a/themes/classic/templates/checkout/_partials/cart-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary.tpl
@@ -1,7 +1,10 @@
 <section id="checkout-cart-summary" class="card card-block -js-cart" data-refresh-url="{$urls.pages.cart}?ajax=1">
   {block name='cart_summary_header'}
     <header>
-      <p>{$cart.summary_string}<span class="pull-xs-right">{$cart.total.amount}</span></p>
+      <div class="card cart-summary">
+               <div class="cart-summary-title" align="center">
+          <h1 class="h1">{l s='Shopping Summary'}</h1>
+        </div>
     </header>
   {/block}
 

--- a/themes/classic/templates/checkout/cart.tpl
+++ b/themes/classic/templates/checkout/cart.tpl
@@ -38,9 +38,12 @@
         {block name='cart_summary'}
           <div class="card cart-summary">
 
-            {block name='cart_summary_line'}
-              {include file='checkout/_partials/cart-summary-items-subtotal.tpl' cart=$cart}
-            {/block}
+            {block name='cart_summary_title'}
+          <div class="card cart-summary">
+               <div class="cart-summary-title" align="center">
+          <h1 class="h1">{l s='Shopping Summary'}</h1>
+          </div>
+           {/block}
 
             {block name='cart_voucher'}
               {include file='checkout/_partials/cart-voucher.tpl'}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | Change and fixes for cart summery pages |
| Type? | [*] |
| Category? | FO |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | None |
| How to test? | Create a voucher and go through the checkout process |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

When on the cart summary page there is a line showing the Products with a total at the top of the right block that in misleading and unnecessary as it actually show the Grand Total of the products with shipping and discounts.
I find the line unnecessary as this total is already shown on the Shopping Cart so I changed to the title Shopping Summary I also changed this is the steps pages.
I also added some CSS to give a bottom margin.

In the steps pages only the Tax was shown in bold as it seems this was missed in the CSS file so this corrects that, I also removed the font-weight to keep the text more in line with the cart summary page.
In the the steps pages if you have a discount the discount line is missing a top margin this will correct that.
I also added an HR to separate the summery from the total.
