### PR TITLE
Production & development cache conflicts fixed

### DIFF
--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -1029,7 +1029,7 @@ class AdminPerformanceControllerCore extends AdminController
             $redirectAdmin = true;
 
             $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-            $sf2Refresh->addCacheClear();
+            $sf2Refresh->addCacheClear(_PS_MODE_DEV_ ? 'dev' : 'prod');
             $sf2Refresh->execute();
         }
 

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -129,6 +129,11 @@ class InstallModelInstall extends InstallAbstractModel
             return false;
         }
 
+        // Clear the cache
+        $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
+        $sf2Refresh->addCacheClear('dev');
+        $sf2Refresh->addCacheClear('prod');
+        $output = $sf2Refresh->execute();
 
         return true;
     }

--- a/src/PrestaShopBundle/Service/Cache/Refresh.php
+++ b/src/PrestaShopBundle/Service/Cache/Refresh.php
@@ -60,10 +60,12 @@ class Refresh
 
     /**
      * Add cache clear.
+     *
+     * @param string $env Environment to clear
      */
-    public function addCacheClear()
+    public function addCacheClear($env = 'dev')
     {
-        $this->commands[] = ['command' => 'cache:clear', '--env' => $this->env, '--no-debug' => true];
+        $this->commands[] = ['command' => 'cache:clear', '--env' => $env, '--no-debug' => true];
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The configuration cache was not synchronized between the production and development mode. This pull request fixes this. |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | BOOM-775 && BOOM-781 |
| How to test? | See below |
## How to test
#### Test 1

1) Set PrestaShop on debug mode
2) Install PrestaShop on a specific database
3) Set PrestaShop on production mode (debug off)
4) Install PrestaShop with another database name
#### Test 2

1) Install PrestaShop on debug mode
2) Go to backoffice product page
3) Change the debug mode to off
4) Refresh the product page

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
