### PR TITLE
Introduce trans() method in Admin controllers

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -388,6 +388,9 @@ class AdminControllerCore extends Controller
     /** @var string */
     protected $tabSlug;
 
+    /** @var PrestaShopBundle\Translation\Translator */
+    private $translator;
+
     public function __construct($forceControllerName = '', $default_theme_name = 'default')
     {
         global $timer_start;
@@ -401,6 +404,8 @@ class AdminControllerCore extends Controller
             $this->controller_name = substr($this->controller_name, 0, -10);
         }
         parent::__construct();
+
+        $this->translator = $this->context->getTranslator();
 
         if ($this->multishop_context == -1) {
             $this->multishop_context = Shop::CONTEXT_ALL | Shop::CONTEXT_GROUP | Shop::CONTEXT_SHOP;
@@ -2705,6 +2710,11 @@ class AdminControllerCore extends Controller
             $class = substr($class, 0, -10);
         }
         return Translate::getAdminTranslation($string, $class, $addslashes, $htmlentities);
+    }
+
+    protected function trans($id, array $parameters = array(), $domain = null, $locale = null)
+    {
+        return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
     /**


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Introduce the new translation system for legacy admin controllers. I chose to create a `trans()` method instead of calling a getter every time, only for readibility sake. |
| Type? | new feature |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
