### PR TITLE
Fix product default category selection on Firefox

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/default-category.js
+++ b/admin-dev/themes/default/js/bundle/product/default-category.js
@@ -18,16 +18,7 @@ var defaultCategory = (function() {
      * Check the radio bouton with the selected value
      */
     'check': function(value) {
-      var defaultCategory = defaultCategoryForm.find('input[value="'+value+'"]');
-      if (defaultCategory.is(':checked')) {
-        console.log('already checked');
-        return;
-      }
-      else {
-        var previousDefault = defaultCategoryForm.find('input:checked');
-        previousDefault.attr('checked', false);
-        defaultCategory.attr('checked', 'checked');
-      }
+      defaultCategoryForm.find('input[value="'+value+'"]').prop('checked', true);
     }
   };
 })();

--- a/admin-dev/themes/new-theme/scss/pages/_product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_product_page.scss
@@ -375,7 +375,7 @@
   #add-categories {
     margin-top: rem(40px);
   }
-  #form_step1_categories {
+  #categories-tree {
     clear: both;
   }
   .ui-widget {
@@ -558,18 +558,43 @@
   display: none;
 }
 .ui-autocomplete {
-  max-width: rem(290px);
   @media screen and (max-width: 1450px) {
     max-width: rem(197px);
   }
-  li:hover {
-    background: $primary-hover;
-    cursor: pointer;
-    a {
-      color: $white;
-      text-decoration: none;
+
+  max-width: rem(290px);
+  position: absolute;
+  z-index: 1000;
+  cursor: default;
+  padding: 0;
+  margin-top: 2px;
+  list-style: none;
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+
+  > li {
+    padding: 3px 20px;
+
+    &:hover {
+      background: $primary-hover;
+      cursor: pointer;
+      a {
+        color: $white;
+        text-decoration: none;
+      }
+    }
+
+    &.ui-state-focus {
+      background-color: #DDD;
     }
   }
+
   a {
     color: $gray-medium;
   }

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
@@ -54,32 +54,3 @@
     {{ 'Add a category'|trans({}, 'AdminProducts') }}
   </a>
 </div>
-<!-- start of CSS plugin: to be moved in his own file -->
-<style>
-  .ui-autocomplete {
-    position: absolute;
-    z-index: 1000;
-    cursor: default;
-    padding: 0;
-    margin-top: 2px;
-    list-style: none;
-    background-color: #ffffff;
-    border: 1px solid #ccc;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    border-radius: 5px;
-    -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-    -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-  }
-  .ui-autocomplete > li {
-    padding: 3px 20px;
-  }
-  .ui-autocomplete > li.ui-state-focus {
-    background-color: #DDD;
-  }
-  .ui-helper-hidden-accessible {
-    display: none;
-  }
-</style>
-<!-- end of CSS plugin -->


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix product default category selection on Firefox |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-796 |
| How to test? | Try to select another default category for a product, save and reload. It should be okay now. |
