### PR TITLE
CO: get carrier by reference using specific language

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -966,7 +966,7 @@ class CarrierCore extends ObjectModel
     /**
      * Get carrier using the reference id
      */
-    public static function getCarrierByReference($id_reference, $id_lang = null))
+    public static function getCarrierByReference($id_reference, $id_lang = null)
     {
         // @todo class var $table must became static. here I have to use 'carrier' because this method is static
         $id_carrier = Db::getInstance()->getValue('SELECT `id_carrier` FROM `'._DB_PREFIX_.'carrier`

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -966,7 +966,7 @@ class CarrierCore extends ObjectModel
     /**
      * Get carrier using the reference id
      */
-    public static function getCarrierByReference($id_reference)
+    public static function getCarrierByReference($id_reference, $id_lang = null))
     {
         // @todo class var $table must became static. here I have to use 'carrier' because this method is static
         $id_carrier = Db::getInstance()->getValue('SELECT `id_carrier` FROM `'._DB_PREFIX_.'carrier`
@@ -974,7 +974,7 @@ class CarrierCore extends ObjectModel
         if (!$id_carrier) {
             return false;
         }
-        return new Carrier($id_carrier);
+        return new Carrier($id_carrier, $id_lang);
     }
 
     /**


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Getting carrier with the reference by the getCarrierByReference() instanciate the Carrier object without an ID lang. This PR let's you to ask the constructor to handle the $id_lang param. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Try to use this method with and without the $id_lang. |
