### PR TITLE
Introduce trans() method in every controller

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -388,9 +388,6 @@ class AdminControllerCore extends Controller
     /** @var string */
     protected $tabSlug;
 
-    /** @var PrestaShopBundle\Translation\Translator */
-    private $translator;
-
     public function __construct($forceControllerName = '', $default_theme_name = 'default')
     {
         global $timer_start;
@@ -404,8 +401,6 @@ class AdminControllerCore extends Controller
             $this->controller_name = substr($this->controller_name, 0, -10);
         }
         parent::__construct();
-
-        $this->translator = $this->context->getTranslator();
 
         if ($this->multishop_context == -1) {
             $this->multishop_context = Shop::CONTEXT_ALL | Shop::CONTEXT_GROUP | Shop::CONTEXT_SHOP;
@@ -2710,11 +2705,6 @@ class AdminControllerCore extends Controller
             $class = substr($class, 0, -10);
         }
         return Translate::getAdminTranslation($string, $class, $addslashes, $htmlentities);
-    }
-
-    protected function trans($id, array $parameters = array(), $domain = null, $locale = null)
-    {
-        return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
     /**

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -78,6 +78,10 @@ abstract class ControllerCore
     /** @var string Controller name */
     public $php_self;
 
+    /** @var PrestaShopBundle\Translation\Translator */
+    protected $translator;
+
+
     /**
      * Check if the controller is available for the current user/visitor
      */
@@ -150,6 +154,7 @@ abstract class ControllerCore
 
         $this->context = Context::getContext();
         $this->context->controller = $this;
+        $this->translator = Context::getContext()->getTranslator();
 
         // Usage of ajax parameter is deprecated
         $this->ajax = Tools::getValue('ajax') || Tools::isSubmit('ajax');
@@ -219,6 +224,12 @@ abstract class ControllerCore
             $this->initCursedPage();
             $this->smartyOutputContent($this->layout);
         }
