### PR TITLE
[-] FO : Fix DOM not closed

### DIFF
--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -556,10 +556,10 @@ abstract class ControllerCore
 
             $javascript = $this->context->smarty->fetch(_PS_ALL_THEMES_DIR_.'javascript.tpl');
 
-            if ($defer && (!isset($this->ajax) || ! $this->ajax)) {
-                echo $html.$javascript;
+            if ($defer) {
+                echo $html.$javascript.(empty($this->ajax) ? '</body></html>' : '');
             } else {
-                echo preg_replace('/(?<!\$)'.$js_tag.'/', $javascript, $html);
+                echo preg_replace('/(?<!\$)'.$js_tag.'/', $javascript, $html).(empty($this->ajax) ? '</body></html>' : '');
             }
         } else {
             echo $html;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The DOM was not properly closed. `</body>` & `</html>` were missing. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-619 |
| How to test? | Just look at the source code to check if the tags are present. |
