### PR TITLE
Migrated "prefered modules" action to Symfony

### DIFF
--- a/admin-dev/.htaccess
+++ b/admin-dev/.htaccess
@@ -54,8 +54,8 @@ DirectoryIndex index.php
     # - disable this feature by commenting the following 2 lines or
     # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
     #   following RewriteCond (best solution)
-    RewriteCond %{ENV:REDIRECT_STATUS} ^$
-    RewriteRule ^index\.php(/(.*)) %{ENV:BASE}/$2 [R=301,L]
+    # RewriteCond %{ENV:REDIRECT_STATUS} ^$
+    # RewriteRule ^index\.php(/(.*)) %{ENV:BASE}/$2 [R=301,L]
 
     # If the requested filename exists, simply serve it.
     # We only want to let Apache serve files and not directories.

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -75,7 +75,7 @@
 		var employee_token = '{getAdminToken tab='AdminEmployees'}';
 		var choose_language_translate = '{l s='Choose language' js=1}';
 		var default_language = '{$default_language|intval}';
-		var admin_modules_link = '{$link->getAdminLink("AdminModules")|addslashes}';
+		var admin_modules_link = '{$link->getAdminLink("AdminModulesSf")|addslashes}';
 		var tab_modules_list = '{if isset($tab_modules_list) && $tab_modules_list}{$tab_modules_list|addslashes}{/if}';
 		var update_success_msg = '{l s='Update successful' js=1}';
 		var errorLogin = '{l s='PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.' js=1}';

--- a/admin-dev/themes/new-theme/template/header.tpl
+++ b/admin-dev/themes/new-theme/template/header.tpl
@@ -44,7 +44,7 @@
     var employee_token = '{getAdminToken tab='AdminEmployees'}';
     var choose_language_translate = '{l s='Choose language' js=1}';
     var default_language = '{$default_language|intval}';
-    var admin_modules_link = '{$link->getAdminLink("AdminModules")|addslashes}';
+    var admin_modules_link = '{$link->getAdminLink("AdminModulesSf")|addslashes}';
     var tab_modules_list = '{if isset($tab_modules_list) && $tab_modules_list}{$tab_modules_list|addslashes}{/if}';
     var update_success_msg = '{l s='Update successful' js=1}';
     var errorLogin = '{l s='PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.' js=1}';

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -25,7 +25,7 @@
  */
 
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class LinkCore
 {
@@ -535,7 +535,7 @@ class LinkCore
                 break;
             case 'AdminModulesSf':
                 // New architecture modification: temporary behavior to switch between old and new controllers.
-                return $sfRouter->generate('admin_module_catalog', array(), true);
+                return $sfRouter->generate('admin_module_catalog', array(), UrlGeneratorInterface::ABSOLUTE_URL);
         }
 
         $id_lang = Context::getContext()->language->id;

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -535,7 +535,7 @@ class LinkCore
                 break;
             case 'AdminModulesSf':
                 // New architecture modification: temporary behavior to switch between old and new controllers.
-                return $sfRouter->generate('admin_module_catalog', array());
+                return $sfRouter->generate('admin_module_catalog', array(), true);
         }
 
         $id_lang = Context::getContext()->language->id;

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -41,6 +41,10 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class ModuleRepository implements ModuleRepositoryInterface
 {
+    const NATIVE_AUTHOR = "PrestaShop";
+
+    const PARTNER_AUTHOR = "PrestaShop Partners";
+
     /**
      * Admin Module Data Provider
      * @var \PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider
@@ -214,6 +218,82 @@ class ModuleRepository implements ModuleRepositoryInterface
             $this->getAddonsCatalogModules(),
             $this->getModulesOnDisk()
         );
+    }
+
+    /**
+     * @return AddonInterface[] retrieve the list of native modules
+     */
+    public function getNativeModules()
+    {
+        static $nativeModules = null;
+
+        if (null === $nativeModules) {
+            $filter = new AddonListFilter();
+            $filter->setOrigin(AddonListFilterOrigin::ADDONS_NATIVE);
+
+            $nativeModules = $this->getFilteredList($filter);
+
+            foreach ($nativeModules as $key => $module) {
+                $moduleAuthor = $module->attributes->get('author');
+                if (self::NATIVE_AUTHOR !== $moduleAuthor) {
+                    unset($nativeModules[$key]);
+                }
+            }
+        }
+
+        return $nativeModules;
+    }
+
+    /**
+     * @return AddonInterface[] retrieve the list of partners modules
+     */
+    public function getPartnersModules()
+    {
+            $filter = new AddonListFilter();
+            $filter->setOrigin(AddonListFilterOrigin::ADDONS_NATIVE);
+
+            $partnersModules = $this->getFilteredList($filter);
+
+            foreach ($partnersModules as $key => $module) {
+                $moduleAuthor = $module->attributes->get('author');
+                if (self::PARTNER_AUTHOR !== $moduleAuthor) {
+                    unset($partnersModules[$key]);
+                }
+            }
+
+        return $partnersModules;
+    }
+
+    /**
+     * @return AddonInterface[] get the list of installed partners modules
+     */
+    public function getInstalledPartnersModules()
+    {
+        $partnersModules = $this->getPartnersModules();
+
+        foreach ($partnersModules as $key => $module) {
+            if (1 !== $module->database->get('installed')) {
+                unset($partnersModules[$key]);
+            }
+        }
+
+        return $partnersModules;
+    }
+
+    /**
+     * @return AddonInterface[] get the list of not installed partners modules
+     */
+    public function getNotInstalledPartnersModules()
+    {
+        $partnersModules = $this->getPartnersModules();
+
+        foreach ($partnersModules as $key => $module) {
+            if (0 !== $module->database->get('installed')) {
+                unset($partnersModules[$key]);
+            }
+        }
+
+        return $partnersModules;
     }
 
     private function getAddonsCatalogModules()

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -133,4 +133,15 @@ class FrameworkBundleAdminController extends Controller
             'title' => $translator->trans($title, [], 'AdminCommon')
         ]);
     }
