### PR TITLE
[-] BO : Fix product friendly-URL not updated with name

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1911,7 +1911,7 @@ var seo = (function() {
       };
 
       /** On product title change, update friendly URL*/
-      $('.form-input-title input').keydown(function() {
+      $('#form_step1_name input').keydown(function() {
         updateFriendlyUrl($(this));
       });
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Bug fix of the friendly URL not updated with the product name. |
| Type? | Bug fix |
| Category? | BO - Product page |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-676](http://forge.prestashop.com/browse/BOOM-676) |
| How to test? | Modify the product title, the friendly URL will be automatically updated at the same time. Wow ! |
