### PR TITLE
Feat/refacto trans twig

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/_partials/_sidebar.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/_partials/_sidebar.html.twig
@@ -1,7 +1,7 @@
 <div id="ps-quicknav-sidebar"  class="_fullspace">
     <div class="quicknav-header">
         <div class="pull-left"><a href="#" data-toggle="sidebar" data-target=".sidebar">×</a></div>
-        <h2>{{ trans(title|raw, {}, 'AdminCommon') }}</h2>
+        <h2>{{ title|raw|trans({}, 'AdminCommon') }}</h2>
     </div>
     <div class="quicknav-scroller _fullspace">
         <object class="_fullspace" data="{{ url }}"></object>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig
@@ -19,13 +19,12 @@
     </ul>
     <ul class="pagination">
         <li style="float: left; margin-left: 2em;">
-            {{ trans("Viewing $from-$to on $total (page # $current_page / $page_count)",
-                {'$from': from+1, '$to': min(to+1, total), '$total': total, '$current_page': current_page, '$page_count': page_count},
+            {{ "Viewing $from-$to on $total (page # $current_page / $page_count)"|trans({'$from': from+1, '$to': min(to+1, total), '$total': total, '$current_page': current_page, '$page_count': page_count},
                 'AdminTab') }}
             &nbsp;
             |
             &nbsp;
-            {{ trans("Items per page:", {}, 'AdminTab') }}&nbsp;
+            {{ "Items per page:"|trans({}, 'AdminTab') }}&nbsp;
             <select name="paginator_select_page_limit" psurl="{{ changeLimitUrl }}" style="display:inline;width:6em;" class="pagination-link">
                 {% if limit not in limit_choices %}<option value="{{ limit }}" selected="selected">{{ limit }}</option>{% endif %}
                 {% for limit_choice in limit_choices %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
@@ -15,8 +15,8 @@
 
             {% if progressbar is defined %}
                 <div class="modal-body" id="{{ progressbar.id }}">
-                    <div class="pull-right progress-details-text" default-value="{{ progressbar.label|default(trans('Processing...', {}, 'AdminTab')) }}">
-                        {{ progressbar.label|default(trans('Processing...', {}, 'AdminTab')) }}
+                    <div class="pull-right progress-details-text" default-value="{{ progressbar.label|default('Processing...'|trans({}, 'AdminTab')) }}">
+                        {{ progressbar.label|default('Processing...'|trans({}, 'AdminTab')) }}
                     </div>
                     <div class="progress active progress-striped" style="display: block; width: 100%">
                         <div class="progress-bar progress-bar-success" role="progressbar" style="width: 0%">
@@ -30,7 +30,7 @@
                 {% if actions is defined %}
                     <div class="modal-footer">
                         {% if closable is defined and closable == true %}
-                            <button type="button" class="btn btn-default" data-dismiss="modal">{{ trans('Close', {}, 'AdminTab') }}</button>
+                            <button type="button" class="btn btn-default" data-dismiss="modal">{{ 'Close'|trans({}, 'AdminTab') }}</button>
                         {% endif %}
                         {% for action in actions %}
                             {% if action.type is defined and action.type == 'link' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig
@@ -25,22 +25,22 @@
 	                var slider = $('#{{ input_name }}');
 	                if (values[0] == {{ min|default('0') }} && values[1] == {{ max|default('10') }}) {
 	                    slider.attr('sql', '');
-	                    return "{{ trans('Not filtered', {}, 'AdminTab') }}";
+	                    return "{{ 'Not filtered'|trans({}, 'AdminTab') }}";
 	                }
 	                if (values[0] == values[1]) {
 	                    slider.attr('sql', ''); //'='+values[0]);
-	                    return "{{ trans('Equals', {}, 'AdminTab') }} " + values[0];
+	                    return "{{ 'Equals'|trans({}, 'AdminTab') }} " + values[0];
 	                }
 	                if (values[0] == {{ min|default('0') }}) {
 	                    slider.attr('sql', '<'+values[1]);
-	                    return "{{ trans('Below', {}, 'AdminTab') }} " + values[1];
+	                    return "{{ 'Below'|trans({}, 'AdminTab') }} " + values[1];
 	                }
 	                if (values[1] == {{ max|default('10') }}) {
 	                    slider.attr('sql', '>'+values[0]);
-	                    return "{{ trans('Above', {}, 'AdminTab') }} " + values[0];
+	                    return "{{ 'Above'|trans({}, 'AdminTab') }} " + values[0];
 	                }
 	                slider.attr('sql', 'BETWEEN '+values[0]+' AND '+values[1]);
-	                return "{{ trans('Inside range', {}, 'AdminTab') }} [" + values[0] + "~" + values[1] + "]";
+	                return "{{ 'Inside range'|trans({}, 'AdminTab') }} [" + values[0] + "~" + values[1] + "]";
 	            }
             },
             min: {{ min|default('0') }},

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
@@ -10,13 +10,13 @@
                             <button type="button" class="close" data-dismiss="modal">&times;</button>
                             <h4 class="modal-title module-modal-title">
                                 {% if module_action == 'disable' %}
-                                    {{ trans("Disable module?", {}, 'AdminModules') }}
+                                    {{ "Disable module?"|trans({}, 'AdminModules') }}
                                 {% endif %}
                                 {% if module_action == 'uninstall' %}
-                                    {{ trans("Uninstall module?", {}, 'AdminModules') }}
+                                    {{ "Uninstall module?"|trans({}, 'AdminModules') }}
                                 {% endif %}
                                 {% if module_action == 'reset' %}
-                                    {{ trans("Reset module?", {}, 'AdminModules') }}
+                                    {{ "Reset module?"|trans({}, 'AdminModules') }}
                                 {% endif %}
                             </h4>
                         </div>
@@ -24,53 +24,53 @@
                             <div class="col-md-12">
                                 <p>
                                     {% if module_action == 'disable' %}
-                                        {{ trans("You're about to disable %moduleName% module.", {'%moduleName%': module.attributes.displayName}, 'AdminModules')|raw }}
+                                        {{ "You're about to disable %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'AdminModules')|raw }}
                                         <br/><br/>
-                                        {{ trans("Your current settings will be saved, but the module will no longer be active.", {}, 'AdminModules')|raw }}
+                                        {{ "Your current settings will be saved, but the module will no longer be active."|trans({}, 'AdminModules')|raw }}
                                     {% endif %}
                                     {% if module_action == 'uninstall' %}
-                                        {{ trans("You're about to uninstall %moduleName% module.", {'%moduleName%': module.attributes.displayName}, 'AdminModules')|raw }}
+                                        {{ "You're about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'AdminModules')|raw }}
                                         <br/><br/>
-                                        {{ trans("This will disable the module and delete all its files. For good.", {}, 'AdminModules')|raw }}
+                                        {{ "This will disable the module and delete all its files. For good."|trans({}, 'AdminModules')|raw }}
                                         <br/>
                                       <p>
                                         <label>
-                                          <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}"> {{ trans("Optional: delete module folder after uninstall.", {}, 'AdminModules')|raw }}
+                                          <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}"> {{ "Optional: delete module folder after uninstall."|trans({}, 'AdminModules')|raw }}
                                         </label>
                                         <br>
                                       </p>
                                       <span class="italic red">
-                                            {{ trans("This action cannot be undone.", {}, 'AdminModules')|raw }}
+                                            {{ "This action cannot be undone."|trans({}, 'AdminModules')|raw }}
                                         </span>
                                     {% endif %}
                                     {% if module_action == 'reset' %}
-                                        {{ trans("You're about to reset %moduleName% module.", {'%moduleName%': module.attributes.displayName}, 'AdminModules')|raw }}
+                                        {{ "You're about to reset %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'AdminModules')|raw }}
                                         <br/><br/>
-                                        {{ trans("This will restore the defaults settings.", {}, 'AdminModules')|raw }}
+                                        {{ "This will restore the defaults settings."|trans({}, 'AdminModules')|raw }}
                                         <br/>
                                         <span class="italic red">
-                                            {{ trans("This action cannot be undone.", {}, 'AdminModules')|raw }}
+                                            {{ "This action cannot be undone."|trans({}, 'AdminModules')|raw }}
                                         </span>
                                     {% endif %}
                                 </p>
                             </div>
                         </div>
                         <div class="modal-footer">
-                            <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="{{ trans("Cancel", {}, 'AdminTabs')|raw }}" />
+                            <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="{{ "Cancel"|trans({}, 'AdminTabs')|raw }}" />
                             {% if module_action == 'disable' %}
                                 <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
                                     data-tech-name="{{module.attributes.name}}"
-                                    href="{{ module_url }}">{{ trans("Yes, I want to disable", {}, 'AdminModules')|raw }}</a>
+                                    href="{{ module_url }}">{{ "Yes, I want to disable"|trans({}, 'AdminModules')|raw }}</a>
                             {% endif %}
                             {% if module_action == 'uninstall' %}
                                 <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
                                     data-tech-name="{{module.attributes.name}}"
-                                    href="{{ module_url }}">{{ trans("Yes, I want to uninstall", {}, 'AdminModules')|raw }}</a>
+                                    href="{{ module_url }}">{{ "Yes, I want to uninstall"|trans({}, 'AdminModules')|raw }}</a>
                             {% endif %}
                             {% if module_action == 'reset' %}
                                 <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
                                     data-tech-name="{{module.attributes.name}}"
-                                    href="{{ module_url }}">{{ trans("Yes, I want to reset", {}, 'AdminModules')|raw }}</a>
+                                    href="{{ module_url }}">{{ "Yes, I want to reset"|trans({}, 'AdminModules')|raw }}</a>
                             {% endif %}
                         </div>
                     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
@@ -18,7 +18,7 @@
 
                   <div id="module-modal-bulk-checkbox">
                     <label>
-                      <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion"> {{ trans("Optional: delete module folder after uninstall.", {}, 'AdminModules')|raw }}
+                      <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion"> {{ "Optional: delete module folder after uninstall."|trans({}, 'AdminModules')|raw }}
                     </label>
                   </div>
               </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more.html.twig
@@ -78,7 +78,7 @@
                 </div>
                 {% endif %}
                 {% if module.attributes.urls.install is defined %}
-                    <a href="{{module.attributes.urls.install}}" class="pull-right module-install-button btn btn-primary btn-sm light-button">{{ trans('Install', {}, 'AdminModules') }}</a>
+                    <a href="{{module.attributes.urls.install}}" class="pull-right module-install-button btn btn-primary btn-sm light-button">{{ 'Install'|trans({}, 'AdminModules') }}</a>
                 {% endif %}
             </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
@@ -5,8 +5,8 @@
             <div class="module-sorting-search-wording">
                 <span class="module-search-result-wording">{{ totalModules }} modules and services selected for you</span>
                 <span class="help-box" data-toggle="popover"
-                    data-title="{{ trans("Selection", {}, 'AdminModules') }}"
-                    data-content="{{ trans("Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules.", {}, 'AdminModules') }}">
+                    data-title="{{ "Selection"|trans({}, 'AdminModules') }}"
+                    data-content="{{ "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'AdminModules') }}">
                 </span>
             </div>
             <p class="module-addons-search">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -58,8 +58,8 @@
 		<div class="module-short-list">
 			<span class="module-search-result-wording">{{modules.modules|length}} installed modules</span>
                            <span class="help-box" data-toggle="popover"
-                                data-title="{{ trans("Installed modules", {}, 'AdminModules') }}"
-                                data-content="{{ trans("These are all the modules you’ve added to your shop, either by buying it from PrestaShop Addons, or by uploading it directly.", {}, 'AdminModules') }}">
+                                data-title="{{ "Installed modules"|trans({}, 'AdminModules') }}"
+                                data-content="{{ "These are all the modules you’ve added to your shop, either by buying it from PrestaShop Addons, or by uploading it directly."|trans({}, 'AdminModules') }}">
                            </span>
                    </div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.modules, 'display_type' : 'list', 'origin' : 'manage'  } %}
@@ -69,8 +69,8 @@
 		<div class="module-short-list">
 			<span class="module-search-result-wording">{{modules.native_modules|length}} built-in modules</span>
                            <span class="help-box" data-toggle="popover"
-                                 data-title="{{ trans("Built-in modules", {}, 'AdminModules') }}"
-                                data-content="{{ trans("These modules from PrestaShop are preinstalled when you set-up your shop. They cover the basics of e-commerce and comes for free.", {}, 'AdminModules') }}">
+                                 data-title="{{ "Built-in modules"|trans({}, 'AdminModules') }}"
+                                data-content="{{ "These modules from PrestaShop are preinstalled when you set-up your shop. They cover the basics of e-commerce and comes for free."|trans({}, 'AdminModules') }}">
                            </span>
 		</div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.native_modules, 'display_type' : 'list', 'origin' : 'manage'  } %}
@@ -80,8 +80,8 @@
 		<div class="module-short-list">
 			<span class="module-search-result-wording">{{modules.theme_bundle|length}} theme modules</span>
                            <span class="help-box" data-toggle="popover"
-                                data-title="{{ trans("Theme modules", {}, 'AdminModules') }}"
-                                data-content="{{ trans("Each theme you install will come with its own set of modules. You’ll find here all the modules related to your active theme.", {}, 'AdminModules') }}">
+                                data-title="{{ "Theme modules"|trans({}, 'AdminModules') }}"
+                                data-content="{{ "Each theme you install will come with its own set of modules. You’ll find here all the modules related to your active theme."|trans({}, 'AdminModules') }}">
                            </span>
 		</div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.theme_bundle, 'display_type' : 'list', 'origin' : 'manage'  } %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -29,8 +29,8 @@
             <div class="module-short-list">
                 <span class="module-search-result-wording">{{modules.to_configure|length}} modules to configure</span> 
                 <span class="help-box" data-toggle="popover"
-                      data-title="{{ trans("Modules to configure", {}, 'AdminModules') }}"
-                      data-content="{{ trans("These modules require your attention: you need to take some action to ensure they are fully operational.", {}, 'AdminModules') }}">
+                      data-title="{{ "Modules to configure"|trans({}, 'AdminModules') }}"
+                      data-content="{{ "These modules require your attention: you need to take some action to ensure they are fully operational."|trans({}, 'AdminModules') }}">
                 </span>
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_configure.html.twig' with { 'modules' : modules.to_configure, 'display_type' : 'list'  } %}
@@ -39,8 +39,8 @@
             <div class="module-short-list">
                 <span class="module-search-result-wording">{{modules.to_update|length}} modules to update</span>
                 <span class="help-box" data-toggle="popover"
-                      data-title="{{ trans("Modules to update", {}, 'AdminModules') }}"
-                      data-content="{{ trans("Update these modules to enjoy their latest versions.", {}, 'AdminModules') }}">
+                      data-title="{{ "Modules to update"|trans({}, 'AdminModules') }}"
+                      data-content="{{ "Update these modules to enjoy their latest versions."|trans({}, 'AdminModules') }}">
                 </span>
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_update.html.twig' with { 'modules' : modules.to_update, 'display_type' : 'list' } %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
@@ -1,19 +1,19 @@
-<h2>{{ trans("Categories", {}, 'AdminProducts') }}
+<h2>{{ "Categories"|trans({}, 'AdminProducts') }}
   <span class="help-box" data-toggle="popover"
-    data-content="{{ trans("Where should the product be available on your site? The default category is the main category for your product.",{}, 'AdminProducts') }}" ></span>
+    data-content="{{ "Where should the product be available on your site? The default category is the main category for your product."|trans({}, 'AdminProducts') }}" ></span>
 </h2>
 <div class="categories-tree js-categories-tree">
   <fieldset class="form-group">
     <div class="ui-widget">
