### PR TITLE
FO: Open newsletter privacy policy in a new page

### DIFF
--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -42,7 +42,7 @@
                <span class="custom-checkbox">
                   <input type="checkbox" name="confirm-optin" value="1" required>
                   <span><i class="material-icons checkbox-checked"></i></span>
-                  <label>{l s='I agree to receive newsletter emails and I am aware of [1]the privacy policy[/1]' tags=['<a href="%s">'|sprintf:$cms_privacy_link] mod='ps_emailsubscription'}</label>
+                  <label>{l s='I agree to receive newsletter emails and I am aware of [1]the privacy policy[/1]' tags=['<a target="_blank" href="%s">'|sprintf:$cms_privacy_link] mod='ps_emailsubscription'}</label>
                 </span>
               {/if}
               {if $msg}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Open privacy policy in a new page for newsletter form |
| Type? | improvement |
| Category? | FO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-128](http://forge.prestashop.com/browse/BOOM-128) |
| How to test? | Enable the opt-in confirmation in the module ps_emailsubscription, go on the front and try the link to the privacy policy. |
