### PR TITLE
Fix combinations generation when using attributes list

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -911,6 +911,8 @@ var form = (function() {
           $('#form_step3_attributes').on('tokenfield:createdtoken', function(e) {
             if (e.attrs.data) {
               $('#attributes-generator').append('<input type="hidden" id="attribute-generator-' + e.attrs.value + '" class="attribute-generator" value="' + e.attrs.value + '" name="options[' + e.attrs.data.id_group + '][' + e.attrs.value + ']" />');
+            } else if (e.handleObj.origType == 'tokenfield:createdtoken') {
+              $('#attributes-generator').append('<input type="hidden" id="attribute-generator-' + $('.js-attribute-checkbox[data-value="'+e.attrs.value+'"]').data('value') + '" class="attribute-generator" value="' + $('.js-attribute-checkbox[data-value="'+e.attrs.value+'"]').data('value') + '" name="options[' + $('.js-attribute-checkbox[data-value="'+e.attrs.value+'"]').data('group-id') + '][' + $('.js-attribute-checkbox[data-value="'+e.attrs.value+'"]').data('value') + ']" />');
             }
           });
 

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -959,6 +959,9 @@ var form = (function() {
               /** initialize form */
               $('input.attribute-generator').remove();
               $('#attributes-generator div.token').remove();
+              $('.js-attribute-checkbox:checked').each(function() {
+                $(this).prop('checked', false);
+              });
             },
             complete: function() {
               $('#create-combinations').removeAttr('disabled');

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -109,6 +109,7 @@
                 id="attribute-{{ attribute.id }}"
                 data-label="{{ attribute_group.name }} : {{ attribute.name }}"
                 data-value="{{ attribute.id }}"
+                data-group-id="{{ attribute_group.id }}"
                 type="checkbox"
               >
               <label class="attribute-label" for="attribute-{{ attribute.id }}">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -15,7 +15,7 @@
       <div class="alert alert-info" role="alert">
         <i class="material-icons">help</i>
         <p class="alert-text">
-          {{ 'To add combinations, enter the wanted attributes (like « size » or « color ») and their respective values (« XS », « red », etc.) in the field below, or select it in the right column. Then click on « Generate »: it will automatically create all the combinations for you! <br> If you haven’t got any attributes yet, you should first create some in <a class="alert-link" href=$adminTaxesUrl target="_blank">Attributes & Features</a>.'|trans({'$adminTaxesUrl': getAdminLink("AdminTaxes")}, 'AdminProducts')|raw }}
+          {{ 'To add combinations, enter the wanted attributes (like « size » or « color ») and their respective values (« XS », « red », etc.) in the field below, or select it in the right column. Then click on « Generate »: it will automatically create all the combinations for you! <br> If you haven’t got any attributes yet, you should first create some in <a class="alert-link" href=$adminTaxesUrl target="_blank">Attributes & Features</a>.'|trans({'$adminTaxesUrl': getAdminLink("AdminAttributesGroups")}, 'AdminProducts')|raw }}
         </p>
       </div>
       <div class="row">


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR completes the https://github.com/PrestaShop/PrestaShop/pull/5605 one. It was impossible to generate combinations, with this PR it's solved. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Use the attributes on the right and click on `Generate`. |
