### PR TITLE
Installer cache generation fixed

### DIFF
--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -145,9 +145,18 @@ class InstallModelInstall extends InstallAbstractModel
         }
 
         // Clear the cache
-        $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-        $sf2Refresh->addCacheClear('dev');
-        $sf2Refresh->addCacheClear('prod');
+
+        $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh('prod');
+        $sf2Refresh->addCacheClear();
+        $output = $sf2Refresh->execute();
+
+        if (0 !== $output['cache:clear']['exitCode']) {
+            $this->setError(explode("\n", $output['cache:clear']['output']));
+            return false;
+        }
+
+        $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh('dev');
+        $sf2Refresh->addCacheClear();
         $output = $sf2Refresh->execute();
 
         if (0 !== $output['cache:clear']['exitCode']) {

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -135,6 +135,11 @@ class InstallModelInstall extends InstallAbstractModel
         $sf2Refresh->addCacheClear('prod');
         $output = $sf2Refresh->execute();
 
+        if (0 !== $output['cache:clear']['exitCode']) {
+            $this->setError(explode("\n", $output['cache:clear']['output']));
+            return false;
+        }
+
         return true;
     }
 

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -196,8 +196,8 @@ class InstallModelInstall extends InstallAbstractModel
         $sf2Refresh->addDoctrineSchemaUpdate();
         $output = $sf2Refresh->execute();
 
-        if (!empty($output['sf2_schema_update'])) {
-            $this->setError($this->language->l('SQL error command <i>doctrine:schema:update</i>, please check your app/config/parameters.yml file'));
+        if (0 !== $output['doctrine:schema:update']['exitCode']) {
+            $this->setError(explode("\n", $output['doctrine:schema:update']['output']));
             return false;
         }
 

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -62,16 +62,31 @@ class InstallModelInstall extends InstallAbstractModel
     }
 
     /**
-     * Generate settings file
+     * Generate the settings file.
      */
-    public function generateSettingsFile($database_host, $database_user, $database_password, $database_name, $database_prefix, $database_engine)
-    {
+    public function generateSettingsFile(
+        $database_host,
+        $database_user,
+        $database_password,
+        $database_name,
+        $database_prefix,
+        $database_engine
+    ) {
         // Check permissions for settings file
-        if (file_exists(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.self::SETTINGS_FILE) && !is_writable(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.self::SETTINGS_FILE)) {
+        if (
+            file_exists(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.self::SETTINGS_FILE)
+            && !is_writable(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.self::SETTINGS_FILE)
+        ) {
             $this->setError($this->language->l('%s file is not writable (check permissions)', self::SETTINGS_FILE));
             return false;
-        } elseif (!file_exists(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.self::SETTINGS_FILE) && !is_writable(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.dirname(self::SETTINGS_FILE))) {
-            $this->setError($this->language->l('%s folder is not writable (check permissions)', dirname(self::SETTINGS_FILE)));
+        } elseif (
+            !file_exists(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.self::SETTINGS_FILE)
+            && !is_writable(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.dirname(self::SETTINGS_FILE))
+        ) {
+            $this->setError($this->language->l(
+                '%s folder is not writable (check permissions)',
+                dirname(self::SETTINGS_FILE))
+            );
             return false;
         }
 
@@ -80,7 +95,7 @@ class InstallModelInstall extends InstallAbstractModel
         $cookie_iv = Tools::passwdGen(56);
 
         if (file_exists(_PS_ROOT_DIR_.'/app/config/parameters.yml')) {
-            $config = Yaml::parse(file_get_contents(_PS_ROOT_DIR_. '/app/config/parameters.yml'));
+            $config = Yaml::parse(file_get_contents(_PS_ROOT_DIR_.'/app/config/parameters.yml'));
             $secret = $config['parameters']['secret'];
             $cookie_key = $config['parameters']['cookie_key'];
             $cookie_iv = $config['parameters']['cookie_iv'];
@@ -105,7 +120,8 @@ class InstallModelInstall extends InstallAbstractModel
                 'mailer_host' => '127.0.0.1',
                 'mailer_user' => '~',
                 'mailer_password' => '~',
-            ));
+            )
+        );
 
         // If mcrypt is activated, add Rijndael 128 configuration
         if (function_exists('mcrypt_encrypt')) {
@@ -122,7 +138,6 @@ class InstallModelInstall extends InstallAbstractModel
             $this->setError($this->language->l('Cannot write settings file'));
             return false;
         }
