### PR TITLE
Render a 404 template if no products found

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -455,8 +455,21 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
             header('Content-Type: application/json');
             die(json_encode($this->getAjaxProductSearchVariables()));
         } else {
-            $this->context->smarty->assign($this->getProductSearchVariables());
-            $this->setTemplate($template);
+            $variables = $this->getProductSearchVariables();
+            if (!empty($variables['products'])) {
+                $this->context->smarty->assign($variables);
+                $this->setTemplate($template);
+            } else {
+                header('HTTP/1.1 404 Not Found');
+                header('Status: 404 Not Found');
+                $this->php_self = 'pagenotfound';
+                $this->page_name = 'pagenotfound';
+                $this->context->smarty->assign(
+                    'title',
+                    $this->trans('No results were found for your search.', array(), 'Shop.Notifications.Error')
+                );
+                $this->setTemplate('errors/404.tpl');
+            }
         }
     }
 

--- a/themes/classic/templates/errors/404.tpl
+++ b/themes/classic/templates/errors/404.tpl
@@ -1,7 +1,11 @@
 {extends file='page.tpl'}
 
 {block name='page_title'}
-  {l s='The page you are looking for was not found.' d='Shop.Theme'}
+  {if $title}
+    {$title}
+  {else}
+    {l s='The page you are looking for was not found.' d='Shop.Theme'}
+  {/if}
 {/block}
 
 {block name='page_content_container'}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Render 404 page is no products found (7 pages concerned) |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1110 |
| How to test? | See forge ticket for description |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
