### PR TITLE
CO: Make Symfony routes working even without URL rewriting

### DIFF
--- a/admin-dev/.htaccess
+++ b/admin-dev/.htaccess
@@ -34,33 +34,33 @@ DirectoryIndex index.php
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
-	# Keep legacy entry points
-	RewriteRule ^(ajax|ajax_products_list|ajax-tab|backup|cron_currency_rates)\.php - [P]
-	RewriteRule ^(displayImage|drawer|footer\.inc|functions|get-file-admin)\.php - [P]
-	RewriteRule ^(grider|header\.inc|init|login|password|pdf|searchcron)\.php - [P]
+    # Keep legacy entry points
+    RewriteRule ^(ajax|ajax_products_list|ajax-tab|backup|cron_currency_rates)\.php - [P]
+    RewriteRule ^(displayImage|drawer|footer\.inc|functions|get-file-admin)\.php - [P]
+    RewriteRule ^(grider|header\.inc|init|login|password|pdf|searchcron)\.php - [P]
 
     # If the URL is a legacy on index.php?controller=..., do not rewrite (let the legacy take it)
     RewriteCond  %{QUERY_STRING} (^|&)controller=|(^|&)tab=
     RewriteRule .* - [P]
 
+    # Redirect to URI without front controller to prevent duplicate content
+    # (with and without `/app.php`). Only do this redirect on the initial
+    # rewrite by Apache and not on subsequent cycles. Otherwise we would get an
+    # endless redirect loop (request -> rewrite to front controller ->
+    # redirect -> request -> ...).
+    # So in case you get a "too many redirects" error or you always get redirected
+    # to the start page because your Apache does not expose the REDIRECT_STATUS
+    # environment variable, you have 2 choices:
+    # - disable this feature by commenting the following 2 lines or
+    # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
+    #   following RewriteCond (best solution)
+    RewriteCond %{ENV:REDIRECT_STATUS} ^$
+    RewriteRule ^index\.php(/(.*)|$) %{ENV:BASE}/$2 [R=301,L]
+
     # If the requested filename exists, simply serve it.
     # We only want to let Apache serve files and not directories.
     RewriteCond %{REQUEST_FILENAME} -f
     RewriteRule .? - [L]
-
-	# Redirect to URI without front controller to prevent duplicate content
-	# (with and without `/app.php`). Only do this redirect on the initial
-	# rewrite by Apache and not on subsequent cycles. Otherwise we would get an
-	# endless redirect loop (request -> rewrite to front controller ->
-	# redirect -> request -> ...).
-	# So in case you get a "too many redirects" error or you always get redirected
-	# to the start page because your Apache does not expose the REDIRECT_STATUS
-	# environment variable, you have 2 choices:
-	# - disable this feature by commenting the following 2 lines or
-	# - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
-	#   following RewriteCond (best solution)
-	RewriteCond %{ENV:REDIRECT_STATUS} ^$
-	RewriteRule ^index\.php(/(.*)|$) %{ENV:BASE}/$2 [R=301,L]
 
     # Rewrite all other queries to the front controller.
     RewriteRule .? %{ENV:BASE}/index.php [L]

