### PR TITLE
[-] PDF : Default HTMLTemplate::getPagination()

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -109,6 +109,16 @@ abstract class HTMLTemplateCore
     }
 
     /**
+     * Returns the template's HTML pagination block
+     *
+     * @return string HTML pagination block
+     */
+    public function getPagination()
+    {
+        return $this->smarty->fetch($this->getTemplate('pagination'));
+    }
+
+    /**
      * Assign common header data to smarty variables
      */
 


### PR DESCRIPTION
Avoid errors like `Fatal error: Call to undefined method HTMLTemplateOleaQuote::getPagination() in .../classes/pdf/PDF.php on line 95`.
