### PR TITLE
[-] CORE : Bring back missing module dashtrends

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,8 @@
     "prestashop/statsvisits": "dev-master",
     "prestashop/trackingfront": "dev-master",
     "prestashop/vatnumber": "dev-master",
-    "prestashop/welcome": "dev-master"
+    "prestashop/welcome": "dev-master",
+    "prestashop/dashtrends": "dev-master"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.5",


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Bring back missing module dashtrends by adding it in `composer.json` |
| Type? | Bug fix |
| Category? | CORE |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-321](http://forge.prestashop.com/browse/BOOM-321) |
| How to test? | Get the PR, make a `composer update`, and reinstall your shop. The module should be pre-installed |
