### PR TITLE
Introduce Symfony translator getter for modules

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2969,6 +2969,11 @@ abstract class ModuleCore
         }
         return $result;
     }
+
+    public function getTranslator()
+    {
+        return Context::getContext()->getTranslator();
+    }
 }
 
 function ps_module_version_sort($a, $b)


### PR DESCRIPTION
Follow up #5722 from @julienbourdeau 

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | At the time we introduce a prestashop translator (implementing the SymfonyInterface). This translator have been fully remove to use the symfony default one. |
| Type? | refacto |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Test trads when it's ready |

Some modules translations updated are coming soon (at least for those "ps_" fully dedicated to 1.7).