-      <input type="text" id="ps-select-product-category" class="form-control autocomplete search m-b-1" placeholder="{{ trans('Search categories', {}, 'AdminProducts') }}">
-      <label class="form-control-label text-uppercase">{{ trans('Categories associated to this product', {}, 'AdminProducts') }}</label>
+      <input type="text" id="ps-select-product-category" class="form-control autocomplete search m-b-1" placeholder="{{ 'Search categories'|trans({}, 'AdminProducts') }}">
+      <label class="form-control-label text-uppercase">{{ 'Categories associated to this product'|trans({}, 'AdminProducts') }}</label>
       {{ include('PrestaShopBundle:Admin:Category/categories.html.twig', {'categories': categories }) }}
       {{ form_errors(form.id_category_default) }}
       {{ form_widget(form.id_category_default) }}
       <div class="categories-tree-actions js-categories-tree-actions">
-        <span class="form-control-label" data-action="expand"><i class="material-icons">expand_more</i>{{ trans("Expand All", {}, 'AdminProducts') }}</span>
-        <span class="form-control-label" data-action="reduce"><i class="material-icons">expand_less</i>{{ trans("Reduce All", {}, 'AdminProducts') }}</span>
-        <span class="form-control-label pull-right">{{ trans("Category by default", {}, 'AdminProducts') }}</span>
+        <span class="form-control-label" data-action="expand"><i class="material-icons">expand_more</i>{{ "Expand All"|trans({}, 'AdminProducts') }}</span>
+        <span class="form-control-label" data-action="reduce"><i class="material-icons">expand_less</i>{{ "Reduce All"|trans({}, 'AdminProducts') }}</span>
+        <span class="form-control-label pull-right">{{ "Category by default"|trans({}, 'AdminProducts') }}</span>
         <hr>
       </div>
       {{ form_widget(form.categories, {'defaultCategory': true}) }} {# see bootstrap_3_layout.html.twig #}
@@ -24,14 +24,14 @@
 </div>
 <div id="add-categories">
   <h2>
-    {{ trans("Add a new category", {}, 'AdminProducts') }}
+    {{ "Add a new category"|trans({}, 'AdminProducts') }}
     <span class="help-box" data-toggle="popover"
-      data-content="{{ trans("If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).",{}, 'AdminProducts') }}" ></span>
+      data-content="{{ "If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.)."|trans({}, 'AdminProducts') }}" ></span>
   </h2>
   <div id="add-categories-content" class="hide">
     <div id="form_step1_new_category" data-action="{{ path('admin_category_simple_add_form', {'id_product': productId }) }}">
       <fieldset class="form-group">
-        <label class="form-control-label">{{ trans("Add a new category", {}, 'AdminProducts') }}</label>
+        <label class="form-control-label">{{ "Add a new category"|trans({}, 'AdminProducts') }}</label>
         {{ form_errors(form.new_category) }}
         {{ form_widget(form.new_category.name) }}
       </fieldset>
@@ -44,14 +44,14 @@
       </fieldset>
 
       <fieldset class="form-group text-xs-right">
-        <button type="reset" id="form_step1_new_category_reset" class="btn btn-tertiary-outline btn-sm">{{ trans('Cancel', {}, 'AdminProducts') }}</button>
-        <button type="button" id="form_step1_new_category_save" class="btn btn-primary save">{{ trans('Create', {}, 'AdminProducts') }}</button>
+        <button type="reset" id="form_step1_new_category_reset" class="btn btn-tertiary-outline btn-sm">{{ 'Cancel'|trans({}, 'AdminProducts') }}</button>
+        <button type="button" id="form_step1_new_category_save" class="btn btn-primary save">{{ 'Create'|trans({}, 'AdminProducts') }}</button>
       </fieldset>
     </div>
 
   <a href="#" class="btn btn-action open" id="add-category-button">
     <i class="material-icons">add</i>
-    {{ trans('Add a category', {}, 'AdminProducts') }}
+    {{ 'Add a category'|trans({}, 'AdminProducts') }}
   </a>
 </div>
 <!-- start of CSS plugin: to be moved in his own file -->

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-specific-price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-specific-price.html.twig
@@ -1,12 +1,12 @@
 <div class="card card-block">
-  <h4>{{ trans('Specific price conditions', {}, 'AdminProducts') }}</h4>
+  <h4>{{ 'Specific price conditions'|trans({}, 'AdminProducts') }}</h4>
   {{ form_errors(form) }}
 
   {% if form.sp_id_shop.vars.choices is defined %}
   <div class="row">
     <div class="col-md-4">
       <fieldset class="form-group">
-        <label>{{ trans('Shop', {}, 'AdminProducts') }}</label>
+        <label>{{ 'Shop'|trans({}, 'AdminProducts') }}</label>
         {{ form_errors(form.sp_id_shop) }}
         {{ form_widget(form.sp_id_shop) }}
       </fieldset>
@@ -19,7 +19,7 @@
   <div class="row">
     <div class="col-md-3">
       <fieldset class="form-group">
-        <label>{{ trans('For', {}, 'AdminProducts') }}</label>
+        <label>{{ 'For'|trans({}, 'AdminProducts') }}</label>
         {{ form_errors(form.sp_id_currency) }}
         {{ form_widget(form.sp_id_currency) }}
       </fieldset>
@@ -40,7 +40,7 @@
     </div>
     <div class="col-md-6">
       <fieldset class="form-group">
-        <label>{{ trans('Customer', {}, 'AdminProduct') }}</label>
+        <label>{{ 'Customer'|trans({}, 'AdminProduct') }}</label>
         {{ form_errors(form.sp_id_customer) }}
         {{ form_widget(form.sp_id_customer) }}
       </fieldset>
@@ -64,7 +64,7 @@
     </div>
     <div class="col-md-3">
       <fieldset class="form-group">
-        <label>{{ trans('to', {}, 'AdminProducts')|raw }}</label>
+        <label>{{ 'to'|trans({}, 'AdminProducts')|raw }}</label>
         {{ form_errors(form.sp_to) }}
         {{ form_widget(form.sp_to) }}
       </fieldset>
@@ -75,13 +75,13 @@
         {{ form_errors(form.sp_from_quantity) }}
         <div class="input-group">
           {{ form_widget(form.sp_from_quantity) }}
-          <span class="input-group-addon">{{ trans('Unit(s)', {}, 'Adminproducts') }}</span>
+          <span class="input-group-addon">{{ 'Unit(s)'|trans({}, 'Adminproducts') }}</span>
         </div>
       </fieldset>
     </div>
   </div>
 
-  <h4>{{ trans('Impact on price', {}, 'Adminproducts') }}</h4>
+  <h4>{{ 'Impact on price'|trans({}, 'Adminproducts') }}</h4>
   <div class="row">
     <div class="col-md-3">
       <fieldset class="form-group">
@@ -101,14 +101,14 @@
   <div class="row">
     <div class="col-md-2">
       <fieldset class="form-group">
-        <label>{{ trans('Product price (tax excl.)', {}, 'Adminproducts') }}</label>
+        <label>{{ 'Product price (tax excl.)'|trans({}, 'Adminproducts') }}</label>
         {{ form_errors(form.sp_reduction) }}
         {{ form_widget(form.sp_reduction) }}
       </fieldset>
     </div>
     <div class="col-md-2">
       <fieldset class="form-group">
-        <label>{{ trans('OR Apply a discount of', {}, 'Adminproducts') }}</label>
+        <label>{{ 'OR Apply a discount of'|trans({}, 'Adminproducts') }}</label>
         {{ form_errors(form.sp_reduction_type) }}
         {{ form_widget(form.sp_reduction_type) }}
       </fieldset>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-supplier-combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-supplier-combination.html.twig
@@ -1,11 +1,11 @@
 {% if suppliers|length > 0 %}
-  <h4>{{ trans('Supplier reference(s)', {}, 'AdminProducts') }}</h4>
+  <h4>{{ 'Supplier reference(s)'|trans({}, 'AdminProducts') }}</h4>
   <div class="row">
     <div class="col-md-12">
       <div class="alert alert-info" role="alert">
         <i class="material-icons">help</i>
         <p>
-          {{ trans('You can specify product reference(s) for each associated supplier. Click "Save" after changing selected suppliers to display the associated product references.', {}, 'AdminProducts')|raw }}
+          {{ 'You can specify product reference(s) for each associated supplier. Click "Save" after changing selected suppliers to display the associated product references.'|trans({}, 'AdminProducts')|raw }}
         </p>
       </div>
     </div>
@@ -22,10 +22,10 @@
         <table class="table table-striped">
           <thead>
             <tr class="text-uppercase">
-              <th width="40%">{{ trans('Product name', {}, 'AdminProducts') }}</th>
-              <th width="20%">{{ trans('Supplier reference', {}, 'AdminProducts') }}</th>
-              <th width="20%">{{ trans('Unit price tax excluded', {}, 'AdminProducts') }}</th>
-              <th width="20%">{{ trans('Unit price currency', {}, 'AdminProducts') }}</th>
+              <th width="40%">{{ 'Product name'|trans({}, 'AdminProducts') }}</th>
+              <th width="20%">{{ 'Supplier reference'|trans({}, 'AdminProducts') }}</th>
+              <th width="20%">{{ 'Unit price tax excluded'|trans({}, 'AdminProducts') }}</th>
+              <th width="20%">{{ 'Unit price currency'|trans({}, 'AdminProducts') }}</th>
             </tr>
           </thead>
           <tbody>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-warehouse-combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-warehouse-combination.html.twig
@@ -1,11 +1,11 @@
 {% if warehouses|length > 0 %}
-    <h4>{{ 'Product location in warehouses'|trans([], 'AdminProducts') }}</h4>
+    <h4>{{ 'Product location in warehouses'|trans({}, 'AdminProducts') }}</h4>
 
     <div class="alert alert-info" style="display:block; position: 'auto';">
-        <p>{{ 'This interface allows you to specify the warehouse in which the product is stocked.'|trans([], 'AdminProducts') }}</p>
-        <p>{{ 'You can also specify product/product combinations as it relates to warehouse location. '|trans([], 'AdminProducts') }}</p>
+        <p>{{ 'This interface allows you to specify the warehouse in which the product is stocked.'|trans({}, 'AdminProducts') }}</p>
+        <p>{{ 'You can also specify product/product combinations as it relates to warehouse location. '|trans({}, 'AdminProducts') }}</p>
     </div>
-    <p>{{ 'Please choose the warehouses associated with this product.'|trans([], 'AdminProducts') }}</p>
+    <p>{{ 'Please choose the warehouses associated with this product.'|trans({}, 'AdminProducts') }}</p>
 
     {% for warehouse in warehouses %}
         <div class="panel panel-default">
@@ -15,7 +15,7 @@
                     <h4>{{ form[collectionName].vars.label }}</h4><br/>
                     {% if form[collectionName]|length() > 1 %}
                         <button type="button" class="btn btn-default check_all_warehouse">
-                            <i class="icon-check-sign"></i> {{ 'Mark / Unmark all'|trans([], 'AdminTab') }}
+                            <i class="icon-check-sign"></i> {{ 'Mark / Unmark all'|trans({}, 'AdminTab') }}
                         </button>
                     {% endif %}
                 </label>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-warehouse-combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-warehouse-combination.html.twig
@@ -1,11 +1,11 @@
 {% if warehouses|length > 0 %}
-    <h4>{{ trans('Product location in warehouses', [], 'AdminProducts') }}</h4>
+    <h4>{{ 'Product location in warehouses'|trans([], 'AdminProducts') }}</h4>
 
     <div class="alert alert-info" style="display:block; position: 'auto';">
-        <p>{{ trans('This interface allows you to specify the warehouse in which the product is stocked.', [], 'AdminProducts') }}</p>
-        <p>{{ trans('You can also specify product/product combinations as it relates to warehouse location. ', [], 'AdminProducts') }}</p>
+        <p>{{ 'This interface allows you to specify the warehouse in which the product is stocked.'|trans([], 'AdminProducts') }}</p>
+        <p>{{ 'You can also specify product/product combinations as it relates to warehouse location. '|trans([], 'AdminProducts') }}</p>
     </div>
-    <p>{{ trans('Please choose the warehouses associated with this product.', [], 'AdminProducts') }}</p>
+    <p>{{ 'Please choose the warehouses associated with this product.'|trans([], 'AdminProducts') }}</p>
 
     {% for warehouse in warehouses %}
         <div class="panel panel-default">
@@ -15,7 +15,7 @@
                     <h4>{{ form[collectionName].vars.label }}</h4><br/>
                     {% if form[collectionName]|length() > 1 %}
                         <button type="button" class="btn btn-default check_all_warehouse">
-                            <i class="icon-check-sign"></i> {{ trans('Mark / Unmark all', [], 'AdminTab') }}
+                            <i class="icon-check-sign"></i> {{ 'Mark / Unmark all'|trans([], 'AdminTab') }}
                         </button>
                     {% endif %}
                 </label>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -22,15 +22,15 @@
         </div>
         <div id="combination_form_{{ form.vars.value.id_product_attribute }}" data="{{ form.vars.value.id_product_attribute }}" class="combination-form hide row">
             <div class="col-xs-12 text-xs-right nav">
-                <a class="btn-sensitive prev pull-left"><i class="material-icons">keyboard_arrow_left</i> {{ trans('Prev. combination', [], 'AdminTabs') }}</a>
-                <a class="next btn-sensitive">{{ trans('Next combination', [], 'AdminTabs') }} <i class="material-icons">keyboard_arrow_right</i></a>
+                <a class="btn-sensitive prev pull-left"><i class="material-icons">keyboard_arrow_left</i> {{ 'Prev. combination'|trans([], 'AdminTabs') }}</a>
+                <a class="next btn-sensitive">{{ 'Next combination'|trans([], 'AdminTabs') }} <i class="material-icons">keyboard_arrow_right</i></a>
             </div>
             <div class="panel col-md-12 p-t-2 p-b-2">
                 <div class="pull-left">
-                    <button type="button" class="btn btn-tertiary-outline btn-back"><i class="material-icons">arrow_back</i> {{ trans('Back to product', [], 'AdminTabs') }}</button>
+                    <button type="button" class="btn btn-tertiary-outline btn-back"><i class="material-icons">arrow_back</i> {{ 'Back to product'|trans([], 'AdminTabs') }}</button>
                 </div>
                 <h2 class="title p-t-2">
-                  {{ trans("Combination details",{}, 'AdminProducts') }} -
+                  {{ "Combination details"|trans({}, 'AdminProducts') }} -
                   {{ form.vars.value.name }}
                 </h2>
                 {{ form_widget(form.attribute_default) }}
@@ -54,7 +54,7 @@
                           <label class="combination-label">
                             {{ form.attribute_minimal_quantity.vars.label }}
                             <span class="help-box" data-toggle="popover"
-                              data-content="{{ trans("The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.",{}, 'AdminProducts') }}" ></span>
+                              data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'AdminProducts') }}" ></span>
                           </label>
                           {{ form_widget(form.attribute_minimal_quantity) }}
                       </fieldset>
@@ -67,7 +67,7 @@
                     </div>
                 </div>
                 <h2 class="title">
-                  {{ trans("Price and impact",{}, 'AdminProducts') }}
+                  {{ "Price and impact"|trans({}, 'AdminProducts') }}
                 </h2>
                 <div class="row">
                     <div class="col-md-3">
@@ -81,7 +81,7 @@
                             <label class="combination-label">
                               {{ form.attribute_price.vars.label }}
                               <span class="help-box" data-toggle="popover"
-                                data-content="{{ trans("Does this combination have a different price? Is it cheaper or more expensive than the default retail price?",{}, 'AdminProducts') }}" ></span>
+                                data-content="{{ "Does this combination have a different price? Is it cheaper or more expensive than the default retail price?"|trans({}, 'AdminProducts') }}" ></span>
                             </label>
                             {{ form_widget(form.attribute_price) }}
                         </fieldset>
@@ -93,7 +93,7 @@
                         </fieldset>
                     </div>
                     <div class="col-md-3">
-                      <small class="combination-label vcenter">{{ trans("Final retail price (tax excl.) will be €00.00",{}, 'AdminProducts') }}</small>
+                      <small class="combination-label vcenter">{{ "Final retail price (tax excl.) will be €00.00"|trans({}, 'AdminProducts') }}</small>
                     </div>
                 </div>
                 <div class="row">
