### PR TITLE
Do not write parameters.yml in bootstrap.php and other minor fixes

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -211,7 +211,7 @@
 				{/if}
 
 				{* Search *}
-				{include file="search_form.tpl" id="header_search" show_clear_btn=1}
+				{include file="search_form.tpl" show_clear_btn=1}
 
 				{* Employee *}
 				<ul id="header_employee_box">

--- a/admin-dev/themes/default/template/search_form.tpl
+++ b/admin-dev/themes/default/template/search_form.tpl
@@ -22,7 +22,7 @@
 * @license   http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
 * International Registered Trademark & Property of PrestaShop SA
 *}
-<form id="{$id|escape:'html':'UTF-8'}" class="bo_search_form" method="post" action="{$baseAdminUrl}index.php?controller=AdminSearch&amp;token={getAdminToken tab='AdminSearch'}" role="search">
+<form id="header_search" class="bo_search_form" method="post" action="{$baseAdminUrl}index.php?controller=AdminSearch&amp;token={getAdminToken tab='AdminSearch'}" role="search">
 	<div class="form-group">
 		<input type="hidden" name="bo_search_type" id="bo_search_type" />
 		<div class="input-group">

--- a/admin-dev/themes/new-theme/template/components/layout/search_form.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/search_form.tpl
@@ -24,7 +24,7 @@
 *}
 
 
-<form id="{$id|escape:'html':'UTF-8'}"
+<form id="header_search"
       class="bo_search_form dropdown-form js-dropdown-form"
       method="post"
       action="{$baseAdminUrl}index.php?controller=AdminSearch&amp;token={getAdminToken tab='AdminSearch'}"

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -36,35 +36,37 @@ ServiceLocator::setServiceContainerInstance($container);
 if (!file_exists(_PS_CACHE_DIR_)) {
     @mkdir(_PS_CACHE_DIR_);
     $warmer = new CacheWarmerAggregate([
-        new PrestaShopBundle\CacheWarmer\LocalizationCacheWarmer(_PS_VERSION_, 'en') //@replace hardcore Lang
+        new PrestaShopBundle\CacheWarmer\LocalizationCacheWarmer(_PS_VERSION_, 'en') //@replace hard-coded Lang
     ]);
     $warmer->warmUp(_PS_CACHE_DIR_);
 }
 
-if (!file_exists(__DIR__. '/../app/config/parameters.yml')) {
-    copy(__DIR__. '/../app/config/parameters.yml.dist', __DIR__. '/../app/config/parameters.yml');
-}
+$fmtParamYml = (int)@filemtime(__DIR__. '/../app/config/parameters.yml');
 
-if (_PS_MODE_DEV_ || !file_exists(_PS_CACHE_DIR_. 'appParameters.php')) {
-    $config = Yaml::parse(file_get_contents(__DIR__. '/../app/config/parameters.yml'));
-    file_put_contents(_PS_CACHE_DIR_ .'appParameters.php', '<?php return ' . var_export($config, true). ';');
-}
+if ($fmtParamYml) {
+    $fmtAppParamPhp = (int)@filemtime(_PS_CACHE_DIR_. 'appParameters.php');
+    // If the parameters.ypl file has been updated, let's update its cache
+    if (!$fmtAppParamPhp || $fmtAppParamPhp < $fmtParamYml) {
+        $config = Yaml::parse(file_get_contents(__DIR__. '/../app/config/parameters.yml'));
+        file_put_contents(_PS_CACHE_DIR_ .'appParameters.php', '<?php return ' . var_export($config, true). ';');
+    }
 
-$config = require_once _PS_CACHE_DIR_ .'appParameters.php';
+    $config = require_once _PS_CACHE_DIR_ .'appParameters.php';
 
-define('_DB_SERVER_', $config['parameters']['database_host']);
-define('_DB_NAME_', $config['parameters']['database_name']);
-define('_DB_USER_', $config['parameters']['database_user']);
-define('_DB_PASSWD_', $config['parameters']['database_password']);
-define('_DB_PREFIX_',  $config['parameters']['database_prefix']);
-define('_MYSQL_ENGINE_',  $config['parameters']['database_engine']);
-define('_PS_CACHING_SYSTEM_',  $config['parameters']['ps_caching']);
-define('_PS_CACHE_ENABLED_', $config['parameters']['ps_cache_enable']);
-define('_COOKIE_KEY_', $config['parameters']['cookie_key']);
-define('_COOKIE_IV_', $config['parameters']['cookie_iv']);
-define('_PS_CREATION_DATE_', $config['parameters']['ps_creation_date']);
+    define('_DB_SERVER_', $config['parameters']['database_host']);
+    define('_DB_NAME_', $config['parameters']['database_name']);
+    define('_DB_USER_', $config['parameters']['database_user']);
+    define('_DB_PASSWD_', $config['parameters']['database_password']);
+    define('_DB_PREFIX_',  $config['parameters']['database_prefix']);
+    define('_MYSQL_ENGINE_',  $config['parameters']['database_engine']);
+    define('_PS_CACHING_SYSTEM_',  $config['parameters']['ps_caching']);
+    define('_PS_CACHE_ENABLED_', $config['parameters']['ps_cache_enable']);
+    define('_COOKIE_KEY_', $config['parameters']['cookie_key']);
+    define('_COOKIE_IV_', $config['parameters']['cookie_iv']);
+    define('_PS_CREATION_DATE_', $config['parameters']['ps_creation_date']);
 
-if (isset($config['parameters']['_rijndael_key']) && isset($config['parameters']['_rijndael_iv'])) {
-    define('_RIJNDAEL_KEY_', $config['parameters']['_rijndael_key']);
-    define('_RIJNDAEL_IV_', $config['parameters']['_rijndael_iv']);
+    if (isset($config['parameters']['_rijndael_key']) && isset($config['parameters']['_rijndael_iv'])) {
+        define('_RIJNDAEL_KEY_', $config['parameters']['_rijndael_key']);
+        define('_RIJNDAEL_IV_', $config['parameters']['_rijndael_iv']);
+    }
 }

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -525,6 +525,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
     public function displayAjaxGetKpi()
     {
         $currency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
+        $tooltip = null;
         switch (Tools::getValue('kpi')) {
             case 'conversion_rate':
                 $visitors = AdminStatsController::getVisits(true, date('Y-m-d', strtotime('-31 day')), date('Y-m-d', strtotime('-1 day')), false /*'day'*/);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Small fixes after testing some pages in prod mode. Also, I changed the bootstrap file in order to regenerate the `appParameters.php` file always when the `parameters.yml` has been updated, thanks to the function `filemtime()`. This avoid unexpected behavior of PrestaShop because of an outdated cache. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | Modify your parameters.yml, the changes must be applied to the cache file `app/cache/<env>/appParameters.php` as soon as you refresh the page. |
