### PR TITLE
Fix alignment in order history

### DIFF
--- a/themes/classic/templates/customer/_partials/order-detail-no-return.tpl
+++ b/themes/classic/templates/customer/_partials/order-detail-no-return.tpl
@@ -7,7 +7,7 @@
       <th>{l s='Product'}</th>
       <th>{l s='Quantity'}</th>
       <th>{l s='Unit price'}</th>
-      <th>{l s='Total price'}</th>
+      <th class="text-xs-right">{l s='Total price'}</th>
     </tr>
   </thead>
 
@@ -15,8 +15,8 @@
     <tr>
       <td>{$product.reference}</td>
       <td>{$product.name}</td>
-      <td class="text-xs-right">{$product.quantity}</td>
-      <td class="text-xs-right">{$product.price}</td>
+      <td>{$product.quantity}</td>
+      <td>{$product.price}</td>
       <td class="text-xs-right">{$product.total}</td>
     </tr>
     {if $product.customizations}

--- a/themes/classic/templates/customer/order-detail.tpl
+++ b/themes/classic/templates/customer/order-detail.tpl
@@ -118,7 +118,7 @@
                 <td>{$line.shipping_date}</td>
                 <td>{$line.carrier_name}</td>
                 <td>{$line.shipping_weight}</td>
-                <td class="text-xs-right">{$line.shipping_cost}</td>
+                <td>{$line.shipping_cost}</td>
                 <td>{$line.tracking}</td>
               </tr>
             {/foreach}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | Customer order history misaligned headings and data |
| Type? | [*] |
| Category? | FO |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | None |
| How to test? | Create an order and look at your order history detail of that order. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

In the customers order history the Total price heading is misaligned with the prices and the products quantity ans price is misaligned with their headings.
In the shipping section the shipping cost is misaligned with it's heading.
