### PR TITLE
Remove a method introduce in PrestaShop 1.5 dev but not used

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -5132,16 +5132,6 @@ class AdminProductsControllerCore extends AdminController
         return $trad[$key];
     }
 
-    protected function _displayUnavailableProductWarning()
-    {
-        $content = '<div class="alert">
-			<span>'.$this->l('Your product will be saved as a draft.').'</span>
-				<a href="#" class="btn btn-default pull-right" onclick="submitAddProductAndPreview()" ><i class="icon-external-link-sign"></i> '.$this->l('Save and preview').'</a>
-				<input type="hidden" name="fakeSubmitAddProductAndPreview" id="fakeSubmitAddProductAndPreview" />
-			</div>';
-        $this->tpl_form_vars['warning_unavailable_product'] = $content;
-    }
-
     public function ajaxProcessCheckProductName()
     {
         if ($this->tabAccess['view'] === '1') {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This method was introduce in december 2011 but the call of it was remove before the release of PS1.5.0.2 |
| Type? | remove code |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | There is nothing to test here. |
