### PR TITLE
Don't trim() the $_POST values if it's an array

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -354,7 +354,7 @@ class AdminStoresControllerCore extends AdminController
         if (isset($_POST['submitAdd'.$this->table])) {
             /* Cleaning fields */
             foreach ($_POST as $kp => $vp) {
-                if (!in_array($kp, array('checkBoxShopGroupAsso_store', 'checkBoxShopAsso_store'))) {
+                if (!in_array($kp, array('checkBoxShopGroupAsso_store', 'checkBoxShopAsso_store')) && !is_array($_POST[$kp])) {
                     $_POST[$kp] = trim($vp);
                 }
             }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | trim() an array() will empty the value. Cause problem for exemple if you add a Tree Map Helper Form on this controller. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
