### PR TITLE
Update Tools.php (function setCurrency)

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -610,7 +610,7 @@ class ToolsCore
             $currency = Currency::getCurrencyInstance((int)$cookie->id_currency);
         }
         if (!Validate::isLoadedObject($currency) || (bool)$currency->deleted || !(bool)$currency->active) {
-            $currency = Currency::getCurrencyInstance(Configuration::get('PS_CURRENCY_DEFAULT'));
+           $currency = (int)Configuration::get('PS_DISPLAY_DEFAULT_CURRENCY') && Currency::getCurrency( (int) Configuration::get('PS_DISPLAY_DEFAULT_CURRENCY')) ? Currency::getCurrencyInstance(Configuration::get('PS_DISPLAY_DEFAULT_CURRENCY')) : Currency::getCurrencyInstance(Configuration::get('PS_CURRENCY_DEFAULT'));
         }
 
         $cookie->id_currency = (int)$currency->id;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | New code allows to change the default currency display when person is firstly visiting shop. The old code assigned the Default Displayed Currency for the first visiting equal to those Currency, which is the one prices of products are indicated (also in DB). The new code allow to change Currency shown during the first visit. This would be usefull if the prices are in dollars, for intance, and the shop is made for audience with the other local currency: it is more convenient to show price in local currency at once. New Config value 'PS_DISPLAY_DEFAULT_CURRENCY'  will allow to make module controlling the Default Displayed Currency without overriding Tools.php |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | set PS_DISPLAY_DEFAULT_CURRENCY (int value of currency id) -> Delete cookies -> Visit shop like a new visitor |
