### PR TITLE
Improved Product related search action

### DIFF
--- a/admin-dev/themes/default/js/bundle/modal-confirmation.js
+++ b/admin-dev/themes/default/js/bundle/modal-confirmation.js
@@ -33,9 +33,7 @@ var modalConfirmation = (function() {
     modalConfirmation.hide();
   });
   return {
-    'init': function init() {
-      console.log('modal initialised');
-    },
+    'init': function init() {},
     'create': function create(content, title, callbacks) {
       if(title != null){
         modal.find('.modal-title').html(title);

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
@@ -26,6 +26,11 @@
           {{ template_collection|raw }}
         </div>
     </div>
+    <script type="text/javascript">
+      $('#{{ form.vars.id }}').on('focusout', function resetSearchBar() {
+        $('#{{ form.vars.id }}').typeahead('val', '');
+      });
+    </script>
 {% endblock %}
 
 {% block typeahead_product_pack_collection_widget %}
@@ -148,7 +153,7 @@
                     limit: 20,
                     minLength: 2,
                     highlight: true,
-                    hint: false,
+                    hint: false
                 }, {
                     display: '{{ mapping_name }}',
                     source: this['{{ form.vars.id }}_source'],


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | search bar input kept the last selected value on related product, now the search bar is correctly set up |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Not realy, but you can take a look to the old BOOM-371 |
| How to test? | Select a related product, click everywhere ... wow ! the search bar didnt display the last selected product anymore :) |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)
