### PR TITLE
Avoid PHP notices in the old template

### DIFF
--- a/admin-dev/themes/default/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/default/template/page_header_toolbar.tpl
@@ -32,7 +32,7 @@
 {/if}
 
 <div class="bootstrap">
-	<div class="page-head {if $current_tab_level == 3}with-tabs{/if}">
+	<div class="page-head {if isset($current_tab_level) && $current_tab_level == 3}with-tabs{/if}">
 		{block name=pageTitle}
 		<h2 class="page-title">
 			{*if isset($toolbar_btn['back'])}
@@ -128,7 +128,7 @@
 			</div>
 		</div>
 		{/block}
-		{if $current_tab_level == 3}
+		{if isset($current_tab_level) && $current_tab_level == 3}
 			<div class="page-head-tabs">
 				{foreach $tabs as $level_1}
 					{foreach $level_1.sub_tabs as $level_2}


### PR DESCRIPTION
> Copy pasted from #5543 by @BrunoJunior 

Avoid an error when $current_tab_level is not set

| Questions | Answers |
| --- | --- |
| Branch? | 1.7 |
| Description? | I have a module to communicate with our software and I have to test it before PrestaShop 1.7 arrive ... In this module, I have an End Handler and an error handler. Thanks to this, I see errors on PrestaShop core. And I had an error in a smarty cahed file. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
