### PR TITLE
Enable Doctrine cache in prod, avoid extra memcached calls

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -26,6 +26,12 @@ class AppKernel extends Kernel
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
         }
 
+        if (extension_loaded('apc')) {
+            $_SERVER['SYMFONY__CACHE__DRIVER'] = 'apc';
+        } else {
+            $_SERVER['SYMFONY__CACHE__DRIVER'] = 'array';
+        }
+
         return $bundles;
     }
 

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -25,3 +25,8 @@ monolog:
             level: debug
         console:
             type:  console
+
+doctrine:
+    orm:
+        metadata_cache_driver: %cache.driver%
+        query_cache_driver:    %cache.driver%

--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -67,6 +67,7 @@ abstract class CacheCore
         'guest',
         'pagenotfound',
         'page_viewed',
+        'employee',
     );
 
     /**
@@ -321,6 +322,10 @@ abstract class CacheCore
      */
     public function deleteQuery($query)
     {
+        if ($this->isBlacklist($query)) {
+            return;
+        }
+
         if (is_null($this->sql_tables_cached)) {
             $this->sql_tables_cached = $this->get(Tools::encryptIV(self::SQL_TABLES_NAME));
             if (!is_array($this->sql_tables_cached)) {

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -244,11 +244,11 @@ class ProductInformation extends CommonAbstractType
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
-            $form = $event->getForm();
 
             //if product type is pack, check if inputPackItems is not empty
             if ($data['type_product'] == 1) {
                 if (!isset($data['inputPackItems']) || empty($data['inputPackItems']['data'])) {
+                    $form = $event->getForm();
                     $error = $this->translator->trans('This pack is empty. You must add at least one product item.', [], 'AdminProducts');
                     $form->get('inputPackItems')->addError(new FormError($error));
                 }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
@@ -214,10 +214,10 @@ class ProductOptions extends CommonAbstractType
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
-            $form = $event->getForm();
 
             //If not supplier selected, remove all supplier combinations collection form
             if (!isset($data['suppliers']) || count($data['suppliers']) == 0) {
+                $form = $event->getForm();
                 foreach ($this->suppliers as $supplier => $id) {
                     $form->remove('supplier_combination_'.$id);
                 }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -196,11 +196,12 @@ class ProductSpecificPrice extends CommonAbstractType
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
-            $form = $event->getForm();
 
             if (empty($data['sp_id_product_attribute'])) {
                 return;
             }
+
+            $form = $event->getForm();
 
             //bypass SF validation, define submitted value in choice list
             $form->add('sp_id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Enable doctrine cache in prod and avoid unnecessary calls to memcached |
| Type? | improvement |
| Category? | CORE |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | run tests |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

[*] CORE : Avoid a few memcached set in deleteQuery for blacklisted tables
[*] BO : only calls getForm() when needed
