### PR TITLE
Fixed missing `legend`  property in ImageRetriever

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -23,6 +23,7 @@ class ImageRetriever
             false,
             $language->id
         );
+
         $images = $productInstance->getImages($language->id);
 
         if (empty($images)) {
@@ -42,10 +43,10 @@ class ImageRetriever
         }
 
         $images = array_map(function (array $image) use ($productInstance, $imageToCombinations) {
-            $image =  array_merge($image, $this->getImage(
+            $image =  array_merge($this->getImage(
                 $productInstance,
                 $image['id_image']
-            ));
+            ), $image);
 
             if (isset($imageToCombinations[$image['id_image']])) {
                 $image['associatedVariants'] = $imageToCombinations[$image['id_image']];
@@ -100,13 +101,13 @@ class ImageRetriever
         $large  = end($urls);
         $medium = $urls[$keys[ceil((count($keys) - 1) / 2)]];
 
-        return [
+        return array(
             'bySize' => $urls,
             'small'  => $small,
             'medium' => $medium,
             'large'  => $large,
-            'legend' => $object->meta_title
-        ];
+            'legend' => $object->meta_title,
+        );
     }
 
     public function getCustomizationImage($imageHash)


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Even if we add a legend to an image in back office, the legend didnt appears in Front office. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-848 |
| How to test? | Add a legend to an image in back office, you should now see the legend as an title in FO (as best described in my screenshot) |

![capture](https://cloud.githubusercontent.com/assets/1247388/16337107/25bfad38-3a13-11e6-85d7-9f28ff449215.png)
