### PR TITLE
Made the final price dynamic according to impact on price in BO

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1577,6 +1577,7 @@ var priceCalculation = (function() {
       /** combinations : update TTC price field on change */
       $('.combination-form .attribute_priceTE').keyup(function() {
         priceCalculation.impactTaxInclude($(this));
+        priceCalculation.impactFinalPrice($(this));
       });
       /** combinations : update HT price field on change */
       $('.combination-form .attribute_priceTI').keyup(function() {
@@ -1625,6 +1626,14 @@ var priceCalculation = (function() {
       var newPrice = ps_round(addTaxes(price, rates, computation_method));
 
       targetInput.val(newPrice);
+    },
+    'impactFinalPrice': function(obj) {
+      var price = parseFloat(obj.val().replace(/,/g, '.'));
+      var finalPrice = obj.closest('div[id^="combination_form_"]').find('.final-price');
+      var defaultFinalPrice = finalPrice.attr('data-price');
+      var priceToBeChanged = new Number(price) + new Number(defaultFinalPrice);
+
+      finalPrice.html(priceToBeChanged.toFixed(2));
     },
     'impactTaxExclude': function(obj) {
       var price = parseFloat(obj.val().replace(/,/g, '.'));

--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -50,7 +50,7 @@ var combinations = (function() {
       }
       var priceImpactInput = tableRow.find('.attribute_priceTE');
       var impactOnPrice = priceImpactInput.val() - priceImpactInput.attr('value');
-      var actualFinalPriceInput = tableRow.find('.attribute-finalprice');
+      var actualFinalPriceInput = tableRow.find('.attribute-finalprice span');
       var actualFinalPrice = actualFinalPriceInput.data('price');
 
       var finalPrice = actualFinalPrice + impactOnPrice;

--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -41,7 +41,7 @@ var combinations = (function() {
   }
 
   /**
-   * Update final price, regarding the impact on price
+   * Update final price, regarding the impact on price in combinations table
    * @param {object} elem - The tableau row parent
    */
   function updateFinalPrice(tableRow) {
@@ -77,6 +77,16 @@ var combinations = (function() {
       $(document).on('keyup', '.attribute-quantity input', function() {
         var id_attribute = $(this).closest('.combination').attr('data');
         $('#combination_form_' + id_attribute).find('input[id^="form_step3_combinations_"][id$="_attribute_quantity"]').val($(this).val());
+      });
+
+      /** on change shortcut impact on price, update form field impact on price */
+      $(document).on('keyup', 'input[id^="form_step3_combinations_"][id$="_attribute_price"]', function() {
+        var id_attribute = $(this).closest('.combination-form').attr('data');
+        var input = $('#accordion_combinations #attribute_' + id_attribute).find('.attribute-price input');
+        input.val($(this).val());
+
+        /* force the update of final price */
+        input.change();
       });
 
       /** on change default attribute, update which combination is the new default */

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -173,4 +173,17 @@ class LegacyContext
     {
         return \LanguageCore::getIsoById($this->getContext()->employee->id_lang);
     }
+
+    /**
+     * Returns Currency set for the current employee
+     */
+    public function getEmployeeCurrency()
+    {
+        static $employeeCurrency;
+
+        if(null === $employeeCurrency) {
+            $employeeCurrency = $this->getContext()->currency->sign;
+        }
+        return $employeeCurrency;
+    }
 }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
@@ -60,7 +60,7 @@ class ProductCombinationBulk extends CommonAbstractType
             'attr' => ['data-display-price-precision' => $this->priceDisplayPrecision],
             'currency' => $this->isoCode,
         ))
-        ->add('impact_on_weight', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
+        ->add('impact_on_weight', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,
             'label' => $this->translator->trans('Impact on weight', [], 'AdminProducts'),
         ))

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -97,7 +97,7 @@
                         </fieldset>
                     </div>
                     <div class="col-md-3">
-                      <small class="combination-label vcenter">{{ "Final retail price (tax excl.) will be"|trans({}, 'AdminProducts') }} <span class="final-price">{{ form.vars.value.final_price }}</span> {{ default_currency }}</small>
+                      <small class="combination-label vcenter">{{ "Final retail price (tax excl.) will be"|trans({}, 'AdminProducts') }} <span class="final-price" data-price="{{ form.vars.value.final_price }}">{{ form.vars.value.final_price }}</span> {{ default_currency }}</small>
                     </div>
                 </div>
                 <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -4,11 +4,13 @@
     <td>{{ form.vars.value.name }}</td>
     <td class="attribute-price">
         <div class="input-group">
-            <span class="input-group-addon">€ </span>
+            <span class="input-group-addon">{{ default_currency }}</span>
             <input type="number" class="attribute_priceTE form-control text-xs-right" value="{{ form.vars.value.attribute_price }}">
         </div>
     </td>
-    <td class="attribute-finalprice text-xs-right" data-price="{{ form.vars.value.final_price }}">{{ form.vars.value.final_price }}</td>
+    <td class="attribute-finalprice text-xs-right">
+      <span data-price="{{ form.vars.value.final_price }}">{{ form.vars.value.final_price }}</span> {{ default_currency }}
+    </td>
     <td class="attribute-quantity">
         <div>
             <input type="text" value="{{ form.vars.value.attribute_quantity }}" class="form-control text-xs-right">
@@ -95,7 +97,11 @@
                         </fieldset>
                     </div>
                     <div class="col-md-3">
+<<<<<<< HEAD
                       <small class="combination-label vcenter">{{ "Final retail price (tax excl.) will be €00.00"|trans({}, 'AdminProducts') }}</small>
+=======
+                      <small class="combination-label vcenter">{{ "Final retail price (tax excl.) will be"|trans({}, 'AdminProducts') }} <span class="final-price">{{ form.vars.value.final_price }}</span> {{ default_currency }}</small>
+>>>>>>> 39f909d... BO: use currency from configuration instead of hardcoded one
                     </div>
                 </div>
                 <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -97,11 +97,7 @@
                         </fieldset>
                     </div>
                     <div class="col-md-3">
-<<<<<<< HEAD
-                      <small class="combination-label vcenter">{{ "Final retail price (tax excl.) will be €00.00"|trans({}, 'AdminProducts') }}</small>
-=======
                       <small class="combination-label vcenter">{{ "Final retail price (tax excl.) will be"|trans({}, 'AdminProducts') }} <span class="final-price">{{ form.vars.value.final_price }}</span> {{ default_currency }}</small>
->>>>>>> 39f909d... BO: use currency from configuration instead of hardcoded one
                     </div>
                 </div>
                 <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form_combinations_bulk.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form_combinations_bulk.html.twig
@@ -12,18 +12,23 @@
   </div>
 
   <div class="col-md-2">
-    <label class="form-control-label">{{ form.impact_on_weight.vars.label }}</label>
-    {{ form_errors(form.impact_on_weight) }}
-    {{ form_widget(form.impact_on_weight) }}
+    <fieldset>
+      <label class="form-control-label">{{ form.impact_on_weight.vars.label }}</label>
+      {{ form_errors(form.impact_on_weight) }}
+      <div class="input-group">
+        <span class="input-group-addon">{{ 'PS_WEIGHT_UNIT'|configuration }}</span>
+        {{ form_widget(form.impact_on_weight) }}
+      </div>
+    </fieldset>
   </div>
 
-  <div class="col-md-2">
+  <div class="col-md-3">
     <label class="form-control-label">{{ form.impact_on_price_te.vars.label }}</label>
     {{ form_errors(form.impact_on_price_te) }}
     {{ form_widget(form.impact_on_price_te) }}
   </div>
 
-  <div class="col-md-2">
+  <div class="col-md-3">
     <label class="form-control-label">{{ form.impact_on_price_ti.vars.label }}</label>
     {{ form_errors(form.impact_on_price_ti) }}
     {{ form_widget(form.impact_on_price_ti) }}

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -67,6 +67,7 @@ class LayoutExtension extends \Twig_Extension implements \Twig_Extension_Globals
     public function getGlobals()
     {
         return array(
+            "default_currency" => $this->context->getEmployeeCurrency(),
             "root_url" => $this->context->getRootUrl(),
             "js_translatable" => [],
         );


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | It's time to remove some hardcoded values in combinations forms :) |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-790 |
| How to test? | Edit a product. In bulk action form, impact on weight in now in kilograms and the currency is not set up by configuration. As we now have the currency, we have added it to final price in the recap table below. More, in combination table, the final price is now correct. I need to made it dynamic according to changes done whe we use the impact on price. |
### final price

![final_price](https://cloud.githubusercontent.com/assets/1247388/15575562/cd320f9c-2353-11e6-8b74-225977b8e2f3.png)
### final price retail

![final_retail_price](https://cloud.githubusercontent.com/assets/1247388/15575561/cd2f2340-2353-11e6-9b5d-ee2384ba635a.png)
### impact on weight

![impact_on_weight](https://cloud.githubusercontent.com/assets/1247388/15575563/cd352b32-2353-11e6-98bc-62e29bce52a7.png)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
