### PR TITLE
FO: Add confirmation checkbox to ps_emailsubscription

### DIFF
--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -25,20 +25,29 @@
 
 <div class="block_newsletter col-md-7">
   <div class="row">
-    <p class="col-md-5">{l s='Get our latest news and special sales' mod='blocknewsletter'}</p>
+    <p class="col-md-5">{l s='Get our latest news and special sales' mod='ps_emailsubscription'}</p>
 
     <div class="col-md-7">
       <form action="{$urls.pages.index}#footer" method="post">
         <div class="row">
           <div class="col-md-8">
-            <input type="text" name="email" value="{$value}" placeholder="{l s='Your email address' mod='blocknewsletter'}">
-            {if $msg}
-              <p class="text-warning notification {if $nw_error}notification-error{else}notification-success{/if}">{$msg}</p>
-            {/if}
+            <input type="text" name="email" value="{$value}" placeholder="{l s='Your email address' mod='ps_emailsubscription'}">
           </div>
           <div class="col-md-4">
-            <input class="btn btn-primary" type="submit" value="{l s='Subscribe' mod='blocknewsletter'}" name="submitNewsletter">
+            <input class="btn btn-primary" type="submit" value="{l s='Subscribe' mod='ps_emailsubscription'}" name="submitNewsletter">
             <input type="hidden" name="action" value="0">
+          </div>
+          <div class="col-md-12">
+              {if $need_confirmation}
+               <span class="custom-checkbox">
+                  <input type="checkbox" name="confirm-optin" value="1" required>
+                  <span><i class="material-icons checkbox-checked"></i></span>
+                  <label>{l s='I agree to receive newsletter emails and I am aware of [1]the privacy policy[/1]' tags=['<a href="%s">'|sprintf:$link->getCMSLink($cms_page)] mod='ps_emailsubscription'}</label>
+                </span>
+              {/if}
+              {if $msg}
+                <p class="text-warning notification {if $nw_error}notification-error{else}notification-success{/if}">{$msg}</p>
+              {/if}
           </div>
         </div>
       </form>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Add a checkbox in the template of newsletter, in order to ask a confirmation to the customer |
| Type? | Improvement |
| Category? | FO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-128)[http://forge.prestashop.com/browse/BOOM-128] |
| How to test? | Get the PR [ps_emailsubscription#2](https://github.com/PrestaShop/ps_emailsubscription/pull/2), open the module configuration page and enable the option asking for a confirmation, choose a CMS page and see the checkbox appear under the newsletter form in the Front-office. |

![capture du 2016-05-13 14-59-50](https://cloud.githubusercontent.com/assets/6768917/15248658/b43ee038-191b-11e6-9a04-381db34b77b0.png)

Without registration confirmation:
![capture du 2016-05-13 15-02-42](https://cloud.githubusercontent.com/assets/6768917/15248685/daaa3f4c-191b-11e6-8677-967f0df6f45b.png)

With registration confirmation:
![capture du 2016-05-13 15-03-21](https://cloud.githubusercontent.com/assets/6768917/15248694/e0b0c9f6-191b-11e6-91c6-418c748c8cf8.png)
