### PR TITLE
Optimised attribute get all call

### DIFF
--- a/src/Adapter/Security/Admin.php
+++ b/src/Adapter/Security/Admin.php
@@ -65,6 +65,10 @@ class Admin
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
+        if (!$event->isMasterRequest() ||  $event->getRequest()->isXmlHttpRequest()) {
+            return;
+        }
+        
         //if employee loggdin in legacy context, authenticate him into sf2 security context
         if (isset($this->legacyContext->employee) && $this->legacyContext->employee->isLoggedBack()) {
             $employee = new Employee($this->legacyContext->employee);
@@ -76,16 +80,5 @@ class Admin
 
         //employee not logged in
         $event->stopPropagation();
-
-        //if http request - add 403 error
-        $request = Request::createFromGlobals();
-        if ($request->isXmlHttpRequest()) {
-            header("HTTP/1.1 403 Forbidden");
-            exit();
-        }
-
-        //redirect to admin home page
-        header("Location: ".$this->context->getAdminLink('', false));
-        exit();
     }
 }

--- a/src/Adapter/Security/SslMiddleware.php
+++ b/src/Adapter/Security/SslMiddleware.php
@@ -45,6 +45,10 @@ class SslMiddleware
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
+        if (!$event->isMasterRequest() ||  $event->getRequest()->isXmlHttpRequest()) {
+            return;
+        }
+        
         // already SSL, do nothing more
         if (\ToolsCore::usingSecureMode()) {
             return;

--- a/src/PrestaShopBundle/Controller/Admin/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AttributeController.php
@@ -41,10 +41,10 @@ class AttributeController extends FrameworkBundleAdminController
      */
     public function getAllAttributesAction()
     {
-        $response = new JsonResponse();
-        $locales = $this->container->get('prestashop.adapter.legacy.context')->getLanguages();
-        $translator = $this->container->get('translator');
-        $attributes = $this->container->get('prestashop.adapter.data_provider.attribute')->getAttributes($locales[0]['id_lang'], true);
+        $locales = $this->get('prestashop.adapter.legacy.context')->getLanguages();
+        $translator = $this->get('translator');
+        $attributes = $this->get('prestashop.adapter.data_provider.attribute')->getAttributes($locales[0]['id_lang'], true);
+        $transAll = $translator->trans('All', [], 'AdminTabs');
 
         $dataGroupAttributes = [];
         $data = [];
@@ -52,7 +52,7 @@ class AttributeController extends FrameworkBundleAdminController
             /** Construct attribute group selector. Ex : Color : All */
             $dataGroupAttributes[$attribute['id_attribute_group']] = [
                 'value' => 'group-'.$attribute['id_attribute_group'],
-                'label' => $attribute['public_name'].' : '.$translator->trans('All', [], 'AdminTabs'),
+                'label' => $attribute['public_name'].' : '.$transAll,
                 'data' => [
                     'id_group' => $attribute['id_attribute_group'],
                     'name' => $attribute['public_name'],
@@ -71,8 +71,7 @@ class AttributeController extends FrameworkBundleAdminController
 
         $data = array_merge($dataGroupAttributes, $data);
 
-        $response->setData($data);
-        return $response;
+        return new JsonResponse($data);
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Make this call more fast by removing all useless calls |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Access Product page and take a look to xhr requests: one of them is `<your-website>/attribute/get-all`, after optimisations this call is faster. |

**Before:**
![before](https://cloud.githubusercontent.com/assets/1247388/16166454/b0471220-34eb-11e6-807f-3d16d0f466b6.PNG)

**After:**
![final_opti](https://cloud.githubusercontent.com/assets/1247388/16166464/bf56ff64-34eb-11e6-8f50-9d05ae1a2191.PNG)

Blackfire analysis required please :)
