### PR TITLE
Travis - Move APT commands in addons, add cache and use another version of MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ addons:
         - deb http://archive.ubuntu.com/ubuntu/ trusty universe
         - deb http://archive.ubuntu.com/ubuntu/ trusty-updates universe
         packages:
-        - mysql-server
+        - mysql-server-5.6
+        - mysql-client-5.6
+        - mysql-client-core-5.6
         - apache2
         - postfix
         - libapache2-mod-fastcgi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.npm
 
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,19 @@ services:
   - mysql
 
 addons:
-    apt_packages:
+    apt:
+        sources:
+        - deb http://archive.ubuntu.com/ubuntu/ trusty multiverse
+        - deb http://archive.ubuntu.com/ubuntu/ trusty-updates multiverse
+        - deb http://archive.ubuntu.com/ubuntu/ trusty universe
+        - deb http://archive.ubuntu.com/ubuntu/ trusty-updates universe
+        packages:
         - mysql-server
         - apache2
         - postfix
+        - libapache2-mod-fastcgi
+        - libappindicator1
+        - fonts-liberation
     sauce_connect: true
     
 cache:
@@ -29,10 +38,6 @@ matrix:
 
 before_install:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then sudo cp tests/php7-pool.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
-  - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty multiverse" && sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty-updates multiverse"
-  - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty universe" && sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty-updates universe"
-  - sudo apt-get update -qq
-  - sudo apt-get install libapache2-mod-fastcgi
   - phpenv config-rm xdebug.ini
   - mysql -u root -e 'create database prestashop;'
   - cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
@@ -48,7 +53,6 @@ before_install:
   - sudo a2ensite prestashop.conf
   - sudo service apache2 restart
   - cp -Rf .composer/* ~/.composer/ & composer global install;
-  - sudo apt-get install -y libappindicator1 fonts-liberation
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
 


### PR DESCRIPTION
:warning: When accepting this PR, please squash the commits instead of merge it.

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Because of the shortage of travis this day, we move the apt commands in the addons configuration. At the same time, I change the version of the MySQL server (5.5 -> 5.6) which is faster and I add the `.npm` folder into the cache. |
| Type? | Improvement |
| Category? | TE |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | See the travis results, and the time needed to run the builds |
