### PR TITLE
Make id_product available in checkout confirmation e-mail

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -456,6 +456,7 @@ abstract class PaymentModuleCore extends Module
                         $product_price = Product::getTaxCalculationMethod() == PS_TAX_EXC ? Tools::ps_round($price, 2) : $price_wt;
 
                         $product_var_tpl = array(
+                            'id_product' => $product['id_product'],
                             'reference' => $product['reference'],
                             'name' => $product['name'].(isset($product['attributes']) ? ' - '.$product['attributes'] : ''),
                             'unit_price' => Tools::displayPrice($product_price, $this->context->currency, false),

--- a/mails/en/order_conf_product_list.tpl
+++ b/mails/en/order_conf_product_list.tpl
@@ -20,6 +20,7 @@
 				<td>
 					<font size="2" face="Open-sans, sans-serif" color="#555454">
 						<strong>{$product['name']}</strong>
+						{hook h='displayProductPriceBlock' product=$product type="unit_price"}
 					</font>
 				</td>
 				<td width="10">&nbsp;</td>

--- a/mails/en/order_conf_product_list.txt
+++ b/mails/en/order_conf_product_list.txt
@@ -4,6 +4,7 @@
 						{$product['name']}
 
 						{$product['price']}
+						{capture "productPriceBlock"}{hook h='displayProductPriceBlock' product=$product type="unit_price"}{/capture}{$smarty.capture.productPriceBlock|strip_tags|trim}
 
 						{$product['quantity']}
 

--- a/themes/classic/templates/_partials/footer.tpl
+++ b/themes/classic/templates/_partials/footer.tpl
@@ -8,5 +8,8 @@
     <div class="row">
       {hook h='displayFooter'}
     </div>
+    <div class="row">
+      {hook h='displayFooterAfter'}
+    </div>
   </div>
 </div>

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -51,14 +51,7 @@
 
           <span itemprop="price" class="price">{$product.price}</span>
 
-          {hook h='displayProductPriceBlock' product=$product type='price'}
           {hook h='displayProductPriceBlock' product=$product type='unit_price'}
-          {hook h='displayProductPriceBlock' product=$product type='list_taxes'}
-          {hook h='displayProductPriceBlock' product=$product type='after_price'}
-
-          {if !$product.is_virtual}
-            {hook h='displayProductDeliveryTime' product=$product}
-          {/if}
 
           {hook h='displayProductPriceBlock' product=$product type='weight'}
         </div>

--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -60,7 +60,6 @@
     {block name='product_unit_price'}
       {if $displayUnitPrice}
         <p class="product-unit-price sub">{l s='(%s)' sprintf=[$product.unit_price_full]}</p>
-        {hook h='displayProductPriceBlock' product=$product type="unit_price"}
       {/if}
     {/block}
 

--- a/themes/classic/templates/checkout/_partials/cart-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary.tpl
@@ -1,6 +1,6 @@
 <section id="checkout-cart-summary" class="card -js-cart" data-refresh-url="{$urls.pages.cart}?ajax=1">
   <div class="card-block">
-
+    {hook h='displayCheckoutSummaryTop'}
     {block name='cart_summary_products'}
       <div class="cart-summary-products">
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Adds id_product in the product-array. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |

Helpful to integrate own hooks in e-mail, that need to have the id_product 
