### PR TITLE
Composer requires friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
   "require-dev": {
     "phpunit/phpunit": "~4.5",
     "phake/phake": "@stable",
-    "fabpot/php-cs-fixer": "^1.10",
+    "friendsofphp/php-cs-fixer": "^1.10",
     "phpdocumentor/phpdocumentor": "2.*"
   },
   "autoload-dev": {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | As you can see on Packagist.org (https://packagist.org/packages/fabpot/php-cs-fixer), the repo _fabpot/php-cs-fixer_ is abandoned. |
| Type? | bug fix |
| Category? | TE |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | You should not have any notice about the old packaged, and your `composer update` should download the proper one. |

![capture du 2016-06-06 10-13-54](https://cloud.githubusercontent.com/assets/6768917/15815786/80644034-2bcf-11e6-9589-224ebc811a9d.png)
