### PR TITLE
[-] CORE : Bugfix blockcart.tpl double negation

### DIFF
--- a/themes/default-bootstrap/modules/blockcart/blockcart.tpl
+++ b/themes/default-bootstrap/modules/blockcart/blockcart.tpl
@@ -147,7 +147,7 @@
 							<div class="cart-prices-line first-line">
 								<span class="price cart_block_shipping_cost ajax_cart_shipping_cost{if !($page_name == 'order-opc') && $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery || $free_ship)} unvisible{/if}">
 									{if $shipping_cost_float == 0}
-										 {if !($page_name == 'order-opc') && (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)}{l s='To be determined' mod='blockcart'}{else}{l s='Free shipping!' mod='blockcart'}{/if}
+										 {if !($page_name == 'order-opc') && (isset($cart->id_address_delivery) || $cart->id_address_delivery)}{l s='To be determined' mod='blockcart'}{else}{l s='Free shipping!' mod='blockcart'}{/if}
 									{else}
 										{$shipping_cost}
 									{/if}


### PR DESCRIPTION
Because of a double negation **/themes/default-bootstrap/modules/blockcart/blockcart.tpl**  the ajax cart always displayed _'free shipping'_  instead of _'To be determined'_. This affects all 1.6.1.x releases.

Whereas the if-clause in line 287 makes no sense when the customer is already logged in, because the cart will always display 'free shipping' when there is a delivery address - no matter if a carrier was selected at that time or not.
