### PR TITLE
FO : Fixed Geolocation behavior for NON existing countries

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -762,7 +762,7 @@ class FrontControllerCore extends Controller
                     $gi = geoip_open(realpath(_PS_GEOIP_DIR_._PS_GEOIP_CITY_FILE_), GEOIP_STANDARD);
                     $record = geoip_record_by_addr($gi, Tools::getRemoteAddr());
 
-                    if (is_object($record)) {
+                    if (is_object($record) && (int)Country::getByIso(strtoupper($record->country_code)) != 0) {
                         if (!in_array(strtoupper($record->country_code), explode(';', Configuration::get('PS_ALLOWED_COUNTRIES'))) && !FrontController::isInWhitelistForGeolocation()) {
                             if (Configuration::get('PS_GEOLOCATION_BEHAVIOR') == _PS_GEOLOCATION_NO_CATALOG_) {
                                 $this->restrictedCountry = true;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | I discovered that if the geolocation is enabled and the visitor is detected as visiting from a country that does NOT exist in the prestashop countries list but is having and ISO code provided by geoloc, then the option "Geolocation behavior for other countries" is not used and customers can not place order (then don't see prices and don't have the "add to cart" button). For example (on 06-23-2016), ALL french Renault car maker employees accessing prestashop shops from their office can not place orders because they are detected as coming from country "EUROPE" with iso code "EU" and of course this is not a country... So they don't see prices or "add to cart" button even with those options selected : "Geolocation behavior for restricted countries : Visitors can see your catalog but cannot place an order."  &&  "Geolocation behavior for other countries : All features are available". My modification seems to work. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | see description and try with removing your country from the country list for example |

I discovered that if the geolocation is enabled and the visitor is detected as visiting from a country that does NOT exist in the prestashop countries list but is having and ISO code provided by geoloc, then the option "Geolocation behavior for other countries" is not used and customers can not place order (then don't see prices and don't have the "add to cart" button).

For example (on 06-23-2016), ALL french Renault car maker employees accessing prestashop shops from their office can not place orders because they are detected as coming from country "EUROPE" with iso code "EU" and of course this is not a country...
So they don't see prices or "add to cart" button even with those options selected : 
Geolocation behavior for restricted countries : "Visitors can see your catalog but cannot place an order."
Geolocation behavior for other countries : "All features are available"

My modification seems to work.
