### PR TITLE
CO: A module can now return more than one termsAndConditions object

### DIFF
--- a/classes/checkout/ConditionsToApproveFinder.php
+++ b/classes/checkout/ConditionsToApproveFinder.php
@@ -35,9 +35,21 @@ class ConditionsToApproveFinderCore
 
     private function getConditionsToApprove()
     {
-        $allConditions = Hook::exec('termsAndConditions', [], null, true);
+        $allConditions = [];
+        $hookedConditions = Hook::exec('termsAndConditions', [], null, true);
         if (!is_array($allConditions)) {
-            $allConditions = [];
+            $hookedConditions = [];
+        }
+        foreach ($hookedConditions as $hookedCondition) {
+            if ($hookedCondition instanceof TermsAndConditions) {
+                $allConditions[] = $hookedCondition;
+            } elseif (is_array($hookedCondition)) {
+                foreach ($hookedCondition as $hookedConditionObject) {
+                    if ($hookedConditionObject instanceof TermsAndConditions) {
+                        $allConditions[] = $hookedConditionObject;
+                    }                    
+                }
+            }
         }
 
         if (Configuration::get('PS_CONDITIONS')) {
@@ -52,7 +64,7 @@ class ConditionsToApproveFinderCore
          */
         $reducedConditions = [];
         foreach ($allConditions as $condition) {
-            if ($condition instanceof TermsAndConditions) {            
+            if ($condition instanceof TermsAndConditions) {
                 $reducedConditions[$condition->getIdentifier()] = $condition;
             }
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | A module can now return more than one termsAndConditions object |
| Type? | improvement |
| Category? | CO |
| Deprecations? | no |
| How to test? | Create a module and use the termsAndConditions hook. There, return an array with two or more objects of "termsAndConditions" |
