### PR TITLE
Add selected_delivery_option in payment step

### DIFF
--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -35,16 +35,22 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
 
     public function render(array $extraParams = array())
     {
-        return $this->renderTemplate(
-            $this->getTemplate(), $extraParams, array(
-                'payment_options' => $this
-                    ->paymentOptionsFinder
-                    ->getPaymentOptionsForTemplate(),
-                'conditions_to_approve' => $this
-                    ->conditionsToApproveFinder
-                    ->getConditionsToApproveForTemplate(),
-                'selected_payment_option' => $this->selected_payment_option,
-            )
-        );
+        $deliveryOptions = $this->getCheckoutSession()->getDeliveryOptions();
+        $deliveryOptionKey = $this->getCheckoutSession()->getSelectedDeliveryOption();
+        $selectedDeliveryOption = $deliveryOptions[$deliveryOptionKey];
+        unset($selectedDeliveryOption['product_list']);
+
+        $assignedVars = array(
+            'payment_options' => $this
+                ->paymentOptionsFinder
+                ->getPaymentOptionsForTemplate(),
+            'conditions_to_approve' => $this
+                ->conditionsToApproveFinder
+                ->getConditionsToApproveForTemplate(),
+            'selected_payment_option' => $this->selected_payment_option,
+            'selected_delivery_option' => $selectedDeliveryOption,
+            );
+
+        return $this->renderTemplate($this->getTemplate(), $extraParams, $assignedVars);
     }
 }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Add selected_delivery_option in payment step in order to create a full order summary before paying |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
