### PR TITLE
Do not allow to pass configuration values even with _PS_MODE_DEV_

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -219,16 +219,6 @@ class FrontControllerCore extends Controller
      */
     public function init()
     {
-        if (_PS_MODE_DEV_) {
-            $m = [];
-            foreach (Tools::getAllValues() as $key => $value) {
-                if (preg_match('/^debug-set-configuration-(.*)$/', $key, $m)) {
-                    $configurationKey = $m[1];
-                    Configuration::set($configurationKey, $value);
-                }
-            }
-        }
-
         /**
          * Globals are DEPRECATED as of version 1.5.0.1
          * Use the Context object to access objects instead.


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | It should not be possible to change configuration variables from the front office even with the PS_MOD_DEV enabled |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
