### PR TITLE
[-] CORE : Fix cart rule tax included amount

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -954,13 +954,7 @@ class CartRuleCore extends ObjectModel
                 $minPrice = false;
                 $cheapest_product = null;
                 foreach ($all_products as $product) {
-                    $price = $product['price'];
-                    if ($use_tax) {
-                        // since later on we won't be able to know the product the cart rule was applied to,
-                        // use average cart VAT for price_wt
-                        $price *= (1 + $context->cart->getAverageProductsTaxRate());
-                    }
-
+                    $price = $use_tax ? $product['price_wt'] : $product['price'];
                     if ($price > 0 && ($minPrice === false || $minPrice > $price)) {
                         $minPrice = $price;
                         $cheapest_product = $product['id_product'].'-'.$product['id_product_attribute'];
@@ -987,11 +981,7 @@ class CartRuleCore extends ObjectModel
                     foreach ($package_products as $product) {
                         if (in_array($product['id_product'].'-'.$product['id_product_attribute'], $selected_products)
                             || in_array($product['id_product'].'-0', $selected_products)) {
-                            $price = $product['price'];
-                            if ($use_tax) {
-                                $price *= (1 + $context->cart->getAverageProductsTaxRate());
-                            }
-
+                            $price = $use_tax ? $product['price_wt'] : $product['price'];
                             $selected_products_reduction += $price * $product['cart_quantity'];
                         }
                     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.X |
| Description? | Incorrect cart rule tax included amount in case of cart containing products with different tax rates (see test case below) |
| Type? | Bug fix |
| Category? | CORE |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | Not found |
| How to test? | See below |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

Test case = cart with
- product 1, tax rate 1
- product 2, tax rate 2 <> tax rate 1
- cart rule = percent discount on product 1

=> cart rule tax included amount is wrong

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5671)
<!-- Reviewable:end -->
