### PR TITLE
Improve combinations list layout according to mockups

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -227,7 +227,7 @@ var combinations = (function() {
         }
 
         if (defaultImageUrl) {
-          var img = '<img src="' + defaultImageUrl + '" class="img-responsive" style="max-width:50px" />';
+          var img = '<img src="' + defaultImageUrl + '" class="img-responsive" />';
           $('#accordion_combinations #attribute_' + $(elem).attr('data')).find('td.img').html(img);
         }
       });

--- a/admin-dev/themes/new-theme/scss/pages/_product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_product_page.scss
@@ -509,6 +509,50 @@
       border-top: $gray-light 2px solid;
     }
   }
+
+  .combinations-list {
+    th, td {
+      color: $gray-medium;
+      vertical-align: middle;
+    }
+
+    .uppercase th {
+      text-transform: uppercase;
+      font-weight: $font-weight-normal;
+      font-size: $font-size-xs;
+    }
+    .table-striped tbody tr:nth-of-type(odd) {
+      background-color: $notice;
+    }
+
+    .combination {
+      .img {
+        width: 8%;
+      }
+
+      .attribute-price, .attribute-quantity {
+        width: 15%;
+      }
+
+      .attribute-finalprice {
+        width: 10%;
+      }
+
+      .attribute-actions {
+        width: 10%;
+        line-height: $font-size-base;
+
+        .btn-sm {
+          padding: 0;
+
+          &:hover {
+            background-color: transparent;
+            border-color: transparent;
+          }
+        }
+      }
+    }
+  }
 }
 .popover-title {
   display: none;
@@ -610,6 +654,14 @@
       &.two-columns {
         columns: 2;
       }
+    }
+  }
+}
+
+.table{
+  &.table-no-bordered {
+    thead, tbody, th {
+      border: 0;
     }
   }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -5,19 +5,20 @@
     <td class="attribute-price">
         <div class="input-group">
             <span class="input-group-addon">€ </span>
-            <input type="number" class="attribute_priceTE form-control" value="{{ form.vars.value.attribute_price }}">
+            <input type="number" class="attribute_priceTE form-control text-xs-right" value="{{ form.vars.value.attribute_price }}">
         </div>
     </td>
-    <td class="attribute-finalprice" data-price="{{ form.vars.value.final_price }}">{{ form.vars.value.final_price }}</td>
+    <td class="attribute-finalprice text-xs-right" data-price="{{ form.vars.value.final_price }}">{{ form.vars.value.final_price }}</td>
     <td class="attribute-quantity">
         <div>
-            <input type="text" value="{{ form.vars.value.attribute_quantity }}" class="form-control">
+            <input type="text" value="{{ form.vars.value.attribute_quantity }}" class="form-control text-xs-right">
         </div>
     </td>
-    <td class="text-right">
-        <div class="btn-group" role="group">
-            <a href="#combination_form_{{ form.vars.value.id_product_attribute }}" class="btn btn-default btn-sm btn-open"><i class="material-icons">mode_edit</i></a>
-            <a href="{{ path('admin_delete_attribute', {'idProduct': id_product}) }}" class="btn btn-default btn-sm delete" data="{{ form.vars.value.id_product_attribute }}"><i class="material-icons">delete</i></a>
+
+    <td class="attribute-actions">
+        <div class="btn-group btn-group-sm" role="group">
+            <a href="#combination_form_{{ form.vars.value.id_product_attribute }}" class="btn btn-open btn-invisible btn-sm"><i class="material-icons">mode_edit</i></a>
+            <a href="{{ path('admin_delete_attribute', {'idProduct': id_product}) }}" class="btn btn-open btn-invisible btn-sm delete" data="{{ form.vars.value.id_product_attribute }}"><i class="material-icons">delete</i></a>
             {% set checked = form.vars.value.attribute_default == 1 ? 'checked' : '' %}
             <input class="attribute-default" type="radio" {{ checked }} data-id="{{ form.vars.value.id_product_attribute }}">
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -45,9 +45,9 @@
       </div>
     </div>
 
-    <div>
+    <div class="combinations-list">
       {{ form_errors(form.combinations) }}
-      <table class="table table-striped">
+      <table class="table table-striped table-no-bordered">
         <thead id="combinations_thead" {% if form.combinations|length == 0 %}style="display: none;"{% endif %}>
         <tr class="uppercase">
           <th>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -69,40 +69,6 @@
         </tbody>
       </table>
     </div>
-
-    <div class="form-group">
-      <div class="row">
-
-        <div class="col-md-12">
-          <h2>{{ 'Availability preferences'|trans({}, 'AdminProducts') }}</h2>
-        </div>
-
-        <div class="col-md-12">
-          <label class="form-control-label">{{ 'Behavior when out of stock'|trans({}, 'AdminProducts') }}</label>
-          {{ form_errors(form.out_of_stock) }}
-          {{ form_widget(form.out_of_stock) }}
-        </div>
-
-        <div class="col-md-4">
-            <label class="form-control-label">{{ form.available_now.vars.label }}</label>
-            {{ form_errors(form.available_now) }}
-            {{ form_widget(form.available_now) }}
-        </div>
-
-        <div class="col-md-4 ">
-            <label class="form-control-label">{{ form.available_later.vars.label }}</label>
-            {{ form_errors(form.available_later) }}
-            {{ form_widget(form.available_later) }}
-        </div>
-
-        <div class="col-md-4 ">
-          <label class="form-control-label">{{ form.available_date.vars.label }}</label>
-          {{ form_errors(form.available_date) }}
-          {{ form_widget(form.available_date) }}
-        </div>
-
-      </div>
-    </div>
   </div>
 
   <div id="attributes-list" class="col-md-3">
@@ -139,5 +105,39 @@
         </div>
       </div>
     {% endfor %}
+  </div>
+</div>
+
+<div class="form-group">
+  <div class="row">
+
+    <div class="col-md-12">
+      <h2>{{ 'Availability preferences'|trans({}, 'AdminProducts') }}</h2>
+    </div>
+
+    <div class="col-md-12">
+      <label class="form-control-label">{{ 'Behavior when out of stock'|trans({}, 'AdminProducts') }}</label>
+      {{ form_errors(form.out_of_stock) }}
+      {{ form_widget(form.out_of_stock) }}
+    </div>
+
+    <div class="col-md-4">
+      <label class="form-control-label">{{ form.available_now.vars.label }}</label>
+      {{ form_errors(form.available_now) }}
+      {{ form_widget(form.available_now) }}
+    </div>
+
+    <div class="col-md-4 ">
+      <label class="form-control-label">{{ form.available_later.vars.label }}</label>
+      {{ form_errors(form.available_later) }}
+      {{ form_widget(form.available_later) }}
+    </div>
+
+    <div class="col-md-4 ">
+      <label class="form-control-label">{{ form.available_date.vars.label }}</label>
+      {{ form_errors(form.available_date) }}
+      {{ form_widget(form.available_date) }}
+    </div>
+
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -33,36 +33,35 @@
       </div>
     </div>
 
-  <div id="combinations-bulk-form">
-    <div class="row">
-      <p data-toggle="collapse" href="#bulk-combinations-container" aria-expanded="false" aria-controls="bulk-combinations-container">
-        <b>{{ trans('Bulk actions', {}, 'AdminProducts') }}</b>
-        <i class="material-icons pull-right">keyboard_arrow_down</i>
-      </p>
-      <div class="col-md-12 collapse" style="border:2px solid #bbcdd2;" id="bulk-combinations-container">
-        {{ include('PrestaShopBundle:Admin/Product:form_combinations_bulk.html.twig', { 'form': form_combination_bulk }) }}
+    <div id="combinations-bulk-form">
+      <div class="row">
+        <p data-toggle="collapse" href="#bulk-combinations-container" aria-expanded="false" aria-controls="bulk-combinations-container">
+          <b>{{ trans('Bulk actions', {}, 'AdminProducts') }}</b>
+          <i class="material-icons pull-right">keyboard_arrow_down</i>
+        </p>
+        <div class="col-md-12 collapse" style="border:2px solid #bbcdd2;" id="bulk-combinations-container">
+          {{ include('PrestaShopBundle:Admin/Product:form_combinations_bulk.html.twig', { 'form': form_combination_bulk }) }}
+        </div>
       </div>
     </div>
-  </div>
 
-  <br>
-  <div>
-    {{ form_errors(form.combinations) }}
-    <table class="table table-striped">
-      <thead id="combinations_thead" {% if form.combinations|length == 0 %}style="display: none;"{% endif %}>
-      <tr class="uppercase">
-        <th>
-          <span>{{ trans('Select', [], 'AdminProducts') }}</span>
-          <input type="checkbox" id="toggle-all-combinations" >
-        </th>
-        <th></th>
-        <th>{{ 'Combination'|trans({}, 'AdminProducts') }}</th>
-        <th>{{ 'Impact on price'|trans({}, 'AdminProducts') }}</th>
-        <th>{{ 'Final price'|trans({}, 'AdminProducts') }}</th>
-        <th>{{ 'Quantity'|trans({}, 'AdminProducts') }}</th>
-        <th></th>
-      </tr>
-      </thead>
+    <div>
+      {{ form_errors(form.combinations) }}
+      <table class="table table-striped">
+        <thead id="combinations_thead" {% if form.combinations|length == 0 %}style="display: none;"{% endif %}>
+        <tr class="uppercase">
+          <th>
+            <span>{{ trans('Select', [], 'AdminProducts') }}</span>
+            <input type="checkbox" id="toggle-all-combinations" >
+          </th>
+          <th></th>
+          <th>{{ 'Combinations'|trans({}, 'AdminProducts') }}</th>
+          <th>{{ 'Impact on price'|trans({}, 'AdminProducts') }}</th>
+          <th>{{ 'Final price'|trans({}, 'AdminProducts') }}</th>
+          <th>{{ 'Quantity'|trans({}, 'AdminProducts') }}</th>
+          <th></th>
+        </tr>
+        </thead>
         <tbody class="panel-group accordion" id="accordion_combinations" data-action-delete-all="{{ path('admin_delete_all_attributes') }}" data-weight-unit="{{ 'PS_WEIGHT_UNIT'|configuration }}" data-action-refresh-images="{{ path('admin_get_form_images_combination') }}">
         {% for combination in form.combinations %}
           {{ include('PrestaShopBundle:Admin/Product/Include:form_combination.html.twig', { 'form': combination, 'loop_index': loop.index0, 'id_product': id_product }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -36,7 +36,7 @@
     <div id="combinations-bulk-form">
       <div class="row">
         <p data-toggle="collapse" href="#bulk-combinations-container" aria-expanded="false" aria-controls="bulk-combinations-container">
-          <b>{{ trans('Bulk actions', {}, 'AdminProducts') }}</b>
+          <b>{{ 'Bulk actions'|trans({}, 'AdminProducts') }}</b>
           <i class="material-icons pull-right">keyboard_arrow_down</i>
         </p>
         <div class="col-md-12 collapse" style="border:2px solid #bbcdd2;" id="bulk-combinations-container">
@@ -51,7 +51,7 @@
         <thead id="combinations_thead" {% if form.combinations|length == 0 %}style="display: none;"{% endif %}>
         <tr class="uppercase">
           <th>
-            <span>{{ trans('Select', [], 'AdminProducts') }}</span>
+            <span>{{ 'Select'|trans([], 'AdminProducts') }}</span>
             <input type="checkbox" id="toggle-all-combinations" >
           </th>
           <th></th>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Improve combinations list layout according to mockups |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Pull the branch and compile the `.scss` files. It should look like the attached mockup |

![capture d ecran 2016-05-23 a 15 08 32](https://cloud.githubusercontent.com/assets/2203436/15471831/5a679322-20f8-11e6-9912-80d7e2e1d650.png)
