### PR TITLE
FO: Fix undefined var on maintenance tpl

### DIFF
--- a/themes/classic/templates/errors/maintenance.tpl
+++ b/themes/classic/templates/errors/maintenance.tpl
@@ -6,7 +6,7 @@
 
     {block name='page_header_container'}
       <header class="page-header">
-        <div class="logo"><img src="{$logo_url}" alt="logo"></div>
+        <div class="logo"><img src="{$shop.logo}" alt="logo"></div>
         {hook h='displayMaintenance'}
         {block name='page_header'}
           <h1>{block name='page_title'}{l s='We\'ll be back soon.'}{/block}</h1>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix undefined var when maintenance mode is enabled |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-764](http://forge.prestashop.com/browse/BOOM-764) |
| How to test? | Enable the maintenance mode, without adding your IP, and go to the front office. The shop logo should be properly displayed |
## Before:

![capture du 2016-05-24 11-56-52](https://cloud.githubusercontent.com/assets/6768917/15500129/b1046a7a-21a7-11e6-9b32-2c4e26869da1.png)
## After:

![capture du 2016-05-24 11-56-41](https://cloud.githubusercontent.com/assets/6768917/15500130/b3483c6c-21a7-11e6-83d9-08433acbdf38.png)
