### PR TITLE
[-] BO : Fix admin tabs

### DIFF
--- a/admin-dev/themes/default/sass/partials/_icons.sass
+++ b/admin-dev/themes/default/sass/partials/_icons.sass
@@ -285,47 +285,6 @@
 .icon-zoom-out
 	@extend .icon-search-minus
 
-//icons page-head
-[class^="icon-Admin"]
-	@extend .icon-fw
-	@extend .icon-2x
-.icon-AdminDashboard
-	@extend .icon-dashboard
-.icon-AdminCatalog
-	@extend .icon-book
-.icon-AdminParentOrders
-	@extend .icon-credit-card
-.icon-AdminParentCustomer
-	@extend .icon-group
-.icon-AdminPriceRule
-	@extend .icon-tags
-.icon-AdminParentShipping
-	@extend .icon-truck
-.icon-AdminParentLocalization
-	@extend .icon-globe
-.icon-AdminParentModules
-	@extend .icon-puzzle-piece
-.icon-AdminParentPreferences
-	@extend .icon-wrench
-.icon-AdminTools
-	@extend .icon-cogs
-.icon-AdminAdmin
-	@extend .icon-cog
-.icon-AdminParentStats
-	@extend .icon-bar-chart
-.icon-AdminStock
-	@extend .icon-archive
-.icon-AdminSearch
-	@extend .icon-search
-.icon-AdminShopUrl
-	@extend .icon-link
-.icon-AdminAttributeGenerator
-	@extend .icon-magic
-.icon-AdminShop
-	@extend .icon-sitemap
-.icon-AdminFlash
-	@extend .icon-flash
-
 //Toolbar
 [class^="process-icon-"]
 	display: block

--- a/admin-dev/themes/default/template/nav.tpl
+++ b/admin-dev/themes/default/template/nav.tpl
@@ -9,7 +9,7 @@
 
 				{if $level_1.class_name == 'AdminDashboard'}
 					<li class="maintab {if $level_1.current}active{/if}" id="tab-{$level_1.class_name}">
-						<a href="{if $level_1.sub_tabs|@count && isset($level_1.sub_tabs[0].href)}{$level_1.sub_tabs[0].href|escape:'html':'UTF-8'}{else}{$level_1.href|escape:'html':'UTF-8'}{/if}" class="title" >
+						<a href="{$level_1.href|escape:'html':'UTF-8'}" class="title" >
 							<i class="material-icons">{$level_1.icon}</i>
 							<span>{if $level_1.name eq ''}{$level_1.class_name|escape:'html':'UTF-8'}{else}{$level_1.name|escape:'html':'UTF-8'}{/if}</span>
 						</a>
@@ -26,7 +26,7 @@
 						{foreach $level_1.sub_tabs as $level_2}
 							{if $level_2.active}
 								<li class="maintab {if $level_2.current}active{/if} {if $level_2.sub_tabs|@count}has_submenu{/if}" id="subtab-{$level_2.class_name|escape:'html':'UTF-8'}" data-submenu="{$level_2.id_tab}">
-									<a href="{if $level_2.sub_tabs|@count && isset($level_2.sub_tabs[0].href)}{$level_2.sub_tabs[0].href|escape:'html':'UTF-8'}{else}{$level_2.href|escape:'html':'UTF-8'}{/if}" class="title {if $level_2.sub_tabs|@count}has_submenu{/if}">
+									<a href="{$level_2.href|escape:'html':'UTF-8'}" class="title {if $level_2.sub_tabs|@count}has_submenu{/if}">
 										<i class="material-icons">{$level_2.icon}</i>
 										<span>
 											{if $level_2.name eq ''}{$level_2.class_name|escape:'html':'UTF-8'}{else}{$level_2.name|escape:'html':'UTF-8'}{/if}
@@ -37,7 +37,7 @@
 											{foreach $level_2.sub_tabs as $level_3}
 												{if $level_3.active}
 													<li class="{if $level_3.current}active{/if}" id="subtab-{$level_3.class_name|escape:'html':'UTF-8'}" data-submenu="{$level_3.id_tab}">
