### PR TITLE
[-] BO : fixed mysql 5.7 "virtual" is a reserved keyword

### DIFF
--- a/controllers/admin/AdminAttachmentsController.php
+++ b/controllers/admin/AdminAttachmentsController.php
@@ -53,7 +53,7 @@ class AdminAttachmentsControllerCore extends AdminController
                 'align' => 'center',
                 'class' => 'fixed-width-xs'
             ),
-            'name' => array(v
+            'name' => array(
                 'title' => $this->l('Name')
             ),
             'file' => array(

--- a/controllers/admin/AdminAttachmentsController.php
+++ b/controllers/admin/AdminAttachmentsController.php
@@ -43,8 +43,8 @@ class AdminAttachmentsControllerCore extends AdminController
         $this->addRowAction('view');
         $this->addRowAction('delete');
 
-        $this->_select = 'IFNULL(virtual.products, 0) as products';
-        $this->_join = 'LEFT JOIN (SELECT id_attachment, COUNT(*) as products FROM '._DB_PREFIX_.'product_attachment GROUP BY id_attachment) virtual ON a.id_attachment = virtual.id_attachment';
+        $this->_select = 'IFNULL(virtual_product_attachment.products, 0) as products';
+        $this->_join = 'LEFT JOIN (SELECT id_attachment, COUNT(*) as products FROM '._DB_PREFIX_.'product_attachment GROUP BY id_attachment) AS virtual_product_attachment ON a.id_attachment = virtual_product_attachment.id_attachment';
         $this->_use_found_rows = false;
 
         $this->fields_list = array(
@@ -53,7 +53,7 @@ class AdminAttachmentsControllerCore extends AdminController
                 'align' => 'center',
                 'class' => 'fixed-width-xs'
             ),
-            'name' => array(
+            'name' => array(v
                 'title' => $this->l('Name')
             ),
             'file' => array(
@@ -66,7 +66,7 @@ class AdminAttachmentsControllerCore extends AdminController
             'products' => array(
                 'title' => $this->l('Associated with'),
                 'suffix' => $this->l('product(s)'),
-                'filter_key' => 'virtual!products',
+                'filter_key' => 'virtual_product_attachment!products',
             ),
         );
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | AdminAttachmentsController fails with mysql 5.7 |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | go to AdminAttachmentsController with mysql 5.7 |