+
+    /**
+     * Get the old but still useful context
+     *
+     */
+    protected function getContext()
+    {
+        $legacyContextProvider = $this->get('prestashop.adapter.legacy.context');
+
+        return $legacyContextProvider->getContext();
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -6,7 +6,7 @@ use Exception;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilter;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterStatus;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterType;
-use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
 use PrestaShopBundle\Entity\ModuleHistory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,7 +16,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ModuleController extends FrameworkBundleAdminController
 {
     /**
-     * Controller responsible for displaying "Catalog" section of Module management pages
+     * Controller responsible for displaying "Catalog" section of Module management pages.
+     *
      * @return Response
      */
     public function catalogAction()
@@ -36,8 +37,10 @@ class ModuleController extends FrameworkBundleAdminController
     }
 
     /**
-     * Controller responsible for displaying "Catalog Module Grid" section of Module management pages with ajax
-     * @param  Request $request
+     * Controller responsible for displaying "Catalog Module Grid" section of Module management pages with ajax.
+     *
+     * @param Request $request
+     *
      * @return Response
      */
     public function refreshCatalogAction(Request $request)
@@ -50,11 +53,11 @@ class ModuleController extends FrameworkBundleAdminController
         $modulesProvider = $this->get('prestashop.core.admin.data_provider.module_interface');
         $translator = $this->get('translator');
         $moduleRepository = $this->get('prestashop.core.admin.module.repository');
-        $responseArray = [];
+        $responseArray = array();
 
         $filters = new AddonListFilter();
         $filters->setType(AddonListFilterType::MODULE | AddonListFilterType::SERVICE)
-            ->setStatus(~ AddonListFilterStatus::INSTALLED);
+            ->setStatus(~AddonListFilterStatus::INSTALLED);
 
         try {
             $products = $modulesProvider->generateAddonsUrls(
@@ -80,20 +83,20 @@ class ModuleController extends FrameworkBundleAdminController
     private function constructJsonCatalogBodyResponse($modulesProvider, $products)
     {
         $products = $modulesProvider->generateAddonsUrls($products);
-        $formattedContent = [];
+        $formattedContent = array();
         $formattedContent['selector'] = '.module-catalog-page';
         $formattedContent['content'] = $this->render(
             'PrestaShopBundle:Admin/Module/Includes:sorting.html.twig',
-            [
-                'totalModules' => count($products)
-            ]
+            array(
+                'totalModules' => count($products),
+            )
         )->getContent();
         $formattedContent['content'] .= $this->render(
             'PrestaShopBundle:Admin/Module/Includes:grid.html.twig',
-            [
+            array(
                 'modules' => $this->getPresentedProducts($products),
-                'requireAddonsSearch' => true
-            ]
+                'requireAddonsSearch' => true,
+            )
         )->getContent();
 
         return $formattedContent;
@@ -101,13 +104,13 @@ class ModuleController extends FrameworkBundleAdminController
 
     private function constructJsonCatalogCategoriesMenuResponse($modulesProvider, $products)
     {
-        $formattedContent = [];
+        $formattedContent = array();
         $formattedContent['selector'] = '.module-menu-item';
         $formattedContent['content'] = $this->render(
             'PrestaShopBundle:Admin/Module/Includes:dropdown_categories.html.twig',
-            [
-                'topMenuData' => $this->getTopMenuData($modulesProvider->getCategoriesFromModules($products))
-            ]
+            array(
+                'topMenuData' => $this->getTopMenuData($modulesProvider->getCategoriesFromModules($products)),
+            )
         )->getContent();
 
         return $formattedContent;
@@ -134,8 +137,8 @@ class ModuleController extends FrameworkBundleAdminController
         $installed_products = $moduleRepository->getFilteredList($filters);
 
         $products = new \stdClass();
-        foreach (['native_modules', 'theme_bundle', 'modules'] as $subpart) {
-            $products->{$subpart} = [];
+        foreach (array('native_modules', 'theme_bundle', 'modules') as $subpart) {
+            $products->{$subpart} = array();
         }
 
         foreach ($installed_products as $installed_product) {
@@ -144,9 +147,9 @@ class ModuleController extends FrameworkBundleAdminController
             } elseif ($installed_product->attributes->has('origin') && $installed_product->attributes->get('origin') === 'native' && $installed_product->attributes->get('author') === 'PrestaShop') {
                 $row = 'native_modules';
             } else {
-                $row= 'modules';
+                $row = 'modules';
             }
-            $products->{$row}[] = (object)$installed_product;
+            $products->{$row}[] = (object) $installed_product;
         }
 
         foreach ($products as $product_label => $products_part) {
@@ -182,7 +185,7 @@ class ModuleController extends FrameworkBundleAdminController
         if (method_exists($moduleManager, $action)) {
             // ToDo : Check if allowed to call this action
             try {
-                if ($action == "uninstall") {
+                if ($action == 'uninstall') {
                     $response[$module]['status'] = $moduleManager->{$action}($module, $forceDeletion);
                 } else {
                     $response[$module]['status'] = $moduleManager->{$action}($module);
@@ -194,7 +197,7 @@ class ModuleController extends FrameworkBundleAdminController
                         '%module% did not return a valid response on %action% action.',
                         array(
                             '%module%' => $module,
-                            '%action%' => $action),
+                            '%action%' => $action, ),
                         'Admin.Notifications.Error'
                         );
                 } elseif ($response[$module]['status'] === false) {
@@ -204,7 +207,7 @@ class ModuleController extends FrameworkBundleAdminController
                         array(
                             '%action%' => str_replace('_', ' ', $action),
                             '%module%' => $module,
-                            '%error_details%' => $error),
+                            '%error_details%' => $error, ),
                         'Admin.Notifications.Error'
                     );
                 } else {
@@ -212,7 +215,7 @@ class ModuleController extends FrameworkBundleAdminController
                         '%action% action on module %module% succeeded.',
                         array(
                             '%action%' => ucfirst(str_replace('_', ' ', $action)),
-                            '%module%' => $module),
+                            '%module%' => $module, ),
                         'Admin.Notifications.Success'
                     );
                 }
@@ -223,7 +226,7 @@ class ModuleController extends FrameworkBundleAdminController
                     array(
                             '%action%' => str_replace('_', ' ', $action),
                             '%module%' => $module,
-                            '%error_details%' => $e->getMessage()),
+                            '%error_details%' => $e->getMessage(), ),
                     'Admin.Notifications.Error'
                 );
 
@@ -279,7 +282,7 @@ class ModuleController extends FrameworkBundleAdminController
 
         $products = new \stdClass();
         foreach (array('to_configure', 'to_update') as $subpart) {
-            $products->{$subpart} = [];
+            $products->{$subpart} = array();
         }
 
         foreach ($installed_products as $installed_product) {
@@ -293,7 +296,7 @@ class ModuleController extends FrameworkBundleAdminController
             }
 
             if ($row) {
-                $products->{$row}[] = (object)$installed_product;
+                $products->{$row}[] = (object) $installed_product;
             }
         }
 
