### PR TITLE
[-] BO : fixed bug when no results with address and map does not exist

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -1369,17 +1369,21 @@
 
 		// Fix wrong maps center when map is hidden
 		$('#tabAddresses').click(function(){
-			x = delivery_map.getZoom();
-			c = delivery_map.getCenter();
-			google.maps.event.trigger(delivery_map, 'resize');
-			delivery_map.setZoom(x);
-			delivery_map.setCenter(c);
-
-			x = invoice_map.getZoom();
-			c = invoice_map.getCenter();
-			google.maps.event.trigger(invoice_map, 'resize');
-			invoice_map.setZoom(x);
-			invoice_map.setCenter(c);
+      if (delivery_map) {
+        x = delivery_map.getZoom();
+        c = delivery_map.getCenter();
+        google.maps.event.trigger(delivery_map, 'resize');
+        delivery_map.setZoom(x);
+        delivery_map.setCenter(c);
+      }
+      
+      if (invoice_map) {
+			  x = invoice_map.getZoom();
+			  c = invoice_map.getCenter();
+			  google.maps.event.trigger(invoice_map, 'resize');
+			  invoice_map.setZoom(x);
+			  invoice_map.setCenter(c);
+		  }
 		});
 	</script>
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | JS error when tere are no results in Address map and click on tab addresses from delivery to invoice |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | N |
| Deprecations? | N |
| Fixed ticket? | N |
| How to test? | Make an order with a non existing address and change address tab from delivery to invoice |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
