### PR TITLE
Minor fixes on composer and translations

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -447,6 +447,12 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $this->addRequirement(
+            function_exists('iconv'),
+            'iconv() must be available',
+            'Install and enable the <strong>iconv</strong> extension.'
+        );
+
+        $this->addRequirement(
             function_exists('json_encode'),
             'json_encode() must be available',
             'Install and enable the <strong>JSON</strong> extension.'
@@ -546,10 +552,10 @@ class SymfonyRequirements extends RequirementCollection
             require_once __DIR__.'/../vendor/autoload.php';
 
             try {
-                $r = new \ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
+                $r = new ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
 
                 $contents = file_get_contents(dirname($r->getFileName()).'/Resources/skeleton/app/SymfonyRequirements.php');
-            } catch (\ReflectionException $e) {
+            } catch (ReflectionException $e) {
                 $contents = '';
             }
             $this->addRecommendation(

--- a/app/check.php
+++ b/app/check.php
@@ -6,7 +6,7 @@ $lineSize = 70;
 $symfonyRequirements = new SymfonyRequirements();
 $iniPath = $symfonyRequirements->getPhpIniConfigPath();
 
-echo_title('Symfony2 Requirements Checker');
+echo_title('Symfony Requirements Checker');
 
 echo '> PHP is using the following php.ini file:'.PHP_EOL;
 if ($iniPath) {
@@ -42,9 +42,9 @@ foreach ($symfonyRequirements->getRecommendations() as $req) {
 }
 
 if ($checkPassed) {
-    echo_block('success', 'OK', 'Your system is ready to run Symfony2 projects');
+    echo_block('success', 'OK', 'Your system is ready to run Symfony projects');
 } else {
-    echo_block('error', 'ERROR', 'Your system is not ready to run Symfony2 projects');
+    echo_block('error', 'ERROR', 'Your system is not ready to run Symfony projects');
 
     echo_title('Fix the following mandatory requirements', 'red');
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "symfony/swiftmailer-bundle": "2.3.11",
     "swiftmailer/swiftmailer": "5.4.1",
     "symfony/monolog-bundle": "2.8.2",
-    "sensio/distribution-bundle": "4.0.1",
+    "sensio/distribution-bundle": "4.0.6",
     "sensio/framework-extra-bundle": "3.0.10",
     "sensio/generator-bundle": "~2.3",
     "composer/installers": "1.0.21",

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
@@ -65,8 +65,8 @@
         <p class="alert-text">
             {% if 'PS_FORCE_FRIENDLY_PRODUCT'|configuration == 1 %}
               <strong>{{ 'The "Force update of friendly URL" option is currently enabled.'|trans({}, 'AdminProducts') }}</strong>
-            {{ trans('To disable it, go to', {}, 'AdminProducts') }}
-            <a href="{{ getAdminLink("AdminPPreferences") }}#configuration_fieldset_products">{{ trans('Product Settings', [], 'AdminProducts') }}</a>
+            {{ 'To disable it, go to'|trans({}, 'AdminProducts') }}
+            <a href="{{ getAdminLink("AdminPPreferences") }}#configuration_fieldset_products">{{ 'Product Settings'|trans({}, 'AdminProducts') }}</a>
           {% endif %}
         </p>
       </div>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR removes the notices displayed on `composer install`, and replace the trans() function as a Twig filter |
| Type? | bug fix |
| Category? | BO / IN |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | Make a `composer update`, the deprecation notices should have disappeared |
## Before:

![capture du 2016-05-23 10-25-04](https://cloud.githubusercontent.com/assets/6768917/15476879/06159322-2112-11e6-8088-da4baf40eec2.png)
## After:

![capture du 2016-05-23 18-13-55](https://cloud.githubusercontent.com/assets/6768917/15476891/20850698-2112-11e6-9dc0-b18cf767ccbd.png)
