### PR TITLE
CO: Remove duplicate VENDOR_DIR constant

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -200,5 +200,3 @@ define('_PS_SMARTY_CONSOLE_OPEN_', 2);
 if (!defined('_PS_JQUERY_VERSION_')) {
     define('_PS_JQUERY_VERSION_', '1.11.0');
 }
-
-define('VENDOR_DIR', _PS_ROOT_DIR_.'/vendor');

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2226,9 +2226,9 @@ class AdminTranslationsControllerCore extends AdminController
         //adding sf2 form translations
         $sf2_loader = new Symfony\Component\Translation\Loader\XliffFileLoader();
         try {
-            $sf2_trans = $sf2_loader->load(VENDOR_DIR.'/symfony/symfony/src/Symfony/Component/Validator/Resources/translations/validators.'.$this->lang_selected->iso_code.'.xlf', $this->lang_selected->iso_code);
+            $sf2_trans = $sf2_loader->load(_PS_VENDOR_DIR_.'/symfony/symfony/src/Symfony/Component/Validator/Resources/translations/validators.'.$this->lang_selected->iso_code.'.xlf', $this->lang_selected->iso_code);
         } catch (\Exception $e) {
-            $sf2_trans = $sf2_loader->load(VENDOR_DIR.'/symfony/symfony/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf', $this->lang_selected->iso_code);
+            $sf2_trans = $sf2_loader->load(_PS_VENDOR_DIR_.'/symfony/symfony/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf', $this->lang_selected->iso_code);
         }
 
         foreach ($sf2_trans->all()['messages'] as $k => $v) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | "VENDOR_DIR" and "_PS_VENDOR_DIR_" serve the same purpose only one is needed. |
| Type? | improvement |
| Category? | Core |
| BC breaks? | Yes (If "VENDOR_DIR" is used by some third party module) |
| Deprecations? | No |
| Fixed ticket? |  |
| How to test? |  |
