### PR TITLE
B2B with internationalization

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1056,18 +1056,7 @@ class ValidateCore
      */
     public static function isSiret($siret)
     {
-        if (Tools::strlen($siret) != 14) {
-            return false;
-        }
-        $sum = 0;
-        for ($i = 0; $i != 14; $i++) {
-            $tmp = ((($i + 1) % 2) + 1) * intval($siret[$i]);
-            if ($tmp >= 10) {
-                $tmp -= 9;
-            }
-            $sum += $tmp;
-        }
-        return ($sum % 10 === 0);
+        return ($siret ? true : false);
     }
 
     /**
@@ -1078,7 +1067,7 @@ class ValidateCore
      */
     public static function isApe($ape)
     {
-        return (bool)preg_match('/^[0-9]{3,4}[a-zA-Z]{1}$/s', $ape);
+        return ($ape ? true : false);
     }
 
     public static function isControllerName($name)


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | 1.7 |
| Description? | B2B have a feature without internationalization. <br/> Allow international customer to use B2B feature by implementing an abstract Validation method for Siret and Ape fields. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | yes |
| Deprecations? | no |
| Fixed ticket? | PSCsX-7835 |
| How to test? | create a customer in B2B mode in countries with any Siret and Ape code |

SIRET and APE is not a feature with international use, then must be and abstract method to allow all countries to use it only by overriding this class. 
