### PR TITLE
BO: Change ajax login URL to use Symfony functionnalities

### DIFF
--- a/js/admin/login.js
+++ b/js/admin/login.js
@@ -186,7 +186,7 @@ function doAjaxLogin(redirect) {
 		$.ajax({
 			type: "POST",
 			headers: { "cache-control": "no-cache" },
-			url: "ajax-tab.php" + '?rand=' + new Date().getTime(),
+			url: "index.php" + '?rand=' + new Date().getTime(),
 			async: true,
 			dataType: "json",
 			data: {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When we are redirected on login to a symfony route, we need to use the index.php file which is the entry point for Symfony. Without this PR, we cannot have a proper "context" and so a wrong URL is returned. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-750](http://forge.prestashop.com/browse/BOOM-750) |
| How to test? | Test the login to your back-office with a `redirect` parameters (in example http://127.0.0.1/admin-dev/index.php?controller=AdminLogin&redirect=AdminProducts). Without the PR, you will have a 404 error once logged. With the PR, you go to the product page. Wow ! |
