### PR TITLE
Upgrade an uploaded module when already installed

### DIFF
--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -199,6 +199,10 @@ class Module implements ModuleInterface
             return false;
         }
 
+        // If not modified, code used in installer is executed:
+        // "Notice: Use of undefined constant _PS_INSTALL_LANGS_PATH_ - assumed '_PS_INSTALL_LANGS_PATH_'"
+        \Module::updateTranslationsAfterInstall(false);
+
         return $this->instance->install();
     }
 

--- a/src/Adapter/Module/ModuleDataUpdater.php
+++ b/src/Adapter/Module/ModuleDataUpdater.php
@@ -84,6 +84,7 @@ class ModuleDataUpdater
             } elseif (\ModuleCore::getUpgradeStatus($name)) {
                 return true;
             }
+            return true;
         }
 
         return false;

--- a/src/Adapter/Module/ModuleZipManager.php
+++ b/src/Adapter/Module/ModuleZipManager.php
@@ -1,0 +1,214 @@
+<?php
+/*
+ * 2007-2016 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2016 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Module;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\TranslatorInterface;
+
+use Exception;
+use Tools;
+
+class ModuleZipManager
+{
+    /*
+     * Data
+     */
+    private static $sources = array();
+    private $attributes = array('name', 'sandboxPath');
+
+    /*
+     * Services
+     */
+    /**
+     * @var Symfony\Component\Filesystem\Filesystem
+     */
+    private $filesystem;
+    /**
+     * @var Symfony\Component\Finder\Finder
+     */
+    private $finder;
+    private $translator;
+    
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->filesystem = new Filesystem();
+        $this->finder = new Finder();
+        $this->translator = $translator;
+    }
+
+    /**
+     * Detect module name from zipball.
+     * @param String $source
+     * @return String
+     * @throws Exception If unable to find the module name
+     */
+    public function getName($source)
+    {
+        $this->initSource($source);
+        
+        if ($this->get($source, 'name') !== null) {
+            return $this->get($source, 'name');
+        }
+
+        if (!file_exists($source)) {
+            throw new Exception(
+                $this->translator->trans(
+                    'Unable to find uploaded module at the following path: %file%',
+                    array('%file%' => $source),
+                    'Admin.Modules.Notification'));
+        }
+
+        $sandboxPath = $this->getSandboxPath($source);
+        if (!Tools::ZipExtract($source, $sandboxPath)) {
+            throw new Exception(
+                $this->translator->trans(
+                    'Cannot extract module in %path% to get its name.',
+                    array('%path%' => $sandboxPath),
+                    'Admin.Modules.Notification'));
+        }
+
+        // Check the structure and get the module name
+        $directories = $this->finder->directories()
+            ->in($sandboxPath)
+            ->depth('== 0')
+            ->exclude(['__MACOSX'])
+            ->ignoreVCS(true);
+
+        $validModuleStructure = false;
+        // We must have only one folder in the zip, which contains the module files
+        if (iterator_count($directories->directories()) == 1) {
+            $directories = iterator_to_array($directories);
+            $moduleName = basename(current($directories)->getFileName());
+
+            // Inside of this folder, we MUST have a file called <module name>.php
+            $moduleFolder = $this->finder->files()
+                    ->in($sandboxPath.$moduleName)
+                    ->depth('== 0')
+                    ->exclude(['__MACOSX'])
+                    ->ignoreVCS(true);
+            foreach (iterator_to_array($moduleFolder) as $file) {
+                if ($file->getFileName() === $moduleName.'.php') {
+                    $validModuleStructure = true;
+                    break;
+                }
+            }
+        }
+
+        if (!$validModuleStructure) {
+            $this->filesystem->remove($sandboxPath);
+            throw new Exception($this->translator->trans(
+                    'This file does not seem to be a valid module zip',
+                    array(),
+                    'Admin.Modules.Notification'));
+        }
+
+        $this->set($source, 'name', $moduleName);
+        return $moduleName;
+    }
+
+    /**
+     * When ready, send the module Zip in the modules folder
+     * @param String $source
+     */
+    public function storeInModulesFolder($source)
+    {
+        $name = $this->get($source, 'name');
+        $sandboxPath = $this->get($source, 'sandboxPath');
+        // Now we are sure to have a valid module, we copy it to the modules folder
+        $modulePath = _PS_MODULE_DIR_.$name;
+        $this->filesystem->mkdir($modulePath);
+        $this->filesystem->mirror(
+            $sandboxPath.$name,
+            $modulePath
+        );
+        $this->filesystem->remove($sandboxPath);
+    }
+
+    private function getSandboxPath($source)
+    {
+        $sandboxPath = $this->get($source, 'sandboxPath');
+        if ($sandboxPath === null) {
+            $sandboxPath = _PS_CACHE_DIR_.'sandbox/'.uniqid().'/';
+            $this->filesystem->mkdir($sandboxPath, 0755);
+            $this->set($source, 'sandboxPath', $sandboxPath);
+        }
+        return $sandboxPath;
+    }
+
+    /**
+     * Get a attribute value about a source
+     * @param String $source
+     * @param String $attr defined in $attributes
+     * @return mixed
+     * @throws Exception if $attr value not in list
+     */
+    private function get($source, $attr)
+    {
+        if (!in_array($attr, $this->attributes)) {
+            throw new Exception('Unknow source attribute');
+        }
+        return self::$sources[$source][$attr];
+    }
+
+    /**
+     * Store a value about a source
+     * @param String $source
+     * @param String $attr
+     * @param mixed $value
+     * @throws Exception if $attr value not in list
+     */
+    private function set($source, $attr, $value)
+    {
+        if (!in_array($attr, $this->attributes)) {
+            throw new Exception('Unknow source attribute');
+        }
+        self::$sources[$source][$attr] = $value;
+    }
+
+    /**
+     * Init all data regarding a source before proceeding it
+     * @param String $source
+     */
+    private function initSource($source)
+    {
+        if ((filter_var($source, FILTER_VALIDATE_URL))) {
+            $source = Tools::createFileFromUrl($source);
+        }
+
+        if (isset(self::$sources[$source])) {
+            foreach ($this->attributes as $attr) {
+                $this->{$attr} = self::$sources[$source][$attr];
+            }
+        } else {
+            foreach ($this->attributes as $attr) {
+                $this->{$attr} = null;
+                self::$sources[$source][$attr] = null;
+            }
+        }
+    }
+}

