### PR TITLE
[*] Core : Please consider removing useless Addons filter on modules list

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -53,7 +53,6 @@ class ModuleController extends FrameworkBundleAdminController
 
         $filters = new AddonListFilter();
         $filters->setType(AddonListFilterType::MODULE | AddonListFilterType::SERVICE)
-            ->setOrigin(AddonListFilterOrigin::ADDONS_ALL)
             ->setStatus(~ AddonListFilterStatus::INSTALLED);
 
         try {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | "develop" |
| Description? | Currently, the modules which are put directly in the "modules" directory do not appear on the modules list in the administration panel, so they can't be install. This limitation is useless since merchants can still upload a zipped module via "Upload a module". It's only annoying for developers that must zip their modules to install them. It become very difficult to run some simple tests on module such like install / uninstall (when they are not on Addons). Moreover, a merchant who have a module installed, if he choose to uninstall it temporarly, he will not be able to reinstall it (or will have to download it via ftp, zip it, and reupload it). Please consider removing this limit, since it won't improve security or Addons experience. |
| Type? | bug fix/improvement |
| Category? | Core |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | / |
| How to test? | Just put a module that is not on Addons in the "modules" directory of PrestaShop and see if it appears |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)
