### PR TITLE
[*] CORE : Fix a case where $context->smarty could be undefined

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -199,6 +199,10 @@ if (!isset($language) || !Validate::isLoadedObject($language)) {
 }
 $context->language = $language;
 
+/* Get smarty */
+require_once($currentDir.'/smarty.config.inc.php');
+$context->smarty = $smarty;
+
 if (!defined('_PS_ADMIN_DIR_')) {
     if (isset($cookie->id_customer) && (int)$cookie->id_customer) {
         $customer = new Customer($cookie->id_customer);
@@ -259,7 +263,3 @@ if (!defined('_MEDIA_SERVER_2_')) {
 if (!defined('_MEDIA_SERVER_3_')) {
     define('_MEDIA_SERVER_3_', Configuration::get('PS_MEDIA_SERVER_3'));
 }
-
-/* Get smarty */
-require_once($currentDir.'/smarty.config.inc.php');
-$context->smarty = $smarty;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Version 1.6, any browser, any theme... |
| Type? | bug fix |
| Category? | CORE |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | no |
| How to test? | See below |

Here is the complete testing process:

On a clean shop (1.6.1.5) we add 2 new addons. Shop must have at least 2 langs :
First is using hook `actionObjectUpdateAfter`
Second is using hook `displayCustomerAccount` and returns string using `$this->display(<template>)` method
1. Login with any customer account
2. Go to "my account" page **/en/my-account**
3. Change lang to FR, going to page **/fr/mon-compte**
4. Refresh the current page (**/fr/mon-compte**)
5. You'll have a fatal error because `$context->smarty` is undefined when running `displayCustomerAccount` hook :

```
Fatal error: Call to a member function assign() on a non-object in /classes/module/Module.php on line 2299
```

This errors occurs because `Customer` is updated into `config.inc.php` and when current language is different from the current one (which fire hook `actionObjectUpdateAfter`).
At this time, Smarty is still not init, and `displayCustomerAccount` is run which cause the error.

In order to fix it, Smarty must be loaded before firing any hook (this PR).