-														<a href="{if $level_3.sub_tabs|@count && isset($level_3.sub_tabs[0].href)}{$level_3.sub_tabs[0].href|escape:'html':'UTF-8'}{else}{$level_3.href|escape:'html':'UTF-8'}{/if}" class="title">
+														<a href="{$level_3.href|escape:'html':'UTF-8'}" class="title">
 															{if $level_3.name eq ''}{$level_3.class_name|escape:'html':'UTF-8'}{else}{$level_3.name|escape:'html':'UTF-8'}{/if}
 														</a>
 													</li>

--- a/admin-dev/themes/new-theme/template/components/layout/nav_bar.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/nav_bar.tpl
@@ -5,9 +5,6 @@
       {if $level1.active}
 
         {$level1Href = $level1.href|escape:'html':'UTF-8'}
-        {if $level1.sub_tabs|@count && isset($level1.sub_tabs[0].href)}
-          {$level1Href = $level1.sub_tabs[0].href|escape:'html':'UTF-8'}
-        {/if}
 
         {$level1Name = $level1.name|escape:'html':'UTF-8'}
         {if $level1.name eq ''}
@@ -33,9 +30,6 @@
               {if $level2.active}
 
                 {$level2Href = $level2.href|escape:'html':'UTF-8'}
-                {if $level2.sub_tabs|@count && isset($level2.sub_tabs[0].href)}
-                  {$level2Href = $level2.sub_tabs[0].href|escape:'html':'UTF-8'}
-                {/if}
 
                 {$level2Name = $level2.name|escape:'html':'UTF-8'}
                 {if $level2.name eq ''}
@@ -52,9 +46,6 @@
                           {if $level3.active}
 
                             {$level3Href = $level3.href|escape:'html':'UTF-8'}
-                            {if $level3.sub_tabs|@count && isset($level3.sub_tabs[0].href)}
-                              {$level3Href = $level3.sub_tabs[0].href|escape:'html':'UTF-8'}
-                            {/if}
 
                             {$level3Name = $level3.name|escape:'html':'UTF-8'}
                             {if $level3.name eq ''}

--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -19,7 +19,7 @@
 
             <!--ORDERS-->
             <tab id="Orders" id_parent="SELL" active="1" hide_host_mode="0" icon="shopping_basket">
-                <class_name>AdminParentOrders</class_name>
+                <class_name>AdminOrders</class_name>
             </tab>
 
                 <tab id="Orders_1" id_parent="Orders" active="1" hide_host_mode="0" icon="">
@@ -53,7 +53,7 @@
                     <class_name>AdminTracking</class_name>
                 </tab>
                 <tab id="Attributes_and_features" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentAttributesGroups</class_name>
+                    <class_name>AdminAttributesGroups</class_name>
                 </tab>
 
                     <tab id="Attributes_and_Values" id_parent="Attributes_and_features" active="1" hide_host_mode="0" icon="">
@@ -64,7 +64,7 @@
                     </tab>
 
                 <tab id="Manufacturers_and_suppliers" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentManufacturers</class_name>
+                    <class_name>AdminManufacturers</class_name>
                 </tab>
 
                     <tab id="Manufacturers" id_parent="Manufacturers_and_suppliers" active="1" hide_host_mode="0" icon="">
@@ -78,7 +78,7 @@
                     <class_name>AdminAttachments</class_name>
                 </tab>
                 <tab id="Price_Rules" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentCartRules</class_name>
+                    <class_name>AdminCartRules</class_name>
                 </tab>
 
                     <tab id="Cart_Rules" id_parent="Price_Rules" active="1" hide_host_mode="0" icon="">
@@ -90,7 +90,7 @@
 
             <!--CUSTOMERS-->
             <tab id="Customers" id_parent="SELL" active="1" hide_host_mode="0" icon="account_circle">
-                <class_name>AdminParentCustomer</class_name>
+                <class_name>AdminCustomer</class_name>
             </tab>
 
                 <tab id="Customers_2" id_parent="Customers" active="1" hide_host_mode="0" icon="">
