### PR TITLE
Add translations on module manager & module page

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -334,7 +334,7 @@ abstract class ModuleCore
         }
 
         // Check if module is installed
-        $result = (new ModuleDataProvider(new LegacyLogger()))->isInstalled($this->name);
+        $result = (new ModuleDataProvider(new LegacyLogger(), $this->getTranslator()))->isInstalled($this->name);
         if ($result) {
             $this->_errors[] = Tools::displayError('This module has already been installed.');
             return false;

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -190,7 +190,7 @@ class ModuleDataProvider
                 $this->translator->trans(
                     'Parse error detected in main class of module %module%!',
                     array('%module%' => $name),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
             return false;
         }
 
@@ -210,7 +210,7 @@ class ModuleDataProvider
                         array(
                             '%module%' => $name,
                             '%error_message%' =>$e->getMessage()),
-                        '<InsertDomain>'));
+                        'Admin.Modules.Notification'));
                 return false;
             }
             return true;

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -63,7 +63,7 @@ class ModuleManager implements AddonManagerInterface
      * @var \Symfony\Component\Translation\TranslatorInterface
      */
     private $translator;
-    
+
     private $employee;
 
     public function __construct(AdminModuleDataProvider $adminModulesProvider,
@@ -99,7 +99,7 @@ class ModuleManager implements AddonManagerInterface
                     $this->translator->trans(
                         'You are not allowed to install modules.',
                         array(),
-                        '<InsertDomain>'));
+                        'Admin.Modules.Notification'));
             }
         }
 
@@ -108,7 +108,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans(
                     'The module %module% is already installed.',
                     array('%module%' => $name),
-                    '<InsertDomain>'
+                    'Admin.Modules.Notification'
                 ));
         }
 
@@ -138,7 +138,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans(
                     'You are not allowed to uninstall this module.',
                     array(),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
         }
 
         // Is module installed ?
@@ -174,7 +174,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans(
                     'You are not allowed to upgrade this module.',
                     array(),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
         }
 
         if (! $this->moduleProvider->isInstalled($name)) {
@@ -182,7 +182,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans(
                     'The module %module% must be installed first',
                     array('%module%' => $name),
-                '<InsertDomain>'));
+                'Admin.Modules.Notification'));
         }
 
         $result = true;
@@ -220,7 +220,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans(
                     'You are not allowed to disable this module.',
                     array(),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
         }
 
         $module = $this->moduleRepository->getModule($name);
@@ -233,7 +233,7 @@ class ModuleManager implements AddonManagerInterface
                     array(
                         '%module%' => $name,
                         '%error_details%' => $e->getMessage()),
-                    '<InsertDomain>'),
+                    'Admin.Modules.Notification'),
                 0, $e);
         }
 
@@ -254,7 +254,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans(
                     'You are not allowed to enable this module.',
                     array(),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
         }
 
         $module = $this->moduleRepository->getModule($name);
@@ -265,7 +265,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans('Error when enabling module %module%. %error_details%.',
                     array('%module%' => $name,
                         '%error_details%' => $e->getMessage()),
-                    '<InsertDomain>'), 0, $e);
+                    'Admin.Modules.Notification'), 0, $e);
         }
 
         return true;
@@ -287,7 +287,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans(
                     'You are not allowed to disable this module on mobile.',
                     array(),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
         }
 
         $module = $this->moduleRepository->getModule($name);
@@ -300,7 +300,7 @@ class ModuleManager implements AddonManagerInterface
                     array(
                         '%module%' => $name,
                         '%error_details%' => $e->getMessage()),
-                    '<InsertDomain>'),
+                    'Admin.Modules.Notification'),
                 0, $e);
         }
     }
@@ -321,7 +321,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans(
                     'You are not allowed to enable this module on mobile.',
                     array(),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
         }
 
         $module = $this->moduleRepository->getModule($name);
@@ -334,7 +334,7 @@ class ModuleManager implements AddonManagerInterface
                     array(
                         '%module%' => $name,
                         '%error_details%' => $e->getMessage()),
-                    '<InsertDomain>'), 0, $e);
+                    'Admin.Modules.Notification'), 0, $e);
         }
     }
 
@@ -353,7 +353,7 @@ class ModuleManager implements AddonManagerInterface
                 $this->translator->trans(
                     'You are not allowed to reset this module.',
                     array(),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
         }
 
         $module = $this->moduleRepository->getModule($name);
@@ -370,7 +370,7 @@ class ModuleManager implements AddonManagerInterface
                     array(
                         '%module%' => $name,
                         '%error_details%' => $e->getMessage()),
-                    '<InsertDomain>'),
+                    'Admin.Modules.Notification'),
                 0, $e);
         }
     }

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater;
 use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Tools;
 
 class ModuleManager implements AddonManagerInterface
@@ -57,18 +58,26 @@ class ModuleManager implements AddonManagerInterface
      */
     private $moduleRepository;
 
+    /**
+     * Translator
+     * @var \Symfony\Component\Translation\TranslatorInterface
+     */
+    private $translator;
+    
     private $employee;
 
     public function __construct(AdminModuleDataProvider $adminModulesProvider,
         ModuleDataProvider $modulesProvider,
         ModuleDataUpdater $modulesUpdater,
         ModuleRepository $moduleRepository,
+        TranslatorInterface $translator,
         Employee $employee = null)
     {
         $this->adminModuleProvider = $adminModulesProvider;
         $this->moduleProvider = $modulesProvider;
         $this->moduleUpdater = $modulesUpdater;
         $this->moduleRepository = $moduleRepository;
+        $this->translator = $translator;
         $this->employee = $employee;
     }
 
@@ -86,12 +95,21 @@ class ModuleManager implements AddonManagerInterface
         // in CLI mode, there is no employee set up
         if (!Tools::isPHPCLI()) {
             if (!$this->employee->can('add', 'AdminModules')) {
-                throw new Exception('You are not allowed to install a module');
+                throw new Exception(
+                    $this->translator->trans(
+                        'You are not allowed to install modules.',
+                        array(),
+                        '<InsertDomain>'));
             }
         }
 
         if ($this->moduleProvider->isInstalled($name)) {
-            throw new Exception(sprintf('The module %s is already installed.', $name));
+            throw new Exception(
+                $this->translator->trans(
+                    'The module %module% is already installed.',
+                    array('%module%' => $name),
+                    '<InsertDomain>'
+                ));
         }
 
         if (! $this->moduleProvider->isOnDisk($name)) {
@@ -116,7 +134,11 @@ class ModuleManager implements AddonManagerInterface
         // * Employee can delete this specific module
         if (!$this->employee->can('delete', 'AdminModules')
             || !$this->moduleProvider->can('uninstall', $name)) {
-            throw new Exception('You are not allowed to uninstall this module.');
+            throw new Exception(
+                $this->translator->trans(
+                    'You are not allowed to uninstall this module.',
+                    array(),
+                    '<InsertDomain>'));
         }
 
         // Is module installed ?
@@ -148,11 +170,19 @@ class ModuleManager implements AddonManagerInterface
     {
         if (!$this->employee->can('edit', 'AdminModules')
             || !$this->moduleProvider->can('configure', $name)) {
-            throw new Exception('You are not allowed to upgrade this module.');
+            throw new Exception(
+                $this->translator->trans(
+                    'You are not allowed to upgrade this module.',
+                    array(),
+                    '<InsertDomain>'));
         }
 
         if (! $this->moduleProvider->isInstalled($name)) {
-            throw new Exception(sprintf('The module %s must be installed first', $name));
+            throw new Exception(
+                $this->translator->trans(
+                    'The module %module% must be installed first',
+                    array('%module%' => $name),
+                '<InsertDomain>'));
         }
 
         $result = true;
@@ -186,14 +216,25 @@ class ModuleManager implements AddonManagerInterface
     {
         if (!$this->employee->can('edit', 'AdminModules')
             || !$this->moduleProvider->can('configure', $name)) {
-            throw new Exception('You are not allowed to disable this module.');
+            throw new Exception(
+                $this->translator->trans(
+                    'You are not allowed to disable this module.',
+                    array(),
+                    '<InsertDomain>'));
         }
 
         $module = $this->moduleRepository->getModule($name);
         try {
             return $module->onDisable();
         } catch (Exception $e) {
-            throw new Exception('Error when disabling module. '. $e->getMessage(), 0, $e);
+            throw new Exception(
+                $this->translator->trans(
+                    'Error when disabling module %module%. %error_details%.',
+                    array(
+                        '%module%' => $name,
+                        '%error_details%' => $e->getMessage()),
+                    '<InsertDomain>'),
+                0, $e);
         }
 
         return true;
@@ -209,14 +250,22 @@ class ModuleManager implements AddonManagerInterface
     {
         if (!$this->employee->can('edit', 'AdminModules')
             || !$this->moduleProvider->can('configure', $name)) {
-            throw new Exception('You are not allowed to enable this module.');
+            throw new Exception(
+                $this->translator->trans(
+                    'You are not allowed to enable this module.',
+                    array(),
+                    '<InsertDomain>'));
         }
 
         $module = $this->moduleRepository->getModule($name);
         try {
             return $module->onEnable();
         } catch (Exception $e) {
-            throw new Exception('Error when enabling module. '. $e->getMessage(), 0, $e);
+            throw new Exception(
+                $this->translator->trans('Error when enabling module %module%. %error_details%.',
+                    array('%module%' => $name,
+                        '%error_details%' => $e->getMessage()),
+                    '<InsertDomain>'), 0, $e);
         }
 
         return true;
@@ -234,14 +283,25 @@ class ModuleManager implements AddonManagerInterface
     {
         if (!$this->employee->can('edit', 'AdminModules')
             || !$this->moduleProvider->can('configure', $name)) {
-            throw new Exception('You are not allowed to disable this module on mobile.');
+            throw new Exception(
+                $this->translator->trans(
+                    'You are not allowed to disable this module on mobile.',
+                    array(),
+                    '<InsertDomain>'));
         }
 
         $module = $this->moduleRepository->getModule($name);
         try {
             return $module->onMobileDisable();
         } catch (Exception $e) {
-            throw new Exception(sprintf('Error when disabling module %s on mobile. %s', $name, $e->getMessage()), 0, $e);
+            throw new Exception(
+                $this->translator->trans(
+                    'Error when disabling module %module% on mobile. %error_details%',
+                    array(
+                        '%module%' => $name,
+                        '%error_details%' => $e->getMessage()),
+                    '<InsertDomain>'),
+                0, $e);
         }
     }
 
@@ -257,14 +317,24 @@ class ModuleManager implements AddonManagerInterface
     {
         if (!$this->employee->can('edit', 'AdminModules')
             || !$this->moduleProvider->can('configure', $name)) {
-            throw new Exception('You are not allowed to enable this module on mobile.');
+            throw new Exception(
+                $this->translator->trans(
+                    'You are not allowed to enable this module on mobile.',
+                    array(),
+                    '<InsertDomain>'));
         }
 
         $module = $this->moduleRepository->getModule($name);
         try {
             return $module->onMobileEnable();
         } catch (Exception $e) {
-            throw new Exception(sprintf('Error when enabling module %s on mobile. %s', $name, $e->getMessage()), 0, $e);
+            throw new Exception(
+                $this->translator->trans(
+                    'Error when enabling module %module% on mobile. %error_details%',
+                    array(
+                        '%module%' => $name,
+                        '%error_details%' => $e->getMessage()),
+                    '<InsertDomain>'), 0, $e);
         }
     }
 
@@ -279,7 +349,11 @@ class ModuleManager implements AddonManagerInterface
         if (!$this->employee->can('add', 'AdminModules')
             || !$this->employee->can('delete', 'AdminModules')
             || !$this->moduleProvider->can('uninstall', $name)) {
-            throw new Exception('You are not allowed to reset this module.');
+            throw new Exception(
+                $this->translator->trans(
+                    'You are not allowed to reset this module.',
+                    array(),
+                    '<InsertDomain>'));
         }
 
         $module = $this->moduleRepository->getModule($name);
@@ -291,7 +365,13 @@ class ModuleManager implements AddonManagerInterface
             }
             return $status;
         } catch (Exception $e) {
-            throw new Exception('Error when resetting module. '. $e->getMessage(), 0, $e);
+            throw new Exception(
+                $this->translator->trans('Error when resetting module %module%. %error_details%',
+                    array(
+                        '%module%' => $name,
+                        '%error_details%' => $e->getMessage()),
+                    '<InsertDomain>'),
+                0, $e);
         }
     }
 

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -262,7 +262,8 @@ class ModuleManager implements AddonManagerInterface
             return $module->onEnable();
         } catch (Exception $e) {
             throw new Exception(
-                $this->translator->trans('Error when enabling module %module%. %error_details%.',
+                $this->translator->trans(
+                    'Error when enabling module %module%. %error_details%.',
                     array('%module%' => $name,
                         '%error_details%' => $e->getMessage()),
                     'Admin.Modules.Notification'), 0, $e);
@@ -366,7 +367,8 @@ class ModuleManager implements AddonManagerInterface
             return $status;
         } catch (Exception $e) {
             throw new Exception(
-                $this->translator->trans('Error when resetting module %module%. %error_details%',
+                $this->translator->trans(
+                    'Error when resetting module %module%. %error_details%',
                     array(
                         '%module%' => $name,
                         '%error_details%' => $e->getMessage()),

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -25,6 +25,7 @@
  */
 namespace PrestaShop\PrestaShop\Core\Addon\Module;
 
+use Context;
 use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
@@ -45,6 +46,7 @@ class ModuleManagerBuilder
     public static $legacyLogger = null;
     public static $moduleDataProvider = null;
     public static $moduleDataUpdater = null;
+    public static $translator = null;
 
     public function __construct()
     {
@@ -55,9 +57,10 @@ class ModuleManagerBuilder
                 $this->getSymfonyRouter(),
                 $addonsDataProvider
             );
+            self::$translator       = Context::getContext()->getTranslator();
             self::$moduleDataUpdater       = new ModuleDataUpdater($addonsDataProvider, self::$adminModuleDataProvider);
             self::$legacyLogger            = new LegacyLogger();
-            self::$moduleDataProvider      = new ModuleDataProvider(self::$legacyLogger);
+            self::$moduleDataProvider      = new ModuleDataProvider(self::$legacyLogger, self::$translator);
         }
     }
 
@@ -77,7 +80,8 @@ class ModuleManagerBuilder
                 self::$moduleDataProvider,
                 self::$moduleDataUpdater,
                 $this->buildRepository(),
-                \Context::getContext()->employee
+                self::$translator,
+                Context::getContext()->employee
             );
         }
     }
