### PR TITLE
BO : fix query export in SQL Manager (#BOOM-841)

### DIFF
--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -293,7 +293,7 @@ class AdminRequestSqlControllerCore extends AdminController
             }
             $this->content .= $this->renderView();
         } elseif ($this->display == 'export') {
-            $this->generateExport();
+            $this->processExport();
         } elseif (!$this->ajax) {
             $this->content .= $this->renderList();
             $this->content .= $this->renderOptions();
@@ -324,7 +324,7 @@ class AdminRequestSqlControllerCore extends AdminController
     /**
      * Genrating a export file
      */
-    public function generateExport()
+    public function processExport($textDelimiter = '"')
     {
         $id = Tools::getValue($this->identifier);
         $export_dir = defined('_PS_HOST_MODE_') ? _PS_ROOT_DIR_.'/export/' : _PS_ADMIN_DIR_.'/export/';
@@ -344,7 +344,7 @@ class AdminRequestSqlControllerCore extends AdminController
                 foreach ($results as $result) {
                     fputs($csv, "\n");
                     foreach ($tab_key as $name) {
-                        fputs($csv, '"'.strip_tags($result[$name]).'";');
+                        fputs($csv, $textDelimiter.strip_tags($result[$name]).$textDelimiter.';');
                     }
                 }
                 if (file_exists($export_dir.$file)) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR fixes the export action in SQL Manager. Query string was exported before, now results are exported |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-841 |
| How to test? | In SQL Manager, add a select query (all products for example). Try to export the query to csv file. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
