### PR TITLE
BO: Removed new filter on id_cart: http://forge.prestashop.com/browse…

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -281,9 +281,7 @@ class SpecificPriceCore extends ObjectModel
             $query_extra .= self::filterOutField('id_product_attribute', $id_product_attribute);
         }
 
-        if ($id_cart !== null) {
-            $query_extra .= self::filterOutField('id_cart', $id_cart);
-        }
+        $query_extra .= self::filterOutField('id_cart', $id_cart);
 
         if ($ending == $now && $beginning == $now) {
             $key = __FUNCTION__.'-'.$first_date.'-'.$last_date;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Removed the null check on the id_cart in the new computeExtraConditions function.  This causes the id_cart column to be removed completely from the query when the prices for the products are requested.  If you have a specific price created for a specific cart it gets returned and you can see it in the product list in the BO, and elsewhere. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | yes |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7849 |
| How to test? | If you create a specific price with the id_cart assigned, it will still be visible in the back office product list. (I believe the same will be true for id_customer but I haven't made any changes to that.) |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
- Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

…/PSCSX-7849
