### PR TITLE
Add missing opening span tag into product-prices.tpl

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -43,7 +43,7 @@
 
     {block name='product_pack_price'}
       {if $displayPackPrice}
-        <p class="product-pack-price">{l s='Instead of %s' sprintf=$noPackPrice}</span></p>
+        <p class="product-pack-price"><span>{l s='Instead of %s' sprintf=$noPackPrice}</span></p>
       {/if}
     {/block}
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Forget html span opening tag |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |

You have  forgotten a <span> line 46
