### PR TITLE
BO: Easier way to go to Maintenance page while shop is turned off

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -308,8 +308,9 @@
               {if isset($maintenance_mode) && $maintenance_mode == true}
                 <span class="shop-state" id="maintenance-mode">
                   <i class="material-icons">build</i>
-                  <span class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
-                    title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in maintenance.'}</strong></p><p class='text-left'>{l s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Preferences > Maintenance.' sprintf='<br />'}</p>">{l s='Maintenance mode'}</span>
+                    <a class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
+                    title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in maintenance.'}</strong></p><p class='text-left'>{l s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Preferences > Maintenance.' sprintf='<br />'}</p>" href="{$link->getAdminLink('AdminMaintenance')|escape:'html':'UTF-8'}">{l s='Maintenance mode'}
+                    </a>
                 </span>
               {/if}
 							{if isset($is_multishop) && $is_multishop && $shop_list && (isset($multishop_context) && $multishop_context & Shop::CONTEXT_GROUP || $multishop_context & Shop::CONTEXT_SHOP)}

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -33,8 +33,9 @@
       <div class="component pull-right">
         <div class="shop-state" id="maintenance-mode">
           <i class="material-icons">build</i>
-          <span class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
-            title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in maintenance.'}</strong></p><p class='text-left'>{l s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Preferences > Maintenance.' sprintf='<br />'}</p>">{l s='Maintenance mode'}</span>
+          <a class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true" title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in maintenance.'}</strong></p><p class='text-left'>{l s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Preferences > Maintenance.' sprintf='<br />'}</p>" href="{$link->getAdminLink('AdminMaintenance')|escape:'html':'UTF-8'}">
+              {l s='Maintenance mode'}
+          </a>
         </div>
       </div>
     {/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | I had some troubles finding maintenance page so I decided to make alert about enabled maintenance mode clickable |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | n/a |
| How to test? | Turn on maintenance mode, go to Maintenance page from link at the top of the page |
| Sponsor company | impSolutions

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