--- a/src/Adapter/Module/ModuleZipManager.php
+++ b/src/Adapter/Module/ModuleZipManager.php
@@ -54,10 +54,10 @@ class ModuleZipManager
     private $finder;
     private $translator;
     
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(Filesystem $filesystem, Finder $finder, TranslatorInterface $translator)
     {
-        $this->filesystem = new Filesystem();
-        $this->finder = new Finder();
+        $this->filesystem = $filesystem;
+        $this->finder = $finder;
         $this->translator = $translator;
     }
 

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Router;
@@ -46,6 +47,7 @@ class ModuleManagerBuilder
     public static $legacyLogger = null;
     public static $moduleDataProvider = null;
     public static $moduleDataUpdater = null;
+    public static $moduleZipManager = null;
     public static $translator = null;
 
     public function __construct()
@@ -61,6 +63,7 @@ class ModuleManagerBuilder
             self::$moduleDataUpdater       = new ModuleDataUpdater($addonsDataProvider, self::$adminModuleDataProvider);
             self::$legacyLogger            = new LegacyLogger();
             self::$moduleDataProvider      = new ModuleDataProvider(self::$legacyLogger, self::$translator);
+            self::$moduleZipManager = new ModuleZipManager(self::$translator);
         }
     }
 
@@ -80,6 +83,7 @@ class ModuleManagerBuilder
                 self::$moduleDataProvider,
                 self::$moduleDataUpdater,
                 $this->buildRepository(),
+                self::$moduleZipManager,
                 self::$translator,
                 Context::getContext()->employee
             );

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -33,6 +33,8 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
 
