### PR TITLE
[*] BO : Update node-sass version

### DIFF
--- a/admin-dev/themes/new-theme/package.json
+++ b/admin-dev/themes/new-theme/package.json
@@ -33,7 +33,7 @@
     "jwerty": "^0.3.2",
     "magnific-popup": "^1.0.1",
     "moment": "^2.11.2",
-    "node-sass": "^3.4.2",
+    "node-sass": "^3.7",
     "path": "^0.12.7",
     "postcss-loader": "^0.8.0",
     "sass-loader": "^3.1.2",


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Update to the latest `node-sass` version in the new BO theme. It will be helpful for those who upgraded their node version to 6.0 |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Just run an npm update and try to build the theme :smile: |