@@ -108,7 +108,7 @@
                             <label class="combination-label">
                               {{ form.attribute_unity.vars.label }}
                               <span class="help-box" data-toggle="popover"
-                                data-content="{{ trans("Does this combination have a different price per unit?",{}, 'AdminProducts') }}" ></span>
+                                data-content="{{ "Does this combination have a different price per unit?"|trans({}, 'AdminProducts') }}" ></span>
                             </label>
                             {{ form_widget(form.attribute_unity) }}
                         </fieldset>
@@ -124,7 +124,7 @@
                     </div>
                 </div>
                 <h2 class="title">
-                  {{ trans("Specific references",{}, 'AdminProducts') }}
+                  {{ "Specific references"|trans({}, 'AdminProducts') }}
                 </h2>
                 <div class="row">
                     <div class="col-md-4">
@@ -138,7 +138,7 @@
                             <label class="combination-label">
                               {{ form.attribute_ean13.vars.label }}
                               <span class="help-box" data-toggle="popover"
-                                data-content="{{ trans("This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America.",{}, 'AdminProducts') }}" ></span>
+                                data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'AdminProducts') }}" ></span>
                             </label>
                             {{ form_widget(form.attribute_ean13) }}
                         </fieldset>
@@ -151,7 +151,7 @@
                     </div>
                 </div>
                 <h2 class="title">
-                  {{ trans("Images",{}, 'AdminProducts') }}
+                  {{ "Images"|trans({}, 'AdminProducts') }}
                 </h2>
                 <div class="row">
                   <div class="col-md-12">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -22,12 +22,12 @@
         </div>
         <div id="combination_form_{{ form.vars.value.id_product_attribute }}" data="{{ form.vars.value.id_product_attribute }}" class="combination-form hide row">
             <div class="col-xs-12 text-xs-right nav">
-                <a class="btn-sensitive prev pull-left"><i class="material-icons">keyboard_arrow_left</i> {{ 'Prev. combination'|trans([], 'AdminTabs') }}</a>
-                <a class="next btn-sensitive">{{ 'Next combination'|trans([], 'AdminTabs') }} <i class="material-icons">keyboard_arrow_right</i></a>
+                <a class="btn-sensitive prev pull-left"><i class="material-icons">keyboard_arrow_left</i> {{ 'Prev. combination'|trans({}, 'AdminTabs') }}</a>
+                <a class="next btn-sensitive">{{ 'Next combination'|trans({}, 'AdminTabs') }} <i class="material-icons">keyboard_arrow_right</i></a>
             </div>
             <div class="panel col-md-12 p-t-2 p-b-2">
                 <div class="pull-left">
-                    <button type="button" class="btn btn-tertiary-outline btn-back"><i class="material-icons">arrow_back</i> {{ 'Back to product'|trans([], 'AdminTabs') }}</button>
+                    <button type="button" class="btn btn-tertiary-outline btn-back"><i class="material-icons">arrow_back</i> {{ 'Back to product'|trans({}, 'AdminTabs') }}</button>
                 </div>
                 <h2 class="title p-t-2">
                   {{ "Combination details"|trans({}, 'AdminProducts') }} -

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -1,15 +1,15 @@
 <div id="combinations">
   <h2>
-    {{ trans('Product combinations', [], 'AdminProducts') }}
+    {{ 'Product combinations'|trans([], 'AdminProducts') }}
     <span
       class="help-box"
       data-toggle="popover"
-      data-content="{{ trans("Creating combinations: \n Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. To create a combination, you need to create your product attributes first. Go to Catalog > Product Attributes for this!", {}, 'AdminProducts')|raw }}"
+      data-content="{{ "Creating combinations: \n Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. To create a combination, you need to create your product attributes first. Go to Catalog > Product Attributes for this!"|trans({}, 'AdminProducts')|raw }}"
     ></span>
   </h2>
   <div id="attributes-generator">
     <p>
-      {{ trans('Create a series of combinations by entering the related attributes below.', [], 'AdminProducts') }}
+      {{ 'Create a series of combinations by entering the related attributes below.'|trans([], 'AdminProducts') }}
     </p>
     <div class="row">
       <div class="col-md-10">
@@ -33,10 +33,10 @@
       <thead id="combinations_thead" {% if form.combinations|length == 0 %}style="display: none;"{% endif %}>
       <tr class="uppercase">
         <th></th>
-        <th>{{ trans('Combination', {}, 'AdminProducts') }}</th>
-        <th>{{ trans('Impact on price', {}, 'AdminProducts') }}</th>
-        <th>{{ trans('Final price', {}, 'AdminProducts') }}</th>
-        <th>{{ trans('Quantity', {}, 'AdminProducts') }}</th>
+        <th>{{ 'Combination'|trans({}, 'AdminProducts') }}</th>
+        <th>{{ 'Impact on price'|trans({}, 'AdminProducts') }}</th>
+        <th>{{ 'Final price'|trans({}, 'AdminProducts') }}</th>
+        <th>{{ 'Quantity'|trans({}, 'AdminProducts') }}</th>
         <th></th>
       </tr>
       </thead>
@@ -54,11 +54,11 @@
   <div class="row">
 
     <div class="col-md-12">
-      <h2>{{ trans('Availability preferences', [], 'AdminProducts') }}</h2>
+      <h2>{{ 'Availability preferences'|trans([], 'AdminProducts') }}</h2>
     </div>
 
     <div class="col-md-12">
-      <label class="form-control-label">{{ trans('Behavior when out of stock', [], 'AdminProducts') }}</label>
+      <label class="form-control-label">{{ 'Behavior when out of stock'|trans([], 'AdminProducts') }}</label>
       {{ form_errors(form.out_of_stock) }}
       {{ form_widget(form.out_of_stock) }}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -1,6 +1,6 @@
 <div id="combinations">
   <h2>
-    {{ 'Product combinations'|trans([], 'AdminProducts') }}
+    {{ 'Product combinations'|trans({}, 'AdminProducts') }}
     <span
       class="help-box"
       data-toggle="popover"
@@ -9,7 +9,7 @@
   </h2>
   <div id="attributes-generator">
     <p>
-      {{ 'Create a series of combinations by entering the related attributes below.'|trans([], 'AdminProducts') }}
+      {{ 'Create a series of combinations by entering the related attributes below.'|trans({}, 'AdminProducts') }}
     </p>
     <div class="row">
       <div class="col-md-10">
@@ -54,11 +54,11 @@
   <div class="row">
 
     <div class="col-md-12">
-      <h2>{{ 'Availability preferences'|trans([], 'AdminProducts') }}</h2>
+      <h2>{{ 'Availability preferences'|trans({}, 'AdminProducts') }}</h2>
     </div>
 
     <div class="col-md-12">
-      <label class="form-control-label">{{ 'Behavior when out of stock'|trans([], 'AdminProducts') }}</label>
+      <label class="form-control-label">{{ 'Behavior when out of stock'|trans({}, 'AdminProducts') }}</label>
       {{ form_errors(form.out_of_stock) }}
       {{ form_widget(form.out_of_stock) }}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_manufacturer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_manufacturer.html.twig
@@ -1,5 +1,5 @@
 <div id="manufacturer-content" class="{{ form.vars.value == '' ? 'hide':'' }}">
-  <h2>{{ trans("Brand", {}, 'AdminProducts') }}</h2>
+  <h2>{{ "Brand"|trans({}, 'AdminProducts') }}</h2>
   <div class="row">
     <div class="col-md-8">
       <fieldset class="form-group">
@@ -19,7 +19,7 @@
 <div class="row">
   <div class="col-md-4">
     <button type="button" class="btn btn-primary-outline sensitive open {{ form.vars.value != '' ? 'hide':'' }}" id="add_brand_button">
-      <i class="material-icons">add_circle</i> {{ trans('Add a brand', {}, 'AdminProducts') }}
+      <i class="material-icons">add_circle</i> {{ 'Add a brand'|trans({}, 'AdminProducts') }}
     </button>
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_related_products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_related_products.html.twig
@@ -1,6 +1,6 @@
 <div id="related-content" class="row {{ form.vars.value.data|length == 0 ? 'hide':'' }}">
   <div class="col-md-12">
-    <h2>{{ trans("Related product", {}, 'AdminProducts') }}</h2>
+    <h2>{{ "Related product"|trans({}, 'AdminProducts') }}</h2>
   </div>
   <div class="col-md-8">
     <fieldset class="form-group">
@@ -16,7 +16,7 @@
 <div class="row">
   <div class="col-md-4">
     <button type="button" class="btn btn-primary-outline sensitive open {{ form.vars.value.data|length > 0 ? 'hide':'' }}" id="add-related-product-button">
-      <i class="material-icons">add_circle</i> {{ trans('Add a related product', {}, 'AdminProducts') }}
+      <i class="material-icons">add_circle</i> {{ 'Add a related product'|trans({}, 'AdminProducts') }}
     </button>
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
@@ -55,11 +55,11 @@
           {% if 'PS_REWRITING_SETTINGS'|configuration == 0 %}
             <strong>{{ 'Friendly URLs are currently disabled.'|trans({}, 'AdminProducts') }}</strong>
             {{ 'To enable it, got to'|trans({}, 'AdminProducts') }}
-            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ 'SEO and URLS'|trans([], 'AdminProducts') }}</a>
+            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ 'SEO and URLS'|trans({}, 'AdminProducts') }}</a>
           {% else %}
             <strong>{{ 'Friendly URLs are currently enabled.'|trans({}, 'AdminProducts') }}</strong>
             {{ 'To disable it, got to'|trans({}, 'AdminProducts') }}
-            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ 'SEO and URLS'|trans([], 'AdminProducts') }}</a>
+            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ 'SEO and URLS'|trans({}, 'AdminProducts') }}</a>
           {% endif %}
         </p>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
@@ -1,7 +1,7 @@
 <div class="col-md-12">
 
-  <h2>{{ trans('Search Engine Optimization', {}, 'AdminProducts') }}</h2>
-  <p class="subtitle">{{ trans('Improve your ranking and how your product page will appear in search engines results.', {}, 'AdminProducts') }}</p>
+  <h2>{{ 'Search Engine Optimization'|trans({}, 'AdminProducts') }}</h2>
+  <p class="subtitle">{{ 'Improve your ranking and how your product page will appear in search engines results.'|trans({}, 'AdminProducts') }}</p>
 
   <div class="row">
     <div class="col-md-9">
@@ -9,7 +9,7 @@
         <label class="form-control-label">
           {{ form.meta_title.vars.label }}
           <span class="help-box" data-toggle="popover"
-            data-content="{{ trans("Public title for the product's page, and for search engines. Leave blank to use the product name. The number of remaining characters is displayed to the left of the field.",{}, 'AdminProducts') }}" ></span>
+            data-content="{{ "Public title for the product's page, and for search engines. Leave blank to use the product name. The number of remaining characters is displayed to the left of the field."|trans({}, 'AdminProducts') }}" ></span>
         </label>
         {{ form_errors(form.meta_title) }}
         {{ form_widget(form.meta_title) }}
@@ -23,7 +23,7 @@
         <label class="form-control-label">
           {{ form.meta_description.vars.label }}
           <span class="help-box" data-toggle="popover"
-            data-content="{{ trans("This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces).",{}, 'AdminProducts') }}" ></span>
+            data-content="{{ "This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)."|trans({}, 'AdminProducts') }}" ></span>
         </label>
         {{ form_errors(form.meta_description) }}
         {{ form_widget(form.meta_description) }}
@@ -34,7 +34,7 @@
     <label class="form-control-label">
       {{ form.link_rewrite.vars.label }}
       <span class="help-box" data-toggle="popover"
-        data-content="{{ trans("This is the human-readable URL, as generated from the product's name. You can change it if you want.",{}, 'AdminProducts') }}" ></span>
+        data-content="{{ "This is the human-readable URL, as generated from the product's name. You can change it if you want."|trans({}, 'AdminProducts') }}" ></span>
     </label>
     {{ form_errors(form.link_rewrite) }}
     <div class="row">
@@ -42,7 +42,7 @@
         {{ form_widget(form.link_rewrite) }}
       </div>
       <div class="col-md-2">
-        <button type="button" class="btn-action btn btn-action btn-block text-uppercase" id="seo-url-regenerate">{{ trans('Reset URL', {}, 'AdminProducts') }}</button>
+        <button type="button" class="btn-action btn btn-action btn-block text-uppercase" id="seo-url-regenerate">{{ 'Reset URL'|trans({}, 'AdminProducts') }}</button>
       </div>
     </div>
   </fieldset>
@@ -53,13 +53,13 @@
         <i class="material-icons">help</i>
         <p class="alert-text">
           {% if 'PS_REWRITING_SETTINGS'|configuration == 0 %}
-            <strong>{{ trans('Friendly URLs are currently disabled.', {}, 'AdminProducts') }}</strong>
-            {{ trans('To enable it, got to', {}, 'AdminProducts') }}
-            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ trans('SEO and URLS', [], 'AdminProducts') }}</a>
+            <strong>{{ 'Friendly URLs are currently disabled.'|trans({}, 'AdminProducts') }}</strong>
+            {{ 'To enable it, got to'|trans({}, 'AdminProducts') }}
+            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ 'SEO and URLS'|trans([], 'AdminProducts') }}</a>
           {% else %}
-            <strong>{{ trans('Friendly URLs are currently enabled.', {}, 'AdminProducts') }}</strong>
-            {{ trans('To disable it, got to', {}, 'AdminProducts') }}
-            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ trans('SEO and URLS', [], 'AdminProducts') }}</a>
+            <strong>{{ 'Friendly URLs are currently enabled.'|trans({}, 'AdminProducts') }}</strong>
+            {{ 'To disable it, got to'|trans({}, 'AdminProducts') }}
+            <a href="{{ getAdminLink("AdminMeta") }}#meta_fieldset_general">{{ 'SEO and URLS'|trans([], 'AdminProducts') }}</a>
           {% endif %}
         </p>
       </div>
@@ -67,9 +67,9 @@
   </div>
 
   <h2>
-    {{ trans('Redirection page', {}, 'AdminProducts') }}
+    {{ 'Redirection page'|trans({}, 'AdminProducts') }}
     <span class="help-box" data-toggle="popover"
-      data-content="{{ trans("When your product is disabled, choose to which page you’d like to redirect the customers visiting its page.",{}, 'AdminProducts') }}" ></span>
+      data-content="{{ "When your product is disabled, choose to which page you’d like to redirect the customers visiting its page."|trans({}, 'AdminProducts') }}" ></span>
   </h2>
 
   <div class="row">
@@ -96,9 +96,9 @@
       <div class="alert alert-info" role="alert">
         <i class="material-icons">help</i>
         <p class="alert-text">
-          {{ trans('No redirection (404) = Do not redirect anywhere and display a 404 « Not Found » page.', {}, 'AdminProducts') }}<br>
-          {{ trans('Permanent redirection (301) = Permanently display another product instead.', {}, 'AdminProducts') }}<br>
-          {{ trans('Temporary redirection (302) = Temporarily display another product instead.', {}, 'AdminProducts') }}
+          {{ 'No redirection (404) = Do not redirect anywhere and display a 404 « Not Found » page.'|trans({}, 'AdminProducts') }}<br>
+          {{ 'Permanent redirection (301) = Permanently display another product instead.'|trans({}, 'AdminProducts') }}<br>
+          {{ 'Temporary redirection (302) = Temporarily display another product instead.'|trans({}, 'AdminProducts') }}
         </p>
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_shipping.html.twig
@@ -1,8 +1,8 @@
 {% set dimension_unit, weight_unit = 'PS_DIMENSION_UNIT'|configuration, 'PS_WEIGHT_UNIT'|configuration %}
 
 <div class="col-md-12 p-b-1">
