### PR TITLE
Fix a smarty warning when opening the Carrier Wizard

### DIFF
--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -473,7 +473,7 @@ class AdminCarrierWizardControllerCore extends AdminController
         $active_form = $this->renderGenericForm(array('form' => $this->fields_form), $fields_value);
         $active_form =  str_replace(array('<fieldset id="fieldset_form">', '</fieldset>'), '', $active_form);
         $template->assign('active_form', $active_form);
-        return $template->fetch('controllers/carrier_wizard/summary.tpl');
+        return $template->fetch();
     }
 
     /**


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | As now, when you reach the Carrier Wizard, you get a Smarty waring with DEV mode enabled. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | See below |
1. Enable DEV Mode
2. Reach the Carrier Wizard
3. See the red warning about template and non object
4. Fetch this commit
5. Reach the Carrier Wizard
6. See that no red warning are there and all is good now.
