### PR TITLE
The broken links on the navigation are fixed

### DIFF
--- a/admin-dev/themes/default/template/nav.tpl
+++ b/admin-dev/themes/default/template/nav.tpl
@@ -26,7 +26,7 @@
 						{foreach $level_1.sub_tabs as $level_2}
 							{if $level_2.active}
 								<li class="maintab {if $level_2.current}active{/if} {if $level_2.sub_tabs|@count}has_submenu{/if}" id="subtab-{$level_2.class_name|escape:'html':'UTF-8'}" data-submenu="{$level_2.id_tab}">
-									<a href="{if $level_2.sub_tabs|@count && isset($level_2.sub_tabs[0].href)}{$level_2.sub_tabs[0].href|escape:'html':'UTF-8'}{else}{$level_2.href|escape:'html':'UTF-8'}{/if}" class="title {if $level_2.sub_tabs|@count}has_submenu{/if}">
+									<a href="{$level_2.href|escape:'html':'UTF-8'}" class="title {if $level_2.sub_tabs|@count}has_submenu{/if}">
 										<i class="material-icons">{$level_2.icon}</i>
 										<span>
 											{if $level_2.name eq ''}{$level_2.class_name|escape:'html':'UTF-8'}{else}{$level_2.name|escape:'html':'UTF-8'}{/if}
@@ -37,7 +37,7 @@
 											{foreach $level_2.sub_tabs as $level_3}
 												{if $level_3.active}
 													<li class="{if $level_3.current}active{/if}" id="subtab-{$level_3.class_name|escape:'html':'UTF-8'}" data-submenu="{$level_3.id_tab}">
-														<a href="{if $level_3.sub_tabs|@count && isset($level_3.sub_tabs[0].href)}{$level_3.sub_tabs[0].href|escape:'html':'UTF-8'}{else}{$level_3.href|escape:'html':'UTF-8'}{/if}" class="title">
+														<a href="{$level_3.href|escape:'html':'UTF-8'}" class="title">
 															{if $level_3.name eq ''}{$level_3.class_name|escape:'html':'UTF-8'}{else}{$level_3.name|escape:'html':'UTF-8'}{/if}
 														</a>
 													</li>

--- a/admin-dev/themes/new-theme/template/components/layout/nav_bar.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/nav_bar.tpl
@@ -33,9 +33,6 @@
               {if $level2.active}
 
                 {$level2Href = $level2.href|escape:'html':'UTF-8'}
-                {if $level2.sub_tabs|@count && isset($level2.sub_tabs[0].href)}
-                  {$level2Href = $level2.sub_tabs[0].href|escape:'html':'UTF-8'}
-                {/if}
 
                 {$level2Name = $level2.name|escape:'html':'UTF-8'}
                 {if $level2.name eq ''}
@@ -52,9 +49,6 @@
                           {if $level3.active}
 
                             {$level3Href = $level3.href|escape:'html':'UTF-8'}
-                            {if $level3.sub_tabs|@count && isset($level3.sub_tabs[0].href)}
-                              {$level3Href = $level3.sub_tabs[0].href|escape:'html':'UTF-8'}
-                            {/if}
 
                             {$level3Name = $level3.name|escape:'html':'UTF-8'}
                             {if $level3.name eq ''}

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1957,6 +1957,9 @@ class AdminControllerCore extends Controller
             $tabs[$index]['href'] = $this->context->link->getAdminLink($tab['class_name']);
 
             $tabs[$index]['sub_tabs'] = array_values($this->getTabs($tab['id_tab'], $level + 1));
+            if (isset($tabs[$index]['sub_tabs'][0])) {
+                $tabs[$index]['href'] = $tabs[$index]['sub_tabs'][0]['href'];
+            }
 
             foreach ($tabs[$index]['sub_tabs'] as $sub_tab) {
                 if ((int)$sub_tab['current'] == true) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In some situations, the dummy link for the navigation is used instead of the child one. This PR fix this by recursively get the first children link if it exists. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | No |
| Deprecations? | No |
| How to test? | Just go on the first Shop Parameters link, and the Order link, no error should occur. |
