### PR TITLE
Fixed "print out" link display condition

### DIFF
--- a/controllers/front/OrderFollowController.php
+++ b/controllers/front/OrderFollowController.php
@@ -111,7 +111,7 @@ class OrderFollowControllerCore extends FrontController
             $orders_returns[$id_order_return] = $order_return;
             $orders_returns[$id_order_return]['return_number'] = sprintf('#%06d', $order_return['id_order_return']);
             $orders_returns[$id_order_return]['return_date'] = Tools::displayDate($order_return['date_add'], null, false);
-            $orders_returns[$id_order_return]['print_url'] = ($order_return['date_add'] == 2) ? $this->context->link->getPageLink('pdf-order-return', true, null, 'id_order_return='.$order_return['id_order_return']) : '';
+            $orders_returns[$id_order_return]['print_url'] = ($order_return['state'] == 2) ? $this->context->link->getPageLink('pdf-order-return', true, null, 'id_order_return='.$order_return['id_order_return']) : '';
             $orders_returns[$id_order_return]['details_url'] = $this->context->link->getPageLink('order-detail', true, null, 'id_order='.(int)$order_return['id_order']);
             $orders_returns[$id_order_return]['return_url'] = $this->context->link->getPageLink('order-return', true, null, 'id_order_return='.(int)$order_return['id_order_return']);
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix the display condition of "print out" link when an order return has a "waiting for package" state. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1070 |
| How to test? | Make sure order return feature is enabled first. Then create an order and change the status to "Delivered" so you can create an order return. Create an order return on customer's side. In BO, change the status of order return to "waiting for package". The "print out" link should now be displayed for customer on "Return Merchandise" page. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
