### PR TITLE
Cart quantity must take into account id_product_quantity

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2818,11 +2818,12 @@ class ProductCore extends ObjectModel
 
         $cart_quantity = 0;
         if ((int)$id_cart) {
-            $cache_id = 'Product::getPriceStatic_'.(int)$id_product.'-'.(int)$id_cart;
+            $cache_id = 'Product::getPriceStatic_'.(int)$id_product.'-'.(int)$id_cart.'-'.(int)$id_product_attribute;
             if (!Cache::isStored($cache_id) || ($cart_quantity = Cache::retrieve($cache_id) != (int)$quantity)) {
                 $sql = 'SELECT SUM(`quantity`)
 				FROM `'._DB_PREFIX_.'cart_product`
 				WHERE `id_product` = '.(int)$id_product.'
+				AND `id_product_attribute` = '.(int)$id_product_attribute.'
 				AND `id_cart` = '.(int)$id_cart;
                 $cart_quantity = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
                 Cache::store($cache_id, $cart_quantity);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When you have a specific price from a defined quantity only for a specific combination, the discount was applied regardless the combination. (Look at the ticket for a more precise description). |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-704 |
