### PR TITLE
Do not limit div height for module failure details

### DIFF
--- a/admin-dev/themes/default/css/bundle/module/module.css
+++ b/admin-dev/themes/default/css/bundle/module/module.css
@@ -357,7 +357,8 @@ img.module-logo-thumb-list {
 .module-import-failure-details {
   word-wrap: break-word;
   font-size: small;
-  max-height: 120px;
+  overflow: auto;
+  overflow-y: hidden;
   margin: 35px 5px 20px 5px;
   text-align: justify;
   display: none;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When a module fails and we want to see more details on the failure, we open a div which was limited on its height. This PR removes this limit. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | Upload a module which fails with a fat error message. The button "Try again" should be properly displayed under the error message, not on it. |
## Before

![capture du 2016-06-14 10-58-36](https://cloud.githubusercontent.com/assets/6768917/16037125/705cb1b6-321f-11e6-8c2f-4ebd1a54d02a.png)
## After

See https://github.com/PrestaShop/PrestaShop/pull/5742#issuecomment-225887190
