### PR TITLE
added getPagination to core PdfTemplate

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -73,6 +73,16 @@ abstract class HTMLTemplateCore
 
         return $this->smarty->fetch($this->getTemplate('footer'));
     }
+    
+    /**
+     * Returns the template's HTML pagination block
+     *
+     * @return string HTML pagination block
+     */
+    public function getPagination()
+    {
+        return $this->smarty->fetch($this->getTemplate('pagination'));
+    }
 
     /**
      * Returns the shop address


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | getPagination is called on every PDF render. but it is only defined in the invoicing template. this causes a fatal error on generating other PDFs |
| Type? | bug fix |
| Category? | PDF |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Generate a PDF other than the invoice of the order. |

---

Seen that there is a [call to getPagination on each render of a pdf](https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/pdf/PDF.php#L95)  I propose that it is added to the core template file.

because when I try to generate a pdf (other then invoice) now I get this error: (using prestashop 1.6.1.5)

```
Fatal error: Call to undefined method HTMLTemplateOrderReturn::getPagination() in /var/www/html/classes/pdf/PDF.php on line 95
Fatal error: Call to undefined method HTMLTemplateDeliverySlip::getPagination() in /var/www/html/classes/pdf/PDF.php on line 95
```
