### PR TITLE
The maintenance text can be customized from the back-office

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -649,6 +649,7 @@ class FrontControllerCore extends Controller
                 $this->context->smarty->assign(array(
                     'shop' => $this->getTemplateVarShop(),
                     'HOOK_MAINTENANCE' => Hook::exec('displayMaintenance', array()),
+                    'maintenance_text' => Configuration::get('PS_MAINTENANCE_TEXT', (int)$this->context->language->id),
                 ));
 
                 $this->smartyOutputContent('errors/maintenance.tpl');

--- a/controllers/admin/AdminMaintenanceController.php
+++ b/controllers/admin/AdminMaintenanceController.php
@@ -55,6 +55,13 @@ class AdminMaintenanceControllerCore extends AdminController
                         'type' => 'maintenance_ip',
                         'default' => ''
                     ),
+                    'PS_MAINTENANCE_TEXT' => array(
+                        'title' => $this->l('Custom maintenance text'),
+                        'hint' => $this->l('Custom text displayed on maintenance page while shop is deactivated.'),
+                        'validation' => 'isCleanHtml',
+                        'type' => 'textareaLang',
+                        'default' => ''
+                    ),
                 ),
                 'submit' => array('title' => $this->l('Save'))
             ),

--- a/controllers/admin/AdminMaintenanceController.php
+++ b/controllers/admin/AdminMaintenanceController.php
@@ -60,6 +60,7 @@ class AdminMaintenanceControllerCore extends AdminController
                         'hint' => $this->l('Custom text displayed on maintenance page while shop is deactivated.'),
                         'validation' => 'isCleanHtml',
                         'type' => 'textareaLang',
+                        'autoload_rte' => true,
                         'default' => ''
                     ),
                 ),

--- a/install-dev/langs/bg/data/configuration.xml
+++ b/install-dev/langs/bg/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/bn/data/configuration.xml
+++ b/install-dev/langs/bn/data/configuration.xml
@@ -18,4 +18,7 @@
   <configuration id='PS_CUSTOMER_SERVICE_SIGNATURE'>
     <value>প্রিয় গ্রাহক,                                        শুভেচ্ছা, গ্রাহক সেবা বিভাগ</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/br/data/configuration.xml
+++ b/install-dev/langs/br/data/configuration.xml
@@ -21,4 +21,7 @@
 Atenciosamente,
 Serviço ao cliente</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/cs/data/configuration.xml
+++ b/install-dev/langs/cs/data/configuration.xml
@@ -21,4 +21,7 @@
 S pozdravem,&#xD;
 Zákaznický servis</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/de/data/configuration.xml
+++ b/install-dev/langs/de/data/configuration.xml
@@ -21,4 +21,7 @@
 Mit freundlichem Gru&#xDF;&#xD;
 Ihr Kundenservice</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/en/data/configuration.xml
+++ b/install-dev/langs/en/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/es/data/configuration.xml
+++ b/install-dev/langs/es/data/configuration.xml
@@ -21,4 +21,7 @@
 Saludos,
 Servicio de atención al cliente</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/fa/data/configuration.xml
+++ b/install-dev/langs/fa/data/configuration.xml
@@ -24,4 +24,7 @@
   <configuration id="PS_ALLOW_ACCENTED_CHARS_URL" name="PS_ALLOW_ACCENTED_CHARS_URL">
     <value>1</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/fr/data/configuration.xml
+++ b/install-dev/langs/fr/data/configuration.xml
@@ -21,4 +21,7 @@
 Cordialement,
 Le service client</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/he/data/configuration.xml
+++ b/install-dev/langs/he/data/configuration.xml
@@ -21,4 +21,7 @@
 בברכה,&#xD;
 שירות לקוחות</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/hr/data/configuration.xml
+++ b/install-dev/langs/hr/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/hu/data/configuration.xml
+++ b/install-dev/langs/hu/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/id/data/configuration.xml
+++ b/install-dev/langs/id/data/configuration.xml
@@ -21,4 +21,7 @@
 Salam kami,
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/it/data/configuration.xml
+++ b/install-dev/langs/it/data/configuration.xml
@@ -21,4 +21,7 @@
 Cordiali saluti,
 Servizio clienti</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/lt/data/configuration.xml
