### PR TITLE
BO: add string as HTML and not only text in carrier wizard summary

### DIFF
--- a/js/admin/carrier_wizard.js
+++ b/js/admin/carrier_wizard.js
@@ -204,10 +204,10 @@ function displaySummary()
 
 
 
-	$('#summary_shipping_cost').text(tmp);
+	$('#summary_shipping_cost').html(tmp);
 
 	// Weight or price ranges
-	$('#summary_range').text(summary_translation_range+' '+summary_translation_range_limit);
+	$('#summary_range').html(summary_translation_range+' '+summary_translation_range_limit);
 
 
 	if ($('input[name="shipping_method"]:checked').val() == 1)


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | On PrestaShop 1.6.1.5, the summary of carrier wizard have span element. As we change element with .text() method instead of .html() jQuery method, the <span> is not interpreted. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Checkout this commit and see the summary in carrier wizard. |
