### PR TITLE
[*] WS : Optionally send in-transit email when updating tracking number

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -500,44 +500,8 @@ class AdminOrdersControllerCore extends AdminController
                     if ($order_carrier->update()) {
                         //send mail only if tracking number is different AND not empty
                         if (!empty($tracking_number) && $old_tracking_number != $tracking_number) {
-                            $customer = new Customer((int)$order->id_customer);
-                            $carrier = new Carrier((int)$order->id_carrier, $order->id_lang);
-                            if (!Validate::isLoadedObject($customer)) {
-                                throw new PrestaShopException('Can\'t load Customer object');
-                            }
-                            if (!Validate::isLoadedObject($carrier)) {
-                                throw new PrestaShopException('Can\'t load Carrier object');
-                            }
-                            $orderLanguage = new Language((int) $order->id_lang);
-                            $templateVars = array(
-                                '{followup}' => str_replace('@', $order->shipping_number, $carrier->url),
-                                '{firstname}' => $customer->firstname,
-                                '{lastname}' => $customer->lastname,
-                                '{id_order}' => $order->id,
-                                '{shipping_number}' => $order->shipping_number,
-                                '{order_name}' => $order->getUniqReference()
-                            );
-
-                            if (@Mail::Send(
-                                (int)$order->id_lang,
-                                'in_transit',
-                                $this->trans(
-                                    'Package in transit',
-                                    array(),
-                                    'Emails.Subject',
-                                    $orderLanguage->locale
-                                ),
-                                $templateVars,
-                                $customer->email,
-                                $customer->firstname . ' ' . $customer->lastname,
-                                null,
-                                null,
-                                null,
-                                null,
-                                _PS_MAIL_DIR_,
-                                true,
-                                (int)$order->id_shop
-                            )) {
+                            if ($order_carrier->sendInTransitEmail($order))
+                            {
                                 Hook::exec('actionAdminOrdersTrackingNumberUpdate', array(
                                     'order' => $order,
                                     'customer' => $customer,


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Optionally send in-transit email when updating tracking number. Moved the email sending to OrderCarrier from admin order controller in order to accomplish this. |
| Type? | improvement |
| Category? | WS |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | n/a |
| How to test? | add sendemail=1 to URL e.g. myshop.com/api/order_carriers/7?sendemail=1 and do a PUT (update) |