+++ b/install-dev/langs/lt/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/mk/data/configuration.xml
+++ b/install-dev/langs/mk/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/nl/data/configuration.xml
+++ b/install-dev/langs/nl/data/configuration.xml
@@ -18,4 +18,7 @@
   <configuration id='PS_CUSTOMER_SERVICE_SIGNATURE'>
     <value>Beste klant, Met vriendelijke groet, Klantenservice</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/no/data/configuration.xml
+++ b/install-dev/langs/no/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/pl/data/configuration.xml
+++ b/install-dev/langs/pl/data/configuration.xml
@@ -21,4 +21,7 @@
 Z wyrazami szacunku,&#xD;
 Dzial obslugi klienta</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/pt/data/configuration.xml
+++ b/install-dev/langs/pt/data/configuration.xml
@@ -6,4 +6,7 @@
 Atenciosamente,&#xD;
 Apoio ao cliente</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/qc/data/configuration.xml
+++ b/install-dev/langs/qc/data/configuration.xml
@@ -21,4 +21,7 @@
 Cordialement,
 Le service client</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/ro/data/configuration.xml
+++ b/install-dev/langs/ro/data/configuration.xml
@@ -21,4 +21,7 @@
 Toate cele bune,&#xD;
 Echipa de asistenta pentru clienti</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/ru/data/configuration.xml
+++ b/install-dev/langs/ru/data/configuration.xml
@@ -21,4 +21,7 @@
 С уважением,&#xD;
 Служба поддержки клиентов</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/si/data/configuration.xml
+++ b/install-dev/langs/si/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/sr/data/configuration.xml
+++ b/install-dev/langs/sr/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/sv/data/configuration.xml
+++ b/install-dev/langs/sv/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/tw/data/configuration.xml
+++ b/install-dev/langs/tw/data/configuration.xml
@@ -21,4 +21,7 @@
 敬祝平安，&#xD;
 客戶服務部門</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/vn/data/configuration.xml
+++ b/install-dev/langs/vn/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/langs/zh/data/configuration.xml
+++ b/install-dev/langs/zh/data/configuration.xml
@@ -21,4 +21,7 @@
 Regards,&#xD;
 Customer service</value>
   </configuration>
+  <configuration id="PS_MAINTENANCE_TEXT">
+    <value>We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.</value>
+  </configuration>
 </entity_configuration>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -109,3 +109,6 @@ ALTER TABLE `PREFIX_cart_product` DROP PRIMARY KEY, ADD PRIMARY KEY (`id_cart`, 
 ALTER TABLE `PREFIX_order_detail` ADD `id_customization` INT(10) NULL DEFAULT '0' AFTER `product_attribute_id`;
 ALTER TABLE `PREFIX_customized_data` ADD `id_module` INT(10) NOT NULL DEFAULT '0', ADD `price` DECIMAL(20,6) NOT NULL DEFAULT '0', ADD `weight` DECIMAL(20,6) NOT NULL DEFAULT '0';
 ALTER TABLE `PREFIX_customization_field` ADD `is_module` TINYINT(1) NOT NULL DEFAULT '0' ;
+
+INSERT INTO `PREFIX_configuration` (name, value, date_add, date_upd) VALUES ('PS_MAINTENANCE_TEXT', 'We are currently updating our shop and will be back really soon.&lt;br&gt;Thanks for your patience.', NOW(), NOW());
+INSERT INTO `PREFIX_configuration_lang` (`id_configuration`, `id_lang`, `value`, `date_upd`) SELECT c.`id_configuration`, l.`id_lang`, c.`value`, NOW() FROM `PREFIX_configuration` c, `PREFIX_lang` l WHERE c.`name` = 'PS_MAINTENANCE_TEXT';

--- a/themes/classic/templates/errors/maintenance.tpl
+++ b/themes/classic/templates/errors/maintenance.tpl
@@ -17,9 +17,7 @@
     {block name='page_content_container'}
       <section id="content" class="page-content page-maintenance">
         {block name='page_content'}
-          {l s='We are currently updating our shop and will be back really soon.' d='Shop.Theme'}
-          <br>
-          {l s='Thanks for your patience.' d='Shop.Theme'}
+          {$maintenance_text nofilter}
         {/block}
       </section>
     {/block}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Possibility to set custom maintenance text from back-office |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | n/a |
| Sponsor company | impSolutions
| How to test? | Set text in BO, check maintenance page while shop is turned off |
