### PR TITLE
Ensure that no more additional PSR2 issues are allowed

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,14 @@
+filter:
+    excluded_paths:
+        - 'vendor/*'
+        - 'tests/*'
+        - 'src/PrestaShopBundle/Tests/*'
+
+tools:
+    php_cs_fixer:
+        config:
+            level: symfony
+            fixers: { long_array_syntax: true }
+
+build_failure_conditions:
+    - 'issues.label("coding-style").new.exists'


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | If Scrutinizer is connected to GitHub PrestaShop repository, the build will fail if new PSR2 issue is detected. We need to connect PrestaShop repository to Scrutinizer free sass service:  _I repeat, we need to connect scrutinizer first to be able to enjoy this improvement_ |
| Type? | improvement |
| Category? | TE ? |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | (optional) If this PR fixes a Forge ticket, please add its complete URL. |
| How to test? | All the next builds will fail after this one if they add new PSR2 issues. Of course, for this time he can't fail because 1) Scrutinizer is not connected 2) Scrutinizer need - at leat - 1 report to compare :) |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
