### PR TITLE
Use physical and virtual products to get the order total

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2781,7 +2781,7 @@ class CartCore extends ObjectModel
         }
 
         // Order total in default currency without fees
-        $order_total = $this->getOrderTotal(true, Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING, $product_list);
+        $order_total = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $product_list);
 
         // Start with shipping cost at 0
         $shipping_cost = 0;


### PR DESCRIPTION
Rework of https://github.com/PrestaShop/PrestaShop/pull/4402 on `1.6.1.x` branch

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | @axometeam quoted "Calculate the carrier price with the REAL price customer is gonna pay, so have to use the BOTH_WITHOUT_SHIPPING const. By now the Discount is not use in the calculation." |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | @axometeam quoted "For example if you have a specific carrier price range for order > 50€ => free shipping. If the customer buy an 60€ item and use a -20% discount, customer gonna pay 48€ AND have the free shipping." It should now be fixed. |