+    }
+
+
+    protected function trans($id, array $parameters = array(), $domain = null, $locale = null)
+    {
+        return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1577,7 +1577,7 @@ class FrontControllerCore extends Controller
 
     protected function getTranslator()
     {
-        return Context::getContext()->getTranslator();
+        return $this->translator;
     }
 
     protected function makeLoginForm()

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -56,12 +56,12 @@ class AddressControllerCore extends FrontController
         $this->address_form->fillWith(Tools::getAllValues());
         if (Tools::isSubmit('submitAddress')) {
             if (!$this->address_form->submit()) {
-                $this->errors[] = $this->getTranslator()->trans('Please fix the error below.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Please fix the error below.', array(), 'Shop.Notifications.Error');
             } else {
                 if (Tools::getValue('id_address')) {
-                    $this->success[] = $this->getTranslator()->trans('Address successfully updated!', array(), 'Shop.Notifications.Success');
+                    $this->success[] = $this->trans('Address successfully updated!', array(), 'Shop.Notifications.Success');
                 } else {
-                    $this->success[] = $this->getTranslator()->trans('Address successfully added!', array(), 'Shop.Notifications.Success');
+                    $this->success[] = $this->trans('Address successfully added!', array(), 'Shop.Notifications.Success');
                 }
                 $this->should_redirect = true;
             }
@@ -86,10 +86,10 @@ class AddressControllerCore extends FrontController
                     Tools::getValue('token')
                 );
                 if ($ok) {
-                    $this->success[] = $this->getTranslator()->trans('Address successfully deleted!', array(), 'Shop.Notifications.Success');
+                    $this->success[] = $this->trans('Address successfully deleted!', array(), 'Shop.Notifications.Success');
                     $this->should_redirect = true;
                 } else {
-                    $this->errors[] = $this->getTranslator()->trans('Could not delete address.', array(), 'Shop.Notifications.Error');
+                    $this->errors[] = $this->trans('Could not delete address.', array(), 'Shop.Notifications.Error');
                 }
             } else {
                 $this->context->smarty->assign('editing', true);
@@ -123,7 +123,7 @@ class AddressControllerCore extends FrontController
         $breadcrumb['links'][] = $this->addMyAccountToBreadcrumb();
 
         $breadcrumb['links'][] = [
-            'title' => $this->getTranslator()->trans('Addresses', array(), 'Shop.Theme'),
+            'title' => $this->trans('Addresses', array(), 'Shop.Theme'),
             'url' => $this->context->link->getPageLink('addresses')
         ];
 

--- a/controllers/front/AddressesController.php
+++ b/controllers/front/AddressesController.php
@@ -53,8 +53,8 @@ class AddressesControllerCore extends FrontController
         parent::initContent();
 
         if (count($this->context->customer->getSimpleAddresses()) <= 0) {
-            $link = '<a href="'.$this->context->link->getPageLink('address', true).'">'.$this->getTranslator()->trans('Add a new address', array(), 'Shop.Theme.Actions').'</a>';
-            $this->warning[] = $this->getTranslator()->trans('No addresses are available. %s', array($link), 'Shop.Notifications.Success');
+            $link = '<a href="'.$this->context->link->getPageLink('address', true).'">'.$this->trans('Add a new address', array(), 'Shop.Theme.Actions').'</a>';
+            $this->warning[] = $this->trans('No addresses are available. %s', array($link), 'Shop.Notifications.Success');
         }
 
         $this->setTemplate('customer/addresses.tpl');

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -181,9 +181,9 @@ class CartControllerCore extends FrontController
             } elseif (CartRule::isFeatureActive()) {
                 if (Tools::getIsset('addDiscount')) {
                     if (!($code = trim(Tools::getValue('discount_name')))) {
-                        $this->errors[] = $this->getTranslator()->trans('You must enter a voucher code.', array(), 'Shop.Notifications.Error');
+                        $this->errors[] = $this->trans('You must enter a voucher code.', array(), 'Shop.Notifications.Error');
                     } elseif (!Validate::isCleanHtml($code)) {
-                        $this->errors[] = $this->getTranslator()->trans('The voucher code is invalid.', array(), 'Shop.Notifications.Error');
+                        $this->errors[] = $this->trans('The voucher code is invalid.', array(), 'Shop.Notifications.Error');
                     } else {
                         if (($cartRule = new CartRule(CartRule::getIdByCode($code))) && Validate::isLoadedObject($cartRule)) {
                             if ($error = $cartRule->checkValidity($this->context, false, true)) {
@@ -227,7 +227,7 @@ class CartControllerCore extends FrontController
             }
 
             if ($total_quantity < $minimal_quantity) {
-                $this->errors[] = $this->getTranslator()->trans('You must add %d minimum quantity', array(!Tools::getValue('ajax'), $minimal_quantity), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('You must add %d minimum quantity', array(!Tools::getValue('ajax'), $minimal_quantity), 'Shop.Notifications.Error');
                 return false;
             }
         }
@@ -267,14 +267,14 @@ class CartControllerCore extends FrontController
         }
 
         if ($this->qty == 0) {
-            $this->errors[] = $this->getTranslator()->trans('Null quantity.', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('Null quantity.', array(), 'Shop.Notifications.Error');
         } elseif (!$this->id_product) {
-            $this->errors[] = $this->getTranslator()->trans('Product not found', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('Product not found', array(), 'Shop.Notifications.Error');
         }
 
         $product = new Product($this->id_product, true, $this->context->language->id);
         if (!$product->id || !$product->active || !$product->checkAccess($this->context->cart->id_customer)) {
-            $this->errors[] = $this->getTranslator()->trans('This product is no longer available.', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('This product is no longer available.', array(), 'Shop.Notifications.Error');
             return;
         }
 
@@ -303,7 +303,7 @@ class CartControllerCore extends FrontController
         // Check product quantity availability
         if ($this->id_product_attribute) {
             if (!Product::isAvailableWhenOutOfStock($product->out_of_stock) && !Attribute::checkAttributeQty($this->id_product_attribute, $qty_to_check)) {
-                $this->errors[] = $this->getTranslator()->trans('There isn\'t enough product in stock', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('There isn\'t enough product in stock', array(), 'Shop.Notifications.Error');
             }
         } elseif ($product->hasAttributes()) {
             $minimumQuantity = ($product->out_of_stock == 2) ? !Configuration::get('PS_ORDER_OUT_OF_STOCK') : !$product->out_of_stock;
@@ -312,10 +312,10 @@ class CartControllerCore extends FrontController
             if (!$this->id_product_attribute) {
                 Tools::redirectAdmin($this->context->link->getProductLink($product));
             } elseif (!Product::isAvailableWhenOutOfStock($product->out_of_stock) && !Attribute::checkAttributeQty($this->id_product_attribute, $qty_to_check)) {
-                $this->errors[] = $this->getTranslator()->trans('There isn\'t enough product in stock', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('There isn\'t enough product in stock', array(), 'Shop.Notifications.Error');
             }
         } elseif (!$product->checkQty($qty_to_check)) {
-            $this->errors[] = $this->getTranslator()->trans('There isn\'t enough product in stock', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('There isn\'t enough product in stock', array(), 'Shop.Notifications.Error');
         }
 
         // If no errors, process product addition
@@ -334,7 +334,7 @@ class CartControllerCore extends FrontController
 
             // Check customizable fields
             if (!$product->hasAllRequiredCustomizableFields() && !$this->customization_id) {
-                $this->errors[] = $this->getTranslator()->trans('Please fill in all of the required fields, and then save your customizations.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Please fill in all of the required fields, and then save your customizations.', array(), 'Shop.Notifications.Error');
             }
 
             if (!$this->errors) {
@@ -344,9 +344,9 @@ class CartControllerCore extends FrontController
                 if ($update_quantity < 0) {
                     // If product has attribute, minimal quantity is set with minimal quantity of attribute
                     $minimal_quantity = ($this->id_product_attribute) ? Attribute::getAttributeMinimalQty($this->id_product_attribute) : $product->minimal_quantity;
-                    $this->errors[] = $this->getTranslator()->trans('You must add %d minimum quantity', array($minimal_quantity), 'Shop.Notifications.Error');
+                    $this->errors[] = $this->trans('You must add %d minimum quantity', array($minimal_quantity), 'Shop.Notifications.Error');
                 } elseif (!$update_quantity) {
-                    $this->errors[] = $this->getTranslator()->trans('You already have the maximum quantity available for this product.', array(), 'Shop.Notifications.Error');
+                    $this->errors[] = $this->trans('You already have the maximum quantity available for this product.', array(), 'Shop.Notifications.Error');
                 }
             }
         }

--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -72,7 +72,7 @@ class CategoryControllerCore extends ProductListingFrontController
         if (!$this->category->checkAccess($this->context->customer->id)) {
             header('HTTP/1.1 403 Forbidden');
             header('Status: 403 Forbidden');
-            $this->errors[] = $this->getTranslator()->trans('You do not have access to this category.', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('You do not have access to this category.', array(), 'Shop.Notifications.Error');
             $this->setTemplate('catalog/forbidden-category.tpl');
             return;
         }

--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -42,7 +42,7 @@ class DiscountControllerCore extends FrontController
         $cart_rules = $this->getTemplateVarCartRules();
 
         if (count($cart_rules) <= 0) {
-            $this->warning[] = $this->getTranslator()->trans('You do not have any vouchers.', array(), 'Shop.Notifications.Warning');
+            $this->warning[] = $this->trans('You do not have any vouchers.', array(), 'Shop.Notifications.Warning');
         }
 
         $this->context->smarty->assign([
@@ -59,14 +59,14 @@ class DiscountControllerCore extends FrontController
         foreach ($vouchers as $key => $voucher) {
             $cart_rules[$key] = $voucher;
             $cart_rules[$key]['voucher_date'] = Tools::displayDate($voucher['date_to'], null, false);
-            $cart_rules[$key]['voucher_minimal'] = ($voucher['minimum_amount'] > 0) ? Tools::displayPrice($voucher['minimum_amount'], (int)$voucher['minimum_amount_currency']) : $this->getTranslator()->trans('None', array(), 'Shop.Theme');
-            $cart_rules[$key]['voucher_cumulable'] = ($voucher['cumulable']) ? $this->getTranslator()->trans('Yes', array(), 'Shop.Theme') : $this->getTranslator()->trans('No', array(), 'Shop.Theme');
+            $cart_rules[$key]['voucher_minimal'] = ($voucher['minimum_amount'] > 0) ? Tools::displayPrice($voucher['minimum_amount'], (int)$voucher['minimum_amount_currency']) : $this->trans('None', array(), 'Shop.Theme');
+            $cart_rules[$key]['voucher_cumulable'] = ($voucher['cumulable']) ? $this->trans('Yes', array(), 'Shop.Theme') : $this->trans('No', array(), 'Shop.Theme');
             if ($voucher['id_discount_type'] == 1) {
                 $cart_rules[$key]['value'] = sprintf('%s%%', $voucher['value']);
             } elseif ($voucher['id_discount_type'] == 2) {
-                $cart_rules[$key]['value'] = sprintf('%s '.($voucher['reduction_tax'] ? $this->getTranslator()->trans('Tax included', array(), 'Shop.Theme.Checkout') : $this->getTranslator()->trans('Tax excluded', array(), 'Shop.Theme.Checkout')), Tools::displayPrice($voucher['value'], (int)$voucher['reduction_currency']));
+                $cart_rules[$key]['value'] = sprintf('%s '.($voucher['reduction_tax'] ? $this->trans('Tax included', array(), 'Shop.Theme.Checkout') : $this->trans('Tax excluded', array(), 'Shop.Theme.Checkout')), Tools::displayPrice($voucher['value'], (int)$voucher['reduction_currency']));
             } elseif ($voucher['id_discount_type'] == 3) {
-                $cart_rules[$key]['value'] = $this->getTranslator()->trans('Free shipping', array(), 'Shop.Theme.Checkout');
+                $cart_rules[$key]['value'] = $this->trans('Free shipping', array(), 'Shop.Theme.Checkout');
             } else {
                 $cart_rules[$key]['value'] = '-';
             }

--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -60,28 +60,28 @@ class GuestTrackingControllerCore extends OrderDetailController
             $email = Tools::getValue('email');
 
             if (empty($order_reference)) {
-                $this->errors[] = $this->getTranslator()->trans('Please provide your order\'s reference number.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Please provide your order\'s reference number.', array(), 'Shop.Notifications.Error');
             } elseif (empty($email) || !Validate::isEmail($email)) {
-                $this->errors[] = $this->getTranslator()->trans('Please provide a valid email address.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Please provide a valid email address.', array(), 'Shop.Notifications.Error');
             } elseif (!Customer::customerExists($email, false, false)) {
-                $this->errors[] = $this->getTranslator()->trans('There is no account associated with this email address.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('There is no account associated with this email address.', array(), 'Shop.Notifications.Error');
             } elseif (Customer::customerExists($email, false, true)) {
-                $this->errors[] = $this->getTranslator()->trans('This page is for guest accounts only. Since your guest account has already been transformed into a customer account, you can no longer view your order here. Please log in to your customer account to view this order', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('This page is for guest accounts only. Since your guest account has already been transformed into a customer account, you can no longer view your order here. Please log in to your customer account to view this order', array(), 'Shop.Notifications.Error');
                 $this->context->smarty->assign('show_login_link', true);
             } elseif (!count($this->order_collection) || $this->order_collection->count() != 1 || !$this->order_collection->getFirst()->isAssociatedAtGuest($email)) {
-                $this->errors[] = $this->getTranslator()->trans('Invalid order reference', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Invalid order reference', array(), 'Shop.Notifications.Error');
             } else {
                 $this->assignOrderTracking($this->order_collection);
                 if (Tools::isSubmit('submitTransformGuestToCustomer')) {
                     $customer = new Customer((int)$this->order_collection->getFirst()->id_customer);
                     if (!Validate::isLoadedObject($customer)) {
-                        $this->errors[] = $this->getTranslator()->trans('Invalid customer', array(), 'Shop.Notifications.Error');
+                        $this->errors[] = $this->trans('Invalid customer', array(), 'Shop.Notifications.Error');
                     } elseif (!Tools::getValue('password')) {
-                        $this->errors[] = $this->getTranslator()->trans('Invalid password.', array(), 'Shop.Notifications.Error');
+                        $this->errors[] = $this->trans('Invalid password.', array(), 'Shop.Notifications.Error');
                     } elseif (!$customer->transformToCustomer($this->context->language->id, Tools::getValue('password'))) {
-                        $this->errors[] = $this->getTranslator()->trans('An error occurred while transforming a guest into a registered customer.', array(), 'Shop.Notifications.Error');
+                        $this->errors[] = $this->trans('An error occurred while transforming a guest into a registered customer.', array(), 'Shop.Notifications.Error');
                     } else {
-                        $this->success[] = $this->getTranslator()->trans('Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper.', array(), 'Shop.Notifications.Success');
+                        $this->success[] = $this->trans('Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper.', array(), 'Shop.Notifications.Success');
                     }
                 }
             }
@@ -120,7 +120,7 @@ class GuestTrackingControllerCore extends OrderDetailController
         $order = $order_collection->getFirst();
 
         if ((int)$order->isReturnable()) {
-            $this->info[] = $this->getTranslator()->trans('You cannot return merchandise with a guest account.', array(), 'Shop.Notifications.Warning');
+            $this->info[] = $this->trans('You cannot return merchandise with a guest account.', array(), 'Shop.Notifications.Warning');
         }
 
         $this->order_to_display['data'] = $this->getTemplateVarOrder($order);

--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -44,13 +44,13 @@ class HistoryControllerCore extends FrontController
         $this->order_presenter = new OrderPresenter();
 
         if (Tools::isSubmit('slowvalidation')) {
-            $this->warning[] = $this->getTranslator()->trans('If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.', array(), 'Shop.Notifications.Warning');
+            $this->warning[] = $this->trans('If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.', array(), 'Shop.Notifications.Warning');
         }
 
         $orders = $this->getTemplateVarOrders();
 
         if (count($orders) <= 0) {
-            $this->warning[] = $this->getTranslator()->trans('You have not placed any orders.', array(), 'Shop.Notifications.Warning');
+            $this->warning[] = $this->trans('You have not placed any orders.', array(), 'Shop.Notifications.Warning');
         }
 
         $this->context->smarty->assign(array(

--- a/controllers/front/IdentityController.php
+++ b/controllers/front/IdentityController.php
@@ -50,10 +50,10 @@ class IdentityControllerCore extends FrontController
         if (Tools::isSubmit('submitCreate')) {
             $customer_form->fillWith(Tools::getAllValues());
             if ($customer_form->submit()) {
-                $this->success[] = $this->getTranslator()->trans('Information successfully updated.', array(), 'Shop.Notifications.Success');
+                $this->success[] = $this->trans('Information successfully updated.', array(), 'Shop.Notifications.Success');
                 $should_redirect = true;
             } else {
-                $this->errors[] = $this->getTranslator()->trans('Could not update your information, please check your data.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Could not update your information, please check your data.', array(), 'Shop.Notifications.Error');
             }
         } else {
             $customer_form->fillFromCustomer(

--- a/controllers/front/ManufacturerController.php
+++ b/controllers/front/ManufacturerController.php
@@ -133,7 +133,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
             $manufacturers_for_display[$manufacturer['id_manufacturer']]['text'] = $manufacturer['short_description'];
             $manufacturers_for_display[$manufacturer['id_manufacturer']]['image'] = _THEME_MANU_DIR_.$manufacturer['id_manufacturer'].'-medium_default.jpg';
             $manufacturers_for_display[$manufacturer['id_manufacturer']]['url'] = $this->context->link->getmanufacturerLink($manufacturer['id_manufacturer']);
-            $manufacturers_for_display[$manufacturer['id_manufacturer']]['nb_products'] = $manufacturer['nb_products'] > 1 ? sprintf($this->getTranslator()->trans('%s products', array(), 'Shop.Theme.Catalog'), $manufacturer['nb_products']) : sprintf($this->getTranslator()->trans('% product', array(), 'Shop.Theme.Catalog'), $manufacturer['nb_products']);
+            $manufacturers_for_display[$manufacturer['id_manufacturer']]['nb_products'] = $manufacturer['nb_products'] > 1 ? sprintf($this->trans('%s products', array(), 'Shop.Theme.Catalog'), $manufacturer['nb_products']) : sprintf($this->trans('% product', array(), 'Shop.Theme.Catalog'), $manufacturer['nb_products']);
         }
 
         return $manufacturers_for_display;

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -48,9 +48,9 @@ class OrderControllerCore extends FrontController
             $oldCart = new Cart(Order::getCartIdStatic($id_order, $this->context->customer->id));
             $duplication = $oldCart->duplicate();
             if (!$duplication || !Validate::isLoadedObject($duplication['cart'])) {
-                $this->errors[] = $this->getTranslator()->trans('Sorry. We cannot renew your order.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Sorry. We cannot renew your order.', array(), 'Shop.Notifications.Error');
             } elseif (!$duplication['success']) {
-                $this->errors[] = $this->getTranslator()->trans(
+                $this->errors[] = $this->trans(
                     'Some items are no longer available, and we are unable to renew your order.', array(), 'Shop.Notifications.Error'
                 );
             } else {

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -55,11 +55,11 @@ class OrderDetailControllerCore extends ProductPresentingFrontControllerCore
             $msgText = Tools::getValue('msgText');
 
             if (!$idOrder || !Validate::isUnsignedId($idOrder)) {
-                $this->errors[] = $this->getTranslator()->trans('The order is no longer valid.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('The order is no longer valid.', array(), 'Shop.Notifications.Error');
             } elseif (empty($msgText)) {
-                $this->errors[] = $this->getTranslator()->trans('The message cannot be blank.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('The message cannot be blank.', array(), 'Shop.Notifications.Error');
             } elseif (!Validate::isMessage($msgText)) {
-                $this->errors[] = $this->getTranslator()->trans('This message is invalid (HTML is not allowed).', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('This message is invalid (HTML is not allowed).', array(), 'Shop.Notifications.Error');
             }
             if (!count($this->errors)) {
                 $order = new Order($idOrder);
@@ -151,17 +151,17 @@ class OrderDetailControllerCore extends ProductPresentingFrontControllerCore
             $this->redirect();
         } else {
             if (Tools::getIsset('errorQuantity')) {
-                $this->errors[] = $this->getTranslator()->trans('You do not have enough products to request an additional merchandise return.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('You do not have enough products to request an additional merchandise return.', array(), 'Shop.Notifications.Error');
             } elseif (Tools::getIsset('errorMsg')) {
-                $this->errors[] = $this->getTranslator()->trans('Please provide an explanation for your RMA.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Please provide an explanation for your RMA.', array(), 'Shop.Notifications.Error');
             } elseif (Tools::getIsset('errorDetail1')) {
-                $this->errors[] = $this->getTranslator()->trans('Please check at least one product you would like to return.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Please check at least one product you would like to return.', array(), 'Shop.Notifications.Error');
             } elseif (Tools::getIsset('errorDetail2')) {
-                $this->errors[] = $this->getTranslator()->trans('For each product you wish to add, please specify the desired quantity.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('For each product you wish to add, please specify the desired quantity.', array(), 'Shop.Notifications.Error');
             } elseif (Tools::getIsset('errorNotReturnable')) {
-                $this->errors[] = $this->getTranslator()->trans('This order cannot be returned', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('This order cannot be returned', array(), 'Shop.Notifications.Error');
             } elseif (Tools::getIsset('messagesent')) {
-                $this->success[] = $this->getTranslator()->trans('Message successfully sent', array(), 'Shop.Notifications.Success');
+                $this->success[] = $this->trans('Message successfully sent', array(), 'Shop.Notifications.Success');
             }
 
             $order = new Order($id_order);

--- a/controllers/front/OrderFollowController.php
+++ b/controllers/front/OrderFollowController.php
@@ -94,7 +94,7 @@ class OrderFollowControllerCore extends FrontController
 
         $ordersReturn = $this->getTemplateVarOrdersReturns();
         if (count($ordersReturn) <= 0) {
-            $this->errors[] = $this->getTranslator()->trans('You have no merchandise return authorizations.', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('You have no merchandise return authorizations.', array(), 'Shop.Notifications.Error');
         }
 
         $this->context->smarty->assign('ordersReturn', $ordersReturn);

--- a/controllers/front/OrderReturnController.php
+++ b/controllers/front/OrderReturnController.php
@@ -54,7 +54,7 @@ class OrderReturnControllerCore extends FrontController
                     $state = new OrderReturnState((int)$order_return->state);
 
                     if ($order_return->state == 1) {
-                        $this->warning[] = $this->getTranslator()->trans('You must wait for confirmation before returning any merchandise.', array(), 'Shop.Notifications.Warning');
+                        $this->warning[] = $this->trans('You must wait for confirmation before returning any merchandise.', array(), 'Shop.Notifications.Warning');
                     }
 
                     $this->context->smarty->assign(array(
@@ -169,7 +169,7 @@ class OrderReturnControllerCore extends FrontController
 
         if (($id_order_return = (int)Tools::getValue('id_order_return')) && Validate::isUnsignedId($id_order_return)) {
             $breadcrumb['links'][] =[
-                'title' => $this->getTranslator()->trans('Merchandise returns', array(), 'Shop.Theme'),
+                'title' => $this->trans('Merchandise returns', array(), 'Shop.Theme'),
                 'url' => $this->context->link->getPageLink('order-follow')
             ];
         }

--- a/controllers/front/OrderSlipController.php
+++ b/controllers/front/OrderSlipController.php
@@ -42,7 +42,7 @@ class OrderSlipControllerCore extends FrontController
         $credit_slips = $this->getTemplateVarCreditSlips();
 
         if (count($credit_slips) <= 0) {
-            $this->warning[] = $this->getTranslator()->trans('You have not received any credit slips.', array(), 'Shop.Notifications.Warning');
+            $this->warning[] = $this->trans('You have not received any credit slips.', array(), 'Shop.Notifications.Warning');
         }
 
         $this->context->smarty->assign([
@@ -59,8 +59,8 @@ class OrderSlipControllerCore extends FrontController
         foreach ($orders_slip as $order_slip) {
             $order = new Order($order_slip['id_order']);
             $credit_slips[$order_slip['id_order_slip']] = $order_slip;
-            $credit_slips[$order_slip['id_order_slip']]['credit_slip_number'] = sprintf($this->getTranslator()->trans('#%06d', array(), 'Shop.Theme.CustomerAccount'), $order_slip['id_order_slip']);
-            $credit_slips[$order_slip['id_order_slip']]['order_number'] = sprintf($this->getTranslator()->trans('#%06d', array(), 'Shop.Theme.CustomerAccount'), $order_slip['id_order']);
+            $credit_slips[$order_slip['id_order_slip']]['credit_slip_number'] = sprintf($this->trans('#%06d', array(), 'Shop.Theme.CustomerAccount'), $order_slip['id_order_slip']);
+            $credit_slips[$order_slip['id_order_slip']]['order_number'] = sprintf($this->trans('#%06d', array(), 'Shop.Theme.CustomerAccount'), $order_slip['id_order']);
             $credit_slips[$order_slip['id_order_slip']]['order_reference'] = $order->reference;
             $credit_slips[$order_slip['id_order_slip']]['credit_slip_date'] = Tools::displayDate($order_slip['date_add'], null, false);
             $credit_slips[$order_slip['id_order_slip']]['url'] = $this->context->link->getPageLink('pdf-order-slip', true, null, 'id_order_slip='.(int)$order_slip['id_order_slip']);

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -44,23 +44,23 @@ class PasswordControllerCore extends FrontController
         } elseif (($token = Tools::getValue('token')) && ($id_customer = (int)Tools::getValue('id_customer'))) {
             $this->changePassword();
         } elseif (Tools::getValue('token') || Tools::getValue('id_customer')) {
-            $this->errors[] = $this->getTranslator()->trans('We cannot regenerate your password with the data you\'ve submitted', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('We cannot regenerate your password with the data you\'ve submitted', array(), 'Shop.Notifications.Error');
         }
     }
 
     protected function sendRenewPasswordLink()
     {
         if (!($email = trim(Tools::getValue('email'))) || !Validate::isEmail($email)) {
-            $this->errors[] = $this->getTranslator()->trans('Invalid email address.', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('Invalid email address.', array(), 'Shop.Notifications.Error');
         } else {
             $customer = new Customer();
             $customer->getByEmail($email);
             if (!Validate::isLoadedObject($customer)) {
-                $this->errors[] = $this->getTranslator()->trans('There is no account registered for this email address.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('There is no account registered for this email address.', array(), 'Shop.Notifications.Error');
             } elseif (!$customer->active) {
-                $this->errors[] = $this->getTranslator()->trans('You cannot regenerate the password for this account.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('You cannot regenerate the password for this account.', array(), 'Shop.Notifications.Error');
             } elseif ((strtotime($customer->last_passwd_gen.'+'.($min_time = (int)Configuration::get('PS_PASSWD_TIME_FRONT')).' minutes') - time()) > 0) {
-                $this->errors[] = $this->getTranslator()->trans('You can regenerate your password only every %d minute(s)', array((int) $min_time), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('You can regenerate your password only every %d minute(s)', array((int) $min_time), 'Shop.Notifications.Error');
             } else {
                 if (!$customer->hasRecentResetPasswordToken()) {
                     $customer->stampResetPasswordToken();
@@ -75,10 +75,10 @@ class PasswordControllerCore extends FrontController
                 ];
 
                 if (Mail::Send($this->context->language->id, 'password_query', Mail::l('Password query confirmation'), $mail_params, $customer->email, $customer->firstname.' '.$customer->lastname)) {
-                    $this->success[] = $this->getTranslator()->trans('A link to reset your password has been sent to your address: %s', array($customer->email), 'Shop.Notifications.Success');
+                    $this->success[] = $this->trans('A link to reset your password has been sent to your address: %s', array($customer->email), 'Shop.Notifications.Success');
                     $this->setTemplate('customer/password-infos.tpl');
                 } else {
-                    $this->errors[] = $this->getTranslator()->trans('An error occurred while sending the email.', array(), 'Shop.Notifications.Error');
+                    $this->errors[] = $this->trans('An error occurred while sending the email.', array(), 'Shop.Notifications.Error');
                 }
             }
         }
@@ -93,9 +93,9 @@ class PasswordControllerCore extends FrontController
             $customer->getByEmail($email);
 
             if (!Validate::isLoadedObject($customer)) {
-                $this->errors[] = $this->getTranslator()->trans('Customer account not found', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('Customer account not found', array(), 'Shop.Notifications.Error');
             } elseif (!$customer->active) {
-                $this->errors[] = $this->getTranslator()->trans('You cannot regenerate the password for this account.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('You cannot regenerate the password for this account.', array(), 'Shop.Notifications.Error');
             }
 
             // Case if both password params not posted or different, then "change password" form is not POSTED, show it.
@@ -105,7 +105,7 @@ class PasswordControllerCore extends FrontController
                 || !Validate::isPasswd($passwd) || !Validate::isPasswd($confirmation)) {
                 // Check if passwords are here anyway, BUT does not match the password validation format
                 if (Tools::isSubmit('passwd') || Tools::isSubmit('confirmation')) {
-                    $this->errors[] = $this->getTranslator()->trans('The password and its confirmation do not match.', array(), 'Shop.Notifications.Error');
+                    $this->errors[] = $this->trans('The password and its confirmation do not match.', array(), 'Shop.Notifications.Error');
                 }
 
                 $this->context->smarty->assign([
@@ -123,12 +123,12 @@ class PasswordControllerCore extends FrontController
                 } else {
                     // To update password, we must have the temporary reset token that matches.
                     if ($customer->getValidResetPasswordToken() !== Tools::getValue('reset_token')) {
-                        $this->errors[] = $this->getTranslator()->trans('The password change request expired. You should ask for a new one.', array(), 'Shop.Notifications.Error');
+                        $this->errors[] = $this->trans('The password change request expired. You should ask for a new one.', array(), 'Shop.Notifications.Error');
                     } else {
                         try {
                             $crypto = new Hashing();
                         } catch (\PrestaShop\PrestaShop\Adapter\CoreException $e) {
-                            $this->errors[] = $this->getTranslator()->trans('An error occurred with your account, which prevents us from updating the new password. Please report this issue using the contact form.', array(), 'Shop.Notifications.Error');
+                            $this->errors[] = $this->trans('An error occurred with your account, which prevents us from updating the new password. Please report this issue using the contact form.', array(), 'Shop.Notifications.Error');
                             return false;
                         }
 
@@ -150,20 +150,20 @@ class PasswordControllerCore extends FrontController
                                 $this->context->smarty->assign([
                                     'customer_email' => $customer->email
                                 ]);
-                                $this->success[] = $this->getTranslator()->trans('Your password has been successfully reset and a confirmation has been sent to your email address: %s', array($customer->email), 'Shop.Notifications.Success');
+                                $this->success[] = $this->trans('Your password has been successfully reset and a confirmation has been sent to your email address: %s', array($customer->email), 'Shop.Notifications.Success');
                                 $this->context->updateCustomer($customer);
                                 $this->redirectWithNotifications('index.php?controller=my-account');
                             } else {
-                                $this->errors[] = $this->getTranslator()->trans('An error occurred while sending the email.', array(), 'Shop.Notifications.Error');
+                                $this->errors[] = $this->trans('An error occurred while sending the email.', array(), 'Shop.Notifications.Error');
                             }
                         } else {
-                            $this->errors[] = $this->getTranslator()->trans('An error occurred with your account, which prevents us from updating the new password. Please report this issue using the contact form.', array(), 'Shop.Notifications.Error');
+                            $this->errors[] = $this->trans('An error occurred with your account, which prevents us from updating the new password. Please report this issue using the contact form.', array(), 'Shop.Notifications.Error');
                         }
                     }
                 }
             }
         } else {
-            $this->errors[] = $this->getTranslator()->trans('We cannot regenerate your password with the data you\'ve submitted', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('We cannot regenerate your password with the data you\'ve submitted', array(), 'Shop.Notifications.Error');
         }
     }
 }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -87,7 +87,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 if (Tools::getValue('adtoken') == Tools::getAdminToken('AdminProducts'.(int) Tab::getIdFromClassName('AdminProducts').(int) Tools::getValue('id_employee')) && $this->product->isAssociatedToShop()) {
                     $this->adminNotifications['inactive_product'] = array(
                         'type' => 'warning',
-                        'message' => $this->getTranslator()->trans('This product is not visible to your customers.', array(), 'Shop.Notifications.Warning'),
+                        'message' => $this->trans('This product is not visible to your customers.', array(), 'Shop.Notifications.Warning'),
                     );
                 } else {
                     if (!$this->product->id_product_redirected || $this->product->id_product_redirected == $this->product->id) {
@@ -110,7 +110,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                         default:
                             header('HTTP/1.1 404 Not Found');
                             header('Status: 404 Not Found');
-                            $this->errors[] = $this->getTranslator()->trans('This product is no longer available.', array(), 'Shop.Notifications.Error');
+                            $this->errors[] = $this->trans('This product is no longer available.', array(), 'Shop.Notifications.Error');
                             $this->setTemplate('errors/404.tpl');
                         break;
                     }
@@ -118,7 +118,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             } elseif (!$this->product->checkAccess(isset($this->context->customer->id) && $this->context->customer->id ? (int) $this->context->customer->id : 0)) {
                 header('HTTP/1.1 403 Forbidden');
                 header('Status: 403 Forbidden');
-                $this->errors[] = $this->getTranslator()->trans('You do not have access to this product.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('You do not have access to this product.', array(), 'Shop.Notifications.Error');
             } else {
                 // Load category
                 $id_category = false;
@@ -192,7 +192,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $this->pictureUpload();
                 $this->textRecord();
             } elseif (Tools::getIsset('deletePicture') && !$this->context->cart->deleteCustomizationToProduct($this->product->id, Tools::getValue('deletePicture'))) {
-                $this->errors[] = $this->getTranslator()->trans('An error occurred while deleting the selected picture.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('An error occurred while deleting the selected picture.', array(), 'Shop.Notifications.Error');
             }
 
             $pictures = array();
@@ -640,11 +640,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 }
                 /* Original file */
                 if (!ImageManager::resize($tmp_name, _PS_UPLOAD_DIR_.$file_name)) {
-                    $this->errors[] = $this->getTranslator()->trans('An error occurred during the image upload process.', array(), 'Shop.Notifications.Error');
+                    $this->errors[] = $this->trans('An error occurred during the image upload process.', array(), 'Shop.Notifications.Error');
                 } elseif (!ImageManager::resize($tmp_name, _PS_UPLOAD_DIR_.$file_name.'_small', $product_picture_width, $product_picture_height)) {
-                    $this->errors[] = $this->getTranslator()->trans('An error occurred during the image upload process.', array(), 'Shop.Notifications.Error');
+                    $this->errors[] = $this->trans('An error occurred during the image upload process.', array(), 'Shop.Notifications.Error');
                 } elseif (!chmod(_PS_UPLOAD_DIR_.$file_name, 0777) || !chmod(_PS_UPLOAD_DIR_.$file_name.'_small', 0777)) {
-                    $this->errors[] = $this->getTranslator()->trans('An error occurred during the image upload process.', array(), 'Shop.Notifications.Error');
+                    $this->errors[] = $this->trans('An error occurred during the image upload process.', array(), 'Shop.Notifications.Error');
                 } else {
                     $this->context->cart->addPictureToProduct($this->product->id, $indexes[$field_name], Product::CUSTOMIZE_FILE, $file_name);
                 }
@@ -672,7 +672,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         foreach ($_POST as $field_name => $value) {
             if (in_array($field_name, $authorized_text_fields) && $value != '') {
                 if (!Validate::isMessage($value)) {
-                    $this->errors[] = $this->getTranslator()->trans('Invalid message', array(), 'Shop.Notifications.Error');
+                    $this->errors[] = $this->trans('Invalid message', array(), 'Shop.Notifications.Error');
                 } else {
                     $this->context->cart->addTextFieldToProduct($this->product->id, $indexes[$field_name], Product::CUSTOMIZE_TEXTFIELD, $value);
                 }
@@ -780,7 +780,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             && $this->product->available_for_order
             && !Configuration::get('PS_CATALOG_MODE')
         );
-        $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->getTranslator()->trans('Items', array(), 'Shop.Theme.Catalog') : $this->getTranslator()->trans('Item', array(), 'Shop.Theme.Catalog');
+        $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->trans('Items', array(), 'Shop.Theme.Catalog') : $this->trans('Item', array(), 'Shop.Theme.Catalog');
         $product_full['quantity_discounts'] = $this->quantity_discounts;
 
         if ($product_full['price'] && $product_full['unit_price_ratio'] > 0) {

--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -60,39 +60,39 @@ class SitemapControllerCore extends FrontController
         if (Configuration::get('PS_STORES_DISPLAY_SITEMAP')) {
             $pages[] = [
                 'id' => 'stores-page',
-                'label' => $this->getTranslator()->trans('Our stores', array(), 'Shop.Theme'),
+                'label' => $this->trans('Our stores', array(), 'Shop.Theme'),
                 'url' => $this->context->link->getPageLink('stores'),
             ];
         }
 
         $pages[] = [
             'id' => 'contact-page',
-            'label' => $this->getTranslator()->trans('Contact us', array(), 'Shop.Theme'),
+            'label' => $this->trans('Contact us', array(), 'Shop.Theme'),
             'url' => $this->context->link->getPageLink('contact'),
         ];
 
         $pages[] = [
             'id' => 'sitemap-page',
-            'label' => $this->getTranslator()->trans('Sitemap', array(), 'Shop.Theme'),
+            'label' => $this->trans('Sitemap', array(), 'Shop.Theme'),
             'url' => $this->context->link->getPageLink('sitemap'),
         ];
 
         $pages[] = [
             'id' => 'login-page',
-            'label' => $this->getTranslator()->trans('Log in', array(), 'Shop.Theme'),
+            'label' => $this->trans('Log in', array(), 'Shop.Theme'),
             'url' => $this->context->link->getPageLink('authentication'),
         ];
 
         $pages[] = [
             'id' => 'register-page',
-            'label' => $this->getTranslator()->trans('Create new account', array(), 'Shop.Theme'),
+            'label' => $this->trans('Create new account', array(), 'Shop.Theme'),
             'url' => $this->context->link->getPageLink('authentication'),
         ];
 
         $catalog = [
             'new-product' => [
                 'id' => 'new-product-page',
-                'label' => $this->getTranslator()->trans('New products', array(), 'Shop.Theme.Catalog'),
+                'label' => $this->trans('New products', array(), 'Shop.Theme.Catalog'),
                 'url' => $this->context->link->getPageLink('new-products'),
             ],
         ];
@@ -100,44 +100,44 @@ class SitemapControllerCore extends FrontController
         if ($catalog_mode && Configuration::get('PS_DISPLAY_BEST_SELLERS')) {
             $catalog['best-sales'] = [
                 'id' => 'best-sales-page',
-                'label' => $this->getTranslator()->trans('Best sellers', array(), 'Shop.Theme.Catalog'),
+                'label' => $this->trans('Best sellers', array(), 'Shop.Theme.Catalog'),
                 'url' => $this->context->link->getPageLink('best-sales'),
             ];
             $catalog['prices-drop'] = [
                 'id' => 'prices-drop-page',
-                'label' => $this->getTranslator()->trans('Price drop', array(), 'Shop.Theme.Catalog'),
+                'label' => $this->trans('Price drop', array(), 'Shop.Theme.Catalog'),
                 'url' => $this->context->link->getPageLink('prices-drop'),
             ];
         }
 
         $catalog['manufacturer'] = [
             'id' => 'manufacturer-page',
-            'label' => $this->getTranslator()->trans('Manufacturers', array(), 'Shop.Theme.Catalog'),
+            'label' => $this->trans('Manufacturers', array(), 'Shop.Theme.Catalog'),
             'url' => $this->context->link->getPageLink('manufacturer'),
         ];
 
         $catalog['supplier'] = [
             'id' => 'supplier-page',
-            'label' => $this->getTranslator()->trans('Suppliers', array(), 'Shop.Theme.Catalog'),
+            'label' => $this->trans('Suppliers', array(), 'Shop.Theme.Catalog'),
             'url' => $this->context->link->getPageLink('supplier'),
         ];
 
         $categories = Category::getRootCategory()->recurseLiteCategTree(0, 0, null, null, 'sitemap');
         $catalog['category'] = [
             'id' => 'category-page',
-            'label' => $this->getTranslator()->trans('Categories', array(), 'Shop.Theme.Catalog'),
+            'label' => $this->trans('Categories', array(), 'Shop.Theme.Catalog'),
             'url' => '#',
             'children' => $categories['children'],
         ];
 
         $sitemap = [[
                 'id' => 'page-page',
-                'label' => $this->getTranslator()->trans('Pages', array(), 'Shop.Theme'),
+                'label' => $this->trans('Pages', array(), 'Shop.Theme'),
                 'url' => '#',
                 'children' => $pages,
             ],[
                 'id' => 'catalog-page',
-                'label' => $this->getTranslator()->trans('Catalog', array(), 'Shop.Theme'),
+                'label' => $this->trans('Catalog', array(), 'Shop.Theme'),
                 'url' => '#',
                 'children' => $catalog,
             ],

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -209,25 +209,25 @@ class StoresControllerCore extends FrontController
             unset($store['hours']);
             $store['business_hours'] = [
                 [
-                    'day' => $this->getTranslator()->trans('Monday', array(), 'Shop.Theme'),
+                    'day' => $this->trans('Monday', array(), 'Shop.Theme'),
                     'hours' => $temp[0],
                 ],[
-                    'day' => $this->getTranslator()->trans('Tuesday', array(), 'Shop.Theme'),
+                    'day' => $this->trans('Tuesday', array(), 'Shop.Theme'),
                     'hours' => $temp[1],
                 ],[
-                    'day' => $this->getTranslator()->trans('Wednesday', array(), 'Shop.Theme'),
+                    'day' => $this->trans('Wednesday', array(), 'Shop.Theme'),
                     'hours' => $temp[2],
                 ],[
-                    'day' => $this->getTranslator()->trans('Thursday', array(), 'Shop.Theme'),
+                    'day' => $this->trans('Thursday', array(), 'Shop.Theme'),
                     'hours' => $temp[3],
                 ],[
-                    'day' => $this->getTranslator()->trans('Friday', array(), 'Shop.Theme'),
+                    'day' => $this->trans('Friday', array(), 'Shop.Theme'),
                     'hours' => $temp[4],
                 ],[
-                    'day' => $this->getTranslator()->trans('Saturday', array(), 'Shop.Theme'),
+                    'day' => $this->trans('Saturday', array(), 'Shop.Theme'),
                     'hours' => $temp[5],
                 ],[
-                    'day' => $this->getTranslator()->trans('Sunday', array(), 'Shop.Theme'),
+                    'day' => $this->trans('Sunday', array(), 'Shop.Theme'),
                     'hours' => $temp[6],
                 ],
             ];

--- a/controllers/front/SupplierController.php
+++ b/controllers/front/SupplierController.php
@@ -134,7 +134,7 @@ class SupplierControllerCore extends ProductListingFrontController
             $suppliers_for_display[$supplier['id_supplier']]['text'] = $supplier['description'];
             $suppliers_for_display[$supplier['id_supplier']]['image'] = _THEME_SUP_DIR_.$supplier['id_supplier'].'-medium_default.jpg';
             $suppliers_for_display[$supplier['id_supplier']]['url'] = $this->context->link->getsupplierLink($supplier['id_supplier']);
-            $suppliers_for_display[$supplier['id_supplier']]['nb_products'] = $supplier['nb_products'] > 1 ? sprintf($this->getTranslator()->trans('%s products', array(), 'Shop.Theme.Catalog'), $supplier['nb_products']) : sprintf($this->getTranslator()->trans('% product', array(), 'Shop.Theme.Catalog'), $supplier['nb_products']);
+            $suppliers_for_display[$supplier['id_supplier']]['nb_products'] = $supplier['nb_products'] > 1 ? sprintf($this->trans('%s products', array(), 'Shop.Theme.Catalog'), $supplier['nb_products']) : sprintf($this->trans('% product', array(), 'Shop.Theme.Catalog'), $supplier['nb_products']);
         }
 
         return $suppliers_for_display;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Introduce trans() method in every controller |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |

AdminController got trans() method recently, I moved it to the Abstract class
of Controller so front and back are similar.

``` php
$this->trans('Words', array(). 'Domain');
```

feels easier than

``` php
$this->getTranslator()->trans('Words', array(). 'Domain');
```
