### PR TITLE
Fix html errors on Home Page

### DIFF
--- a/themes/classic/modules/blocklanguages/blocklanguages.tpl
+++ b/themes/classic/modules/blocklanguages/blocklanguages.tpl
@@ -27,7 +27,7 @@
   <a data-target="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="material-icons expand-more">&#xE5C5;</i>
   </a>
-  <ul class="dropdown-menu" aria-labelledby="dLabel">
+  <ul class="dropdown-menu">
     {foreach from=$languages item=language}
       <li {if $language.id_lang == $current_language.id_lang} class="current" {/if}>
         <a href="{$link->getLanguageLink($language.id_lang)}" class="dropdown-item">{$language.name_simple}</a>

--- a/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -5,7 +5,7 @@
       <ul>
         {foreach $linkBlock.links as $link}
           <li>
-            <a  id="{$link.id}"
+            <a id="{$link.id}"
                 class="{$link.class}"
                 href="{$link.url}"
                 title="{$link.description}">

--- a/themes/classic/modules/ps_mainmenu/ps_mainmenu.tpl
+++ b/themes/classic/modules/ps_mainmenu/ps_mainmenu.tpl
@@ -7,10 +7,13 @@
         {foreach from=$nodes item=node}
           {if $node.children|count}
             <li class="{$node.type}{if $node.current} current {/if}">
-              <a class="{if $depth >= 0}dropdown-item{/if}{if $depth === 1} dropdown-submenu{/if}"
-                 {if $depth === 0} data-toggle="dropdown" {/if}
-                   href="{$node.url nofilter}" data-depth="{$depth}"
-                 {if $node.open_in_new_window} target="_blank" {/if}
+              <a
+                class="{if $depth >= 0}dropdown-item{/if}{if $depth === 1} dropdown-submenu{/if}"
+                {if $depth === 0}
+                  data-toggle="dropdown" 
+                {/if}
+                href="{$node.url nofilter}" data-depth="{$depth}"
+                {if $node.open_in_new_window} target="_blank" {/if}
               >
                 {$node.label}
               </a>
@@ -20,8 +23,12 @@
             </li>
           {else}
             <li>
-              <a href="{$node.url nofilter}" data-depth="{$depth}"
-                 {if $node.open_in_new_window} target="_blank" {/if}
+              <a
+                href="{$node.url nofilter}"
+                data-depth="{$depth}"
+                {if $node.open_in_new_window}
+                  target="_blank"
+                {/if}
               >
                 {$node.label}
               </a>

--- a/themes/classic/modules/ps_mainmenu/ps_mainmenu.tpl
+++ b/themes/classic/modules/ps_mainmenu/ps_mainmenu.tpl
@@ -1,18 +1,16 @@
 {function name="menu" nodes=[] depth=0 parent=null}
-  {strip}
     {if $depth === 1}
       <a class="top-menu-link" href="{$node.url nofilter}" title="{$node.label}">{$node.label}</a>
     {/if}
     {if $nodes|count}
-      <ul aria-labelledby="dLabel" data-depth="{$depth}" class="top-menu">
+      <ul data-depth="{$depth}" class="top-menu">
         {foreach from=$nodes item=node}
           {if $node.children|count}
             <li class="{$node.type}{if $node.current} current {/if}">
-              <a {if $depth === 0} data-toggle="dropdown" {/if}
-                 class = "{if $depth >= 0}dropdown-item{/if}{if $depth === 1} dropdown-submenu{/if}"
-                 href  = "{$node.url nofilter}"
+              <a class="{if $depth >= 0}dropdown-item{/if}{if $depth === 1} dropdown-submenu{/if}"
+                 {if $depth === 0} data-toggle="dropdown" {/if}
+                   href="{$node.url nofilter}" data-depth="{$depth}"
                  {if $node.open_in_new_window} target="_blank" {/if}
-                 data-depth="{$depth}"
               >
                 {$node.label}
               </a>
@@ -22,9 +20,8 @@
             </li>
           {else}
             <li>
-              <a href  = "{$node.url nofilter}"
+              <a href="{$node.url nofilter}" data-depth="{$depth}"
                  {if $node.open_in_new_window} target="_blank" {/if}
-                 data-depth="{$depth}"
               >
                 {$node.label}
               </a>
@@ -33,7 +30,6 @@
         {/foreach}
       </ul>
     {/if}
-  {/strip}
 {/function}
 
 <div class="menu col-md-8 js-top-menu">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | I've removed HTML errors from homepage |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Use the W3C validator on homepage. Before, there are errors, and after only few warnings remains |

> Note that https://github.com/PrestaShop/ps_linklist/pull/8 from `ps_linklist` module needs to be merged to remove 2 additional HTML errors.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
