### PR TITLE
Fixed cart rule removal with gift product

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -971,7 +971,7 @@ class CartCore extends ObjectModel
         ));
 
         if ((int)$quantity <= 0) {
-            return $this->deleteProduct($id_product, $id_product_attribute, (int)$id_customization);
+            return $this->deleteProduct($id_product, $id_product_attribute, (int)$id_customization, 0, $auto_add_cart_rule);
         } elseif (!$product->available_for_order || (Configuration::get('PS_CATALOG_MODE') && !defined('_PS_ADMIN_DIR_'))) {
             return false;
         } else {
@@ -1012,7 +1012,7 @@ class CartCore extends ObjectModel
 
                 /* Delete product from cart */
                 if ($new_qty <= 0) {
-                    return $this->deleteProduct((int)$id_product, (int)$id_product_attribute, (int)$id_customization);
+                    return $this->deleteProduct((int)$id_product, (int)$id_product_attribute, (int)$id_customization, 0, $auto_add_cart_rule);
                 } elseif ($new_qty < $minimal_quantity) {
                     return -1;
                 } else {
@@ -1249,7 +1249,7 @@ class CartCore extends ObjectModel
      * @param int $id_customization Customization id
      * @return bool result
      */
-    public function deleteProduct($id_product, $id_product_attribute = null, $id_customization = null, $id_address_delivery = 0)
+    public function deleteProduct($id_product, $id_product_attribute = null, $id_customization = null, $id_address_delivery = 0, $auto_add_cart_rule = true)
     {
         if (isset(self::$_nbProducts[$this->id])) {
             unset(self::$_nbProducts[$this->id]);
@@ -1320,7 +1320,9 @@ class CartCore extends ObjectModel
             // refresh cache of self::_products
             $this->_products = $this->getProducts(true);
             CartRule::autoRemoveFromCart();
-            CartRule::autoAddToCart();
+            if ($auto_add_cart_rule) {
+                CartRule::autoAddToCart();
+            }
 
             return $return;
         }

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -110,6 +110,7 @@ class ParentOrderControllerCore extends FrontController
                                 $this->errors[] = $error;
                             } else {
                                 $this->context->cart->addCartRule($cartRule->id);
+                                CartRule::autoAddToCart($this->context);
                                 if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 1) {
                                     Tools::redirect('index.php?controller=order-opc&addingCartRule=1');
                                 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Fixed cart rule removal with gift product |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |

Step to reproduce:
On a clean setup create 2 cart rule as follow:
Name: Discount 
Priority: 1
Code: discount
Action: 30% discount

Name: free t-shit
Priority: 2
Minimum amount: 50 with tax
Uncompatible with: Discount
Action: free gift (a random product eg. demo_1)

Now add enough products to get free gift. On checkout add "discount" voucher.
The free t-shirt should be remove from cart ("free t-shit" rule is incompatible with "discount") but it's not !!
