### PR TITLE
BO: Load proper service to get the translator

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -60,7 +60,7 @@ class FrameworkBundleAdminController extends Controller
             return $errors;
         }
 
-        $translator = $this->container->get('prestashop.twig.extension.translation');
+        $translator = $this->container->get('translator');
 
         foreach ($form->getErrors(true) as $error) {
             if (!$error->getCause()) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When an error has to be displayed on the product page, we can an error 500 because of a wrong call to the translator service. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| How to test? | Create a product but do not fill its name. You will see that you cannot save anymore, because of an error 500 on the previous form save. The error message won't be displayed under the title field too. Get the PR and these different issues should be fixed. |
