### PR TITLE
Fix call to undefined method for PDF generation

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -232,4 +232,14 @@ abstract class HTMLTemplateCore
             Shop::setContext(Shop::CONTEXT_SHOP, (int)$this->shop->id);
         }
     }
+    
+    /**
+     * Returns the template's HTML pagination block
+     *
+     * @return string HTML pagination block
+     */
+    public function getPagination()
+    {
+        return $this->smarty->fetch($this->getTemplate('pagination'));
+    }
 }

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -503,14 +503,4 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             date('Y', strtotime($this->order_invoice->date_add))
         ).'.pdf';
     }
-
-    /**
-     * Returns the template's HTML pagination block
-     *
-     * @return string HTML pagination block
-     */
-    public function getPagination()
-    {
-        return $this->smarty->fetch($this->getTemplate('pagination'));
-    }
 }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix a 500 error while generating a delivery slip. This is a cherry-pick from #5411, so thanks to @firstred for the fix! |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-626 |
| How to test? | Just go to an order in BO and try to open a delivery slip, it should work now! |
