### PR TITLE
Fixed enable/disable mobile bulk actions on modules

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -809,8 +809,8 @@ var AdminModuleController = function () {
             'bulk-uninstall': 'uninstall',
             'bulk-disable': 'disable',
             'bulk-enable': 'enable',
-            'bulk-disable-mobile': 'disable-mobile',
-            'bulk-enable-mobile': 'enable-mobile',
+            'bulk-disable-mobile': 'disable_mobile',
+            'bulk-enable-mobile': 'enable_mobile',
             'bulk-reset': 'reset'
         };
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Before, the enable/disable module for mobile was'nt working when used in bulk action |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1008 |
| How to test? | Try to enable/disable multiples modules using "Enable Mobile" and "Disable Mobile" options. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
