### PR TITLE
FO: Limit title attribute in footer

### DIFF
--- a/themes/default-bootstrap/modules/blockcategories/category-tree-branch.tpl
+++ b/themes/default-bootstrap/modules/blockcategories/category-tree-branch.tpl
@@ -24,8 +24,8 @@
 *}
 
 <li {if isset($last) && $last == 'true'}class="last"{/if}>
-	<a 
-	href="{$node.link|escape:'html':'UTF-8'}"{if isset($currentCategoryId) && $node.id == $currentCategoryId} class="selected"{/if} title="{$node.desc|strip_tags|trim|escape:'html':'UTF-8'}">
+	<a
+	href="{$node.link|escape:'html':'UTF-8'}"{if isset($currentCategoryId) && $node.id == $currentCategoryId} class="selected"{/if} title="{$node.desc|strip_tags|trim|truncate:512|escape:'html':'UTF-8'}">
 		{$node.name|escape:'html':'UTF-8'}
 	</a>
 	{if $node.children|@count > 0}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Truncate the title attributes for categories in the footer. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | no |
| How to test? | Hover category links in the footer after filling their descriptions with a lot of text. |

Browsers differ implementation, the most conservative seems to be IE that limits at 512 chars, anyway the title tag becomes less and less useful with more text.  
See http://stackoverflow.com/a/17444937/1092853 and https://msdn.microsoft.com/library/ms534683(v=vs.85).aspx
