### PR TITLE
Fix unexpected loading on modules page

### DIFF
--- a/admin-dev/themes/new-theme/js/product-page/nested-categories.js
+++ b/admin-dev/themes/new-theme/js/product-page/nested-categories.js
@@ -7,6 +7,11 @@ export default function() {
   var nestedCategoriesForm = $('#form_step1_categories');
   return {
     'init': function() {
+
+      if (0 === nestedCategoriesForm.length) {
+        return;
+      }
+      
       nestedCategoriesForm.categorytree();
       this.removeDefaultIfNeeded();
 

--- a/admin-dev/themes/new-theme/public/bundle.js
+++ b/admin-dev/themes/new-theme/public/bundle.js
@@ -88021,6 +88021,11 @@
 	  var nestedCategoriesForm = (0, _jquery2.default)('#form_step1_categories');
 	  return {
 	    'init': function init() {
+
+	      if (0 === nestedCategoriesForm.length) {
+	        return;
+	      }
+
 	      nestedCategoriesForm.categorytree();
 	      this.removeDefaultIfNeeded();
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | nested categories module shouldn't be loaded on module page |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Does it break backward compatibility? no |
| Deprecations? | Does it deprecate an existing feature? no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-865 |
| How to test? | Go to the module page: wow modules are correctly loaded now |
