### PR TITLE
[*] FO Product Image Cover and Layer Hover

### DIFF
--- a/themes/classic/_dev/css/modules/products.scss
+++ b/themes/classic/_dev/css/modules/products.scss
@@ -151,8 +151,8 @@
     @include display(flex);
     align-items: center;
     justify-content: center;
-    width: 452px;
-    height: 452px;
+    width: 100%;
+    height: 100%;
     background: white;
     position: absolute;
     left: 0;

--- a/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -1,7 +1,7 @@
 <div class="images-container">
   {block name='product_cover'}
     <div class="product-cover">
-      <img class="js-qv-product-cover" src="{$product.cover.bySize.medium_default.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" width="{$product.cover.bySize.medium_default.width}" itemprop="image">
+      <img class="js-qv-product-cover" src="{$product.cover.bySize.medium_default.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" width="100%" itemprop="image">
       <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
         <i class="material-icons zoom-in">&#xE8FF;</i>
       </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | Product image cover and layer hover do not scale correctly in when you switch to 2 column layout (small left) or in default layout (full width) |
| Type? | [*] |
| Category? | FO |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | None |
| How to test? | In full layout use inspector to highlight the layer hover and in 2 column layout the right column seems to overlap the image due to the cover and layer background not scaling correctly. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

When switching to a 2 column layout (small left) the image cover and layer hover backgrounds do not scale to the images scaled width and height causing the right description area to look at though it is overlapping the image..
This change also fixes the Full page layout scaling issues.
