### PR TITLE
Fix displayHeader hook called twice

### DIFF
--- a/themes/classic/templates/_partials/head.tpl
+++ b/themes/classic/templates/_partials/head.tpl
@@ -28,5 +28,5 @@
 {/if}
 
 {block name='hook_header'}
-  {hook h='displayHeader'}
+  {$HOOK_HEADER}
 {/block}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | displayHeader hook was called twice |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | open anything in FO |