@@ -98,7 +102,8 @@ class ModuleManagerBuilder
                     self::$adminModuleDataProvider,
                     self::$moduleDataProvider,
                     self::$moduleDataUpdater,
-                    self::$legacyLogger
+                    self::$legacyLogger,
+                    self::$translator
                 );
             }
         }
@@ -125,7 +130,7 @@ class ModuleManagerBuilder
      */
     private function getLanguageIso()
     {
-        $langId = \Context::getContext()->employee instanceof \Employee ? \Context::getContext()->employee->id_lang : \Context::getContext()->language->iso_code;
+        $langId = Context::getContext()->employee instanceof \Employee ? Context::getContext()->employee->id_lang : Context::getContext()->language->iso_code;
 
         return \LanguageCore::getIsoById($langId);
     }

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Addon\AddonListFilterOrigin;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterStatus;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterType;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class ModuleRepository implements ModuleRepositoryInterface
 {
@@ -65,6 +66,12 @@ class ModuleRepository implements ModuleRepositoryInterface
     private $moduleUpdater;
 
     /**
+     * Translator
+     * @var \Symfony\Component\Translation\TranslatorInterface
+     */
+    private $translator;
+
+    /**
      * Module Data Provider
      * @var \PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater
      */
@@ -81,12 +88,14 @@ class ModuleRepository implements ModuleRepositoryInterface
         AdminModuleDataProvider $adminModulesProvider,
         ModuleDataProvider $modulesProvider,
         ModuleDataUpdater $modulesUpdater,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        TranslatorInterface $translator
     ) {
         $this->adminModuleProvider = $adminModulesProvider;
         $this->logger = $logger;
         $this->moduleProvider      = $modulesProvider;
         $this->moduleUpdater       = $modulesUpdater;
+        $this->translator = $translator;
         $this->finder              = new Finder();
         $this->cacheFilePath       = _PS_CACHE_DIR_.'modules.json';
         $this->cache               = $this->readCacheFile();
@@ -217,9 +226,21 @@ class ModuleRepository implements ModuleRepositoryInterface
                     $modules[$name] = $module;
                 }
             } catch (\ParseError $e) {
-                $this->logger->critical(sprintf('Parse error on module %s. %s', $name, $e->getMessage()));
+                $this->logger->critical(
+                    $this->translator->trans(
+                        'Parse error on module %module%. %error_details%',
+                        array(
+                            '%module%' => $name,
+                            '%error_details%' => $e->getMessage()),
+                        '<InsertDomain>'));
             } catch (Exception $e) {
-                $this->logger->critical(sprintf('Unexpected exception on module %s. %s', $name, $e->getMessage()));
+                $this->logger->critical(
+                    $this->translator->trans(
+                        'Unexpected exception on module %module%. %error_details%',
+                        array(
+                            '%module%' => $name,
+                            '%error_details%' => $e->getMessage()),
+                        '<InsertDomain>'));
             }
         }
 
@@ -253,7 +274,11 @@ class ModuleRepository implements ModuleRepositoryInterface
                 (array)array_shift($module_catalog_data)
             );
         } catch (Exception $e) {
-            $this->logger->alert(sprintf('Loading data from Addons failed. %s', $e->getMessage()));
+            $this->logger->alert(
+                $this->translator->trans(
+                    'Loading data from Addons failed. %error_details%',
+                    array('%error_details%' => $e->getMessage()),
+                    '<InsertDomain>'));
         }
 
         // Now, we check that cache is up to date
@@ -337,7 +362,21 @@ class ModuleRepository implements ModuleRepositoryInterface
                     $modules[$moduleName] = $module;
                 }
             } catch (\ParseError $e) {
-                // Bypass this module
+                $this->logger->critical(
+                    $this->translator->trans(
+                        'Parse error detected in module %module%. %error_details%.',
+                        array(
+                            '%module%' => $moduleName,
+                            '%error_details%' => $e->getMessage()),
+                        '<InsertDomain>'));
+            } catch (Exception $e) {
+                $this->logger->critical(
+                    $this->translator->trans(
+                        'Exception detected while loading module %module%. %error_details%.',
+                        array(
+                            '%module%' => $moduleName,
+                            '%error_details%' => $e->getMessage()),
+                        '<InsertDomain>'));
             }
         }
 
@@ -355,6 +394,9 @@ class ModuleRepository implements ModuleRepositoryInterface
      */
     private function generateCacheFile($data)
     {
+        if (!$data) {
+            return;
+        }
         $encoded_data          = json_encode($data);
         file_put_contents($this->cacheFilePath, $encoded_data);
 

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -232,7 +232,7 @@ class ModuleRepository implements ModuleRepositoryInterface
                         array(
                             '%module%' => $name,
                             '%error_details%' => $e->getMessage()),
-                        '<InsertDomain>'));
+                        'Admin.Modules.Notification'));
             } catch (Exception $e) {
                 $this->logger->critical(
                     $this->translator->trans(
@@ -240,7 +240,7 @@ class ModuleRepository implements ModuleRepositoryInterface
                         array(
                             '%module%' => $name,
                             '%error_details%' => $e->getMessage()),
-                        '<InsertDomain>'));
+                        'Admin.Modules.Notification'));
             }
         }
 
@@ -278,7 +278,7 @@ class ModuleRepository implements ModuleRepositoryInterface
                 $this->translator->trans(
                     'Loading data from Addons failed. %error_details%',
                     array('%error_details%' => $e->getMessage()),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
         }
 
         // Now, we check that cache is up to date
@@ -368,7 +368,7 @@ class ModuleRepository implements ModuleRepositoryInterface
                         array(
                             '%module%' => $moduleName,
                             '%error_details%' => $e->getMessage()),
-                        '<InsertDomain>'));
+                        'Admin.Modules.Notification'));
             } catch (Exception $e) {
                 $this->logger->critical(
                     $this->translator->trans(
@@ -376,7 +376,7 @@ class ModuleRepository implements ModuleRepositoryInterface
                         array(
                             '%module%' => $moduleName,
                             '%error_details%' => $e->getMessage()),
-                        '<InsertDomain>'));
+                        'Admin.Modules.Notification'));
             }
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -156,7 +156,7 @@ class ModuleController extends FrameworkBundleAdminController
 
         return $this->render('PrestaShopBundle:Admin/Module:manage.html.twig', array(
                 'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
-                'layoutTitle' => $translator->trans('Manage my modules', array(), 'Admin.Modules'),
+                'layoutTitle' => $translator->trans('Manage my modules', array(), 'Admin.Modules.Feature'),
                 'modules' => $products,
                 'topMenuData' => $this->getTopMenuData($modulesProvider->getCategoriesFromModules($installed_products)),
                 'requireAddonsSearch' => false,
@@ -302,7 +302,7 @@ class ModuleController extends FrameworkBundleAdminController
 
         return $this->render('PrestaShopBundle:Admin/Module:notifications.html.twig', array(
                 'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
-                'layoutTitle' => $translator->trans('Module notifications', array(), 'Admin.Modules'),
+                'layoutTitle' => $translator->trans('Module notifications', array(), 'Admin.Modules.Feature'),
                 'modules' => $products,
                 'requireAddonsSearch' => false,
                 'requireBulkActions' => false,
@@ -460,9 +460,9 @@ class ModuleController extends FrameworkBundleAdminController
         $toolbarButtons = array();
         $toolbarButtons['add_module'] = array(
             'href' => '#',
-            'desc' => $translator->trans('Upload a module', array(), 'Admin.Actions'),
+            'desc' => $translator->trans('Upload a module', array(), 'Admin.Modules.Feature'),
             'icon' => 'cloud_upload',
-            'help' => $translator->trans('Upload a module', array(), 'Admin.Actions'),
+            'help' => $translator->trans('Upload a module', array(), 'Admin.Modules.Feature'),
         );
         $toolbarButtons['addons_connect'] = $this->getAddonsConnectToolbar();
 
@@ -490,14 +490,14 @@ class ModuleController extends FrameworkBundleAdminController
                         array(
                             '%file%' => $fileToInflate,
                             '%code%' => $extractionStatus),
-                        '<InsertDomain>'));
+                        'Admin.Modules.Notification'));
             }
         } else {
             throw new Exception(
                 $translator->trans(
                     'Unable to find uploaded module at the following path: %file%',
                     array('%file%' => $fileToInflate),
-                    '<InsertDomain>'));
+                    'Admin.Modules.Notification'));
         }
     }
 
@@ -536,14 +536,14 @@ class ModuleController extends FrameworkBundleAdminController
                 'href' => $this->generateUrl('admin_addons_logout'),
                 'desc' => $addonsEmail['username_addons'],
                 'icon' => 'exit_to_app',
