### PR TITLE
Allow uppercase extensions to be uploaded

### DIFF
--- a/classes/Uploader.php
+++ b/classes/Uploader.php
@@ -64,6 +64,11 @@ class UploaderCore
         if (!isset($file_name)) {
             return tempnam($this->getSavePath(), $this->getUniqueFileName());
         }
+        
+        $path_info = pathinfo($file_name);
+        if (isset($path_info['extension'])) {
+            $file_name = $path_info['filename'].'.'.Tools::strtolower($path_info['extension']);
+        }
 
         return $this->getSavePath().$file_name;
     }
@@ -250,7 +255,7 @@ class UploaderCore
         $types = $this->getAcceptTypes();
 
         //TODO check mime type.
-        if (isset($types) && !in_array(pathinfo($file['name'], PATHINFO_EXTENSION), $types)) {
+        if (isset($types) && !in_array(Tools::strtolower(pathinfo($file['name'], PATHINFO_EXTENSION)), $types)) {
             $file['error'] = Tools::displayError('Filetype not allowed');
             return false;
         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When a file with an uppercase extension is submitted, it won't be accepted by the Uploader class. This fix converts the extension to lowercase in order to make a proper validation. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Try to upload a file with an uppercase extension |
