### PR TITLE
Add modal for Addons logout on module page

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -41,6 +41,7 @@ var AdminModuleController = function () {
     this.addonsSearchSelector = '.module-addons-search';
     this.addonsSearchLinkSelector = '.module-addons-search-link';
     this.addonsLoginButtonSelector = '#addons_login_btn';
+    this.addonsLogoutButtonSelector = '#addons_logout_btn';
     this.categoryResetBtnSelector = '.module-category-reset';
     this.moduleInstallBtnSelector = 'input.module-install-btn';
     this.moduleInstallLoaderSelector = '.module-install-loader';
@@ -73,9 +74,11 @@ var AdminModuleController = function () {
     /* Selectors for Module Import and Addons connect */
     this.dropModuleBtnSelector = '#page-header-desc-configuration-add_module';
     this.addonsConnectModalBtnSelector = '#page-header-desc-configuration-addons_connect';
+    this.addonsLogoutModalBtnSelector = '#page-header-desc-configuration-addons_logout';
     this.dropZoneModalSelector = '#module-modal-import';
     this.dropZoneImportZoneSelector = '#importDropzone';
     this.addonsConnectModalSelector = '#module-modal-addons-connect';
+    this.addonsLogoutModalSelector = '#module-modal-addons-logout';
     this.addonsConnectForm = '#addons-connect-form';
     this.moduleImportModalCloseBtn = '#module-modal-import-closing-cross';
     this.moduleImportStartSelector = '.module-import-start';
@@ -534,7 +537,10 @@ var AdminModuleController = function () {
             $(this.addonsConnectModalBtnSelector).attr('data-toggle', 'modal');
             $(this.addonsConnectModalBtnSelector).attr('data-target', this.addonsConnectModalSelector);
         }
-
+        if ($(this.addonsLogoutModalBtnSelector).attr('href') == '#') {
+            $(this.addonsLogoutModalBtnSelector).attr('data-toggle', 'modal');
+            $(this.addonsLogoutModalBtnSelector).attr('data-target', this.addonsLogoutModalSelector);
+        }
         $('body').on('submit', this.addonsConnectForm, function (event) {
             event.preventDefault();
             event.stopPropagation();

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -552,9 +552,7 @@ class ModuleController extends FrameworkBundleAdminController
             'icon' => 'cloud_upload',
             'help' => $translator->trans('Upload a module', array(), 'Admin.Modules.Feature'),
         );
-        $toolbarButtons['addons_connect'] = $this->getAddonsConnectToolbar();
-
-        return $toolbarButtons;
+        return array_merge($toolbarButtons, $this->getAddonsConnectToolbar());
     }
 
     private function getPresentedProducts(array &$products)
@@ -585,17 +583,19 @@ class ModuleController extends FrameworkBundleAdminController
     {
         $addonsProvider = $this->get('prestashop.core.admin.data_provider.addons_interface');
         $translator = $this->get('translator');
+        $addonsConnect = array();
 
         if ($addonsProvider->isAddonsAuthenticated()) {
             $addonsEmail = $addonsProvider->getAddonsEmail();
-            $addonsConnect = array(
-                'href' => $this->generateUrl('admin_addons_logout'),
+            $addonsConnect['addons_logout'] = array(
+                'href' => '#',
                 'desc' => $addonsEmail['username_addons'],
                 'icon' => 'exit_to_app',
                 'help' => $translator->trans('Synchronized with Addons marketplace!', array(), 'Admin.Modules.Notification'),
+                'data-trololo' => 'lol',
             );
         } else {
-            $addonsConnect = array(
+            $addonsConnect['addons_connect'] = array(
                 'href' => '#',
                 'desc' => $translator->trans('Connect to Addons marketplace', array(), 'Admin.Modules.Feature'),
                 'icon' => 'vpn_key',

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
@@ -39,3 +39,28 @@
     </div>
   </div>
 </div>
+<div id="module-modal-addons-logout" class="modal  modal-vcenter fade" role="dialog">
+  <div class="modal-dialog">
+    <!-- Modal content-->
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title module-modal-title">{{ 'Confirm logout'|trans({}, 'Admin.Modules.Feature') }}</h4>
+      </div>
+      <div class="modal-body">
+          <div class="row">
+              <div class="col-md-12">
+                  <p>
+                    {{ "You're about to log out your Addons account. You might miss important updates of Addons you've bought."|trans({}, 'Admin.Modules.Notification') }}
+                  </p>
+              </div>
+          </div>
+      </div>
+      <div class="modal-footer">
+          <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
+          <a class="btn btn-primary uppercase" href="{{ path('admin_addons_logout') }}" id="module-modal-addons-logout-ack">{{ 'Yes, log out'|trans({}, 'Admin.Modules.Feature') }}</a>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
@@ -25,7 +25,7 @@
           </div>
       </div>
       <div class="modal-footer">
-          <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="Annuler">
+          <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
           <a class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules.Feature') }}</a>
       </div>
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Before logout a merchant, display a modal to ask for confirmation |
| Type? | improvement |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-45](http://forge.prestashop.com/browse/BOOM-45) |
| How to test? | A modal should now appear when you try to disconnect from the Marketplace |

![capture du 2016-07-27 15-23-40](https://cloud.githubusercontent.com/assets/6768917/17177219/a5fbf224-5410-11e6-9ecd-310ba2b44f32.png)
