### PR TITLE
When string uses domains sprintf() must be an array and tags() must be removed

### DIFF
--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -60,6 +60,22 @@ function smartyTranslate($params, &$smarty)
     $sprintf = isset($params['sprintf']) ? $params['sprintf'] : array();
 
     if (!empty($params['d'])) {
+        if (isset($params['tags'])) {
+            $backTrace = debug_backtrace();
+
+            $errorMessage = sprintf(
+                'Unable to translate "%s" in %s. tags() is not supported anymore, please use sprintf().',
+                $params['s'],
+                $backTrace[0]['args'][1]->template_resource
+            );
+
+            if (_PS_MODE_DEV_) {
+                throw new Exception($errorMessage);
+            } else {
+                PrestaShopLogger::addLog($errorMessage);
+            }
+        }
+
         if (!is_array($sprintf)) {
             $backTrace = debug_backtrace();
 

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -57,10 +57,27 @@ function smartyTranslate($params, &$smarty)
     $htmlentities = !isset($params['js']);
     $pdf = isset($params['pdf']);
     $addslashes = (isset($params['slashes']) || isset($params['js']));
-    $sprintf = isset($params['sprintf']) ? $params['sprintf'] : null;
+    $sprintf = isset($params['sprintf']) ? $params['sprintf'] : array();
 
     if (!empty($params['d'])) {
-        return Context::getContext()->getTranslator()->trans($params['s'], (array) $sprintf, $params['d']);
+        if (!is_array($sprintf)) {
+            $backTrace = debug_backtrace();
+
+            $errorMessage = sprintf(
+                'Unable to translate "%s" in %s. sprintf() parameter should be an array.',
+                $params['s'],
+                $backTrace[0]['args'][1]->template_resource
+            );
+
+            if (_PS_MODE_DEV_) {
+                throw new Exception($errorMessage);
+            } else {
+                PrestaShopLogger::addLog($errorMessage);
+                return $params['s'];
+            }
+        }
+
+        return Context::getContext()->getTranslator()->trans($params['s'], $sprintf, $params['d']);
     }
 
     if ($pdf) {

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -181,6 +181,22 @@ function smartyTranslate($params, &$smarty)
     }
 
     if (!empty($params['d'])) {
+        if (isset($params['tags'])) {
+            $backTrace = debug_backtrace();
+
+            $errorMessage = sprintf(
+                'Unable to translate "%s" in %s. tags() is not supported anymore, please use sprintf().',
+                $params['s'],
+                $backTrace[0]['args'][1]->template_resource
+            );
+
+            if (_PS_MODE_DEV_) {
+                throw new Exception($errorMessage);
+            } else {
+                PrestaShopLogger::addLog($errorMessage);
+            }
+        }
+
         if (!is_array($params['sprintf'])) {
             $backTrace = debug_backtrace();
 

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -177,11 +177,28 @@ function smartyTranslate($params, &$smarty)
         $params['mod'] = false;
     }
     if (!isset($params['sprintf'])) {
-        $params['sprintf'] = null;
+        $params['sprintf'] = array();
     }
-    
+
     if (!empty($params['d'])) {
-        return Context::getContext()->getTranslator()->trans($params['s'], (array) $params['sprintf'], $params['d']);
+        if (!is_array($params['sprintf'])) {
+            $backTrace = debug_backtrace();
+
+            $errorMessage = sprintf(
+                'Unable to translate "%s" in %s. sprintf() parameter should be an array.',
+                $params['s'],
+                $backTrace[0]['args'][1]->template_resource
+            );
+
+            if (_PS_MODE_DEV_) {
+                throw new Exception($errorMessage);
+            } else {
+                PrestaShopLogger::addLog($errorMessage);
+                return $params['s'];
+            }
+        }
+
+        return Context::getContext()->getTranslator()->trans($params['s'], $params['sprintf'], $params['d']);
     }
 
     $string = str_replace('\'', '\\\'', $params['s']);

--- a/themes/classic/modules/blockcart/modal.tpl
+++ b/themes/classic/modules/blockcart/modal.tpl
@@ -28,9 +28,9 @@
           <div class="col-md-6">
             <div class="cart-content">
               {if $cart.products_count > 1}
-                <p class="cart-products-count">{l s='There are %s items in your cart.' sprintf=$cart.products_count d='Shop.Theme.Checkout'}</p>
+                <p class="cart-products-count">{l s='There are %products_count% items in your cart.' sprintf=['%products_count%' => $cart.products_count] d='Shop.Theme.Checkout'}</p>
               {else}
-                <p class="cart-products-count">{l s='There is %s item in your cart.' sprintf=$cart.products_count d='Shop.Theme.Checkout'}</p>
+                <p class="cart-products-count">{l s='There is %product_count% item in your cart.' sprintf=['%product_count%' =>$cart.products_count] d='Shop.Theme.Checkout'}</p>
               {/if}
               <p><strong>{l s='Total products:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.subtotals.products.value}</p>
               <p><strong>{l s='Total shipping:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.subtotals.shipping.value}</p>

--- a/themes/classic/modules/ps_contactinfo/nav.tpl
+++ b/themes/classic/modules/ps_contactinfo/nav.tpl
@@ -24,7 +24,16 @@
 *}
 <div id="contact-link">
   {if $contact_infos.phone}
-    {l s='Call us: [1]%phone%[/1]' tags=['<span>'] sprintf=['%phone%' => $contact_infos.phone] d='Shop.Theme'}
+    {* [1][/1] is for a HTML tag. *}
+    {l
+      s='Call us: [1]%phone%[/1]'
+      sprintf=[
+        '[1]' => '<span>',
+        '[/1]' => '</span>',
+        '%phone%' => $contact_infos.phone
+      ]
+      d='Shop.Theme'
+    }
   {else}
     <a href="{$urls.pages.contact}">{l s='Contact us' d='Shop.Theme'}</a>
   {/if}

--- a/themes/classic/modules/ps_contactinfo/nav.tpl
+++ b/themes/classic/modules/ps_contactinfo/nav.tpl
@@ -24,7 +24,7 @@
 *}
 <div id="contact-link">
   {if $contact_infos.phone}
-    {l s='Call us: [1]%s[/1]' tags=['<span>'] sprintf=$contact_infos.phone d='Shop.Theme'}
+    {l s='Call us: [1]%phone%[/1]' tags=['<span>'] sprintf=['%phone%' => $contact_infos.phone] d='Shop.Theme'}
   {else}
     <a href="{$urls.pages.contact}">{l s='Contact us' d='Shop.Theme'}</a>
   {/if}

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -26,7 +26,7 @@
 <div class="block-contact col-md-4 pull-md-right">
 	<h4 class="text-uppercase block-contact-title">{l s='Store information' d='Shop.Theme'}</h4>
     {$contact_infos.address.formatted nofilter}
-    {if $contact_infos.phone}<br>{l s='Call us: [1]%s[/1]' tags=['<span>'] sprintf=$contact_infos.phone}{/if}
-    {if $contact_infos.fax}<br>{l s='Fax: [1]%s[/1]' tags=['<span>'] sprintf=$contact_infos.fax}{/if}
-    {if $contact_infos.email}<br>{l s='Email us: [1]%s[/1]' tags=['<span>'] sprintf=$contact_infos.email}{/if}
+    {if $contact_infos.phone}<br>{l s='Call us: [1]%phone%[/1]' tags=['<span>'] sprintf=['%phone%' => $contact_infos.phone]}{/if}
+    {if $contact_infos.fax}<br>{l s='Fax: [1]%fax%[/1]' tags=['<span>'] sprintf=['%fax%' => $contact_infos.fax]}{/if}
+    {if $contact_infos.email}<br>{l s='Email us: [1]%email%[/1]' tags=['<span>'] sprintf=['%email%' => $contact_infos.email]}{/if}
 </div>

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -26,7 +26,7 @@
 <div class="block-contact col-md-4 pull-md-right">
 	<h4 class="text-uppercase block-contact-title">{l s='Store information' d='Shop.Theme'}</h4>
     {$contact_infos.address.formatted nofilter}
-    {if $contact_infos.phone}<br>{l s='Call us: [1]%phone%[/1]' tags=['<span>'] sprintf=['%phone%' => $contact_infos.phone]}{/if}
-    {if $contact_infos.fax}<br>{l s='Fax: [1]%fax%[/1]' tags=['<span>'] sprintf=['%fax%' => $contact_infos.fax]}{/if}
-    {if $contact_infos.email}<br>{l s='Email us: [1]%email%[/1]' tags=['<span>'] sprintf=['%email%' => $contact_infos.email]}{/if}
+    {if $contact_infos.phone}<br>{l s='Call us: [1]%phone%[/1]' tags=['<span>'] sprintf=['%phone%' => $contact_infos.phone] d='Shop.Theme'}{/if}
+    {if $contact_infos.fax}<br>{l s='Fax: [1]%fax%[/1]' tags=['<span>'] sprintf=['%fax%' => $contact_infos.fax] d='Shop.Theme'}{/if}
+    {if $contact_infos.email}<br>{l s='Email us: [1]%email%[/1]' tags=['<span>'] sprintf=['%email%' => $contact_infos.email] d='Shop.Theme'}{/if}
 </div>

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -26,7 +26,42 @@
 <div class="block-contact col-md-4 pull-md-right">
 	<h4 class="text-uppercase block-contact-title">{l s='Store information' d='Shop.Theme'}</h4>
     {$contact_infos.address.formatted nofilter}
-    {if $contact_infos.phone}<br>{l s='Call us: [1]%phone%[/1]' tags=['<span>'] sprintf=['%phone%' => $contact_infos.phone] d='Shop.Theme'}{/if}
-    {if $contact_infos.fax}<br>{l s='Fax: [1]%fax%[/1]' tags=['<span>'] sprintf=['%fax%' => $contact_infos.fax] d='Shop.Theme'}{/if}
-    {if $contact_infos.email}<br>{l s='Email us: [1]%email%[/1]' tags=['<span>'] sprintf=['%email%' => $contact_infos.email] d='Shop.Theme'}{/if}
+    {if $contact_infos.phone}
+      <br>
+      {* [1][/1] is for a HTML tag. *}
+      {l s='Call us: [1]%phone%[/1]'
+        sprintf=[
+        '[1]' => '<span>',
+        '[/1]' => '</span>',
+        '%phone%' => $contact_infos.phone
+        ]
+        d='Shop.Theme'
+      }
+    {/if}
+    {if $contact_infos.fax}
+      <br>
+      {* [1][/1] is for a HTML tag. *}
+      {l
+        s='Fax: [1]%fax%[/1]'
+        sprintf=[
+          '[1]' => '<span>',
+          '[/1]' => '</span>',
+          '%fax%' => $contact_infos.fax
+        ]
+        d='Shop.Theme'
+      }
+    {/if}
+    {if $contact_infos.email}
+      <br>
+      {* [1][/1] is for a HTML tag. *}
+      {l
+        s='Email us: [1]%email%[/1]'
+        sprintf=[
+          '[1]' => '<span>',
+          '[/1]' => '</span>',
+          '%email%' => $contact_infos.email
+        ]
+        d='Shop.Theme'
+      }
+    {/if}
 </div>

--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -53,9 +53,13 @@
                   <input type="checkbox" name="confirm-optin" value="1" required>
                   <span><i class="material-icons checkbox-checked"></i></span>
                   <label>
+                    {* [1][/1] is for a HTML tag. *}
                     {l
                       s='I want to receive the free newsletter and have read and accepted the [1]conditions[/1].'
-                      tags=['<a data-toggle="modal" data-target="#ps_emailsubscription-modal">']
+                      sprintf=[
+                        '[1]' => '<a data-toggle="modal" data-target="#ps_emailsubscription-modal">',
+                        '[/1]' => '</a>'
+                      ]
                       d='Shop.Theme'
                     }
                   </label>

--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -9,7 +9,11 @@
   {block name='product_minimal_quantity'}
     {if $product.minimal_quantity > 1}
       <p class="product-minimal-quantity">
-        {l s='The minimum purchase order quantity for the product is %s.' d='Shop.Theme.Checkout' sprintf=$product.minimal_quantity}
+        {l
+          s='The minimum purchase order quantity for the product is %quantity%.'
+          d='Shop.Theme.Checkout'
+          sprintf=['%quantity%' => $product.minimal_quantity]
+        }
       </p>
     {/if}
   {/block}

--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -27,9 +27,9 @@
 
         {if $product.has_discount}
           {if $product.discount_type === 'percentage'}
-            <span class="discount discount-percentage">{l s='Save %s' d='Shop.Theme.Catalog' sprintf=$product.discount_percentage}</span>
+            <span class="discount discount-percentage">{l s='Save %percentage%' d='Shop.Theme.Catalog' sprintf=['%percentage%' => $product.discount_percentage]}</span>
           {else}
-            <span class="discount discount-amount">{l s='Save %s' d='Shop.Theme.Catalog' sprintf=$product.discount_amount}</span>
+            <span class="discount discount-amount">{l s='Save %amount%' d='Shop.Theme.Catalog' sprintf=['%amount%' => $product.discount_amount]}</span>
           {/if}
         {/if}
       </p>
@@ -37,19 +37,19 @@
 
     {block name='product_without_taxes'}
       {if $priceDisplay == 2}
-        <p class="product-without-taxes">{l s='%s tax excl.' d='Shop.Theme.Catalog' sprintf=$product.price_tax_exc}</p>
+        <p class="product-without-taxes">{l s='%price% tax excl.' d='Shop.Theme.Catalog' sprintf=['%price%' => $product.price_tax_exc]}</p>
       {/if}
     {/block}
 
     {block name='product_pack_price'}
       {if $displayPackPrice}
-        <p class="product-pack-price"><span>{l s='Instead of %s' d='Shop.Theme.Catalog' sprintf=$noPackPrice}</span></p>
+        <p class="product-pack-price"><span>{l s='Instead of %price%' d='Shop.Theme.Catalog' sprintf=['%price%' => $noPackPrice]}</span></p>
       {/if}
     {/block}
 
     {block name='product_ecotax'}
       {if $product.ecotax.amount > 0}
-        <p class="price-ecotax">{l s='Including %s for ecotax' d='Shop.Theme.Catalog' sprintf=$product.ecotax.value}
+        <p class="price-ecotax">{l s='Including %amount% for ecotax' d='Shop.Theme.Catalog' sprintf=['%amount%' => $product.ecotax.value]}
           {if $product.has_discount}
             {l s='(not impacted by the discount)' d='Shop.Theme.Catalog'}
           {/if}
@@ -59,7 +59,7 @@
 
     {block name='product_unit_price'}
       {if $displayUnitPrice}
-        <p class="product-unit-price sub">{l s='(%s)' d='Shop.Theme.Catalog' sprintf=[$product.unit_price_full]}</p>
+        <p class="product-unit-price sub">{l s='(%unit_price%)' d='Shop.Theme.Catalog' sprintf=['%unit_price%' => $product.unit_price_full]}</p>
       {/if}
     {/block}
 

--- a/themes/classic/templates/catalog/_partials/products.tpl
+++ b/themes/classic/templates/catalog/_partials/products.tpl
@@ -8,9 +8,9 @@
           <div class="products-select">
             <div>
               {if $products|count > 1}
-                <p>{l s='There are %s products.' d='Shop.Theme.Catalog' sprintf=$products|count}</p>
+                <p>{l s='There are %product_count% products.' d='Shop.Theme.Catalog' sprintf=['%product_count%' => $products|count]}</p>
               {else}
-                <p>{l s='There is %s products.' d='Shop.Theme.Catalog' sprintf=$products|count}</p>
+                <p>{l s='There is %products_count% products.' d='Shop.Theme.Catalog' sprintf=['%products_count%' => $products|count]}</p>
               {/if}
             </div>
             <div>

--- a/themes/classic/templates/catalog/manufacturer.tpl
+++ b/themes/classic/templates/catalog/manufacturer.tpl
@@ -4,7 +4,7 @@
   <section id="main">
 
     {block name='manufacturer_header'}
-      <h1>{l s='List of products by manufacturer %s' d='Shop.Theme.Catalog' sprintf=$manufacturer.name}</h1>
+      <h1>{l s='List of products by manufacturer %name%' d='Shop.Theme.Catalog' sprintf=['%name%' => $manufacturer.name]}</h1>
       <div id="manufacturer-short_description">{$manufacturer.short_description nofilter}</div>
       <div id="manufacturer-description">{$manufacturer.description nofilter}</div>
     {/block}

--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -109,7 +109,7 @@
                               <tr data-discount-type="{$quantity_discount.reduction_type}" data-discount="{$quantity_discount.real_value}" data-discount-quantity="{$quantity_discount.quantity}">
                                 <td>{$quantity_discount.quantity}</td>
                                 <td>{$quantity_discount.discount}</td>
-                                <td>{l s='Up to %s' d='Shop.Theme.Catalog' sprintf=$quantity_discount.save}</td>
+                                <td>{l s='Up to %discount%' d='Shop.Theme.Catalog' sprintf=['%discount%' => $quantity_discount.save]}</td>
                               </tr>
                             {/foreach}
                           </tbody>

--- a/themes/classic/templates/catalog/supplier.tpl
+++ b/themes/classic/templates/catalog/supplier.tpl
@@ -4,7 +4,7 @@
   <section id="main">
 
     {block name='supplier_header'}
-      <h1>{l s='List of products by supplier %s' d='Shop.Theme.Catalog' sprintf=$supplier.name}</h1>
+      <h1>{l s='List of products by supplier %name%' d='Shop.Theme.Catalog' sprintf=['%name%' => $supplier.name]}</h1>
       <div id="supplier-description">{$supplier.description nofilter}</div>
     {/block}
 

--- a/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
@@ -4,9 +4,9 @@
 <div id="order-items" class="col-md-12">
   <h3 class="card-title h3">
     {if $products_count == 1}
-       {l s='%s item in your cart' sprintf=$products_count d='Shop.Theme.Checkout'}
+       {l s='%product_count% item in your cart' sprintf=['%product_count%' => $products_count] d='Shop.Theme.Checkout'}
     {else}
-       {l s='%s items in your cart' sprintf=$products_count d='Shop.Theme.Checkout'}
+       {l s='%products_count% items in your cart' sprintf=['%products_count%' => $products_count] d='Shop.Theme.Checkout'}
     {/if}
   	<a href="{url entity=cart params=['action' => 'show']}"><span class="step-edit"><i class="material-icons edit">mode_edit</i> edit</span></a>
   </h3>

--- a/themes/classic/templates/checkout/_partials/steps/personal-information.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/personal-information.tpl
@@ -4,9 +4,9 @@
   {if $customer.is_logged && !$customer.is_guest}
 
     <p class="identity">
-      {l s='Connected as [1]%1$s %2$s[/1].'
+      {l s='Connected as [1]%firstname% %lastname%[/1].'
         d='Shop.Theme.CustomerAccount'
-        sprintf=[$customer.firstname, $customer.lastname]
+        sprintf=['%firstname%' => $customer.firstname, '%lastname%' => $customer.lastname]
         tags=["<a href='{$urls.pages.identity}'>"]
       }
     </p>

--- a/themes/classic/templates/checkout/_partials/steps/personal-information.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/personal-information.tpl
@@ -4,13 +4,28 @@
   {if $customer.is_logged && !$customer.is_guest}
 
     <p class="identity">
+      {* [1][/1] is for a HTML tag. *}
       {l s='Connected as [1]%firstname% %lastname%[/1].'
         d='Shop.Theme.CustomerAccount'
-        sprintf=['%firstname%' => $customer.firstname, '%lastname%' => $customer.lastname]
-        tags=["<a href='{$urls.pages.identity}'>"]
+        sprintf=[
+          '[1]' => "<a href='{$urls.pages.identity}'>",
+          '[/1]' => "</a>",
+          '%firstname%' => $customer.firstname,
+          '%lastname%' => $customer.lastname
+        ]
       }
     </p>
-    <p>{l s='Not you? [1]Log out[/1]' d='Shop.Theme.CustomerAccount' tags=["<a href='{$urls.actions.logout}'>"]}</p>
+    <p>
+      {* [1][/1] is for a HTML tag. *}
+      {l
+        s='Not you? [1]Log out[/1]'
+        d='Shop.Theme.CustomerAccount'
+        sprintf=[
+        '[1]' => "<a href='{$urls.actions.logout}'>",
+        '[/1]' => "</a>"
+        ]
+      }
+    </p>
     <p><small>{l s='If you sign out now, your cart will be emptied.' d='Shop.Theme.Checkout'}</small></p>
 
   {else}

--- a/themes/classic/templates/checkout/order-confirmation.tpl
+++ b/themes/classic/templates/checkout/order-confirmation.tpl
@@ -9,7 +9,7 @@
               <i class="material-icons done">&#xE876;</i>{l s='Your order is confirmed' d='Shop.Theme.Checkout'}
             </h3>
             <p>
-              {l s='An email has been sent to your mail address %s.' d='Shop.Theme.Checkout' sprintf=$customer.email}
+              {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $customer.email]}
               {if $order.details.invoice_url}
                 {l
                   s='You can also [1]download your invoice[/1]'
@@ -43,10 +43,10 @@
         <div id="order-details" class="col-md-4">
           <h3 class="h3 card-title">{l s='Order details' d='Shop.Theme.Checkout'}:</h3>
           <ul>
-            <li>{l s='Order reference: %s' d='Shop.Theme.Checkout' sprintf=$order.details.reference}</li>
-            <li>{l s='Payment method: %s' d='Shop.Theme.Checkout' sprintf=$order.details.payment}</li>
+            <li>{l s='Order reference: %reference%' d='Shop.Theme.Checkout' sprintf=['%reference%' => $order.details.reference]}</li>
+            <li>{l s='Payment method: %method%' d='Shop.Theme.Checkout' sprintf=['%method%' => $order.details.payment]}</li>
             {if !$order.details.is_virtual}
-              <li>{l s='Shipping method: %s' d='Shop.Theme.Checkout' sprintf=$order.carrier.name}</li>
+              <li>{l s='Shipping method: %method%' d='Shop.Theme.Checkout' sprintf=['%method%' => $order.carrier.name]}</li>
             {/if}
           </ul>
         </div>

--- a/themes/classic/templates/checkout/order-confirmation.tpl
+++ b/themes/classic/templates/checkout/order-confirmation.tpl
@@ -11,10 +11,14 @@
             <p>
               {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $customer.email]}
               {if $order.details.invoice_url}
+                {* [1][/1] is for a HTML tag. *}
                 {l
                   s='You can also [1]download your invoice[/1]'
                   d='Shop.Theme.Checkout'
-                  tags=["<a href='{$order.details.invoice_url}'>"]
+                  sprintf=[
+                    '[1]' => "<a href='{$order.details.invoice_url}'>",
+                    '[/1]' => "</a>"
+                  ]
                 }
               {/if}
             </p>

--- a/themes/classic/templates/cms/category.tpl
+++ b/themes/classic/templates/cms/category.tpl
@@ -7,7 +7,7 @@
 {block name='page_content'}
   {block name='cms_sub_categories'}
     {if $sub_categories}
-      <p>{l s='List of sub categories in %s:' d='Shop.Theme' sprintf=$cms_category.name}</p>
+      <p>{l s='List of sub categories in %name%:' d='Shop.Theme' sprintf=['%name%' => $cms_category.name]}</p>
       <ul>
         {foreach from=$sub_categories item=sub_category}
           <li><a href="{$sub_category.link}">{$sub_category.name}</a></li>
@@ -18,7 +18,7 @@
 
   {block name='cms_sub_pages'}
     {if $cms_pages}
-      <p>{l s='List of pages in %s:' d='Shop.Theme' sprintf=$cms_category.name}</p>
+      <p>{l s='List of pages in %name%:' d='Shop.Theme' sprintf=['%name%' => $cms_category.name]}</p>
       <ul>
         {foreach from=$cms_pages item=cms_page}
           <li><a href="{$cms_page.link}">{$cms_page.meta_title}</a></li>

--- a/themes/classic/templates/customer/order-detail.tpl
+++ b/themes/classic/templates/customer/order-detail.tpl
@@ -10,9 +10,9 @@
       <div class="box">
           <strong>
             {l
-              s='Order Reference %s - placed on %s'
+              s='Order Reference %reference% - placed on %date%'
               d='Shop.Theme.CustomerAccount'
-              sprintf=[$order.details.reference, $order.details.order_date]
+              sprintf=['%reference%' => $order.details.reference, '%date%' => $order.details.order_date]
             }
           </strong>
           {if $order.details.reorder_url}
@@ -89,7 +89,7 @@
       {if $order.addresses.delivery}
         <div class="col-lg-6 col-md-6 col-sm-6">
           <article id="delivery-address" class="box">
-            <h4>{l s='Delivery address %s' d='Shop.Theme.Checkout' sprintf=$order.addresses.delivery.alias}</h4>
+            <h4>{l s='Delivery address %alias%' d='Shop.Theme.Checkout' sprintf=['%alias%' => $order.addresses.delivery.alias]}</h4>
             <address>{$order.addresses.delivery.formatted nofilter}</address>
           </article>
         </div>
@@ -97,7 +97,7 @@
 
       <div class="col-lg-6 col-md-6 col-sm-6">
         <article id="invoice-address" class="box">
-          <h4>{l s='Invoice address %s' d='Shop.Theme.Checkout' sprintf=$order.addresses.invoice.alias}</h4>
+          <h4>{l s='Invoice address %alias%' d='Shop.Theme.Checkout' sprintf=['%alias%' => $order.addresses.invoice.alias]}</h4>
           <address>{$order.addresses.invoice.formatted nofilter}</address>
         </article>
       </div>

--- a/themes/classic/templates/customer/order-return.tpl
+++ b/themes/classic/templates/customer/order-return.tpl
@@ -8,10 +8,10 @@
   {block name='order_return_infos'}
     <div id="order-return-infos" class="card">
       <div class="card-block">
-        <p><strong>{l s='RE#%s on %s' d='Shop.Theme.CustomerAccount' sprintf=[$orderRet.return_number, $orderRet.return_date]}</strong></p>
+        <p><strong>{l s='RE#%number% on %date%' d='Shop.Theme.CustomerAccount' sprintf=['%number%' => $orderRet.return_number, '%date%' => $orderRet.return_date]}</strong></p>
         <p>{l s='We have logged your return request.' d='Shop.Theme.CustomerAccount'}</p>
-        <p>{l s='Your package must be returned to us within %s days of receiving your order.' d='Shop.Theme.CustomerAccount' sprintf=$nbdaysreturn}</p>
-        <p>{l s='The current status of your merchandise return is: [1] %s [/1]' d='Shop.Theme.CustomerAccount' sprintf=$state_name tags=['<strong>']}</p>
+        <p>{l s='Your package must be returned to us within %number% days of receiving your order.' d='Shop.Theme.CustomerAccount' sprintf=['%number%' => $nbdaysreturn]}</p>
+        <p>{l s='The current status of your merchandise return is: [1] %state% [/1]' d='Shop.Theme.CustomerAccount' sprintf=['%state%' => $state_name] tags=['<strong>']}</p>
         <p>{l s='List of items to be returned:' d='Shop.Theme.CustomerAccount'}</p>
         <table class="table table-striped table-bordered">
           <thead class="thead-default">

--- a/themes/classic/templates/customer/order-return.tpl
+++ b/themes/classic/templates/customer/order-return.tpl
@@ -11,7 +11,18 @@
         <p><strong>{l s='RE#%number% on %date%' d='Shop.Theme.CustomerAccount' sprintf=['%number%' => $orderRet.return_number, '%date%' => $orderRet.return_date]}</strong></p>
         <p>{l s='We have logged your return request.' d='Shop.Theme.CustomerAccount'}</p>
         <p>{l s='Your package must be returned to us within %number% days of receiving your order.' d='Shop.Theme.CustomerAccount' sprintf=['%number%' => $nbdaysreturn]}</p>
-        <p>{l s='The current status of your merchandise return is: [1] %state% [/1]' d='Shop.Theme.CustomerAccount' sprintf=['%state%' => $state_name] tags=['<strong>']}</p>
+        <p>
+          {* [1][/1] is for a HTML tag. *}
+          {l
+            s='The current status of your merchandise return is: [1] %state% [/1]'
+            d='Shop.Theme.CustomerAccount'
+            sprintf=[
+              '[1]' => '<strong>',
+              '[/1]' => '</strong>',
+              '%state%' => $state_name
+            ]
+          }
+        </p>
         <p>{l s='List of items to be returned:' d='Shop.Theme.CustomerAccount'}</p>
         <table class="table table-striped table-bordered">
           <thead class="thead-default">
@@ -58,8 +69,26 @@
       <div class="card-block">
         <h3 class="card-title h3">{l s='Reminder' d='Shop.Theme.CustomerAccount'}</h3>
         <p class="card-text">{l s='All merchandise must be returned in its original packaging and in its original state.' d='Shop.Theme.CustomerAccount'}<br>
-          {l s='Please print out the [1]PDF return slip[/1] and include it with your package.' d='Shop.Theme.CustomerAccount' tags=['<a href="'|cat:$orderRet.return_pdf_url|cat:'">']}<br>
-          {l s='Please see the PDF return slip ([1]for the correct address[/1]).' d='Shop.Theme.CustomerAccount' tags=['<a href="'|cat:$orderRet.return_pdf_url|cat:'">']}</p>
+          {* [1][/1] is for a HTML tag. *}
+          {l
+            s='Please print out the [1]PDF return slip[/1] and include it with your package.'
+            d='Shop.Theme.CustomerAccount'
+            sprintf=[
+              '[1]' => '<a href="'|cat:$orderRet.return_pdf_url|cat:'">',
+              '[/1]' => '</a>'
+            ]
+          }
+          <br>
+          {* [1][/1] is for a HTML tag. *}
+          {l
+            s='Please see the PDF return slip ([1]for the correct address[/1]).'
+            d='Shop.Theme.CustomerAccount'
+            sprintf=[
+              '[1]' => '<a href="'|cat:$orderRet.return_pdf_url|cat:'">',
+              '[/1]' => '</a>'
+            ]
+          }
+        </p>
         <p class="card-text">{l s='When we receive your package, we will notify you by email. We will then begin processing order reimbursement.' d='Shop.Theme.CustomerAccount'}<br>
           <a href="{$urls.pages.contact}">{l s='Please let us know if you have any questions.' d='Shop.Theme.CustomerAccount'}</a><br>
           {l s='If the conditions of return listed above are not respected, we reserve the right to refuse your package and/or reimbursement.' d='Shop.Theme.CustomerAccount'}</p>

--- a/themes/classic/templates/customer/password-new.tpl
+++ b/themes/classic/templates/customer/password-new.tpl
@@ -10,7 +10,7 @@
       <section class="form-fields">
 
         <label>
-          <span>{l s='Email address: %s' d='Shop.Theme.CustomerAccount' sprintf=$customer_email|stripslashes}</span>
+          <span>{l s='Email address: %email%' d='Shop.Theme.CustomerAccount' sprintf=['%email%' => $customer_email|stripslashes]}</span>
         </label>
 
         <label>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When string uses domains sprintf() must be an array and tags() must be removed. No more silent errors, when it encounters on one one these functions it raises an exception in dev mode or log it when you're in production. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
