### PR TITLE
Tax entry should be displayed before totals

### DIFF
--- a/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
@@ -64,14 +64,17 @@
         </tr>
       {/if}
     {/foreach}
+    
+    {if $subtotals.tax.label !== null}
+      <tr class="sub">
+        <td>{$subtotals.tax.label}</td>
+        <td>{$subtotal.tax.value}</td>
+      </tr>
+    {/if}
 
     <tr class="font-weight-bold">
       <td><span class="text-uppercase">{$totals.total.label}</span> {$labels.tax_short}</td>
       <td>{$totals.total.value}</td>
-    </tr>
-    <tr class="sub">
-      <td>{$subtotals.tax.label}</td>
-      <td>{$subtotal.tax.value}</td>
     </tr>
   </table>
 </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | It's only an integration issue, the tax row should be displayed before totals in order confirmation page |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Don't fix, only completes http://forge.prestashop.com/browse/BOOM-723 |
| How to test? | In front office, complete the checkout and the paiement of an item, and look at order confirmation page: the tax row should be displayed in the right place. |
