### PR TITLE
[-] CORE : Fix bug #PSCSX-6142 - wrong default cover id in webservice in 1.6.1.x

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5372,7 +5372,7 @@ class ProductCore extends ObjectModel
     public function setCoverWs($id_image)
     {
         Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.'image_shop` image_shop, `'._DB_PREFIX_.'image` i
-			SET image_shop.`cover` = 0
+			SET image_shop.`cover` = NULL
 			WHERE i.`id_product` = '.(int)$this->id.' AND i.id_image = image_shop.id_image
 			AND image_shop.id_shop='.(int)Context::getContext()->shop->id);
         Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.'image_shop`


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | This was supposed to be fixed in https://github.com/PrestaShop/PrestaShop/commit/2f165db08aeec2fa6899ee6cc380a9b027e44c77 (see http://forge.prestashop.com/browse/PSCSX-6461 and http://forge.prestashop.com/browse/PSCSX-6142). Merely bringing in the changes made in develop branch back in 2015 into stable branch. The issue fixed here is that updating a product's cover image through webservice method would throw a duplicate entry database error due to cover being set to 0 instead of nulled |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
