### PR TITLE
Prevent a guest customer to access to auth required pages

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -281,7 +281,7 @@ class FrontControllerCore extends Controller
             $this->context->cookie->id_cart = (int)$id_cart;
         }
 
-        if ($this->auth && !$this->context->customer->isLogged($this->guestAllowed)) {
+        if ($this->auth && !$this->context->customer->isLogged()) {
             Tools::redirect('index.php?controller=authentication'.($this->authRedirection ? '&back='.$this->authRedirection : ''));
         }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Prevent a guest customer to access to pages requiring authentication (eg: My account) |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | none |
| How to test? | Make a cart a start the checkout like a guest. Click on the first step, and click on your name. You should now be redirected to a login page and not access to the form to edit your personal information. |
