### PR TITLE
CO: Keep regenerating images after PHP-FPM conn. lost

### DIFF
--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -614,6 +614,7 @@ class AdminImagesControllerCore extends AdminController
         $this->start_time = time();
         ini_set('max_execution_time', $this->max_execution_time); // ini_set may be disabled, we need the real value
         $this->max_execution_time = (int)ini_get('max_execution_time');
+        ignore_user_abort(true); // Keep going, even after the PHP-FPM connection is lost
         $languages = Language::getLanguages(false);
 
         $process = array(


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | After the `PHP-FPM` connection is lost (e.g. user navigates away), the process quits before PrestaShop is done processing the images. Enabling `ignore_user_abort` would allow the process to finish. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Run PrestaShop with `PHP-FPM`. Navigate away and see if the process finishes. |
