### PR TITLE
[-] Tests : Separate two tests to avoid timeout

### DIFF
--- a/tests/Selenium/commands/init.js
+++ b/tests/Selenium/commands/init.js
@@ -34,14 +34,8 @@ module.exports = function initializePrestaShopBrowserCommands (browser) {
 
   browser.addCommand('logout', function logout () {
     return browser
-      .url()
-      .then(function (initialURL) {
-        return browser
-          .url('/')
-          .click('#header a.logout')
-          .url(initialURL)
-        ;
-      })
+      .deleteCookie()
+      .refresh()
     ;
   });
 

--- a/tests/Selenium/specs/customer/identity.js
+++ b/tests/Selenium/specs/customer/identity.js
@@ -40,6 +40,11 @@ describe('Customer Identity', function () {
         .setValue('[name="new_password"]', 'new password')
         .click('#customer-form button')
         .waitForVisible('.alert-success')
+        ;
+    });
+    
+    it('should allow the customer to use the new password', function () {
+      return browser
         // try to login with the new password
         .logout()
         .loginDefaultCustomer({password: 'new password'})


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The version 5.4 of PHP is too slow to render the tests fast enough. We separate two of them in order to not reach a timeout of 8s. |
| Type? | Bug fix |
| Category? | Tests |
| BC breaks? | Nope |
| Deprecations? | Does it deprecate an existing feature? yes/no |
| How to test? | Tests should be running properly. Also, the line `should allow the customer to change their password` should not be around 8000ms anymore. |
