### PR TITLE
BO : Fix return of deleted combination (PSCSX-7470)

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -468,6 +468,13 @@ class StockAvailableCore extends ObjectModel
             return false;
         }
 
+        if ((int)$id_product_attribute) {
+            $combination = new Combination((int)$id_product_attribute);
+            if (!Validate::isLoadedObject($combination)) {
+                return false;
+            }
+        }
+
         $stockManager = Adapter_ServiceLocator::get('Core_Business_Stock_StockManager');
         $stockManager->updateQuantity($product, $id_product_attribute, $delta_quantity, $id_shop = null);
         return true;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Error when returning a combination that has been deleted |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7470 |
| How to test? | Place an order with a product combination, delete the combination, return the item |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5829)
<!-- Reviewable:end -->
