### PR TITLE
Fixed invalid HTML list on Category Page 

### DIFF
--- a/themes/classic/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
+++ b/themes/classic/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
@@ -62,6 +62,6 @@
 <div class="block-categories">
   <ul class="category-top-menu">
     <li><a class="text-uppercase h6" href="{$categories.link nofilter}">{$categories.name}</a></li>
-    {categories nodes=$categories.children}
+    <li>{categories nodes=$categories.children}</li>
   </ul>
 </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Every children of `ul` element MUST be a list item |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | Does it break backward compatibility? no |
| Deprecations? | Does it deprecate an existing feature? no |
| How to test? | Use the W3C validator on category page |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