--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -23,6 +23,7 @@ var AdminModuleController = function () {
     this.pstaggerInput = null;
     this.lastBulkAction = null;
     this.isUploadStarted = false;
+    this.baseAdminDir = '';
 
     /* Selectors into vars to make it easier to change them while keeping same code logic */
     this.searchBarSelector = '#module-search-bar';
@@ -407,7 +408,7 @@ var AdminModuleController = function () {
     };
 
     this.ajaxLoadPage = function() {
-        var urlToCall = baseAdminDir + 'module/catalog/refresh';
+        var urlToCall = this.baseAdminDir + 'module/catalog/refresh';
         var _this = this;
 
         $.ajax({
@@ -676,7 +677,7 @@ var AdminModuleController = function () {
                  $(_this.moduleImportProcessingSelector).fadeOut(function() {
                       if (responseObject.status === true) {
                           if (responseObject.is_configurable === true) {
-                              var configureLink = baseAdminDir + 'module/manage/action/configure/' + responseObject.module_name;
+                              var configureLink = this.baseAdminDir + 'module/manage/action/configure/' + responseObject.module_name;
                               $(_this.moduleImportSuccessConfigureBtnSelector).attr('href', configureLink);
                               $(_this.moduleImportSuccessConfigureBtnSelector).show();
                           }
@@ -706,6 +707,11 @@ var AdminModuleController = function () {
             this.currentDisplay = 'list';
         } else {
             this.currentDisplay = 'grid';
+        }
+        // If index.php found in the current URL, we need it also in the baseAdminDir
+        this.baseAdminDir = baseAdminDir;
+        if (window.location.href.indexOf('index.php') != -1) {
+            this.baseAdminDir += 'index.php/';
         }
     };
 
@@ -811,7 +817,7 @@ var AdminModuleController = function () {
 
         //@NOTE:
         // "@" char is used only to be easy to replace by the end of this function
-        var baseActionUrl = baseAdminDir + 'module/manage/action/@/';
+        var baseActionUrl = this.baseAdminDir + 'module/manage/action/@/';
 
         //@NOTE:
         // Note no grid selector used yet since we do not needed it at dev time

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -494,6 +494,10 @@ class LinkCore
 
         $params = $with_token ? array('token' => Tools::getAdminTokenLite($controller)) : array();
 
+        // Even if URL rewriting is not enabled, the page handled by Symfony must work !
+        // For that, we add an 'index.php' in the URL before the route
+        $index = filter_input(INPUT_SERVER, 'HTTP_MOD_REWRITE') ? '' : '/index.php';
+
         switch ($controller) {
             case 'AdminProducts':
                 // New architecture modification: temporary behavior to switch between old and new controllers.
@@ -503,25 +507,25 @@ class LinkCore
                 if (!$redirectLegacy) {
                     if (array_key_exists('id_product', $sfRouteParams)) {
                         if (array_key_exists('deleteproduct', $sfRouteParams)) {
-                            return $this->getBaseLink().basename(_PS_ADMIN_DIR_).'/product/unit/delete/' . $sfRouteParams['id_product'];
+                            return $this->getBaseLink().basename(_PS_ADMIN_DIR_).$index.'/product/unit/delete/'.$sfRouteParams['id_product'];
                         }
                         //default: if (array_key_exists('updateproduct', $sfRouteParams))
-                        return $this->getBaseLink().basename(_PS_ADMIN_DIR_).'/product/form/' . $sfRouteParams['id_product'];
+                        return $this->getBaseLink().basename(_PS_ADMIN_DIR_).$index.'/product/form/'.$sfRouteParams['id_product'];
                     }
                     if (array_key_exists('submitFilterproduct', $sfRouteParams)) {
-                        return rtrim($this->getBaseLink().basename(_PS_ADMIN_DIR_).'/product/catalog_filters/'
+                        return rtrim($this->getBaseLink().basename(_PS_ADMIN_DIR_).$index.'/product/catalog_filters/'
                             .(array_key_exists('filter_column_sav_quantity', $sfRouteParams)?urlencode($sfRouteParams['filter_column_sav_quantity']):'none').'/'
                             .(array_key_exists('filter_column_active', $sfRouteParams)?$sfRouteParams['filter_column_active']:'none').'/',
                         '/');
                     }
-                    return $this->getBaseLink().basename(_PS_ADMIN_DIR_).'/product/catalog';
+                    return $this->getBaseLink().basename(_PS_ADMIN_DIR_).$index.'/product/catalog';
                 } else {
                     $params = array_merge($params, $sfRouteParams);
                 }
                 break;
             case 'AdminModulesSf':
                 // New architecture modification: temporary behavior to switch between old and new controllers.
-                return $this->getBaseLink().basename(_PS_ADMIN_DIR_).'/module/catalog';
+                return $this->getBaseLink().basename(_PS_ADMIN_DIR_).$index.'/module/catalog';
                 break;
         }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When then URL rewriting is not enabled on Apache, the merchant cannot reach the pages working on Symfony. This PR fixes the issue by adding a missing `index.php/` in the URL |
| Type? | Improvement |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | Disable the URL rewriting on your Apache server, the product and module pages should still be accessible with a modified URL. |
