### PR TITLE
Added a call to the Context's Translator in smarty l() when a domain is provided

### DIFF
--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -59,6 +59,10 @@ function smartyTranslate($params, &$smarty)
     $addslashes = (isset($params['slashes']) || isset($params['js']));
     $sprintf = isset($params['sprintf']) ? $params['sprintf'] : null;
 
+    if (!empty($params['d'])) {
+        return Context::getContext()->getTranslator()->trans($params['s'], $sprintf, $params['d']);
+    }
+    
     if ($pdf) {
         return Translate::smartyPostProcessTranslation(Translate::getPdfTranslation($params['s'], $sprintf), $params);
     }

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -179,6 +179,10 @@ function smartyTranslate($params, &$smarty)
     if (!isset($params['sprintf'])) {
         $params['sprintf'] = null;
     }
+    
+    if (!empty($params['d'])) {
+        return Context::getContext()->getTranslator()->trans($params['s'], (array) $params['sprintf'], $params['d']);
+    }
 
     $string = str_replace('\'', '\\\'', $params['s']);
     $filename = ((!isset($smarty->compiler_object) || !is_object($smarty->compiler_object->template)) ? $smarty->template_resource : $smarty->compiler_object->template->getTemplateFilepath());


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Added a call to the Context's Translator in smarty l() when a domain is provided |
| Type? | improvement |
| Category? | LO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | no |
| How to test? | `{l s='Showing %from%-%to% of %total% item(s)' sprintf=['%from%' => 'potato' ,'%to%' => 'potatoes', '%total%' => 42] d='Shop.Theme.Catalog'}` |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

…ain is provided
