### PR TITLE
Increases social share button blick pad

### DIFF
--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -464,6 +464,9 @@ li.product-flag {
     margin-left: $font-size-base;
     @include transition(all .2s ease-in);
     a {
+      display:block;
+      width:100%;
+      height:100%;
       white-space: nowrap;
       text-indent: 100%;
       overflow: hidden;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The click pad is only 20% of the button size making it not clickable |
| Type? | Improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | See images below |

Before change

http://pix.toile-libre.org/upload/original/1466723137.png

After Change

http://pix.toile-libre.org/upload/original/1466723294.png
