### PR TITLE
[-] BO : added missing delete confirmation poppin on product page form

### DIFF
--- a/admin-dev/themes/default/js/bundle/modal-confirmation.js
+++ b/admin-dev/themes/default/js/bundle/modal-confirmation.js
@@ -1,0 +1,61 @@
+/**
+ * modal confirmation management
+ */
+var modalConfirmation = (function() {
+  var modal = $('#confirmation_modal');
+
+  if(!modal) {
+    throw new Error('Modal confirmation is not available');
+  }
+
+  var actionsCallbacks = {
+    onCancel: function() {
+      console.log('modal canceled');
+      return;
+    },
+    onContinue: function() {
+      console.log('modal continued');
+      return;
+    }
+  };
+
+  modal.find('button.cancel').click(function() {
+    if (typeof actionsCallbacks.onCancel === 'function') {
+      actionsCallbacks.onCancel();
+    }
+    modalConfirmation.hide();
+  });
+
+  modal.find('button.continue').click(function() {
+    if (typeof actionsCallbacks.onContinue === 'function') {
+      actionsCallbacks.onContinue();
+    }
+    modalConfirmation.hide();
+  });
+  return {
+    'init': function init() {
+      console.log('modal initialised');
+    },
+    'create': function create(content, title, callbacks) {
+      if(title != null){
+        modal.find('.modal-title').html(title);
+      }
+      if(content != null){
+        modal.find('.modal-body').html(content);
+      }
+
+      actionsCallbacks = callbacks;
+      return this;
+    },
+    'show': function show() {
+      modal.modal('show');
+    },
+    'hide': function hide() {
+      modal.modal('hide');
+    }
+  };
+})();
+
+BOEvent.on("Modal confirmation started", function initModalConfirmationSystem() {
+  modalConfirmation.init();
+}, "Back office");

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -51,6 +51,7 @@ $(document).ready(function() {
   BOEvent.emitEvent("Product Default category Management started", "CustomEvent");
   BOEvent.emitEvent("Product Manufacturer Management started", "CustomEvent");
   BOEvent.emitEvent("Product Related Management started", "CustomEvent");
+  BOEvent.emitEvent("Modal confirmation started", "CustomEvent");
 
   /** Type product fields display management */
   $('#form_step1_type_product').change(function(){
@@ -1862,56 +1863,6 @@ var priceCalculation = (function() {
       var newPrice = ps_round(removeTaxes(ps_round(price, displayPricePrecision), rates, computation_method), displayPricePrecision);
 
       targetInput.val(newPrice);
-    }
-  };
-})();
-
-
-/**
- * modal confirmation management
- */
-var modalConfirmation = (function() {
-  var modal = $('#confirmation_modal');
-  var actionsCallbacks = {
-    onCancel: function(){
-      return;
-    },
-    onContinue: function(){
-      return;
-    }
-  };
-
-  modal.find('button.cancel').click(function(){
-    if (typeof actionsCallbacks.onCancel === 'function') {
-      actionsCallbacks.onCancel();
-    }
-    modalConfirmation.hide();
-  });
-
-  modal.find('button.continue').click(function(){
-    if (typeof actionsCallbacks.onContinue === 'function') {
-      actionsCallbacks.onContinue();
-    }
-    modalConfirmation.hide();
-  });
-
-  return {
-    'create': function(content, title, callbacks) {
-      if(title != null){
-        modal.find('.modal-title').html(title);
-      }
-      if(content != null){
-        modal.find('.modal-body').html(content);
-      }
-
-      actionsCallbacks = callbacks;
-      return this;
-    },
-    'show': function() {
-      modal.modal('show');
-    },
-    'hide': function() {
-      modal.modal('hide');
     }
   };
 })();

--- a/admin-dev/themes/default/js/bundle/product/product-manufacturer.js
+++ b/admin-dev/themes/default/js/bundle/product/product-manufacturer.js
@@ -17,9 +17,13 @@ var manufacturer = (function() {
       });
       resetButton.on('click', function(e) {
         e.preventDefault();
-        manufacturerContent.addClass('hide');
-        selectManufacturer.val('').trigger('change');
-        addButton.show();
+        modalConfirmation.create(translate_javascripts['Are you sure to delete this?'], null, {
+          onContinue: function(){
+            manufacturerContent.addClass('hide');
+            selectManufacturer.val('').trigger('change');
+            addButton.show();
+          }
+        }).show();
       });
     }
   };

--- a/admin-dev/themes/default/js/bundle/product/product-related.js
+++ b/admin-dev/themes/default/js/bundle/product/product-related.js
@@ -8,6 +8,8 @@ var relatedProduct = (function() {
       var resetButton = $('#reset_related_product');
       var relatedContent = $('#related-content');
       var productItems = $('#form_step1_related_products-data');
+      var searchProductsBar = $('#form_step1_related_products');
+
       addButton.on('click', function(e) {
         e.preventDefault();
         relatedContent.removeClass('hide');
@@ -15,9 +17,20 @@ var relatedProduct = (function() {
       });
       resetButton.on('click', function(e) {
         e.preventDefault();
-        productItems.remove();
-        relatedContent.addClass('hide');
-        addButton.show();
+        modalConfirmation.create(translate_javascripts['Are you sure to delete this?'], null, {
+          onContinue: function onContinue(){
+            var items = productItems.find('li').toArray();
+
+            items.forEach(function removeItem(item) {
+              console.log(item);
+              item.remove();
+            });
+            searchProductsBar.val('');
+
+            relatedContent.addClass('hide');
+            addButton.show();
+          }
+        }).show();
       });
     }
   };

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -1086,12 +1086,14 @@
 {% block javascripts %}
   {{ parent() }}
   <script src="{{ asset('themes/default/js/bundle/product/form.js') }}"></script>
+
   <script src="{{ asset('themes/default/js/bundle/product/product-manufacturer.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/product/product-related.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/product/product-category-tags.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/product/default-category.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/category-tree.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/module/module_card.js') }}"></script>
+  <script src="{{ asset('themes/default/js/bundle/modal-confirmation.js') }}"></script>
   <script src="{{ asset('../js/tiny_mce/tiny_mce.js') }}"></script>
   <script src="{{ asset('../js/admin/tinymce.inc.js') }}"></script>
   <script src="{{ asset('../js/admin/tinymce_loader.js') }}"></script>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Some missing confirmation poppin on field deletion have been found on product page form |
| Type? | bugfix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-371 |
| How to test? | try to delete a manufacturer/brand, a related product on Product edition |