@@ -317,11 +320,7 @@ class ModuleController extends FrameworkBundleAdminController
     public function getPreferredModulesAction(Request $request)
     {
         $tabModulesList = $request->request->get('tab_modules_list');
-        $back = $request->request->get('back_tab_modules_list');
 
-        if ($back) {
-            $back .= '&tab_modules_open=1';
-        }
         if ($tabModulesList) {
             $tabModulesList = explode(',', $tabModulesList);
             $modulesListUnsorted = $this->getModulesByInstallation($tabModulesList, $request->request->get('admin_list_from_source'));
@@ -332,7 +331,7 @@ class ModuleController extends FrameworkBundleAdminController
         foreach ($tabModulesList as $key => $value) {
             $continue = 0;
             foreach ($modulesListUnsorted['installed'] as $moduleInstalled) {
-                if ($moduleInstalled->name == $value) {
+                if ($moduleInstalled['attributes']['name'] == $value) {
                     $continue = 1;
                     $installed[] = $moduleInstalled;
                 }
@@ -340,21 +339,21 @@ class ModuleController extends FrameworkBundleAdminController
             if ($continue) {
                 continue;
             }
-            foreach ($modulesListUnsorted['not_installed'] as $moduleNotinstalled) {
-                if ($moduleNotinstalled->name == $value) {
-                    $uninstalled[] = $moduleNotinstalled;
+            foreach ($modulesListUnsorted['not_installed'] as $moduleNotInstalled) {
+                if ($moduleNotInstalled['attributes']['name'] == $value) {
+                    $uninstalled[] = $moduleNotInstalled;
                 }
             }
         }
 
         $moduleListSorted = array(
             'installed' => $installed,
-            'notInstalled' => $uninstalled
+            'notInstalled' => $uninstalled,
         );
 
         $twigParams = array(
             'currentIndex' => '',
-            'modulesList' => $moduleListSorted
+            'modulesList' => $moduleListSorted,
         );
 
         if ($request->request->has('admin_list_from_source')) {
@@ -364,28 +363,25 @@ class ModuleController extends FrameworkBundleAdminController
         return $this->render('PrestaShopBundle:Admin/Module:tab-modules-list.html.twig', $twigParams);
     }
 
-    protected function getModulesByInstallation($tab_modules_list = null, $install_source_tracking = false)
+    private function getModulesByInstallation($modulesSelectList = null)
     {
-        $addonsProvider = $this->get('prestashop.core.admin.data_provider.addons_interface');
-        $listModulesPartners = [];
+        $addonsProvider = $this->get('prestashop.core.admin.data_provider.module_interface');
+        $moduleRepository = $this->get('prestashop.core.admin.module.repository');
+        $modulePresenter = $this->get('prestashop.adapter.presenter.module');
 
-        $all_modules = \Module::getModulesOnDisk(true, $addonsProvider->isAddonsAuthenticated(), $this->getContext()->employee->id);
-        $all_unik_modules = array();
-        $modules_list = array('installed' =>array(), 'not_installed' => array());
+        $modulesOnDisk = $moduleRepository->getList();
 
-        foreach ($all_modules as $mod) {
-            if (!isset($all_unik_modules[$mod->name])) {
-                $all_unik_modules[$mod->name] = $mod;
-            }
-        }
+        $modulesList = array(
+            'installed' => array(),
+            'not_installed' => array(),
+        );
 
-        $all_modules = $all_unik_modules;
-
-        foreach ($all_modules as $module) {
-            if (!isset($tab_modules_list) || in_array($module->name, $tab_modules_list)) {
+        $modulesOnDisk = $addonsProvider->generateAddonsUrls($modulesOnDisk);
+        foreach ($modulesOnDisk as $module) {
+            if (!isset($modulesSelectList) || in_array($module->get('name'), $modulesSelectList)) {
                 $perm = true;
-                if ($module->id) {
-                    $perm &= \Module::getPermissionStatic($module->id, 'configure');
+                if ($module->get('id')) {
+                    $perm &= \Module::getPermissionStatic($module->get('id'), 'configure');
                 } else {
                     $id_admin_module = \Tab::getIdFromClassName('AdminModules');
                     $access = \Profile::getProfileAccess($this->getContext()->employee->id_profile, $id_admin_module);
@@ -394,364 +390,29 @@ class ModuleController extends FrameworkBundleAdminController
                     }
                 }
 
-                if (in_array($module->name, $listModulesPartners)) {
-                    $module->type = 'addonsPartner';
+                if ($module->get('author') === ModuleRepository::PARTNER_AUTHOR) {
+                    $module->set('type', 'addonsPartner');
                 }
 
                 if ($perm) {
-                    $this->fillModuleData($module, 'array', null, $install_source_tracking);
-                    if ($module->id) {
-                        $modules_list['installed'][] = $module;
+                    $module->fillLogo();
+                    if ($module->database->get('installed') == 1) {
+                        $modulesList['installed'][] = $modulePresenter->present($module);
                     } else {
-                        $modules_list['not_installed'][] = $module;
+                        $modulesList['not_installed'][] = $modulePresenter->present($module);
                     }
                 }
             }
         }
 
-        return $modules_list;
+        return $modulesList;
     }
 
     /**
-     * @param Module $module
-     * @param string $output_type
-     * @param string|null $back
-     * @param string|bool $install_source_tracking
-     */
-    public function fillModuleData(&$module, $output_type = 'link', $back = null, $install_source_tracking = false)
-    {
-        $translator = $this->get('translator');
-        /** @var Module $obj */
-        $obj = null;
-        if ($module->onclick_option) {
-            $obj = new $module->name();
-        }
-        // Fill module data
-        $module->logo = '../../img/questionmark.png';
-
-        if (@filemtime(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.basename(_PS_MODULE_DIR_).DIRECTORY_SEPARATOR.$module->name
-            .DIRECTORY_SEPARATOR.'logo.gif')) {
-            $module->logo = 'logo.gif';
-        }
-        if (@filemtime(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.basename(_PS_MODULE_DIR_).DIRECTORY_SEPARATOR.$module->name
-            .DIRECTORY_SEPARATOR.'logo.png')) {
-            $module->logo = 'logo.png';
-        }
-
-        $link_admin_modules = $this->getContext()->link->getAdminLink('AdminModules', true);
-
-        $module->options['install_url'] = $link_admin_modules.'&install='.urlencode($module->name).'&tab_module='.$module->tab.'&module_name='.$module->name
-            .'&anchor='.ucfirst($module->name).($install_source_tracking ? '&source='.$install_source_tracking : '');
-        $module->options['update_url'] = $link_admin_modules.'&update='.urlencode($module->name).'&tab_module='.$module->tab.'&module_name='.$module->name.'&anchor='.ucfirst($module->name);
-        $module->options['uninstall_url'] = $link_admin_modules.'&uninstall='.urlencode($module->name).'&tab_module='.$module->tab.'&module_name='.$module->name.'&anchor='.ucfirst($module->name);
-
-        // free modules get their source tracking data here
-        $module->optionsHtml = $this->displayModuleOptions($module, $output_type, $back, $install_source_tracking);
-        // pay modules get their source tracking data here
-        if ($install_source_tracking && isset($module->addons_buy_url)) {
-            $module->addons_buy_url .= ($install_source_tracking ? '&utm_term='.$install_source_tracking : '');
-        }
-
-        $module->options['uninstall_onclick'] = ((!$module->onclick_option) ?
-            ((empty($module->confirmUninstall)) ? 'return confirm(\''.$translator->trans('Do you really want to uninstall this module?').'\');' : 'return confirm(\''.addslashes($module->confirmUninstall).'\');') :
-            $obj->onclickOption('uninstall', $module->options['uninstall_url']));
-
-        if ((\Tools::getValue('module_name') == $module->name || in_array($module->name, explode('|', \Tools::getValue('modules_list')))) && (int)\Tools::getValue('conf') > 0) {
-            $module->message = $this->_conf[(int)\Tools::getValue('conf')];
-        }
-
-        if ((\Tools::getValue('module_name') == $module->name || in_array($module->name, explode('|', \Tools::getValue('modules_list')))) && (int)\Tools::getValue('conf') > 0) {
-            unset($obj);
-        }
-
-        if (!empty($module->image) && false !== strpos($module->image, '../img')) {
-            $module->image_absolute = str_replace('../', _PS_BASE_URL_.__PS_BASE_URI__, $module->image);
-        }
-    }
-
-    /**
-     * Display modules list
+     * Controller responsible for importing new module from DropFile zone in BO.
      *
-     * @param Module $module
-     * @param string $output_type (link or select)
-     * @param string|null $back
-     * @param string|bool $install_source_tracking
-     * @return string|array
-     */
-    public function displayModuleOptions($module, $output_type = 'link', $back = null, $install_source_tracking = false)
-    {
-        $translator = $this->get('translator');
-        if (!isset($module->enable_device)) {
-            $module->enable_device = \Context::DEVICE_COMPUTER | \Context::DEVICE_TABLET | \Context::DEVICE_MOBILE;
-        }
-
-        $this->translationsTab['confirm_uninstall_popup'] = (isset($module->confirmUninstall) ? $module->confirmUninstall : $translator->trans('Do you really want to uninstall this module?'));
-        if (!isset($this->translationsTab['Disable this module'])) {
-            $this->translationsTab['Disable this module'] = $translator->trans('Disable this module');
-            $this->translationsTab['Enable this module for all shops'] = $translator->trans('Enable this module for all shops');
-            $this->translationsTab['Disable'] = $translator->trans('Disable');
-            $this->translationsTab['Enable'] = $translator->trans('Enable');
-            $this->translationsTab['Disable on mobiles'] = $translator->trans('Disable on mobiles');
-            $this->translationsTab['Disable on tablets'] = $translator->trans('Disable on tablets');
-            $this->translationsTab['Disable on computers'] = $translator->trans('Disable on computers');
-            $this->translationsTab['Display on mobiles'] = $translator->trans('Display on mobiles');
-            $this->translationsTab['Display on tablets'] = $translator->trans('Display on tablets');
-            $this->translationsTab['Display on computers'] = $translator->trans('Display on computers');
-            $this->translationsTab['Reset'] = $translator->trans('Reset');
-            $this->translationsTab['Configure'] = $translator->trans('Configure');
-            $this->translationsTab['Delete'] = $translator->trans('Delete');
-            $this->translationsTab['Install'] = $translator->trans('Install');
-            $this->translationsTab['Uninstall'] = $translator->trans('Uninstall');
-            $this->translationsTab['Would you like to delete the content related to this module ?'] = $translator->trans('Would you like to delete the content related to this module ?');
-            $this->translationsTab['This action will permanently remove the module from the server. Are you sure you want to do this?'] = $translator->trans('This action will permanently remove the module from the server. Are you sure you want to do this?');
-            $this->translationsTab['Remove from Favorites'] = $translator->trans('Remove from Favorites');
-            $this->translationsTab['Mark as Favorite'] = $translator->trans('Mark as Favorite');
-        }
-
-        $link_admin_modules = $this->getContext()->link->getAdminLink('AdminModules', true);
-        $modules_options = array();
-
-        $configure_module = array(
-            'href' => $link_admin_modules.'&configure='.urlencode($module->name).'&tab_module='.$module->tab.'&module_name='.urlencode($module->name),
-            'onclick' => $module->onclick_option && isset($module->onclick_option_content['configure']) ? $module->onclick_option_content['configure'] : '',
-            'title' => '',
-            'text' => $this->translationsTab['Configure'],
-            'cond' => $module->id && isset($module->is_configurable) && $module->is_configurable,
-            'icon' => 'wrench',
-        );
-
-        $desactive_module = array(
-            'href' => $link_admin_modules.'&module_name='.urlencode($module->name).'&'.($module->active ? 'enable=0' : 'enable=1').'&tab_module='.$module->tab,
-            'onclick' => $module->active && $module->onclick_option && isset($module->onclick_option_content['desactive']) ? $module->onclick_option_content['desactive'] : '' ,
-            'title' => \Shop::isFeatureActive() ? htmlspecialchars($module->active ? $this->translationsTab['Disable this module'] : $this->translationsTab['Enable this module for all shops']) : '',
-            'text' => $module->active ? $this->translationsTab['Disable'] : $this->translationsTab['Enable'],
-            'cond' => $module->id,
-            'icon' => 'off',
-        );
-        $link_reset_module = $link_admin_modules.'&module_name='.urlencode($module->name).'&reset&tab_module='.$module->tab;
-
-        $is_reset_ready = false;
-        if (\Validate::isModuleName($module->name)) {
-            if (method_exists(\Module::getInstanceByName($module->name), 'reset')) {
-                $is_reset_ready = true;
-            }
-        }
-
-        $reset_module = array(
-            'href' => $link_reset_module,
-            'onclick' => $module->onclick_option && isset($module->onclick_option_content['reset']) ? $module->onclick_option_content['reset'] : '',
-            'title' => '',
-            'text' => $this->translationsTab['Reset'],
-            'cond' => $module->id && $module->active,
-            'icon' => 'undo',
-            'class' => ($is_reset_ready ? 'reset_ready' : '')
-        );
-
-        $delete_module = array(
-            'href' => $link_admin_modules.'&delete='.urlencode($module->name).'&tab_module='.$module->tab.'&module_name='.urlencode($module->name),
-            'onclick' => $module->onclick_option && isset($module->onclick_option_content['delete']) ? $module->onclick_option_content['delete'] : 'return confirm(\''.$this->translationsTab['This action will permanently remove the module from the server. Are you sure you want to do this?'].'\');',
-            'title' => '',
-            'text' => $this->translationsTab['Delete'],
-            'cond' => true,
-            'icon' => 'trash',
-            'class' => 'text-danger'
-        );
-
-        $display_mobile = array(
-            'href' => $link_admin_modules.'&module_name='.urlencode($module->name).'&'.($module->enable_device & \Context::DEVICE_MOBILE ? 'disable_device' : 'enable_device').'='.\Context::DEVICE_MOBILE.'&tab_module='.$module->tab,
-            'onclick' => '',
-            'title' => htmlspecialchars($module->enable_device & \Context::DEVICE_MOBILE ? $this->translationsTab['Disable on mobiles'] : $this->translationsTab['Display on mobiles']),
-            'text' => $module->enable_device & \Context::DEVICE_MOBILE ? $this->translationsTab['Disable on mobiles'] : $this->translationsTab['Display on mobiles'],
-            'cond' => $module->id,
-            'icon' => 'mobile'
-        );
-
-        $display_tablet = array(
-            'href' => $link_admin_modules.'&module_name='.urlencode($module->name).'&'.($module->enable_device & \Context::DEVICE_TABLET ? 'disable_device' : 'enable_device').'='.\Context::DEVICE_TABLET.'&tab_module='.$module->tab,
-            'onclick' => '',
-            'title' => htmlspecialchars($module->enable_device & \Context::DEVICE_TABLET ? $this->translationsTab['Disable on tablets'] : $this->translationsTab['Display on tablets']),
-            'text' => $module->enable_device & \Context::DEVICE_TABLET ? $this->translationsTab['Disable on tablets'] : $this->translationsTab['Display on tablets'],
-            'cond' => $module->id,
-            'icon' => 'tablet'
-        );
-
-        $display_computer = array(
-            'href' => $link_admin_modules.'&module_name='.urlencode($module->name).'&'.($module->enable_device & \Context::DEVICE_COMPUTER ? 'disable_device' : 'enable_device').'='.\Context::DEVICE_COMPUTER.'&tab_module='.$module->tab,
-            'onclick' => '',
-            'title' => htmlspecialchars($module->enable_device & \Context::DEVICE_COMPUTER ? $this->translationsTab['Disable on computers'] : $this->translationsTab['Display on computers']),
-            'text' => $module->enable_device & \Context::DEVICE_COMPUTER ? $this->translationsTab['Disable on computers'] : $this->translationsTab['Display on computers'],
-            'cond' => $module->id,
-            'icon' => 'desktop'
-        );
-
-        $install = array(
-            'href' => $link_admin_modules.'&install='.urlencode($module->name).'&tab_module='.$module->tab.'&module_name='.$module->name.'&anchor='.ucfirst($module->name)
-                .(!is_null($back) ? '&back='.urlencode($back) : '').($install_source_tracking ? '&source='.$install_source_tracking : ''),
-            'onclick' => '',
-            'title' => $this->translationsTab['Install'],
-            'text' => $this->translationsTab['Install'],
-            'cond' => $module->id,
-            'icon' => 'plus-sign-alt'
-        );
-
-        $uninstall = array(
-            'href' => $link_admin_modules.'&uninstall='.urlencode($module->name).'&tab_module='.$module->tab.'&module_name='.$module->name.'&anchor='.ucfirst($module->name).(!is_null($back) ? '&back='.urlencode($back) : ''),
-            'onclick' => (isset($module->onclick_option_content['uninstall']) ? $module->onclick_option_content['uninstall'] : 'return confirm(\''.$this->translationsTab['confirm_uninstall_popup'].'\');'),
-            'title' => $this->translationsTab['Uninstall'],
-            'text' => $this->translationsTab['Uninstall'],
-            'cond' => $module->id,
-            'icon' => 'minus-sign-alt'
-        );
-
-        $remove_from_favorite = array(
-            'href' => '#',
-            'class' => 'action_unfavorite toggle_favorite',
-            'onclick' =>'',
-            'title' => $this->translationsTab['Remove from Favorites'],
-            'text' => $this->translationsTab['Remove from Favorites'],
-            'cond' => $module->id,
-            'icon' => 'star',
-            'data-value' => '0',
-            'data-module' => $module->name
-        );
-
-        $mark_as_favorite = array(
-            'href' => '#',
-            'class' => 'action_favorite toggle_favorite',
-            'onclick' => '',
-            'title' => $this->translationsTab['Mark as Favorite'],
-            'text' => $this->translationsTab['Mark as Favorite'],
-            'cond' => $module->id,
-            'icon' => 'star',
-            'data-value' => '1',
-            'data-module' => $module->name
-        );
-
-        $update = array(
-            'href' => $module->options['update_url'],
-            'onclick' => '',
-            'title' => 'Update it!',
-            'text' => 'Update it!',
-            'icon' => 'refresh',
-            'cond' => $module->id,
-        );
-
-        $divider = array(
-            'href' => '#',
-            'onclick' => '',
-            'title' => 'divider',
-            'text' => 'divider',
-            'cond' => $module->id,
-        );
-
-        if (isset($module->version_addons) && $module->version_addons) {
-            $modules_options[] = $update;
-        }
-
-        if ($module->active) {
-            $modules_options[] = $configure_module;
-            $modules_options[] = $desactive_module;
-            $modules_options[] = $display_mobile;
-            $modules_options[] = $display_tablet;
-            $modules_options[] = $display_computer;
-        } else {
-            $modules_options[] = $desactive_module;
-            $modules_options[] = $configure_module;
-        }
-
-        $modules_options[] = $reset_module;
-
-        if ($output_type == 'select') {
-            if (!$module->id) {
-                $modules_options[] = $install;
-            } else {
-                $modules_options[] = $uninstall;
-            }
-        } elseif ($output_type == 'array') {
-            if ($module->id) {
-                $modules_options[] = $uninstall;
-            }
-        }
-
-        if (isset($module->preferences) && isset($module->preferences['favorite']) && $module->preferences['favorite'] == 1) {
-            $remove_from_favorite['style'] = '';
-            $mark_as_favorite['style'] = 'display:none;';
-            $modules_options[] = $remove_from_favorite;
-            $modules_options[] = $mark_as_favorite;
-        } else {
-            $mark_as_favorite['style'] = '';
-            $remove_from_favorite['style'] = 'display:none;';
-            $modules_options[] = $remove_from_favorite;
-            $modules_options[] = $mark_as_favorite;
-        }
-
-        if ($module->id == 0) {
-            $install['cond'] = 1;
-            $install['flag_install'] = 1;
-            $modules_options[] = $install;
-        }
-        $modules_options[] = $divider;
-        $modules_options[] = $delete_module;
-
-        $return = '';
-        foreach ($modules_options as $option_name => $option) {
-            if ($option['cond']) {
-                if ($output_type == 'link') {
-                    $return .= '<li><a class="'.$option_name.' action_module';
-                    $return .= '" href="'.$option['href'].(!is_null($back) ? '&back='.urlencode($back) : '').'"';
-                    $return .= ' onclick="'.$option['onclick'].'"  title="'.$option['title'].'"><i class="icon-'.(isset($option['icon']) && $option['icon'] ? $option['icon']:'cog').'"></i>&nbsp;'.$option['text'].'</a></li>';
-                } elseif ($output_type == 'array') {
-                    if (!is_array($return)) {
-                        $return = array();
-                    }
-
-                    $html = '<a class="';
-
-                    $is_install = isset($option['flag_install']) ? true : false;
-
-                    if (isset($option['class'])) {
-                        $html .= $option['class'];
-                    }
-                    if ($is_install) {
-                        $html .= ' btn btn-success';
-                    }
-                    if (!$is_install && count($return) == 0) {
-                        $html .= ' btn btn-default';
-                    }
-
-                    $html .= '"';
-
-                    if (isset($option['data-value'])) {
-                        $html .= ' data-value="'.$option['data-value'].'"';
-                    }
-
-                    if (isset($option['data-module'])) {
-                        $html .= ' data-module="'.$option['data-module'].'"';
-                    }
-
-                    if (isset($option['style'])) {
-                        $html .= ' style="'.$option['style'].'"';
-                    }
-
-                    $html .= ' href="'.htmlentities($option['href']).(!is_null($back) ? '&back='.urlencode($back) : '').'" onclick="'.$option['onclick'].'"  title="'.$option['title'].'"><i class="icon-'.(isset($option['icon']) && $option['icon'] ? $option['icon']:'cog').'"></i> '.$option['text'].'</a>';
-                    $return[] = $html;
-                } elseif ($output_type == 'select') {
-                    $return .= '<option id="'.$option_name.'" data-href="'.htmlentities($option['href']).(!is_null($back) ? '&back='.urlencode($back) : '').'" data-onclick="'.$option['onclick'].'">'.$option['text'].'</option>';
-                }
-            }
-        }
-
-        if ($output_type == 'select') {
-            $return = '<select id="select_'.$module->name.'">'.$return.'</select>';
-        }
-
-        return $return;
-    }
-
-
-    /**
-     * Controller responsible for importing new module from DropFile zone in BO
-     * @param  Request $request
+     * @param Request $request
+     *
      * @return JsonResponse
      */
     public function importModuleAction(Request $request)
@@ -770,13 +431,13 @@ class ModuleController extends FrameworkBundleAdminController
                         'application/gzip',
                         'application/x-gtar',
                         'application/x-tgz',
-            ))));
+            ), )), );
 
             $violations = $this->get('validator')->validateValue($file_uploaded, $constraints);
             if (0 !== count($violations)) {
                 $violationsMessages = '';
                 foreach ($violations as $violation) {
-                    $violationsMessages .= $violation->getMessage() . PHP_EOL;
+                    $violationsMessages .= $violation->getMessage().PHP_EOL;
                 }
                 throw new Exception($violationsMessages);
             }
@@ -789,11 +450,11 @@ class ModuleController extends FrameworkBundleAdminController
             // Try to inflate archive given, and do check to verify we have a valid module architecture
             $module_name = $this->inflateModule($file_uploaded_tmp_fullpath);
             // Install the module
-            $installation_response = [
+            $installation_response = array(
                 'status' => $moduleManager->install($module_name),
                 'msg' => '',
                 'module_name' => $module_name,
-            ];
+            );
 
             if ($installation_response['status'] === null) {
                 $installation_response['status'] = false;
@@ -806,7 +467,7 @@ class ModuleController extends FrameworkBundleAdminController
                     'Installation of module %module% succeeded',
                     array('%module%' => $module_name),
                     'Admin.Modules.Notification');
-                $installation_response['is_configurable'] = (bool)$this->get('prestashop.core.admin.module.repository')->getModule($module_name)->attributes->get('is_configurable');
+                $installation_response['is_configurable'] = (bool) $this->get('prestashop.core.admin.module.repository')->getModule($module_name)->attributes->get('is_configurable');
             } else {
                 $installation_response['msg'] = $translator->trans(
                     'Installation of module %module% failed.',
@@ -817,19 +478,20 @@ class ModuleController extends FrameworkBundleAdminController
             return new JsonResponse(
                 $installation_response,
                 200,
-                array( 'Content-Type' => 'application/json' )
+                array('Content-Type' => 'application/json')
             );
         } catch (Exception $e) {
             if (isset($module_name)) {
                 $moduleManager->uninstall($module_name);
                 $moduleManager->removeModuleFromDisk($module_name);
             }
+
             return new JsonResponse(
                 array(
                 'status' => false,
-                'msg' => $e->getMessage()),
+                'msg' => $e->getMessage(), ),
                 200,
-                array( 'Content-Type' => 'application/json' )
+                array('Content-Type' => 'application/json')
             );
         }
     }
