### PR TITLE
Fix delete alert when switching from a combination to another

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -18,7 +18,7 @@
     <td class="attribute-actions">
         <div class="btn-group btn-group-sm" role="group">
             <a href="#combination_form_{{ form.vars.value.id_product_attribute }}" class="btn btn-open btn-invisible btn-sm"><i class="material-icons">mode_edit</i></a>
-            <a href="{{ path('admin_delete_attribute', {'idProduct': id_product}) }}" class="btn btn-open btn-invisible btn-sm delete" data="{{ form.vars.value.id_product_attribute }}"><i class="material-icons">delete</i></a>
+            <a href="{{ path('admin_delete_attribute', {'idProduct': id_product}) }}" class="btn btn-invisible btn-sm delete" data="{{ form.vars.value.id_product_attribute }}"><i class="material-icons">delete</i></a>
             {% set checked = form.vars.value.attribute_default == 1 ? 'checked' : '' %}
             <input class="attribute-default" type="radio" {{ checked }} data-id="{{ form.vars.value.id_product_attribute }}">
         </div>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When you edit a combination and click on "next" or "previous" there was a modal asking you if you want to delete the combination. This PR fixes this. |
| Type? | bug fix / improvement / new feature |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-766 |
| How to test? | Just go to a product with combinations, edit one and click on "next" and/or "prev" |
