### PR TITLE
Fix CSV import on PHP 7

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1066,7 +1066,7 @@ class AdminImportControllerCore extends AdminController
         }
 
         foreach ($array as $k => $row) {
-            if (!call_user_func_array($funcname, array($row, $k, $user_data))) {
+            if (!call_user_func_array($funcname, array($row, $k, &$user_data))) {
                 return false;
             }
         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When running PrestaShop on PHP7, we cannot make any CSV import. A variable is expected to be sent as a reference, but a function get a value instead. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | CSV import must now be running on PHP7, but of course on PHP5.x too. |
