### PR TITLE
[-] Missing Core in classname

### DIFF
--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-class WebserviceOutputJSON implements WebserviceOutputInterface
+class WebserviceOutputJSONCore implements WebserviceOutputInterface
 {
     public $docUrl = '';
     public $languages = array();


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Core is missing in classname, so json webservice cannot be used |
| Type? | bug fix |
| Category? | WS |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

fix : Missing Core in classname