-  <h2>{{ 'Package dimension'|trans([], 'AdminProducts') }}</h2>
-  <p class="subtitle">{{ 'Adjust your shipping costs by filling in the product dimensions.'|trans([], 'AdminProducts') }}</p>
+  <h2>{{ 'Package dimension'|trans({}, 'AdminProducts') }}</h2>
+  <p class="subtitle">{{ 'Adjust your shipping costs by filling in the product dimensions.'|trans({}, 'AdminProducts') }}</p>
 </div>
 
 <div class="col-md-2">
@@ -53,7 +53,7 @@
       <span class="help-box" data-toggle="popover"
         data-content="{{ "If a carrier has a tax, it will be added to the shipping fees."|trans({}, 'AdminProducts') }}" ></span>
     </h2>
-    <label class="form-control-label">{{ 'Does this product incur additional shipping cost?'|trans([], 'AdminProducts') }}</label>
+    <label class="form-control-label">{{ 'Does this product incur additional shipping cost?'|trans({}, 'AdminProducts') }}</label>
     <div class="row">
       <div class="col-md-2">
         {{ form_widget(form.additional_shipping_cost) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_shipping.html.twig
@@ -1,8 +1,8 @@
 {% set dimension_unit, weight_unit = 'PS_DIMENSION_UNIT'|configuration, 'PS_WEIGHT_UNIT'|configuration %}
 
 <div class="col-md-12 p-b-1">
-  <h2>{{ trans('Package dimension', [], 'AdminProducts') }}</h2>
-  <p class="subtitle">{{ trans('Adjust your shipping costs by filling in the product dimensions.', [], 'AdminProducts') }}</p>
+  <h2>{{ 'Package dimension'|trans([], 'AdminProducts') }}</h2>
+  <p class="subtitle">{{ 'Adjust your shipping costs by filling in the product dimensions.'|trans([], 'AdminProducts') }}</p>
 </div>
 
 <div class="col-md-2">
@@ -51,9 +51,9 @@
     <h2>
       {{ form.additional_shipping_cost.vars.label }}
       <span class="help-box" data-toggle="popover"
-        data-content="{{ trans("If a carrier has a tax, it will be added to the shipping fees.",{}, 'AdminProducts') }}" ></span>
+        data-content="{{ "If a carrier has a tax, it will be added to the shipping fees."|trans({}, 'AdminProducts') }}" ></span>
     </h2>
-    <label class="form-control-label">{{ trans('Does this product incur additional shipping cost?', [], 'AdminProducts') }}</label>
+    <label class="form-control-label">{{ 'Does this product incur additional shipping cost?'|trans([], 'AdminProducts') }}</label>
     <div class="row">
       <div class="col-md-2">
         {{ form_widget(form.additional_shipping_cost) }}
@@ -72,7 +72,7 @@
 <div class="col-md-12">
   <div class="alert alert-warning" role="alert">
     <i class="material-icons">info_outline</i>
-    <p>{{ trans('If no carrier is selected then all the carriers will be available for customers orders.', {}, 'AdminProducts')|raw }}</p>
+    <p>{{ 'If no carrier is selected then all the carriers will be available for customers orders.'|trans({}, 'AdminProducts')|raw }}</p>
   </div>
 </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
@@ -20,33 +20,33 @@
         <div class="row">
           <div class="pull-right">
             <a id="desc-product-export" class="list-toolbar-btn" href="{{ path('admin_product_export_action') }}">
-              <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{{ trans("Export", {}, 'AdminTab') }}" data-html="true" data-placement="top">
+              <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{{ "Export"|trans({}, 'AdminTab') }}" data-html="true" data-placement="top">
                 <i class="material-icons">cloud_upload</i>
               </span>
             </a>
             <a id="desc-product-import" class="list-toolbar-btn" href="{{ import_link }}">
-              <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{{ trans("Import", {}, 'AdminTab') }}" data-html="true" data-placement="top">
+              <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{{ "Import"|trans({}, 'AdminTab') }}" data-html="true" data-placement="top">
                 <i class="material-icons">cloud_download</i>
               </span>
             </a>
             <a id="desc-product-show-sql" class="list-toolbar-btn" href="javascript:void(0);" onclick="showLastSqlQuery();">
-              <span class="label-tooltip" data-toggle="tooltip" data-original-title="{{ trans("Show SQL query", {}, 'AdminTab') }}" data-html="true" data-placement="top">
+              <span class="label-tooltip" data-toggle="tooltip" data-original-title="{{ "Show SQL query"|trans({}, 'AdminTab') }}" data-html="true" data-placement="top">
                 <i class="material-icons">code</i>
               </span>
             </a>
             <a id="desc-product-sql-manager" class="list-toolbar-btn" href="javascript:void(0);" onclick="sendLastSqlQuery(createSqlQueryName());">
-              <span class="label-tooltip" data-toggle="tooltip" data-original-title="{{ trans("Export to SQL Manager", {}, 'AdminTab') }}" data-html="true" data-placement="top">
+              <span class="label-tooltip" data-toggle="tooltip" data-original-title="{{ "Export to SQL Manager"|trans({}, 'AdminTab') }}" data-html="true" data-placement="top">
                 <i class="material-icons">storage</i>
               </span>
             </a>
           </div>
           <h2>
-            {{ trans("Products", {}, 'AdminProducts') }}
+            {{ "Products"|trans({}, 'AdminProducts') }}
             {% if has_category_filter == true and activate_drag_and_drop == true %}
-              {{ trans("(ordering)", {}, 'AdminProducts') }}
+              {{ "(ordering)"|trans({}, 'AdminProducts') }}
             {% else %}
               {% if has_filter == true %}
-                {{ trans("(filtered)", {}, 'AdminProducts') }}
+                {{ "(filtered)"|trans({}, 'AdminProducts') }}
               {% endif %}
             {% endif %}
             {% if has_filter == true %}{{ product_count_filtered }} / {{ product_count }}{% endif %}
@@ -66,7 +66,7 @@
               class="btn btn-primary-outline btn-xs"
               id="product_catalog_category_tree_filter_expand"
             >
-              {{ trans('Expand All', {}, 'AdminTab') }}
+              {{ 'Expand All'|trans({}, 'AdminTab') }}
             </button>
             <button
               name="product_catalog_category_tree_filter_collapse"
@@ -74,7 +74,7 @@
               class="btn btn-primary-outline btn-xs"
               id="product_catalog_category_tree_filter_collapse"
             >
-              {{ trans('Collapse All', {}, 'AdminTab') }}
+              {{ 'Collapse All'|trans({}, 'AdminTab') }}
             </button>
             <button
               name="product_catalog_category_tree_filter_reset"
@@ -82,7 +82,7 @@
               class="btn btn-warning"
               id="product_catalog_category_tree_filter_reset"
             >
-              {{ trans('Unselect', {}, 'AdminTab') }}
+              {{ 'Unselect'|trans({}, 'AdminTab') }}
             </button>
           </div>
         </div>
@@ -116,56 +116,56 @@
               <thead>
                 <tr class="column-headers">
                   <th style="width: 8%">
-                    {{ trans("ID", {}, 'AdminProducts') }}
+                    {{ "ID"|trans({}, 'AdminProducts') }}
                     {% include 'PrestaShopBundle:Admin/Product/Include:catalog_order_carrets.html.twig' with {
                       'column': 'id_product'
                     } %}
                   </th>
                   <th>
-                    {{ trans("Image", {}, 'AdminProducts') }}
+                    {{ "Image"|trans({}, 'AdminProducts') }}
                   </th>
                   <th>
-                    {{ trans("Name", {}, 'AdminProducts') }}
+                    {{ "Name"|trans({}, 'AdminProducts') }}
                     {% include 'PrestaShopBundle:Admin/Product/Include:catalog_order_carrets.html.twig' with {
                       'column': 'name'
                     } %}
                   </th>
                   <th style="width: 9%">
-                    {{ trans("Reference", {}, 'AdminProducts') }}
+                    {{ "Reference"|trans({}, 'AdminProducts') }}
                     {% include 'PrestaShopBundle:Admin/Product/Include:catalog_order_carrets.html.twig' with {
                       'column': 'reference'
                     } %}
                   </th>
                   <th>
-                    {{ trans("Category", {}, 'AdminProducts') }}
+                    {{ "Category"|trans({}, 'AdminProducts') }}
                     {% include 'PrestaShopBundle:Admin/Product/Include:catalog_order_carrets.html.twig' with {
                       'column': 'name_category'
                     } %}
                   </th>
                   <th style="width: 9%">
-                    {{ trans("Base price", {}, 'AdminProducts') }}
+                    {{ "Base price"|trans({}, 'AdminProducts') }}
                     {% include 'PrestaShopBundle:Admin/Product/Include:catalog_order_carrets.html.twig' with {
                       'column': 'price'
                     } %}
                   </th>
                   <th>
-                    {{ trans("Final price", {}, 'AdminProducts') }}
+                    {{ "Final price"|trans({}, 'AdminProducts') }}
                   </th>
                   <th style="width: 9%">
-                    {{ trans("Quantity", {}, 'AdminProducts') }}
+                    {{ "Quantity"|trans({}, 'AdminProducts') }}
                     {% include 'PrestaShopBundle:Admin/Product/Include:catalog_order_carrets.html.twig' with {
                       'column': 'sav_quantity'
                     } %}
                   </th>
                   <th>
-                    {{ trans("Status", {}, 'AdminProducts') }}
+                    {{ "Status"|trans({}, 'AdminProducts') }}
                     {% include 'PrestaShopBundle:Admin/Product/Include:catalog_order_carrets.html.twig' with {
                       'column': 'active'
                     } %}
                   </th>
                   {% if has_category_filter == true %}
                     <th>
-                      {{ trans("Position", {}, 'AdminProducts') }}
+                      {{ "Position"|trans({}, 'AdminProducts') }}
                       {% include 'PrestaShopBundle:Admin/Product/Include:catalog_order_carrets.html.twig' with {
                         'column': 'position'
                       } %}
@@ -179,8 +179,8 @@
                       'input_name': "filter_column_id_product",
                       'min': '0',
                       'max': '1000000',
-                      'minLabel': trans("Min", {}, 'AdminProducts'),
-                      'maxLabel': trans("Max", {}, 'AdminProducts'),
+                      'minLabel': "Min"|trans({}, 'AdminProducts'),
+                      'maxLabel': "Max"|trans({}, 'AdminProducts'),
                       'value': filter_column_id_product,
                     } %}
                   </th>
@@ -189,7 +189,7 @@
                     <input
                       type="text"
                       class="form-control"
-                      placeholder="{{ trans("Search name", {}, 'AdminProducts') }}"
+                      placeholder="{{ "Search name"|trans({}, 'AdminProducts') }}"
                       name="filter_column_name"
                       value="{{ filter_column_name }}"
                     />
@@ -198,7 +198,7 @@
                     <input
                       type="text"
                       class="form-control"
-                      placeholder="{{ trans("Search ref.", {}, 'AdminProducts') }}"
+                      placeholder="{{ "Search ref."|trans({}, 'AdminProducts') }}"
                       name="filter_column_reference"
                       value="{{ filter_column_reference }}"
                     />
@@ -207,7 +207,7 @@
                     <input
                       type="text"
                       class="form-control"
-                      placeholder="{{ trans("Search category", {}, 'AdminProducts') }}"
+                      placeholder="{{ "Search category"|trans({}, 'AdminProducts') }}"
                       name="filter_column_name_category"
                       value="{{ filter_column_name_category }}"
                     />
@@ -217,8 +217,8 @@
                       'input_name': "filter_column_price",
                       'min': '0',
                       'max': '1000000',
-                      'minLabel': trans("Min", {}, 'AdminProducts'),
-                      'maxLabel': trans("Max", {}, 'AdminProducts'),
+                      'minLabel': "Min"|trans({}, 'AdminProducts'),
+                      'maxLabel': "Max"|trans({}, 'AdminProducts'),
                       'value': filter_column_price,
                     } %}
                   </th>
@@ -228,8 +228,8 @@
                       'input_name': "filter_column_sav_quantity",
                       'min': '-1000000',
                       'max': '1000000',
-                      'minLabel': trans("Min", {}, 'AdminProducts'),
-                      'maxLabel': trans("Max", {}, 'AdminProducts'),
+                      'minLabel': "Min"|trans({}, 'AdminProducts'),
+                      'maxLabel': "Max"|trans({}, 'AdminProducts'),
                       'value': filter_column_sav_quantity,
                     } %}
                   </th>
@@ -243,7 +243,7 @@
                   {% if has_category_filter == true %}
                     <th>
                       {% if not(activate_drag_and_drop) %}
-                        <input type="button" class="btn" name="products_filter_position_asc" value="{{ trans("Sort", {}, 'AdminProducts') }}" onclick="productOrderPrioritiesTable();" />
+                        <input type="button" class="btn" name="products_filter_position_asc" value="{{ "Sort"|trans({}, 'AdminProducts') }}" onclick="productOrderPrioritiesTable();" />
                       {% endif %}
                     </th>
                   {% endif %}
@@ -252,7 +252,7 @@
                       type="submit"
                       class="btn btn-action"
                       name="products_filter_submit"
-                      title="{{ trans("Filter", {}, 'AdminProducts') }}"
+                      title="{{ "Filter"|trans({}, 'AdminProducts') }}"
                     >
                       <i class="material-icons">search</i>
                     </button>
@@ -261,7 +261,7 @@
                       class="btn btn-invisible"
                       name="products_filter_reset"
                       onclick="productColumnFilterReset($(this).closest('tr.column-filters'))"
-                      title="{{ trans("Reset", {}, 'AdminProducts') }}"
+                      title="{{ "Reset"|trans({}, 'AdminProducts') }}"
                     >
                       <i class="material-icons">clear</i>
                     </button>
@@ -289,7 +289,7 @@
                   id="bulk_action_select_all"
                   onclick="$(this).closest('form').find('table td.checkbox-column input:checkbox').prop('checked', $(this).prop('checked')); updateBulkMenu();"
                 />
-                {{ trans("Select all", {}, 'AdminTab') }}
+                {{ "Select all"|trans({}, 'AdminTab') }}
               </label>
             </div>
           </div>
@@ -307,35 +307,35 @@
               'div_style': "btn-group dropup",
               'button_id': "product_bulk_menu",
               'disabled': true,
-              'menu_label': trans("Bulk actions", {}, 'AdminTab'),
+              'menu_label': "Bulk actions"|trans({}, 'AdminTab'),
               'menu_icon': "icon-caret-up",
               'items':[{
                 "onclick": "bulkProductAction(this, 'activate_all');",
                 "icon": "radio_button_checked",
-                "label": trans("Activate selection", {}, 'AdminTab')
+                "label": "Activate selection"|trans({}, 'AdminTab')
               }, {
                 "onclick": "bulkProductAction(this, 'deactivate_all');",
                 "icon": "radio_button_unchecked",
-                "label": trans("Deactivate selection", {}, 'AdminTab')
+                "label": "Deactivate selection"|trans({}, 'AdminTab')
               }, {
                 "divider": true
               }, {
                 "onclick": "bulkProductAction(this, 'duplicate_all');",
                 "icon": "content_copy",
-                "label": trans("Duplicate selection", {}, 'AdminTab')
+                "label": "Duplicate selection"|trans({}, 'AdminTab')
               }, {
                 "divider": true
               }, {
                 "onclick": "bulkProductAction(this, 'delete_all');",
                 "icon": "delete",
-                "label": trans("Delete selection", {}, 'AdminTab')
+                "label": "Delete selection"|trans({}, 'AdminTab')
               }]
             }%}
           </div>
           <div class="col-md-8 text-md-right" id="bulk_edition_toolbar" style="display: none;">
