### PR TITLE
Friendly URL are fixed on the Product page

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1676,18 +1676,20 @@ var seo = (function() {
 
       /** Update friendly URL */
       var updateFriendlyUrl = function(elem) {
-        var id_lang = elem.attr('name').match(/\d+/)[0];
+        /** Attr name equals "form[step1][name][1]".
+         * We need in this string the second integer */
+        var id_lang = elem.attr('name').match(/\d+/g)[1];
         $('#form_step5_link_rewrite_' + id_lang).val(str2url(elem.val(), 'UTF-8'));
       };
 
       /** On product title change, update friendly URL*/
-      $('.form-input-title input').keydown(function() {
+      $('#form_step1_names.friendly-url-force-update input').keyup(function() {
         updateFriendlyUrl($(this));
       });
 
       /** Reset all languages title to friendly url*/
       $('#seo-url-regenerate').click(function() {
-        $.each($('.form-input-title input'), function() {
+        $.each($('#form_step1_names input'), function() {
           updateFriendlyUrl($(this));
         });
       });

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
@@ -64,7 +64,7 @@
     margin-top: 2px;
     list-style: none;
     background-color: #ffffff;
-    border: 1px solid #ccc
+    border: 1px solid #ccc;
     -webkit-border-radius: 5px;
     -moz-border-radius: 5px;
     border-radius: 5px;

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
@@ -62,6 +62,13 @@
             <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ 'SEO and URLS'|trans({}, 'AdminProducts') }}</a>
           {% endif %}
         </p>
+        <p class="alert-text">
+            {% if 'PS_FORCE_FRIENDLY_PRODUCT'|configuration == 1 %}
+              <strong>{{ 'The "Force update of friendly URL" option is currently enabled.'|trans({}, 'AdminProducts') }}</strong>
+            {{ trans('To disable it, go to', {}, 'AdminProducts') }}
+            <a href="{{ getAdminLink("AdminPPreferences") }}#configuration_fieldset_products">{{ trans('Product Settings', [], 'AdminProducts') }}</a>
+          {% endif %}
+        </p>
       </div>
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -16,7 +16,7 @@
 
       <div class="col-md-10 col-md-offset-1">
         <div class="row">
-          <div class="col-md-7 big-input">
+          <div class="col-md-7 big-input {{ 'PS_FORCE_FRIENDLY_PRODUCT'|configuration == 1 ? 'friendly-url-force-update' : '' }}" id="form_step1_names">
             {{ form_widget(form.step1.name) }}
           </div>
           <div class="col-md-2 form_step1_type_product">


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Add mutliple fixes regarding the Product friendly URL |
| Type? | bug fix & improvement |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-676](http://forge.prestashop.com/browse/BOOM-676) |
| How to test? | See the dedicated part at the bottom of the PR description. |
## PR content

This PR fixes the following points:
- Handle force update of friendly URL option
- Fix URL update when multiple languages
- When force update ON : Fix URL not properly updated when taping in the product name
- Add notice when force update ON
## How to test?
### Force friendly URL ENABLED
- A message should be displayed to warn the merchant about this option enable, need the friendly URL field
  ![capture du 2016-05-10 14-37-30](https://cloud.githubusercontent.com/assets/6768917/15146746/599dcc58-16bd-11e6-9c67-513ad216a50e.png)
- Taping in the title field must update at the same time the friendly URL field
- The proper language of the friendly URL should be updated
### Force friendly URL DISABLED
- Modifying the product name MUST NOT update the friendly URL at the same time
- A click on the "Reset" button near the friendly URL should generate a new one regarding the product name, not reloading the one in the database.
