### PR TITLE
CORE checkCompliancy minimal version <=

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -390,7 +390,7 @@ abstract class ModuleCore
 
     public function checkCompliancy()
     {
-        if (version_compare(_PS_VERSION_, $this->ps_versions_compliancy['min'], '<') || version_compare(_PS_VERSION_, $this->ps_versions_compliancy['max'], '>')) {
+        if (version_compare(_PS_VERSION_, $this->ps_versions_compliancy['min'], '<=') || version_compare(_PS_VERSION_, $this->ps_versions_compliancy['max'], '>')) {
             return false;
         } else {
             return true;


### PR DESCRIPTION
Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | "develop" |
| Description? | In PS 1.7 the `_PS_VERSION_` is `1.7`.  All the new modules (paymentexample, bankwire ..) have the version `1.7` as-well but the `checkCompliancy` check  only if it is bigger than. To fix it should check equal or bigger than. |
| Type? | bug fix |
| Category? | CORE |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | If you try to install a new module in the backoffice with the version 1.7 now you could not. With the change in the PR you could. |