@@ -63,7 +65,7 @@ class ModuleManagerBuilder
             self::$moduleDataUpdater       = new ModuleDataUpdater($addonsDataProvider, self::$adminModuleDataProvider);
             self::$legacyLogger            = new LegacyLogger();
             self::$moduleDataProvider      = new ModuleDataProvider(self::$legacyLogger, self::$translator);
-            self::$moduleZipManager = new ModuleZipManager(self::$translator);
+            self::$moduleZipManager = new ModuleZipManager(new Filesystem, new Finder, self::$translator);
         }
     }
 

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -3,6 +3,10 @@ imports:
     - { resource: admin/services-form.yml }
 
 services:
+    finder:
+        class: Symfony\Component\Finder\Finder
+        public: false
+
     prestashop.database.naming_strategy:
         class: PrestaShopBundle\Service\Database\DoctrineNamingStrategy
         arguments: ["%database_prefix%"]
@@ -205,6 +209,8 @@ services:
     prestashop.module.zip.manager:
         class: PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager
         arguments:
+            - "@filesystem"
+            - "@finder"
             - "@translator"
 
     # TRANSLATIONS

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -198,8 +198,14 @@ services:
             - "@prestashop.adapter.data_provider.module"
             - "@prestashop.core.module.updater"
             - "@prestashop.core.admin.module.repository"
+            - "@prestashop.module.zip.manager"
             - "@translator"
             - "@=service('prestashop.adapter.legacy.context').getContext().employee"
+            
+    prestashop.module.zip.manager:
+        class: PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager
+        arguments:
+            - "@translator"
 
     # TRANSLATIONS
     prestashop.translations.database_loader:

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -37,6 +37,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
     private $moduleProviderS; // S means "Stub"
     private $moduleUpdaterS;
     private $moduleRepositoryS;
+    private $moduleZipManagerS;
     private $translatorS;
     private $employeeS;
 
@@ -49,6 +50,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
             $this->moduleProviderS,
             $this->moduleUpdaterS,
             $this->moduleRepositoryS,
+            $this->moduleZipManagerS,
             $this->translatorS,
             $this->employeeS
         );
@@ -64,8 +66,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
     public function testInstallSuccessful()
     {
         $this->assertTrue($this->moduleManager->install(self::UNINSTALLED_MODULE));
-        $this->setExpectedException('Exception', 'The module %module% is already installed.');
-        $this->moduleManager->install(self::INSTALLED_MODULE);
+        $this->assertTrue($this->moduleManager->install(self::INSTALLED_MODULE));
     }
 
     public function testUninstallSuccessful()
@@ -143,6 +144,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
         $this->mockModuleProvider();
         $this->mockModuleUpdater();
         $this->mockModuleRepository();
+        $this->mockModuleZipManager();
         $this->mockTranslator();
         $this->mockEmployee();
     }
@@ -274,6 +276,20 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
             ->willReturn($moduleS);
     }
 
+    private function mockModuleZipManager()
+    {
+        $this->moduleZipManagerS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->moduleZipManagerS
+            ->method('getName')
+            ->will($this->returnArgument(0));
+
+        $this->moduleZipManagerS
+            ->method('storeInModulesFolder');
+    }
+
     private function mockTranslator()
     {
         $this->translatorS = $this->getMockBuilder('Symfony\Component\Translation\Translator')
@@ -303,6 +319,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
         $this->moduleProviderS = null;
         $this->moduleUpdaterS = null;
         $this->moduleUpdaterS = null;
+        $this->moduleZipManagerS = null;
         $this->translatorS = null;
         $this->employeeS = null;
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Currently, when we upload a module which is already installed, an error is thrown by the ModuleManager. In case of faillure, the ModuleController cleans the uploaded files, which are ... the module previously installed. This PR fixes the issue by launching an upgrade instead.<br/> At the same time, we introduce a ModuleZipManager to handle in only one place all the tasks about module name detection and saving. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-637](http://forge.prestashop.com/browse/BOOM-637) |
| How to test? | Upload an already installed module. You should not have the error 'this module is already installed' anymore. |
