### PR TITLE
IN: avoid fetch() on null query result

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -365,13 +365,16 @@ class DbPDOCore extends Db
 
         $sql = 'SHOW VARIABLES WHERE Variable_name = \'have_innodb\'';
         $result = $this->link->query($sql);
+
         if (!$result) {
             $value = 'MyISAM';
+        }else {
+            $row = $result->fetch();
+            if (!$row || strtolower($row['Value']) != 'yes') {
+                $value = 'MyISAM';
+            }
         }
-        $row = $result->fetch();
-        if (!$row || strtolower($row['Value']) != 'yes') {
-            $value = 'MyISAM';
-        }
+
 
         /* MySQL >= 5.6 */
         $sql = 'SHOW ENGINES';


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When database is not innoDB, we try to fetch() a boolean result.. |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Needs to do it before start http://forge.prestashop.com/browse/BOOM-772 |
| How to test? | Try to install PrestaShop using PHP 7 and MySQL 5.7 |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