-
 
         if (!file_put_contents(_PS_ROOT_DIR_.'/app/config/parameters.yml', Yaml::dump($parameters))) {
             $this->setError($this->language->l('Cannot write app/config/parameters.yml file'));

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -168,17 +168,17 @@ services:
     prestashop.core.module.updater:
         class: PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater
         arguments:
-            - @prestashop.adapter.data_provider.addon
-            - @prestashop.adapter.admin.data_provider.module
+            - "@prestashop.adapter.data_provider.addon"
+            - "@prestashop.adapter.admin.data_provider.module"
 
     # Repositories
     prestashop.core.admin.module.repository:
         class: PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository
         arguments:
-            - @prestashop.adapter.admin.data_provider.module
-            - @prestashop.adapter.data_provider.module
-            - @prestashop.core.module.updater
-            - @prestashop.adapter.legacy.logger
+            - "@prestashop.adapter.admin.data_provider.module"
+            - "@prestashop.adapter.data_provider.module"
+            - "@prestashop.core.module.updater"
+            - "@prestashop.adapter.legacy.logger"
             
     prestashop.core.admin.theme.repository:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository
@@ -192,8 +192,8 @@ services:
     prestashop.module.manager:
         class: PrestaShop\PrestaShop\Core\Addon\Module\ModuleManager
         arguments:
-            - @prestashop.adapter.admin.data_provider.module
-            - @prestashop.adapter.data_provider.module
-            - @prestashop.core.module.updater
-            - @prestashop.core.admin.module.repository
+            - "@prestashop.adapter.admin.data_provider.module"
+            - "@prestashop.adapter.data_provider.module"
+            - "@prestashop.core.module.updater"
+            - "@prestashop.core.admin.module.repository"
             - "@=service('prestashop.adapter.legacy.context').getContext().employee"

--- a/src/PrestaShopBundle/Service/Cache/Refresh.php
+++ b/src/PrestaShopBundle/Service/Cache/Refresh.php
@@ -41,16 +41,16 @@ class Refresh
     /**
      * Constructor.
      *
-     * Construct SF2 env
+     * Construct the symfony environment.
      *
-     * @param string $env prod|dev
+     * @param string $env Environment to set.
      */
     public function __construct($env = 'prod')
     {
         umask(0000);
         set_time_limit(0);
         $this->env = _PS_MODE_DEV_ ? 'dev' : 'prod';
-        $this->commands = [];
+        $this->commands = array();
 
         require_once _PS_ROOT_DIR_.'/app/AppKernel.php';
         $kernel = new \AppKernel($this->env, false);
@@ -59,9 +59,9 @@ class Refresh
     }
 
     /**
-     * Add cache clear.
+     * Add cache:clear to the execution.
      *
-     * @param string $env Environment to clear
+     * @param string $env Environment to clear.
      */
     public function addCacheClear($env = 'dev')
     {
@@ -74,11 +74,16 @@ class Refresh
     }
 
     /**
-     * Add doctrine schema update.
+     * Add doctrine:schema:update to the execution.
      */
     public function addDoctrineSchemaUpdate()
     {
-        $this->commands[] = ['command' => 'doctrine:schema:update', '--env' => $this->env, '--no-debug' => false, '--force' => true];
+        $this->commands[] = array(
+            'command' => 'doctrine:schema:update',
+            '--env' => $this->env,
+            '--no-debug' => true,
+            '--force' => true,
+        );
     }
 
     /**

--- a/src/PrestaShopBundle/Service/Cache/Refresh.php
+++ b/src/PrestaShopBundle/Service/Cache/Refresh.php
@@ -65,7 +65,12 @@ class Refresh
      */
     public function addCacheClear($env = 'dev')
     {
-        $this->commands[] = ['command' => 'cache:clear', '--env' => $env, '--no-debug' => true];
+        $this->commands[] = array(
+            'command' => 'cache:clear',
+            '--env' => $env,
+            '--no-debug' => true,
+            '--no-warmup' => true,
+        );
     }
 
     /**

--- a/src/PrestaShopBundle/Service/Cache/Refresh.php
+++ b/src/PrestaShopBundle/Service/Cache/Refresh.php
@@ -45,11 +45,17 @@ class Refresh
      *
      * @param string $env Environment to set.
      */
-    public function __construct($env = 'prod')
+    public function __construct($env = null)
     {
         umask(0000);
         set_time_limit(0);
-        $this->env = _PS_MODE_DEV_ ? 'dev' : 'prod';
+
+        if (null === $env) {
+            $this->env = _PS_MODE_DEV_ ? 'dev' : 'prod';
+        } else {
+            $this->env = $env;
+        }
+
         $this->commands = array();
 
         require_once _PS_ROOT_DIR_.'/app/AppKernel.php';
@@ -63,12 +69,10 @@ class Refresh
      *
      * @param string $env Environment to clear.
      */
-    public function addCacheClear($env = 'dev')
+    public function addCacheClear()
     {
         $this->commands[] = array(
             'command' => 'cache:clear',
-            '--env' => $env,
-            '--no-debug' => true,
             '--no-warmup' => true,
         );
     }
@@ -80,8 +84,6 @@ class Refresh
     {
         $this->commands[] = array(
             'command' => 'doctrine:schema:update',
-            '--env' => $this->env,
-            '--no-debug' => true,
             '--force' => true,
         );
     }

--- a/src/PrestaShopBundle/Service/Cache/Refresh.php
+++ b/src/PrestaShopBundle/Service/Cache/Refresh.php
@@ -26,7 +26,7 @@
 namespace PrestaShopBundle\Service\Cache;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Input\ArrayInput;
 
 /**
@@ -83,7 +83,7 @@ class Refresh
      */
     public function execute()
     {
-        $output = null;
+        $bufferedOutput = new BufferedOutput();
         $commandOutput = array();
 
         if (empty($this->commands)) {
@@ -91,18 +91,12 @@ class Refresh
         }
 
         foreach ($this->commands as $command) {
-            if (_PS_MODE_DEV_ && isset($command['--no-debug'])) {
-                $command['--no-debug'] = false;
-            }
+            $exitCode = $this->application->run(new ArrayInput($command), $bufferedOutput);
 
-            if (false === _PS_MODE_DEV_) {
-                $output = new NullOutput();
-            }
-
-            $exitCode = $this->application->run(new ArrayInput($command), $output);
-
-            $commandOutput[$command['command']] = $exitCode;
-
+            $commandOutput[$command['command']] = array(
+                'exitCode' => $exitCode,
+                'output' => $bufferedOutput->fetch(),
+            );
         }
 
         return $commandOutput;

--- a/src/PrestaShopBundle/Service/Cache/Refresh.php
+++ b/src/PrestaShopBundle/Service/Cache/Refresh.php
@@ -92,7 +92,7 @@ class Refresh
         $commandOutput = array();
 
         if (empty($this->commands)) {
-            throw new \Exception('Error, you need to define at least on command');
+            throw new \Exception('Error, you need to define at least one command');
         }
 
         foreach ($this->commands as $command) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | On some servers, the cache cannot be correctly generated. This fix it. |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | BOOM-781 |
| How to test? | Manually clear the cache folder, entirely, the reinstall. |