-            <input type="button" id="bulk_edition_save_keep" class="btn" onclick="bulkProductAction(this, 'edition');" value="{{ trans("Save & refresh", {}, 'AdminProducts')|raw }}" />
-            <input type="submit" id="bulk_edition_save_next" class="btn btn-primary" onclick="return bulkProductAction(this, 'edition_next');" value="{{ trans("Save & next page", {}, 'AdminProducts')|raw }}" />
-            <input type="button" class="btn btn-warning" onclick="bulkProductEdition(this, 'cancel');" value="{{ trans("Cancel", {}, 'AdminProducts') }}" />
+            <input type="button" id="bulk_edition_save_keep" class="btn" onclick="bulkProductAction(this, 'edition');" value="{{ "Save & refresh"|trans({}, 'AdminProducts')|raw }}" />
+            <input type="submit" id="bulk_edition_save_next" class="btn btn-primary" onclick="return bulkProductAction(this, 'edition_next');" value="{{ "Save & next page"|trans({}, 'AdminProducts')|raw }}" />
+            <input type="button" class="btn btn-warning" onclick="bulkProductEdition(this, 'cancel');" value="{{ "Cancel"|trans({}, 'AdminProducts') }}" />
           </div>
         </div>
 
@@ -356,19 +356,19 @@
 
   {% embed 'PrestaShopBundle:Admin/Helpers:bootstrap_popup.html.twig' with {
     'id': "catalog_duplication_modal",
-    'title': trans("Duplication in progress...", {}, 'AdminProducts'),
+    'title': "Duplication in progress..."|trans({}, 'AdminProducts'),
     'closable': true,
     'progressbar': {
     'id': "catalog_duplication_progression",
-    'label': trans("Duplicating...", {}, 'AdminProducts')
+    'label': "Duplicating..."|trans({}, 'AdminProducts')
   },
     'actions': [],
   }%}
     {% block content %}
       <div class="modal-body">
-        {{ trans('Duplication can take time. Please wait...', {}, 'AdminProducts') }}
+        {{ 'Duplication can take time. Please wait...'|trans({}, 'AdminProducts') }}
         <span id="catalog_duplication_failure" style="display: none;color: darkred;">
-          {{ trans('Duplication failed!', {}, 'AdminProducts') }}
+          {{ 'Duplication failed!'|trans({}, 'AdminProducts') }}
         </span>
       </div>
     {% endblock %}
@@ -376,29 +376,29 @@
 
   {% embed 'PrestaShopBundle:Admin/Helpers:bootstrap_popup.html.twig' with {
     'id': "catalog_deletion_modal",
-    'title': trans("Please confirm deletion", {}, 'AdminProducts'),
+    'title': "Please confirm deletion"|trans({}, 'AdminProducts'),
     'closable': true,
     'actions': [{
       'type': 'button',
-      'label': trans("Delete now", {}, 'AdminProducts'),
+      'label': "Delete now"|trans({}, 'AdminProducts'),
       'value': 'confirm',
       'class': 'btn btn-warning',
     }],
   }%}
     {% block content %}
       <div class="modal-body">
-        {{ trans('Deletion is permanent. Please confirm.', {}, 'AdminProducts') }}
+        {{ 'Deletion is permanent. Please confirm.'|trans({}, 'AdminProducts') }}
       </div>
     {% endblock %}
   {% endembed %}
 
   {% embed 'PrestaShopBundle:Admin/Helpers:bootstrap_popup.html.twig' with {
     'id': "catalog_sql_query_modal",
-    'title': trans("SQL query", {}, 'AdminProducts'),
+    'title': "SQL query"|trans({}, 'AdminProducts'),
     'closable': true,
     'actions': [{
       'type': 'button',
-      'label': trans("Export to SQL Manager", {}, 'AdminTab'),
+      'label': "Export to SQL Manager"|trans({}, 'AdminTab'),
       'value': 'sql_manager',
       'class': 'btn',
     }],

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog_empty.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog_empty.html.twig
@@ -6,10 +6,10 @@
       <i class="material-icons">add_shopping_cart</i>
     </div>
     <div class="m-t-1">
-      <a class="btn btn-primary" id="product_empty_list_add_btn" href="{{ path('admin_product_new') }}">{{ trans('Add your first product', [], 'AdminProducts') }}</a>
+      <a class="btn btn-primary" id="product_empty_list_add_btn" href="{{ path('admin_product_new') }}">{{ 'Add your first product'|trans([], 'AdminProducts') }}</a>
     </div>
     <div class="m-t-1">
-      <a href="{{ import_url }}" class="external-link" id="product_empty_list_go_to_import">{{ trans('or import a list of product (.csv file)', [], 'AdminProducts') }}</a>
+      <a href="{{ import_url }}" class="external-link" id="product_empty_list_go_to_import">{{ 'or import a list of product (.csv file)'|trans([], 'AdminProducts') }}</a>
     </div>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog_empty.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog_empty.html.twig
@@ -6,10 +6,10 @@
       <i class="material-icons">add_shopping_cart</i>
     </div>
     <div class="m-t-1">
-      <a class="btn btn-primary" id="product_empty_list_add_btn" href="{{ path('admin_product_new') }}">{{ 'Add your first product'|trans([], 'AdminProducts') }}</a>
+      <a class="btn btn-primary" id="product_empty_list_add_btn" href="{{ path('admin_product_new') }}">{{ 'Add your first product'|trans({}, 'AdminProducts') }}</a>
     </div>
     <div class="m-t-1">
-      <a href="{{ import_url }}" class="external-link" id="product_empty_list_go_to_import">{{ 'or import a list of product (.csv file)'|trans([], 'AdminProducts') }}</a>
+      <a href="{{ import_url }}" class="external-link" id="product_empty_list_go_to_import">{{ 'or import a list of product (.csv file)'|trans({}, 'AdminProducts') }}</a>
     </div>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -9,7 +9,7 @@
       {% if is_multishop_context %}
         <div class="col-md-12">
           <div class="alert alert-warning" role="alert">
-            <i class="material-icons">info_outline</i><p class="alert-text">{{ trans('Be carefull, you are in a multishop context, all modifcation will be apply to each shop or group shop', {}, 'AdminProducts') }}</p>
+            <i class="material-icons">info_outline</i><p class="alert-text">{{ 'Be carefull, you are in a multishop context, all modifcation will be apply to each shop or group shop'|trans({}, 'AdminProducts') }}</p>
           </div>
         </div>
       {% endif %}
@@ -22,7 +22,7 @@
           <div class="col-md-2 form_step1_type_product">
             {{ form_widget(form.step1.type_product) }}
             <span class="help-box pull-xs-right" data-toggle="popover"
-              data-content="{{ trans("Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, mail-sent product?", {}, 'AdminProducts') }}"></span>
+              data-content="{{ "Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, mail-sent product?"|trans({}, 'AdminProducts') }}"></span>
           </div>
           <div class="col-md-1 form_switch_language {{ languages|length == 1 ? 'hide' : '' }}">
             <select id="form_switch_language" class="form-control" data-toggle="select2">
@@ -32,34 +32,34 @@
             </select>
           </div>
           <div class="col-lg-2 text-md-right">
-            <a class="toolbar-button btn-sales" href="{{ stats_link }}" target="_blank" title="{{ trans('Sales', [], 'AdminTab') }}"
+            <a class="toolbar-button btn-sales" href="{{ stats_link }}" target="_blank" title="{{ 'Sales'|trans([], 'AdminTab') }}"
                id="product_form_go_to_sales">
               <i class="material-icons">assessment</i>
-              <span class="title">{{ trans('Sales', {}, 'AdminProducts') }}</span>
+              <span class="title">{{ 'Sales'|trans({}, 'AdminProducts') }}</span>
             </a>
 
             <a
               class="toolbar-button btn-quicknav btn-sidebar"
               href="#"
-              title="{{ trans('Quick navigation', [], 'AdminTab') }}"
+              title="{{ 'Quick navigation'|trans([], 'AdminTab') }}"
               data-toggle="sidebar"
               data-target="#right-sidebar"
               data-url="{{ path('admin_product_list', {limit: 'last', offset: 'last', view: 'quicknav'}) }}"
               id="product_form_open_quicknav"
             >
               <i class="material-icons">list</i>
-              <span class="title">{{ trans('Product list', {}, 'AdminProducts') }}</span>
+              <span class="title">{{ 'Product list'|trans({}, 'AdminProducts') }}</span>
             </a>
 
             <a class="toolbar-button btn-help btn-sidebar" href="#"
-               title="{{ trans('Help', [], 'AdminTab') }}"
+               title="{{ 'Help'|trans([], 'AdminTab') }}"
                data-toggle="sidebar"
                data-target="#right-sidebar"
                data-url="{{ help_link }}"
                id="product_form_open_help"
             >
               <i class="material-icons">help</i>
-              <span class="title">{{ trans('Help', {}, 'AdminProducts') }}</span>
+              <span class="title">{{ 'Help'|trans({}, 'AdminProducts') }}</span>
             </a>
           </div>
         </div>
@@ -83,14 +83,14 @@
     <div id="form-loading" class="col-md-10 col-md-offset-1">
 
       <ul class="nav nav-tabs" id="form-nav" role="tablist">
-        <li id="tab_step1" class="nav-item"><a href="#step1" role="tab" data-toggle="tab" class="nav-link active">{{ trans('Basic settings', {}, 'AdminProducts') }}</a></li>
-        <li id="tab_step3" class="nav-item"><a href="#step3" role="tab" data-toggle="tab" class="nav-link">{{ trans('Quantities', {}, 'AdminProducts') }}</a></li>
-        <li id="tab_step4" class="nav-item"><a href="#step4" role="tab" data-toggle="tab" class="nav-link">{{ trans('Shipping', {}, 'AdminProducts') }}</a></li>
-        <li id="tab_step2" class="nav-item"><a href="#step2" role="tab" data-toggle="tab" class="nav-link">{{ trans('Pricing', {}, 'AdminProducts') }}</a></li>
-        <li id="tab_step5" class="nav-item"><a href="#step5" role="tab" data-toggle="tab" class="nav-link">{{ trans('SEO', {}, 'AdminProducts') }}</a></li>
-        <li id="tab_step6" class="nav-item"><a href="#step6" role="tab" data-toggle="tab" class="nav-link">{{ trans('Options', {}, 'AdminProducts') }}</a></li>
+        <li id="tab_step1" class="nav-item"><a href="#step1" role="tab" data-toggle="tab" class="nav-link active">{{ 'Basic settings'|trans({}, 'AdminProducts') }}</a></li>
+        <li id="tab_step3" class="nav-item"><a href="#step3" role="tab" data-toggle="tab" class="nav-link">{{ 'Quantities'|trans({}, 'AdminProducts') }}</a></li>
+        <li id="tab_step4" class="nav-item"><a href="#step4" role="tab" data-toggle="tab" class="nav-link">{{ 'Shipping'|trans({}, 'AdminProducts') }}</a></li>
+        <li id="tab_step2" class="nav-item"><a href="#step2" role="tab" data-toggle="tab" class="nav-link">{{ 'Pricing'|trans({}, 'AdminProducts') }}</a></li>
+        <li id="tab_step5" class="nav-item"><a href="#step5" role="tab" data-toggle="tab" class="nav-link">{{ 'SEO'|trans({}, 'AdminProducts') }}</a></li>
+        <li id="tab_step6" class="nav-item"><a href="#step6" role="tab" data-toggle="tab" class="nav-link">{{ 'Options'|trans({}, 'AdminProducts') }}</a></li>
         {% if hookcount('displayAdminProductsExtra') > 0 %}
-          <li id="tab_hooks" class="nav-item"><a href="#hooks" role="tab" data-toggle="tab" class="nav-link">&laquo;{{ trans('Modules options', {}, 'AdminProducts') }}&raquo;</a></li>
+          <li id="tab_hooks" class="nav-item"><a href="#hooks" role="tab" data-toggle="tab" class="nav-link">&laquo;{{ 'Modules options'|trans({}, 'AdminProducts') }}&raquo;</a></li>
         {% endif %}
       </ul>
 
@@ -132,15 +132,15 @@
                               <div class="dz-success-mark"></div>
                               <div class="dz-error-mark"></div>
                               {% if image.cover %}
-                                <div class="iscover">{{ trans('Cover', {}, 'AdminProducts') }}</div>
+                                <div class="iscover">{{ 'Cover'|trans({}, 'AdminProducts') }}</div>
                               {% endif %}
                             </div>
                           {% endfor %}
                         {% endif %}
                       </div>
                       <div class="dropzone-expander text-xs-center">
-                        <span class="expand">{{ trans('View all images', {}, 'AdminProducts') }}</span>
-                        <span class="compress">{{ trans('View less', {}, 'AdminProducts') }}</span>
+                        <span class="expand">{{ 'View all images'|trans({}, 'AdminProducts') }}</span>
+                        <span class="compress">{{ 'View less'|trans({}, 'AdminProducts') }}</span>
                       </div>
                       <div id="product-images-form-container" class="col-lg-5 panel">
                         <div id="product-images-form" class="col-lg-12"></div>
@@ -148,8 +148,8 @@
                     </div>
 
                     <ul class="nav nav-tabs bordered">
-                      <li id="tab_description_short" class="nav-item"><a href="#description_short" data-toggle="tab" class="nav-link active">{{ trans('Summary', {}, 'AdminProducts') }}</a></li>
-                      <li id="tab_description" class="nav-item"><a href="#description" data-toggle="tab" class="nav-link">{{ trans('Description', {}, 'AdminProducts') }}</a></li>
+                      <li id="tab_description_short" class="nav-item"><a href="#description_short" data-toggle="tab" class="nav-link active">{{ 'Summary'|trans({}, 'AdminProducts') }}</a></li>
+                      <li id="tab_description" class="nav-item"><a href="#description" data-toggle="tab" class="nav-link">{{ 'Description'|trans({}, 'AdminProducts') }}</a></li>
                     </ul>
 
                     <div class="tab-content bordered">
@@ -163,7 +163,7 @@
 
                     <div id="features" class="m-b-1 m-t-1">
                       <div id="features-content" class="content {{ form.step1.features|length == 0 ? 'hide':'' }}">
-                        <h2>{{ trans('Features', [], 'AdminProducts') }}</h2>
+                        <h2>{{ 'Features'|trans([], 'AdminProducts') }}</h2>
                         {{ form_errors(form.step1.features) }}
                         <div
                           class="feature-collection nostyle"
@@ -178,7 +178,7 @@
                       </div>
                       <div class="row">
                         <div class="col-md-4">
-                          <button type="button" class="btn btn-primary-outline sensitive add" id="add_feature_button"><i class="material-icons">add_circle</i> {{ trans('Add a feature', {}, 'AdminProducts') }}</button>
+                          <button type="button" class="btn btn-primary-outline sensitive add" id="add_feature_button"><i class="material-icons">add_circle</i> {{ 'Add a feature'|trans({}, 'AdminProducts') }}</button>
                         </div>
                       </div>
                     </div>
@@ -201,27 +201,27 @@
 
                           <div class="form-group" id="show_variations_selector">
                             <h2>
-                              {{ trans("Combinations", {}, 'AdminProducts') }}
+                              {{ "Combinations"|trans({}, 'AdminProducts') }}
                               <span class="help-box" data-toggle="popover"
-                                data-content="{{ trans("Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?",{}, 'AdminProducts') }}" ></span>
+                                data-content="{{ "Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?"|trans({}, 'AdminProducts') }}" ></span>
                             </h2>
                             <div class="radio">
                               <label>
                                 <input type="radio" name="show_variations" value="0" {% if not has_combinations %}checked="checked"{% endif %}>
-                                {{ trans("Simple product", {}, 'AdminProducts') }}
+                                {{ "Simple product"|trans({}, 'AdminProducts') }}
                               </label>
                             </div>
                             <div class="radio">
                               <label>
                                 <input type="radio" name="show_variations" value="1" {% if has_combinations %}checked="checked"{% endif %}>
-                                {{ trans("Product with combinations", {}, 'AdminProducts') }}
+                                {{ "Product with combinations"|trans({}, 'AdminProducts') }}
                               </label>
                               <div id="product_type_combinations_shortcut">
                                 <span class="small font-secondary">
-                                  {{ trans("Advanced settings available in", {}, 'AdminProducts') }}
+                                  {{ "Advanced settings available in"|trans({}, 'AdminProducts') }}
                                 </span>
                                 <a href="#tab-step3" onclick="$('a[href=\'#step3\']').tab('show');" class="btn sensitive p-x-0">
-                                  <i class="material-icons">open_in_new</i> {{ trans("Combinations", {}, 'AdminProducts')|raw }}
+                                  <i class="material-icons">open_in_new</i> {{ "Combinations"|trans({}, 'AdminProducts')|raw }}
                                 </a>
                               </div>
                             </div>
@@ -229,9 +229,9 @@
 
                           <div class="form-group" id="product_qty_0_shortcut_div">
                             <h2>
-                              {{ trans("Quantity", {}, 'AdminProducts') }}
+                              {{ "Quantity"|trans({}, 'AdminProducts') }}
                               <span class="help-box" data-toggle="popover"
-                                data-content="{{ trans("How many products should be available for sale?",{}, 'AdminProducts') }}" ></span>
+                                data-content="{{ "How many products should be available for sale?"|trans({}, 'AdminProducts') }}" ></span>
                             </h2>
                             {{ form_errors(form.step1.qty_0_shortcut) }}
                             <div class="row">
@@ -240,46 +240,46 @@
                               </div>
                             </div>
                             <span class="small font-secondary">
-                              {{ trans("Advanced settings available in", {}, 'AdminProducts') }}
+                              {{ "Advanced settings available in"|trans({}, 'AdminProducts') }}
                             </span>
                             <a href="#tab-step3" onclick="$('a[href=\'#step3\']').tab('show');" class="btn sensitive p-x-0">
-                              <i class="material-icons">open_in_new</i> {{ trans("Quantities", {}, 'AdminProducts') }}
+                              <i class="material-icons">open_in_new</i> {{ "Quantities"|trans({}, 'AdminProducts') }}
                             </a>
                           </div>
 
                           <div class="form-group">
                             <h2>
-                              {{ trans("Price", {}, 'AdminProducts') }}
+                              {{ "Price"|trans({}, 'AdminProducts') }}
                               <span class="help-box" data-toggle="popover"
-                                data-content="{{ trans("This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.",{}, 'AdminProducts') }}" ></span>
+                                data-content="{{ "This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'AdminProducts') }}" ></span>
                             </h2>
                             <div class="row">
                               <div class="col-md-6">
