### PR TITLE
[-] Install

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2052,6 +2052,18 @@ CREATE TABLE IF NOT EXISTS `PREFIX_shop_url` (
   UNIQUE KEY `full_shop_url_ssl` (`domain_ssl`, `physical_uri`, `virtual_uri`)
 ) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8 COLLATION;
 
+CREATE TABLE IF NOT EXISTS `PREFIX_theme_meta` (
+  `id_theme_meta` int(11) NOT NULL AUTO_INCREMENT,
+  `id_theme` int(11) NOT NULL,
+  `id_meta` int(10) unsigned NOT NULL,
+  `left_column` tinyint(1) NOT NULL DEFAULT '1',
+  `right_column` tinyint(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id_theme_meta`),
+  UNIQUE KEY `id_theme_2` (`id_theme`,`id_meta`),
+  KEY `id_theme` (`id_theme`),
+  KEY `id_meta` (`id_meta`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
+
 CREATE TABLE `PREFIX_country_shop` (
 `id_country` INT( 11 ) UNSIGNED NOT NULL,
 `id_shop` INT( 11 ) UNSIGNED NOT NULL ,


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | 1.7 Alpha 4 install fails with error ps_theme_meta does not exist |
| Type? | [-] |
| Category? | Install |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | None |
| How to test? | Install Alpha 4 |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

1.7.0.0 Alpha 4 fails during install with this message
An SQL error occurred for entity theme_meta: Table 'xxxxxx_shop17test.ps_theme_meta' doesn't exist

I also notice that in the XML folder there is a theme.xml that points to default-bootstrap I had also added this table as well but removed because the theme.xml points to default-bootstrap which appears to be 1.6.

The install works with this fix.
