### PR TITLE
Remove pagination override in ManufacturersController

### DIFF
--- a/controllers/front/ManufacturerController.php
+++ b/controllers/front/ManufacturerController.php
@@ -115,8 +115,6 @@ class ManufacturerControllerCore extends FrontController
         if (Configuration::get('PS_DISPLAY_SUPPLIERS')) {
             $data = Manufacturer::getManufacturers(false, $this->context->language->id, true, false, false, false);
             $nbProducts = count($data);
-            $this->n = abs((int)Tools::getValue('n', Configuration::get('PS_PRODUCTS_PER_PAGE')));
-            $this->p = abs((int)Tools::getValue('p', 1));
             $data = Manufacturer::getManufacturers(true, $this->context->language->id, true, $this->p, $this->n, false);
             $this->pagination($nbProducts);
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | File : front controller : ManufacturerController.php. This pagination override in this file lead to get a wrong pagination list. If you have selected a different value of pagination than default (so in your cookie), this override won't take this into account, and will diplay only the default prestashop configured pagination number of manufacturers. Removing it, leave the main FrontController manage correctly the pagination. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | In Manufacturer page list, change the pagination to a non-default one. Then reload the page removing "n=" in the URL. Finally check if the correct number of Manufacturers is listed. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
