### PR TITLE
Use already defined tax variable instead of recalculate it

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -384,11 +384,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
 
         $product_price = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, false);
-        $address = new Address($this->context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
         $this->quantity_discounts = $this->formatQuantityDiscounts($quantity_discounts, $product_price, (float) $tax, $this->product->ecotax);
 
         $this->context->smarty->assign(array(
-            'no_tax' => Tax::excludeTaxeOption() || !$this->product->getTaxesRate($address),
+            'no_tax' => Tax::excludeTaxeOption() || !$tax,
             'tax_enabled' => Configuration::get('PS_TAX') && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'),
             'customer_group_without_tax' => Group::getPriceDisplayMethod($this->context->customer->id_default_group),
         ));


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | There is already the variable $tax calculated (line 359), so we can use it to be assigned as smarty variable. It saves a new Address object creation. Rework of https://github.com/PrestaShop/PrestaShop/pull/4499/ |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
