### PR TITLE
Fixed CTA action on read more modal in Module list

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more.html.twig
@@ -105,9 +105,7 @@
               {% endfor %}
             </div>
         {% endif %}
-        {% if module.attributes.urls.install is defined %}
-            <a href="{{module.attributes.urls.install}}" class="pull-right module-install-button btn-primary-outline btn module-install-button btn-sm light-button">{{ 'Install'|trans({}, 'Admin.Actions') }}</a>
-        {% endif %}
+        {% include 'PrestaShopBundle:Admin/Module/Includes:action_menu.html.twig' with { 'module': module } %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | CTA is now consistent between "read more" modal and modules list |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1004 |
| How to test? | Click on read more modal of a module, the CTA (call to action button) should have the same label (install, the price, etc ...) |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
