### PR TITLE
Fixed actionCustomerUpdate/actionCustomerAccountAdd hooks calls

### DIFF
--- a/classes/form/CustomerPersister.php
+++ b/classes/form/CustomerPersister.php
@@ -112,7 +112,7 @@ class CustomerPersisterCore
             $this->context->updateCustomer($customer);
             $this->context->cart->update();
             Hook::exec('actionCustomerAccountUpdate', [
-                'newCustomer' => $customer
+                'customer' => $customer
             ]);
             if ($guest_to_customer) {
                 $this->sendConfirmationMail($customer);
@@ -168,7 +168,7 @@ class CustomerPersisterCore
             $this->context->cart->update();
             $this->sendConfirmationMail($customer);
             Hook::exec('actionCustomerAccountAdd', array(
-                'customer' => $customer
+                'newCustomer' => $customer
             ));
         }
 

--- a/classes/form/CustomerPersister.php
+++ b/classes/form/CustomerPersister.php
@@ -111,7 +111,7 @@ class CustomerPersisterCore
         if ($ok) {
             $this->context->updateCustomer($customer);
             $this->context->cart->update();
-            Hook::exec('actionCustomerAccountAdd', [
+            Hook::exec('actionCustomerAccountUpdate', [
                 'newCustomer' => $customer
             ]);
             if ($guest_to_customer) {
@@ -167,7 +167,7 @@ class CustomerPersisterCore
             $this->context->updateCustomer($customer);
             $this->context->cart->update();
             $this->sendConfirmationMail($customer);
-            Hook::exec('actionCustomerAccountUpdate', array(
+            Hook::exec('actionCustomerAccountAdd', array(
                 'customer' => $customer
             ));
         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch | develop |
| Description | Added proper hook execution. While customer updates an account - hookactionCustomerUpdate should be spawned. If customer creates an account (register) hook: actionCustomerAccountAdd should be spawned. |
| Type | bug fix |
| Category | CO |
| BC breaks | NO |
| Deprecations? | NO |
| Fixed ticket | - |
| How to test | create new customer account / save customer on "identity" page |