-                                <label class="form-control-label">{{ trans("Tax excluded", {}, 'AdminProducts') }}</label>
+                                <label class="form-control-label">{{ "Tax excluded"|trans({}, 'AdminProducts') }}</label>
                                 {{ form_widget(form.step1.price_shortcut) }}
                                 {{ form_errors(form.step1.price_shortcut) }}
                               </div>
                               <div class="col-md-6 col-offset-md-1">
-                                <label class="form-control-label">{{ trans("Tax included", {}, 'AdminProducts') }}</label>
+                                <label class="form-control-label">{{ "Tax included"|trans({}, 'AdminProducts') }}</label>
                                 {{ form_widget(form.step1.price_ttc_shortcut) }}
                                 {{ form_errors(form.step1.price_ttc_shortcut) }}
                               </div>
                               <div class="col-md-12 m-t-1">
-                                <label class="form-control-label">{{ trans("Tax rule", {}, 'AdminProducts') }}</label>
+                                <label class="form-control-label">{{ "Tax rule"|trans({}, 'AdminProducts') }}</label>
                                 {{ render(controller('PrestaShopBundle:Admin/Product:renderField', {'productId': id_product, 'step': 'step2', 'fieldName': 'id_tax_rules_group' })) }}
                               </div>
                               <div class="col-md-12">
                                 <span class="small font-secondary">
-                                  {{ trans("Advanced settings available in", {}, 'AdminProducts') }}
+                                  {{ "Advanced settings available in"|trans({}, 'AdminProducts') }}
                                 </span>
                                 <a href="#tab-step2" onclick="$('a[href=\'#step2\']').tab('show');" class="btn sensitive p-x-0">
-                                  <i class="material-icons">open_in_new</i> {{ trans("Pricing", {}, 'AdminProducts') }}
+                                  <i class="material-icons">open_in_new</i> {{ "Pricing"|trans({}, 'AdminProducts') }}
                                 </a>
                               </div>
                             </div>
                             <div class="row hide">
                               <div class="col-md-12">
-                                <label>{{ trans("Tax rule", {}, 'AdminProducts') }}</label>
+                                <label>{{ "Tax rule"|trans({}, 'AdminProducts') }}</label>
                               </div>
                               <div class="clearfix"></div>
                               <div class="col-md-11" id="tax_rule_shortcut">
@@ -310,7 +310,7 @@
                   <div class="col-md-12">
 
                     <div id="quantities" style="{% if has_combinations or form.step3.depends_on_stock.vars.value != "0" %}display: none;{% endif %}">
-                      <h2>{{ trans('Quantities', [], 'AdminProducts') }}</h2>
+                      <h2>{{ 'Quantities'|trans([], 'AdminProducts') }}</h2>
                       <fieldset class="form-group">
                         <div class="row">
                           <div class="col-md-4">
@@ -349,8 +349,8 @@
                               {{ form_widget(form.step3.virtual_product.file) }}
                             </div>
                             <div id="form_step3_virtual_product_file_details" class="{{ form.step3.virtual_product.vars.value.filename is defined ? 'show' : 'hide' }}">
-                              <a href="{{ form.step3.virtual_product.vars.value.file_download_link is defined ? form.step3.virtual_product.vars.value.file_download_link : '' }}" class="btn btn-default btn-sm download">{{ trans('Download file', {}, 'AdminProducts') }}</a>
-                              <a href="{{ path('admin_product_virtual_remove_file_action') }}" class="btn btn-danger btn-sm delete">{{ trans('Delete this file', {}, 'AdminProducts') }}</a>
+                              <a href="{{ form.step3.virtual_product.vars.value.file_download_link is defined ? form.step3.virtual_product.vars.value.file_download_link : '' }}" class="btn btn-default btn-sm download">{{ 'Download file'|trans({}, 'AdminProducts') }}</a>
+                              <a href="{{ path('admin_product_virtual_remove_file_action') }}" class="btn btn-danger btn-sm delete">{{ 'Delete this file'|trans({}, 'AdminProducts') }}</a>
                             </div>
                           </fieldset>
                         </div>
@@ -395,7 +395,7 @@
                           {{ form_errors(form.step3.advanced_stock_management) }}
                           {{ form_widget(form.step3.advanced_stock_management) }}
                           {% if form.step1.type_product.vars.value == "1" %}
-                            {{ trans('When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.', {}, 'AdminProducts') }}
+                            {{ 'When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.'|trans({}, 'AdminProducts') }}
                           {% endif %}
                         </div>
                       </div>
@@ -454,9 +454,9 @@
                 <div class="row">
 
                   <div class="col-md-12">
-                    <h2>{{ trans('Retail price', {}, 'AdminProducts') }}
+                    <h2>{{ 'Retail price'|trans({}, 'AdminProducts') }}
                       <span class="help-box" data-toggle="popover"
-                        data-content="{{ trans("This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.",{}, 'AdminProducts') }}" ></span>
+                        data-content="{{ "This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'AdminProducts') }}" ></span>
                     </h2>
                   </div>
 
@@ -478,7 +478,7 @@
                         <label class="form-control-label">
                           {{ form.step2.unit_price.vars.label }}
                           <span class="help-box" data-toggle="popover"
-                            data-content="{{ trans("Some products can be purchased by unit (per bottle, per pound, etc.),  and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter.",{}, 'AdminProducts') }}" ></span>
+                            data-content="{{ "Some products can be purchased by unit (per bottle, per pound, etc.),  and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter."|trans({}, 'AdminProducts') }}" ></span>
                         </label>
                         <div class="row">
                           <div class="col-md-6">
@@ -509,7 +509,7 @@
                       <div class="col-md-8">
                         <label class="form-control-label">&nbsp;</label>
                         <a class="form-control-static external-link" href="{{ getAdminLink("AdminTaxes") }}">
-                          <i class="material-icons">open_in_new</i> {{ trans('Manage tax rules', {}, 'AdminProducts') }}
+                          <i class="material-icons">open_in_new</i> {{ 'Manage tax rules'|trans({}, 'AdminProducts') }}
                         </a>
                       </div>
                       <div class="col-md-12 p-t-1">
@@ -521,9 +521,9 @@
                             <div class="alert alert-info" role="alert">
                               <i class="material-icons">help</i>
                               <p class="alert-text">
-                                {{ trans('Final retail price : ', {}, 'AdminProducts') }}
-                                <strong><span id="final_retail_price_ti"></span> {{ trans('tax incl.', [], 'AdminProducts') }}</strong> /
-                                <span id="final_retail_price_te"></span> {{ trans('tax excl.', [], 'AdminProducts') }}
+                                {{ 'Final retail price : '|trans({}, 'AdminProducts') }}
+                                <strong><span id="final_retail_price_ti"></span> {{ 'tax incl.'|trans([], 'AdminProducts') }}</strong> /
+                                <span id="final_retail_price_te"></span> {{ 'tax excl.'|trans([], 'AdminProducts') }}
                               </p>
                             </div>
                           </div>
@@ -536,9 +536,9 @@
                     <div class="row">
                       <div class="col-md-12">
                         <h2>
-                          {{ trans('Cost price', {}, 'AdminProducts') }}
+                          {{ 'Cost price'|trans({}, 'AdminProducts') }}
                           <span class="help-box" data-toggle="popover"
-                            data-content="{{ trans("The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin.",{}, 'AdminProducts') }}" ></span>
+                            data-content="{{ "The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin."|trans({}, 'AdminProducts') }}" ></span>
                         </h2>
                       </div>
                       <div class="col-md-2 form-group">
@@ -553,30 +553,30 @@
                     <div class="row">
                       <div class="col-md-12">
                         <h2>
-                          {{ trans('Specific prices', {}, 'AdminProducts') }}
+                          {{ 'Specific prices'|trans({}, 'AdminProducts') }}
                           <span class="help-box" data-toggle="popover"
-                            data-content="{{ trans("You can set specific prices for customers belonging to different groups, different countries, etc.",{}, 'AdminProducts') }}" ></span>
+                            data-content="{{ "You can set specific prices for customers belonging to different groups, different countries, etc."|trans({}, 'AdminProducts') }}" ></span>
                         </h2>
                       </div>
                       <div class="col-md-12">
                         <div id="specific-price" class="m-b-2">
                           <a class="btn btn-action m-b-2" data-toggle="collapse" href="#specific_price_form" aria-expanded="false">
                             <i class="material-icons">add_circle</i>
-                            {{ trans('Add a specific price', {}, 'AdminProducts') }}
+                            {{ 'Add a specific price'|trans({}, 'AdminProducts') }}
                           </a>
                           <table id="js-specific-price-list" class="table table-striped hide seo-table" data="{{ path('admin_specific_price_list') }}" data-action-delete="{{ path('admin_delete_specific_price') }}">
                             <thead>
                             <tr>
-                              <th>{{ trans('Rule', {}, 'AdminProducts') }}</th>
-                              <th>{{ trans('Combination', {}, 'AdminProducts') }}</th>
-                              <th>{{ trans('Currency', {}, 'AdminProducts') }}</th>
-                              <th>{{ trans('Country', {}, 'AdminProducts') }}</th>
-                              <th>{{ trans('Group', {}, 'AdminProducts') }}</th>
-                              <th>{{ trans('Customer', {}, 'AdminProducts') }}</th>
-                              <th>{{ trans('Fixed price', {}, 'AdminProducts') }}</th>
-                              <th>{{ trans('Impact', {}, 'AdminProducts') }}</th>
-                              <th>{{ trans('Period', {}, 'AdminProducts') }}</th>
-                              <th>{{ trans('From', {}, 'AdminProducts') }}</th>
+                              <th>{{ 'Rule'|trans({}, 'AdminProducts') }}</th>
+                              <th>{{ 'Combination'|trans({}, 'AdminProducts') }}</th>
+                              <th>{{ 'Currency'|trans({}, 'AdminProducts') }}</th>
+                              <th>{{ 'Country'|trans({}, 'AdminProducts') }}</th>
+                              <th>{{ 'Group'|trans({}, 'AdminProducts') }}</th>
+                              <th>{{ 'Customer'|trans({}, 'AdminProducts') }}</th>
+                              <th>{{ 'Fixed price'|trans({}, 'AdminProducts') }}</th>
+                              <th>{{ 'Impact'|trans({}, 'AdminProducts') }}</th>
+                              <th>{{ 'Period'|trans({}, 'AdminProducts') }}</th>
+                              <th>{{ 'From'|trans({}, 'AdminProducts') }}</th>
                               <th></th>
                             </tr>
                             </thead>
@@ -594,22 +594,22 @@
                     <div class="row">
                       <div class="col-md-12">
                         <h2>
-                          {{ trans('Priority management', {}, 'AdminProducts') }}
+                          {{ 'Priority management'|trans({}, 'AdminProducts') }}
                           <span class="help-box" data-toggle="popover"
-                            data-content="{{ trans("Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first.",{}, 'AdminProducts') }}" ></span>
+                            data-content="{{ "Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first."|trans({}, 'AdminProducts') }}" ></span>
                         </h2>
                       </div>
                       <div class="col-md-12">
                         <div class="alert alert-info" role="alert">
                           <i class="material-icons">help</i>
                           <p class="alert-text">
-                            {{ trans('Sometimes one customer can fit into multiple price rules. Priorities allow you to define wich rule applies to the customer.', {}, 'AdminProducts') }}
+                            {{ 'Sometimes one customer can fit into multiple price rules. Priorities allow you to define wich rule applies to the customer.'|trans({}, 'AdminProducts') }}
                           </p>
                         </div>
                       </div>
                       <div class="col-md-3">
                         <fieldset class="form-group">
-                          <label>{{ trans('Priorities', {}, 'AdminProducts') }}</label>
+                          <label>{{ 'Priorities'|trans({}, 'AdminProducts') }}</label>
                           {{ form_errors(form.step2.specificPricePriority_0) }}
                           {{ form_widget(form.step2.specificPricePriority_0) }}
                         </fieldset>
@@ -673,8 +673,8 @@
 
                     <div class="row">
                       <div class="col-md-12">
-                        <h2>{{ trans('Visibility', {}, 'AdminProducts') }}</h2>
-                        <p class="subtitle">{{ trans('Where do you want your product to appear?', {}, 'AdminProducts') }}</p>
+                        <h2>{{ 'Visibility'|trans({}, 'AdminProducts') }}</h2>
+                        <p class="subtitle">{{ 'Where do you want your product to appear?'|trans({}, 'AdminProducts') }}</p>
                       </div>
                     </div>
 
@@ -703,21 +703,21 @@
                     </div>
                     <div class="row form-group">
                       <div class="col-md-8">
-                        <label class="form-control-label">{{ trans('Tags', {}, 'AdminProducts') }}</label>
+                        <label class="form-control-label">{{ 'Tags'|trans({}, 'AdminProducts') }}</label>
                         {{ form_errors(form.step6.tags) }}
                         {{ form_widget(form.step6.tags) }}
                         <div class="alert alert-info alert-drop m-t-1" role="alert">
                           <i class="material-icons">help</i>
-                          <p class="alert-text" data-title="{{ trans('Read more', {}, 'AdminProducts')|raw }}">
-                            {{ trans('Tags are meant to help your customers find your products via the search bar.', {}, 'AdminProducts')|raw }}
-                            <strong>{{ trans('Read more', {}, 'AdminProducts')|raw }}</strong>
+                          <p class="alert-text" data-title="{{ 'Read more'|trans({}, 'AdminProducts')|raw }}">
+                            {{ 'Tags are meant to help your customers find your products via the search bar.'|trans({}, 'AdminProducts')|raw }}
+                            <strong>{{ 'Read more'|trans({}, 'AdminProducts')|raw }}</strong>
                           </p>
                         </div>
                         <div class="alert alert-info alert-down" role="alert">
                           <p class="alert-down-text">
