### PR TITLE
Move cms link generation in module controller

### DIFF
--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -38,11 +38,11 @@
             <input type="hidden" name="action" value="0">
           </div>
           <div class="col-md-12">
-              {if $need_confirmation}
+              {if isset($need_confirmation) && $need_confirmation}
                <span class="custom-checkbox">
                   <input type="checkbox" name="confirm-optin" value="1" required>
                   <span><i class="material-icons checkbox-checked"></i></span>
-                  <label>{l s='I agree to receive newsletter emails and I am aware of [1]the privacy policy[/1]' tags=['<a href="%s">'|sprintf:$link->getCMSLink($cms_page)] mod='ps_emailsubscription'}</label>
+                  <label>{l s='I agree to receive newsletter emails and I am aware of [1]the privacy policy[/1]' tags=['<a href="%s">'|sprintf:$cms_privacy_link] mod='ps_emailsubscription'}</label>
                 </span>
               {/if}
               {if $msg}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Move a link generation in the module class and send it in the template. Plus, we fix a notice when a variable does not exist. (Follow up #5565) |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | Nope |
| Deprecations? | Nope. |
| How to test? | If the module has never been updated, you should not have any notice under the newsletter form. |
