### PR TITLE
Take into account the unit price impact set by combination

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4448,6 +4448,13 @@ class ProductCore extends ObjectModel
             'context'   => $context
         ]);
 
+        $combination = new Combination($id_product_attribute);
+
+        if (0 != $combination->unit_price_impact && 0 != $row['unit_price_ratio']) {
+            $unitPrice = ($row['price_tax_exc'] / $row['unit_price_ratio']) + $combination->unit_price_impact;
+            $row['unit_price_ratio'] = $row['price_tax_exc'] / $unitPrice;
+        }
+
         self::$producPropertiesCache[$cache_key] = $row;
         return self::$producPropertiesCache[$cache_key];
     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -292,7 +292,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'accessories' => $accessories,
                 'product' => $product_for_template,
                 'displayUnitPrice' => (!empty($this->product->unity) && $this->product->unit_price_ratio > 0.000000) ? true : false,
-                'unit_price' => ($this->product->unit_price_ratio > 0) ? ($productPrice / $this->product->unit_price_ratio) : 0,
                 'product_manufacturer' => new Manufacturer((int) $this->product->id_manufacturer, $this->context->language->id),
                 'last_qties' => (int) Configuration::get('PS_LAST_QTIES'),
                 'display_discount_price' => Configuration::get('PS_DISPLAY_DISCOUNT_PRICE'),


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | You can set a unit price impact for each combination but it wasn't taken into account. This PR fixes it. Also, I removed an unnecessary smarty assign. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-804 |
| How to test? | Set an impact on the unit price for a combination and check if it is refreshed on the front office. Please, note that the impact is set without taxes. |
