### PR TITLE
Prevent hooks displayMaintenance & displayHome to be called twice

### DIFF
--- a/themes/classic/templates/errors/maintenance.tpl
+++ b/themes/classic/templates/errors/maintenance.tpl
@@ -7,7 +7,7 @@
     {block name='page_header_container'}
       <header class="page-header">
         <div class="logo"><img src="{$shop.logo}" alt="logo"></div>
-        {hook h='displayMaintenance'}
+        {$HOOK_MAINTENANCE nofilter}
         {block name='page_header'}
           <h1>{block name='page_title'}{l s='We\'ll be back soon.' d='Shop.Theme'}{/block}</h1>
         {/block}

--- a/themes/classic/templates/index.tpl
+++ b/themes/classic/templates/index.tpl
@@ -1,5 +1,5 @@
 {extends file='page.tpl'}
 
 {block name='page_content'}
-    {hook h='displayHome'}
+    {$HOOK_HOME nofilter}
 {/block}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | On the classic theme, the displayMaintenance and displayHome hooks are called while they are already called on the controllers |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
