### PR TITLE
Optional final checkout summary before payment

### DIFF
--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -49,6 +49,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
                 ->getConditionsToApproveForTemplate(),
             'selected_payment_option' => $this->selected_payment_option,
             'selected_delivery_option' => $selectedDeliveryOption,
+            'show_final_summary' => Configuration::get('PS_FINAL_SUMMARY_ENABLED'),
             );
 
         return $this->renderTemplate($this->getTemplate(), $extraParams, $assignedVars);

--- a/controllers/admin/AdminOrderPreferencesController.php
+++ b/controllers/admin/AdminOrderPreferencesController.php
@@ -51,6 +51,13 @@ class AdminOrderPreferencesControllerCore extends AdminController
                 'title' =>    $this->l('General'),
                 'icon' =>    'icon-cogs',
                 'fields' =>    array(
+                    'PS_FINAL_SUMMARY_ENABLED' => array(
+                        'title' => $this->l('Enable final summary'),
+                        'hint' => $this->l('Display an overview of the addresses, shipping method and cart just before the order button (required in some European countries).'),
+                        'validation' => 'isBool',
+                        'cast' => 'intval',
+                        'type' => 'bool'
+                    ),
                     'PS_GUEST_CHECKOUT_ENABLED' => array(
                         'title' => $this->l('Enable guest checkout'),
                         'hint' => $this->l('Allow guest visitors to place an order without registering.'),

--- a/themes/classic/_dev/css/components/checkout.scss
+++ b/themes/classic/_dev/css/components/checkout.scss
@@ -268,6 +268,42 @@ body#checkout {
       vertical-align: middle;
     }
   }
+  #order-summary-content {
+    padding-top: em(25px);
+    h4.h4 {
+      font-size: em(16px);
+      margin-top: em(10px);
+      margin-bottom: em(20px);
+      color: $gray;      
+    }
+    h4.black {
+      color: #000000;
+    }
+    h4.addresshead {
+      margin-top: em(3px);
+    }
+    .noshadow {
+      box-shadow: none;
+    }
+    #order-items {
+      border-right: 0;
+      h3.h3 {
+        color: $gray;
+        margin-top: em(20px);
+      }
+    }
+    .step-edit {
+      display: inline;
+    }
+    .step-edit:hover {
+      cursor: pointer;
+    }
+    a {
+      .step-edit {
+        color: $gray;
+      }
+    }
+  }
   #footer {
     @include box-shadow;
     margin-top: em(90px);

--- a/themes/classic/_dev/js/checkout.js
+++ b/themes/classic/_dev/js/checkout.js
@@ -25,6 +25,15 @@ function setupMyCheckoutScripts() {
 
     $('#modal').modal('show');
   });
+
+  $('#order-summary-content span.step-to-addresses').on('click', (event) => {
+	  $('#checkout-addresses-step h1.step-title').trigger('click');
+  });
+
+  $('#order-summary-content span.step-to-delivery').on('click', (event) => {
+	  $('#checkout-delivery-step h1.step-title').trigger('click');
+  });
+  
 }
 
 $(document).ready(() => {

--- a/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
@@ -1,5 +1,7 @@
+{block name='order-items-table-head'}
 <div id="order-items" class="col-md-8">
   <h3 class="card-title h3">{l s='Order items' d='Shop.Theme.Checkout'}</h3>
+{/block}
   <table class="table">
     {foreach from=$products item=product}
       <tr>

--- a/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
@@ -1,0 +1,13 @@
+{extends file='checkout/_partials/order-confirmation-table.tpl'}
+
+{block name='order-items-table-head'}
+<div id="order-items" class="col-md-12">
+  <h3 class="card-title h3">
+    {if $products_count == 1}
+       {l s='%s item in your cart' sprintf=$products_count d='Shop.Theme.Checkout'}
+    {else}
+       {l s='%s items in your cart' sprintf=$products_count d='Shop.Theme.Checkout'}
+    {/if}
+  	<a href="{url entity=cart params=['action' => 'show']}"><span class="step-edit"><i class="material-icons edit">mode_edit</i> edit</span></a>
+  </h3>
+{/block}

--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -1,0 +1,78 @@
+<section id="order-summary-content" class="page-content page-order-confirmation">
+  <div class="row">
+    <div class="col-md-12">
+      <h4 class="h4 black">{l s='Please check your order before payment' d='Shop.Theme.Checkout'}</h4>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12">
+      <h4 class="h4">
+      {l s='Addresses' d='Shop.Theme.Checkout'}
+        <span class="step-edit step-to-addresses"><i class="material-icons edit">mode_edit</i> edit</span>
+      </h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="card noshadow">
+        <div class="card-block">
+          <h4 class="h4 black addresshead">{l s='My Delivery Address' d='Shop.Theme.Checkout'}</h4>
+          {$customer.addresses[$cart.id_address_delivery]['formatted'] nofilter}
+        </div>      
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="card noshadow">
+        <div class="card-block">
+          <h4 class="h4 black addresshead">{l s='My Invoice Address' d='Shop.Theme.Checkout'}</h4>
+          {$customer.addresses[$cart.id_address_invoice]['formatted'] nofilter}
+        </div>
+      </div>
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-md-12">
+      <h4 class="h4">
+      {l s='Shipping Method' d='Shop.Theme.Checkout'}
+        <span class="step-edit step-to-delivery"><i class="material-icons edit">mode_edit</i> edit</span>
+      </h4>
+
+      <div class="col-md-12">
+        <div class="row">
+          <div class="col-md-2">
+            <div class="logo-container">
+              {if $selected_delivery_option.logo}
+                <img src="{$selected_delivery_option.logo}" alt="{$selected_delivery_option.name}">
+              {else}
+                &nbsp;
+              {/if}                              
+            </div>
+          </div>
+          <div class="col-md-4">
+            <span class="carrier-name">{$selected_delivery_option.name}</span>
+          </div>
+          <div class="col-md-4">
+            <span class="carrier-delay">{$selected_delivery_option.delay}</span>
+          </div>
+          <div class="col-md-2">
+            <span class="carrier-price">{$selected_delivery_option.price}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+  <div class="row">    
+    {block name='order_confirmation_table'}
+      {include file='checkout/_partials/order-final-summary-table.tpl'
+         products=$cart.products
+         products_count=$cart.products_count
+         subtotals=$cart.subtotals
+         totals=$cart.totals
+         labels=$cart.labels
+       }
+    {/block}
+  </div>
+</section>

--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -61,6 +61,10 @@
       <p class="alert alert-danger">{l s='Unfortunately, there are no payment method available.' d='Shop.Theme.Checkout'}</p>
     {/foreach}
   </div>
+  
+  {if $show_final_summary}
+    {include file='checkout/_partials/order-final-summary.tpl'}	
+  {/if}
 
   {if $conditions_to_approve|count}
     <p class="ps-hidden-by-js">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Optional final checkout summary to be displayed before the final payment is triggered. |
| Type? | new feature |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-105 |
| How to test? | Activate the new option in backoffice and go through the checkout process. In step 4, payment, the summary will be shown. |
