### PR TITLE
[*] FO : CSS-class when showing tax-label; global Template-Var

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1308,6 +1308,7 @@ class FrontControllerCore extends Controller
 
 
         return [
+            'display_taxes_label' => $this->getDisplayTaxesLabel(),
             'is_b2b' => (bool)Configuration::get('PS_B2B_ENABLE'),
             'is_catalog' => (bool)Configuration::get('PS_CATALOG_MODE'),
             'show_prices' => (Configuration::get('PS_CATALOG_MODE')
@@ -1319,6 +1320,11 @@ class FrontControllerCore extends Controller
             ],
         ];
     }
+
+    protected function getDisplayTaxesLabel()
+    {
+        return (Module::isEnabled('ps_legalcompliance') && (bool)Configuration::get('AEUC_LABEL_TAX_INC_EXC')) || $this->context->country->display_tax_label;
+    }    
 
     public function getTemplateVarCurrency()
     {
@@ -1418,6 +1424,7 @@ class FrontControllerCore extends Controller
             'currency-'.$this->context->currency->iso_code => true,
             $this->context->shop->theme->getLayoutNameForPage($this->php_self) => true,
             'page-'.$this->php_self => true,
+            'tax-display-'.($this->getDisplayTaxesLabel() ? 'enabled' : 'disabled') => true,
         ];
 
         if (in_array($this->php_self, $my_account_controllers)) {

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -296,9 +296,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'unit_price' => ($this->product->unit_price_ratio > 0) ? ($productPrice / $this->product->unit_price_ratio) : 0,
                 'product_manufacturer' => new Manufacturer((int)$this->product->id_manufacturer, $this->context->language->id),
                 'last_qties' =>  (int)Configuration::get('PS_LAST_QTIES'),
-                'display_taxes_label' => (Module::isEnabled('ps_legalcompliance')
-                                          && (bool)Configuration::get('AEUC_LABEL_TAX_INC_EXC'))
-                                         || $this->context->country->display_tax_label,
                 'display_discount_price' => Configuration::get('PS_DISPLAY_DISCOUNT_PRICE')
             ));
 


### PR DESCRIPTION
Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Adds a css-class to the body tag whether tax-labels are enabled or not. |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
