### PR TITLE
Add .editorconfig rule to avoid trimming Markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ indent_size = 2
 
 [*.php]
 indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In Markdown there are legitimate reasons to leave trailing whitespace at the end of lines. It's the only way to insert a line break without creating a new paragraph. This adds a rule to .editorconfig |
| Type? | improvement |
| Category? | Project |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | no |
| How to test? | Open a `.md` file after checking out this commit, and try to save after adding a couple of spaces at the end of a line. If the editor behaves well, it will not trim the space. |