@@ -105,7 +105,7 @@
 
             <!--CUSTOMER SERVICE-->
             <tab id="Customer_Service" id_parent="SELL" active="1" hide_host_mode="0" icon="chat">
-                <class_name>AdminParentCustomerThreads</class_name>
+                <class_name>AdminCustomerThreads</class_name>
             </tab>
 
                 <tab id="Customer_Service_2" id_parent="Customer_Service" active="1" hide_host_mode="0" icon="">
@@ -132,7 +132,7 @@
                     <class_name>AdminWarehouses</class_name>
                 </tab>
                 <tab id="Stock_Management" id_parent="Advanced_stock_management" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentStockManagement</class_name>
+                    <class_name>AdminStockManagement</class_name>
                 </tab>
 
                     <tab id="Stock_Management" id_parent="Stock_Management" active="1" hide_host_mode="0" icon="">
@@ -178,7 +178,7 @@
 
             <!--LOOK & FEEL-->
             <tab id="Look_feel" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="desktop_mac">
-                <class_name>AdminParentThemes</class_name>
+                <class_name>AdminThemes</class_name>
             </tab>
 
                 <tab id="Themes" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
@@ -198,7 +198,7 @@
                 </tab>
 
                 <tab id="Shipping" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="local_shipping">
-                    <class_name>AdminParentShipping</class_name>
+                    <class_name>AdminShipping</class_name>
                 </tab>
 
                     <tab id="Carriers" id_parent="Shipping" active="1" hide_host_mode="0" icon="">
@@ -209,7 +209,7 @@
                     </tab>
 
                 <tab id="Payment" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="payment">
-                    <class_name>AdminParentPayment</class_name>
+                    <class_name>AdminPayment</class_name>
                 </tab>
 
                     <tab id="Payment_methods" id_parent="Payment" active="1" hide_host_mode="0" icon="">
@@ -221,11 +221,11 @@
 
             <!--INTERNATIONAL OK-->
             <tab id="International" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="language">
-                <class_name>AdminInternational</class_name>
+                <class_name>AdminLocalization</class_name>
             </tab>
 
                 <tab id="Localization" id_parent="International" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentLocalization</class_name>
+                    <class_name>AdminLocalization</class_name>
                 </tab>
 
                     <tab id="Localization_1" id_parent="Localization" active="1" hide_host_mode="0" icon="">
@@ -242,7 +242,7 @@
                     </tab>
 
                 <tab id="Locations" id_parent="International" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentCountries</class_name>
+                    <class_name>AdminCountries</class_name>
                 </tab>
 
                     <tab id="Countries" id_parent="Locations" active="1" hide_host_mode="0" icon="">
@@ -256,7 +256,7 @@
                     </tab>
 
                 <tab id="Tax_Management" id_parent="International" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentTaxes</class_name>
+                    <class_name>AdminTaxes</class_name>
                 </tab>
 
                     <tab id="Taxes" id_parent="Tax_Management" active="1" hide_host_mode="0" icon="">
@@ -281,7 +281,7 @@
             </tab>
 
                 <tab id="General" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentPreferences</class_name>
+                    <class_name>AdminPreferences</class_name>
                 </tab>
 
                     <tab id="General_1" id_parent="General" active="1" hide_host_mode="0" icon="">
@@ -292,7 +292,7 @@
                     </tab>
 
                 <tab id="Order_settings" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentOrderPreferences</class_name>
+                    <class_name>AdminOrderPreferences</class_name>
                 </tab>
 
                     <tab id="Order_settings_2" id_parent="Order_settings" active="1" hide_host_mode="0" icon="">
@@ -306,7 +306,7 @@
                     <class_name>AdminPPreferences</class_name>
                 </tab>
                 <tab id="Customer_settings" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentCustomerPreferences</class_name>
+                    <class_name>AdminCustomerPreferences</class_name>
                 </tab>
 
                     <tab id="Customers_2" id_parent="Customer_settings" active="1" hide_host_mode="0" icon="">
@@ -320,7 +320,7 @@
                     </tab>
 
                 <tab id="Contact" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentStores</class_name>