@@ -847,15 +509,15 @@ class ModuleController extends FrameworkBundleAdminController
         // Get current employee ID
         $currentEmployeeID = $legacyContext->employee->id;
         // Get accessed module DB ID
-        $moduleAccessedID = (int)$moduleAccessed->database->get('id');
+        $moduleAccessedID = (int) $moduleAccessed->database->get('id');
 
         // Save history for this module
         $moduleHistory = $this->getDoctrine()
             ->getRepository('PrestaShopBundle:ModuleHistory')
-            ->findOneBy([
+            ->findOneBy(array(
                 'idEmployee' => $currentEmployeeID,
-                'idModule' => $moduleAccessedID
-            ]);
+                'idModule' => $moduleAccessedID,
+            ));
 
         if (is_null($moduleHistory)) {
             $moduleHistory = new ModuleHistory();
@@ -873,6 +535,7 @@ class ModuleController extends FrameworkBundleAdminController
             // do not transmit limit & offset: go to the first page when redirecting
             'configure' => $module_name,
         );
+
         return $this->redirect(
             $legacyUrlGenerator->generate('admin_module_configure_action', $redirectionParams),
             302
@@ -917,7 +580,7 @@ class ModuleController extends FrameworkBundleAdminController
                         'Cannot open the following archive: %file% (error code: %code%)',
                         array(
                             '%file%' => $fileToInflate,
-                            '%code%' => $extractionStatus),
+                            '%code%' => $extractionStatus, ),
                         'Admin.Modules.Notification'));
             }
         } else {
@@ -932,7 +595,7 @@ class ModuleController extends FrameworkBundleAdminController
     private function getPresentedProducts(array &$products)
     {
         $modulePresenter = $this->get('prestashop.adapter.presenter.module');
-        $presentedProducts = [];
+        $presentedProducts = array();
         foreach ($products as $name => $product) {
             $presentedProducts[$name] = $modulePresenter->present($product);
         }
@@ -950,7 +613,7 @@ class ModuleController extends FrameworkBundleAdminController
             }
         }
 
