### PR TITLE
Add Not Null check on module upload

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -11,7 +11,7 @@ use PrestaShopBundle\Entity\ModuleHistory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Validator\Constraints\File;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ModuleController extends FrameworkBundleAdminController
 {
@@ -336,18 +336,19 @@ class ModuleController extends FrameworkBundleAdminController
         $moduleManager = $this->get('prestashop.module.manager');
         try {
             $file_uploaded = $request->files->get('file_uploaded');
-            $violations = $this->get('validator')->validate($file_uploaded, new File(
-                [
+            $constraints = array(
+                new Assert\NotNull(),
+                new Assert\File(array(
                     'maxSize' => ini_get('upload_max_filesize'),
-                    'mimeTypes' => [
+                    'mimeTypes' => array(
                         'application/zip',
                         'application/x-gzip',
                         'application/gzip',
                         'application/x-gtar',
-                        'application/x-tgz'
-                    ],
-                ]
-            ));
+                        'application/x-tgz',
+            ))));
+
+            $violations = $this->get('validator')->validateValue($file_uploaded, $constraints);
             if (0 !== count($violations)) {
                 $violationsMessages = '';
                 foreach ($violations as $violation) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When the uploaded module has a too big size, the server does not receive anything but tries to use it anyway. Not we check the value is not null. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | Send a fat zip file. You should have an error `File is too big (81.48MiB). Max filesize: 50MiB.` or `No file has been received. The server may have refused it because of its size.` |
