### PR TITLE
FO: delete call to Tools::safePostVars() on FrontController::display()

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -588,8 +588,6 @@ class FrontControllerCore extends Controller
      */
     public function display()
     {
-        Tools::safePostVars();
-
         // assign css_files and js_files at the very last time
         if (is_writable(_PS_THEME_DIR_.'cache')) {
             // CSS compressor management


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The call to this method was kept for retro-compatibility with older themes. Now that the theme was rewrite from scratch, this call can be removed. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | yes |
| Deprecations? | yes |
