### PR TITLE
Allow slash character in phone numbers

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -543,7 +543,7 @@ class ValidateCore
      */
     public static function isPhoneNumber($number)
     {
-        return preg_match('/^[+0-9. ()-]*$/', $number);
+        return preg_match('/^[+0-9. ()\/-]*$/', $number);
     }
 
     /**


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Allow slash character in phone numbers, as we usually write phone numbers like this 0498/12.34.56 (ie. in Belgium) |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Edit a store phone number in back office |
