### PR TITLE
FO : Prevent customer to view all codes

### DIFF
--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -39,7 +39,7 @@ class DiscountControllerCore extends FrontController
     {
         parent::initContent();
 
-        $cart_rules = CartRule::getCustomerCartRules($this->context->language->id, $this->context->customer->id, true, true, true);
+        $cart_rules = CartRule::getCustomerCartRules($this->context->language->id, $this->context->customer->id, true, true, true, null, false, true);
         $nb_cart_rules = count($cart_rules);
 
         foreach ($cart_rules as $key => &$discount ) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | PrestaShop 1.6 (bugfixes only). |
| Description? | Prestashop 1.6.1.6, when customer logs in and go to "my vouchers", all voucher codes are listed, even if set to highlight=0. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | Does it break backward compatibility? no |
| Deprecations? | Does it deprecate an existing feature? no |
| Fixed ticket? |  |
| How to test? | Create a few voucher codes, set highlight = 0, they should not be listed on the my voucher page. |

The discount page list all public codes even if set to don't list.
