### PR TITLE
You can exclude already discounted products from voucher

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
@@ -115,6 +115,23 @@
 	</div>
 </div>
 
+<div id="apply_discount_to_product_special" class="form-group">
+ 	<label class="control-label col-lg-3">{l s='Exclude products on special'}</label>
+ 	<div class="col-lg-9">
+ 		<span class="switch prestashop-switch fixed-width-lg">
+ 			<input type="radio" name="reduction_exclude_special" id="reduction_exclude_special_on" value="1"{if $currentTab->getFieldValue($currentObject, 'reduction_exclude_special')|intval} checked="checked"{/if}/>
+ 			<label class="t" for="reduction_exclude_special_on">
+ 				{l s='Yes'}
+ 			</label>
+ 			<input type="radio" name="reduction_exclude_special" id="reduction_exclude_special_off" value="0"{if !$currentTab->getFieldValue($currentObject, 'reduction_exclude_special')|intval} checked="checked"{/if}/>
+ 			<label class="t" for="reduction_exclude_special_off">
+ 				{l s='No'}
+ 			</label>
+ 			<a class="slide-button btn"></a>
+ 		</span>
+ 	</div>
+ </div>
+
 <div class="form-group">
 	<label class="control-label col-lg-3">{l s='Send a free gift'}</label>
 	<div class="col-lg-9">

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -144,6 +144,7 @@ function toggleApplyDiscount(percent, amount, apply_to)
 		$('*[for=apply_discount_to_cheapest]').show();
 		$('#apply_discount_to_selection').show();
 		$('*[for=apply_discount_to_selection]').show();
+		$('#apply_discount_to_product_special').show(400);
 	}
 	else
 	{
@@ -162,6 +163,7 @@ function toggleApplyDiscount(percent, amount, apply_to)
 		$('#apply_discount_to_selection').hide();
 		$('*[for=apply_discount_to_selection]').hide();
 		$('#apply_discount_to_selection').prop('checked', false);
+		$('#apply_discount_to_product_special').hide(200);
 	}
 	else
 	{

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -186,6 +186,7 @@ CREATE TABLE `PREFIX_cart_rule` (
 	`reduction_tax` tinyint(1) unsigned NOT NULL DEFAULT '0',
 	`reduction_currency` int(10) unsigned NOT NULL DEFAULT '0',
 	`reduction_product` int(10) NOT NULL DEFAULT '0',
+  `reduction_exclude_special` tinyint(1) unsigned NOT NULL DEFAULT '0',
 	`gift_product` int(10) unsigned NOT NULL DEFAULT '0',
 	`gift_product_attribute` int(10) unsigned NOT NULL DEFAULT '0',
 	`highlight` tinyint(1) unsigned NOT NULL DEFAULT '0',

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -142,3 +142,5 @@ DROP TABLE `PREFIX_access_old`;
 DROP TABLE `PREFIX_module_access_old`;
 
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_CUSTOMER_NWSL';
+
+ALTER TABLE  `PREFIX_cart_rule` ADD  `reduction_exclude_special` TINYINT(1) UNSIGNED NOT NULL DEFAULT  '0' AFTER  `reduction_percent`;

--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -368,15 +368,18 @@ class CartPresenter implements PresenterInterface
             $vouchers[$cartVoucher['id_cart_rule']]['reduction_currency'] = $cartVoucher['reduction_currency'];
             $vouchers[$cartVoucher['id_cart_rule']]['reduction_amount'] = $cartVoucher['reduction_amount'];
 
-            if (isset($cartVoucher['reduction_percent']) && $cartVoucher['reduction_percent'] == '0.00') {
-                $cartVoucher['reduction_formated'] = $cartVoucher['reduction_percent'].'%';
-            } elseif (isset($cartVoucher['reduction_amount'])) {
-                $cartVoucher['reduction_formated'] = $this->priceFormatter->format($cartVoucher['reduction_amount']);
+            if (isset($cartVoucher['reduction_percent']) && $cartVoucher['reduction_amount'] == '0.00') {
+                $cartVoucher['reduction_formatted'] = $cartVoucher['reduction_percent'].'%';
+            } elseif (isset($cartVoucher['reduction_amount']) && $cartVoucher['reduction_amount'] > 0) {
+                $cartVoucher['reduction_formatted'] = $this->priceFormatter->format($cartVoucher['reduction_amount']);
             }
 
             $vouchers[$cartVoucher['id_cart_rule']]['reduction_formatted'] = '-'.$cartVoucher['reduction_formatted'];
             $vouchers[$cartVoucher['id_cart_rule']]['delete_url'] = $this->link->getPageLink(
-                'cart', true, null, array(
+                'cart',
+                true,
+                null,
+                array(
                     'deleteDiscount' => $cartVoucher['id_cart_rule'],
                     'token' => Tools::getToken(false),
                 )

--- a/themes/classic/templates/checkout/_partials/cart-voucher.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-voucher.tpl
@@ -8,7 +8,7 @@
               <span class="label">{$voucher.name}</span>
               <a href="{$voucher.delete_url}" data-link-action="remove-voucher"><i class="material-icons">{l s='delete' d='Shop.Theme.Actions'}</i></a>
               <div class="pull-xs-right">
-                {$voucher.reduction_formated}
+                {$voucher.reduction_formatted}
               </div>
             </li>
           {/foreach}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This is rework of #2060 |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | many feature requests i guess ;) |
| How to test? | Add new voucher with selected option "Exclude specials" to "Yes", try to use voucher while having already discounted products in cart, if you have more than one product and one product is not discounted voucher will work only for this product |
| Sponsor company | impSolutions

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

Vouchers didn't work at all before this fix for undefined notice, i think it will be good to add tests to StarterTheme spec for this mechanism!