-        return (array)$topMenuData;
+        return (array) $topMenuData;
     }
 
     private function getAddonsConnectToolbar()
@@ -960,19 +623,19 @@ class ModuleController extends FrameworkBundleAdminController
 
         if ($addonsProvider->isAddonsAuthenticated()) {
             $addonsEmail = $addonsProvider->getAddonsEmail();
-            $addonsConnect = [
+            $addonsConnect = array(
                 'href' => $this->generateUrl('admin_addons_logout'),
                 'desc' => $addonsEmail['username_addons'],
                 'icon' => 'exit_to_app',
-                'help' => $translator->trans('Synchronized with Addons marketplace!', array(), 'Admin.Modules.Notification')
-            ];
+                'help' => $translator->trans('Synchronized with Addons marketplace!', array(), 'Admin.Modules.Notification'),
+            );
         } else {
-            $addonsConnect = [
+            $addonsConnect = array(
                 'href' => '#',
                 'desc' => $translator->trans('Connect to Addons marketplace', array(), 'Admin.Modules.Feature'),
                 'icon' => 'vpn_key',
-                'help' => $translator->trans('Connect to Addons marketplace', array(), 'Admin.Modules.Feature')
-            ];
+                'help' => $translator->trans('Connect to Addons marketplace', array(), 'Admin.Modules.Feature'),
+            );
         }
 
         return $addonsConnect;

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig
@@ -1,0 +1,100 @@
+<tr>
+  <td class="fixed-with-sm center">
+    <img
+      class="img-thumbnail"
+      alt="{{ module.name }}"
+      src="{% if module.image_absolute is defined %}
+        {{ module.image_absolute }}
+        {% else %}
+          {{ constant('_MODULE_DIR_') ~ module.name ~ '/' ~ module.logo }}
+        {% endif %}"
+    />
+  </td>
+  <td>
+    <div id="anchor{{ module.name|capitalize }}" title="{{ module.displayName }}">
+      <div class="module_name">
+        <span style="display:none">{{ module.name }}</span>
+        {{ module.displayName }}
+        <small class="text-muted">v{{ module.version }} - by {{ module.author }}</small>
+        {% if module.type is defined and module.type == 'addonsBought' %}
+        - <span class="module-badge-bought help-tooltip text-warning" data-title="{{ 'You bought this module on PrestaShop Addons. Thank You.'|trans({}) }}"><i class="icon-pushpin"></i> <small>{{ 'Bought'|trans({}) }}</small></span>
+        {% elseif module.type is defined and module.type == 'addonsMustHave' %}
+        - <span class="module-badge-popular help-tooltip text-primary" data-title="{{ 'This module is available on PrestaShop Addons.'|trans({}) }}"><i class="icon-group"></i> <small>{{ 'Popular'|trans({}) }}</small></span>
+        {% elseif module.type is defined and module.type == 'addonsPartner' %}
+        - <span class="module-badge-partner help-tooltip text-warning" data-title="{{ 'This module is available for free thanks to our partner.'|trans({}) }}"><i class="icon-pushpin"></i> <small>{{ 'Official'|trans({}) }}</small></span>
+        {% elseif module.id is defined and module.id >= 0 %}
+          {% if module.version_addons is defined and module.version_addons %}
+            <span class="label label-warning">{{ 'Need update'|trans({}) }}</span>
+          {% endif %}
+        {% endif %}
+      </div>
+      <p class="module_description">
+        {% if module.description is defined and module.description is not empty %}
+          {{ module.description }}
+        {% endif %}
+      </p>
+      {% if (module.message is defined and module.name is not empty) and (module.type is not defined or module.type != 'addonsMustHave' or module.type != 'addonsNative') %}
+        <div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">&times;</button>{{ module.message }}</div>
+      {% endif %}
+    </div>
+  </td>
+
+  {% if module.type is defined and module.type == 'addonsMustHave' %}
+  <td>&nbsp;</td>
+  <td style="text-align: right;">
+    <p>
+      <a href="{{ module.addons_buy_url|replace({' ': '+'})|e('html') }}" onclick="return !window.open(this.href, '_blank');" class="button updated _blank">
+          <span class="btn btn-default">
+            <i class="icon-shopping-cart"></i>
+            {% if module.price is defined %}
+              {% if module.price == 0 %}
+                {{ 'Free'|trans({}) }}
+              {% elseif module.id_currency is defined %}
+                &nbsp;&nbsp; {{ module.price }} {{ module.id_currency }}
+              {% endif %}
+            {% endif %}
+          </span>
+      </a>
+    </p>
+  </td>
+  {% elseif module.not_on_disk is not defined %}
+  <td>&nbsp;</td>
+  <td class="actions">
+    <div class="btn-group-action">
+      {% if module.optionsHtml|length > 0 %}
+      <div class="btn-group">
+        {% set firstOption = module.optionsHtml[0] %}
+        {{ firstOption|raw }}
+        {% if module.optionsHtml|length > 0 %}
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" >
+          <span class="caret">&nbsp;</span>
+        </button>
+        <ul class="dropdown-menu pull-right">
+
+          {% for key, option in module.optionsHtml  %}
+            {% if key != 0 %}
+              {% if 'title="divider"' not in option %}
+                <li class="divider"></li>
+              {% else %}
+                <li>{{ option }}</li>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+      {% endif %}
+    </div>
+  </td>
+  {% else %}
+  <td>&nbsp;</td>
+  <td style="text-align: right;">
+    <p>
+      <a href="{{ module.options.install_url|e('html') }}" class="btn btn-success">
+        <i class="icon-plus-sign-alt"></i>
+        {{ 'Install'|trans({}) }}
+      </a>
+    </p>
+  </td>
+  {% endif %}
+</tr>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig
@@ -2,99 +2,43 @@
   <td class="fixed-with-sm center">
     <img
       class="img-thumbnail"
