### PR TITLE
Set absolute path instead of relative for tests

### DIFF
--- a/tests/Selenium/prepare-shop.php
+++ b/tests/Selenium/prepare-shop.php
@@ -1,6 +1,6 @@
 <?php
 define('_PS_MODE_DEV_', false);
-require '../../config/config.inc.php';
+require(__DIR__.'/../../config/config.inc.php');
 
 // useful variables
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When we try to execute the script `prepare_shop.php` from any folder, the script cannot find the file `../../config.inc.php`. This PR makes it work when called from anywhere |
| Type? | bug fix |
| Category? | TE |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | The tests must pass |

:hand: This pull-request is required to make the tests working on the StarterTheme repository. By merging it, you can save the world.
