### PR TITLE
Change sort by scoring order to desc in module list

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -908,6 +908,7 @@ var AdminModuleController = function () {
                 break;
             case availableSorts[3]:
                 dataAttr = ['data-scoring', 'data-tech-name'];
+                sortOrder = 'desc';
                 sortKind = 'num';
                 break;
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Version: Prestashop 1.7 Alpha 4. The sort order for scoring was ascending. It's now by descending |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-627 |
| How to test? | In BO, modules list (both Selection and Installed module tabs), try to sort by scoring. If all scores are set to 0, then you'll have to edit one or two data-scoring attributes in Firefox/Chrome developer tool in order to test the sorting |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
