### PR TITLE
Warn you if you forgot composer update

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -43,7 +43,7 @@ ini_set('default_charset', 'utf-8');
 /* in dev mode - check if composer was executed */
 if (is_dir(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'admin-dev') && (!is_dir(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'vendor') ||
         !file_exists(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'autoload.php'))) {
-    die('Error : please install <a href="https://getcomposer.org/">composer</a> or execute "./getcomposer.sh"<br/>Then run "php composer.phar install"');
+    die('Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
 }
 
 /* No settings file? goto installer... */

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -40,6 +40,12 @@ if (!defined('_PS_CORE_DIR_')) {
     define('_PS_CORE_DIR_', realpath(dirname(__FILE__).'/..'));
 }
 
+/* in dev mode - check if composer was executed */
+if ((!is_dir(_PS_CORE_DIR_.DIRECTORY_SEPARATOR.'vendor') ||
+    !file_exists(_PS_CORE_DIR_.DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'autoload.php'))) {
+    die('Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
+}
+
 $themes = glob(dirname(dirname(__FILE__)).'/themes/*/config/theme.yml');
 usort($themes, function ($a, $b) {
     return strcmp($b, $a);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Display error if your forgot `composer install`, avoid fatal. |
| Type? | improvement |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Clone, go to localhost/install-dev before you _composer install_ |
