### PR TITLE
On new product category creation, create also the label in tree

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -295,6 +295,14 @@ var formCategory = (function() {
 
         //inject new category in parent category selector
         $('#form_step1_new_category_id_parent').append('<option value="' + response.category.id + '">' + response.category.name[1] + '</option>');
+
+        // create label
+        var tag = {
+          'name': response.category.name[1],
+          'id': response.category.id,
+          'breadcrumb': ''
+        };
+        productCategoriesTags.createTag(tag);
       },
       error: function(response) {
         $.each(jQuery.parseJSON(response.responseText), function(key, errors) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | A little bug on category creation: even if the category is created, the label was not. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-776 |
| How to test? | Create a new category product on product page, you should see a new label appears  in product categries tree without any need to refresh page. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
