### PR TITLE
Replaced |sprintf: with sprintf= in smarty templates

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/list.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/list.tpl
@@ -38,7 +38,7 @@
 				<tr>
 					<td class="{{$smarty.capture.moduleStatutClass}} text-center" style="width: 1%;">
 						{if (isset($module->id) && $module->id > 0) || !isset($module->type) || $module->type != 'addonsMustHave'}
-						<input type="checkbox" name="modules" value="{$module->name|escape:'html':'UTF-8'}" class="noborder" title="{l s='Module %1s '|sprintf:$module->name}"{if !isset($module->confirmUninstall) OR empty($module->confirmUninstall)} data-rel="false"{else} data-rel="{$module->confirmUninstall|addslashes}"{/if}/>
+						<input type="checkbox" name="modules" value="{$module->name|escape:'html':'UTF-8'}" class="noborder" title="{l s='Module %1s ' sprintf=$module->name}"{if !isset($module->confirmUninstall) OR empty($module->confirmUninstall)} data-rel="false"{else} data-rel="{$module->confirmUninstall|addslashes}"{/if}/>
 						{/if}
 					</td>
 					<td class="fixed-width-xs">

--- a/admin-dev/themes/default/template/controllers/products/helpers/uploader/ajax.tpl
+++ b/admin-dev/themes/default/template/controllers/products/helpers/uploader/ajax.tpl
@@ -137,7 +137,7 @@
 			if (typeof {$id|escape:'html':'UTF-8'}_max_files !== 'undefined') {
 				if ({$id|escape:'html':'UTF-8'}_total_files >= {$id|escape:'html':'UTF-8'}_max_files) {
 					e.preventDefault();
-					alert('{l s='You can upload a maximum of %s files'|sprintf:$max_files}');
+					alert('{l s='You can upload a maximum of %s files' sprintf=$max_files}');
 					return;
 				}
 			}

--- a/admin-dev/themes/default/template/controllers/products/helpers/uploader/virtual_product.tpl
+++ b/admin-dev/themes/default/template/controllers/products/helpers/uploader/virtual_product.tpl
@@ -133,7 +133,7 @@
 			$('#{$id|escape:'html':'UTF-8'}').closest('form').on('submit', function(e) {
 				if ($('#{$id|escape:'html':'UTF-8'}')[0].files.length > {$id|escape:'html':'UTF-8'}_max_files) {
 					e.preventDefault();
-					alert('{l s='You can upload a maximum of %s files'|sprintf:$max_files}');
+					alert('{l s='You can upload a maximum of %s files' sprintf=$max_files}');
 				}
 			});
 		}

--- a/admin-dev/themes/default/template/controllers/products/virtualproduct.tpl
+++ b/admin-dev/themes/default/template/controllers/products/virtualproduct.tpl
@@ -59,7 +59,7 @@
 				<div class="col-lg-push-3 col-lg-9">
 					<div class="alert alert-danger" id="file_missing">
 						{$download_product_file_missing} :<br/>
-						<strong>{l s='Server file name : %s'|sprintf:$product->productDownload->filename}</strong>
+						<strong>{l s='Server file name : %s' sprintf=$product->productDownload->filename}</strong>
 					</div>
 				</div>
 			</div>

--- a/admin-dev/themes/default/template/controllers/supply_orders_change_state/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/supply_orders_change_state/helpers/form/form.tpl
@@ -41,7 +41,7 @@ $(document).ready(function() {
 });
 </script>
 {assign var=order_state value=$supply_order_state->name[$employee->id_lang]|regex_replace:"/[^A-Za-z_ \t]/":""}
-<div class="alert alert-warning"><strong>{l s='Current order status: %s'|sprintf:$order_state}</strong></div>
+<div class="alert alert-warning"><strong>{l s='Current order status: %s' sprintf=$order_state}</strong></div>
 <div class="alert alert-info">{l s='Choose the new status for your order'}</div>
 <div class="form-horizontal">
 	<input type="hidden" name="id_supply_order" id="id_supply_order" value="{$supply_order->id}">

--- a/admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl
@@ -24,7 +24,7 @@
 *}
 <div class="alert alert-success">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
-    {l s='The "%1$s" theme has been successfully installed.'|sprintf:$theme_name}
+    {l s='The "%1$s" theme has been successfully installed.' sprintf=$theme_name}
 </div>
 
 {hook h='displayAfterThemeInstallation' theme_name=$theme_name}
@@ -64,7 +64,7 @@
         <ul>
             {foreach $img_error['error'] as $error}
                 <li>
-                    {l s='Name image type:'} <strong>{$error['name']}</strong> {l s='(width: %1$spx, height: %2$spx).'|sprintf:$error['width']:$error['height']}
+                    {l s='Name image type:'} <strong>{$error['name']}</strong> {l s='(width: %1$spx, height: %2$spx).' sprintf=$error['width']:$error['height']}
                 </li>
             {/foreach}
         </ul>
@@ -78,7 +78,7 @@
         <ul>
             {foreach $img_error['ok'] as $error}
                 <li>
-                    {l s='Name image type:'} <strong>{$error['name']}</strong> {l s='(width: %1$spx, height: %2$spx).'|sprintf:$error['width']:$error['height']}
+                    {l s='Name image type:'} <strong>{$error['name']}</strong> {l s='(width: %1$spx, height: %2$spx).' sprintf=$error['width']:$error['height']}
                 </li>
             {/foreach}
         </ul>

--- a/admin-dev/themes/default/template/helpers/uploader/ajax.tpl
+++ b/admin-dev/themes/default/template/helpers/uploader/ajax.tpl
@@ -167,7 +167,7 @@
 			if (typeof {$id|escape:'html':'UTF-8'}_max_files !== 'undefined') {
 				if ({$id|escape:'html':'UTF-8'}_total_files >= {$id|escape:'html':'UTF-8'}_max_files) {
 					e.preventDefault();
-					alert('{l s='You cannot have more than %s images in total. Please remove some of the current images before adding new ones.'|sprintf:$max_files}');
+					alert('{l s='You cannot have more than %s images in total. Please remove some of the current images before adding new ones.' sprintf=$max_files}');
 					return;
 				}
 			}

--- a/admin-dev/themes/default/template/helpers/uploader/simple.tpl
+++ b/admin-dev/themes/default/template/helpers/uploader/simple.tpl
@@ -131,7 +131,7 @@
 			$('#{$id|escape:'html':'UTF-8'}').closest('form').on('submit', function(e) {
 				if ($('#{$id|escape:'html':'UTF-8'}')[0].files.length > {$id|escape:'html':'UTF-8'}_max_files) {
 					e.preventDefault();
-					alert('{l s='You can upload a maximum of %s files'|sprintf:$max_files}');
+					alert('{l s='You can upload a maximum of %s files' sprintf=$max_files}');
 				}
 			});
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Replaced |
| Type? | improvement |
| Category? | LO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | no |
| How to test? | - |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
