### PR TITLE
[-] BO : Module page remove notifications to install

### DIFF
--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -42,6 +42,11 @@ class ModuleDataProvider
         $this->logger = $logger;
     }
 
+    /**
+     * Return all module information from database
+     * @param string $name The technical module name to search
+     * @return array
+     */
     public function findByName($name)
     {
         $result = \Db::getInstance()->getRow('SELECT `id_module` as `id`, `active`, `version` FROM `'._DB_PREFIX_.'module` WHERE `name` = "'.pSQL($name).'"');
@@ -55,6 +60,11 @@ class ModuleDataProvider
         return ['installed' => 0];
     }
 
+    /**
+     * Return translated module *Display Name*
+     * @param string $module The technical module name
+     * @return string The translated Module displayName
+     */
     public function getModuleName($module)
     {
         return \Module::getModuleName($module);
@@ -74,6 +84,11 @@ class ModuleDataProvider
         );
     }
 
+    /**
+     * Check if a module is enabled in the current shop context
+     * @param boolean $name The technical module name
+     * @return boolean True if enable
+     */
     public function isEnabled($name)
     {
         $id_shops = (new Context())->getContextListShopID();

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -244,7 +244,7 @@ class ModuleController extends FrameworkBundleAdminController
         $installed_products = $moduleRepository->getFilteredList($filters);
 
         $products = new \stdClass;
-        foreach (['to_configure', 'to_update', 'to_install'] as $subpart) {
+        foreach (['to_configure', 'to_update'] as $subpart) {
             $products->{$subpart} = [];
         }
 
@@ -262,12 +262,6 @@ class ModuleController extends FrameworkBundleAdminController
                 $products->{$row}[] = (object)$installed_product;
             }
         }
-
-        $filters = new AddonListFilter();
-        $filters->setType(AddonListFilterType::MODULE)
-            ->removeStatus(AddonListFilterStatus::INSTALLED)
-            ->setOrigin(AddonListFilterOrigin::DISK | AddonListFilterOrigin::ADDONS_CUSTOMER);
-        $products->to_install = $moduleRepository->getFilteredList($filters);
 
         foreach ($products as $product_label => $products_part) {
             $products->{$product_label} = $modulesProvider->generateAddonsUrls($products_part);

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/notification_kpis.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/notification_kpis.html.twig
@@ -12,11 +12,6 @@
                 <span class="module-kpi-number">{{modules.to_update|length}}</span>  modules to update
             </div>
 
-            <div class="module-kpi">
-                <i class="material-icons">file_download</i>
-                <span class="module-kpi-number">{{modules.to_install|length}}</span>  modules to install
-            </div>
-
         </div>
     </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -44,12 +44,6 @@
                 </span>
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_update.html.twig' with { 'modules' : modules.to_update, 'display_type' : 'list' } %}
-
-            <hr class="top-menu-separator">
-            <div class="module-short-list">
-                <span class="module-search-result-wording">{{modules.to_install|length}} modules to install</span>
-            </div>
-            {% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.to_install, 'display_type' : 'list' } %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Drop the part Notifications:Modules to install |
| Type? | Improvement |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Yep |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-681 |
| How to test? | Nothing is displayed for the modules to install in the notifications tab, but the modules available on the disk not installed can be found in the selection. |

Follows-up #5494 
