### PR TITLE
Add a new hook on cart product line

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -325,5 +325,8 @@
     <hook id="actionEmailAddAfterContent" live_edit="0">
       <name>actionEmailAddAfterContent</name><title>Add extra content after mail content</title><description>This hook is called just after fetching mail template</description>
     </hook>
+    <hook id="displayCartExtraProductActions" live_edit="0">
+      <name>displayCartExtraProductActions</name><title>Extra buttons in shopping cart</title><description>This hook adds extra buttons to the product lines, in the shopping cart</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.6.1.7.sql
+++ b/install-dev/upgrade/sql/1.6.1.7.sql
@@ -1,0 +1,3 @@
+SET NAMES 'utf8';
+
+INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('displayCartExtraProductActions', 'Extra buttons in shopping cart', 'This hook adds extra buttons to the product lines, in the shopping cart', 0);

--- a/themes/default-bootstrap/shopping-cart-product-line.tpl
+++ b/themes/default-bootstrap/shopping-cart-product-line.tpl
@@ -133,6 +133,7 @@
 				{/if}
 			{/if}
 		</span>
+		{hook h='displayCartExtraProductActions' product=$product}
 	</td>
 
 </tr>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | This PR adds a new hook called `displayCartExtraProductActions` on cart product line. It's a rework of #5668 for `1.6.1.x` |
| Type? | new feature |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1011 |
