### PR TITLE
Get module errors on failure and fix upload popup

### DIFF
--- a/admin-dev/themes/default/css/bundle/module/module.css
+++ b/admin-dev/themes/default/css/bundle/module/module.css
@@ -357,9 +357,7 @@ img.module-logo-thumb-list {
 .module-import-failure-details {
   word-wrap: break-word;
   font-size: small;
-  color: #CECCCC;
   max-height: 120px;
-  overflow: scroll;
   margin: 35px 5px 20px 5px;
   text-align: justify;
   display: none;

--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -676,7 +676,7 @@ var AdminModuleController = function () {
                  $(_this.moduleImportProcessingSelector).finish().fadeOut(function() {
                       if (responseObject.status === true) {
                           if (responseObject.is_configurable === true) {
-                              var configureLink = this.baseAdminDir + 'module/manage/action/configure/' + responseObject.module_name;
+                              var configureLink = _this.baseAdminDir + 'module/manage/action/configure/' + responseObject.module_name;
                               $(_this.moduleImportSuccessConfigureBtnSelector).attr('href', configureLink);
                               $(_this.moduleImportSuccessConfigureBtnSelector).show();
                           }

--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -653,10 +653,9 @@ var AdminModuleController = function () {
               // State that we start module upload
               _this.isUploadStarted = true;
               var _that = _this;
-             $(_this.moduleImportStartSelector).fadeOut(function(){
-                 $('.dropzone').css('border', 'none');
-                 $(_that.moduleImportProcessingSelector).fadeIn();
-             });
+             $(_this.moduleImportStartSelector).hide(0);
+             $('.dropzone').css('border', 'none');
+             $(_that.moduleImportProcessingSelector).fadeIn();
           },
           /* processing(file, response) */
           processing: function () {
@@ -664,7 +663,7 @@ var AdminModuleController = function () {
           },
           /* error(file, errorMessage) */
           error: function (file, message) {
-            $(_this.moduleImportProcessingSelector).fadeOut(function() {
+            $(_this.moduleImportProcessingSelector).finish().fadeOut(function() {
               $(_this.moduleImportFailureMsgDetailsSelector).html(message);
               $(_this.moduleImportFailureSelector).fadeIn();
             });
@@ -674,7 +673,7 @@ var AdminModuleController = function () {
               if (file.status !== 'error') {
                   var responseObject = jQuery.parseJSON(file.xhr.response);
 
-                 $(_this.moduleImportProcessingSelector).fadeOut(function() {
+                 $(_this.moduleImportProcessingSelector).finish().fadeOut(function() {
                       if (responseObject.status === true) {
                           if (responseObject.is_configurable === true) {
                               var configureLink = this.baseAdminDir + 'module/manage/action/configure/' + responseObject.module_name;

--- a/src/Core/Addon/AddonManagerInterface.php
+++ b/src/Core/Addon/AddonManagerInterface.php
@@ -33,4 +33,5 @@ interface AddonManagerInterface
     public function enable($name);
     public function disable($name);
     public function reset($name);
+    public function getError($name);
 }

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -126,12 +126,7 @@ class ModuleManager implements AddonManagerInterface
 
         // Get module instance and uninstall it
         $module = $this->moduleRepository->getModule($name);
-        try {
-            $result = $module->onUninstall();
-        } catch (Exception $e) {
-            $this->msgs_error[$name][] = 'Error on module uninstallation. '. $e->getMessage();
-            $result = false;
-        }
+        $result = $module->onUninstall();
 
         if ($result && (bool)$file_deletion) {
             $result &= $this->removeModuleFromDisk($name);
@@ -331,5 +326,22 @@ class ModuleManager implements AddonManagerInterface
     public function removeModuleFromDisk($name)
     {
         return $this->moduleUpdater->removeModuleFromDisk($name);
+    }
+
+    /**
+     * Returns the last error, if found
+     *
+     * @param string $name The technical module name
+     * @return string|null The last error added to the module if found
+     */
+    public function getError($name)
+    {
+        $module = $this->moduleRepository->getModule($name);
+        if ($module->hasValidInstance()) {
+            $errors = $module->getInstance()->getErrors();
+            return array_pop($errors);
+        }
+
+        return null;
     }
 }

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -193,6 +193,17 @@ class ThemeManager implements AddonManagerInterface
         return $this->disable($theme_name) && $this->enable($theme_name);
     }
 
+    /**
+     * Returns the last error, if found
+     *
+     * @param string $name The technical theme name
+     * @return string|null The last error if found
+     */
+    public function getError($theme_name)
+    {
+        return null;
+    }
+
     private function doCreateCustomHooks(array $hooks)
     {
         foreach ($hooks as $hook) {

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -190,9 +190,11 @@ class ModuleController extends FrameworkBundleAdminController
                 if ($ret[$module]['status'] === null) {
                     $ret[$module]['status'] = false;
                     $ret[$module]['msg'] = $module .' did not return a valid response on '.$action .' action';
+                } elseif ($ret[$module]['status'] === false) {
+                    $error = $moduleManager->getError($module);
+                    $ret[$module]['msg'] = sprintf('Cannot %s module %s. %s', str_replace('_', ' ', $action), $module, $error);
                 } else {
-                    $ret[$module]['msg'] = ucfirst(str_replace('_', ' ', $action)). ' action on module '. $module;
-                    $ret[$module]['msg'] .= $ret[$module]['status']?' succeeded':' failed';
+                    $ret[$module]['msg'] = sprintf('%s action on module %s succeeded.', ucfirst(str_replace('_', ' ', $action)), $module);
                 }
             } catch (Exception $e) {
                 $ret[$module]['status'] = false;
@@ -343,9 +345,9 @@ class ModuleController extends FrameworkBundleAdminController
                 $installation_response['msg'] = 'Install action on module '. $module_name;
                 if ($installation_response['status'] === true) {
                     $installation_response['is_configurable'] = (bool)$this->get('prestashop.core.admin.module.repository')->getModule($module_name)->attributes->get('is_configurable');
-                    $installation_response['msg'] .= 'succeeded';
+                    $installation_response['msg'] .= ' succeeded.';
                 } else {
-                    $installation_response['msg'] .= 'failed';
+                    $installation_response['msg'] .= ' failed. '. $moduleManager->getError($module_name);
                 }
             }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When we try an action on a module (install, uninstall, reset etc.) and it fails, we now try to get the last error saved in the module. Also, this PR fixes an interface issue when the server answers too fast to an upload request. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-731](http://forge.prestashop.com/browse/BOOM-731) and maybe [BOOM-789](http://forge.prestashop.com/browse/BOOM-789) |
| How to test? | Install a module which fails (in example because it is not compatible with PrestaShop 1.7). You should now have a more detailed message explaining that point. |
## Results on module installation

![capture du 2016-05-26 14-56-35](https://cloud.githubusercontent.com/assets/6768917/15575386/da96c516-2352-11e6-8986-abca0ae13b6f.png)
## Results on module upload

![capture du 2016-05-26 15-24-45](https://cloud.githubusercontent.com/assets/6768917/15576010/ff05e366-2355-11e6-8656-4682572556c6.png)
