### PR TITLE
[Bug fix] BO : Fix helper form for select tag when is not multiple

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -390,9 +390,11 @@
 																	{/if}
 																{/foreach}
 															{else}
-																{if $fields_value[$input.name] == $option[$input.options.id]}
-																	selected="selected"
-																{/if}
+																{foreach $fields_value[$input.name] as $field_value}
+																	{if $field_value == $option[$input.options.id]}
+																		selected="selected"
+																	{/if}
+																{/foreach}
 															{/if}
 														>{$option[$input.options.name]}</option>
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Form helper select tag. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | overriding AdminCategoriesController.php and add select field in `$this->fields_form_override` in renderForm method |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

If you dump the $fields_value[$input.name] you are an array (see below), each language is returned, so the condition `$fields_value[$input.name] == $option[$input.options.id]` always return false and the select can't be selected

```
{
  [1]=>
  string(2) "16"
  [2]=>
  string(2) "16"
  [3]=>
  string(2) "16"
  [4]=>
  string(2) "16"
  [5]=>
  string(2) "16"
}                                                      
```

For information I use select helper in an AdminCategoriesController override class

``` php
$this->fields_form_override = array(
    array(
        'type' => 'text',
        'label' => $this->l('Video'),
        'name' => 'video',
        'lang' => true,
    ),
    array(
        'type' => 'select',
        'label' => $this->l('My select tag'),
        'name' => 'my_name',
        'lang' => true,
        'options' => array(
            'query' => $options,
            'id' => 'my_name',
            'name' => 'name',
        )
    )
);
```

Even with `'lang' => true` `$fields_value[$input.name]` is still an array.

May be the issue come from `'lang' => true` because the language selector in BO is not displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5434)
<!-- Reviewable:end -->
