### PR TITLE
Avoid error on install first step if app/log is not writable

### DIFF
--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -33,23 +33,17 @@ class InstallModelInstall extends InstallAbstractModel
 {
     const SETTINGS_FILE = 'config/settings.inc.php';
 
-    /**
-     * @var FileLogger
-     */
-    public $logger;
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        $cacheDir = _PS_ROOT_DIR_.'/app/logs/';
-        $file = $cacheDir .(_PS_MODE_DEV_ ? 'dev' : 'prod').'_'.@date('Ymd').'_installation.log';
-        $this->logger = new FileLogger();
-        $this->logger->setFilename($file);
-    }
-
     public function setError($errors)
     {
+        static $logger = null;
+
+        if (null === $logger) {
+            $cacheDir = _PS_ROOT_DIR_.'/app/logs/';
+            $file = $cacheDir .(_PS_MODE_DEV_ ? 'dev' : 'prod').'_'.@date('Ymd').'_installation.log';
+            $logger = new FileLogger();
+            $logger->setFilename($file);
+        }
+
         if (!is_array($errors)) {
             $errors = array($errors);
         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | since #5389 the installer dies at the first step if the app/logs directory is not writable |
| Type? | small fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | no |
| How to test? | rm write access to the app/logs/ directory and launch the installer |
