### PR TITLE
[*]BO: .gitinore now ignore the parameters.old.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ config/themes/*
 !config/xml/themes/default.xml
 tests/Selenium/settings.js
 themes/*/config/settings_*.json
+app/config/parameters.old.yml
 
 # Themes, modules and overrides
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:
-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When installing PrestaShop, a copy of the parameters.old.php is generated from the current parameters file. This PR just allow git to ignore this file. |
| Type? | improvement |
| Category? | CORE |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Work with GIT! |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
