### PR TITLE
Fix typo and warning in ConditionsToApproveFinder.php

### DIFF
--- a/classes/checkout/ConditionsToApproveFinder.php
+++ b/classes/checkout/ConditionsToApproveFinder.php
@@ -5,7 +5,7 @@ use PrestaShop\PrestaShop\Core\Checkout\TermsAndConditions;
 
 class ConditionsToApproveFinderCore
 {
-    private $transator;
+    private $translator;
     private $context;
 
     public function __construct(
@@ -47,7 +47,7 @@ class ConditionsToApproveFinderCore
                 foreach ($hookedCondition as $hookedConditionObject) {
                     if ($hookedConditionObject instanceof TermsAndConditions) {
                         $allConditions[] = $hookedConditionObject;
-                    }                    
+                    }
                 }
             }
         }

--- a/classes/checkout/ConditionsToApproveFinder.php
+++ b/classes/checkout/ConditionsToApproveFinder.php
@@ -37,7 +37,7 @@ class ConditionsToApproveFinderCore
     {
         $allConditions = [];
         $hookedConditions = Hook::exec('termsAndConditions', [], null, true);
-        if (!is_array($allConditions)) {
+        if (!is_array($hookedConditions)) {
             $hookedConditions = [];
         }
         foreach ($hookedConditions as $hookedCondition) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix a typo for a private variable and a warning related to #5547 |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | none |
| How to test? | In the checkout, check if there is no warning displayed between step 3 and 4 |