-                            {{ trans('Use terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.', {}, 'AdminProducts')|raw }}<br>
-                            {{ trans('You can manage tag aliases in the Alias section.', {}, 'AdminProducts')|raw }}
-                            <!--TODO:: re-add the link:: '%link%': '<a href="'~ getAdminLink("AdminSearchConf") ~'">'~trans('Alias', {}, 'AdminProducts')~'</a>' -->
+                            {{ 'Use terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.'|trans({}, 'AdminProducts')|raw }}<br>
+                            {{ 'You can manage tag aliases in the Alias section.'|trans({}, 'AdminProducts')|raw }}
+                            <!--TODO:: re-add the link:: '%link%': '<a href="'~ getAdminLink("AdminSearchConf") ~'">'~'Alias'|trans({}, 'AdminProducts')~'</a>' -->
                           </p>
                         </div>
                       </div>
@@ -725,7 +725,7 @@
 
                     <div class="row">
                       <div class="col-md-12">
-                        <h2>{{ trans('Condition & References', {}, 'AdminProducts')|raw }}</h2>
+                        <h2>{{ 'Condition & References'|trans({}, 'AdminProducts')|raw }}</h2>
                       </div>
                     </div>
 
@@ -734,7 +734,7 @@
                         <label class="form-control-label">
                           {{ form.step6.condition.vars.label }}
                           <span class="help-box" data-toggle="popover"
-                            data-content="{{ trans("Not all shops sell new products. This option enables you to indicate the condition of the product. This information can be required on some marketplaces.",{}, 'AdminProducts') }}" ></span>
+                            data-content="{{ "Not all shops sell new products. This option enables you to indicate the condition of the product. This information can be required on some marketplaces."|trans({}, 'AdminProducts') }}" ></span>
                         </label>
                         {{ form_errors(form.step6.condition) }}
                         {{ form_widget(form.step6.condition) }}
@@ -749,7 +749,7 @@
                         <label class="form-control-label">
                           {{ form.step6.reference.vars.label }}
                           <span class="help-box" data-toggle="popover"
-                            data-content="{{ trans("Your internal reference code for this product. Allowed special characters: .-_#\.",{}, 'AdminProducts') }}" ></span>
+                            data-content="{{ "Your internal reference code for this product. Allowed special characters: .-_#\."|trans({}, 'AdminProducts') }}" ></span>
                         </label>
                         {{ form_errors(form.step6.reference) }}
                         {{ form_widget(form.step6.reference) }}
@@ -758,7 +758,7 @@
                         <label class="form-control-label">
                           {{ form.step6.isbn.vars.label }}
                           <span class="help-box" data-toggle="popover"
-                            data-content="{{ trans("This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America.",{}, 'AdminProducts') }}" ></span>
+                            data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'AdminProducts') }}" ></span>
                         </label>
                         {{ form_errors(form.step6.isbn) }}
                         {{ form_widget(form.step6.isbn) }}
@@ -769,7 +769,7 @@
                         <label class="form-control-label">
                           {{ form.step6.upc.vars.label }}
                           <span class="help-box" data-toggle="popover"
-                            data-content="{{ trans("This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries.",{}, 'AdminProducts') }}" ></span>
+                            data-content="{{ "This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries."|trans({}, 'AdminProducts') }}" ></span>
                         </label>
                         {{ form_errors(form.step6.upc) }}
                         {{ form_widget(form.step6.upc) }}
@@ -778,7 +778,7 @@
                         <label class="form-control-label">
                           {{ form.step6.ean13.vars.label }}
                           <span class="help-box" data-toggle="popover"
-                            data-content="{{ trans("This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America.",{}, 'AdminProducts') }}" ></span>
+                            data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'AdminProducts') }}" ></span>
                         </label>
                         {{ form_errors(form.step6.ean13) }}
                         {{ form_widget(form.step6.ean13) }}
@@ -789,7 +789,7 @@
                       <div class="col-md-12">
                         <div id="custom_fields" class="m-b-2">
                           <h2>{{ form.step6.custom_fields.vars.label }}</h2>
-                          <p class="subtitle">{{ trans('Customers can personalized the product by entering some text or by providing custom files (image, video, etc.).', {}, 'AdminProducts') }}</p>
+                          <p class="subtitle">{{ 'Customers can personalized the product by entering some text or by providing custom files (image, video, etc.).'|trans({}, 'AdminProducts') }}</p>
                           {{ form_errors(form.step6.custom_fields) }}
                           <ul class="customFieldCollection nostyle" data-prototype="
                                       {% filter escape %}
@@ -803,7 +803,7 @@
                           </ul>
                           <a href="#" class="btn btn-action add">
                             <i class="material-icons">add_circle</i>
-                            {{ trans('Add a customization field', {}, 'AdminProducts') }}
+                            {{ 'Add a customization field'|trans({}, 'AdminProducts') }}
                           </a>
                         </div>
                       </div>
@@ -811,13 +811,13 @@
 
                     <div class="row">
                       <div class="col-md-8">
-                        <h2>{{ trans('Attached files', {}, 'AdminProducts') }}</h2>
+                        <h2>{{ 'Attached files'|trans({}, 'AdminProducts') }}</h2>
                         {{ form_widget(form.step6.attachments) }}
                       </div>
                     </div>
                     <div class="row">
                       <div class="col-md-8">
-                        <h2>{{ trans('Create a new attachment', {}, 'AdminProducts') }}</h2>
+                        <h2>{{ 'Create a new attachment'|trans({}, 'AdminProducts') }}</h2>
                         <fieldset class="form-group">
                           {{ form_errors(form.step6.attachment_product) }}
                           <div id="form_step6_attachment_product" data-action="{{ form.step6.attachment_product.vars.attr['data-action'] }}">
@@ -838,27 +838,27 @@
                               <div class="alert alert-info alert-drop" role="alert">
                                 <i class="material-icons">help</i>
                                 <p class="alert-text">
-                                  {{ trans('This interface allows you to specify the suppliers of the current product and eventually its combinations.', {}, 'AdminProducts')|raw }}<br>
-                                  {{ trans('It is also possible to specify supplier references according to previously associated suppliers.', {}, 'AdminProducts')|raw }}
-                                  <strong>{{ trans('Read more', {}, 'AdminProducts')|raw }}</strong>
+                                  {{ 'This interface allows you to specify the suppliers of the current product and eventually its combinations.'|trans({}, 'AdminProducts')|raw }}<br>
+                                  {{ 'It is also possible to specify supplier references according to previously associated suppliers.'|trans({}, 'AdminProducts')|raw }}
+                                  <strong>{{ 'Read more'|trans({}, 'AdminProducts')|raw }}</strong>
                                 </p>
                               </div>
                               <div class="alert alert-info alert-down" role="alert">
                                 <p class="alert-down-text">
-                                  {{ trans('When using the advanced stock managment tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.', {}, 'AdminProducts')|raw }}
+                                  {{ 'When using the advanced stock managment tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.'|trans({}, 'AdminProducts')|raw }}
                                 </p>
                               </div>
                             </div>
                             {{ form_errors(form.step6.suppliers) }}
                             <div class="col-md-4">
                               <fieldset class="form-group">
-                                <label>{{ trans('Choose the suppliers associated with this product', {}, 'AdminProducts') }}</label>
+                                <label>{{ 'Choose the suppliers associated with this product'|trans({}, 'AdminProducts') }}</label>
                                 {{ form_widget(form.step6.suppliers) }}
                               </fieldset>
                             </div>
                             <div class="col-md-4" id="default_supplier_list">
                               <fieldset class="form-group">
-                                <label>{{ trans('Choose a default supplier', {}, 'AdminProducts') }}</label>
+                                <label>{{ 'Choose a default supplier'|trans({}, 'AdminProducts') }}</label>
                                 {{ form_widget(form.step6.default_supplier) }}
                               </fieldset>
                             </div>
@@ -927,7 +927,7 @@
           class="btn btn-invisible btn-lg delete"
           data-toggle="tooltip"
           id="product_form_delete_btn"
-          title="{{ trans('Permanently delete this product.', {}, 'AdminProducts') }}"
+          title="{{ 'Permanently delete this product.'|trans({}, 'AdminProducts') }}"
         >
           <i class="material-icons">delete</i>
         </a>
@@ -938,13 +938,13 @@
           class="btn btn-tertiary btn-submit hidden-xs preview"
           data-toggle="tooltip"
           id="product_form_preview_btn"
-          title="{{ trans('View the product draft on the site.', {}, 'AdminProducts') }}"
+          title="{{ 'View the product draft on the site.'|trans({}, 'AdminProducts') }}"
          >
-          {{ trans('Preview', {}, 'AdminProducts') }}
+          {{ 'Preview'|trans({}, 'AdminProducts') }}
         </a>
 
-        <h2 class="for-switch online-title" {% if not form.step1.vars.value.active %}style="display:none;"{% endif %}>{{ trans('Online', {}, 'AdminProducts') }}</h2>
-        <h2 class="for-switch offline-title" {% if form.step1.vars.value.active %}style="display:none;"{% endif %}>{{ trans('Offline', {}, 'AdminProducts') }}</h2>
+        <h2 class="for-switch online-title" {% if not form.step1.vars.value.active %}style="display:none;"{% endif %}>{{ 'Online'|trans({}, 'AdminProducts') }}</h2>
+        <h2 class="for-switch offline-title" {% if form.step1.vars.value.active %}style="display:none;"{% endif %}>{{ 'Offline'|trans({}, 'AdminProducts') }}</h2>
         <input
           id="form_step1_active"
           data-toggle="switch"
@@ -962,18 +962,18 @@
           id="product_form_save_duplicate_btn"
           data-redirect="{{ path('admin_product_unit_action', {action: 'duplicate', id: id_product}) }}?redirect_url={{ path('admin_product_catalog') }}"
           data-toggle="tooltip"
-          title="{{ trans('Save and duplicate (CTRL+D) the current product, then go to the new product.', {}, 'AdminProducts') }}"
+          title="{{ 'Save and duplicate (CTRL+D) the current product, then go to the new product.'|trans({}, 'AdminProducts') }}"
           >
-          {{ trans('Duplicate', {}, 'AdminProducts')|raw }}
+          {{ 'Duplicate'|trans({}, 'AdminProducts')|raw }}
         </button>
         <button
           type="button"
           class="btn btn-tertiary-outline btn-submit hidden-xs uppercase go-catalog"
           id="product_form_save_go_to_catalog_btn"
           data-redirect="{{ path('admin_product_catalog', {'offset': 'last', 'limit': 'last'}) }}"
-          data-toggle="tooltip" title="{{ trans('Save and go back to the catalog (CTRL+Q)', {}, 'AdminProducts') }}"
+          data-toggle="tooltip" title="{{ 'Save and go back to the catalog (CTRL+Q)'|trans({}, 'AdminProducts') }}"
           >
-          {{ trans('Go to catalog', {}, 'AdminProducts')|raw }}
+          {{ 'Go to catalog'|trans({}, 'AdminProducts')|raw }}
         </button>
         <button
           type="button"
@@ -981,17 +981,17 @@
           id="product_form_save_new_btn"
           data-redirect="{{ path('admin_product_new') }}"
           data-toggle="tooltip"
-          title="{{ trans('Save and create (CTRL+P) a new product.', {}, 'AdminProducts') }}"
+          title="{{ 'Save and create (CTRL+P) a new product.'|trans({}, 'AdminProducts') }}"
           >
-          {{ trans('Add new product', {}, 'AdminProducts')|raw }}
+          {{ 'Add new product'|trans({}, 'AdminProducts')|raw }}
         </button>
         <input
           id="submit"
           type="submit"
           class="btn btn-primary save uppercase"
-          value="{{ trans('Save', {}, 'AdminProducts') }}"
+          value="{{ 'Save'|trans({}, 'AdminProducts') }}"
           data-toggle="tooltip"
-          title="{{ trans('Save (CTRL+S) the product and stay on the current page.', {}, 'AdminProducts') }}"
+          title="{{ 'Save (CTRL+S) the product and stay on the current page.'|trans({}, 'AdminProducts') }}"
           />
       </div>
     </div>
