### PR TITLE
Applied 6 decimals for all money inputs in Back Office

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
   /* validate price fields , as Thomas de Nabord said */
   $(".money-type input[type='text']").change(function validate() {
     var inputValue = $(this).val();
-    var parsedValue = parseFloat(inputValue).toFixed(6);
+    var parsedValue = truncateDecimals(parseFloat(inputValue),6);
 
     $(this).val(parsedValue);
   });
@@ -1508,7 +1508,7 @@ var priceCalculation = (function() {
       }
     }
 
-    return price_with_taxes.toFixed(6);
+    return price_with_taxes;
   }
 
   /**
@@ -1625,9 +1625,10 @@ var priceCalculation = (function() {
       var rates = taxElem.find('option:selected').attr('data-rates').split(',');
       var computation_method = taxElem.find('option:selected').attr('data-computation-method');
       var newPrice = new Number(ps_round(addTaxes(price, rates, computation_method), displayPricePrecision)) + new Number(getEcotaxTaxIncluded());
+      newPrice = truncateDecimals(newPrice, 6);
 
-      priceTTCElem.val(newPrice.toFixed(6));
-      priceTTCShorcutElem.val(newPrice.toFixed(6));
+      priceTTCElem.val(newPrice);
+      priceTTCShorcutElem.val(newPrice);
     },
     'taxExclude': function() {
       var price = parseFloat(priceTTCElem.val().replace(/,/g, '.'));
@@ -1638,6 +1639,7 @@ var priceCalculation = (function() {
       var rates = taxElem.find('option:selected').attr('data-rates').split(',');
       var computation_method = taxElem.find('option:selected').attr('data-computation-method');
       var newPrice = ps_round(removeTaxes(ps_round(price - getEcotaxTaxIncluded(), displayPricePrecision), rates, computation_method), displayPricePrecision);
+      newPrice = truncateDecimals(newPrice, 6);
 
       priceHTElem.val(newPrice);
       priceHTShortcutElem.val(newPrice);
@@ -1652,6 +1654,7 @@ var priceCalculation = (function() {
       var rates = taxElem.find('option:selected').attr('data-rates').split(',');
       var computation_method = taxElem.find('option:selected').attr('data-computation-method');
       var newPrice = ps_round(addTaxes(price, rates, computation_method));
+      newPrice = truncateDecimals(newPrice, 6);
 
       targetInput.val(newPrice);
     },
@@ -1660,8 +1663,9 @@ var priceCalculation = (function() {
       var finalPrice = obj.closest('div[id^="combination_form_"]').find('.final-price');
       var defaultFinalPrice = finalPrice.attr('data-price');
       var priceToBeChanged = new Number(price) + new Number(defaultFinalPrice);
+      priceToBeChanged = truncateDecimals(newPrice, 6);
 
-      finalPrice.html(ps_round(priceToBeChanged, 6));
+      finalPrice.html(priceToBeChanged);
     },
     'impactTaxExclude': function(obj) {
       var price = parseFloat(obj.val().replace(/,/g, '.'));
@@ -1673,6 +1677,7 @@ var priceCalculation = (function() {
       var rates = taxElem.find('option:selected').attr('data-rates').split(',');
       var computation_method = taxElem.find('option:selected').attr('data-computation-method');
       var newPrice = ps_round(removeTaxes(ps_round(price, displayPricePrecision), rates, computation_method), displayPricePrecision);
+      newPrice = truncateDecimals(newPrice, 6);
 
       targetInput.val(newPrice);
     }

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -56,6 +56,14 @@ $(document).ready(function() {
     displayFieldsManager.refresh();
   });
 
+  /* validate price fields , as Thomas de Nabord said */
+  $(".money-type input[type='text']").change(function validate() {
+    var inputValue = $(this).val();
+    var parsedValue = parseFloat(inputValue).toFixed(6);
+
+    $(this).val(parsedValue);
+  });
+
   /** Attach date picker */
   $('.datepicker').datetimepicker({
     locale: iso_user,

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -57,7 +57,7 @@ $(document).ready(function() {
   });
 
   /* validate price fields , as Thomas de Nabord said */
-  $(".money-type input[type='text']").change(function validate() {
+  $(".money-type input[type='text'], .attribute-price input[type='number']").change(function validate() {
     var inputValue = $(this).val();
     var parsedValue = truncateDecimals(parseFloat(inputValue),6);
 

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1668,7 +1668,6 @@ var priceCalculation = (function() {
       finalPrice.html(priceToBeChanged);
     },
     'impactTaxExclude': function(obj) {
-      console.log('yo');
       var price = parseFloat(obj.val().replace(/,/g, '.'));
       var targetInput = obj.closest('div[id^="combination_form_"]').find('input.attribute_priceTE');
       if (isNaN(price)) {

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1481,10 +1481,11 @@ var priceCalculation = (function() {
    */
   function addTaxes(price, rates, computation_method) {
     var price_with_taxes = price;
+
     var i = 0;
     if (computation_method === '0') {
       for (i in rates) {
-        price_with_taxes *= (1 + rates[i] / 100);
+        price_with_taxes *= (1.00 + parseFloat(rates[i]) / 100.00);
         break;
       }
     } else if (computation_method === '1') {
@@ -1492,14 +1493,14 @@ var priceCalculation = (function() {
       for (i in rates) {
         rate += rates[i];
       }
-      price_with_taxes *= (1 + rate / 100);
+      price_with_taxes *= (1.00 + parseFloat(rate) / 100.00);
     } else if (computation_method === '2') {
       for (i in rates) {
-        price_with_taxes *= (1 + rates[i] / 100);
+        price_with_taxes *= (1.00 + parseFloat(rates[i]) / 100.00);
       }
     }
 
-    return price_with_taxes;
+    return price_with_taxes.toFixed(6);
   }
 
   /**
@@ -1531,8 +1532,12 @@ var priceCalculation = (function() {
   }
 
   function getEcotaxTaxIncluded() {
-    var ecotax_tax_excl = ecoTaxElem.val().replace(/,/g, '.') / (1 + ecoTaxRate);
     var displayPrecision = 6;
+    if ( ecoTaxElem.val() == 0) {
+      return ecoTaxElem.val();
+    }
+    var ecotax_tax_excl = ecoTaxElem.val()replace(/,/g, '.') / (1 + ecoTaxRate);
+
     return ps_round(ecotax_tax_excl * (1 + ecoTaxRate), displayPrecision);
   }
 
@@ -1604,17 +1609,17 @@ var priceCalculation = (function() {
       $('#form_step2_price, #form_step2_price_ttc').change();
     },
     'taxInclude': function() {
-      var price = parseFloat(priceHTElem.val().replace(/,/g, '.'));
+      var price = priceHTElem.val().replace(/,/g, '.');
       if (isNaN(price)) {
         price = 0;
       }
 
       var rates = taxElem.find('option:selected').attr('data-rates').split(',');
       var computation_method = taxElem.find('option:selected').attr('data-computation-method');
-      var newPrice = ps_round(addTaxes(price, rates, computation_method), displayPricePrecision) + getEcotaxTaxIncluded();
+      var newPrice = new Number(ps_round(addTaxes(price, rates, computation_method), displayPricePrecision)) + new Number(getEcotaxTaxIncluded());
 
-      priceTTCElem.val(newPrice);
-      priceTTCShorcutElem.val(newPrice);
+      priceTTCElem.val(newPrice.toFixed(6));
+      priceTTCShorcutElem.val(newPrice.toFixed(6));
     },
     'taxExclude': function() {
       var price = parseFloat(priceTTCElem.val().replace(/,/g, '.'));

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1532,7 +1532,8 @@ var priceCalculation = (function() {
 
   function getEcotaxTaxIncluded() {
     var ecotax_tax_excl = ecoTaxElem.val().replace(/,/g, '.') / (1 + ecoTaxRate);
-    return ps_round(ecotax_tax_excl * (1 + ecoTaxRate), 2);
+    var displayPrecision = 6;
+    return ps_round(ecotax_tax_excl * (1 + ecoTaxRate), displayPrecision);
   }
 
   function getEcotaxTaxExcluded() {
@@ -1647,7 +1648,7 @@ var priceCalculation = (function() {
       var defaultFinalPrice = finalPrice.attr('data-price');
       var priceToBeChanged = new Number(price) + new Number(defaultFinalPrice);
 
-      finalPrice.html(priceToBeChanged.toFixed(2));
+      finalPrice.html(ps_round(priceToBeChanged, 6));
     },
     'impactTaxExclude': function(obj) {
       var price = parseFloat(obj.val().replace(/,/g, '.'));

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -57,7 +57,7 @@ $(document).ready(function() {
   });
 
   /* validate price fields , as Thomas de Nabord said */
-  $(".money-type input[type='text'], .attribute-price input[type='number']").change(function validate() {
+  $(".money-type input[type='text']").change(function validate(event) {
     var inputValue = $(this).val();
     var parsedValue = truncateDecimals(parseFloat(inputValue),6);
 
@@ -1653,7 +1653,7 @@ var priceCalculation = (function() {
       }
       var rates = taxElem.find('option:selected').attr('data-rates').split(',');
       var computation_method = taxElem.find('option:selected').attr('data-computation-method');
-      var newPrice = ps_round(addTaxes(price, rates, computation_method));
+      var newPrice = ps_round(addTaxes(price, rates, computation_method), 6);
       newPrice = truncateDecimals(newPrice, 6);
 
       targetInput.val(newPrice);
@@ -1663,11 +1663,12 @@ var priceCalculation = (function() {
       var finalPrice = obj.closest('div[id^="combination_form_"]').find('.final-price');
       var defaultFinalPrice = finalPrice.attr('data-price');
       var priceToBeChanged = new Number(price) + new Number(defaultFinalPrice);
-      priceToBeChanged = truncateDecimals(newPrice, 6);
+      priceToBeChanged = truncateDecimals(priceToBeChanged, 6);
 
       finalPrice.html(priceToBeChanged);
     },
     'impactTaxExclude': function(obj) {
+      console.log('yo');
       var price = parseFloat(obj.val().replace(/,/g, '.'));
       var targetInput = obj.closest('div[id^="combination_form_"]').find('input.attribute_priceTE');
       if (isNaN(price)) {
@@ -1676,7 +1677,7 @@ var priceCalculation = (function() {
       }
       var rates = taxElem.find('option:selected').attr('data-rates').split(',');
       var computation_method = taxElem.find('option:selected').attr('data-computation-method');
-      var newPrice = ps_round(removeTaxes(ps_round(price, displayPricePrecision), rates, computation_method), displayPricePrecision);
+      var newPrice = removeTaxes(ps_round(price, displayPricePrecision), rates, computation_method);
       newPrice = truncateDecimals(newPrice, 6);
 
       targetInput.val(newPrice);

--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -54,7 +54,7 @@ var combinations = (function() {
       var actualFinalPrice = actualFinalPriceInput.data('price');
 
       var finalPrice = new Number(actualFinalPrice) + new Number(impactOnPrice);
-      actualFinalPriceInput.html(finalPrice.toFixed(2));
+      actualFinalPriceInput.html(ps_round(finalPrice, 6));
   }
 
   return {

--- a/admin-dev/themes/default/template/controllers/attribute_generator/content.tpl
+++ b/admin-dev/themes/default/template/controllers/attribute_generator/content.tpl
@@ -50,9 +50,9 @@
 			if (!isNaN(element_price))
 			{
 				if (element_has_tax)
-					other_element_price = parseFloat(element_price / ((product_tax / 100) + 1)).toFixed(6);
+					other_element_price = ps_round(parseFloat(element_price / ((product_tax / 100) + 1)), 6);
 				else
-					other_element_price = ps_round(parseFloat(element_price * ((product_tax / 100) + 1)), 2).toFixed(2);
+					other_element_price = ps_round(parseFloat(element_price * ((product_tax / 100) + 1)), 6);
 			}
 
 			$('#related_to_'+element.attr('name')).val(other_element_price);

--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -351,7 +351,7 @@
 				id_product: id_product,
 				id_product_attribute: id_product_attribute,
 				id_customer: id_customer,
-				price: ps_round(new Number(new_price.replace(",",".")), 6).toString(),
+				price: ps_round(new Number(new_price.replace(",",".")), 6).toString()
 				},
 			success : function(res)
 			{

--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -351,7 +351,7 @@
 				id_product: id_product,
 				id_product_attribute: id_product_attribute,
 				id_customer: id_customer,
-				price: new Number(new_price.replace(",",".")).toFixed(4).toString()
+				price: ps_round(new Number(new_price.replace(",",".")), 6).toString(),
 				},
 			success : function(res)
 			{

--- a/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
+++ b/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
@@ -173,7 +173,7 @@ export default function() {
         jQueryFinalPriceEl.data('price', newPrice);
         // calculate new price
         var newFinalPrice = new Number(newPrice) + new Number(impactOnPrice);
-        jQueryFinalPriceEl.text(newFinalPrice.toFixed(2));
+        jQueryFinalPriceEl.text(ps_round(newFinalPrice, 6));
       });
     }
   };

--- a/admin-dev/themes/new-theme/public/bundle.js
+++ b/admin-dev/themes/new-theme/public/bundle.js
@@ -88264,7 +88264,7 @@
 	        jQueryFinalPriceEl.data('price', newPrice);
 	        // calculate new price
 	        var newFinalPrice = new Number(newPrice) + new Number(impactOnPrice);
-	        jQueryFinalPriceEl.text(newFinalPrice.toFixed(2));
+	        jQueryFinalPriceEl.text(ps_round(newFinalPrice, 6));
 	      });
 	    }
 	  };

--- a/js/tools.js
+++ b/js/tools.js
@@ -42,7 +42,7 @@ function formatedNumberToFloat(price, currencyFormat, currencySign)
 
 /**
  * @deprecated Please use asynchronous formatNumberCldr() instead.
- * 
+ *
  * @param value float The number to format
  * @param numberOfDecimal Size of fractionnal part in the number
  * @param thousenSeparator Not used anymore
@@ -61,14 +61,14 @@ function formatNumber(value, numberOfDecimal, thousenSeparator, virgule)
 /**
  * This call will load CLDR data to format a number according to the page locale, and then send formatted
  * number into parameter of the callback function. This function is asynchronous as AJAX calls may occur.
- * 
+ *
  * @param value float The number to format
  * @param callback The function to call with the resulting formatted number as unique parameter
  * @param numberOfDecimal Size of fractionnal part in the number
  */
 function formatNumberCldr(value, callback, numberOfDecimal) {
 	if (typeof numberOfDecimal === 'undefined') numberOfDecimal = 2;
-	
+
 	cldrForNumber(function(globalize) {
 		var result = globalize.numberFormatter({
 			minimumFractionDigits: 2,
@@ -80,7 +80,7 @@ function formatNumberCldr(value, callback, numberOfDecimal) {
 
 /**
  * @deprecated Please use asynchronous formatCurrencyCldr() instead.
- * 
+ *
  * @param price float The value to format in a price
  * @param currencyFormat Not used anymore
  * @param currencySign Not used anymore
@@ -98,7 +98,7 @@ function formatCurrency(price, currencyFormat, currencySign, currencyBlank)
 /**
  * This call will load CLDR data to format a price according to the page locale, and then send formatted
  * price into parameter of the callback function. This function is asynchronous as AJAX calls may occur.
- * 
+ *
  * @param price float The price to format
  * @param callback The function to call with the resulting formatted price as unique parameter
  */
@@ -246,6 +246,15 @@ function toggleMultiple(tab)
     for (var i = 0; i < len; i++)
         if (tab[i].style)
             toggle(tab[i], tab[i].style.display == 'none');
+}
+
+function truncateDecimals(value, decimals)
+{
+  var numPower = Math.pow(10, decimals);
+
+  var value = ~~(value * numPower)/numPower;
+
+  return value.toFixed(decimals);
 }
 
 /**

--- a/src/Adapter/Tools.php
+++ b/src/Adapter/Tools.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2015 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -23,11 +23,10 @@
  *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *  International Registered Trademark & Property of PrestaShop SA
  */
-
 namespace PrestaShop\PrestaShop\Adapter;
 
 /**
- * This adapter will complete the new architecture Tools
+ * This adapter will complete the new architecture Tools.
  *
  * Please put only wrappers and equivalents from Legacy \Tools class.
  * (only for this purpose, this is not here to put new utils functions).
@@ -35,10 +34,11 @@ namespace PrestaShop\PrestaShop\Adapter;
 class Tools
 {
     /**
-     * Return the friendly url from the provided string
+     * Return the friendly url from the provided string.
      *
      * @param string $str
-     * @param bool $utf8_decode (deprecated)
+     * @param bool   $utf8_decode (deprecated)
+     *
      * @return string
      */
     public function link_rewrite($str, $utf8_decode = null)
@@ -46,6 +46,74 @@ class Tools
         if ($utf8_decode !== null) {
             \ToolsCore::displayParameterAsDeprecated('utf8_decode');
         }
+
         return \ToolsCore::str2url($str);
+    }
+
+    /**
+     * Polyfill for bcadd if BC Math extension is not installed.
+     */
+    public function bcadd($left_operand, $right_operand, $scale = null)
+    {
+        if (function_exists('bcadd')) {
+            return bcadd($left_operand, $right_operand, $scale);
+        }
+
+        // from http://php.net/manual/en/function.bcadd.php#92252
+        // check if they're valid positive numbers, extract the whole numbers and decimals
+        if (!preg_match("/^\+?(\d+)(\.\d+)?$/", $left_operand, $Tmp1) ||
+            !preg_match("/^\+?(\d+)(\.\d+)?$/", $right_operand, $Tmp2)) {
+            return '0';
+        }
+
+        // this is where the result is stored
+        $Output = array();
+
+        // remove ending zeroes from decimals and remove point
+        $Dec1 = isset($Tmp1[2]) ? rtrim(substr($Tmp1[2], 1), '0') : '';
+        $Dec2 = isset($Tmp2[2]) ? rtrim(substr($Tmp2[2], 1), '0') : '';
+
+        // calculate the longest length of decimals
+        $DLen = max(strlen($Dec1), strlen($Dec2));
+
+        // if $Scale is null, automatically set it to the amount of decimal places for accuracy
+        if ($scale == null) {
+            $Scale = $DLen;
+        }
+
+        // remove leading zeroes and reverse the whole numbers, then append padded decimals on the end
+        $Num1 = strrev(ltrim($Tmp1[1], '0').str_pad($Dec1, $DLen, '0'));
+        $Num2 = strrev(ltrim($Tmp2[1], '0').str_pad($Dec2, $DLen, '0'));
+
+        // calculate the longest length we need to process
+        $MLen = max(strlen($Num1), strlen($Num2));
+
+        // pad the two numbers so they are of equal length (both equal to $MLen)
+        $Num1 = str_pad($Num1, $MLen, '0');
+        $Num2 = str_pad($Num2, $MLen, '0');
+
+        // process each digit, keep the ones, carry the tens (remainders)
+        for ($i = 0;$i < $MLen;++$i) {
+            $Sum = ((int) $Num1{$i} + (int) $Num2{$i});
+            if (isset($Output[$i])) {
+                $Sum += $Output[$i];
+            }
+            $Output[$i] = $Sum % 10;
+            if ($Sum > 9) {
+                $Output[$i + 1] = 1;
+            }
+        }
+
+        // convert the array to string and reverse it
+        $Output = strrev(implode($Output));
+
+        // substring the decimal digits from the result, pad if necessary (if $Scale > amount of actual decimals)
+        // next, since actual zero values can cause a problem with the substring values, if so, just simply give '0'
+        // next, append the decimal value, if $Scale is defined, and return result
+        $Decimal = str_pad(substr($Output, -$DLen, $scale), $scale, '0');
+        $Output = (($MLen - $DLen < 1) ? '0' : substr($Output, 0, -$DLen));
+        $Output .= (($scale > 0) ? ".{$Decimal}" : '');
+
+        return $Output;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
@@ -57,7 +57,7 @@ class ProductCombinationBulk extends CommonAbstractType
         ->add('cost_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Cost Price', [], 'Admin.Catalog.Feature'),
-            'attr' => ['data-display-price-precision' => $this->priceDisplayPrecision],
+            'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
             'currency' => $this->isoCode,
         ))
         ->add('impact_on_weight', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -83,7 +83,7 @@ class ProductPrice extends CommonAbstractType
         $builder->add('price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
-            'attr' => ['data-display-price-precision' => $this->configuration->get('_PS_PRICE_DISPLAY_PRECISION_')],
+            'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
             'currency' => $this->currency->iso_code,
             'constraints' => array(
                 new Assert\NotBlank(),

--- a/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
@@ -33,6 +33,8 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
  */
 abstract class CommonAbstractType extends AbstractType
 {
+    const PRESTASHOP_DECIMALS = 6;
+    
     /**
      * Get the configuration adapter
      *

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * 2007-2015 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CustomMoneyType extends AbstractTypeExtension
+{
+    const PRESTASHOP_DECIMALS = 6;
+    
+    public function getExtendedType()
+    {
+        return 'Symfony\Component\Form\Extension\Core\Type\MoneyType';
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $scale = function (Options $options) {
+            if (null !== $options['precision']) {
+                @trigger_error('The form option "precision" is deprecated since version 2.7 and will be removed in 3.0. Use "scale" instead.', E_USER_DEPRECATED);
+
+                return $options['precision'];
+            }
+
+            return self::PRESTASHOP_DECIMALS;
+        };
+
+        $resolver->setDefaults(array(
+            // deprecated as of Symfony 2.7, to be removed in Symfony 3.0
+            'precision' => null,
+            'scale' => $scale,
+            'grouping' => false,
+            'divisor' => 1,
+            'currency' => 'EUR',
+            'compound' => false,
+        ));
+
+        $resolver->setAllowedTypes('scale', 'int');
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -26,38 +26,25 @@
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CustomMoneyType extends AbstractTypeExtension
 {
     const PRESTASHOP_DECIMALS = 6;
-    
+
     public function getExtendedType()
     {
         return 'Symfony\Component\Form\Extension\Core\Type\MoneyType';
     }
-    
+
     /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $scale = function (Options $options) {
-            if (null !== $options['precision']) {
-                @trigger_error('The form option "precision" is deprecated since version 2.7 and will be removed in 3.0. Use "scale" instead.', E_USER_DEPRECATED);
-
-                return $options['precision'];
-            }
-
-            return self::PRESTASHOP_DECIMALS;
-        };
-
         $resolver->setDefaults(array(
-            // deprecated as of Symfony 2.7, to be removed in Symfony 3.0
             'precision' => null,
-            'scale' => $scale,
+            'scale' => self::PRESTASHOP_DECIMALS,
             'grouping' => false,
             'divisor' => 1,
             'currency' => 'EUR',

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Adapter\Warehouse\WarehouseDataProvider;
 use PrestaShop\PrestaShop\Adapter\Feature\FeatureDataProvider;
 use PrestaShop\PrestaShop\Adapter\Pack\PackDataProvider;
 use PrestaShop\PrestaShop\Adapter\Shop\Context as ShopContext;
+use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 
 /**
  * This form class is responsible to map the form data to the product object
@@ -781,7 +782,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             'attribute_price_impact' => $attribute_price_impact,
             'attribute_price' => $combination['price'],
             'attribute_price_display' => $this->cldrRepository->getPrice($combination['price'], $this->contextShop->currency->iso_code),
-            'final_price' => $this->product->price + $combination['price'],
+            'final_price' => $this->tools->bcadd($this->product->price, $combination['price'], CommonAbstractType::PRESTASHOP_DECIMALS),
             'attribute_priceTI' => '',
             'attribute_ecotax' => $combination['ecotax'],
             'attribute_weight_impact' => $attribute_weight_impact,

--- a/src/PrestaShopBundle/Resources/config/admin/services-form.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services-form.yml
@@ -189,3 +189,8 @@ services:
         class: PrestaShopBundle\Form\Admin\Type\TextEmptyType
         tags:
             - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\TextType }
+    
+    form.type.extension.money:
+        class: PrestaShopBundle\Form\Admin\Type\CustomMoneyType
+        tags:
+            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\MoneyType }

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_3_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_3_layout.html.twig
@@ -21,7 +21,7 @@
 {%- endblock %}
 
 {% block money_widget -%}
-    <div class="input-group">
+    <div class="input-group money-type">
         {% set prepend = '{{' == money_pattern[0:2] %}
         {% if not prepend %}
             <span class="input-group-addon">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Once and for all, as prices are stored with 6 decimals in Back Office, lets display it the right way |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-912 |
| How to test? | Every money type in back office, for Product page now have 6 decimals. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
