### PR TITLE
Use symfony level for php-cs-fixer (git pre-commit hook)

### DIFF
--- a/tools/contrib/pre-commit
+++ b/tools/contrib/pre-commit
@@ -29,7 +29,7 @@ done
 echo "Running Code Sniffer..."
 for FILE in $SFILES
 do
-	php bin/php-cs-fixer fix $PROJECT_PATH/$FILE --diff --level=psr2
+	php bin/php-cs-fixer fix $PROJECT_PATH/$FILE --diff --level=symfony
 	if [ $? != 0 ]
 	then
 		echo "PSR2 errors found, please fix it before commit."


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Since we follow symfony norm, we can use the symfony php-cs-fixer level. |
| Type? | improvement |
| Category? | Tooling |
| BC breaks? | no |
| Deprecations? | no |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

Read: http://build.prestashop.com/news/prestashop-coding-standards/
