### PR TITLE
Add taxes to modal and a link to product detail in summary

### DIFF
--- a/themes/classic/modules/blockcart/modal.tpl
+++ b/themes/classic/modules/blockcart/modal.tpl
@@ -34,6 +34,9 @@
               {/if}
               <p><strong>{l s='Total products:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.subtotals.products.value}</p>
               <p><strong>{l s='Total shipping:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.subtotals.shipping.value}</p>
+              {if isset($cart.subtotals.tax.label)}
+              	<p><strong>{$cart.subtotals.tax.label}</strong>&nbsp;{$cart.subtotals.tax.value}</p>
+              {/if}
               <p><strong>{l s='Total:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.totals.total.value}</p>
               <button type="button" class="btn btn-secondary" data-dismiss="modal">{l s='Continue shopping' d='Shop.Theme.Actions'}</button>
               <a href="{$cart_url}" class="btn btn-primary"><i class="material-icons">&#xE876;</i>{l s='proceed to checkout' d='Shop.Theme.Actions'}</a>

--- a/themes/classic/modules/blockcart/modal.tpl
+++ b/themes/classic/modules/blockcart/modal.tpl
@@ -34,7 +34,7 @@
               {/if}
               <p><strong>{l s='Total products:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.subtotals.products.value}</p>
               <p><strong>{l s='Total shipping:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.subtotals.shipping.value}</p>
-              {if isset($cart.subtotals.tax.label)}
+              {if $cart.subtotals.tax}
               	<p><strong>{$cart.subtotals.tax.label}</strong>&nbsp;{$cart.subtotals.tax.value}</p>
               {/if}
               <p><strong>{l s='Total:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.totals.total.value} {$cart.labels.tax_short}</p>

--- a/themes/classic/modules/blockcart/modal.tpl
+++ b/themes/classic/modules/blockcart/modal.tpl
@@ -37,7 +37,7 @@
               {if isset($cart.subtotals.tax.label)}
               	<p><strong>{$cart.subtotals.tax.label}</strong>&nbsp;{$cart.subtotals.tax.value}</p>
               {/if}
-              <p><strong>{l s='Total:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.totals.total.value}</p>
+              <p><strong>{l s='Total:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.totals.total.value} {$cart.labels.tax_short}</p>
               <button type="button" class="btn btn-secondary" data-dismiss="modal">{l s='Continue shopping' d='Shop.Theme.Actions'}</button>
               <a href="{$cart_url}" class="btn btn-primary"><i class="material-icons">&#xE876;</i>{l s='proceed to checkout' d='Shop.Theme.Actions'}</a>
             </div>

--- a/themes/classic/templates/_partials/head.tpl
+++ b/themes/classic/templates/_partials/head.tpl
@@ -28,5 +28,5 @@
 {/if}
 
 {block name='hook_header'}
-  {$HOOK_HEADER}
+  {$HOOK_HEADER nofilter}
 {/block}

--- a/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
@@ -13,7 +13,9 @@
           </span>
         </td>
         <td>
-          {$product.name}
+          {if isset($is_final_summary)}<a href="{$product.url}" target="_blank">{/if}
+            {$product.name}
+          {if isset($is_final_summary)}</a>{/if}
           {foreach from=$product.attributes key="attribute" item="value"}
             - <span class="value">{$value}</span>
           {/foreach}

--- a/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
@@ -13,9 +13,9 @@
           </span>
         </td>
         <td>
-          {if isset($is_final_summary)}<a href="{$product.url}" target="_blank">{/if}
+          {if $add_product_link}<a href="{$product.url}" target="_blank">{/if}
             {$product.name}
-          {if isset($is_final_summary)}</a>{/if}
+          {if $add_product_link}</a>{/if}
           {foreach from=$product.attributes key="attribute" item="value"}
             - <span class="value">{$value}</span>
           {/foreach}

--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -72,7 +72,7 @@
          subtotals=$cart.subtotals
          totals=$cart.totals
          labels=$cart.labels
-         is_final_summary=true
+         add_product_link=true
        }
     {/block}
   </div>

--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -72,6 +72,7 @@
          subtotals=$cart.subtotals
          totals=$cart.totals
          labels=$cart.labels
+         is_final_summary=true
        }
     {/block}
   </div>

--- a/themes/classic/templates/checkout/order-confirmation.tpl
+++ b/themes/classic/templates/checkout/order-confirmation.tpl
@@ -41,6 +41,7 @@
             subtotals=$order.subtotals
             totals=$order.totals
             labels=$order.labels
+            add_product_link=false
           }
         {/block}
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Adds a new line with tax info to the modal layer, adds a link to the product detail view in the final summary |
| Type? | improvement |
| Category? | FO |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1027 and http://forge.prestashop.com/browse/BOOM-1059 |
| How to test? | Add product to cart and activate "display taxes" in Taxes menu; Activate final summary in checkout |
