### PR TITLE
Fix trans() when no domain is set

### DIFF
--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -34,7 +34,9 @@ trait PrestaShopTranslatorTrait
      */
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
-        $domain = preg_replace('/\./', '', $domain);
+        if (null !== $domain) {
+            $domain = preg_replace('/\./', '', $domain);
+        }
 
         if (!$this->isSprintfString($id) || empty($parameters)) {
             return parent::trans($id, $parameters, $domain, $locale);
@@ -48,7 +50,9 @@ trait PrestaShopTranslatorTrait
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
-        $domain = preg_replace('/\./', '', $domain);
+        if (null !== $domain) {
+            $domain = preg_replace('/\./', '', $domain);
+        }
 
         if (!$this->isSprintfString($id)) {
             return parent::transChoice($id, $number, $parameters, $domain, $locale);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | My previous PR #5878 introduce a bug when no domain were set. the preg_match will cast null to string. This fix ensure an empty domain become "messages" |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
