### PR TITLE
Select the cover image and not the first one if set in back office

### DIFF
--- a/src/Core/Product/AbstractProductPresenter.php
+++ b/src/Core/Product/AbstractProductPresenter.php
@@ -55,11 +55,10 @@ abstract class AbstractProductPresenter
 
         if (isset($product['id_product_attribute'])) {
             foreach ($presentedProduct['images'] as $image) {
-                foreach ($image['associatedVariants'] as $id) {
-                    if ((int) $id === (int) $product['id_product_attribute']) {
-                        $presentedProduct['cover'] = $image;
-                        break 2;
-                    }
+                if (isset($image['cover']) && null !== $image['cover']) {
+                    $presentedProduct['cover'] = $image;
+
+                    break;
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The cover was always the first picture in product image, it's now the selected cover. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-846 |
| How to test? | The cover was always the first picture in product image, it's now the selected cover. |
