### PR TITLE
[-] FO Product Image

### DIFF
--- a/themes/classic/assets/css/theme.css
+++ b/themes/classic/assets/css/theme.css
@@ -6115,8 +6115,8 @@ body#checkout {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 452px;
-    height: 452px;
+    width: 100%;
+    height: 100%;
     background: white;
     position: absolute;
     left: 0;

--- a/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -1,7 +1,7 @@
 <div class="images-container">
   {block name='product_cover'}
     <div class="product-cover">
-      <img class="js-qv-product-cover" src="{$product.cover.bySize.medium_default.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" width="{$product.cover.bySize.medium_default.width}" itemprop="image" />
+      <img class="js-qv-product-cover" src="{$product.cover.bySize.medium_default.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" width="100%" itemprop="image" />
       <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
         <i class="material-icons zoom-in">&#xE8FF;</i>
       </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | Product page description appears to overlap image in 2 column layout, the product cover and hover backgrounds do not scale to the widow width. |
| Type? | [-] |
| Category? | FO |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | None |
| How to test? | Change to a 2 column layout on the product page |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

When switching to a 2 column layout on the product page the right column description area appears to overlap the image this is due to the product cover and hover backgrounds not scaling to the window width.
This change will scale both to fit the scaled image and works in all layouts.
