### PR TITLE
FO: Introduce new `hook_block` for Smarty

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -66,6 +66,7 @@ smartyRegisterFunction($smarty, 'modifier', 'secureReferrer', array('Tools', 'se
 smartyRegisterFunction($smarty, 'function', 'dump', 'smartyDump'); // Debug only
 smartyRegisterFunction($smarty, 'function', 'l', 'smartyTranslate', false);
 smartyRegisterFunction($smarty, 'function', 'hook', 'smartyHook');
+smartyRegisterFunction($smarty, 'block', 'hook_block', 'smartyHookBlock');
 smartyRegisterFunction($smarty, 'function', 'toolsConvertPrice', 'toolsConvertPrice');
 smartyRegisterFunction($smarty, 'modifier', 'json_encode', array('Tools', 'jsonEncode'));
 smartyRegisterFunction($smarty, 'modifier', 'json_decode', array('Tools', 'jsonDecode'));
@@ -172,6 +173,37 @@ function smartyRegisterFunction($smarty, $type, $function, $params, $lazy = true
     } else {
         $smarty->registerPlugin($type, $function, $params);
     }
+}
+
+function smartyHookBlock($params, $default_content, &$smarty)
+{
+    $content = '';
+    // TODO: Backup smarty variables and restore them to avoid
+    // new global vars from modules
+
+    if (null === $default_content) {
+        if (_PS_MODE_DEV_) {
+            $content .= '<!-- BEGIN '.$params['h'].' -->';
+        }
+        $params['h'] .= 'Before';
+        $content .= smartyHook($params, $smarty);
+        return $content;
+    }
+
+    // TODO: Shall we pass the $default_content to the hook ?
+    $hook = smartyHook($params, $smarty);
+    if ($hook) {
+        $content .= $hook;
+    } else {
+        $content .= $default_content;
+    }
+
+    $params['h'] .= 'After';
+    $content .= smartyHook($params, $smarty);
+    if (_PS_MODE_DEV_) {
+        $content = '<!-- END '.$params['h'].' -->';
+    }
+    return $content;
 }
 
 function smartyHook($params, &$smarty)


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This is a proposal for an improved hook system in Smarty, the point is to have a default behavior that can be overridden by modules. |
| Type? | bug fix / improvement / new feature |
| Category? | GO |
| BC breaks? | yes. `{hook}` tag will have to be closed |
| Deprecations? | no |
| How to test? | Create a module that overrides something! Best example being [Advanced EU Compliance](https://github.com/PrestaShop/advancedeucompliance) |
### Example
#### Before

``` smarty
{if $product.ecotax.amount > 0}
  <p class="price-ecotax">{l s='Including %s for ecotax' sprintf=$product.ecotax.value}
    {if $product.has_discount}
      {l s='(not impacted by the discount)'}
    {/if}
  </p>
{/if}
{hook h='displaySomeExtraInfo' }
```
#### After

``` smarty
{hook_block h='displayPrice' product=$product type='ecotax' page='product'}
  {if $product.ecotax.amount > 0}
    <p class="price-ecotax">{l s='Including %s for ecotax' sprintf=$product.ecotax.value}
      {if $product.has_discount}
        {l s='(not impacted by the discount)'}
      {/if}
    </p>
  {/if}
{/hook_block}
```

Hence you can completely changed what is displayed here and if no modules are hooked we display the default content.
### TODO
- [x] Let theme declare default behavior for any hook
- [x] Automatically generate a _hookBefore_ and _hookAfter_
- [ ] Rename all `{hook_block}` to `{hook}` and close all existing hook tags.
- [ ] Provide command so contributors can easily close their hook tag
- [ ] Make sure hooks cannot modify global scope
