### PR TITLE
Increase max. length of catalog price rule name (#BOOM-924)

### DIFF
--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -182,7 +182,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                     'type' => 'text',
                     'label' => $this->l('Name'),
                     'name' => 'name',
-                    'maxlength' => 64,
+                    'maxlength' => 255,
                     'required' => true,
                     'hint' => $this->l('Forbidden characters').' <>;=#{}'
                 ),

--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -182,7 +182,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                     'type' => 'text',
                     'label' => $this->l('Name'),
                     'name' => 'name',
-                    'maxlength' => 32,
+                    'maxlength' => 64,
                     'required' => true,
                     'hint' => $this->l('Forbidden characters').' <>;=#{}'
                 ),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Maximum length of catalog price rule name was set to 32, which is not enough. It is now 255. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-924 |
| How to test? | Try to set a name with a length greater than 32 |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