-      alt="{{ module.name }}"
-      src="{% if module.image_absolute is defined %}
-        {{ module.image_absolute }}
+      alt="{{ module.attributes.name }}"
+      src="{% if module.attributes.image_absolute is not empty %}
+        {{ module.attributes.image_absolute }}
         {% else %}
-          {{ constant('_MODULE_DIR_') ~ module.name ~ '/' ~ module.logo }}
+          {{ constant('_MODULE_DIR_') ~ module.attributes.name ~ '/' ~ module.attributes.logo }}
         {% endif %}"
     />
   </td>
   <td>
-    <div id="anchor{{ module.name|capitalize }}" title="{{ module.displayName }}">
+    <div id="anchor{{ module.attributes.name|capitalize }}" title="{{ module.attributes.displayName }}">
       <div class="module_name">
-        <span style="display:none">{{ module.name }}</span>
-        {{ module.displayName }}
-        <small class="text-muted">v{{ module.version }} - by {{ module.author }}</small>
-        {% if module.type is defined and module.type == 'addonsBought' %}
+        <span style="display:none">{{ module.attributes.name }}</span>
+        {{ module.attributes.displayName }}
+        <small class="text-muted">v{{ module.attributes.version }} - by {{ module.attributes.author }}</small>
+        {% if module.attributes.type is not empty and module.attributes.type == 'addonsBought' %}
         - <span class="module-badge-bought help-tooltip text-warning" data-title="{{ 'You bought this module on PrestaShop Addons. Thank You.'|trans({}) }}"><i class="icon-pushpin"></i> <small>{{ 'Bought'|trans({}) }}</small></span>
