### PR TITLE
Fix AdminStoresController from nulling out form fields with multiple values

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -355,7 +355,13 @@ class AdminStoresControllerCore extends AdminController
             /* Cleaning fields */
             foreach ($_POST as $kp => $vp) {
                 if (!in_array($kp, array('checkBoxShopGroupAsso_store', 'checkBoxShopAsso_store'))) {
-                    $_POST[$kp] = trim($vp);
+                    if (is_array($vp)) {
+                        foreach ($vp as $vpi => $vpv) {
+                            $_POST[$kp][$vpi] = trim($vpv);
+                        }
+                    } else {
+                        $_POST[$kp] = trim($vp);
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | If you add additional form fields to AdminStoreController views, and any of those form fields accept multiple values (i.e., a multiple select box), when you submit the page, the controller attempts to trim() all values in $_POST (except for the multistore checkboxes which are specifically excluded for some reason). Running a trim() on a value that's of type array results in the data being lost. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | n/a |
| How to test? | Create a module that hooks **actionAdminStoresFormModifier** and adds a field of `"type" => "select"` with `"multiple" => true` and some options in `"options"`. Then, on the BO view select more than one value and submit. After the trim() loop runs, the contents of the field will be empty before this fix is implemented. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5457)
<!-- Reviewable:end -->
