### PR TITLE
Properly migrate old 1.6 settings during composer install / update & upgrade script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     "incenteev/composer-parameter-handler": "~2.0",
     "curl/curl": "1.2.1",
     "ircmaxell/password-compat": "1.0.4",
+    "ircmaxell/random-lib": "*",
     "shudrum/array-finder": "1.1.0",
     "phpoffice/phpexcel": "1.8",
     "prestashop/smarty": "dev-master",
@@ -136,6 +137,7 @@
   },
   "scripts": {
     "post-install-cmd": [
+      "PrestaShop\\PrestaShop\\Core\\Migrate\\Migrate::migrateSettingsFile",
       "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
       "PrestaShop\\PrestaShop\\Core\\Cldr\\Composer\\Hook::init",
       "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
@@ -145,6 +147,7 @@
       "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
     ],
     "post-update-cmd": [
+      "PrestaShop\\PrestaShop\\Core\\Migrate\\Migrate::migrateSettingsFile",
       "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
       "PrestaShop\\PrestaShop\\Core\\Cldr\\Composer\\Hook::init",
       "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",

--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "PrestaShop\\PrestaShop\\Core\\Migrate\\Migrate::migrateSettingsFile",
+      "PrestaShopBundle\\Utils\\Migrate::migrateSettingsFile",
       "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
       "PrestaShop\\PrestaShop\\Core\\Cldr\\Composer\\Hook::init",
       "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
@@ -147,7 +147,7 @@
       "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
     ],
     "post-update-cmd": [
-      "PrestaShop\\PrestaShop\\Core\\Migrate\\Migrate::migrateSettingsFile",
+      "PrestaShopBundle\\Utils\\Migrate::migrateSettingsFile",
       "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
       "PrestaShop\\PrestaShop\\Core\\Cldr\\Composer\\Hook::init",
       "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -28,8 +28,6 @@ use PrestaShop\PrestaShop\Core\Cldr\Update;
 
 class InstallControllerHttpProcess extends InstallControllerHttp implements HttpConfigureInterface
 {
-    const SETTINGS_FILE = 'config/settings.inc.php';
-
     protected $model_install;
     public $process_steps = array();
     public $previous_button = false;
@@ -311,7 +309,7 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
         $low_memory = Tools::getMemoryLimit() < Tools::getOctets('42M');
 
         // We fill the process step used for Ajax queries
-        $this->process_steps[] = array('key' => 'generateSettingsFile', 'lang' => $this->translator->trans('Create settings.inc file', array(), 'Install'));
+        $this->process_steps[] = array('key' => 'generateSettingsFile', 'lang' => $this->translator->trans('Create file parameters', array(), 'Install'));
         $this->process_steps[] = array('key' => 'installDatabase', 'lang' => $this->translator->trans('Create database tables', array(), 'Install'));
         $this->process_steps[] = array('key' => 'installDefaultData', 'lang' => $this->translator->trans('Create default shop and languages', array(), 'Install'));
 

--- a/install-dev/langs/en/install.php
+++ b/install-dev/langs/en/install.php
@@ -50,7 +50,7 @@ return array(
         'Database is connected' => 'Database is connected',
         'Database is created' => 'Database is created',
         'Cannot create the database automatically' => 'Cannot create the database automatically',
-        'Create settings.inc file' => 'Create settings.inc file',
+        'Create file parameters' => 'Create file parameters',
         'Create database tables' => 'Create database tables',
         'Create default shop and languages' => 'Create default shop and languages',
         'Populate database tables' => 'Populate database tables',

--- a/install-dev/upgrade/php/ps1700_stores.php
+++ b/install-dev/upgrade/php/ps1700_stores.php
@@ -34,8 +34,12 @@ function ps1700_stores()
     $result = false;
     foreach ($stores as $store) {
         $hours = Tools::unSerialize($store['hours']);
-        foreach ($hours as $key => $h) {
-            $hours[$key] = [$h];
+        if (is_array($hours)) {
+            foreach ($hours as $key => $h) {
+                $hours[$key] = [$h];
+            }
+        } else {
+            $hours = array();
         }
         $hours = json_encode($hours);
 

--- a/install-dev/upgrade/php/ps_1702_right_management.php
+++ b/install-dev/upgrade/php/ps_1702_right_management.php
@@ -51,7 +51,7 @@ function ps_1702_right_management()
     $oldAccess = Db::getInstance()->executeS('SELECT * FROM `'._DB_PREFIX_.'access_old`');
     foreach ($oldAccess as $currOldAccess) {
         foreach (array('view', 'add', 'edit', 'delete') as $action) {
-            if ($currOldAccess[$action] == '1') {
+            if (array_key_exists($action, $currOldAccess) && $currOldAccess[$action] == '1') {
                 $accessObject->updateLgcAccess(
                     $currOldAccess['id_profile'],
                     $currOldAccess['id_tab'],
@@ -66,7 +66,7 @@ function ps_1702_right_management()
     $oldAccess = Db::getInstance()->executeS('SELECT * FROM `'._DB_PREFIX_.'module_access_old`');
     foreach ($oldAccess as $currOldAccess) {
         foreach (array('configure', 'view', 'uninstall') as $action) {
-            if ($currOldAccess[$action] == '1') {
+            if (array_key_exists($action, $currOldAccess) && $currOldAccess[$action] == '1') {
                 $accessObject->updateLgcAccess(
                     $currOldAccess['id_profile'],
                     $currOldAccess['id_tab'],

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -43,7 +43,7 @@ CREATE TABLE `PREFIX_module_history` (
   `date_upd` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_employee` (`id_employee`,`id_module`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
 
 ALTER TABLE `PREFIX_product` ADD `show_condition` TINYINT(1) NOT NULL DEFAULT '0' AFTER `available_date`;
@@ -118,22 +118,22 @@ CREATE TABLE `PREFIX_authorization_role` (
   `id_authorization_role` int(10) unsigned NOT NULL auto_increment,
   `slug` VARCHAR(255) NOT NULL,
   PRIMARY KEY (`id_authorization_role`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
-RENAME TABLE `PREFIX_access` TO `PREFIX_access_old` 
-RENAME TABLE `PREFIX_module_access` TO `PREFIX_module_access_old` 
+RENAME TABLE `PREFIX_access` TO `PREFIX_access_old`;
+RENAME TABLE `PREFIX_module_access` TO `PREFIX_module_access_old`;
 
 CREATE TABLE `PREFIX_access` (
   `id_profile` int(10) unsigned NOT NULL,
   `id_authorization_role` int(10) unsigned NOT NULL,
   PRIMARY KEY (`id_profile`,`id_authorization_role`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
 CREATE TABLE `PREFIX_module_access` (
   `id_profile` int(10) unsigned NOT NULL,
   `id_authorization_role` int(10) unsigned NOT NULL,
   PRIMARY KEY (`id_profile`,`id_authorization_role`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
 /* Add Payment Preferences tab. SuperAdmin profile is the only one to access it. */
 /* PHP:ps_1702_right_management(); */;

--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -1,4 +1,7 @@
 <?php
+
+use PrestaShop\PrestaShop\Core\Migrate\Migrate;
+
 /**
  * 2007-2015 PrestaShop
  *
@@ -59,14 +62,6 @@ define('INSTALL_PATH', dirname(dirname(__FILE__)).'/');
 
 require_once(INSTALL_PATH . 'install_version.php');
 
-define('SETTINGS_FILE', INSTALL_PATH . '/../config/settings.inc.php');
-
-if (file_exists(SETTINGS_FILE)) {
-    include_once(SETTINGS_FILE);
-} else {
-    die('settings.inc.php is missing (error code 30).');
-}
-
 // need for upgrade before 1.5
 if (!defined('__PS_BASE_URI__')) {
     define('__PS_BASE_URI__', str_replace('//', '/', '/'.trim(preg_replace('#/(install(-dev)?/upgrade)$#', '/', str_replace('\\', '/', dirname($_SERVER['REQUEST_URI']))), '/').'/'));
@@ -78,6 +73,9 @@ if (!defined('_THEME_NAME_')) {
 }
 
 require_once(dirname(__FILE__).'/../init.php');
+Migrate::migrateSettingsFile();
+require_once(_PS_CONFIG_DIR_.'bootstrap.php');
+
 
 // set logger
 require_once(_PS_INSTALL_PATH_.'upgrade/classes/AbstractLogger.php');

--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -1,6 +1,6 @@
 <?php
 
-use PrestaShop\PrestaShop\Core\Migrate\Migrate;
+use PrestaShopBundle\Utils\Migrate;
 
 /**
  * 2007-2015 PrestaShop

--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -142,7 +142,7 @@ if ($versionCompare == '-1') {
     $logger->logError(sprintf('You already have the %s version.', _PS_INSTALL_VERSION_));
     $fail_result .= '<action result="fail" error="28" />'."\n";
 } elseif ($versionCompare === false) {
-    $logger->logError('There is no older version. Did you delete or rename the config/settings.inc.php file?');
+    $logger->logError('There is no older version. Did you delete or rename the app/config/parameters.yml file?');
     $fail_result .= '<action result="fail" error="29" />'."\n";
 }
 
@@ -309,24 +309,6 @@ if (empty($fail_result)) {
         $sqlContent = preg_split("/;\s*[\r\n]+/", $sqlContent);
 
         $sqlContentVersion[$version] = $sqlContent;
-    }
-}
-
-
-if (empty($fail_result)) {
-    error_reporting($oldLevel);
-    $confFile = new AddConfToFile(SETTINGS_FILE, 'w');
-    if ($confFile->error) {
-        $logger->logError($confFile->error);
-        $fail_result .= '<action result="fail" error="'.$confFile->error.'" />'."\n";
-    } else {
-        foreach ($datas as $data) {
-            $confFile->writeInFile($data[0], $data[1]);
-        }
-    }
-    if ($confFile->error != false) {
-        $logger->logError($confFile->error);
-        $fail_result .= '<action result="fail" error="'.$confFile->error.'" />'."\n";
     }
 }
 

--- a/src/Core/Migrate/Migrate.php
+++ b/src/Core/Migrate/Migrate.php
@@ -36,6 +36,8 @@ class Migrate
             $generator = $factory->getLowStrengthGenerator();
             $secret    = $generator->generateString(56);
 
+            $default_parameters = Yaml::parse($root_dir.'/app/config/parameters.yml.dist');
+
             $parameters = array(
                 'parameters' => array(
                     'database_host'     => _LEGACY_DB_SERVER_,
@@ -55,7 +57,7 @@ class Migrate
                     'mailer_host'       => '127.0.0.1',
                     'mailer_user'       => '~',
                     'mailer_password'   => '~',
-                )
+                ) + $default_parameters['parameters']
             );
 
             if (file_put_contents($root_dir.'/app/config/parameters.yml', Yaml::dump($parameters))) {

--- a/src/Core/Migrate/Migrate.php
+++ b/src/Core/Migrate/Migrate.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Migrate;
+
+use Symfony\Component\Yaml\Yaml;
+use RandomLib;
+use Composer\Script\Event;
+
+class Migrate
+{
+    const SETTINGS_FILE = 'config/settings.inc.php';
+
+    public static function migrateSettingsFile(Event $event = null)
+    {
+        if ($event !== null) {
+            $event->getIO()->write("Migrating old setting file...");
+        }
+
+        if ($event) {
+            $root_dir = realpath('');
+        } else {
+            $root_dir = realpath('../../');
+        }
+
+        if (file_exists($root_dir.'/app/config/parameters.yml')) {
+            return false;
+        }
+
+        if (file_exists($root_dir.'/'.self::SETTINGS_FILE)) {
+            $tmp_settings = file_get_contents($root_dir.'/'.self::SETTINGS_FILE);
+            $tmp_settings = preg_replace('/(\'|")\_/', '$1_LEGACY_', $tmp_settings);
+            file_put_contents($root_dir.'/'.self::SETTINGS_FILE, $tmp_settings);
+            include $root_dir.'/'.self::SETTINGS_FILE;
+
+            $factory   = new RandomLib\Factory;
+            $generator = $factory->getLowStrengthGenerator();
+            $secret    = $generator->generateString(56);
+
+            $parameters = array(
+                'parameters' => array(
+                    'database_host'     => _LEGACY_DB_SERVER_,
+                    'database_port'     => '~',
+                    'database_user'     => _LEGACY_DB_USER_,
+                    'database_password' => _LEGACY_DB_PASSWD_,
+                    'database_name'     => _LEGACY_DB_NAME_,
+                    'database_prefix'   => _LEGACY_DB_PREFIX_,
+                    'database_engine'   => _LEGACY_MYSQL_ENGINE_,
+                    'cookie_key'        => _LEGACY_COOKIE_KEY_,
+                    'cookie_iv'         => _LEGACY_COOKIE_IV_,
+                    'ps_caching'        => _LEGACY_PS_CACHING_SYSTEM_,
+                    'ps_cache_enable'   => _LEGACY_PS_CACHE_ENABLED_,
+                    'ps_creation_date'  => _LEGACY_PS_CREATION_DATE_,
+                    'secret'            => $secret,
+                    'mailer_transport'  => 'smtp',
+                    'mailer_host'       => '127.0.0.1',
+                    'mailer_user'       => '~',
+                    'mailer_password'   => '~',
+                )
+            );
+
+            if (file_put_contents($root_dir.'/app/config/parameters.yml', Yaml::dump($parameters))) {
+                $settings_content = "<?php\n";
+                $settings_content .= "//@deprecated 1.7";
+
+                file_put_contents($root_dir.'/'.self::SETTINGS_FILE, $settings_content);
+            }
+        }
+        if ($event !== null) {
+            $event->getIO()->write("Finished...");
+        }
+    }
+}

--- a/src/PrestaShopBundle/Utils/Migrate.php
+++ b/src/PrestaShopBundle/Utils/Migrate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PrestaShop\PrestaShop\Core\Migrate;
+namespace PrestaShopBundle\Utils;
 
 use Symfony\Component\Yaml\Yaml;
 use RandomLib;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Properly migrate old 1.6 setting during composer install / upgrade & upgrade script |
| Type? | improvement |
| Category? | IN |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? |  |
| How to test? | composer install / update or php upgrade.php with a 1.6 config/settings.inc.php. It should generates properly the config/parameters.yml file. |