+                    <class_name>AdminStores</class_name>
                 </tab>
 
                     <tab id="Contacts" id_parent="Contact" active="1" hide_host_mode="0" icon="">
@@ -331,7 +331,7 @@
                     </tab>
 
                 <tab id="Traffic" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentMeta</class_name>
+                    <class_name>AdminMeta</class_name>
                 </tab>
 
                     <tab id="SEO_URLs" id_parent="Traffic" active="1" hide_host_mode="0" icon="">
@@ -345,7 +345,7 @@
                     </tab>
 
                 <tab id="Search" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentSearchConf</class_name>
+                    <class_name>AdminSearchConf</class_name>
                 </tab>
 
                     <tab id="Search_1" id_parent="Search" active="1" hide_host_mode="0" icon="">
@@ -369,6 +369,14 @@
                 <tab id="Administration" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
                     <class_name>AdminAdminPreferences</class_name>
                 </tab>
+
+                    <tab id="Administration_1" id_parent="Administration" active="1" hide_host_mode="0" icon="">
+                        <class_name>AdminAdminPreferences</class_name>
+                    </tab>
+                    <tab id="Tabs" id_parent="Administration" active="1" hide_host_mode="0" icon="">
+                        <class_name>AdminTabs</class_name>
+                    </tab>
+
                 <tab id="E-mail" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
                     <class_name>AdminEmails</class_name>
                 </tab>
@@ -377,7 +385,7 @@
                 </tab>
 
                 <tab id="Employees" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentEmployees</class_name>
+                    <class_name>AdminEmployees</class_name>
                 </tab>
 
                     <tab id="Employees_1" id_parent="Employees" active="1" hide_host_mode="0" icon="">
@@ -391,7 +399,7 @@
                     </tab>
 
                 <tab id="Database" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminParentRequestSql</class_name>
+                    <class_name>AdminRequestSql</class_name>
                 </tab>
 
                     <tab id="SQL_Manager" id_parent="Database" active="1" hide_host_mode="0" icon="">

--- a/install-dev/langs/en/data/tab.xml
+++ b/install-dev/langs/en/data/tab.xml
@@ -5,6 +5,7 @@
     <tab id="CONFIGURE" name="CONFIGURE" />
     <tab id="Addresses" name="Addresses" />
     <tab id="Administration" name="Administration" />
+    <tab id="Administration_1" name="Administration" />
     <tab id="Module_Page" name="Module Catalog" />
     <tab id="Advanced_Parameters" name="Advanced Parameters" />
     <tab id="Attachments" name="Files" />
@@ -111,6 +112,7 @@
     <tab id="Store_Contacts" name="Stores" />
     <tab id="Suppliers" name="Suppliers" />
     <tab id="Supply_orders" name="Supply orders" />
+    <tab id="Tabs" name="Tabs" />
     <tab id="Tags" name="Tags" />
     <tab id="Tax_Management" name="Taxes" />
     <tab id="Tax_Rules" name="Tax Rules" />

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -99,3 +99,4 @@ ALTER TABLE `PREFIX_image_type` DROP `scenes`;
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_SCENE_FEATURE_ACTIVE';
 
 UPDATE `PREFIX_configuration` SET value=1 WHERE name='PS_TAX_DISPLAY';
+UPDATE `PREFIX_tab` SET `class_name` = REPLACE (`class_name`, 'AdminParent', 'Admin') WHERE `class_name` LIKE '%AdminParent%';


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 'develop' |
| Description? | i renamed `AdminParent` to just `Admin`, `AdminInternational` to `AdminLocalization` and add missing `AdminTabs` |
| Type? | bug fix |
| Category? | BO, Installer and LO |
| Deprecations? | yes |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-628 |
| How to test? | reinstall Prestashop, or run SQL query below |

```
UPDATE `ps_tab`
SET `class_name` = REPLACE (`class_name`, 'AdminParent', 'Admin')
WHERE `class_name` LIKE '%AdminParent%';
UPDATE `ps_tab`
SET `class_name` = REPLACE (`class_name`, 'AdminInternational', 'AdminLocalization')
WHERE `class_name` LIKE '%AdminInternational%';
```
