### PR TITLE
Add last level category for product breadcrumb

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -134,7 +134,7 @@ class CategoryCore extends ObjectModel
 
     public function __construct($id_category = null, $id_lang = null, $id_shop = null)
     {
-        parent::__construct($id_category, $id_lang, $id_shop);
+        parent::__construct((int)$id_category, (int)$id_lang, (int)$id_shop);
         $this->id_image = ($this->id && file_exists(_PS_CAT_IMG_DIR_.(int)$this->id.'.jpg')) ? (int)$this->id : false;
         $this->image_dir = _PS_CAT_IMG_DIR_;
     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -806,13 +806,15 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
-        $categoryDefault = new Category($this->product->id_category_default);
+        $categoryDefault = new Category($this->product->id_category_default, $this->context->language->id);
 
         foreach ($categoryDefault->getAllParents() as $category) {
             if ($category->id_parent != 0 && !$category->is_root_category) {
                 $breadcrumb['links'][] = $this->getCategoryPath($category);
             }
         }
+
+        $breadcrumb['links'][] = $this->getCategoryPath($categoryDefault);
 
         $breadcrumb['links'][] = array(
             'title' => $this->context->controller->product->name,


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The last level of category was not displayed into the product breadcrumb. It's now solved. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-932 |
| How to test? | Just check the breadcrumb is complete |