-        {% elseif module.type is defined and module.type == 'addonsMustHave' %}
+        {% elseif module.attributes.type is not empty and module.attributes.type == 'addonsMustHave' %}
         - <span class="module-badge-popular help-tooltip text-primary" data-title="{{ 'This module is available on PrestaShop Addons.'|trans({}) }}"><i class="icon-group"></i> <small>{{ 'Popular'|trans({}) }}</small></span>
-        {% elseif module.type is defined and module.type == 'addonsPartner' %}
+        {% elseif module.attributes.type is not empty and module.attributes.type == 'addonsPartner' %}
         - <span class="module-badge-partner help-tooltip text-warning" data-title="{{ 'This module is available for free thanks to our partner.'|trans({}) }}"><i class="icon-pushpin"></i> <small>{{ 'Official'|trans({}) }}</small></span>
-        {% elseif module.id is defined and module.id >= 0 %}
-          {% if module.version_addons is defined and module.version_addons %}
+        {% elseif module.attributes.id is defined and module.attributes.id >= 0 %}
+          {% if module.attributes.version_addons is defined and module.attributes.version_addons %}
             <span class="label label-warning">{{ 'Need update'|trans({}) }}</span>
           {% endif %}
         {% endif %}
       </div>
       <p class="module_description">
-        {% if module.description is defined and module.description is not empty %}
-          {{ module.description }}
+        {% if module.attributes.description is defined and module.attributes.description is not empty %}
+          {{ module.attributes.description }}
         {% endif %}
       </p>
