### PR TITLE
IN: Fix composer install with no-dev option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "sensio/generator-bundle": "~2.3",
     "composer/installers": "1.0.21",
     "icanboogie/cldr": "1.3.9",
+    "incenteev/composer-parameter-handler": "~2.0",
     "curl/curl": "1.2.1",
     "ircmaxell/password-compat": "1.0.4",
     "shudrum/array-finder": "1.1.0",
@@ -119,8 +120,7 @@
     "phpunit/phpunit": "~4.5",
     "phake/phake": "@stable",
     "fabpot/php-cs-fixer": "^1.10",
-    "phpdocumentor/phpdocumentor": "2.*",
-    "incenteev/composer-parameter-handler": "~2.0"
+    "phpdocumentor/phpdocumentor": "2.*"
   },
   "autoload-dev": {
     "psr-4": {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix `composer install` with `--no-dev` option |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | Clone PrestaShop and make a `composer install --no-interaction --no-dev`. You should not have any error. |
## Before:

![capture du 2016-05-23 10-11-09](https://cloud.githubusercontent.com/assets/6768917/15464596/a073d560-20d0-11e6-852c-2a3390b3f9a8.png)
## After:

![capture du 2016-05-23 10-25-04](https://cloud.githubusercontent.com/assets/6768917/15464600/a566b538-20d0-11e6-875b-96a49cce8035.png)
