### PR TITLE
[-] CORE : Fix Smarty SQL Cache

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -43,7 +43,7 @@ if (!Tools::getSafeModeStatus()) {
 $smarty->setConfigDir(_PS_SMARTY_DIR_.'configs');
 $smarty->caching = false;
 if (Configuration::get('PS_SMARTY_CACHING_TYPE') == 'mysql') {
-    include(_PS_CLASS_DIR_.'/SmartyCacheResourceMysql.php');
+    include(_PS_CLASS_DIR_.'Smarty/SmartyCacheResourceMysql.php');
     $smarty->caching_type = 'mysql';
 }
 $smarty->force_compile = (Configuration::get('PS_SMARTY_FORCE_COMPILE') == _PS_SMARTY_FORCE_COMPILE_) ? true : false;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Unable to find `SmartyCacheResourceMysql.php` because the file was moved. |
| Type? | bug fix |
| Category? | CORE |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Dunno |
| How to test? | Enable MYSQL Caching on the page "Advanced Parameters > Performance" |
