### PR TITLE
Synchronized final price when we bulk edit the impact on price

### DIFF
--- a/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
+++ b/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
@@ -9,7 +9,7 @@ export default function() {
   var combinationsTable = $('#accordion_combinations');
   var deleteCombinationsBtn = $('#delete-combinations');
   var applyChangesBtn = $('#apply-on-combinations');
-  var syncedCollection = $('*[data-uniqid]');
+  var syncedCollection = $('[data-uniqid]');
 
   return {
     'init': function init() {
@@ -26,11 +26,17 @@ export default function() {
       });
 
       syncedCollection.on('DOMSubtreeModified', (event) => {
-        event.stopPropagation();
+
         var uniqid = event.target.getAttribute('data-uniqid');
         var newValue = event.target.innerText;
 
-        $('[data-uniqid="'+uniqid+'"]').text(newValue);
+        var spans = $('[data-uniqid="'+uniqid+'"]');
+
+        spans.each( function( index, element ){
+          if ($(this).text() !== newValue) {
+            $(this).text(newValue);
+          }
+        });
       });
 
       // bulk select animation
@@ -126,7 +132,7 @@ class Combination {
     return this.form;
   }
 
-  /**http://prestashop-sf.dev/admin-dev/index.php?controller=AdminCustomerThreads&token=ee0b16eab386f352c89c7c5a72121ae5
+  /**
    * Returns the related input field in legacy form from
    * bulk form field
    *

--- a/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
+++ b/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
@@ -9,6 +9,7 @@ export default function() {
   var combinationsTable = $('#accordion_combinations');
   var deleteCombinationsBtn = $('#delete-combinations');
   var applyChangesBtn = $('#apply-on-combinations');
+  var syncedCollection = $('*[data-uniqid]');
 
   return {
     'init': function init() {
@@ -22,6 +23,14 @@ export default function() {
       applyChangesBtn.on('click', (event) => {
         event.preventDefault();
         that.applyChangesOnCombinations();
+      });
+
+      syncedCollection.on('DOMSubtreeModified', (event) => {
+        event.stopPropagation();
+        var uniqid = event.target.getAttribute('data-uniqid');
+        var newValue = event.target.innerText;
+
+        $('[data-uniqid="'+uniqid+'"]').text(newValue);
       });
 
       // bulk select animation
@@ -111,13 +120,13 @@ class Combination {
 
   updateForm(values) {
     values.forEach((valueObject) => {
-      var valueId = valueObject.id.substr(this.inputBulkPattern.length);console.log('#'+this.convertInput(valueId));
+      var valueId = valueObject.id.substr(this.inputBulkPattern.length);
       $('#'+this.convertInput(valueId)).val(valueObject.value);
     });
     return this.form;
   }
 
-  /**
+  /**http://prestashop-sf.dev/admin-dev/index.php?controller=AdminCustomerThreads&token=ee0b16eab386f352c89c7c5a72121ae5
    * Returns the related input field in legacy form from
    * bulk form field
    *
@@ -173,8 +182,12 @@ class Combination {
 
       if (syncedProperties.indexOf(valueId) !== -1){
         valueId = valueId === 'quantity' ? 'quantity' : 'price';
-        $(`#attribute_${this.domId} .attribute-${valueId} input`).val(value);
+        var input = $(`#attribute_${this.domId} .attribute-${valueId} input`);
+        input.val(value);
+        input.change();
       }
     });
+
+    return true;
   }
 }

--- a/admin-dev/themes/new-theme/public/bundle.js
+++ b/admin-dev/themes/new-theme/public/bundle.js
@@ -87751,6 +87751,7 @@
 	  var combinationsTable = (0, _jquery2.default)('#accordion_combinations');
 	  var deleteCombinationsBtn = (0, _jquery2.default)('#delete-combinations');
 	  var applyChangesBtn = (0, _jquery2.default)('#apply-on-combinations');
+	  var syncedCollection = (0, _jquery2.default)('*[data-uniqid]');
 
 	  return {
 	    'init': function init() {
@@ -87764,6 +87765,14 @@
 	      applyChangesBtn.on('click', function (event) {
 	        event.preventDefault();
 	        that.applyChangesOnCombinations();
+	      });
+
+	      syncedCollection.on('DOMSubtreeModified', function (event) {
+	        event.stopPropagation();
+	        var uniqid = event.target.getAttribute('data-uniqid');
+	        var newValue = event.target.innerText;
+
+	        (0, _jquery2.default)('[data-uniqid="' + uniqid + '"]').text(newValue);
 	      });
 
 	      // bulk select animation
@@ -87869,13 +87878,13 @@
 	      var _this = this;
 
 	      values.forEach(function (valueObject) {
-	        var valueId = valueObject.id.substr(_this.inputBulkPattern.length);console.log('#' + _this.convertInput(valueId));
+	        var valueId = valueObject.id.substr(_this.inputBulkPattern.length);
 	        (0, _jquery2.default)('#' + _this.convertInput(valueId)).val(valueObject.value);
 	      });
 	      return this.form;
 	    }
 
-	    /**
+	    /**http://prestashop-sf.dev/admin-dev/index.php?controller=AdminCustomerThreads&token=ee0b16eab386f352c89c7c5a72121ae5
 	     * Returns the related input field in legacy form from
 	     * bulk form field
 	     *
@@ -87935,9 +87944,13 @@
 
 	        if (syncedProperties.indexOf(valueId) !== -1) {
 	          valueId = valueId === 'quantity' ? 'quantity' : 'price';
-	          (0, _jquery2.default)('#attribute_' + _this2.domId + ' .attribute-' + valueId + ' input').val(value);
+	          var input = (0, _jquery2.default)('#attribute_' + _this2.domId + ' .attribute-' + valueId + ' input');
+	          input.val(value);
+	          input.change();
 	        }
 	      });
+
+	      return true;
 	    }
 	  }]);
 

--- a/admin-dev/themes/new-theme/public/bundle.js
+++ b/admin-dev/themes/new-theme/public/bundle.js
@@ -87751,7 +87751,7 @@
 	  var combinationsTable = (0, _jquery2.default)('#accordion_combinations');
 	  var deleteCombinationsBtn = (0, _jquery2.default)('#delete-combinations');
 	  var applyChangesBtn = (0, _jquery2.default)('#apply-on-combinations');
-	  var syncedCollection = (0, _jquery2.default)('*[data-uniqid]');
+	  var syncedCollection = (0, _jquery2.default)('[data-uniqid]');
 
 	  return {
 	    'init': function init() {
@@ -87768,11 +87768,17 @@
 	      });
 
 	      syncedCollection.on('DOMSubtreeModified', function (event) {
-	        event.stopPropagation();
+
 	        var uniqid = event.target.getAttribute('data-uniqid');
 	        var newValue = event.target.innerText;
 
-	        (0, _jquery2.default)('[data-uniqid="' + uniqid + '"]').text(newValue);
+	        var spans = (0, _jquery2.default)('[data-uniqid="' + uniqid + '"]');
+
+	        spans.each(function (index, element) {
+	          if ((0, _jquery2.default)(this).text() !== newValue) {
+	            (0, _jquery2.default)(this).text(newValue);
+	          }
+	        });
 	      });
 
 	      // bulk select animation
@@ -87884,7 +87890,7 @@
 	      return this.form;
 	    }
 
-	    /**http://prestashop-sf.dev/admin-dev/index.php?controller=AdminCustomerThreads&token=ee0b16eab386f352c89c7c5a72121ae5
+	    /**
 	     * Returns the related input field in legacy form from
 	     * bulk form field
 	     *

--- a/admin-dev/themes/new-theme/public/theme.css
+++ b/admin-dev/themes/new-theme/public/theme.css
@@ -16083,7 +16083,7 @@ ul.category-tree {
       visibility: visible; }
   .product-page #add-categories {
     margin-top: 2.5rem; }
-  .product-page #form_step1_categories {
+  .product-page #categories-tree {
     clear: both; }
   .product-page .ui-widget > .form-control-label {
     font-size: 0.625rem;
@@ -16212,16 +16212,34 @@ ul.category-tree {
   display: none; }
 
 .ui-autocomplete {
-  max-width: 18.125rem; }
+  max-width: 18.125rem;
+  position: absolute;
+  z-index: 1000;
+  cursor: default;
+  padding: 0;
+  margin-top: 2px;
+  list-style: none;
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2); }
   @media screen and (max-width: 1450px) {
     .ui-autocomplete {
       max-width: 12.3125rem; } }
-  .ui-autocomplete li:hover {
-    background: #3ED2F0;
-    cursor: pointer; }
-    .ui-autocomplete li:hover a {
-      color: #FFFFFF;
-      text-decoration: none; }
+  .ui-autocomplete > li {
+    padding: 3px 20px; }
+    .ui-autocomplete > li:hover {
+      background: #3ED2F0;
+      cursor: pointer; }
+      .ui-autocomplete > li:hover a {
+        color: #FFFFFF;
+        text-decoration: none; }
+    .ui-autocomplete > li.ui-state-focus {
+      background-color: #DDD; }
   .ui-autocomplete a {
     color: #6C868E; }
 
@@ -16246,8 +16264,10 @@ ul.category-tree {
   #attributes-list .attribute-group .attributes {
     border-top: 2px solid #BBCDD2;
     padding: 0.4375em;
-    height: 9.875rem;
-    overflow: auto; }
+    height: 10.125rem;
+    overflow-x: hidden; }
+    #attributes-list .attribute-group .attributes .two-columns {
+      columns: 2; }
     #attributes-list .attribute-group .attributes .attribute .js-attribute-checkbox {
       display: none; }
       #attributes-list .attribute-group .attributes .attribute .js-attribute-checkbox + .attribute-label {
@@ -16272,8 +16292,6 @@ ul.category-tree {
             content: "\E5CA";
             font-family: "Material Icons";
             line-height: 0.75rem; }
-    #attributes-list .attribute-group .attributes.two-columns {
-      columns: 2; }
 
 .table.table-no-bordered thead, .table.table-no-bordered tbody, .table.table-no-bordered th {
   border: 0; }

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -9,7 +9,7 @@
         </div>
     </td>
     <td class="attribute-finalprice text-xs-right">
-      <span data-price="{{ form.vars.value.final_price }}">{{ form.vars.value.final_price }}</span> {{ default_currency }}
+      <span data-price="{{ form.vars.value.final_price }}" data-uniqid="{{ form.vars.value.id_product_attribute }}">{{ form.vars.value.final_price }}</span> {{ default_currency }}
     </td>
     <td class="attribute-quantity">
         <div>
@@ -97,7 +97,7 @@
                         </fieldset>
                     </div>
                     <div class="col-md-3">
-                      <small class="combination-label vcenter">{{ "Final retail price (tax excl.) will be"|trans({}, 'AdminProducts') }} <span class="final-price" data-price="{{ form.vars.value.final_price }}">{{ form.vars.value.final_price }}</span> {{ default_currency }}</small>
+                      <small class="combination-label vcenter">{{ "Final retail price (tax excl.) will be"|trans({}, 'AdminProducts') }} <span class="final-price" data-price="{{ form.vars.value.final_price }}" data-uniqid="{{ form.vars.value.id_product_attribute }}">{{ form.vars.value.final_price }}</span> {{ default_currency }}</small>
                     </div>
                 </div>
                 <div class="row">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The final price wasnt update in combination form when bulk edited. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | this follow #BOOM-790 |
| How to test? | Use the combinations bulk action on combinations and apply an impact on price. The final price should be updated on table AND on each related combination form. |

PS: I'm aware synchronisation is missing in "Pricing" tab, the next pull request will fix it.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