-                'help' => $translator->trans('Synchronized with Addons marketplace!', array(), 'Admin.Notifications.Success')
+                'help' => $translator->trans('Synchronized with Addons marketplace!', array(), 'Admin.Modules.Notification')
             ];
         } else {
             $addonsConnect = [
                 'href' => '#',
-                'desc' => $translator->trans('Connect to Addons marketplace', array(), 'Admin.Actions'),
+                'desc' => $translator->trans('Connect to Addons marketplace', array(), 'Admin.Modules.Feature'),
                 'icon' => 'vpn_key',
-                'help' => $translator->trans('Connect to Addons marketplace', array(), 'Admin.Actions')
+                'help' => $translator->trans('Connect to Addons marketplace', array(), 'Admin.Modules.Feature')
             ];
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -192,7 +192,9 @@ class ModuleController extends FrameworkBundleAdminController
                     $response[$module]['status'] = false;
                     $response[$module]['msg'] = $translator->trans(
                         '%module% did not return a valid response on %action% action.',
-                        array('%module%' => $module, '%action%' => $action),
+                        array(
+                            '%module%' => $module,
+                            '%action%' => $action),
                         'Admin.Notifications.Error'
                         );
                 } elseif ($response[$module]['status'] === false) {
@@ -486,7 +488,8 @@ class ModuleController extends FrameworkBundleAdminController
                 return $moduleName;
             } else {
                 throw new Exception(
-                    $translator->trans('Cannot open the following archive: %file% (error code: %code%)',
+                    $translator->trans(
+                        'Cannot open the following archive: %file% (error code: %code%)',
                         array(
                             '%file%' => $fileToInflate,
                             '%code%' => $extractionStatus),

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -191,29 +191,37 @@ class ModuleController extends FrameworkBundleAdminController
                 if ($response[$module]['status'] === null) {
                     $response[$module]['status'] = false;
                     $response[$module]['msg'] = $translator->trans(
-                        '%s did not return a valid response on %s action.',
-                        array($module, $action),
+                        '%module% did not return a valid response on %action% action.',
+                        array('%module%' => $module, '%action%' => $action),
                         'Admin.Notifications.Error'
                         );
                 } elseif ($response[$module]['status'] === false) {
                     $error = $moduleManager->getError($module);
                     $response[$module]['msg'] = $translator->trans(
-                        'Cannot %s module %s. %s',
-                        array(str_replace('_', ' ', $action), $module, $error),
+                        'Cannot %action% module %module%. %error_details%',
+                        array(
+                            '%action%' => str_replace('_', ' ', $action),
+                            '%module%' => $module,
+                            '%error_details%' => $error),
                         'Admin.Notifications.Error'
                     );
                 } else {
                     $response[$module]['msg'] = $translator->trans(
-                        '%s action on module %s succeeded.',
-                        array(ucfirst(str_replace('_', ' ', $action)), $module),
+                        '%action% action on module %module% succeeded.',
+                        array(
+                            '%action%' => ucfirst(str_replace('_', ' ', $action)),
+                            '%module%' => $module),
                         'Admin.Notifications.Success'
                     );
                 }
             } catch (Exception $e) {
                 $response[$module]['status'] = false;
                 $response[$module]['msg'] = $translator->trans(
-                    'Exception thrown by addon %s on %s. %s',
-                    array($module, $action, $e->getMessage()),
+                    'Exception thrown by addon %module% on %action%. %error_details%',
+                    array(
+                            '%action%' => str_replace('_', ' ', $action),
+                            '%module%' => $module,
+                            '%error_details%' => $e->getMessage()),
                     'Admin.Notifications.Error'
                 );
 
@@ -456,6 +464,7 @@ class ModuleController extends FrameworkBundleAdminController
 
     private function inflateModule($fileToInflate)
     {
+        $translator = $this->get('translator');
         if (file_exists($fileToInflate)) {
             $zipArchive = new \ZipArchive();
             $extractionStatus = $zipArchive->open($fileToInflate);
@@ -469,10 +478,19 @@ class ModuleController extends FrameworkBundleAdminController
 
                 return $moduleName;
             } else {
-                throw new Exception('Cannot open the following archive: '.$fileToInflate.' (error code: '.$extractionStatus.')');
+                throw new Exception(
+                    $translator->trans('Cannot open the following archive: %file% (error code: %code%)',
+                        array(
+                            '%file%' => $fileToInflate,
+                            '%code%' => $extractionStatus),
+                        '<InsertDomain>'));
             }
         } else {
-            throw new Exception('Unable to find uploaded module at the following path: '.$fileToInflate);
+            throw new Exception(
+                $translator->trans(
+                    'Unable to find uploaded module at the following path: %file%',
+                    array('%file%' => $fileToInflate),
+                    '<InsertDomain>'));
         }
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -330,6 +330,7 @@ class ModuleController extends FrameworkBundleAdminController
      */
     public function importModuleAction(Request $request)
     {
+        $translator = $this->get('translator');
         $moduleManager = $this->get('prestashop.module.manager');
         try {
             $file_uploaded = $request->files->get('file_uploaded');
@@ -369,15 +370,21 @@ class ModuleController extends FrameworkBundleAdminController
 
             if ($installation_response['status'] === null) {
                 $installation_response['status'] = false;
-                $installation_response['msg'] = $module_name .' did not return a valid response on install action';
+                $installation_response['msg'] = $translator->trans(
+                    '%module% did not return a valid response on installation',
+                    array('%module' => $module_name),
+                    '<InsertDomain>');
+            } elseif ($installation_response['status'] === true) {
+                $installation_response['msg'] = $translator->trans(
+                    'Installation of module %module% succeded',
+                    array('%module%' => $module_name),
+                    '<InsertDomain>');
+                $installation_response['is_configurable'] = (bool)$this->get('prestashop.core.admin.module.repository')->getModule($module_name)->attributes->get('is_configurable');
             } else {
-                $installation_response['msg'] = 'Install action on module '. $module_name;
-                if ($installation_response['status'] === true) {
-                    $installation_response['is_configurable'] = (bool)$this->get('prestashop.core.admin.module.repository')->getModule($module_name)->attributes->get('is_configurable');
-                    $installation_response['msg'] .= ' succeeded.';
-                } else {
-                    $installation_response['msg'] .= ' failed. '. $moduleManager->getError($module_name);
-                }
+                $installation_response['msg'] = $translator->trans(
+                    'Installation of module %module% failed',
+                    array('%module%' => $module_name),
+                    '<InsertDomain>');
             }
 
             return new JsonResponse(

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -113,7 +113,7 @@ services:
 
     prestashop.adapter.data_provider.module:
         class: PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider
-        arguments: ["@prestashop.adapter.legacy.logger", "@doctrine.orm.entity_manager"]
+        arguments: ["@prestashop.adapter.legacy.logger", "@translator", "@doctrine.orm.entity_manager"]
 
     # Presenters
     prestashop.adapter.presenter.module:
@@ -167,6 +167,7 @@ services:
             - "@prestashop.adapter.data_provider.module"
             - "@prestashop.core.module.updater"
             - "@prestashop.adapter.legacy.logger"
+            - "@translator"
 
     prestashop.core.admin.theme.repository:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository
@@ -184,4 +185,5 @@ services:
             - "@prestashop.adapter.data_provider.module"
             - "@prestashop.core.module.updater"
             - "@prestashop.core.admin.module.repository"
+            - "@translator"
             - "@=service('prestashop.adapter.legacy.context').getContext().employee"

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -2,7 +2,7 @@
   {% if module.attributes.url_active == 'buy' %}
       <a class="btn btn-primary-outline btn-sm light-button module_action_menu_go_to_addons" href="{{module.attributes.url }}" target="_blank">
         {% if module.attributes.price.raw != '0.00' %}{{module.attributes.price.displayPrice}}
-        {% else %}{{ 'Discover'|trans({}, 'Admin.Modules') }}{% endif %}
+        {% else %}{{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}{% endif %}
       </a>
   {% else %}
       <a class="btn btn-primary-outline btn-sm light-button module_action_menu_{{ module.attributes.url_active }}" href="{{module.attributes.urls[module.attributes.url_active]}}" data-confirm_modal="module-modal-confirm-{{module.attributes.name}}-{{ module.attributes.url_active }}">{{module.attributes.url_active|capitalize|replace({'_': " "})}}</a>
@@ -10,7 +10,7 @@
       {% if module.attributes.urls|length > 1 %}
           <button type="button" class="btn btn-primary-outline  btn-sm dropdown-toggle light-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="caret"></span>
-            <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules') }}</span>
+            <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
           </button>
           <div class="dropdown-menu">
             {% for module_action, module_url in module.attributes.urls %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -1,26 +1,26 @@
 <div class="pull-right btn-group">
   {% if module.attributes.url_active == 'buy' %}
-  <a class="btn btn-primary-outline btn-sm light-button module_action_menu_go_to_addons" href="{{module.attributes.url }}" target="_blank">
-    {% if module.attributes.price.raw != '0.00' %}{{module.attributes.price.displayPrice}}
-  {% else %}Discover{% endif %}
-  </a>
-{% else %}
-  <a class="btn btn-primary-outline btn-sm light-button module_action_menu_{{ module.attributes.url_active }}" href="{{module.attributes.urls[module.attributes.url_active]}}" data-confirm_modal="module-modal-confirm-{{module.attributes.name}}-{{ module.attributes.url_active }}">{{module.attributes.url_active|capitalize|replace({'_': " "})}}</a>
+      <a class="btn btn-primary-outline btn-sm light-button module_action_menu_go_to_addons" href="{{module.attributes.url }}" target="_blank">
+        {% if module.attributes.price.raw != '0.00' %}{{module.attributes.price.displayPrice}}
+        {% else %}{{ 'Discover'|trans({}, 'Admin.Modules') }}{% endif %}
+      </a>
+  {% else %}
+      <a class="btn btn-primary-outline btn-sm light-button module_action_menu_{{ module.attributes.url_active }}" href="{{module.attributes.urls[module.attributes.url_active]}}" data-confirm_modal="module-modal-confirm-{{module.attributes.name}}-{{ module.attributes.url_active }}">{{module.attributes.url_active|capitalize|replace({'_': " "})}}</a>
 
-  {% if module.attributes.urls|length > 1 %}
-  <button type="button" class="btn btn-primary-outline  btn-sm dropdown-toggle light-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <span class="caret"></span>
-    <span class="sr-only">Toggle Dropdown</span>
-  </button>
-  <div class="dropdown-menu">
-    {% for module_action, module_url in module.attributes.urls %}
-    {% if module_action != module.attributes.url_active %}
-  <li>
-    <a class="dropdown-item module_action_menu_{{ module_action }}" href="{{module_url}}" data-confirm_modal="module-modal-confirm-{{module.attributes.name}}-{{ module_action }}">{{module_action|capitalize|replace({'_': " "})}}</a>
-  </li>
+      {% if module.attributes.urls|length > 1 %}
+          <button type="button" class="btn btn-primary-outline  btn-sm dropdown-toggle light-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="caret"></span>
+            <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules') }}</span>
+          </button>
+          <div class="dropdown-menu">
+            {% for module_action, module_url in module.attributes.urls %}
+                {% if module_action != module.attributes.url_active %}
+                    <li>
+                      <a class="dropdown-item module_action_menu_{{ module_action }}" href="{{module_url}}" data-confirm_modal="module-modal-confirm-{{module.attributes.name}}-{{ module_action }}">{{module_action|capitalize|replace({'_': " "})}}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+          </div>
+      {% endif %}
   {% endif %}
-  {% endfor %}
-</div>
-{% endif %}
-{% endif %}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card.html.twig
@@ -49,7 +49,7 @@
             {% endif %}
           </div>
           <div class="module-read-more-{{display_type}} small no-padding">
-            <a class="module-read-more-{{display_type}}-btn url" href="#" data-toggle="modal" data-target="#module-modal-read-more-{{module.attributes.name }}{{ additionalModalSuffix|default('') }}">Read More</a>
+            <a class="module-read-more-{{display_type}}-btn url" href="#" data-toggle="modal" data-target="#module-modal-read-more-{{module.attributes.name }}{{ additionalModalSuffix|default('') }}">{{ 'Read More'|trans({}, 'Admin.Modules.Feature') }}</a>
           </div>
       {% endblock %}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card.html.twig
@@ -31,10 +31,10 @@
       <div class="text-ellipsis xsmall module-version-author-{{display_type}}">
         {% block addon_version %}
             {% if module.attributes.productType == "service" %}
-                {{ 'Service by '|trans({}, 'Admin.Modules') }}
+                {{ 'Service by '|trans({}, 'Admin.Modules.Feature') }}
                 <a class="url" href="#">{{ module.attributes.author }}</a>
             {% else %}
-                {{ 'v%version% by '|trans({ '%version%' : module.attributes.version }, 'Admin.Modules') }}
+                {{ 'v%version% by '|trans({ '%version%' : module.attributes.version }, 'Admin.Modules.Feature') }}
                 <a class="url" href="#">{{ module.attributes.author }}</a>
             {% endif %}
         {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card.html.twig
@@ -15,58 +15,57 @@
      data-active="{{isModuleActive}}">
   <div class="module-item-wrapper-{{display_type}}">
     <div class="module-item-heading-{{display_type}}"
-        data-toggle="modal"
-        data-target="#module-modal-read-more-{{module.attributes.name}}">
+         data-toggle="modal"
+         data-target="#module-modal-read-more-{{module.attributes.name}}">
       <img class="module-logo-thumb-{{display_type}}" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}"/>
       <h3 class="text-ellipsis module-name-{{display_type}}"
           data-toggle="tooltip"
           data-placement="top"
           title="{{ module.attributes.displayName|raw }}">
         {% if module.attributes.displayName %}
-        {{ module.attributes.displayName|raw }}
-      {% else %}
-        {{ module.attributes.name }}
+            {{ module.attributes.displayName|raw }}
+        {% else %}
+            {{ module.attributes.name }}
         {% endif %}
       </h3>
       <div class="text-ellipsis xsmall module-version-author-{{display_type}}">
         {% block addon_version %}
-        {% if module.attributes.productType == "service" %}
-        Service by
-        <a class="url" href="#">{{ module.attributes.author }}</a>
-      {% else %}
-        v{{ module.attributes.version }}
-        by
-        <a class="url" href="#">{{ module.attributes.author }}</a>
-        {% endif %}
+            {% if module.attributes.productType == "service" %}
+                {{ 'Service by '|trans({}, 'Admin.Modules') }}
+                <a class="url" href="#">{{ module.attributes.author }}</a>
+            {% else %}
+                {{ 'v%version% by '|trans({ '%version%' : module.attributes.version }, 'Admin.Modules') }}
+                <a class="url" href="#">{{ module.attributes.author }}</a>
+            {% endif %}
         {% endblock %}
       </div>
     </div>
     <div class="module-quick-description-{{display_type}} small no-padding">
       {% block addon_description %}
-      <div class="module-quick-description-text">
-        {{ module.attributes.description|raw }}
-        {% if module.attributes.description|length < module.attributes.fullDescription|length %}
-        ...
-        {% endif %}
-      </div>
-      <div class="module-read-more-{{display_type}} small no-padding">
-        <a class="module-read-more-{{display_type}}-btn url" href="#" data-toggle="modal" data-target="#module-modal-read-more-{{module.attributes.name }}{{ additionalModalSuffix|default('') }}">Read More</a>
-      </div>
+          <div class="module-quick-description-text">
+            {{ module.attributes.description|raw }}
+            {% if module.attributes.description|length < module.attributes.fullDescription|length %}
+                ...
+            {% endif %}
+          </div>
+          <div class="module-read-more-{{display_type}} small no-padding">
+            <a class="module-read-more-{{display_type}}-btn url" href="#" data-toggle="modal" data-target="#module-modal-read-more-{{module.attributes.name }}{{ additionalModalSuffix|default('') }}">Read More</a>
+          </div>
       {% endblock %}
     </div>
 
     <div class="module-container module-quick-action-{{display_type}} clearfix">
       {% if module.attributes.nbRates > 0 %}
-      <div class="module-star-ranking-grid-{{ module.attributes.starsRate}}">
-        (
-        {{ module.attributes.nbRates }}
-        )
-      </div>
+          <div class="module-star-ranking-grid-{{ module.attributes.starsRate}}">
+            (
+            {{ module.attributes.nbRates }}
+            )
+          </div>
       {% endif %}
       {% if requireBulkActions is defined and requireBulkActions == true %}
-      <div class="pull-right">
-        <input type="checkbox" data-name="{{ module.attributes.displayName }}" data-tech-name="{{module.attributes.name}}" class="module-checkbox-bulk-{{display_type}}"/>
-      </div>
+          <div class="pull-right">
+            <input type="checkbox" data-name="{{ module.attributes.displayName }}" data-tech-name="{{module.attributes.name}}" class="module-checkbox-bulk-{{display_type}}"/>
+          </div>
       {% endif %}
       {% include 'PrestaShopBundle:Admin/Module/Includes:action_menu.html.twig' with { 'module': module } %}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
@@ -21,7 +21,7 @@
 
         </ul>
     {% else %}
-        <i>No changelog provided</i>
+        <i>{{ 'No changelog provided'|trans({}, 'Admin.Modules') }}</i>
     {% endif %}
 
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
@@ -21,7 +21,7 @@
 
         </ul>
     {% else %}
-        <i>{{ 'No changelog provided'|trans({}, 'Admin.Modules') }}</i>
+        <i>{{ 'No changelog provided'|trans({}, 'Admin.Modules.Notification') }}</i>
     {% endif %}
 
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories.html.twig
@@ -4,14 +4,14 @@
         <span type="button"  id="{{refMenu}}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="js-selected-item selected-item module-category-selector-label">
                 {{menu.name}}
-            </span> 
+            </span>
             <i class="material-icons arrow-down">keyboard_arrow_down</i>
         </span>
         <div class="ps-dropdown-menu dropdown-menu module-category-selector" aria-labelledby="{{refMenu}}">
             <ul class="items-list js-items-list">
                 <li class="module-category-reset">
                     <a class="dropdown-item" href="#">
-                            {{ 'All Categories'|trans({}, 'Admin.Modules') }}
+                            {{ 'All Categories'|trans({}, 'Admin.Modules.Feature') }}
                     </a>
                 </li>
                 {% for subMenu in menu.subMenu|arrayCast %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories.html.twig
@@ -11,7 +11,7 @@
             <ul class="items-list js-items-list">
                 <li class="module-category-reset">
                     <a class="dropdown-item" href="#">
-                            All Categories
+                            {{ 'All Categories'|trans({}, 'Admin.Modules') }}
                     </a>
                 </li>
                 {% for subMenu in menu.subMenu|arrayCast %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig
@@ -1,6 +1,6 @@
 <div class="ps-dropdown dropdown btn-group">
     <span type="button"  id="module-status-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <span class="js-selected-item selected-item module-status-selector-label">Show all modules</span> 
+        <span class="js-selected-item selected-item module-status-selector-label">{{ 'Show all modules'|trans({}, 'Admin.Modules') }}</span> 
         <i class="material-icons arrow-down">keyboard_arrow_down</i>
     </span>
     
@@ -8,17 +8,17 @@
         <ul class="items-list js-items-list module-status-selector">
             <li class="module-status-reset">
                 <a class="dropdown-item" href="#">
-                    Show all modules
+                    {{ 'Show all modules'|trans({}, 'Admin.Modules') }}
                 </a>
             </li>
             <li class="module-status-menu" data-status-ref="1">
                 <a class="dropdown-item" href="#">
-                    Enabled Modules
+                    {{ 'Enabled Modules'|trans({}, 'Admin.Modules') }}
                 </a>
             </li>
             <li class="module-status-menu" data-status-ref="0">
                 <a class="dropdown-item" href="#">
-                    Disabled Modules
+                    {{ 'Disabled Modules'|trans({}, 'Admin.Modules') }}
                 </a>
             </li>
         </ul>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig
@@ -1,24 +1,24 @@
 <div class="ps-dropdown dropdown btn-group">
     <span type="button"  id="module-status-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <span class="js-selected-item selected-item module-status-selector-label">{{ 'Show all modules'|trans({}, 'Admin.Modules') }}</span> 
+        <span class="js-selected-item selected-item module-status-selector-label">{{ 'Show all modules'|trans({}, 'Admin.Modules.Feature') }}</span>
         <i class="material-icons arrow-down">keyboard_arrow_down</i>
     </span>
-    
+
     <div class="ps-dropdown-menu dropdown-menu" aria-labelledby="module-status-dropdown">
         <ul class="items-list js-items-list module-status-selector">
             <li class="module-status-reset">
                 <a class="dropdown-item" href="#">
-                    {{ 'Show all modules'|trans({}, 'Admin.Modules') }}
+                    {{ 'Show all modules'|trans({}, 'Admin.Modules.Feature') }}
                 </a>
             </li>
             <li class="module-status-menu" data-status-ref="1">
                 <a class="dropdown-item" href="#">
-                    {{ 'Enabled Modules'|trans({}, 'Admin.Modules') }}
+                    {{ 'Enabled Modules'|trans({}, 'Admin.Modules.Feature') }}
                 </a>
             </li>
             <li class="module-status-menu" data-status-ref="0">
                 <a class="dropdown-item" href="#">
-                    {{ 'Disabled Modules'|trans({}, 'Admin.Modules') }}
+                    {{ 'Disabled Modules'|trans({}, 'Admin.Modules.Feature') }}
                 </a>
             </li>
         </ul>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
@@ -30,10 +30,10 @@
                 <div class="module-addons-item-{{display_type}} {{col_lg}}">
                     <div class="module-addons-item-wrapper-{{display_type}}">
                         <span class="module-icon-addons-exit-{{display_type}}">
-                            <img src="{{ asset('themes/default/img/preston.png') }}" alt="{{ 'Exit to PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules') }}" />
+                            <img src="{{ asset('themes/default/img/preston.png') }}" alt="{{ 'Exit to PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}" />
                         </span>
-                        {{ 'See all results for your search on '|trans({}, 'Admin.Modules') }}<br/>
-                        <a class="url" href="#">{{ 'PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules') }}</a>
+                        {{ 'See all results for your search on '|trans({}, 'Admin.Modules.Feature') }}<br/>
+                        <a class="url" href="#">{{ 'PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}</a>
                     </div>
                 </div>
             {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
@@ -30,10 +30,10 @@
                 <div class="module-addons-item-{{display_type}} {{col_lg}}">
                     <div class="module-addons-item-wrapper-{{display_type}}">
                         <span class="module-icon-addons-exit-{{display_type}}">
-                            <img src="{{ asset('themes/default/img/preston.png') }}" alt="Exit to PrestaShop Addons Marketplace" />
+                            <img src="{{ asset('themes/default/img/preston.png') }}" alt="{{ 'Exit to PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules') }}" />
                         </span>
-                        See all results for your search on <br/>
-                        <a class="url" href="#">PrestaShop Addons Marketplace</a>
+                        {{ 'See all results for your search on '|trans({}, 'Admin.Modules') }}<br/>
+                        <a class="url" href="#">{{ 'PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules') }}</a>
                     </div>
                 </div>
             {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_loader.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_loader.html.twig
@@ -27,7 +27,7 @@
       <div class="module-placeholders-failure-wrapper col-md-12">
           <div class='module-placeholders-failure-msg'>
           </div>
-          <button id='module-placeholders-failure-retry' type="button" class="btn btn-primary">Retry</button>
+          <button id='module-placeholders-failure-retry' type="button" class="btn btn-primary">{{ 'Retry'|trans({}, 'Admin.Modules') }}</button>
       </div>
 
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_loader.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_loader.html.twig
@@ -27,7 +27,7 @@
       <div class="module-placeholders-failure-wrapper col-md-12">
           <div class='module-placeholders-failure-msg'>
           </div>
-          <button id='module-placeholders-failure-retry' type="button" class="btn btn-primary">{{ 'Retry'|trans({}, 'Admin.Modules') }}</button>
+          <button id='module-placeholders-failure-retry' type="button" class="btn btn-primary">{{ 'Try again'|trans({}, 'Admin.Actions') }}</button>
       </div>
 
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
@@ -4,34 +4,34 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h4 class="modal-title module-modal-title">{{ 'Connect to addons marketplace'|trans({}, 'Admin.Modules') }}</h4>
+        <h4 class="modal-title module-modal-title">{{ 'Connect to Addons marketplace'|trans({}, 'Admin.Modules.Feature') }}</h4>
       </div>
       <div class="modal-body">
           <div class="row">
               <div class="col-md-12">
                   <p>
-                      {{ "Link your shop to your addons account: it will automatically import the modules you purchased. Don't have an account yet ?"|trans({}, 'Admin.Modules') }}
-                      <a href="http://addons.prestashop.com/authentication.php" target="_blank">{{ 'Sign up now'|trans({}, 'Admin.Modules') }}</a>
+                      {{ "Link your shop to your addons account: it will automatically import the modules you purchased. Don't have an account yet?"|trans({}, 'Admin.Modules.Feature') }}
+                      <a href="http://addons.prestashop.com/authentication.php" target="_blank">{{ 'Sign up now'|trans({}, 'Admin.Modules.Feature') }}</a>
                   </p>
                   <form id="addons-connect-form"  action="{{ path('admin_addons_login') }}" method="POST">
                   <div class="form-group">
-                    <label for="module-addons-connect-email">{{ 'Email address'|trans({}, 'Admin.Modules') }}</label>
+                    <label for="module-addons-connect-email">{{ 'Email address'|trans({}, 'Admin.Global') }}</label>
                     <input name="username_addons" type="email" class="form-control" id="module-addons-connect-email" placeholder="Email">
                   </div>
                   <div class="form-group">
-                    <label for="module-addons-connect-password">{{ 'Password'|trans({}, 'Admin.Modules') }}</label>
+                    <label for="module-addons-connect-password">{{ 'Password'|trans({}, 'Admin.Global') }}</label>
                     <input name="password_addons" type="password" class="form-control" id="module-addons-connect-password" placeholder="Password">
                   </div>
                   <div class="checkbox">
                     <label>
-                      <input name="addons_remember_me" type="checkbox"> {{ 'Remember me'|trans({}, 'Admin.Modules') }}
+                      <input name="addons_remember_me" type="checkbox"> {{ 'Remember me'|trans({}, 'Admin.Global') }}
                     </label>
                   </div>
-                  <button type="submit" class="btn btn-primary">{{ "Let's go!"|trans({}, 'Admin.Modules') }}</button>
+                  <button type="submit" class="btn btn-primary">{{ "Let's go!"|trans({}, 'Admin.Actions') }}</button>
                   <button id="addons_login_btn" class="btn btn-primary-reverse btn-lg onclick" style="display:none;"></button>
                 </form>
                 <p>
-                    <a href="http://addons.prestashop.com/password.php" target="_blank">{{ 'Forgot your password ?'|trans({}, 'Admin.Modules') }}</a>
+                    <a href="http://addons.prestashop.com/password.php" target="_blank">{{ 'Forgot your password?'|trans({}, 'Admin.Global') }}</a>
                 </p>
               </div>
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
@@ -4,39 +4,38 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h4 class="modal-title module-modal-title">Connect to addons marketplace</h4>
+        <h4 class="modal-title module-modal-title">{{ 'Connect to addons marketplace'|trans({}, 'Admin.Modules') }}</h4>
       </div>
       <div class="modal-body">
           <div class="row">
               <div class="col-md-12">
                   <p>
-                      Link your shop to your addons account: it will automatically import the modules you purchased. Don't have an account yet ?
-                      <a href="http://addons.prestashop.com/authentication.php" target="_blank">Sign up now</a>
+                      {{ "Link your shop to your addons account: it will automatically import the modules you purchased. Don't have an account yet ?"|trans({}, 'Admin.Modules') }}
+                      <a href="http://addons.prestashop.com/authentication.php" target="_blank">{{ 'Sign up now'|trans({}, 'Admin.Modules') }}</a>
                   </p>
                   <form id="addons-connect-form"  action="{{ path('admin_addons_login') }}" method="POST">
                   <div class="form-group">
-                    <label for="module-addons-connect-email">Email address</label>
+                    <label for="module-addons-connect-email">{{ 'Email address'|trans({}, 'Admin.Modules') }}</label>
                     <input name="username_addons" type="email" class="form-control" id="module-addons-connect-email" placeholder="Email">
                   </div>
                   <div class="form-group">
-                    <label for="module-addons-connect-password">Password</label>
+                    <label for="module-addons-connect-password">{{ 'Password'|trans({}, 'Admin.Modules') }}</label>
                     <input name="password_addons" type="password" class="form-control" id="module-addons-connect-password" placeholder="Password">
                   </div>
                   <div class="checkbox">
                     <label>
-                      <input name="addons_remember_me" type="checkbox"> Remember me
+                      <input name="addons_remember_me" type="checkbox"> {{ 'Remember me'|trans({}, 'Admin.Modules') }}
                     </label>
                   </div>
-                  <button type="submit" class="btn btn-primary">Let's go!</button>
+                  <button type="submit" class="btn btn-primary">{{ "Let's go!"|trans({}, 'Admin.Modules') }}</button>
                   <button id="addons_login_btn" class="btn btn-primary-reverse btn-lg onclick" style="display:none;"></button>
                 </form>
                 <p>
-                    <a href="http://addons.prestashop.com/password.php" target="_blank">Forgot your password ? </a>
+                    <a href="http://addons.prestashop.com/password.php" target="_blank">{{ 'Forgot your password ?'|trans({}, 'Admin.Modules') }}</a>
                 </p>
               </div>
           </div>
       </div>
-
     </div>
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
@@ -10,13 +10,13 @@
                     <button type="button" class="close" data-dismiss="modal">&times;</button>
                     <h4 class="modal-title module-modal-title">
                       {% if module_action == 'disable' %}
-                          {{ "Disable module?"|trans({}, 'Admin.Modules') }}
+                          {{ "Disable module?"|trans({}, 'Admin.Modules.Feature') }}
                       {% endif %}
                       {% if module_action == 'uninstall' %}
-                          {{ "Uninstall module?"|trans({}, 'Admin.Modules') }}
+                          {{ "Uninstall module?"|trans({}, 'Admin.Modules.Feature') }}
                       {% endif %}
                       {% if module_action == 'reset' %}
-                      {{ "Reset module?"|trans({}, 'Admin.Modules') }}
+                      {{ "Reset module?"|trans({}, 'Admin.Modules.Feature') }}
                     {% endif %}
                   </h4>
                 </div>
@@ -24,32 +24,32 @@
                   <div class="col-md-12">
                     <p>
                       {% if module_action == 'disable' %}
-                          {{ "You're about to disable %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules') }}
+                          {{ "You're about to disable %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
                           <br/><br/>
-                          {{ "Your current settings will be saved, but the module will no longer be active."|trans({}, 'Admin.Modules') }}
+                          {{ "Your current settings will be saved, but the module will no longer be active."|trans({}, 'Admin.Modules.Notification') }}
                       {% endif %}
                       {% if module_action == 'uninstall' %}
-                          {{ "You're about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules') }}
+                          {{ "You're about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
                           <br/><br/>
-                          {{ "This will disable the module and delete all its files. For good."|trans({}, 'Admin.Modules') }}
+                          {{ "This will disable the module and delete all its files. For good."|trans({}, 'Admin.Modules.Notification') }}
                           <br/>
                       <p>
                         <label>
-                          <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules') }}
+                          <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
                         </label>
                         <br>
                       </p>
                       <span class="italic red">
-                        {{ "This action cannot be undone."|trans({}, 'Admin.Modules') }}
+                        {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
                       </span>
                     {% endif %}
                     {% if module_action == 'reset' %}
-                    {{ "You're about to reset %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules') }}
+                    {{ "You're about to reset %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
                     <br/><br/>
-                    {{ "This will restore the defaults settings."|trans({}, 'Admin.Modules') }}
+                    {{ "This will restore the defaults settings."|trans({}, 'Admin.Modules.Notification') }}
                     <br/>
                     <span class="italic red">
-                      {{ "This action cannot be undone."|trans({}, 'Admin.Modules') }}
+                      {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
                     </span>
                     {% endif %}
                         </p>
@@ -60,17 +60,17 @@
                     {% if module_action == 'disable' %}
                         <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
                            data-tech-name="{{module.attributes.name}}"
-                           href="{{ module_url }}">{{ "Yes, I want to disable"|trans({}, 'Admin.Modules') }}</a>
+                           href="{{ module_url }}">{{ "Yes, disable it"|trans({}, 'Admin.Modules.Feature') }}</a>
                     {% endif %}
                     {% if module_action == 'uninstall' %}
                         <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
                            data-tech-name="{{module.attributes.name}}"
-                           href="{{ module_url }}">{{ "Yes, I want to uninstall"|trans({}, 'Admin.Modules') }}</a>
+                           href="{{ module_url }}">{{ "Yes, uninstall it"|trans({}, 'Admin.Modules.Feature') }}</a>
                     {% endif %}
                     {% if module_action == 'reset' %}
                     <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
                        data-tech-name="{{module.attributes.name}}"
-                       href="{{ module_url }}">{{ "Yes, I want to reset"|trans({}, 'Admin.Modules') }}</a>
+                       href="{{ module_url }}">{{ "Yes, reset it"|trans({}, 'Admin.Modules.Feature') }}</a>
                     {% endif %}
                     </div>
                   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
@@ -3,79 +3,79 @@
         {% if module_action in ['disable', 'uninstall', 'reset'] %}
 
             <div id="module-modal-confirm-{{module.attributes.name}}-{{ module_action }}" class="modal modal-vcenter fade" role="dialog">
-                <div class="modal-dialog">
-                    <!-- Modal content-->
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal">&times;</button>
-                            <h4 class="modal-title module-modal-title">
-                                {% if module_action == 'disable' %}
-                                    {{ "Disable module?"|trans({}, 'AdminModules') }}
-                                {% endif %}
-                                {% if module_action == 'uninstall' %}
-                                    {{ "Uninstall module?"|trans({}, 'AdminModules') }}
-                                {% endif %}
-                                {% if module_action == 'reset' %}
-                                    {{ "Reset module?"|trans({}, 'AdminModules') }}
-                                {% endif %}
-                            </h4>
-                        </div>
-                        <div class="modal-body row">
-                            <div class="col-md-12">
-                                <p>
-                                    {% if module_action == 'disable' %}
-                                        {{ "You're about to disable %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'AdminModules')|raw }}
-                                        <br/><br/>
-                                        {{ "Your current settings will be saved, but the module will no longer be active."|trans({}, 'AdminModules')|raw }}
-                                    {% endif %}
-                                    {% if module_action == 'uninstall' %}
-                                        {{ "You're about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'AdminModules')|raw }}
-                                        <br/><br/>
-                                        {{ "This will disable the module and delete all its files. For good."|trans({}, 'AdminModules')|raw }}
-                                        <br/>
-                                      <p>
-                                        <label>
-                                          <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}"> {{ "Optional: delete module folder after uninstall."|trans({}, 'AdminModules')|raw }}
-                                        </label>
-                                        <br>
-                                      </p>
-                                      <span class="italic red">
-                                            {{ "This action cannot be undone."|trans({}, 'AdminModules')|raw }}
-                                        </span>
-                                    {% endif %}
-                                    {% if module_action == 'reset' %}
-                                        {{ "You're about to reset %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'AdminModules')|raw }}
-                                        <br/><br/>
-                                        {{ "This will restore the defaults settings."|trans({}, 'AdminModules')|raw }}
-                                        <br/>
-                                        <span class="italic red">
-                                            {{ "This action cannot be undone."|trans({}, 'AdminModules')|raw }}
-                                        </span>
-                                    {% endif %}
-                                </p>
-                            </div>
-                        </div>
-                        <div class="modal-footer">
-                            <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="{{ "Cancel"|trans({}, 'AdminTabs')|raw }}" />
-                            {% if module_action == 'disable' %}
-                                <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
-                                    data-tech-name="{{module.attributes.name}}"
-                                    href="{{ module_url }}">{{ "Yes, I want to disable"|trans({}, 'AdminModules')|raw }}</a>
-                            {% endif %}
-                            {% if module_action == 'uninstall' %}
-                                <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
-                                    data-tech-name="{{module.attributes.name}}"
-                                    href="{{ module_url }}">{{ "Yes, I want to uninstall"|trans({}, 'AdminModules')|raw }}</a>
-                            {% endif %}
-                            {% if module_action == 'reset' %}
-                                <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
-                                    data-tech-name="{{module.attributes.name}}"
-                                    href="{{ module_url }}">{{ "Yes, I want to reset"|trans({}, 'AdminModules')|raw }}</a>
-                            {% endif %}
-                        </div>
-                    </div>
+              <div class="modal-dialog">
+                <!-- Modal content-->
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="modal-title module-modal-title">
+                      {% if module_action == 'disable' %}
+                          {{ "Disable module?"|trans({}, 'Admin.Modules') }}
+                      {% endif %}
+                      {% if module_action == 'uninstall' %}
+                          {{ "Uninstall module?"|trans({}, 'Admin.Modules') }}
+                      {% endif %}
+                      {% if module_action == 'reset' %}
+                      {{ "Reset module?"|trans({}, 'Admin.Modules') }}
+                    {% endif %}
+                  </h4>
                 </div>
-            </div>
+                <div class="modal-body row">
+                  <div class="col-md-12">
+                    <p>
+                      {% if module_action == 'disable' %}
+                          {{ "You're about to disable %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules') }}
+                          <br/><br/>
+                          {{ "Your current settings will be saved, but the module will no longer be active."|trans({}, 'Admin.Modules') }}
+                      {% endif %}
+                      {% if module_action == 'uninstall' %}
+                          {{ "You're about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules') }}
+                          <br/><br/>
+                          {{ "This will disable the module and delete all its files. For good."|trans({}, 'Admin.Modules') }}
+                          <br/>
+                      <p>
+                        <label>
+                          <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules') }}
+                        </label>
+                        <br>
+                      </p>
+                      <span class="italic red">
+                        {{ "This action cannot be undone."|trans({}, 'Admin.Modules') }}
+                      </span>
+                    {% endif %}
+                    {% if module_action == 'reset' %}
+                    {{ "You're about to reset %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules') }}
+                    <br/><br/>
+                    {{ "This will restore the defaults settings."|trans({}, 'Admin.Modules') }}
+                    <br/>
+                    <span class="italic red">
+                      {{ "This action cannot be undone."|trans({}, 'Admin.Modules') }}
+                    </span>
+                    {% endif %}
+                        </p>
+                    </div>
+                  </div>
+                  <div class="modal-footer">
+                    <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="{{ "Cancel"|trans({}, 'AdminTabs') }}" />
+                    {% if module_action == 'disable' %}
+                        <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
+                           data-tech-name="{{module.attributes.name}}"
+                           href="{{ module_url }}">{{ "Yes, I want to disable"|trans({}, 'Admin.Modules') }}</a>
+                    {% endif %}
+                    {% if module_action == 'uninstall' %}
+                        <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
+                           data-tech-name="{{module.attributes.name}}"
+                           href="{{ module_url }}">{{ "Yes, I want to uninstall"|trans({}, 'Admin.Modules') }}</a>
+                    {% endif %}
+                    {% if module_action == 'reset' %}
+                    <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}"  data-dismiss="modal"
+                       data-tech-name="{{module.attributes.name}}"
+                       href="{{ module_url }}">{{ "Yes, I want to reset"|trans({}, 'Admin.Modules') }}</a>
+                    {% endif %}
+                    </div>
+                  </div>
+                </div>
+              </div>
 
         {% endif %}
     {% endfor %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
@@ -4,21 +4,22 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h4 class="modal-title module-modal-title">Bulk action confirmation</h4>
+        <h4 class="modal-title module-modal-title">{{ 'Bulk action confirmation'|trans({}, 'Admin.Modules') }}</h4>
       </div>
       <div class="modal-body">
           <div class="row">
               <div class="col-md-12">
                   <p>
-                     You're about to "bulk <span id="module-modal-bulk-confirm-action-name">[Module Action]</span>" the following modules:
+                    {{ "You're about to 'bulk [1][Module Action][/1]' the following modules:"|trans({}, 'Admin.Modules')|replace({'[1]' : '<span id="module-modal-bulk-confirm-action-name">', '[/1]' : '</span>'})|raw }}
+                     <
                   </p>
                   <p id="module-modal-bulk-confirm-list">
-                      [Module List Up To 10 Max]
+                      {{ '[Module List Up To 10 Max]'|trans({}, 'Admin.Modules') }}
                   </p>
 
                   <div id="module-modal-bulk-checkbox">
                     <label>
-                      <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion"> {{ "Optional: delete module folder after uninstall."|trans({}, 'AdminModules')|raw }}
+                      <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules') }}
                     </label>
                   </div>
               </div>
@@ -26,7 +27,7 @@
       </div>
       <div class="modal-footer">
           <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="Annuler">
-          <a class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">Yes, I want to do it</a>
+          <a class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules') }}</a>
       </div>
 
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
@@ -4,13 +4,13 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h4 class="modal-title module-modal-title">{{ 'Bulk action confirmation'|trans({}, 'Admin.Modules') }}</h4>
+        <h4 class="modal-title module-modal-title">{{ 'Bulk action confirmation'|trans({}, 'Admin.Modules.Feature') }}</h4>
       </div>
       <div class="modal-body">
           <div class="row">
               <div class="col-md-12">
                   <p>
-                    {{ "You're about to 'bulk [1][Module Action][/1]' the following modules:"|trans({}, 'Admin.Modules')|replace({'[1]' : '<span id="module-modal-bulk-confirm-action-name">', '[/1]' : '</span>'})|raw }}
+                    {{ "You're about to 'bulk [1][Module Action][/1]' the following modules:"|trans({}, 'Admin.Modules.Notification')|replace({'[1]' : '<span id="module-modal-bulk-confirm-action-name">', '[/1]' : '</span>'})|raw }}
                      <
                   </p>
                   <p id="module-modal-bulk-confirm-list">
@@ -19,7 +19,7 @@
 
                   <div id="module-modal-bulk-checkbox">
                     <label>
-                      <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules') }}
+                      <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
                     </label>
                   </div>
               </div>
@@ -27,7 +27,7 @@
       </div>
       <div class="modal-footer">
           <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="Annuler">
-          <a class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules') }}</a>
+          <a class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules.Feature') }}</a>
       </div>
 
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
@@ -10,11 +10,10 @@
           <div class="row">
               <div class="col-md-12">
                   <p>
-                    {{ "You're about to 'bulk [1][Module Action][/1]' the following modules:"|trans({}, 'Admin.Modules.Notification')|replace({'[1]' : '<span id="module-modal-bulk-confirm-action-name">', '[/1]' : '</span>'})|raw }}
-                     <
+                    {{ "You're about to 'bulk [1]' the following modules:"|trans({}, 'Admin.Modules.Notification')|replace({'[1]' : '<span id="module-modal-bulk-confirm-action-name">[Module Action]</span>'})|raw }}
                   </p>
                   <p id="module-modal-bulk-confirm-list">
-                      {{ '[Module List Up To 10 Max]'|trans({}, 'Admin.Modules') }}
+                      [Module List Up To 10 Max]
                   </p>
 
                   <div id="module-modal-bulk-checkbox">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
               <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
-              <h4 class="modal-title module-modal-title">{{ 'Upload a new module'|trans({}, 'Admin.Modules') }}</h4>
+              <h4 class="modal-title module-modal-title">{{ 'Upload a module'|trans({}, 'Admin.Modules.Feature') }}</h4>
             </div>
             <div class="modal-body">
                 <div class="row">
@@ -13,33 +13,33 @@
                             <div class="module-import-start">
                                 <i class="module-import-start-icon material-icons">cloud_upload</i><br/>
                                 <p class=module-import-start-main-text>
-                                    {{ 'Drop your module archive here or [1]select file[/1]'|trans({}, 'Admin.Modules')|replace({'[1]' : '<a href="#" class="module-import-start-select-manual">', '[/1]' : '</a>'})|raw }}
+                                    {{ 'Drop your module archive here or [1]select file[/1]'|trans({}, 'Admin.Modules.Feature')|replace({'[1]' : '<a href="#" class="module-import-start-select-manual">', '[/1]' : '</a>'})|raw }}
                                 </p>
                                 <p class=module-import-start-footer-text>
-                                    {{ 'Please upload one file at time, .zip or tarball format (.tar, .tar.gz or .tgz).'|trans({}, 'Admin.Modules') }}
-                                    {{ 'Your module will be installed right after that.'|trans({}, 'Admin.Modules') }}
+                                    {{ 'Please upload one file at a time, .zip or tarball format (.tar, .tar.gz or .tgz).'|trans({}, 'Admin.Modules.Help') }}
+                                    {{ 'Your module will be installed right after that.'|trans({}, 'Admin.Modules.Help') }}
                                 </p>
                             </div>
                             <div class='module-import-processing'>
                                 <!-- Loader -->
                                 <button class="btn btn-primary-reverse btn-lg onclick" ></button>
-                                <p class=module-import-processing-main-text>{{ 'Installing module ...'|trans({}, 'Admin.Modules') }}</p>
+                                <p class=module-import-processing-main-text>{{ 'Installing module ...'|trans({}, 'Admin.Modules.Notification') }}</p>
                                 <p class=module-import-processing-footer-text>
-                                    {{ "It will close as soon as the module is installed. It won't be long !"|trans({}, 'Admin.Modules') }}
+                                    {{ "It will close as soon as the module is installed. It won't be long !"|trans({}, 'Admin.Modules.Notification') }}
                                 </p>
                             </div>
                             <div class='module-import-success'>
                                 <i class="module-import-success-icon material-icons">done</i><br/>
-                                <p class='module-import-success-msg'>{{ 'Module installed!'|trans({}, 'Admin.Modules') }}</p>
+                                <p class='module-import-success-msg'>{{ 'Module installed!'|trans({}, 'Admin.Modules.Notification') }}</p>
                                 <p class="module-import-success-details"></p>
-                                <a class="module-import-success-configure btn btn-primary btn-sm light-button" href='#'>{{ 'Configure'|trans({}, 'Admin.Modules') }}</a>
+                                <a class="module-import-success-configure btn btn-primary btn-sm light-button" href='#'>{{ 'Configure'|trans({}, 'Admin.Actions') }}</a>
                             </div>
                             <div class='module-import-failure'>
                                 <i class="module-import-failure-icon material-icons">error</i><br/>
-                                <p class='module-import-failure-msg'>{{ 'Oops... Upload failed.'|trans({}, 'Admin.Modules') }}</p>
-                                <a href="#" class="module-import-failure-details-action">{{ 'What happened?'|trans({}, 'Admin.Modules') }}</a>
+                                <p class='module-import-failure-msg'>{{ 'Oops... Upload failed.'|trans({}, 'Admin.Modules.Notification') }}</p>
+                                <a href="#" class="module-import-failure-details-action">{{ 'What happened?'|trans({}, 'Admin.Modules.Help') }}</a>
                                 <div class='module-import-failure-details'></div>
-                                <a class="module-import-failure-retry btn btn-tertiary" href='#'>{{ 'Try again'|trans({}, 'Admin.Modules') }}</a>
+                                <a class="module-import-failure-retry btn btn-tertiary" href='#'>{{ 'Try again'|trans({}, 'Admin.Actions') }}</a>
                             </div>
                         </form>
                     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
               <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
-              <h4 class="modal-title module-modal-title">Upload a new module</h4>
+              <h4 class="modal-title module-modal-title">{{ 'Upload a new module'|trans({}, 'Admin.Modules') }}</h4>
             </div>
             <div class="modal-body">
                 <div class="row">
@@ -13,33 +13,33 @@
                             <div class="module-import-start">
                                 <i class="module-import-start-icon material-icons">cloud_upload</i><br/>
                                 <p class=module-import-start-main-text>
-                                    Drop your module archive here or <a href="#" class="module-import-start-select-manual">select file</a>
+                                    {{ 'Drop your module archive here or [1]select file[/1]'|trans({}, 'Admin.Modules')|replace({'[1]' : '<a href="#" class="module-import-start-select-manual">', '[/1]' : '</a>'})|raw }}
                                 </p>
                                 <p class=module-import-start-footer-text>
-                                    Please upload one file at time, .zip or tarball format (.tar, .tar.gz or .tgz).
-                                    Your module will be installed right after that.
+                                    {{ 'Please upload one file at time, .zip or tarball format (.tar, .tar.gz or .tgz).'|trans({}, 'Admin.Modules') }}
+                                    {{ 'Your module will be installed right after that.'|trans({}, 'Admin.Modules') }}
                                 </p>
                             </div>
                             <div class='module-import-processing'>
                                 <!-- Loader -->
                                 <button class="btn btn-primary-reverse btn-lg onclick" ></button>
-                                <p class=module-import-processing-main-text>Installing module ...</p>
+                                <p class=module-import-processing-main-text>{{ 'Installing module ...'|trans({}, 'Admin.Modules') }}</p>
                                 <p class=module-import-processing-footer-text>
-                                    It will close as soon as the module is installed. It won't be long !
+                                    {{ "It will close as soon as the module is installed. It won't be long !"|trans({}, 'Admin.Modules') }}
                                 </p>
                             </div>
                             <div class='module-import-success'>
                                 <i class="module-import-success-icon material-icons">done</i><br/>
-                                <p class='module-import-success-msg'>Module installed!</p>
+                                <p class='module-import-success-msg'>{{ 'Module installed!'|trans({}, 'Admin.Modules') }}</p>
                                 <p class="module-import-success-details"></p>
-                                <a class="module-import-success-configure btn btn-primary btn-sm light-button" href='#'>Configure</a>
+                                <a class="module-import-success-configure btn btn-primary btn-sm light-button" href='#'>{{ 'Configure'|trans({}, 'Admin.Modules') }}</a>
                             </div>
                             <div class='module-import-failure'>
                                 <i class="module-import-failure-icon material-icons">error</i><br/>
-                                <p class='module-import-failure-msg'>Oops... Upload failed.</p>
-                                <a href="#" class="module-import-failure-details-action">What happened?</a>
+                                <p class='module-import-failure-msg'>{{ 'Oops... Upload failed.'|trans({}, 'Admin.Modules') }}</p>
+                                <a href="#" class="module-import-failure-details-action">{{ 'What happened?'|trans({}, 'Admin.Modules') }}</a>
                                 <div class='module-import-failure-details'></div>
-                                <a class="module-import-failure-retry btn btn-tertiary" href='#'>Try again</a>
+                                <a class="module-import-failure-retry btn btn-tertiary" href='#'>{{ 'Try again'|trans({}, 'Admin.Modules') }}</a>
                             </div>
                         </form>
                     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more.html.twig
@@ -20,7 +20,7 @@
           <div class="modal-title module-modal-title">
             <h1>{{ module.attributes.displayName }}<br>
               <small class="version">
-                {{ 'v%version% by '|trans({'%version%' : module.attributes.version}, 'Admin.Modules') }}
+                {{ 'v%version% by '|trans({'%version%' : module.attributes.version}, 'Admin.Modules.Feature') }}
                 {{ module.attributes.author }}
               </small>
             </h1>
@@ -37,16 +37,16 @@
           <nav class="navbar navbar-light">
             <ul class="nav navbar-nav navbar-separator">
               <li class="nav-item active">
-                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#overview-{{module.attributes.name}}">{{ 'Overview'|trans({}, 'Admin.Modules') }}</a>
+                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#overview-{{module.attributes.name}}">{{ 'Overview'|trans({}, 'Admin.Modules.Feature') }}</a>
               </li>
               {% if module.attributes.additionalDescription is defined and module.attributes.additionalDescription|length %}
                   <li class="nav-item">
-                    <a class="nav-link module-readmore-tab" data-toggle="tab" href="#benefits-{{module.attributes.name}}">{{ 'Benefits'|trans({}, 'Admin.Modules') }}</a>
+                    <a class="nav-link module-readmore-tab" data-toggle="tab" href="#benefits-{{module.attributes.name}}">{{ 'Benefits'|trans({}, 'Admin.Modules.Feature') }}</a>
                   </li>
               {% endif %}
               {% if module.attributes.changeLog is defined and module.attributes.changeLog|length %}
                   <li class="nav-item">
-                    <a class="nav-link module-readmore-tab" data-toggle="tab" href="#changelog-{{module.attributes.name}}">{{ 'Changelog'|trans({}, 'Admin.Modules') }}</a>
+                    <a class="nav-link module-readmore-tab" data-toggle="tab" href="#changelog-{{module.attributes.name}}">{{ 'Changelog'|trans({}, 'Admin.Modules.Feature') }}</a>
                   </li>
               {% endif %}
             </ul>
@@ -57,7 +57,7 @@
                 {% if module.attributes.fullDescription is defined and module.attributes.fullDescription|length %}
                     {{ module.attributes.fullDescription|raw }}
                 {% else %}
-                    {{ 'No description found for this module :('|trans({}, 'Admin.Modules') }}
+                    {{ 'No description found for this module :('|trans({}, 'Admin.Modules.Notification') }}
                 {% endif %}
               </p>
             </div>
@@ -66,14 +66,14 @@
                 {% if module.attributes.additionalDescription is defined %}
                     {{ module.attributes.additionalDescription|raw }}
                 {% else %}
-                    {{ 'No benefits description provided for this module :('|trans({}, 'Admin.Modules') }}
+                    {{ 'No benefits description provided for this module :('|trans({}, 'Admin.Modules.Notification') }}
                 {% endif %}
               </p>
             </div>
             <!-- WAITING FOR API UPDATE
             <div id="features-{{module.attributes.name}}" class="tab-pane fade">
               <p class="module-readmore-tab-content">
-                {{ 'No feature list provided for this module :('|trans({}, 'Admin.Modules') }}
+                {{ 'No feature list provided for this module :('|trans({}, 'Admin.Modules.Notification') }}
               </p>
             </div> -->
             <div id="changelog-{{module.attributes.name}}" class="tab-pane fade">
@@ -89,7 +89,7 @@
                     {% endfor %}
                   </ul>
               {% else %}
-                  {{ 'No changelog provided for this module :('|trans({}, 'Admin.Modules') }}
+                  {{ 'No changelog provided for this module :('|trans({}, 'Admin.Modules.Notification') }}
               {% endif %}
             </div>
           </div>
@@ -106,7 +106,7 @@
             </div>
         {% endif %}
         {% if module.attributes.urls.install is defined %}
-            <a href="{{module.attributes.urls.install}}" class="pull-right module-install-button btn-primary-outline btn module-install-button btn-sm light-button">{{ 'Install'|trans({}, 'Admin.Modules') }}</a>
+            <a href="{{module.attributes.urls.install}}" class="pull-right module-install-button btn-primary-outline btn module-install-button btn-sm light-button">{{ 'Install'|trans({}, 'Admin.Actions') }}</a>
         {% endif %}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more.html.twig
@@ -9,19 +9,18 @@
           </span>
         </button>
         {% if module.attributes.nbRates > 0 %}
-        <div class="read-more-stars module-star-ranking-grid-{{ module.attributes.starsRate}}">
-          (
-          {{ module.attributes.nbRates }}
-          )
-        </div>
+            <div class="read-more-stars module-star-ranking-grid-{{ module.attributes.starsRate}}">
+              (
+              {{ module.attributes.nbRates }}
+              )
+            </div>
         {% endif %}
         <div>
           <img class="module-logo-thumb" height="57" width="57" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}"/>
           <div class="modal-title module-modal-title">
             <h1>{{ module.attributes.displayName }}<br>
               <small class="version">
-                v{{ module.attributes.version }}
-                by
+                {{ 'v%version% by '|trans({'%version%' : module.attributes.version}, 'Admin.Modules') }}
                 {{ module.attributes.author }}
               </small>
             </h1>
@@ -38,17 +37,17 @@
           <nav class="navbar navbar-light">
             <ul class="nav navbar-nav navbar-separator">
               <li class="nav-item active">
-                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#overview-{{module.attributes.name}}">Overview</a>
+                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#overview-{{module.attributes.name}}">{{ 'Overview'|trans({}, 'Admin.Modules') }}</a>
               </li>
               {% if module.attributes.additionalDescription is defined and module.attributes.additionalDescription|length %}
-              <li class="nav-item">
-                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#benefits-{{module.attributes.name}}">Benefits</a>
-              </li>
+                  <li class="nav-item">
+                    <a class="nav-link module-readmore-tab" data-toggle="tab" href="#benefits-{{module.attributes.name}}">{{ 'Benefits'|trans({}, 'Admin.Modules') }}</a>
+                  </li>
               {% endif %}
               {% if module.attributes.changeLog is defined and module.attributes.changeLog|length %}
-              <li class="nav-item">
-                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#changelog-{{module.attributes.name}}">Changelog</a>
-              </li>
+                  <li class="nav-item">
+                    <a class="nav-link module-readmore-tab" data-toggle="tab" href="#changelog-{{module.attributes.name}}">{{ 'Changelog'|trans({}, 'Admin.Modules') }}</a>
+                  </li>
               {% endif %}
             </ul>
           </nav>
@@ -56,41 +55,41 @@
             <div id="overview-{{module.attributes.name}}" class="tab-pane fade in active">
               <p class="module-readmore-tab-content">
                 {% if module.attributes.fullDescription is defined and module.attributes.fullDescription|length %}
-                {{ module.attributes.fullDescription|raw }}
+                    {{ module.attributes.fullDescription|raw }}
                 {% else %}
-                No description found for this module :(
+                    {{ 'No description found for this module :('|trans({}, 'Admin.Modules') }}
                 {% endif %}
               </p>
             </div>
             <div id="benefits-{{module.attributes.name}}" class="tab-pane fade">
               <p class="module-readmore-tab-content">
                 {% if module.attributes.additionalDescription is defined %}
-                {{ module.attributes.additionalDescription|raw }}
-              {% else %}
-                No benefits description provided for this module :(
+                    {{ module.attributes.additionalDescription|raw }}
+                {% else %}
+                    {{ 'No benefits description provided for this module :('|trans({}, 'Admin.Modules') }}
                 {% endif %}
               </p>
             </div>
             <!-- WAITING FOR API UPDATE
             <div id="features-{{module.attributes.name}}" class="tab-pane fade">
               <p class="module-readmore-tab-content">
-                No feature list provided for this module :(
+                {{ 'No feature list provided for this module :('|trans({}, 'Admin.Modules') }}
               </p>
             </div> -->
             <div id="changelog-{{module.attributes.name}}" class="tab-pane fade">
               {% if module.attributes.changeLog is defined %}
-              <ul class="module-readmore-tab-content">
-                {% for version, lines in module.attributes.changeLog|arrayCast|reverse %}
-                <li>
-                  <b>{{version}}:</b>
-                  {% for line in lines %}
-                  {{line}}<br/>
-                  {% endfor %}
-                </li>
-                {% endfor %}
-              </ul>
-            {% else %}
-              No changelog provided for this module :(
+                  <ul class="module-readmore-tab-content">
+                    {% for version, lines in module.attributes.changeLog|arrayCast|reverse %}
+                        <li>
+                          <b>{{version}}:</b>
+                          {% for line in lines %}
+                              {{line}}<br/>
+                          {% endfor %}
+                        </li>
+                    {% endfor %}
+                  </ul>
+              {% else %}
+                  {{ 'No changelog provided for this module :('|trans({}, 'Admin.Modules') }}
               {% endif %}
             </div>
           </div>
@@ -99,15 +98,15 @@
 
       <div class="modal-footer module-modal-footer">
         {% if module.attributes.badges is defined %}
-        <div class="pull-left module-badges-display">
-          {% for badge in module.attributes.badges %}
-          <img src="{{badge.img}}" alt="{{badge.label}}"/>
-          {{badge.label}}
-          {% endfor %}
-        </div>
+            <div class="pull-left module-badges-display">
+              {% for badge in module.attributes.badges %}
+                  <img src="{{badge.img}}" alt="{{badge.label}}"/>
+                  {{badge.label}}
+              {% endfor %}
+            </div>
         {% endif %}
         {% if module.attributes.urls.install is defined %}
-        <a href="{{module.attributes.urls.install}}" class="pull-right module-install-button btn-primary-outline btn module-install-button btn-sm light-button">{{ 'Install'|trans({}, 'AdminModules') }}</a>
+            <a href="{{module.attributes.urls.install}}" class="pull-right module-install-button btn-primary-outline btn module-install-button btn-sm light-button">{{ 'Install'|trans({}, 'Admin.Modules') }}</a>
         {% endif %}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/notification_kpis.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/notification_kpis.html.twig
@@ -4,12 +4,12 @@
 
             <div class="module-kpi">
                 <i class="material-icons">settings</i>
-                {{ '%nbModules% modules to configure'|trans({'%nbModules%' : modules.to_configure|length}, 'Admin.Modules')|replace({'[1]' : '<span class="module-kpi-number">', '[/1]' : '</span>'})|raw }}
+                {{ '%nbModules% modules to configure'|trans({'%nbModules%' : modules.to_configure|length}, 'Admin.Modules.Feature')|replace({'[1]' : '<span class="module-kpi-number">', '[/1]' : '</span>'})|raw }}
             </div>
 
             <div class="module-kpi">
                 <i class="material-icons">update</i>
-                {{ '%nbModules% modules to update'|trans({'%nbModules%' : modules.to_update|length}, 'Admin.Modules')|replace({'[1]' : '<span class="module-kpi-number">', '[/1]' : '</span>'})|raw }}
+                {{ '%nbModules% modules to update'|trans({'%nbModules%' : modules.to_update|length}, 'Admin.Modules.Feature')|replace({'[1]' : '<span class="module-kpi-number">', '[/1]' : '</span>'})|raw }}
             </div>
 
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/notification_kpis.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/notification_kpis.html.twig
@@ -4,12 +4,12 @@
 
             <div class="module-kpi">
                 <i class="material-icons">settings</i>
-                <span class="module-kpi-number">{{modules.to_configure|length}}</span> modules to configure
+                {{ '%nbModules% modules to configure'|trans({'%nbModules%' : modules.to_configure|length}, 'Admin.Modules')|replace({'[1]' : '<span class="module-kpi-number">', '[/1]' : '</span>'})|raw }}
             </div>
 
             <div class="module-kpi">
                 <i class="material-icons">update</i>
-                <span class="module-kpi-number">{{modules.to_update|length}}</span>  modules to update
+                {{ '%nbModules% modules to update'|trans({'%nbModules%' : modules.to_update|length}, 'Admin.Modules')|replace({'[1]' : '<span class="module-kpi-number">', '[/1]' : '</span>'})|raw }}
             </div>
 
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
@@ -3,15 +3,15 @@
 
         <div class="col-lg-6">
             <div class="module-sorting-search-wording">
-                <span class="module-search-result-wording">{{ totalModules }} modules and services selected for you</span>
+                <span class="module-search-result-wording">{{ '%nbModules% modules and services selected for you'|trans({'%nbModules%' : totalModules}, 'Admin.Modules') }}</span>
                 <span class="help-box" data-toggle="popover"
-                    data-title="{{ "Selection"|trans({}, 'AdminModules') }}"
-                    data-content="{{ "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'AdminModules') }}">
+                    data-title="{{ "Selection"|trans({}, 'Admin.Modules') }}"
+                    data-content="{{ "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'Admin.Modules') }}">
                 </span>
             </div>
             <p class="module-addons-search">
                 <a class='module-addons-search-link' href="#">
-                    See all results for this search on Addons Marketplace
+                    {{ 'See all results for this search on Addons Marketplace'|trans({}, 'Admin.Modules') }}
                     <span>
                         <i class="icon-signout"></i>
                     </span>
@@ -26,12 +26,12 @@
             </div>
             <div class="module-sorting module-sorting-author pull-right">
                 <select class="c-select c-select-sm">
-                  <option value="" disabled selected>- Sort by -</option>
-                  <option value="sort-by-name">Name</option>
-                  <option value="sort-by-price-asc">Increasing Price</option>
-                  <option value="sort-by-price-desc">Decreasing Price</option>
-                  <option value="sort-by-scoring">Score</option>
-                  <option value="sort-by-access-date">Last access</option>
+                  <option value="" disabled selected>{{ '- Sort by -'|trans({}, 'Admin.Modules') }}</option>
+                  <option value="sort-by-name">{{ 'Name'|trans({}, 'Admin.Modules') }}</option>
+                  <option value="sort-by-price-asc">{{ 'Increasing Price'|trans({}, 'Admin.Modules') }}</option>
+                  <option value="sort-by-price-desc">{{ 'Decreasing Price'|trans({}, 'Admin.Modules') }}</option>
+                  <option value="sort-by-scoring">{{ 'Score'|trans({}, 'Admin.Modules') }}</option>
+                  <option value="sort-by-access-date">{{ 'Last access'|trans({}, 'Admin.Modules') }}</option>
                 </select>
             </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
@@ -3,15 +3,15 @@
 
         <div class="col-lg-6">
             <div class="module-sorting-search-wording">
-                <span class="module-search-result-wording">{{ '%nbModules% modules and services selected for you'|trans({'%nbModules%' : totalModules}, 'Admin.Modules') }}</span>
+                <span class="module-search-result-wording">{{ '%nbModules% modules and services selected for you'|trans({'%nbModules%' : totalModules}, 'Admin.Modules.Feature') }}</span>
                 <span class="help-box" data-toggle="popover"
-                    data-title="{{ "Selection"|trans({}, 'Admin.Modules') }}"
-                    data-content="{{ "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'Admin.Modules') }}">
+                    data-title="{{ "Selection"|trans({}, 'Admin.Modules.Feature') }}"
+                    data-content="{{ "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'Admin.Modules.Help') }}">
                 </span>
             </div>
             <p class="module-addons-search">
                 <a class='module-addons-search-link' href="#">
-                    {{ 'See all results for this search on Addons Marketplace'|trans({}, 'Admin.Modules') }}
+                    {{ 'See all results for this search on Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}
                     <span>
                         <i class="icon-signout"></i>
                     </span>
@@ -26,12 +26,12 @@
             </div>
             <div class="module-sorting module-sorting-author pull-right">
                 <select class="c-select c-select-sm">
-                  <option value="" disabled selected>{{ '- Sort by -'|trans({}, 'Admin.Modules') }}</option>
-                  <option value="sort-by-name">{{ 'Name'|trans({}, 'Admin.Modules') }}</option>
-                  <option value="sort-by-price-asc">{{ 'Increasing Price'|trans({}, 'Admin.Modules') }}</option>
-                  <option value="sort-by-price-desc">{{ 'Decreasing Price'|trans({}, 'Admin.Modules') }}</option>
-                  <option value="sort-by-scoring">{{ 'Score'|trans({}, 'Admin.Modules') }}</option>
-                  <option value="sort-by-access-date">{{ 'Last access'|trans({}, 'Admin.Modules') }}</option>
+                  <option value="" disabled selected>- {{ 'Sort by'|trans({}, 'Admin.Actions') }} -</option>
+                  <option value="sort-by-name">{{ 'Name'|trans({}, 'Admin.Global') }}</option>
+                  <option value="sort-by-price-asc">{{ 'Increasing Price'|trans({}, 'Admin.Modules.Feature') }}</option>
+                  <option value="sort-by-price-desc">{{ 'Decreasing Price'|trans({}, 'Admin.Modules.Feature') }}</option>
+                  <option value="sort-by-scoring">{{ 'Score'|trans({}, 'Admin.Modules.Feature') }}</option>
+                  <option value="sort-by-access-date">{{ 'Last access'|trans({}, 'Admin.Modules.Feature') }}</option>
                 </select>
             </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -31,24 +31,24 @@
                     <div class="col-lg-12">
                         <div class="module-sorting module-bulk-actions pull-right">
                             <select class="c-select c-select-sm">
-                              <option value="" disabled selected>{{ 'Bulk Actions'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="bulk-uninstall">{{ 'Uninstall'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="bulk-disable">{{ 'Disable'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="bulk-enable">{{ 'Enable'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="bulk-reset">{{ 'Reset'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="bulk-enable-mobile">{{ 'Enable Mobile'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="bulk-disable-mobile">{{ 'Disable Mobile'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="" disabled selected>{{ 'Bulk Actions'|trans({}, 'Admin.Global') }}</option>
+                              <option value="bulk-uninstall">{{ 'Uninstall'|trans({}, 'Admin.Actions') }}</option>
+                              <option value="bulk-disable">{{ 'Disable'|trans({}, 'Admin.Actions') }}</option>
+                              <option value="bulk-enable">{{ 'Enable'|trans({}, 'Admin.Actions') }}</option>
+                              <option value="bulk-reset">{{ 'Reset'|trans({}, 'Admin.Actions') }}</option>
+                              <option value="bulk-enable-mobile">{{ 'Enable Mobile'|trans({}, 'Admin.Modules.Feature') }}</option>
+                              <option value="bulk-disable-mobile">{{ 'Disable Mobile'|trans({}, 'Admin.Modules.Feature') }}</option>
                             </select>
                             <input type="checkbox" class="module-checkbox-bulk-select-all" />
                         </div>
                         <div class="module-sorting module-sorting-author pull-right">
                             <select class="c-select c-select-sm">
-                              <option value="" disabled selected>{{ '- Sort by -'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="sort-by-name">{{ 'Name'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="sort-by-price-asc">{{ 'Increasing Price'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="sort-by-price-desc">{{ 'Decreasing Price'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="sort-by-scoring">{{ 'Score'|trans({}, 'Admin.Modules') }}</option>
-                              <option value="sort-by-access-date">{{ 'Last access'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="" disabled selected>- {{ 'Sort by'|trans({}, 'Admin.Actions') }} -</option>
+                              <option value="sort-by-name">{{ 'Name'|trans({}, 'Admin.Global') }}</option>
+                              <option value="sort-by-price-asc">{{ 'Increasing Price'|trans({}, 'Admin.Modules.Feature') }}</option>
+                              <option value="sort-by-price-desc">{{ 'Decreasing Price'|trans({}, 'Admin.Modules.Feature') }}</option>
+                              <option value="sort-by-scoring">{{ 'Score'|trans({}, 'Admin.Modules.Feature') }}</option>
+                              <option value="sort-by-access-date">{{ 'Last access'|trans({}, 'Admin.Modules.Feature') }}</option>
                             </select>
                         </div>
                     </div>
@@ -57,10 +57,10 @@
 
             {# Actual Page Content #}
 		<div class="module-short-list">
-			<span class="module-search-result-wording">{{ '%nbModules% installed modules'|trans({'%nbModules%' : modules.modules|length}, 'Admin.Modules') }}</span>
+			<span class="module-search-result-wording">{{ '%nbModules% installed modules'|trans({'%nbModules%' : modules.modules|length}, 'Admin.Modules.Feature') }}</span>
                            <span class="help-box" data-toggle="popover"
-                                data-title="{{ "Installed modules"|trans({}, 'Admin.Modules') }}"
-                                data-content="{{ "These are all the modules you’ve added to your shop, either by buying it from PrestaShop Addons, or by uploading it directly."|trans({}, 'Admin.Modules') }}">
+                                data-title="{{ "Installed modules"|trans({}, 'Admin.Modules.Feature') }}"
+                                data-content="{{ "These are all the modules you’ve added to your shop, either by buying it from PrestaShop Addons, or by uploading it directly."|trans({}, 'Admin.Modules.Help') }}">
                            </span>
                    </div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.modules, 'display_type' : 'list', 'origin' : 'manage'  } %}
@@ -68,10 +68,10 @@
 		<hr class="top-menu-separator">
 
 		<div class="module-short-list">
-			<span class="module-search-result-wording">{{ '%nbModules% built-in modules'|trans({'%nbModules%' : modules.native_modules|length}, 'Admin.Modules') }}</span>
+			<span class="module-search-result-wording">{{ '%nbModules% built-in modules'|trans({'%nbModules%' : modules.native_modules|length}, 'Admin.Modules.Feature') }}</span>
                            <span class="help-box" data-toggle="popover"
-                                 data-title="{{ "Built-in modules"|trans({}, 'Admin.Modules') }}"
-                                data-content="{{ "These modules from PrestaShop are preinstalled when you set-up your shop. They cover the basics of e-commerce and comes for free."|trans({}, 'Admin.Modules') }}">
+                                 data-title="{{ "Built-in modules"|trans({}, 'Admin.Modules.Feature') }}"
+                                data-content="{{ "These modules from PrestaShop are preinstalled when you set-up your shop. They cover the basics of e-commerce and comes for free."|trans({}, 'Admin.Modules.Help') }}">
                            </span>
 		</div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.native_modules, 'display_type' : 'list', 'origin' : 'manage'  } %}
@@ -79,10 +79,10 @@
 		<hr class="top-menu-separator">
 
 		<div class="module-short-list">
-			<span class="module-search-result-wording">{{ '%nbModules% theme modules'|trans({'%nbModules%' : modules.theme_bundle|length}, 'Admin.Modules') }}</span>
+			<span class="module-search-result-wording">{{ '%nbModules% theme modules'|trans({'%nbModules%' : modules.theme_bundle|length}, 'Admin.Modules.Feature') }}</span>
                            <span class="help-box" data-toggle="popover"
-                                data-title="{{ "Theme modules"|trans({}, 'Admin.Modules') }}"
-                                data-content="{{ "Each theme you install will come with its own set of modules. You’ll find here all the modules related to your active theme."|trans({}, 'Admin.Modules') }}">
+                                data-title="{{ "Theme modules"|trans({}, 'Admin.Modules.Feature') }}"
+                                data-content="{{ "Each theme you install will come with its own set of modules. You’ll find here all the modules related to your active theme."|trans({}, 'Admin.Modules.Help') }}">
                            </span>
 		</div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.theme_bundle, 'display_type' : 'list', 'origin' : 'manage'  } %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -31,24 +31,24 @@
                     <div class="col-lg-12">
                         <div class="module-sorting module-bulk-actions pull-right">
                             <select class="c-select c-select-sm">
-                              <option value="" disabled selected>Bulk Actions</option>
-                              <option value="bulk-uninstall">Uninstall</option>
-                              <option value="bulk-disable">Disable</option>
-                              <option value="bulk-enable">Enable</option>
-                              <option value="bulk-reset">Reset</option>
-                              <option value="bulk-enable-mobile">Enable Mobile</option>
-                              <option value="bulk-disable-mobile">Disable Mobile</option>
+                              <option value="" disabled selected>{{ 'Bulk Actions'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="bulk-uninstall">{{ 'Uninstall'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="bulk-disable">{{ 'Disable'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="bulk-enable">{{ 'Enable'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="bulk-reset">{{ 'Reset'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="bulk-enable-mobile">{{ 'Enable Mobile'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="bulk-disable-mobile">{{ 'Disable Mobile'|trans({}, 'Admin.Modules') }}</option>
                             </select>
                             <input type="checkbox" class="module-checkbox-bulk-select-all" />
                         </div>
                         <div class="module-sorting module-sorting-author pull-right">
                             <select class="c-select c-select-sm">
-                              <option value="" disabled selected>- Sort by -</option>
-                              <option value="sort-by-name">Name</option>
-                              <option value="sort-by-price-asc">Increasing Price</option>
-                              <option value="sort-by-price-desc">Decreasing Price</option>
-                              <option value="sort-by-scoring">Score</option>
-                              <option value="sort-by-access-date">Last access</option>
+                              <option value="" disabled selected>{{ '- Sort by -'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="sort-by-name">{{ 'Name'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="sort-by-price-asc">{{ 'Increasing Price'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="sort-by-price-desc">{{ 'Decreasing Price'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="sort-by-scoring">{{ 'Score'|trans({}, 'Admin.Modules') }}</option>
+                              <option value="sort-by-access-date">{{ 'Last access'|trans({}, 'Admin.Modules') }}</option>
                             </select>
                         </div>
                     </div>
@@ -57,10 +57,10 @@
 
             {# Actual Page Content #}
 		<div class="module-short-list">
-			<span class="module-search-result-wording">{{modules.modules|length}} installed modules</span>
+			<span class="module-search-result-wording">{{ '%nbModules% installed modules'|trans({'%nbModules%' : modules.modules|length}, 'Admin.Modules') }}</span>
                            <span class="help-box" data-toggle="popover"
-                                data-title="{{ "Installed modules"|trans({}, 'AdminModules') }}"
-                                data-content="{{ "These are all the modules you’ve added to your shop, either by buying it from PrestaShop Addons, or by uploading it directly."|trans({}, 'AdminModules') }}">
+                                data-title="{{ "Installed modules"|trans({}, 'Admin.Modules') }}"
+                                data-content="{{ "These are all the modules you’ve added to your shop, either by buying it from PrestaShop Addons, or by uploading it directly."|trans({}, 'Admin.Modules') }}">
                            </span>
                    </div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.modules, 'display_type' : 'list', 'origin' : 'manage'  } %}
@@ -68,10 +68,10 @@
 		<hr class="top-menu-separator">
 
 		<div class="module-short-list">
-			<span class="module-search-result-wording">{{modules.native_modules|length}} built-in modules</span>
+			<span class="module-search-result-wording">{{ '%nbModules% built-in modules'|trans({'%nbModules%' : modules.native_modules|length}, 'Admin.Modules') }}</span>
                            <span class="help-box" data-toggle="popover"
-                                 data-title="{{ "Built-in modules"|trans({}, 'AdminModules') }}"
-                                data-content="{{ "These modules from PrestaShop are preinstalled when you set-up your shop. They cover the basics of e-commerce and comes for free."|trans({}, 'AdminModules') }}">
+                                 data-title="{{ "Built-in modules"|trans({}, 'Admin.Modules') }}"
+                                data-content="{{ "These modules from PrestaShop are preinstalled when you set-up your shop. They cover the basics of e-commerce and comes for free."|trans({}, 'Admin.Modules') }}">
                            </span>
 		</div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.native_modules, 'display_type' : 'list', 'origin' : 'manage'  } %}
@@ -79,10 +79,10 @@
 		<hr class="top-menu-separator">
 
 		<div class="module-short-list">
-			<span class="module-search-result-wording">{{modules.theme_bundle|length}} theme modules</span>
+			<span class="module-search-result-wording">{{ '%nbModules% theme modules'|trans({'%nbModules%' : modules.theme_bundle|length}, 'Admin.Modules') }}</span>
                            <span class="help-box" data-toggle="popover"
-                                data-title="{{ "Theme modules"|trans({}, 'AdminModules') }}"
-                                data-content="{{ "Each theme you install will come with its own set of modules. You’ll find here all the modules related to your active theme."|trans({}, 'AdminModules') }}">
+                                data-title="{{ "Theme modules"|trans({}, 'Admin.Modules') }}"
+                                data-content="{{ "Each theme you install will come with its own set of modules. You’ll find here all the modules related to your active theme."|trans({}, 'Admin.Modules') }}">
                            </span>
 		</div>
 		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules' : modules.theme_bundle, 'display_type' : 'list', 'origin' : 'manage'  } %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -27,20 +27,20 @@
         <div class="col-lg-10 col-lg-offset-1">
 
             <div class="module-short-list">
-                <span class="module-search-result-wording">{{ '%nbModules% modules to configure'|trans({'%nbModules%' : modules.to_configure|length}, 'Admin.Modules') }}</span> 
+                <span class="module-search-result-wording">{{ '%nbModules% modules to configure'|trans({'%nbModules%' : modules.to_configure|length}, 'Admin.Modules.Feature') }}</span>
                 <span class="help-box" data-toggle="popover"
-                      data-title="{{ "Modules to configure"|trans({}, 'Admin.Modules') }}"
-                      data-content="{{ "These modules require your attention: you need to take some action to ensure they are fully operational."|trans({}, 'Admin.Modules') }}">
+                      data-title="{{ "Modules to configure"|trans({}, 'Admin.Modules.Feature') }}"
+                      data-content="{{ "These modules require your attention: you need to take some action to ensure they are fully operational."|trans({}, 'Admin.Modules.Help') }}">
                 </span>
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_configure.html.twig' with { 'modules' : modules.to_configure, 'display_type' : 'list'  } %}
 
             <hr class="top-menu-separator">
             <div class="module-short-list">
-                <span class="module-search-result-wording">{{ '%nbModules% modules to update'|trans({'%nbModules%' : modules.to_update|length}, 'Admin.Modules') }}</span>
+                <span class="module-search-result-wording">{{ '%nbModules% modules to update'|trans({'%nbModules%' : modules.to_update|length}, 'Admin.Modules.Feature') }}</span>
                 <span class="help-box" data-toggle="popover"
-                      data-title="{{ "Modules to update"|trans({}, 'Admin.Modules') }}"
-                      data-content="{{ "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules') }}">
+                      data-title="{{ "Modules to update"|trans({}, 'Admin.Modules.Feature') }}"
+                      data-content="{{ "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help') }}">
                 </span>
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_update.html.twig' with { 'modules' : modules.to_update, 'display_type' : 'list' } %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -27,20 +27,20 @@
         <div class="col-lg-10 col-lg-offset-1">
 
             <div class="module-short-list">
-                <span class="module-search-result-wording">{{modules.to_configure|length}} modules to configure</span> 
+                <span class="module-search-result-wording">{{ '%nbModules% modules to configure'|trans({'%nbModules%' : modules.to_configure|length}, 'Admin.Modules') }}</span> 
                 <span class="help-box" data-toggle="popover"
-                      data-title="{{ "Modules to configure"|trans({}, 'AdminModules') }}"
-                      data-content="{{ "These modules require your attention: you need to take some action to ensure they are fully operational."|trans({}, 'AdminModules') }}">
+                      data-title="{{ "Modules to configure"|trans({}, 'Admin.Modules') }}"
+                      data-content="{{ "These modules require your attention: you need to take some action to ensure they are fully operational."|trans({}, 'Admin.Modules') }}">
                 </span>
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_configure.html.twig' with { 'modules' : modules.to_configure, 'display_type' : 'list'  } %}
 
             <hr class="top-menu-separator">
             <div class="module-short-list">
-                <span class="module-search-result-wording">{{modules.to_update|length}} modules to update</span>
+                <span class="module-search-result-wording">{{ '%nbModules% modules to update'|trans({'%nbModules%' : modules.to_update|length}, 'Admin.Modules') }}</span>
                 <span class="help-box" data-toggle="popover"
-                      data-title="{{ "Modules to update"|trans({}, 'AdminModules') }}"
-                      data-content="{{ "Update these modules to enjoy their latest versions."|trans({}, 'AdminModules') }}">
+                      data-title="{{ "Modules to update"|trans({}, 'Admin.Modules') }}"
+                      data-content="{{ "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules') }}">
                 </span>
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_update.html.twig' with { 'modules' : modules.to_update, 'display_type' : 'list' } %}

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -37,6 +37,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
     private $moduleProviderS; // S means "Stub"
     private $moduleUpdaterS;
     private $moduleRepositoryS;
+    private $translatorS;
     private $employeeS;
 
     public function setUp()
@@ -48,6 +49,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
             $this->moduleProviderS,
             $this->moduleUpdaterS,
             $this->moduleRepositoryS,
+            $this->translatorS,
             $this->employeeS
         );
     }
@@ -62,7 +64,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
     public function testInstallSuccessful()
     {
         $this->assertTrue($this->moduleManager->install(self::UNINSTALLED_MODULE));
-        $this->setExpectedException('Exception', sprintf('The module %s is already installed.', self::INSTALLED_MODULE));
+        $this->setExpectedException('Exception', 'The module %module% is already installed.');
         $this->moduleManager->install(self::INSTALLED_MODULE);
     }
 
@@ -141,6 +143,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
         $this->mockModuleProvider();
         $this->mockModuleUpdater();
         $this->mockModuleRepository();
+        $this->mockTranslator();
         $this->mockEmployee();
     }
 
@@ -271,6 +274,17 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
             ->willReturn($moduleS);
     }
 
+    private function mockTranslator()
+    {
+        $this->translatorS = $this->getMockBuilder('Symfony\Component\Translation\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->translatorS
+            ->method('trans')
+            ->will($this->returnArgument(0));
+    }
+
     private function mockEmployee()
     {
         /* this is a super admin */
@@ -289,6 +303,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
         $this->moduleProviderS = null;
         $this->moduleUpdaterS = null;
         $this->moduleUpdaterS = null;
+        $this->translatorS = null;
         $this->employeeS = null;
     }
 }

--- a/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
@@ -97,9 +97,16 @@ class ModuleRepositoryTest extends UnitTestCase
             ->method('getCatalogModulesNames')
             ->willReturn([]);
 
+        $this->translatorStub = $this->getMockBuilder('Symfony\Component\Translation\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->translatorStub
+            ->method('trans')
+            ->will($this->returnArgument(0));
+
         $this->moduleRepositoryStub = $this->getMock(
             'PrestaShop\\PrestaShop\\Core\\Addon\\Module\\ModuleRepository',
-            ['readCacheFile'],
+            ['readCacheFile', 'generateCacheFile'],
             [
                 $this->adminModuleDataProviderStub,
                 $this->moduleDataProviderStub,
@@ -108,7 +115,8 @@ class ModuleRepositoryTest extends UnitTestCase
                     $this->sfRouter,
                     $this->addonsDataProviderS
                 )),
-                new FakeLogger()
+                new FakeLogger(),
+                $this->translatorStub
             ]
         );
 
@@ -118,6 +126,13 @@ class ModuleRepositoryTest extends UnitTestCase
         $this->moduleRepositoryStub
             ->method('readCacheFile')
             ->willReturn([]);
+
+        /**
+         * Mock function 'readCacheFile()' to disable the cache
+         */
+        $this->moduleRepositoryStub
+            ->method('generateCacheFile')
+            ->will($this->returnArgument(0));
 
         /**
          * End of mocking for modules folder


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Strings related to module management or module page are now translatable. Requesting @AlexEven help for the missing domains. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-894](http://forge.prestashop.com/browse/BOOM-894) / [BOOM-892](http://forge.prestashop.com/browse/BOOM-892) |
| How to test? | The strings must now appear on Crowdin (when 1.7 available on Crowdin ^^) |
