### PR TITLE
put legacy context on cache during a request

### DIFF
--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -45,12 +45,16 @@ class LegacyContext
      */
     public function getContext()
     {
-        $legacyContext = OldContext::getContext();
+        static $legacyContext = null;
+        
+        if(null === $legacyContext) {
+            $legacyContext = OldContext::getContext();
 
-        if ($legacyContext && !empty($legacyContext->shop) && !isset($legacyContext->controller) && isset($legacyContext->employee)) {
-            //init real legacy shop context
-            $adminController = new \AdminControllerCore();
-            $adminController->initShopContext();
+            if ($legacyContext && !empty($legacyContext->shop) && !isset($legacyContext->controller) && isset($legacyContext->employee)) {
+                //init real legacy shop context
+                $adminController = new \AdminControllerCore();
+                $adminController->initShopContext();
+            }
         }
 
         return $legacyContext;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Build context is a very extensive task, we shouldnt construct it multiple times during 1 single request |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Launch a Blackfire analysis and monitor the call to `getContext()` before/after. On product page, the function was called 7 times, now it's only one. |

Related Blackfire graph => https://blackfire.io/profiles/compare/042b18e8-304d-415b-b05d-a71a7f0db04f/graph