-      {% if (module.message is defined and module.name is not empty) and (module.type is not defined or module.type != 'addonsMustHave' or module.type != 'addonsNative') %}
-        <div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">&times;</button>{{ module.message }}</div>
+      {% if (module.attributes.message is defined and module.attributes.name is not empty) and (module.attributes.type is not defined or module.attributes.type != 'addonsMustHave' or module.attributes.type != 'addonsNative') %}
+        <div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">&times;</button>{{ module.attributes.message }}</div>
       {% endif %}
     </div>
   </td>
-
-  {% if module.type is defined and module.type == 'addonsMustHave' %}
-  <td>&nbsp;</td>
-  <td style="text-align: right;">
-    <p>
-      <a href="{{ module.addons_buy_url|replace({' ': '+'})|e('html') }}" onclick="return !window.open(this.href, '_blank');" class="button updated _blank">
-          <span class="btn btn-default">
-            <i class="icon-shopping-cart"></i>
-            {% if module.price is defined %}
-              {% if module.price == 0 %}
-                {{ 'Free'|trans({}) }}
-              {% elseif module.id_currency is defined %}
-                &nbsp;&nbsp; {{ module.price }} {{ module.id_currency }}
-              {% endif %}
-            {% endif %}
-          </span>
-      </a>
-    </p>
+  <td class="module-container module-quick-action-list clearfix">
+    {{ include('PrestaShopBundle:Admin/Module/Includes:action_menu.html.twig',{'module': module}) }}
   </td>
-  {% elseif module.not_on_disk is not defined %}
-  <td>&nbsp;</td>
-  <td class="actions">
-    <div class="btn-group-action">
-      {% if module.optionsHtml|length > 0 %}
-      <div class="btn-group">
-        {% set firstOption = module.optionsHtml[0] %}
-        {{ firstOption|raw }}
-        {% if module.optionsHtml|length > 0 %}
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" >
-          <span class="caret">&nbsp;</span>
-        </button>
-        <ul class="dropdown-menu pull-right">
-
-          {% for key, option in module.optionsHtml  %}
-            {% if key != 0 %}
-              {% if 'title="divider"' not in option %}
-                <li class="divider"></li>
-              {% else %}
-                <li>{{ option }}</li>
-              {% endif %}
-            {% endif %}
-          {% endfor %}
-        </ul>
-        {% endif %}
-      </div>
-      {% endif %}
-    </div>
-  </td>
-  {% else %}
-  <td>&nbsp;</td>
-  <td style="text-align: right;">
-    <p>
-      <a href="{{ module.options.install_url|e('html') }}" class="btn btn-success">
-        <i class="icon-plus-sign-alt"></i>
-        {{ 'Install'|trans({}) }}
-      </a>
-    </p>
-  </td>
-  {% endif %}
 </tr>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
@@ -36,7 +36,6 @@
       {% for module in modulesList.installed %}
         {{ include('PrestaShopBundle:Admin/Module/Includes:tab-module-line.html.twig',{'module': module}) }}
       {% endfor %}
-
     </table>
   </div>
   {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
@@ -1,0 +1,47 @@
+{% if modulesList is defined and modulesList is not empty %}
+<div class="row row-margin-bottom">
+  <div class="col-lg-12">
+    <ul class="nav nav-pills">
+      {% if modulesList.notInstalled|length > 0 %}
+      <li class="active">
+        <a href="#tab_modules_list_not_installed" data-toggle="tab">
+          {{ 'Not Installed'|trans({}) }}
+        </a>
+      </li>
+      {% endif %}
+
+      {% if modulesList.installed|length > 0 %}
+        <li {% if modulesList.notInstalled|length == 0 %}class="active"{% endif %}>
+        <a href="#tab_modules_list_installed" data-toggle="tab">
+          {{ 'Installed'|trans({}) }}
+        </a>
+        </li>
+      {% endif %}
+    </ul>
+  </div>
+</div>
+<div id="modules_list_container_content" class="tab-content modal-content-overflow">
+  {% if modulesList.notInstalled is defined and modulesList.notInstalled is not empty %}
+  <div class="tab-pane active" id="tab_modules_list_not_installed">
+    <table id="tab_modules_list_not_installed" class="table">
+      {% for module in modulesList.notInstalled %}
+        {{ include('PrestaShopBundle:Admin/Module/Includes:tab-module-line.html.twig',{'module': module}) }}
+      {% endfor %}
+    </table>
+  </div>
+  {% endif %}
+  {% if modulesList.installed|length > 0 %}
+  <div class="tab-pane {% if modulesList.notInstalled|length == 0 %}active{% endif %}" id="tab_modules_list_installed">
+    <table id="tab_modules_list_installed" class="table">
+      {% for module in modulesList.installed %}
+        {{ include('PrestaShopBundle:Admin/Module/Includes:tab-module-line.html.twig',{'module': module}) }}
+      {% endfor %}
+
+    </table>
+  </div>
+  {% endif %}
+</div>
+{% endif %}
+<div class="alert alert-addons row-margin-top">
+  <a href="http://addons.prestashop.com/?utm_source=back-office&amp;utm_medium=dispatch&amp;utm_campaign=back-office-{{ app.request.locale }}&amp;utm_content=download{% if adminListFromSource is defined %}&amp;utm_term={{ adminListFromSource }}{% endif %}" onclick="return !window.open(this.href);">{{ 'More modules on addons.prestashop.com'|trans({}) }}</a>
+</div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | the block that suggest the prefered modules and services is broken. This contribution is a "as it" migration to Symfony architecture. |
| Type? | new feature |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-783 |
| How to test? | click on "Recommended modules and services" link in any legacy page. |
### Expected

> Note: the UI/UX is not ready, this contribution is about made the block works.

![installed](https://cloud.githubusercontent.com/assets/1247388/16517138/29fe8c8e-3f7c-11e6-958c-5fd640e05e7d.png)
![not_installed](https://cloud.githubusercontent.com/assets/1247388/16517137/29fe36a8-3f7c-11e6-8f5d-42c0596ec252.png)
### To do
- [x] Move/refactor `ModuleController::getModulesByInstallation` function using `ModuleRepository` service
- [x] Move/refactor `ModuleController::fillModuleData` function using `Adapter\Module\Module`
- [x] ~~Move/refactor `ModuleController::displayModuleOptions` function using a template and a "sub action".~~
