### PR TITLE
Fix "Export to SQL Manager" buttons

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1620,15 +1620,15 @@ function refresh_kpis()
 
 function createSqlQueryName()
 {
-	var container = false;
-	if ($('.breadcrumb-container'))
-		container = $('.breadcrumb-container').first().text().replace(/\s+/g, ' ').trim();
-	var current = false;
-	if ($('.breadcrumb-current'))
-		current = $('.breadcrumb-current').first().text().replace(/\s+/g, ' ').trim();
-	var title = false;
-	if ($('.page-title'))
-		title = $('.page-title').first().text().replace(/\s+/g, ' ').trim();
+  var container = false;
+  var current = false;
+  if ($('.breadcrumb')) {
+    container = $('.breadcrumb li').eq(0).text().replace(/\s+/g, ' ').trim();
+    current = $('.breadcrumb li').eq(-1).text().replace(/\s+/g, ' ').trim();
+  }
+  var title = false;
+  if ($('h2.title'))
+    title = $('h2.title').first().text().replace(/\s+/g, ' ').trim();
 
 	var name = false;
 	if (container && current && container != current)


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fixes the "export to SQL Manager" action on Catalog page (BO). The function that generate the name of query from breadcrumb content was not working. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-580   &   http://forge.prestashop.com/browse/BOOM-702 |
| How to test? | First, in BO, Catalog > Products, try to click on "Export to SQL Manager". It should works now. Still in BO, Catalog > Products, click on "Show SQL query" then click on "Export to SQL Manager". It should go to SQL manager too. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
