### PR TITLE
Replace bad check of PDO extension

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -81,7 +81,7 @@ class ConfigurationTestCore
                 'phpversion' => false,
                 'apache_mod_rewrite' => false,
                 'gd' => false,
-                'mysql_support' => false,
+                'pdo_mysql' => false,
                 'config_dir' => 'config',
                 'files' => false,
                 'mails_dir' => 'mails',


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | there is a bad column name in ConfigurationTest::getDefaultTests() which prevents the installation |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | no |
