### PR TITLE
Cast id_cart to int to keep it in the SQL query

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -275,7 +275,7 @@ class SpecificPriceCore extends ObjectModel
             $ending = $now;
         }
         $id_customer = (int)$id_customer;
-		$id_cart = (int)$id_cart;
+        $id_cart = (int)$id_cart;
 
         $query_extra = '';
 

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -275,6 +275,7 @@ class SpecificPriceCore extends ObjectModel
             $ending = $now;
         }
         $id_customer = (int)$id_customer;
+		$id_cart = (int)$id_cart;
 
         $query_extra = '';
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Added cast to int for id_cart as with id_customer.  When function is called with id_cart null, id_cart is dropped from the query and it returns all specific prices assigned to carts.  These can be seen in the BO in the plist of products. Previously, and as with id_customer, the minimum was to have 'AND id_cart IN (0, 0')' in hte final query. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7849 |
| How to test? | Create a new specific price, assigned to a specific id_cart, you will be able to see it in the back office as the final price for that product. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

…ys being included in query and preventing specific prices assigned to carts being returned when calling method with id_cart of null: http://forge.prestashop.com/browse/PSCSX-7849
