### PR TITLE
Set translated product names when empty

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -713,7 +713,8 @@ var form = (function() {
       target = false;
     }
     seo.onSave();
-
+    updateMissingTranslatedNames();
+    
     var data = $('input, textarea, select', elem).not(':input[type=button], :input[type=submit], :input[type=reset]').serialize();
     $.ajax({
       type: 'POST',
@@ -772,6 +773,20 @@ var form = (function() {
   function switchLanguage(iso_code) {
     $('div.translations.tabbable > div > div.tab-pane:not(.translation-label-' + iso_code + ')').removeClass('active');
     $('div.translations.tabbable > div > div.tab-pane.translation-label-' + iso_code).addClass('active');
+  }
+  
+  function updateMissingTranslatedNames() {
+      var namesDiv = $('#form_step1_names');
+      var defaultLanguageValue = null;
+      $("input[id^='form_step1_name_']", namesDiv).each(function(index) {
+          var value = $(this).val();
+          // The first language is ALWAYS the employee language
+          if (0 === index) {
+              defaultLanguageValue = value;
+          } else if (0 === value.length) {
+              $(this).val(defaultLanguageValue);
+          }
+      });
   }
 
   return {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | On the product page in the back office: when the translated names are not set, they are automatically filled with the default language value. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-403](http://forge.prestashop.com/browse/BOOM-403) |
| How to test? | Set only the product name for the default language. The other languages should be filled on save. |
