### PR TITLE
Solve 2 small buggs involving the OrderState::invoiceAvailable:

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -182,7 +182,7 @@ class OrderDetailControllerCore extends FrontController
                     'currency' => new Currency($order->id_currency),
                     'order_state' => (int)$id_order_state,
                     'invoiceAllowed' => (int)Configuration::get('PS_INVOICE'),
-                    'invoice' => (OrderState::invoiceAvailable($id_order_state) && count($order->getInvoicesCollection())),
+                    'invoice' => (OrderState::invoiceAvailable($id_order_state) && $order->invoice_number),
                     'logable' => (bool)$order_status->logable,
                     'order_history' => $order->getHistory($this->context->language->id, false, true),
                     'products' => $products,

--- a/controllers/front/PdfInvoiceController.php
+++ b/controllers/front/PdfInvoiceController.php
@@ -58,7 +58,7 @@ class PdfInvoiceControllerCore extends FrontController
             die(Tools::displayError('The invoice was not found.'));
         }
 
-        if (!OrderState::invoiceAvailable($order->getCurrentState()) && !$order->invoice_number) {
+        if (!OrderState::invoiceAvailable($order->getCurrentState()) || !$order->invoice_number) {
             die(Tools::displayError('No invoice is available.'));
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | \* Assuming order_invoice with number = 0 are not real invoice (delivery slip for instance) you can't rely on getInvoicesCollection to know if you have an invoive to display.<br> \* The other one is just a logic error on the same idea. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Build an order that has a delivery state but not yet an invoice state. Costumer will be able to see the invoice in the order-detail screen without this patch and won't with it. Same for PdfInvoice. |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5679)
<!-- Reviewable:end -->