@@ -1001,16 +1001,16 @@
 
   {% embed 'PrestaShopBundle:Admin/Helpers:bootstrap_popup.html.twig' with {
     'id': 'confirmation_modal',
-    'title': trans("Warning", {}, 'AdminTabs'),
+    'title': "Warning"|trans({}, 'AdminTabs'),
     'closable': false,
     'actions': [
       {
         'type': 'button',
-        'label': trans("Yes", {}, 'AdminTabs'),
+        'label': "Yes"|trans({}, 'AdminTabs'),
         'class': 'btn btn-danger continue'
       },{
         'type': 'button',
-        'label': trans("No", {}, 'AdminTabs'),
+        'label': "No"|trans({}, 'AdminTabs'),
         'class': 'btn btn-default cancel'
       }
     ],
@@ -1045,22 +1045,22 @@
 {% endblock %}
 
 {% set js_translatable = {
-"Form update success": trans("Form update success", {}, 'AdminProducts'),
-"Form update errors": trans("Form update errors", {}, 'AdminProducts'),
-"Delete": trans("Delete", {}, 'AdminProducts'),
-"ToLargeFile": trans("The file is too large ({{filesize}}). Allowed maximum size is {{maxFilesize}}.", {}, 'AdminProducts'),
-"Drop images here": trans("Drop images here", {}, 'AdminProducts'),
-"or select files": trans("or select files", {}, 'AdminProducts'),
-"files recommandations": trans("Recommended size 800 x 800px for default theme.", {}, 'AdminProducts'),
-"files recommandations2": trans("JPG, GIF or PNG format.", {}, 'AdminProducts'),
-"Cover": trans("Cover", {}, 'AdminProducts'),
-"Are you sure to disable variations ? they will all be deleted": trans("Are you sure to disable variations ? they will all be deleted", {}, 'AdminProducts'),
-"Are you sure to delete this?": trans("Are you sure to delete this?", {}, 'AdminProducts'),
-"Quantities": trans("Quantities", {}, 'AdminProducts'),
-"Combinations": trans("Combinations", {}, 'AdminProducts'),
-"Virtual product": trans("Virtual product", {}, 'AdminProducts'),
-"tax incl.": trans("tax incl.", {}, 'AdminProducts'),
-"tax excl.": trans("tax excl.", {}, 'AdminProducts'),
-"You can't create pack product with variations. Are you sure to disable variations ? they will all be deleted.": trans("You can't create pack product with variations. Are you sure to disable variations ? they will all be deleted.", {}, "AdminProducts"),
-"You can't create virtual product with variations. Are you sure to disable variations ? they will all be deleted.": trans("You can't create virtual product with variations. Are you sure to disable variations ? they will all be deleted.", {}, "AdminProducts"),
+"Form update success": "Form update success"|trans({}, 'AdminProducts'),
+"Form update errors": "Form update errors"|trans({}, 'AdminProducts'),
+"Delete": "Delete"|trans({}, 'AdminProducts'),
+"ToLargeFile": "The file is too large ({{filesize}}). Allowed maximum size is {{maxFilesize}}."|trans({}, 'AdminProducts'),
+"Drop images here": "Drop images here"|trans({}, 'AdminProducts'),
+"or select files": "or select files"|trans({}, 'AdminProducts'),
+"files recommandations": "Recommended size 800 x 800px for default theme."|trans({}, 'AdminProducts'),
+"files recommandations2": "JPG, GIF or PNG format."|trans({}, 'AdminProducts'),
+"Cover": "Cover"|trans({}, 'AdminProducts'),
+"Are you sure to disable variations ? they will all be deleted": "Are you sure to disable variations ? they will all be deleted"|trans({}, 'AdminProducts'),
+"Are you sure to delete this?": "Are you sure to delete this?"|trans({}, 'AdminProducts'),
+"Quantities": "Quantities"|trans({}, 'AdminProducts'),
+"Combinations": "Combinations"|trans({}, 'AdminProducts'),
+"Virtual product": "Virtual product"|trans({}, 'AdminProducts'),
+"tax incl.": "tax incl."|trans({}, 'AdminProducts'),
+"tax excl.": "tax excl."|trans({}, 'AdminProducts'),
+"You can't create pack product with variations. Are you sure to disable variations ? they will all be deleted.": "You can't create pack product with variations. Are you sure to disable variations ? they will all be deleted."|trans({}, "AdminProducts"),
+"You can't create virtual product with variations. Are you sure to disable variations ? they will all be deleted.": "You can't create virtual product with variations. Are you sure to disable variations ? they will all be deleted."|trans({}, "AdminProducts"),
 }|merge(js_translatable) %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -32,7 +32,7 @@
             </select>
           </div>
           <div class="col-lg-2 text-md-right">
-            <a class="toolbar-button btn-sales" href="{{ stats_link }}" target="_blank" title="{{ 'Sales'|trans([], 'AdminTab') }}"
+            <a class="toolbar-button btn-sales" href="{{ stats_link }}" target="_blank" title="{{ 'Sales'|trans({}, 'AdminTab') }}"
                id="product_form_go_to_sales">
               <i class="material-icons">assessment</i>
               <span class="title">{{ 'Sales'|trans({}, 'AdminProducts') }}</span>
@@ -41,7 +41,7 @@
             <a
               class="toolbar-button btn-quicknav btn-sidebar"
               href="#"
-              title="{{ 'Quick navigation'|trans([], 'AdminTab') }}"
+              title="{{ 'Quick navigation'|trans({}, 'AdminTab') }}"
               data-toggle="sidebar"
               data-target="#right-sidebar"
               data-url="{{ path('admin_product_list', {limit: 'last', offset: 'last', view: 'quicknav'}) }}"
@@ -52,7 +52,7 @@
             </a>
 
             <a class="toolbar-button btn-help btn-sidebar" href="#"
-               title="{{ 'Help'|trans([], 'AdminTab') }}"
+               title="{{ 'Help'|trans({}, 'AdminTab') }}"
                data-toggle="sidebar"
                data-target="#right-sidebar"
                data-url="{{ help_link }}"
@@ -163,7 +163,7 @@
 
                     <div id="features" class="m-b-1 m-t-1">
                       <div id="features-content" class="content {{ form.step1.features|length == 0 ? 'hide':'' }}">
-                        <h2>{{ 'Features'|trans([], 'AdminProducts') }}</h2>
+                        <h2>{{ 'Features'|trans({}, 'AdminProducts') }}</h2>
                         {{ form_errors(form.step1.features) }}
                         <div
                           class="feature-collection nostyle"
@@ -310,7 +310,7 @@
                   <div class="col-md-12">
 
                     <div id="quantities" style="{% if has_combinations or form.step3.depends_on_stock.vars.value != "0" %}display: none;{% endif %}">
-                      <h2>{{ 'Quantities'|trans([], 'AdminProducts') }}</h2>
+                      <h2>{{ 'Quantities'|trans({}, 'AdminProducts') }}</h2>
                       <fieldset class="form-group">
                         <div class="row">
                           <div class="col-md-4">
@@ -522,8 +522,8 @@
                               <i class="material-icons">help</i>
                               <p class="alert-text">
                                 {{ 'Final retail price : '|trans({}, 'AdminProducts') }}
-                                <strong><span id="final_retail_price_ti"></span> {{ 'tax incl.'|trans([], 'AdminProducts') }}</strong> /
-                                <span id="final_retail_price_te"></span> {{ 'tax excl.'|trans([], 'AdminProducts') }}
+                                <strong><span id="final_retail_price_ti"></span> {{ 'tax incl.'|trans({}, 'AdminProducts') }}</strong> /
+                                <span id="final_retail_price_te"></span> {{ 'tax excl.'|trans({}, 'AdminProducts') }}
                               </p>
                             </div>
                           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/formDisable.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/formDisable.html.twig
@@ -2,6 +2,6 @@
 
 {% block content %}
     <div class="panel">
-        <div class="alert alert-danger" role="alert">{{ trans('Sorry, you can not edit/add a product when shop context is defined to a group of shop', {}, 'AdminProducts') }}</div>
+        <div class="alert alert-danger" role="alert">{{ 'Sorry, you can not edit/add a product when shop context is defined to a group of shop'|trans({}, 'AdminProducts') }}</div>
     </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/list.html.twig
@@ -16,26 +16,26 @@
               <a href="{{ product.url|default('') }}#tab-step1">{{ product.image|raw }}</a>
             </td>
             <td>
-              <a href="{{ product.url|default('') }}#tab-step1">{{ product.name|default(trans('N/A', {}, 'AdminTab')) }}</a>
+              <a href="{{ product.url|default('') }}#tab-step1">{{ product.name|default('N/A'|trans({}, 'AdminTab')) }}</a>
             </td>
             <td>
-              <a href="{{ product.url|default('') }}#tab-step6">{{ product.reference|default(trans('N/A', {}, 'AdminTab')) }}</a>
+              <a href="{{ product.url|default('') }}#tab-step6">{{ product.reference|default('N/A'|trans({}, 'AdminTab')) }}</a>
             </td>
             <td>
               <a href="{{ product.url|default('') }}#tab-step1">{{ product.name_category|default('') }}</a>
             </td>
             <td>
-              <a href="{{ product.url|default('') }}#tab-step2">{{ product.price|default(trans('N/A', {}, 'AdminTab')) }}</a>
+              <a href="{{ product.url|default('') }}#tab-step2">{{ product.price|default('N/A'|trans({}, 'AdminTab')) }}</a>
             </td>
             <td>
-              <a href="{{ product.url|default('') }}#tab-step2">{{ product.price_final|default(trans('N/A', {}, 'AdminTab')) }}</a>
+              <a href="{{ product.url|default('') }}#tab-step2">{{ product.price_final|default('N/A'|trans({}, 'AdminTab')) }}</a>
             </td>
             <td class="product-sav-quantity" productquantityvalue="{{ product.sav_quantity|default('') }}">
               <a href="{{ product.url|default('') }}#tab-step3">
                 {% if product.sav_quantity is defined and product.sav_quantity > 0 %}
                   {{ product.sav_quantity }}
                 {% else %}
-                  <span class="badge badge-danger">{{ product.sav_quantity|default(trans('N/A', {}, 'AdminTab')) }}</span>
+                  <span class="badge badge-danger">{{ product.sav_quantity|default('N/A'|trans({}, 'AdminTab')) }}</span>
                 {% endif %}
               </a>
             </td>
@@ -74,17 +74,17 @@
                           "href": product.preview_url|default('#'),
                           "target": "_blank",
                           "icon": "remove_red_eye",
-                          "label": trans("Preview", {}, 'AdminTab')
+                          "label": "Preview"|trans({}, 'AdminTab')
                         },
                         {
                           "onclick": "unitProductAction(this, 'duplicate');",
                           "icon": "content_copy",
-                          "label": trans("Duplicate", {}, 'AdminTab')
+                          "label": "Duplicate"|trans({}, 'AdminTab')
                         },
                         {
                           "onclick": "unitProductAction(this, 'delete');",
                           "icon": "delete",
-                          "label": trans("Delete", {}, 'AdminTab')
+                          "label": "Delete"|trans({}, 'AdminTab')
                         }
                       ]
                     } %}
@@ -93,7 +93,7 @@
         </tr>
     {% else %}
         <tr><td colspan="11">
-            {{ trans("There is no result for this search. You should remove some criteria.", {}, 'AdminProducts') }}
+            {{ "There is no result for this search. You should remove some criteria."|trans({}, 'AdminProducts') }}
         </td></tr>
     {% endfor %}
 </tbody>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/list_quicknav.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/list_quicknav.html.twig
@@ -1,23 +1,23 @@
 <div>
     <div class="quicknav-header">
         <div class="pull-left"><a href="#" data-toggle="sidebar" data-target=".sidebar">&times;</a></div>
-        <h2>{{ trans("Quick navigation", {}, 'AdminProducts') }}</h2>
+        <h2>{{ "Quick navigation"|trans({}, 'AdminProducts') }}</h2>
     </div>
     <div class="quicknav-scroller">
         <table class="table table-condensed table-striped product quicknav-products">
             <thead>
                 <tr class="column-headers">
                     <th class="hidden-xs hidden-sm hidden-md">
-                        {{ trans("ID", {}, 'AdminProducts') }}
+                        {{ "ID"|trans({}, 'AdminProducts') }}
                     </th>
                     <th>
-                        {{ trans("Name", {}, 'AdminProducts') }}
+                        {{ "Name"|trans({}, 'AdminProducts') }}
                     </th>
                     <th class="hidden-xs hidden-sm">
-                        {{ trans("Base price", {}, 'AdminProducts') }}
+                        {{ "Base price"|trans({}, 'AdminProducts') }}
                     </th>
                     <th class="hidden-xs">
-                        {{ trans("Quantity", {}, 'AdminProducts') }}
+                        {{ "Quantity"|trans({}, 'AdminProducts') }}
                     </th>
                 </tr>
             </thead>
@@ -28,24 +28,24 @@
                             <a href="{{ product.url|default('') }}#tab-step1">{{ product.id_product }}</a>
                         </td>
                         <td>
-                            <a href="{{ product.url|default('') }}#tab-step1">{{ product.name|default(trans('N/A', {}, 'AdminTab')) }}</a>
+                            <a href="{{ product.url|default('') }}#tab-step1">{{ product.name|default('N/A'|trans({}, 'AdminTab')) }}</a>
                         </td>
                         <td class="hidden-xs hidden-sm">
-                            <a href="{{ product.url|default('') }}#tab-step2">{{ product.price|default(trans('N/A', {}, 'AdminTab')) }}</a>
+                            <a href="{{ product.url|default('') }}#tab-step2">{{ product.price|default('N/A'|trans({}, 'AdminTab')) }}</a>
                         </td>
                         <td class="hidden-xs product-sav-quantity" productquantityvalue="{{ product.sav_quantity|default('') }}">
                             <a href="{{ product.url|default('') }}#tab-step3">
                                 {% if product.sav_quantity is defined and product.sav_quantity > 0 %}
                                     {{ product.sav_quantity }}
                                 {% else %}
-                                    <span class="badge badge-danger">{{ product.sav_quantity|default(trans('N/A', {}, 'AdminTab')) }}</span>
+                                    <span class="badge badge-danger">{{ product.sav_quantity|default('N/A'|trans({}, 'AdminTab')) }}</span>
                                 {% endif %}
                             </a>
                         </td>
                     </tr>
                 {% else %}
                     <tr><td colspan="5">
-                        {{ trans("There is no result for this search. You should remove some criteria.", {}, 'AdminProducts') }}
+                        {{ "There is no result for this search. You should remove some criteria."|trans({}, 'AdminProducts') }}
                     </td></tr>
                 {% endfor %}
             </tbody>

--- a/src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig
@@ -5,9 +5,9 @@
 {{ form_errors(form.legend) }}
 
 {{ form_widget(form.cover) }}
-<i class="icon-search-plus"></i> <a href="{{ image.base_image_url }}.{{ image.format }}" class="open-image" target="_blank">{{ trans('Enlarge image', {}, 'AdminProducts') }}</a>
+<i class="icon-search-plus"></i> <a href="{{ image.base_image_url }}.{{ image.format }}" class="open-image" target="_blank">{{ 'Enlarge image'|trans({}, 'AdminProducts') }}</a>
 
 <div class="actions">
-    <button type="button" class="btn btn-sm tn-primary" onclick="formImagesProduct.send({{ image.id }})">{{ trans('Save', {}, 'AdminProducts') }}</button>
-    <button type="button" class="btn btn-sm btn-danger" onclick="formImagesProduct.delete({{ image.id }})"><i class="icon-trash"></i> {{ trans('Delete', {}, 'AdminProducts') }}</button>
+    <button type="button" class="btn btn-sm tn-primary" onclick="formImagesProduct.send({{ image.id }})">{{ 'Save'|trans({}, 'AdminProducts') }}</button>
+    <button type="button" class="btn btn-sm btn-danger" onclick="formImagesProduct.delete({{ image.id }})"><i class="icon-trash"></i> {{ 'Delete'|trans({}, 'AdminProducts') }}</button>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_3_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_3_layout.html.twig
@@ -227,15 +227,15 @@
 
 {% block _form_step6_attachments_widget %}
     <div class="js-options-no-attachments {{ form|length >1 ? 'hide' : '' }}">
-        <small>{{ trans('There is no attachments yet.', {}, 'AdminProducts') }}</small>
+        <small>{{ 'There is no attachments yet.'|trans({}, 'AdminProducts') }}</small>
     </div>
     <div class="js-options-with-attachments {{ form|length == 0 ? 'hide' : '' }}">
         <table id="product-attachment-file" class="table table-striped table-fixed">
             <thead>
             <tr>
-                <th class="col-md-3"><input type="checkbox" id="product-attachment-files-check"> {{ trans('Title', {}, 'AdminProducts') }}</th>
-                <th class="col-md-6">{{ trans('File name', {}, 'AdminProducts') }}</th>
-                <th class="col-md-2">{{ trans('Type', {}, 'AdminProducts') }}</th>
+                <th class="col-md-3"><input type="checkbox" id="product-attachment-files-check"> {{ 'Title'|trans({}, 'AdminProducts') }}</th>
+                <th class="col-md-6">{{ 'File name'|trans({}, 'AdminProducts') }}</th>
+                <th class="col-md-2">{{ 'Type'|trans({}, 'AdminProducts') }}</th>
             </tr>
             </thead>
           <tbody>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block typeahead_product_pack_collection_widget %}
-    <h2 class="title-products {{ collection is defined and collection|length > 0 ? '' : 'hide' }}">{{ trans('List of products for this pack', {}, 'AdminProducts') }}</h2>
+    <h2 class="title-products {{ collection is defined and collection|length > 0 ? '' : 'hide' }}">{{ 'List of products for this pack'|trans({}, 'AdminProducts') }}</h2>
     <ul id="{{ form.vars.id }}-data" class="typeahead-list pack nostyle row">
         {% if collection is defined and collection|length > 0 %}
             {% for item in collection %}
@@ -65,7 +65,7 @@
             <div class="input-group">
                 <button id="{{ form.vars.id }}-curPackItemAdd" class="btn btn-action btn-block">
                     <i class="material-icons">add</i>
-                    {{ trans("Add this product", {}, "AdminProducts") }}
+                    {{ "Add this product"|trans({}, "AdminProducts") }}
                 </button>
             </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
@@ -68,7 +68,7 @@
     >
         <img
                 src="{{ asset('themes/default/img/bundle/dashboard_loading.gif') }}"
-                style="margin-top: 10em;" alt="{{ 'Loading...'|trans([], 'AdminTab') }}"
+                style="margin-top: 10em;" alt="{{ 'Loading...'|trans({}, 'AdminTab') }}"
         />
     </nav>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
@@ -68,7 +68,7 @@
     >
         <img
                 src="{{ asset('themes/default/img/bundle/dashboard_loading.gif') }}"
-                style="margin-top: 10em;" alt="{{ trans('Loading...', [], 'AdminTab') }}"
+                style="margin-top: 10em;" alt="{{ 'Loading...'|trans([], 'AdminTab') }}"
         />
     </nav>
 {% endblock %}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Since we are dropping the `trans()` function in twig, we had to replace it with `|trans` filter |
| Type? | refacto |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | yes. do not use `trans()` function anymore |
### Note

refactored with

```
  codemod -m -d src/ --extensions twig \
    '(trans\(){1}"{1}([^"]+)("{1},{1}\s*\{{1}){1}' \
    '"\2"|trans({'

  codemod -m -d src/ --extensions twig \
    "(trans\('){1}([^']+)('{1},{1}\s+\{{1}){1}" \
    "'\2'|trans({"

  codemod -m -d src/ --extensions twig \
    "(trans\('){1}([^']+)('{1},{1}\s*\[{1}){1}" \
    "'\2'|trans(["

  codemod -m -d src/ --extensions twig \
    "(\|trans\(){1}(\[){1}([^\[\]]+)(]){1}(,{1}\s)*" \
    "|trans({}\5"

```
