### PR TITLE
Fix isAllProductsInStock calculation

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3993,7 +3993,7 @@ class CartCore extends ObjectModel
         $product_in_stock = 0;
         foreach ($this->getProducts() as $product) {
             if (!$exclusive) {
-                if (((int)$product['quantity_available'] - (int)$product['cart_quantity']) <= 0
+                if (((int)$product['quantity_available'] - (int)$product['cart_quantity']) < 0
                     && (!$ignore_virtual || !$product['is_virtual'])) {
                     return false;
                 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | `1.6.1.x`, `develop` |
| Description? | The `isAllProductsInStock` calculation is off. If the available quantity of a product minus the amount in the cart equals `0`, it still means that the quantity in the cart is in stock and can be ordered. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Try to print the outcome of `Context::getContext()->cart->isAllProductsInStock()` somewhere and see if it shows `true` when there is just one item of a product in stock and added to the cart. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
