### PR TITLE
BO : Allow stock transfer as soon as more than one warehouse exist

### DIFF
--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -101,7 +101,7 @@ class AdminStockManagementControllerCore extends AdminController
         $this->addRowAction('addstock');
         $this->addRowAction('removestock');
 
-        if (count(Warehouse::getWarehouses()) > 1) {
+        if (count(Warehouse::getWarehouses(true)) > 1) {
             $this->addRowAction('transferstock');
         }
 
@@ -820,7 +820,7 @@ class AdminStockManagementControllerCore extends AdminController
             $this->addRowAction('addstock');
             $this->addRowAction('removestock');
 
-            if (count(Warehouse::getWarehouses()) > 1) {
+            if (count(Warehouse::getWarehouses(true)) > 1) {
                 $this->addRowAction('transferstock');
             }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Unable to transfer stock |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Maybe http://forge.prestashop.com/browse/PSCSX-7830 |
| How to test? | Create 2 shops and 2 warehouses, one to one related. Stock transfer is not possible whatever the shop context is (even "All shops") |
