### PR TITLE
Switch error messages to new translation system

### DIFF
--- a/controllers/admin/AdminAccessController.php
+++ b/controllers/admin/AdminAccessController.php
@@ -139,10 +139,10 @@ class AdminAccessControllerCore extends AdminController
     public function ajaxProcessUpdateAccess()
     {
         if (_PS_MODE_DEMO_) {
-            throw new PrestaShopException(Tools::displayError('This functionality has been disabled.'));
+            throw new PrestaShopException($this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error'));
         }
         if ($this->access('edit') != '1') {
-            throw new PrestaShopException(Tools::displayError('You do not have permission to edit this.'));
+            throw new PrestaShopException($this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error'));
         }
 
         if (Tools::isSubmit('submitAddAccess')) {
@@ -164,10 +164,10 @@ class AdminAccessControllerCore extends AdminController
     public function ajaxProcessUpdateModuleAccess()
     {
         if (_PS_MODE_DEMO_) {
-            throw new PrestaShopException(Tools::displayError('This functionality has been disabled.'));
+            throw new PrestaShopException($this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error'));
         }
         if ($this->access('edit') != '1') {
-            throw new PrestaShopException(Tools::displayError('You do not have permission to edit this.'));
+            throw new PrestaShopException($this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error'));
         }
 
         if (Tools::isSubmit('changeModuleAccess')) {
@@ -214,7 +214,7 @@ class AdminAccessControllerCore extends AdminController
     private function getChildrenTab(array &$tabs, $id_parent = 0)
     {
         $children = [];
-        foreach($tabs as &$tab) {
+        foreach ($tabs as &$tab) {
             $id = $tab['id_tab'];
 
             if ($tab['id_parent'] == $id_parent) {

--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -379,11 +379,11 @@ class AdminAddressesControllerCore extends AdminController
         $postcode = Tools::getValue('postcode');
         /* Check zip code format */
         if ($country->zip_code_format && !$country->checkZipCode($postcode)) {
-            $this->errors[] = $this->trans('Your Zip/postal code is incorrect.', array(), 'Admin.OrdersCustomers.Notification').'<br />'.$this->trans('It must be entered as follows:', array(), 'Admin.OrdersCustomers.Notification').' '.str_replace('C', $country->iso_code, str_replace('N', '0', str_replace('L', 'A', $country->zip_code_format)));
+            $this->errors[] = $this->trans('Your Zip/postal code is incorrect.', array(), 'Admin.Notifications.Error').'<br />'.$this->trans('It must be entered as follows:', array(), 'Admin.Notifications.Error').' '.str_replace('C', $country->iso_code, str_replace('N', '0', str_replace('L', 'A', $country->zip_code_format)));
         } elseif (empty($postcode) && $country->need_zip_code) {
-            $this->errors[] = $this->trans('A Zip/postal code is required.', array(), 'Admin.OrdersCustomers.Notification');
+            $this->errors[] = $this->trans('A Zip/postal code is required.', array(), 'Admin.Notifications.Error');
         } elseif ($postcode && !Validate::isPostCode($postcode)) {
-            $this->errors[] = $this->trans('The Zip/postal code is invalid.', array(), 'Admin.OrdersCustomers.Notification');
+            $this->errors[] = $this->trans('The Zip/postal code is invalid.', array(), 'Admin.Notifications.Error');
         }
 
         /* If this address come from order's edition and is the same as the other one (invoice or delivery one)

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -209,22 +209,22 @@ class AdminCartRulesControllerCore extends AdminController
 
             // Idiot-proof control
             if (strtotime(Tools::getValue('date_from')) > strtotime(Tools::getValue('date_to'))) {
-                $this->errors[] = Tools::displayError('The voucher cannot end before it begins.');
+                $this->errors[] = $this->trans('The voucher cannot end before it begins.', array(), 'Admin.Catalog.Notification');
             }
             if ((int)Tools::getValue('minimum_amount') < 0) {
-                $this->errors[] = Tools::displayError('The minimum amount cannot be lower than zero.');
+                $this->errors[] = $this->trans('The minimum amount cannot be lower than zero.', array(), 'Admin.Catalog.Notification');
             }
             if ((float)Tools::getValue('reduction_percent') < 0 || (float)Tools::getValue('reduction_percent') > 100) {
-                $this->errors[] = Tools::displayError('Reduction percentage must be between 0% and 100%');
+                $this->errors[] = $this->trans('Reduction percentage must be between 0% and 100%', array(), 'Admin.Catalog.Notification');
             }
             if ((int)Tools::getValue('reduction_amount') < 0) {
-                $this->errors[] = Tools::displayError('Reduction amount cannot be lower than zero.');
+                $this->errors[] = $this->trans('Reduction amount cannot be lower than zero.', array(), 'Admin.Catalog.Notification');
             }
             if (Tools::getValue('code') && ($same_code = (int)CartRule::getIdByCode(Tools::getValue('code'))) && $same_code != Tools::getValue('id_cart_rule')) {
-                $this->errors[] = sprintf(Tools::displayError('This cart rule code is already used (conflict with cart rule %d)'), $same_code);
+                $this->errors[] = $this->trans('This cart rule code is already used (conflict with cart rule %rulename%)', array( '%rulename%' => $same_code), 'Admin.Catalog.Notification');
             }
             if (Tools::getValue('apply_discount') == 'off' && !Tools::getValue('free_shipping') && !Tools::getValue('free_gift')) {
-                $this->errors[] = Tools::displayError('An action is required for this cart rule.');
+                $this->errors[] = $this->trans('An action is required for this cart rule.', array(), 'Admin.Catalog.Notification');
             }
         }
         return parent::postProcess();
@@ -581,7 +581,7 @@ class AdminCartRulesControllerCore extends AdminController
                 'found' => true
             );
         } else {
-            return array('found' => false, 'notfound' => Tools::displayError('No product has been found.'));
+            return array('found' => false, 'notfound' => $this->trans('No product has been found.', array(), 'Admin.Catalog.Notification'));
         }
     }
 

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -358,10 +358,10 @@ class AdminCartsControllerCore extends AdminController
         if ($this->access('edit')) {
             $errors = array();
             if ((!$id_product = (int)Tools::getValue('id_product')) || !Validate::isInt($id_product)) {
-                $errors[] = Tools::displayError('Invalid product');
+                $errors[] = $this->trans('Invalid product', array(), 'Admin.Catalog.Notification');
             }
             if (($id_product_attribute = (int)Tools::getValue('id_product_attribute')) && !Validate::isInt($id_product_attribute)) {
-                $errors[] = Tools::displayError('Invalid combination');
+                $errors[] = $this->trans('Invalid combination', array(), 'Admin.Catalog.Notification');
             }
             if (count($errors)) {
                 die(json_encode($errors));
@@ -390,18 +390,18 @@ class AdminCartsControllerCore extends AdminController
                     if ($customization_field['type'] == Product::CUSTOMIZE_TEXTFIELD) {
                         if (!Tools::getValue($field_id)) {
                             if ($customization_field['required']) {
-                                $errors[] = Tools::displayError('Please fill in all the required fields.');
+                                $errors[] = $this->trans('Please fill in all the required fields.', array(), 'Admin.Notifications.Error');
                             }
                             continue;
                         }
                         if (!Validate::isMessage(Tools::getValue($field_id))) {
-                            $errors[] = Tools::displayError('Invalid message');
+                            $errors[] = $this->trans('Invalid message', array(), 'Admin.Notifications.Error');
                         }
                         $this->context->cart->addTextFieldToProduct((int)$product->id, (int)$customization_field['id_customization_field'], Product::CUSTOMIZE_TEXTFIELD, Tools::getValue($field_id));
                     } elseif ($customization_field['type'] == Product::CUSTOMIZE_FILE) {
                         if (!isset($_FILES[$field_id]) || !isset($_FILES[$field_id]['tmp_name']) || empty($_FILES[$field_id]['tmp_name'])) {
                             if ($customization_field['required']) {
-                                $errors[] = Tools::displayError('Please fill in all the required fields.');
+                                $errors[] = $this->trans('Please fill in all the required fields.', array(), 'Admin.Notifications.Error');
                             }
                             continue;
                         }
@@ -409,15 +409,15 @@ class AdminCartsControllerCore extends AdminController
                             $errors[] = $error;
                         }
                         if (!($tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !move_uploaded_file($_FILES[$field_id]['tmp_name'], $tmp_name)) {
-                            $errors[] = Tools::displayError('An error occurred during the image upload process.');
+                            $errors[] = $this->trans('An error occurred during the image upload process.', array(), 'Admin.Catalog.Notification');
                         }
                         $file_name = md5(uniqid(rand(), true));
                         if (!ImageManager::resize($tmp_name, _PS_UPLOAD_DIR_.$file_name)) {
                             continue;
                         } elseif (!ImageManager::resize($tmp_name, _PS_UPLOAD_DIR_.$file_name.'_small', (int)Configuration::get('PS_PRODUCT_PICTURE_WIDTH'), (int)Configuration::get('PS_PRODUCT_PICTURE_HEIGHT'))) {
-                            $errors[] = Tools::displayError('An error occurred during the image upload process.');
+                            $errors[] = $this->trans('An error occurred during the image upload process.', array(), 'Admin.Catalog.Notification');
                         } elseif (!chmod(_PS_UPLOAD_DIR_.$file_name, 0777) || !chmod(_PS_UPLOAD_DIR_.$file_name.'_small', 0777)) {
-                            $errors[] = Tools::displayError('An error occurred during the image upload process.');
+                            $errors[] = $this->trans('An error occurred during the image upload process.', array(), 'Admin.Catalog.Notification');
                         } else {
                             $this->context->cart->addPictureToProduct((int)$product->id, (int)$customization_field['id_customization_field'], Product::CUSTOMIZE_FILE, $file_name);
                         }
@@ -441,28 +441,28 @@ class AdminCartsControllerCore extends AdminController
                 return;
             }
             if ($this->context->cart->OrderExists()) {
-                $errors[] = Tools::displayError('An order has already been placed with this cart.');
+                $errors[] = $this->trans('An order has already been placed with this cart.', array(), 'Admin.Catalog.Notification');
             } elseif (!($id_product = (int)Tools::getValue('id_product')) || !($product = new Product((int)$id_product, true, $this->context->language->id))) {
-                $errors[] = Tools::displayError('Invalid product');
+                $errors[] = $this->trans('Invalid product', array(), 'Admin.Catalog.Notification');
             } elseif (!($qty = Tools::getValue('qty')) || $qty == 0) {
-                $errors[] = Tools::displayError('Invalid quantity');
+                $errors[] = $this->trans('Invalid quantity', array(), 'Admin.Catalog.Notification');
             }
 
             // Don't try to use a product if not instanciated before due to errors
             if (isset($product) && $product->id) {
                 if (($id_product_attribute = Tools::getValue('id_product_attribute')) != 0) {
                     if (!Product::isAvailableWhenOutOfStock($product->out_of_stock) && !Attribute::checkAttributeQty((int)$id_product_attribute, (int)$qty)) {
-                        $errors[] = Tools::displayError('There is not enough product in stock.');
+                        $errors[] = $this->trans('There is not enough product in stock.', array(), 'Admin.Catalog.Notification');
                     }
                 } elseif (!$product->checkQty((int)$qty)) {
-                    $errors[] = Tools::displayError('There is not enough product in stock.');
+                    $errors[] = $this->trans('There is not enough product in stock.', array(), 'Admin.Catalog.Notification');
                 }
                 if (!($id_customization = (int)Tools::getValue('id_customization', 0)) && !$product->hasAllRequiredCustomizableFields()) {
-                    $errors[] = Tools::displayError('Please fill in all the required fields.');
+                    $errors[] = $this->trans('Please fill in all the required fields.', array(), 'Admin.Notifications.Error');
                 }
                 $this->context->cart->save();
             } else {
-                $errors[] = Tools::displayError('This product cannot be added to the cart.');
+                $errors[] = $this->trans('This product cannot be added to the cart.', array(), 'Admin.Catalog.Notification');
             }
 
             if (!count($errors)) {
@@ -474,7 +474,7 @@ class AdminCartsControllerCore extends AdminController
                 }
 
                 if (!($qty_upd = $this->context->cart->updateQty($qty, $id_product, (int)$id_product_attribute, (int)$id_customization, $operator))) {
-                    $errors[] = Tools::displayError('You already have the maximum quantity available for this product.');
+                    $errors[] = $this->trans('You already have the maximum quantity available for this product.', array(), 'Admin.Catalog.Notification');
                 } elseif ($qty_upd < 0) {
                     $minimal_qty = $id_product_attribute ? Attribute::getAttributeMinimalQty((int)$id_product_attribute) : $product->minimal_quantity;
                     $errors[] = sprintf(Tools::displayError('You must add a minimum quantity of %d', false), $minimal_qty);
@@ -557,14 +557,14 @@ class AdminCartsControllerCore extends AdminController
         if ($this->access('edit')) {
             $errors = array();
             if (!$id_order = Tools::getValue('id_order')) {
-                $errors[] = Tools::displayError('Invalid order');
+                $errors[] = $this->trans('Invalid order', array(), 'Admin.OrdersCustomers.Notification');
             }
             $cart = Cart::getCartByOrderId($id_order);
             $new_cart = $cart->duplicate();
             if (!$new_cart || !Validate::isLoadedObject($new_cart['cart'])) {
-                $errors[] = Tools::displayError('The order cannot be renewed.');
+                $errors[] = $this->trans('The order cannot be renewed.', array(), 'Admin.OrdersCustomers.Notification');
             } elseif (!$new_cart['success']) {
-                $errors[] = Tools::displayError('The order cannot be renewed.');
+                $errors[] = $this->trans('The order cannot be renewed.', array(), 'Admin.OrdersCustomers.Notification');
             } else {
                 $this->context->cart = $new_cart['cart'];
                 echo json_encode($this->ajaxReturnVars());
@@ -616,7 +616,7 @@ class AdminCartsControllerCore extends AdminController
         if ($this->access('edit')) {
             $errors = array();
             if (!($id_cart_rule = Tools::getValue('id_cart_rule')) || !$cart_rule = new CartRule((int)$id_cart_rule)) {
-                $errors[] = Tools::displayError('Invalid voucher.');
+                $errors[] = $this->trans('Invalid voucher.', array(), 'Admin.Catalog.Notification');
             } elseif ($err = $cart_rule->checkValidity($this->context)) {
                 $errors[] = $err;
             }

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -344,7 +344,7 @@ class AdminCategoriesControllerCore extends AdminController
                     $this->display = 'add';
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
 
@@ -710,7 +710,7 @@ class AdminCategoriesControllerCore extends AdminController
         if (($id_thumb = Tools::getValue('deleteThumb', false)) !== false) {
             if (file_exists(_PS_CAT_IMG_DIR_.(int)Tools::getValue('id_category').'-'.(int)$id_thumb.'_thumb.jpg')
                 && !unlink(_PS_CAT_IMG_DIR_.(int)Tools::getValue('id_category').'-'.(int)$id_thumb.'_thumb.jpg')) {
-                $this->context->controller->errors[] = Tools::displayError('Error while delete');
+                $this->context->controller->errors[] = $this->trans('Error while delete', array(), 'Admin.Notifications.Error');
             }
 
             if (empty($this->context->controller->errors)) {
@@ -773,10 +773,10 @@ class AdminCategoriesControllerCore extends AdminController
         if ($id_category) {
             if ($id_category != $id_parent) {
                 if (!Category::checkBeforeMove($id_category, $id_parent)) {
-                    $this->errors[] = Tools::displayError('The category cannot be moved here.');
+                    $this->errors[] = $this->trans('The category cannot be moved here.', array(), 'Admin.Catalog.Notification');
                 }
             } else {
-                $this->errors[] = Tools::displayError('The category cannot be a parent of itself.');
+                $this->errors[] = $this->trans('The category cannot be a parent of itself.', array(), 'Admin.Catalog.Notification');
             }
         }
         $object = parent::processAdd();
@@ -821,7 +821,7 @@ class AdminCategoriesControllerCore extends AdminController
                 return false;
             }
         } else {
-            $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+            $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
         }
     }
 
@@ -831,14 +831,14 @@ class AdminCategoriesControllerCore extends AdminController
             /** @var Category $category */
             $category = $this->loadObject();
             if ($category->isRootCategoryForAShop()) {
-                $this->errors[] = Tools::displayError('You cannot remove this category because one of your shops uses it as a root category.');
+                $this->errors[] = $this->trans('You cannot remove this category because one of your shops uses it as a root category.', array(), 'Admin.Catalog.Notification');
             } elseif (parent::processDelete()) {
                 $this->setDeleteMode();
                 $this->processFatherlessProducts((int)$category->id_parent);
                 return true;
             }
         } else {
-            $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+            $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
         }
         return false;
     }
@@ -871,13 +871,13 @@ class AdminCategoriesControllerCore extends AdminController
     public function processPosition()
     {
         if ($this->access('edit') !== '1') {
-            $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+            $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
         } elseif (!Validate::isLoadedObject($object = new Category((int)Tools::getValue($this->identifier, Tools::getValue('id_category_to_move', 1))))) {
-            $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.').' <b>'.
-                $this->table.'</b> '.Tools::displayError('(cannot load object)');
+            $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error').' <b>'.
+                $this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
         }
         if (!$object->updatePosition((int)Tools::getValue('way'), (int)Tools::getValue('position'))) {
-            $this->errors[] = Tools::displayError('Failed to update the position.');
+            $this->errors[] = $this->trans('Failed to update the position.', array(), 'Admin.Notifications.Error');
         } else {
             $object->regenerateEntireNtree();
             Tools::redirectAdmin(self::$currentIndex.'&'.$this->table.'Orderby=position&'.$this->table.'Orderway=asc&conf=5'.(($id_category = (int)Tools::getValue($this->identifier, Tools::getValue('id_category_parent', 1))) ? ('&'.$this->identifier.'='.$id_category) : '').'&token='.Tools::getAdminTokenLite('AdminCategories'));
@@ -898,7 +898,7 @@ class AdminCategoriesControllerCore extends AdminController
                         (int)$image_type['width'],
                         (int)$image_type['height']
                     )) {
-                        $this->errors = Tools::displayError('An error occurred while uploading category image.');
+                        $this->errors = $this->trans('An error occurred while uploading category image.', array(), 'Admin.Catalog.Notification');
                     }
                 }
             }
@@ -922,7 +922,7 @@ class AdminCategoriesControllerCore extends AdminController
                                 (int)$image_type['width'],
                                 (int)$image_type['height']
                             )) {
-                                $this->errors = Tools::displayError('An error occurred while uploading thumbnail image.');
+                                $this->errors = $this->trans('An error occurred while uploading thumbnail image.', array(), 'Admin.Catalog.Notification');
                             } elseif (($infos = getimagesize($tmpName)) && is_array($infos)) {
                                 ImageManager::resize(
                                     $tmpName,
@@ -1022,8 +1022,8 @@ class AdminCategoriesControllerCore extends AdminController
             $total_errors = array();
 
             if (count($available_keys) < count($files)) {
-                $total_errors['name'] = sprintf(Tools::displayError('An error occurred while uploading the image :'));
-                $total_errors['error'] = sprintf(Tools::displayError('You cannot upload more files'));
+                $total_errors['name'] = $this->trans('An error occurred while uploading the image:', array(), 'Admin.Catalog.Notification');
+                $total_errors['error'] = $this->trans('You cannot upload more files', array(), 'Admin.Notifications.Error');
                 die(Tools::jsonEncode(array('thumbnail' => array($total_errors))));
             }
 
@@ -1037,7 +1037,7 @@ class AdminCategoriesControllerCore extends AdminController
                 // Copy new image
                 if (!isset($file['save_path']) || (empty($errors) && !ImageManager::resize($file['save_path'], _PS_CAT_IMG_DIR_
                             .(int)Tools::getValue('id_category').'-'.$id.'_thumb.jpg'))) {
-                    $errors[] = Tools::displayError('An error occurred while uploading the image.');
+                    $errors[] = $this->trans('An error occurred while uploading the image.', array(), 'Admin.Catalog.Notification');
                 }
 
                 if (count($errors)) {

--- a/controllers/admin/AdminCmsCategoriesController.php
+++ b/controllers/admin/AdminCmsCategoriesController.php
@@ -102,7 +102,7 @@ class AdminCmsCategoriesControllerCore extends AdminController
             if ($id_cms_category = (int)Tools::getValue('id_cms_category')) {
                 $this->id_object = $id_cms_category;
                 if (!CMSCategory::checkBeforeMove($id_cms_category, (int)Tools::getValue('id_parent'))) {
-                    $this->errors[] = Tools::displayError('The CMS Category cannot be moved here.');
+                    $this->errors[] = $this->trans('The page Category cannot be moved here.', array(), 'Admin.Design.Notification');
                     return false;
                 }
             }
@@ -121,14 +121,14 @@ class AdminCmsCategoriesControllerCore extends AdminController
                         $identifier = ((int)$object->id_parent ? '&id_cms_category='.(int)$object->id_parent : '');
                         Tools::redirectAdmin(self::$currentIndex.'&conf=5'.$identifier.'&token='.Tools::getValue('token'));
                     } else {
-                        $this->errors[] = Tools::displayError('An error occurred while updating the status.');
+                        $this->errors[] = $this->trans('An error occurred while updating the status.', array(), 'Admin.Notifications.Error');
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.')
-                        .' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                    $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error')
+                        .' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
         /* Delete object */
@@ -137,8 +137,8 @@ class AdminCmsCategoriesControllerCore extends AdminController
                 if (Validate::isLoadedObject($object = $this->loadObject()) && isset($this->fieldImageSettings)) {
                     // check if request at least one object with noZeroObject
                     if (isset($object->noZeroObject) && count($taxes = call_user_func(array($this->className, $object->noZeroObject))) <= 1) {
-                        $this->errors[] = Tools::displayError('You need at least one object.')
-                            .' <b>'.$this->table.'</b><br />'.Tools::displayError('You cannot delete all of the items.');
+                        $this->errors[] = $this->trans('You need at least one object.', array(), 'Admin.Notifications.Error')
+                            .' <b>'.$this->table.'</b><br />'.$this->trans('You cannot delete all of the items.', array(), 'Admin.Notifications.Error');
                     } else {
                         $identifier = ((int)$object->id_parent ? '&'.$this->identifier.'='.(int)$object->id_parent : '');
                         if ($this->deleted) {
@@ -149,24 +149,24 @@ class AdminCmsCategoriesControllerCore extends AdminController
                         } elseif ($object->delete()) {
                             Tools::redirectAdmin(self::$currentIndex.'&conf=1&token='.Tools::getValue('token').$identifier);
                         }
-                        $this->errors[] = Tools::displayError('An error occurred during deletion.');
+                        $this->errors[] = $this->trans('An error occurred during deletion.', array(), 'Admin.Notifications.Error');
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('An error occurred while deleting the object.')
-                        .' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                    $this->errors[] = $this->trans('An error occurred while deleting the object.', array(), 'Admin.Notifications.Error')
+                        .' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
             }
         } elseif (Tools::isSubmit('position')) {
             $object = new CMSCategory((int)Tools::getValue($this->identifier, Tools::getValue('id_cms_category_to_move', 1)));
             if (!$this->access('edit')) {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             } elseif (!Validate::isLoadedObject($object)) {
-                $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.')
-                    .' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error')
+                    .' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
             } elseif (!$object->updatePosition((int)Tools::getValue('way'), (int)Tools::getValue('position'))) {
-                $this->errors[] = Tools::displayError('Failed to update the position.');
+                $this->errors[] = $this->trans('Failed to update the position.', array(), 'Admin.Notifications.Error');
             } else {
                 $identifier = ((int)$object->id_parent ? '&'.$this->identifier.'='.(int)$object->id_parent : '');
                 $token = Tools::getAdminTokenLite('AdminCmsContent');
@@ -187,12 +187,12 @@ class AdminCmsCategoriesControllerCore extends AdminController
                         $token = Tools::getAdminTokenLite('AdminCmsContent');
                         Tools::redirectAdmin(self::$currentIndex.'&conf=2&token='.$token.'&id_cms_category='.(int)Tools::getValue('id_cms_category'));
                     }
-                    $this->errors[] = Tools::displayError('An error occurred while deleting this selection.');
+                    $this->errors[] = $this->trans('An error occurred while deleting this selection.', array(), 'Admin.Notifications.Error');
                 } else {
-                    $this->errors[] = Tools::displayError('You must select at least one element to delete.');
+                    $this->errors[] = $this->trans('You must select at least one element to delete.', array(), 'Admin.Notifications.Error');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
             }
         }
         parent::postProcess();

--- a/controllers/admin/AdminCmsController.php
+++ b/controllers/admin/AdminCmsController.php
@@ -297,7 +297,7 @@ class AdminCmsControllerCore extends AdminController
             $cms = new CMS((int)Tools::getValue('id_cms'));
             $cms->cleanPositions($cms->id_cms_category);
             if (!$cms->delete()) {
-                $this->errors[] = Tools::displayError('An error occurred while deleting the object.')
+                $this->errors[] = $this->trans('An error occurred while deleting the object.', array(), 'Admin.Notifications.Error')
                     .' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
             } else {
                 Tools::redirectAdmin(self::$currentIndex.'&id_cms_category='.$cms->id_cms_category.'&conf=1&token='.Tools::getAdminTokenLite('AdminCmsContent'));
@@ -314,12 +314,12 @@ class AdminCmsControllerCore extends AdminController
                         $token = Tools::getAdminTokenLite('AdminCmsContent');
                         Tools::redirectAdmin(self::$currentIndex.'&conf=2&token='.$token.'&id_cms_category='.(int)Tools::getValue('id_cms_category'));
                     }
-                    $this->errors[] = Tools::displayError('An error occurred while deleting this selection.');
+                    $this->errors[] = $this->trans('An error occurred while deleting this selection.', array(), 'Admin.Notifications.Error');
                 } else {
-                    $this->errors[] = Tools::displayError('You must select at least one element to delete.');
+                    $this->errors[] = $this->trans('You must select at least one element to delete.', array(), 'Admin.Notifications.Error');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
             }
         } elseif (Tools::isSubmit('submitAddcms') || Tools::isSubmit('submitAddcmsAndPreview')) {
             parent::validateRules();
@@ -330,7 +330,7 @@ class AdminCmsControllerCore extends AdminController
                 $cms = new CMS();
                 $this->copyFromPost($cms, 'cms');
                 if (!$cms->add()) {
-                    $this->errors[] = Tools::displayError('An error occurred while creating an object.').' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
+                    $this->errors[] = $this->trans('An error occurred while creating an object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
                 } else {
                     $this->updateAssoShop($cms->id);
                 }
@@ -338,7 +338,7 @@ class AdminCmsControllerCore extends AdminController
                 $cms = new CMS($id_cms);
                 $this->copyFromPost($cms, 'cms');
                 if (!$cms->update()) {
-                    $this->errors[] = Tools::displayError('An error occurred while updating an object.').' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
+                    $this->errors[] = $this->trans('An error occurred while updating an object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
                 } else {
                     $this->updateAssoShop($cms->id);
                 }
@@ -353,12 +353,12 @@ class AdminCmsControllerCore extends AdminController
         } elseif (Tools::isSubmit('way') && Tools::isSubmit('id_cms') && (Tools::isSubmit('position'))) {
             /** @var CMS $object */
             if (!$this->access('edit')) {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             } elseif (!Validate::isLoadedObject($object = $this->loadObject())) {
-                $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.')
-                    .' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error')
+                    .' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
             } elseif (!$object->updatePosition((int)Tools::getValue('way'), (int)Tools::getValue('position'))) {
-                $this->errors[] = Tools::displayError('Failed to update the position.');
+                $this->errors[] = $this->trans('Failed to update the position.', array(), 'Admin.Notifications.Error');
             } else {
                 Tools::redirectAdmin(self::$currentIndex.'&'.$this->table.'Orderby=position&'.$this->table.'Orderway=asc&conf=4&id_cms_category='.(int)$object->id_cms_category.'&token='.Tools::getAdminTokenLite('AdminCmsContent'));
             }
@@ -371,14 +371,14 @@ class AdminCmsControllerCore extends AdminController
                     if ($object->toggleStatus()) {
                         Tools::redirectAdmin(self::$currentIndex.'&conf=5&id_cms_category='.(int)$object->id_cms_category.'&token='.Tools::getValue('token'));
                     } else {
-                        $this->errors[] = Tools::displayError('An error occurred while updating the status.');
+                        $this->errors[] = $this->trans('An error occurred while updating the status.', array(), 'Admin.Notifications.Error');
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.')
-                        .' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                    $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error')
+                        .' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
         /* Delete multiple CMS content */
@@ -395,7 +395,7 @@ class AdminCmsControllerCore extends AdminController
                     Tools::redirectAdmin(self::$currentIndex.'&conf=2&token='.Tools::getAdminTokenLite('AdminCmsContent').'&id_cms_category='.$id_cms_category);
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
             }
         } else {
             parent::postProcess(true);

--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -401,12 +401,12 @@ class AdminCountriesControllerCore extends AdminController
     {
         if (!Tools::getValue('id_'.$this->table)) {
             if (Validate::isLanguageIsoCode(Tools::getValue('iso_code')) && (int)Country::getByIso(Tools::getValue('iso_code'))) {
-                $this->errors[] = Tools::displayError('This ISO code already exists.You cannot create two countries with the same ISO code.');
+                $this->errors[] = $this->trans('This ISO code already exists.You cannot create two countries with the same ISO code.', array(), 'Admin.International.Notification');
             }
         } elseif (Validate::isLanguageIsoCode(Tools::getValue('iso_code'))) {
             $id_country = (int)Country::getByIso(Tools::getValue('iso_code'));
             if ($id_country != 0 && $id_country != Tools::getValue('id_'.$this->table)) {
-                $this->errors[] = Tools::displayError('This ISO code already exists.You cannot create two countries with the same ISO code.');
+                $this->errors[] = $this->trans('This ISO code already exists.You cannot create two countries with the same ISO code.', array(), 'Admin.International.Notification');
             }
         }
 

--- a/controllers/admin/AdminCurrenciesController.php
+++ b/controllers/admin/AdminCurrenciesController.php
@@ -181,8 +181,8 @@ class AdminCurrenciesControllerCore extends AdminController
                 return true;
             }
         } else {
-            $this->errors[] = Tools::displayError('An error occurred while deleting the object.').'
-                <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+            $this->errors[] = $this->trans('An error occurred while deleting the object.', array(), 'Admin.Notifications.Error').'
+                <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
         }
 
         return false;
@@ -197,8 +197,8 @@ class AdminCurrenciesControllerCore extends AdminController
                 return true;
             }
         } else {
-            $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.').'
-				<b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+            $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error').'
+				<b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
         }
 
         return false;
@@ -275,14 +275,14 @@ class AdminCurrenciesControllerCore extends AdminController
             if ($this->access('edit')) {
                 $this->action = 'exchangeRates';
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
         if (Tools::isSubmit('submitAddcurrency') && !Tools::getValue('id_currency') && Currency::exists(Tools::getValue('iso_code'))) {
-            $this->errors[] = Tools::displayError('This currency already exists.');
+            $this->errors[] = $this->trans('This currency already exists.', array(), 'Admin.International.Notification');
         }
         if (Tools::isSubmit('submitAddcurrency') && (float)Tools::getValue('conversion_rate') <= 0) {
-            $this->errors[] = Tools::displayError('The currency conversion rate can not be equal to 0.');
+            $this->errors[] = $this->trans('The currency conversion rate can not be equal to 0.', array(), 'Admin.International.Notification');
         }
         parent::initProcess();
     }

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -395,7 +395,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         $cm->add();
                     }
                 } else {
-                    $this->errors[] = '<div class="alert error">'.Tools::displayError('The email address is invalid.').'</div>';
+                    $this->errors[] = '<div class="alert error">'.$this->trans('The email address is invalid.', array(), 'Admin.Notifications.Error').'</div>';
                 }
             }
             if (Tools::isSubmit('submitReply')) {
@@ -411,7 +411,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                 if (($error = $cm->validateField('message', $cm->message, null, array(), true)) !== true) {
                     $this->errors[] = $error;
                 } elseif (isset($_FILES) && !empty($_FILES['joinFile']['name']) && $_FILES['joinFile']['error'] != 0) {
-                    $this->errors[] = Tools::displayError('An error occurred during the file upload process.');
+                    $this->errors[] = $this->trans('An error occurred during the file upload process.', array(), 'Admin.Notifications.Error');
                 } elseif ($cm->add()) {
                     $file_attachment = null;
                     if (!empty($_FILES['joinFile']['name'])) {
@@ -453,7 +453,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         self::$currentIndex.'&id_customer_thread='.(int)$id_customer_thread.'&viewcustomer_thread&token='.Tools::getValue('token')
                     );
                 } else {
-                    $this->errors[] = Tools::displayError('An error occurred. Your message was not sent. Please contact your system administrator.');
+                    $this->errors[] = $this->trans('An error occurred. Your message was not sent. Please contact your system administrator.', array(), 'Admin.OrdersCustomers.Notification');
                 }
             }
         }
@@ -868,7 +868,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
     public function updateOptionPsSavImapOpt($value)
     {
         if ($this->access('edit') != '1') {
-            throw new PrestaShopException(Tools::displayError('You do not have permission to edit this.'));
+            throw new PrestaShopException($this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error'));
         }
 
         if (!$this->errors && $value) {
@@ -879,7 +879,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
     public function ajaxProcessMarkAsRead()
     {
         if ($this->access('edit') != '1') {
-            throw new PrestaShopException(Tools::displayError('You do not have permission to edit this.'));
+            throw new PrestaShopException($this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error'));
         }
 
         $id_thread = Tools::getValue('id_thread');
@@ -897,7 +897,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
     public function ajaxProcessSyncImap()
     {
         if ($this->access('edit') != '1') {
-            throw new PrestaShopException(Tools::displayError('You do not have permission to edit this.'));
+            throw new PrestaShopException($this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error'));
         }
 
         if (Tools::isSubmit('syncImapMail')) {
@@ -1050,7 +1050,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         if (!isset($overview->from)
                             || (!preg_match('/<('.Tools::cleanNonUnicodeSupport('[a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+[._a-z\p{L}0-9-]*\.[a-z0-9]+').')>/', $overview->from, $from_parsed)
                             && !Validate::isEmail($overview->from))) {
-                            $message_errors[] = Tools::displayError('An unindentified message has no valid "FROM" information, cannot create it in a new thread.');
+                            $message_errors[] = $this->trans('Cannot create message in a new thread.', array(), 'Admin.OrdersCustomers.Notification');
                             continue;
                         }
 
@@ -1115,7 +1115,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         $message = iconv($this->getEncoding($structure), 'utf-8', $message);
                         $message = nl2br($message);
                         if (!$message || strlen($message)==0) {
-                            $message_errors[] = Tools::displayError('The message body is empty, cannot import it.');
+                            $message_errors[] = $this->trans('The message body is empty, cannot import it.', array(), 'Admin.OrdersCustomers.Notification');
                             $fetch_succeed = false;
                             continue;
                         }
@@ -1128,7 +1128,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                                 $cm->message = $message;
                                 $cm->add();
                             } catch (PrestaShopException $pse) {
-                                $message_errors[] = Tools::displayError('The message content is not valid, cannot import it.');
+                                $message_errors[] = $this->trans('The message content is not valid, cannot import it.', array(), 'Admin.OrdersCustomers.Notification');
                                 $fetch_succeed = false;
                                 continue;
                             }

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -337,13 +337,13 @@ class AdminDashboardControllerCore extends AdminController
         if (Tools::isSubmit('submitDateRange')) {
             if (!Validate::isDate(Tools::getValue('date_from'))
                 || !Validate::isDate(Tools::getValue('date_to'))) {
-                $this->errors[] = Tools::displayError('The selected date range is not valid.');
+                $this->errors[] = $this->trans('The selected date range is not valid.', array(), 'Admin.Notifications.Error');
             }
 
             if (Tools::getValue('datepicker_compare')) {
                 if (!Validate::isDate(Tools::getValue('compare_date_from'))
                     || !Validate::isDate(Tools::getValue('compare_date_to'))) {
-                    $this->errors[] = Tools::displayError('The selected date range is not valid.');
+                    $this->errors[] = $this->trans('The selected date range is not valid.', array(), 'Admin.Notifications.Error');
                 }
             }
 

--- a/controllers/admin/AdminDeliverySlipController.php
+++ b/controllers/admin/AdminDeliverySlipController.php
@@ -113,7 +113,7 @@ class AdminDeliverySlipControllerCore extends AdminController
                 if (count(OrderInvoice::getByDeliveryDateInterval(Tools::getValue('date_from'), Tools::getValue('date_to')))) {
                     Tools::redirectAdmin($this->context->link->getAdminLink('AdminPdf').'&submitAction=generateDeliverySlipsPDF&date_from='.urlencode(Tools::getValue('date_from')).'&date_to='.urlencode(Tools::getValue('date_to')));
                 } else {
-                    $this->errors[] = Tools::displayError('No delivery slip was found for this period.');
+                    $this->errors[] = $this->trans('No delivery slip was found for this period.', array(), 'Admin.OrdersCustomers.Notification');
                 }
             }
         } else {

--- a/controllers/admin/AdminEmailsController.php
+++ b/controllers/admin/AdminEmailsController.php
@@ -304,7 +304,7 @@ class AdminEmailsControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
         /* PrestaShop demo mode*/
@@ -316,7 +316,7 @@ class AdminEmailsControllerCore extends AdminController
 
         if (isset($_POST['PS_MAIL_METHOD']) && $_POST['PS_MAIL_METHOD'] == 2
             && (empty($_POST['PS_MAIL_SERVER']) || empty($_POST['PS_MAIL_SMTP_PORT']))) {
-            $this->errors[] = Tools::displayError('You must define an SMTP server and an SMTP port. If you do not know it, use the PHP mail() function instead.');
+            $this->errors[] = $this->trans('You must define an SMTP server and an SMTP port. If you do not know it, use the PHP mail() function instead.', array(), 'Admin.Parameters.Notification');
         }
     }
 
@@ -324,7 +324,7 @@ class AdminEmailsControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            die(Tools::displayError('This functionality has been disabled.'));
+            die($this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error'));
         }
         /* PrestaShop demo mode */
         if ($this->access('view')) {

--- a/controllers/admin/AdminEmployeesController.php
+++ b/controllers/admin/AdminEmployeesController.php
@@ -218,7 +218,7 @@ class AdminEmployeesControllerCore extends AdminController
         $available_profiles = Profile::getProfiles($this->context->language->id);
 
         if ($obj->id_profile == _PS_ADMIN_PROFILE_ && $this->context->employee->id_profile != _PS_ADMIN_PROFILE_) {
-            $this->errors[] = Tools::displayError('You cannot edit the SuperAdmin profile.');
+            $this->errors[] = $this->trans('You cannot edit the SuperAdmin profile.', array(), 'Admin.Parameters.Notification');
             return parent::renderForm();
         }
 
@@ -434,13 +434,13 @@ class AdminEmployeesControllerCore extends AdminController
         }
 
         if (Tools::getValue('id_profile') == _PS_ADMIN_PROFILE_ && $this->context->employee->id_profile != _PS_ADMIN_PROFILE_) {
-            $this->errors[] = Tools::displayError('The provided profile is invalid');
+            $this->errors[] = $this->trans('The provided profile is invalid', array(), 'Admin.Parameters.Notification');
         }
 
         $email = $this->getFieldValue($obj, 'email');
         if (Validate::isEmail($email) && Employee::employeeExists($email) && (!Tools::getValue('id_employee')
             || ($employee = new Employee((int)Tools::getValue('id_employee'))) && $employee->email != $email)) {
-            $this->errors[] = Tools::displayError('An account already exists for this email address:').' '.$email;
+            $this->errors[] = $this->trans('An account already exists for this email address:', array(), 'Admin.OrdersCustomers.Notification').' '.$email;
         }
     }
 
@@ -479,20 +479,20 @@ class AdminEmployeesControllerCore extends AdminController
     protected function canModifyEmployee()
     {
         if ($this->restrict_edition) {
-            $this->errors[] = Tools::displayError('You cannot disable or delete your own account.');
+            $this->errors[] = $this->trans('You cannot disable or delete your own account.', array(), 'Admin.Parameters.Notification');
             return false;
         }
 
         $employee = new Employee(Tools::getValue('id_employee'));
         if ($employee->isLastAdmin()) {
-            $this->errors[] = Tools::displayError('You cannot disable or delete the administrator account.');
+            $this->errors[] = $this->trans('You cannot disable or delete the administrator account.', array(), 'Admin.Parameters.Notification');
             return false;
         }
 
         // It is not possible to delete an employee if he manages warehouses
         $warehouses = Warehouse::getWarehousesByEmployee((int)Tools::getValue('id_employee'));
         if (Tools::isSubmit('deleteemployee') && count($warehouses) > 0) {
-            $this->errors[] = Tools::displayError('You cannot delete this account because it manages warehouses. Check your warehouses first.');
+            $this->errors[] = $this->trans('You cannot delete this account because it manages warehouses. Check your warehouses first.', array(), 'Admin.Parameters.Notification');
             return false;
         }
 
@@ -507,9 +507,9 @@ class AdminEmployeesControllerCore extends AdminController
         if ($this->restrict_edition) {
             $current_password = trim(Tools::getValue('old_passwd'));
             if (Tools::getValue('passwd') && (empty($current_password) || !Validate::isPasswdAdmin($current_password) || !$employee->getByEmail($employee->email, $current_password))) {
-                $this->errors[] = Tools::displayError('Your current password is invalid.');
+                $this->errors[] = $this->trans('Your current password is invalid.', array(), 'Admin.Parameters.Notification');
             } elseif (Tools::getValue('passwd') && (!Tools::getValue('passwd2') || Tools::getValue('passwd') !== Tools::getValue('passwd2'))) {
-                $this->errors[] = Tools::displayError('The confirmation password does not match.');
+                $this->errors[] = $this->trans('The confirmation password does not match.', array(), 'Admin.Parameters.Notification');
             }
 
             $_POST['id_profile'] = $_GET['id_profile'] = $employee->id_profile;
@@ -564,12 +564,12 @@ class AdminEmployeesControllerCore extends AdminController
 
         if ($employee->isLastAdmin()) {
             if (Tools::getValue('id_profile') != (int)_PS_ADMIN_PROFILE_) {
-                $this->errors[] = Tools::displayError('You should have at least one employee in the administrator group.');
+                $this->errors[] = $this->trans('You should have at least one employee in the administrator group.', array(), 'Admin.Parameters.Notification');
                 return false;
             }
 
             if (Tools::getvalue('active') == 0) {
-                $this->errors[] = Tools::displayError('You cannot disable or delete the administrator account.');
+                $this->errors[] = $this->trans('You cannot disable or delete the administrator account.', array(), 'Admin.Parameters.Notification');
                 return false;
             }
         }
@@ -578,7 +578,7 @@ class AdminEmployeesControllerCore extends AdminController
             $bo_theme = explode('|', Tools::getValue('bo_theme_css'));
             $_POST['bo_theme'] = $bo_theme[0];
             if (!in_array($bo_theme[0], scandir(_PS_ADMIN_DIR_.DIRECTORY_SEPARATOR.'themes'))) {
-                $this->errors[] = Tools::displayError('Invalid theme');
+                $this->errors[] = $this->trans('Invalid theme', array(), 'Admin.Parameters.Notification');
                 return false;
             }
             if (isset($bo_theme[1])) {
@@ -589,7 +589,7 @@ class AdminEmployeesControllerCore extends AdminController
         $assos = $this->getSelectedAssoShop($this->table);
         if (!$assos && $this->table = 'employee') {
             if (Shop::isFeatureActive() && _PS_ADMIN_PROFILE_ != $_POST['id_profile']) {
-                $this->errors[] = Tools::displayError('The employee must be associated with at least one shop.');
+                $this->errors[] = $this->trans('The employee must be associated with at least one shop.', array(), 'Admin.Parameters.Notification');
             }
         }
 
@@ -605,7 +605,7 @@ class AdminEmployeesControllerCore extends AdminController
         $employee = new Employee((int)Tools::getValue('id_employee'));
 
         if (!Validate::isLoadedObject($employee) && !Validate::isPasswd(Tools::getvalue('passwd'), Validate::ADMIN_PASSWORD_LENGTH)) {
-            return !($this->errors[] = sprintf(Tools::displayError('The password must be at least %s characters long.'),
+            return !($this->errors[] = sprintf($this->trans('The password must be at least %s characters long.', array(), 'Admin.Parameters.Notification'),
                 Validate::ADMIN_PASSWORD_LENGTH));
         }
 
@@ -616,7 +616,7 @@ class AdminEmployeesControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if ((Tools::isSubmit('submitBulkdeleteemployee') || Tools::isSubmit('submitBulkdisableSelectionemployee') || Tools::isSubmit('deleteemployee') || Tools::isSubmit('status') || Tools::isSubmit('statusemployee') || Tools::isSubmit('submitAddemployee')) && _PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
 

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -124,7 +124,7 @@ class AdminFeaturesControllerCore extends AdminController
             $this->addRowAction('delete');
 
             if (!Validate::isLoadedObject($obj = new Feature((int)$id))) {
-                $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.').' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
                 return;
             }
 

--- a/controllers/admin/AdminGendersController.php
+++ b/controllers/admin/AdminGendersController.php
@@ -197,7 +197,7 @@ class AdminGendersControllerCore extends AdminController
     {
         if (isset($this->fieldImageSettings['name']) && isset($this->fieldImageSettings['dir'])) {
             if (!Validate::isInt(Tools::getValue('img_width')) || !Validate::isInt(Tools::getValue('img_height'))) {
-                $this->errors[] = Tools::displayError('Width and height must be numeric values.');
+                $this->errors[] = $this->trans('Width and height must be numeric values.', array(), 'Admin.Parameters.Notification');
             } else {
                 if ((int)Tools::getValue('img_width') > 0 && (int)Tools::getValue('img_height') > 0) {
                     $width = (int)Tools::getValue('img_width');

--- a/controllers/admin/AdminGeolocationController.php
+++ b/controllers/admin/AdminGeolocationController.php
@@ -91,12 +91,12 @@ class AdminGeolocationControllerCore extends AdminController
         }
         // stop processing if geolocation is set to yes but geolite pack is not available
         elseif (Tools::getValue('PS_GEOLOCATION_ENABLED')) {
-            $this->errors[] = Tools::displayError('The geolocation database is unavailable.');
+            $this->errors[] = $this->trans('The geolocation database is unavailable.', array(), 'Admin.International.Notification');
         }
 
         if (empty($this->errors)) {
             if (!is_array(Tools::getValue('countries')) || !count(Tools::getValue('countries'))) {
-                $this->errors[] = Tools::displayError('Country selection is invalid.');
+                $this->errors[] = $this->trans('Country selection is invalid.', array(), 'Admin.International.Notification');
             } else {
                 Configuration::updateValue(
                     'PS_GEOLOCATION_BEHAVIOR',
@@ -107,7 +107,7 @@ class AdminGeolocationControllerCore extends AdminController
             }
 
             if (!Validate::isCleanHtml(Tools::getValue('PS_GEOLOCATION_WHITELIST'))) {
-                $this->errors[] = Tools::displayError('Invalid whitelist');
+                $this->errors[] = $this->trans('Invalid whitelist', array(), 'Admin.International.Notification');
             } else {
                 Configuration::updateValue(
                     'PS_GEOLOCATION_WHITELIST',

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -451,7 +451,7 @@ class AdminGroupsControllerCore extends AdminController
     public function processSave()
     {
         if (!$this->validateDiscount(Tools::getValue('reduction'))) {
-            $this->errors[] = Tools::displayError('The discount value is incorrect (must be a percentage).');
+            $this->errors[] = $this->trans('The discount value is incorrect (must be a percentage).', array(), 'Admin.Parameters.Notification');
         } else {
             $this->updateCategoryReduction();
             $object = parent::processSave();
@@ -476,10 +476,10 @@ class AdminGroupsControllerCore extends AdminController
 
         $result = array();
         if (!Validate::isUnsignedId($id_category)) {
-            $result['errors'][] = Tools::displayError('Wrong category ID.');
+            $result['errors'][] = $this->trans('Wrong category ID.', array(), 'Admin.Parameters.Notification');
             $result['hasError'] = true;
         } elseif (!$this->validateDiscount($category_reduction)) {
-            $result['errors'][] = Tools::displayError('The discount value is incorrect (must be a percentage).');
+            $result['errors'][] = $this->trans('The discount value is incorrect (must be a percentage).', array(), 'Admin.Parameters.Notification');
             $result['hasError'] = true;
         } else {
             $result['id_category'] = (int)$id_category;
@@ -525,7 +525,7 @@ class AdminGroupsControllerCore extends AdminController
             }
             foreach ($category_reduction as $cat => $reduction) {
                 if (!Validate::isUnsignedId($cat) || !$this->validateDiscount($reduction)) {
-                    $this->errors[] = Tools::displayError('The discount value is incorrect.');
+                    $this->errors[] = $this->trans('The discount value is incorrect.', array(), 'Admin.Parameters.Notification');
                 } else {
                     $category = new Category((int)$cat);
                     $category->addGroupsIfNoExist((int)Tools::getValue('id_group'));
@@ -534,7 +534,7 @@ class AdminGroupsControllerCore extends AdminController
                     $group_reduction->reduction = (float)($reduction / 100);
                     $group_reduction->id_category = (int)$cat;
                     if (!$group_reduction->save()) {
-                        $this->errors[] = Tools::displayError('You cannot save group reductions.');
+                        $this->errors[] = $this->trans('You cannot save group reductions.', array(), 'Admin.Parameters.Notification');
                     }
                 }
             }
@@ -548,11 +548,11 @@ class AdminGroupsControllerCore extends AdminController
     {
         $group = new Group($this->id_object);
         if (!Validate::isLoadedObject($group)) {
-            $this->errors[] = Tools::displayError('An error occurred while updating this group.');
+            $this->errors[] = $this->trans('An error occurred while updating this group.', array(), 'Admin.Parameters.Notification');
         }
         $update = Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.'group` SET show_prices = '.($group->show_prices ? 0 : 1).' WHERE `id_group` = '.(int)$group->id);
         if (!$update) {
-            $this->errors[] = Tools::displayError('An error occurred while updating this group.');
+            $this->errors[] = $this->trans('An error occurred while updating this group.', array(), 'Admin.Parameters.Notification');
         }
         Tools::clearSmartyCache();
         Tools::redirectAdmin(self::$currentIndex.'&token='.$this->token);

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -344,7 +344,7 @@ class AdminImagesControllerCore extends AdminController
                     Tools::redirectAdmin(self::$currentIndex.'&conf=9'.'&token='.$this->token);
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         } elseif (Tools::isSubmit('submitMoveImages'.$this->table)) {
             if ($this->access('edit')) {
@@ -352,16 +352,16 @@ class AdminImagesControllerCore extends AdminController
                     Tools::redirectAdmin(self::$currentIndex.'&conf=25'.'&token='.$this->token);
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         } elseif (Tools::isSubmit('submitOptions'.$this->table)) {
             if ($this->access('edit')) {
                 if ((int)Tools::getValue('PS_JPEG_QUALITY') < 0
                     || (int)Tools::getValue('PS_JPEG_QUALITY') > 100) {
-                    $this->errors[] = Tools::displayError('Incorrect value for the selected JPEG image compression.');
+                    $this->errors[] = $this->trans('Incorrect value for the selected JPEG image compression.', array(), 'Admin.Design.Notification');
                 } elseif ((int)Tools::getValue('PS_PNG_QUALITY') < 0
                     || (int)Tools::getValue('PS_PNG_QUALITY') > 9) {
-                    $this->errors[] = Tools::displayError('Incorrect value for the selected PNG image compression.');
+                    $this->errors[] = $this->trans('Incorrect value for the selected PNG image compression.', array(), 'Admin.Design.Notification');
                 } elseif (!Configuration::updateValue('PS_IMAGE_QUALITY', Tools::getValue('PS_IMAGE_QUALITY'))
                     || !Configuration::updateValue('PS_JPEG_QUALITY', Tools::getValue('PS_JPEG_QUALITY'))
                     || !Configuration::updateValue('PS_PNG_QUALITY', Tools::getValue('PS_PNG_QUALITY'))) {
@@ -371,7 +371,7 @@ class AdminImagesControllerCore extends AdminController
                 }
                 return parent::postProcess();
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         } else {
             return parent::postProcess();
@@ -386,7 +386,7 @@ class AdminImagesControllerCore extends AdminController
     protected function _childValidation()
     {
         if (!Tools::getValue('id_image_type') && Validate::isImageTypeName($typeName = Tools::getValue('name')) && ImageType::typeAlreadyExists($typeName)) {
-            $this->errors[] = Tools::displayError('This name already exists.');
+            $this->errors[] = $this->trans('This name already exists.', array(), 'Admin.Design.Notification');
         }
     }
 
@@ -497,14 +497,14 @@ class AdminImagesControllerCore extends AdminController
 
                         if (!file_exists($newDir.substr($image, 0, -4).'-'.stripslashes($imageType['name']).'.jpg')) {
                             if (!file_exists($dir.$image) || !filesize($dir.$image)) {
-                                $this->errors[] = sprintf(Tools::displayError('Source file does not exist or is empty (%s)'), $dir.$image);
+                                $this->errors[] = $this->trans('Source file does not exist or is empty (%filepath%)', array('%filepath%' => $dir.$image), 'Admin.Design.Notification');
                             } elseif (!ImageManager::resize($dir.$image, $newDir.substr(str_replace('_thumb.', '.', $image), 0, -4).'-'.stripslashes($imageType['name']).'.jpg', (int)$imageType['width'], (int)$imageType['height'])) {
-                                $this->errors[] = sprintf(Tools::displayError('Failed to resize image file (%s)'), $dir.$image);
+                                $this->errors[] = $this->trans('Failed to resize image file (%filepath%)', array('%filepath%' => $dir.$image), 'Admin.Design.Notification');
                             }
 
                             if ($generate_hight_dpi_images) {
                                 if (!ImageManager::resize($dir.$image, $newDir.substr($image, 0, -4).'-'.stripslashes($imageType['name']).'2x.jpg', (int)$imageType['width']*2, (int)$imageType['height']*2)) {
-                                    $this->errors[] = sprintf(Tools::displayError('Failed to resize image file to high resolution (%s)'), $dir.$image);
+                                    $this->errors[] = $this->trans('Failed to resize image file to high resolution (%filepath%)', array('%filepath%' => $dir.$image), 'Admin.Design.Notification');
                                 }
                             }
                         }
@@ -523,18 +523,39 @@ class AdminImagesControllerCore extends AdminController
                     foreach ($type as $imageType) {
                         if (!file_exists($dir.$imageObj->getExistingImgPath().'-'.stripslashes($imageType['name']).'.jpg')) {
                             if (!ImageManager::resize($existing_img, $dir.$imageObj->getExistingImgPath().'-'.stripslashes($imageType['name']).'.jpg', (int)$imageType['width'], (int)$imageType['height'])) {
-                                $this->errors[] = sprintf(Tools::displayError('Original image is corrupt (%s) for product ID %2$d or bad permission on folder'), $existing_img, (int)$imageObj->id_product);
+                                $this->errors[] = $this->trans(
+                                    'Original image is corrupt (%filename%) for product ID %id% or bad permission on folder.',
+                                    array(
+                                        '%filename%' => $existing_img,
+                                        '%id%' => (int)$imageObj->id_product,
+                                    ),
+                                    'Admin.Design.Notification'
+                                );
                             }
 
                             if ($generate_hight_dpi_images) {
                                 if (!ImageManager::resize($existing_img, $dir.$imageObj->getExistingImgPath().'-'.stripslashes($imageType['name']).'2x.jpg', (int)$imageType['width']*2, (int)$imageType['height']*2)) {
-                                    $this->errors[] = sprintf(Tools::displayError('Original image is corrupt (%s) for product ID %2$d or bad permission on folder'), $existing_img, (int)$imageObj->id_product);
+                                    $this->errors[] = $this->trans(
+                                        'Original image is corrupt (%filename%) for product ID %id% or bad permission on folder.',
+                                        array(
+                                            '%filename%' => $existing_img,
+                                            '%id%' => (int)$imageObj->id_product,
+                                        ),
+                                        'Admin.Design.Notification'
+                                    );
                                 }
                             }
                         }
                     }
                 } else {
-                    $this->errors[] = sprintf(Tools::displayError('Original image is missing or empty (%1$s) for product ID %2$d'), $existing_img, (int)$imageObj->id_product);
+                    $this->errors[] = $this->trans(
+                        'Original image is missing or empty (%filename%) for product ID %id%',
+                        array(
+                            '%filename%' => $existing_img,
+                            '%id%' => (int)$imageObj->id_product,
+                        ),
+                        'Admin.Design.Notification'
+                    );
                 }
                 if (time() - $this->start_time > $this->max_execution_time - 4) { // stop 4 seconds before the tiemout, just enough time to process the end of the page on a slow server
                     return 'timeout';
@@ -651,11 +672,11 @@ class AdminImagesControllerCore extends AdminController
                     $this->errors[] = sprintf(Tools::displayError('Cannot write images for this type: %s. Please check the %s folder\'s writing permissions.'), $proc['type'], $proc['dir']);
                 }
             } elseif ($return == 'timeout') {
-                $this->errors[] = Tools::displayError('Only part of the images have been regenerated. The server timed out before finishing.');
+                $this->errors[] = $this->trans('Only part of the images have been regenerated. The server timed out before finishing.', array(), 'Admin.Design.Notification');
             } else {
                 if ($proc['type'] == 'products') {
                     if ($this->_regenerateWatermark($proc['dir'], $formats) == 'timeout') {
-                        $this->errors[] = Tools::displayError('Server timed out. The watermark may not have been applied to all images.');
+                        $this->errors[] = $this->trans('Server timed out. The watermark may not have been applied to all images.', array(), 'Admin.Design.Notification');
                     }
                 }
                 if (!count($this->errors)) {
@@ -687,15 +708,15 @@ class AdminImagesControllerCore extends AdminController
     protected function _moveImagesToNewFileSystem()
     {
         if (!Image::testFileSystem()) {
-            $this->errors[] = Tools::displayError('Error: Your server configuration is not compatible with the new image system. No images were moved.');
+            $this->errors[] = $this->trans('Error: Your server configuration is not compatible with the new image system. No images were moved.', array(), 'Admin.Design.Notification');
         } else {
             ini_set('max_execution_time', $this->max_execution_time); // ini_set may be disabled, we need the real value
             $this->max_execution_time = (int)ini_get('max_execution_time');
             $result = Image::moveToNewFileSystem($this->max_execution_time);
             if ($result === 'timeout') {
-                $this->errors[] = Tools::displayError('Not all images have been moved. The server timed out before finishing. Click on "Move images" again to resume the moving process.');
+                $this->errors[] = $this->trans('Not all images have been moved. The server timed out before finishing. Click on "Move images" again to resume the moving process.', array(), 'Admin.Design.Notification');
             } elseif ($result === false) {
-                $this->errors[] = Tools::displayError('Error: Some -- or all -- images cannot be moved.');
+                $this->errors[] = $this->trans('Error: Some -- or all -- images cannot be moved.', array(), 'Admin.Design.Notification');
             }
         }
         return (count($this->errors) > 0 ? false : true);

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -693,27 +693,27 @@ class AdminImportControllerCore extends AdminController
         if (isset($_FILES['file']) && !empty($_FILES['file']['error'])) {
             switch ($_FILES['file']['error']) {
                 case UPLOAD_ERR_INI_SIZE:
-                    $_FILES['file']['error'] = Tools::displayError('The uploaded file exceeds the upload_max_filesize directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess.');
+                    $_FILES['file']['error'] = $this->trans('The uploaded file exceeds the upload_max_filesize directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess.', array(), 'Admin.Design.Notification');
                     break;
                 case UPLOAD_ERR_FORM_SIZE:
-                    $_FILES['file']['error'] = Tools::displayError('The uploaded file exceeds the post_max_size directive in php.ini.
-						If your server configuration allows it, you may add a directive in your .htaccess, for example:')
+                    $_FILES['file']['error'] = $this->trans('The uploaded file exceeds the post_max_size directive in php.ini.
+						If your server configuration allows it, you may add a directive in your .htaccess, for example:', array(), 'Admin.Design.Notification')
                     .'<br/><a href="'.$this->context->link->getAdminLink('AdminMeta').'" >
 					<code>php_value post_max_size 20M</code> '.
-                    Tools::displayError('(click to open "Generators" page)').'</a>';
+                    $this->trans('(click to open "Generators" page)', array(), 'Admin.Parameters.Notification').'</a>';
                     break;
                 break;
                 case UPLOAD_ERR_PARTIAL:
-                    $_FILES['file']['error'] = Tools::displayError('The uploaded file was only partially uploaded.');
+                    $_FILES['file']['error'] = $this->trans('The uploaded file was only partially uploaded.', array(), 'Admin.Parameters.Notification');
                     break;
                 break;
                 case UPLOAD_ERR_NO_FILE:
-                    $_FILES['file']['error'] = Tools::displayError('No file was uploaded.');
+                    $_FILES['file']['error'] = $this->trans('No file was uploaded.', array(), 'Admin.Notifications.Error');
                     break;
                 break;
             }
         } elseif (!preg_match('#(.*?)\.(csv|xls[xt]?|o[dt]s)#is', $_FILES['file']['name'])) {
-            $_FILES['file']['error'] = Tools::displayError('The extension of your file should be .csv.');
+            $_FILES['file']['error'] = $this->trans('The extension of your file should be .csv.', array(), 'Admin.Parameters.Notification');
         } elseif (!@filemtime($_FILES['file']['tmp_name']) ||
             !@move_uploaded_file($_FILES['file']['tmp_name'], AdminImportController::getPath().$filename_prefix.str_replace("\0", '', $_FILES['file']['name']))) {
             $_FILES['file']['error'] = $this->l('An error occurred while uploading / copying the file.');
@@ -1339,7 +1339,7 @@ class AdminImportControllerCore extends AdminController
                 } else {
                     if (!$validateOnly) {
                         $this->errors[] = sprintf(
-                            Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                            $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                             $category_to_create->name[$id_lang],
                             (isset($category_to_create->id) && !empty($category_to_create->id))? $category_to_create->id : 'null'
                         );
@@ -1368,14 +1368,14 @@ class AdminImportControllerCore extends AdminController
             $category->link_rewrite = Tools::link_rewrite($category->name[$default_language_id]);
             if ($category->link_rewrite == '') {
                 $category->link_rewrite = 'friendly-url-autogeneration-failed';
-                $this->warnings[] = sprintf(Tools::displayError('URL rewriting failed to auto-generate a friendly URL for: %s'), $category->name[$default_language_id]);
+                $this->warnings[] = sprintf($this->trans('URL rewriting failed to auto-generate a friendly URL for: %s', array(), 'Admin.Parameters.Notification'), $category->name[$default_language_id]);
             }
             $category->link_rewrite = AdminImportController::createMultiLangField($category->link_rewrite);
         }
 
         if (!$valid_link) {
             $this->informations[] = sprintf(
-                Tools::displayError('Rewrite link for %1$s (ID %2$s): re-written as %3$s.'),
+                $this->trans('Rewrite link for %1$s (ID %2$s): re-written as %3$s.', array(), 'Admin.Parameters.Notification'),
                 $bak,
                 (isset($info['id']) && !empty($info['id']))? $info['id'] : 'null',
                 $category->link_rewrite[$default_language_id]
@@ -1401,7 +1401,7 @@ class AdminImportControllerCore extends AdminController
 
             if ($category->id && $category->id == $category->id_parent) {
                 $this->errors[] = sprintf(
-                    Tools::displayError('A category cannot be its own parent. The parent category ID is either missing or unknown (ID: %1$s).'),
+                    $this->trans('A category cannot be its own parent. The parent category ID is either missing or unknown (ID: %1$s).', array(), 'Admin.Parameters.Notification'),
                     (isset($info['id']) && !empty($info['id']))? $info['id'] : 'null'
                 );
                 return;
@@ -1419,7 +1419,7 @@ class AdminImportControllerCore extends AdminController
                 $res = $category->update();
             }
             if ($category->id == Configuration::get('PS_ROOT_CATEGORY')) {
-                $this->errors[] = Tools::displayError('The root category cannot be modified.');
+                $this->errors[] = $this->trans('The root category cannot be modified.', array(), 'Admin.Parameters.Notification');
             }
             // If no id_category or update failed
             $category->force_id = (bool)$force_ids;
@@ -1436,7 +1436,7 @@ class AdminImportControllerCore extends AdminController
         //copying images of categories
         if (isset($category->image) && !empty($category->image)) {
             if (!(AdminImportController::copyImg($category->id, null, $category->image, 'categories', !$regenerate))) {
-                $this->warnings[] = $category->image.' '.Tools::displayError('cannot be copied.');
+                $this->warnings[] = $category->image.' '.$this->trans('cannot be copied.', array(), 'Admin.Parameters.Notification');
             }
         }
         // If both failed, mysql error
@@ -1670,7 +1670,7 @@ class AdminImportControllerCore extends AdminController
                 $this->addProductWarning(
                     'id_tax_rules_group',
                     $product->id_tax_rules_group,
-                    Tools::displayError('Unknown tax rule group ID. You need to create a group with this ID first.')
+                    $this->trans('Unknown tax rule group ID. You need to create a group with this ID first.', array(), 'Admin.Parameters.Notification')
                 );
             }
         }
@@ -1692,7 +1692,7 @@ class AdminImportControllerCore extends AdminController
                 } else {
                     if (!$validateOnly) {
                         $this->errors[] = sprintf(
-                            Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                            $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                             $manufacturer->name,
                             (isset($manufacturer->id) && !empty($manufacturer->id))? $manufacturer->id : 'null'
                         );
@@ -1724,7 +1724,7 @@ class AdminImportControllerCore extends AdminController
                 } else {
                     if (!$validateOnly) {
                         $this->errors[] = sprintf(
-                            Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                            $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                             $supplier->name,
                             (isset($supplier->id) && !empty($supplier->id))? $supplier->id : 'null'
                         );
@@ -1775,7 +1775,7 @@ class AdminImportControllerCore extends AdminController
                         } else {
                             if (!$validateOnly) {
                                 $this->errors[] = sprintf(
-                                    Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                                    $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                                     $category_to_create->name[$default_language_id],
                                     (isset($category_to_create->id) && !empty($category_to_create->id))? $category_to_create->id : 'null'
                                 );
@@ -1791,7 +1791,7 @@ class AdminImportControllerCore extends AdminController
                     if ($category['id_category']) {
                         $product->id_category[] = (int)$category['id_category'];
                     } else {
-                        $this->errors[] = sprintf(Tools::displayError('%1$s cannot be saved'), trim($value));
+                        $this->errors[] = sprintf($this->trans('%1$s cannot be saved', array(), 'Admin.Parameters.Notification'), trim($value));
                     }
                 }
             }
@@ -1829,7 +1829,7 @@ class AdminImportControllerCore extends AdminController
 
         if (!$valid_link) {
             $this->informations[] = sprintf(
-                Tools::displayError('Rewrite link for %1$s (ID %2$s): re-written as %3$s.'),
+                $this->trans('Rewrite link for %1$s (ID %2$s): re-written as %3$s.', array(), 'Admin.Parameters.Notification'),
                 $product->name[$id_lang],
                 (isset($info['id']) && !empty($info['id']))? $info['id'] : 'null',
                 $link_rewrite
@@ -1960,7 +1960,7 @@ class AdminImportControllerCore extends AdminController
         // If both failed, mysql error
         if (!$res) {
             $this->errors[] = sprintf(
-                Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                 (isset($info['name']) && !empty($info['name']))? Tools::safeOutput($info['name']) : 'No Name',
                 (isset($info['id']) && !empty($info['id']))? Tools::safeOutput($info['id']) : 'No ID'
             );
@@ -2107,7 +2107,7 @@ class AdminImportControllerCore extends AdminController
                             $image->associateTo($shops);
                             if (!AdminImportController::copyImg($product->id, $image->id, $url, 'products', !$regenerate)) {
                                 $image->delete();
-                                $this->warnings[] = sprintf(Tools::displayError('Error copying image: %s'), $url);
+                                $this->warnings[] = sprintf($this->trans('Error copying image: %s', array(), 'Admin.Parameters.Notification'), $url);
                             }
                         } else {
                             $error = true;
@@ -2117,7 +2117,7 @@ class AdminImportControllerCore extends AdminController
                     }
 
                     if ($error) {
-                        $this->warnings[] = sprintf(Tools::displayError('Product #%1$d: the picture (%2$s) cannot be saved.'), $image->id_product, $url);
+                        $this->warnings[] = sprintf($this->trans('Product #%1$d: the picture (%2$s) cannot be saved.', array(), 'Admin.Parameters.Notification'), $image->id_product, $url);
                     }
                 }
             }
@@ -2161,9 +2161,9 @@ class AdminImportControllerCore extends AdminController
             // set advanced stock managment
             if (!$validateOnly && isset($product->advanced_stock_management)) {
                 if ($product->advanced_stock_management != 1 && $product->advanced_stock_management != 0) {
-                    $this->warnings[] = sprintf(Tools::displayError('Advanced stock management has incorrect value. Not set for product %1$s '), $product->name[$default_language_id]);
+                    $this->warnings[] = sprintf($this->trans('Advanced stock management has incorrect value. Not set for product %1$s ', array(), 'Admin.Parameters.Notification'), $product->name[$default_language_id]);
                 } elseif (!Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') && $product->advanced_stock_management == 1) {
-                    $this->warnings[] = sprintf(Tools::displayError('Advanced stock management is not enabled, cannot enable on product %1$s '), $product->name[$default_language_id]);
+                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, cannot enable on product %1$s ', array(), 'Admin.Parameters.Notification'), $product->name[$default_language_id]);
                 } elseif ($update_advanced_stock_management_value) {
                     $product->setAdvancedStockManagement($product->advanced_stock_management);
                 }
@@ -2176,7 +2176,7 @@ class AdminImportControllerCore extends AdminController
             // Check if warehouse exists
             if (isset($product->warehouse) && $product->warehouse) {
                 if (!Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
-                    $this->warnings[] = sprintf(Tools::displayError('Advanced stock management is not enabled, warehouse not set on product %1$s '), $product->name[$default_language_id]);
+                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, warehouse not set on product %1$s ', array(), 'Admin.Parameters.Notification'), $product->name[$default_language_id]);
                 } elseif (!$validateOnly) {
                     if (Warehouse::exists($product->warehouse)) {
                         // Get already associated warehouses
@@ -2196,7 +2196,7 @@ class AdminImportControllerCore extends AdminController
                         }
                         StockAvailable::synchronize($product->id);
                     } else {
-                        $this->warnings[] = sprintf(Tools::displayError('Warehouse did not exist, cannot set on product %1$s.'), $product->name[$default_language_id]);
+                        $this->warnings[] = sprintf($this->trans('Warehouse did not exist, cannot set on product %1$s.', array(), 'Admin.Parameters.Notification'), $product->name[$default_language_id]);
                     }
                 }
             }
@@ -2204,9 +2204,9 @@ class AdminImportControllerCore extends AdminController
             // stock available
             if (isset($product->depends_on_stock)) {
                 if ($product->depends_on_stock != 0 && $product->depends_on_stock != 1) {
-                    $this->warnings[] = sprintf(Tools::displayError('Incorrect value for "depends on stock" for product %1$s '), $product->name[$default_language_id]);
+                    $this->warnings[] = sprintf($this->trans('Incorrect value for "depends on stock" for product %1$s ', array(), 'Admin.Parameters.Notification'), $product->name[$default_language_id]);
                 } elseif ((!$product->advanced_stock_management || $product->advanced_stock_management == 0) && $product->depends_on_stock == 1) {
-                    $this->warnings[] = sprintf(Tools::displayError('Advanced stock management not enabled, cannot set "depends on stock" for product %1$s '), $product->name[$default_language_id]);
+                    $this->warnings[] = sprintf($this->trans('Advanced stock management not enabled, cannot set "depends on stock" for product %1$s ', array(), 'Admin.Parameters.Notification'), $product->name[$default_language_id]);
                 } elseif (!$validateOnly) {
                     StockAvailable::setProductDependsOnStock($product->id, $product->depends_on_stock);
                 }
@@ -2272,7 +2272,7 @@ class AdminImportControllerCore extends AdminController
             ($lang_field_error = $category_to_create->validateFieldsLang(UNFRIENDLY_ERROR, true)) !== true ||
             !$category_to_create->add()) {
             $this->errors[] = sprintf(
-                Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                 $category_to_create->name[$default_language_id],
                 (isset($category_to_create->id) && !empty($category_to_create->id))? $category_to_create->id : 'null'
             );
@@ -2422,7 +2422,7 @@ class AdminImportControllerCore extends AdminController
                         $image->associateTo($id_shop_list);
 // FIXME: 2s/image !
                         if (!AdminImportController::copyImg($product->id, $image->id, $url, 'products', !$regenerate)) {
-                            $this->warnings[] = sprintf(Tools::displayError('Error copying image: %s'), $url);
+                            $this->warnings[] = sprintf($this->trans('Error copying image: %s', array(), 'Admin.Parameters.Notification'), $url);
                             $image->delete();
                         } else {
                             $id_image[] = (int)$image->id;
@@ -2431,7 +2431,7 @@ class AdminImportControllerCore extends AdminController
                     } else {
                         if (!$validateOnly) {
                             $this->warnings[] = sprintf(
-                                Tools::displayError('%s cannot be saved'),
+                                $this->trans('%s cannot be saved', array(), 'Admin.Parameters.Notification'),
                                 (isset($image->id_product) ? ' ('.$image->id_product.')' : '')
                             );
                         }
@@ -2459,7 +2459,7 @@ class AdminImportControllerCore extends AdminController
                     }
                     if (empty($id_image)) {
                         $this->warnings[] = sprintf(
-                            Tools::displayError('No image was found for combination with id_product = %s and image position = %s.'),
+                            $this->trans('No image was found for combination with id_product = %s and image position = %s.', array(), 'Admin.Parameters.Notification'),
                             $product->id,
                             (int)$position
                         );
@@ -2577,7 +2577,7 @@ class AdminImportControllerCore extends AdminController
                     $info['available_date'] = Validate::isDate($info['available_date']) ? $info['available_date'] : null;
 
                     if (!Validate::isEan13($info['ean13'])) {
-                        $this->warnings[] = sprintf(Tools::displayError('EAN13 "%1s" has incorrect value for product with id %2d.'), $info['ean13'], $product->id);
+                        $this->warnings[] = sprintf($this->trans('EAN13 "%1s" has incorrect value for product with id %2d.', array(), 'Admin.Parameters.Notification'), $info['ean13'], $product->id);
                         $info['ean13'] = '';
                     }
 
@@ -2688,9 +2688,9 @@ class AdminImportControllerCore extends AdminController
             // set advanced stock managment
             if (isset($info['advanced_stock_management'])) {
                 if ($info['advanced_stock_management'] != 1 && $info['advanced_stock_management'] != 0) {
-                    $this->warnings[] = sprintf(Tools::displayError('Advanced stock management has incorrect value. Not set for product with id %d.'), $product->id);
+                    $this->warnings[] = sprintf($this->trans('Advanced stock management has incorrect value. Not set for product with id %d.', array(), 'Admin.Parameters.Notification'), $product->id);
                 } elseif (!Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') && $info['advanced_stock_management'] == 1) {
-                    $this->warnings[] = sprintf(Tools::displayError('Advanced stock management is not enabled, cannot enable on product with id %d.'), $product->id);
+                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, cannot enable on product with id %d.', array(), 'Admin.Parameters.Notification'), $product->id);
                 } elseif (!$validateOnly) {
                     $product->setAdvancedStockManagement($info['advanced_stock_management']);
                 }
@@ -2703,7 +2703,7 @@ class AdminImportControllerCore extends AdminController
             // Check if warehouse exists
             if (isset($info['warehouse']) && $info['warehouse']) {
                 if (!Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
-                    $this->warnings[] = sprintf(Tools::displayError('Advanced stock management is not enabled, warehouse is not set on product with id %d.'), $product->id);
+                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, warehouse is not set on product with id %d.', array(), 'Admin.Parameters.Notification'), $product->id);
                 } else {
                     if (Warehouse::exists($info['warehouse'])) {
                         $warehouse_location_entity = new WarehouseProductLocation();
@@ -2719,7 +2719,7 @@ class AdminImportControllerCore extends AdminController
                             StockAvailable::synchronize($product->id);
                         }
                     } else {
-                        $this->warnings[] = sprintf(Tools::displayError('Warehouse did not exist, cannot set on product %1$s.'), $product->name[$default_language]);
+                        $this->warnings[] = sprintf($this->trans('Warehouse did not exist, cannot set on product %1$s.', array(), 'Admin.Parameters.Notification'), $product->name[$default_language]);
                     }
                 }
             }
@@ -2727,9 +2727,9 @@ class AdminImportControllerCore extends AdminController
             // stock available
             if (isset($info['depends_on_stock'])) {
                 if ($info['depends_on_stock'] != 0 && $info['depends_on_stock'] != 1) {
-                    $this->warnings[] = sprintf(Tools::displayError('Incorrect value for depends on stock for product %1$s '), $product->name[$default_language]);
+                    $this->warnings[] = sprintf($this->trans('Incorrect value for depends on stock for product %1$s ', array(), 'Admin.Notifications.Error'), $product->name[$default_language]);
                 } elseif ((!$info['advanced_stock_management'] || $info['advanced_stock_management'] == 0) && $info['depends_on_stock'] == 1) {
-                    $this->warnings[] = sprintf(Tools::displayError('Advanced stock management is not enabled, cannot set depends on stock %1$s '), $product->name[$default_language]);
+                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, cannot set depends on stock %1$s ', array(), 'Admin.Parameters.Notification'), $product->name[$default_language]);
                 } elseif (!$validateOnly) {
                     StockAvailable::setProductDependsOnStock($product->id, $info['depends_on_stock'], null, $id_product_attribute);
                 }
@@ -3094,7 +3094,7 @@ class AdminImportControllerCore extends AdminController
                 } else {
                     if (!$validateOnly) {
                         $default_language_id = (int)Configuration::get('PS_LANG_DEFAULT');
-                        $this->errors[] = sprintf(Tools::displayError('%s cannot be saved'), $country->name[$default_language_id]);
+                        $this->errors[] = sprintf($this->trans('%s cannot be saved', array(), 'Admin.Parameters.Notification'), $country->name[$default_language_id]);
                     }
                     if ($field_error !== true || isset($lang_field_error) && $lang_field_error !== true) {
                         $this->errors[] = ($field_error !== true ? $field_error : '').(isset($lang_field_error) && $lang_field_error !== true ? $lang_field_error : '').
@@ -3126,7 +3126,7 @@ class AdminImportControllerCore extends AdminController
                     $address->id_state = (int)$state->id;
                 } else {
                     if (!$validateOnly) {
-                        $this->errors[] = sprintf(Tools::displayError('%s cannot be saved'), $state->name);
+                        $this->errors[] = sprintf($this->trans('%s cannot be saved', array(), 'Admin.Parameters.Notification'), $state->name);
                     }
                     if ($field_error !== true || isset($lang_field_error) && $lang_field_error !== true) {
                         $this->errors[] = ($field_error !== true ? $field_error : '').(isset($lang_field_error) && $lang_field_error !== true ? $lang_field_error : '').
@@ -3150,7 +3150,7 @@ class AdminImportControllerCore extends AdminController
                     );
                 }
             } else {
-                $this->errors[] = sprintf(Tools::displayError('"%s" is not a valid email address.'), $address->customer_email);
+                $this->errors[] = sprintf($this->trans('"%s" is not a valid email address.', array(), 'Admin.Parameters.Notification'), $address->customer_email);
                 return;
             }
         } elseif (isset($address->id_customer) && !empty($address->id_customer)) {
@@ -3192,7 +3192,7 @@ class AdminImportControllerCore extends AdminController
                 } else {
                     if (!$validateOnly) {
                         $this->errors[] = Db::getInstance()->getMsgError().' '.sprintf(
-                            Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                            $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                             $manufacturer->name,
                             (isset($manufacturer->id) && !empty($manufacturer->id))? $manufacturer->id : 'null'
                         );
@@ -3221,7 +3221,7 @@ class AdminImportControllerCore extends AdminController
                 } else {
                     if (!$validateOnly) {
                         $this->errors[] = Db::getInstance()->getMsgError().' '.sprintf(
-                            Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                            $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                             $supplier->name,
                             (isset($supplier->id) && !empty($supplier->id))? $supplier->id : 'null'
                         );
@@ -3261,7 +3261,7 @@ class AdminImportControllerCore extends AdminController
         if (!$res) {
             if (!$validateOnly) {
                 $this->errors[] = sprintf(
-                    Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                    $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                     $info['alias'],
                     (isset($info['id']) && !empty($info['id']))? $info['id'] : 'null'
                 );
@@ -3344,7 +3344,7 @@ class AdminImportControllerCore extends AdminController
             //copying images of manufacturer
             if (!$validateOnly && isset($manufacturer->image) && !empty($manufacturer->image)) {
                 if (!AdminImportController::copyImg($manufacturer->id, null, $manufacturer->image, 'manufacturers', !$regenerate)) {
-                    $this->warnings[] = $manufacturer->image.' '.Tools::displayError('cannot be copied.');
+                    $this->warnings[] = $manufacturer->image.' '.$this->trans('cannot be copied.', array(), 'Admin.Parameters.Notification');
                 }
             }
 
@@ -3374,7 +3374,7 @@ class AdminImportControllerCore extends AdminController
         if (!$res) {
             if (!$validateOnly) {
                 $this->errors[] = Db::getInstance()->getMsgError().' '.sprintf(
-                    Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                    $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                     (isset($info['name']) && !empty($info['name']))? Tools::safeOutput($info['name']) : 'No Name',
                     (isset($info['id']) && !empty($info['id']))? Tools::safeOutput($info['id']) : 'No ID'
                 );
@@ -3460,13 +3460,13 @@ class AdminImportControllerCore extends AdminController
             //copying images of suppliers
             if (!$validateOnly && isset($supplier->image) && !empty($supplier->image)) {
                 if (!AdminImportController::copyImg($supplier->id, null, $supplier->image, 'suppliers', !$regenerate)) {
-                    $this->warnings[] = $supplier->image.' '.Tools::displayError('cannot be copied.');
+                    $this->warnings[] = $supplier->image.' '.$this->trans('cannot be copied.', array(), 'Admin.Parameters.Notification');
                 }
             }
 
             if (!$res) {
                 $this->errors[] = Db::getInstance()->getMsgError().' '.sprintf(
-                    Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                    $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                     (isset($info['name']) && !empty($info['name']))? Tools::safeOutput($info['name']) : 'No Name',
                     (isset($info['id']) && !empty($info['id']))? Tools::safeOutput($info['id']) : 'No ID'
                 );
@@ -3563,7 +3563,7 @@ class AdminImportControllerCore extends AdminController
 
             if (!$res) {
                 $this->errors[] = Db::getInstance()->getMsgError().' '.sprintf(
-                    Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                    $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                     $info['name'],
                     (isset($info['id']) ? $info['id'] : 'null')
                 );
@@ -3628,7 +3628,7 @@ class AdminImportControllerCore extends AdminController
 
         if (isset($store->image) && !empty($store->image)) {
             if (!(AdminImportController::copyImg($store->id, null, $store->image, 'stores', !$regenerate))) {
-                $this->warnings[] = $store->image.' '.Tools::displayError('cannot be copied.');
+                $this->warnings[] = $store->image.' '.$this->trans('cannot be copied.', array(), 'Admin.Parameters.Notification');
             }
         }
 
@@ -3659,7 +3659,7 @@ class AdminImportControllerCore extends AdminController
                 } else {
                     if (!$validateOnly) {
                         $default_language_id = (int)Configuration::get('PS_LANG_DEFAULT');
-                        $this->errors[] = sprintf(Tools::displayError('%s cannot be saved'), $country->name[$default_language_id]);
+                        $this->errors[] = sprintf($this->trans('%s cannot be saved', array(), 'Admin.Parameters.Notification'), $country->name[$default_language_id]);
                     }
                     if ($field_error !== true || isset($lang_field_error) && $lang_field_error !== true) {
                         $this->errors[] = ($field_error !== true ? $field_error : '').(isset($lang_field_error) && $lang_field_error !== true ? $lang_field_error : '').
@@ -3691,7 +3691,7 @@ class AdminImportControllerCore extends AdminController
                     $store->id_state = (int)$state->id;
                 } else {
                     if (!$validateOnly) {
-                        $this->errors[] = sprintf(Tools::displayError('%s cannot be saved'), $state->name);
+                        $this->errors[] = sprintf($this->trans('%s cannot be saved', array(), 'Admin.Parameters.Notification'), $state->name);
                     }
                     if ($field_error !== true || isset($lang_field_error) && $lang_field_error !== true) {
                         $this->errors[] = ($field_error !== true ? $field_error : '').(isset($lang_field_error) && $lang_field_error !== true ? $lang_field_error : '').
@@ -3714,7 +3714,7 @@ class AdminImportControllerCore extends AdminController
 
             if (!$res) {
                 $this->errors[] = Db::getInstance()->getMsgError().' '.sprintf(
-                    Tools::displayError('%1$s (ID: %2$s) cannot be saved'),
+                    $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Parameters.Notification'),
                     $info['name'],
                     (isset($info['id']) ? $info['id'] : 'null')
                 );
@@ -4054,7 +4054,7 @@ class AdminImportControllerCore extends AdminController
         }
 
         if (!$handle) {
-            $this->errors[] = Tools::displayError('Cannot read the .CSV file');
+            $this->errors[] = $this->trans('Cannot read the .CSV file', array(), 'Admin.Parameters.Notification');
             return null; // error case
         }
 
@@ -4232,7 +4232,7 @@ class AdminImportControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
 

--- a/controllers/admin/AdminLanguagesController.php
+++ b/controllers/admin/AdminLanguagesController.php
@@ -300,7 +300,7 @@ class AdminLanguagesControllerCore extends AdminController
             return false;
         }
         if (!$this->deleteNoPictureImages((int)$object->id)) {
-            $this->errors[] = Tools::displayError('An error occurred while deleting the object.').' <b>'.$this->table.'</b> ';
+            $this->errors[] = $this->trans('An error occurred while deleting the object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b> ';
         }
 
         return parent::processDelete();
@@ -316,7 +316,7 @@ class AdminLanguagesControllerCore extends AdminController
                     return false;
                 }
                 if (!$this->deleteNoPictureImages((int)$object->id)) {
-                    $this->errors[] = Tools::displayError('An error occurred while deleting the object.').' <b>'.$this->table.'</b> ';
+                    $this->errors[] = $this->trans('An error occurred while deleting the object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b> ';
                     return false;
                 }
             }
@@ -327,7 +327,7 @@ class AdminLanguagesControllerCore extends AdminController
     protected function checkDeletion($object)
     {
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
 
@@ -340,7 +340,7 @@ class AdminLanguagesControllerCore extends AdminController
                 return true;
             }
         } else {
-            $this->errors[] = Tools::displayError('(cannot load object)');
+            $this->errors[] = $this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
         }
 
         return false;
@@ -349,14 +349,14 @@ class AdminLanguagesControllerCore extends AdminController
     protected function checkDisableStatus($object)
     {
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
         if (!Validate::isLoadedObject($object)) {
-            $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.').' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+            $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
         } else {
             if ($object->id == (int)Configuration::get('PS_LANG_DEFAULT')) {
-                $this->errors[] = Tools::displayError('You cannot change the status of the default language.');
+                $this->errors[] = $this->trans('You cannot change the status of the default language.', array(), 'Admin.International.Notification');
             } else {
                 return true;
             }
@@ -391,12 +391,12 @@ class AdminLanguagesControllerCore extends AdminController
     public function processAdd()
     {
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
 
         if (isset($_POST['iso_code']) && !empty($_POST['iso_code']) && Validate::isLanguageIsoCode(Tools::getValue('iso_code')) && Language::getIdByIso($_POST['iso_code'])) {
-            $this->errors[] = Tools::displayError('This ISO code is already linked to another language.');
+            $this->errors[] = $this->trans('This ISO code is already linked to another language.', array(), 'Admin.International.Notification');
         }
         if ((!empty($_FILES['no_picture']['tmp_name']) || !empty($_FILES['flag']['tmp_name'])) && Validate::isLanguageIsoCode(Tools::getValue('iso_code'))) {
             if ($_FILES['no_picture']['error'] == UPLOAD_ERR_OK) {
@@ -404,7 +404,7 @@ class AdminLanguagesControllerCore extends AdminController
             }
             unset($_FILES['no_picture']);
         } else {
-            $this->errors[] = Tools::displayError('Flag and "No picture" image fields are required.');
+            $this->errors[] = $this->trans('Flag and "No picture" image fields are required.', array(), 'Admin.International.Notification');
         }
 
         return parent::processAdd();
@@ -413,7 +413,7 @@ class AdminLanguagesControllerCore extends AdminController
     public function processUpdate()
     {
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
 
@@ -455,24 +455,24 @@ class AdminLanguagesControllerCore extends AdminController
                     return false;
                 }
                 if (!ImageManager::resize($tmp_name, _PS_IMG_DIR_.'p/'.$language.'.jpg')) {
-                    $this->errors[] = Tools::displayError('An error occurred while copying "No Picture" image to your product folder.');
+                    $this->errors[] = $this->trans('An error occurred while copying "No Picture" image to your product folder.', array(), 'Admin.International.Notification');
                 }
                 if (!ImageManager::resize($tmp_name, _PS_IMG_DIR_.'c/'.$language.'.jpg')) {
-                    $this->errors[] = Tools::displayError('An error occurred while copying "No picture" image to your category folder.');
+                    $this->errors[] = $this->trans('An error occurred while copying "No picture" image to your category folder.', array(), 'Admin.International.Notification');
                 }
                 if (!ImageManager::resize($tmp_name, _PS_IMG_DIR_.'m/'.$language.'.jpg')) {
-                    $this->errors[] = Tools::displayError('An error occurred while copying "No picture" image to your brand folder.');
+                    $this->errors[] = $this->trans('An error occurred while copying "No picture" image to your brand folder.', array(), 'Admin.International.Notification');
                 } else {
                     $images_types = ImageType::getImagesTypes('products');
                     foreach ($images_types as $k => $image_type) {
                         if (!ImageManager::resize($tmp_name, _PS_IMG_DIR_.'p/'.$language.'-default-'.stripslashes($image_type['name']).'.jpg', $image_type['width'], $image_type['height'])) {
-                            $this->errors[] = Tools::displayError('An error occurred while resizing "No picture" image to your product directory.');
+                            $this->errors[] = $this->trans('An error occurred while resizing "No picture" image to your product directory.', array(), 'Admin.International.Notification');
                         }
                         if (!ImageManager::resize($tmp_name, _PS_IMG_DIR_.'c/'.$language.'-default-'.stripslashes($image_type['name']).'.jpg', $image_type['width'], $image_type['height'])) {
-                            $this->errors[] = Tools::displayError('An error occurred while resizing "No picture" image to your category directory.');
+                            $this->errors[] = $this->trans('An error occurred while resizing "No picture" image to your category directory.', array(), 'Admin.International.Notification');
                         }
                         if (!ImageManager::resize($tmp_name, _PS_IMG_DIR_.'m/'.$language.'-default-'.stripslashes($image_type['name']).'.jpg', $image_type['width'], $image_type['height'])) {
-                            $this->errors[] = Tools::displayError('An error occurred while resizing "No picture" image to your brand directory.');
+                            $this->errors[] = $this->trans('An error occurred while resizing "No picture" image to your brand directory.', array(), 'Admin.International.Notification');
                         }
                     }
                 }
@@ -496,14 +496,14 @@ class AdminLanguagesControllerCore extends AdminController
             foreach ($images_types as $k => $image_type) {
                 if (file_exists($dir.$language.'-default-'.stripslashes($image_type['name']).'.jpg')) {
                     if (!unlink($dir.$language.'-default-'.stripslashes($image_type['name']).'.jpg')) {
-                        $this->errors[] = Tools::displayError('An error occurred during image deletion process.');
+                        $this->errors[] = $this->trans('An error occurred during image deletion process.', array(), 'Admin.International.Notification');
                     }
                 }
             }
 
             if (file_exists($dir.$language.'.jpg')) {
                 if (!unlink($dir.$language.'.jpg')) {
-                    $this->errors[] = Tools::displayError('An error occurred during image deletion process.');
+                    $this->errors[] = $this->trans('An error occurred during image deletion process.', array(), 'Admin.International.Notification');
                 }
             }
         }

--- a/controllers/admin/AdminLocalizationController.php
+++ b/controllers/admin/AdminLocalizationController.php
@@ -161,7 +161,7 @@ class AdminLocalizationControllerCore extends AdminController
     public function postProcess()
     {
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
 
@@ -187,15 +187,15 @@ class AdminLocalizationControllerCore extends AdminController
                 }
 
                 if (!$pack && !($pack = @Tools::file_get_contents($path))) {
-                    $this->errors[] = Tools::displayError('Cannot load the localization pack.');
+                    $this->errors[] = $this->trans('Cannot load the localization pack.', array(), 'Admin.International.Notification');
                 }
 
                 if (!$selection = Tools::getValue('selection')) {
-                    $this->errors[] = Tools::displayError('Please select at least one item to import.');
+                    $this->errors[] = $this->trans('Please select at least one item to import.', array(), 'Admin.International.Notification');
                 } else {
                     foreach ($selection as $selected) {
                         if (!Validate::isLocalizationPackSelection($selected)) {
-                            $this->errors[] = Tools::displayError('Invalid selection');
+                            $this->errors[] = $this->trans('Invalid selection', array(), 'Admin.Notifications.Error');
                             return;
                         }
                     }

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -72,7 +72,7 @@ class AdminLoginControllerCore extends AdminController
             $clientIsMaintenanceOrLocal = in_array(Tools::getRemoteAddr(), array_merge(array('127.0.0.1'), explode(',', Configuration::get('PS_MAINTENANCE_IP'))));
             // If ssl is enabled, https protocol is required. Exception for maintenance and local (127.0.0.1) IP
             if ($clientIsMaintenanceOrLocal) {
-                $warningSslMessage = Tools::displayError('SSL is activated. However, your IP is allowed to enter unsecure mode for maintenance or local IP issues.');
+                $warningSslMessage = $this->trans('SSL is activated. However, your IP is allowed to enter unsecure mode for maintenance or local IP issues.', array(), 'Admin.Notifications.Error');
             } else {
                 $url = 'https://'.Tools::safeOutput(Tools::getServerName()).Tools::safeOutput($_SERVER['REQUEST_URI']);
                 $warningSslMessage = sprintf(
@@ -185,15 +185,15 @@ class AdminLoginControllerCore extends AdminController
         $passwd = trim(Tools::getValue('passwd'));
         $email = trim(Tools::getValue('email'));
         if (empty($email)) {
-            $this->errors[] = Tools::displayError('Email is empty.');
+            $this->errors[] = $this->trans('Email is empty.', array(), 'Admin.Notifications.Error');
         } elseif (!Validate::isEmail($email)) {
-            $this->errors[] = Tools::displayError('Invalid email address.');
+            $this->errors[] = $this->trans('Invalid email address.', array(), 'Admin.Notifications.Error');
         }
 
         if (empty($passwd)) {
-            $this->errors[] = Tools::displayError('The password field is blank.');
+            $this->errors[] = $this->trans('The password field is blank.', array(), 'Admin.Notifications.Error');
         } elseif (!Validate::isPasswd($passwd)) {
-            $this->errors[] = Tools::displayError('Invalid password.');
+            $this->errors[] = $this->trans('Invalid password.', array(), 'Admin.Notifications.Error');
         }
 
         if (!count($this->errors)) {
@@ -202,10 +202,10 @@ class AdminLoginControllerCore extends AdminController
             $is_employee_loaded = $this->context->employee->getByEmail($email, $passwd);
             $employee_associated_shop = $this->context->employee->getAssociatedShops();
             if (!$is_employee_loaded) {
-                $this->errors[] = Tools::displayError('The Employee does not exist, or the password provided is incorrect.');
+                $this->errors[] = $this->trans('The Employee does not exist, or the password provided is incorrect.', array(), 'Admin.Notifications.Error');
                 $this->context->employee->logout();
             } elseif (empty($employee_associated_shop) && !$this->context->employee->isSuperAdmin()) {
-                $this->errors[] = Tools::displayError('This employee does not manage the shop anymore (Either the shop has been deleted or permissions have been revoked).');
+                $this->errors[] = $this->trans('This employee does not manage the shop anymore (Either the shop has been deleted or permissions have been revoked).', array(), 'Admin.Notifications.Error');
                 $this->context->employee->logout();
             } else {
                 PrestaShopLogger::addLog(sprintf($this->l('Back Office connection from %s', 'AdminTab', false, false), Tools::getRemoteAddr()), 1, null, '', 0, true, (int)$this->context->employee->id);
@@ -248,18 +248,18 @@ class AdminLoginControllerCore extends AdminController
     public function processForgot()
     {
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
         } elseif (!($email = trim(Tools::getValue('email_forgot')))) {
-            $this->errors[] = Tools::displayError('Email is empty.');
+            $this->errors[] = $this->trans('Email is empty.', array(), 'Admin.Notifications.Error');
         } elseif (!Validate::isEmail($email)) {
-            $this->errors[] = Tools::displayError('Invalid email address.');
+            $this->errors[] = $this->trans('Invalid email address.', array(), 'Admin.Notifications.Error');
         } else {
             $employee = new Employee();
             if (!$employee->getByEmail($email) || !$employee) {
-                $this->errors[] = Tools::displayError('This account does not exist.');
+                $this->errors[] = $this->trans('This account does not exist.', array(), 'Admin.Notifications.Error');
             } elseif ((strtotime($employee->last_passwd_gen.'+'.Configuration::get('PS_PASSWD_TIME_BACK').' minutes') - time()) > 0) {
                 $this->errors[] = sprintf(
-                    Tools::displayError('You can reset your password every %d minute(s) only. Please try again later.'),
+                    $this->trans('You can reset your password every %d minute(s) only. Please try again later.', array(), 'Admin.Notifications.Error'),
                     Configuration::get('PS_PASSWD_TIME_BACK')
                 );
             }
@@ -289,7 +289,7 @@ class AdminLoginControllerCore extends AdminController
             } else {
                 die(Tools::jsonEncode(array(
                     'hasErrors' => true,
-                    'errors' => array(Tools::displayError('An error occurred while attempting to reset your password.'))
+                    'errors' => array($this->trans('An error occurred while attempting to reset your password.', array(), 'Admin.Notifications.Error'))
                 )));
             }
         } elseif (Tools::isSubmit('ajax')) {
@@ -300,35 +300,35 @@ class AdminLoginControllerCore extends AdminController
     public function processReset()
     {
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
         } elseif (!($reset_token_value = trim(Tools::getValue('reset_token')))) {
             // hidden fields
-            $this->errors[] = Tools::displayError('Some identification information is missing.');
+            $this->errors[] = $this->trans('Some identification information is missing.', array(), 'Admin.Login.Notification');
         } elseif (!($id_employee = trim(Tools::getValue('id_employee')))) {
-            $this->errors[] = Tools::displayError('Some identification information is missing.');
+            $this->errors[] = $this->trans('Some identification information is missing.', array(), 'Admin.Login.Notification');
         } elseif (!($reset_email = trim(Tools::getValue('reset_email')))) {
-            $this->errors[] = Tools::displayError('Some identification information is missing.');
+            $this->errors[] = $this->trans('Some identification information is missing.', array(), 'Admin.Login.Notification');
         } elseif (!($reset_password = trim(Tools::getValue('reset_passwd')))) {
             // password (twice)
-            $this->errors[] = Tools::displayError('The password is missing: please enter your new password.');
+            $this->errors[] = $this->trans('The password is missing: please enter your new password.', array(), 'Admin.Login.Notification');
         } elseif (!Validate::isPasswd($reset_password)) {
-            $this->errors[] = Tools::displayError('The password is not in a valid format.');
+            $this->errors[] = $this->trans('The password is not in a valid format.', array(), 'Admin.Login.Notification');
         } elseif (!($reset_confirm = trim(Tools::getValue('reset_confirm')))) {
-            $this->errors[] = Tools::displayError('The confirmation is empty: please fill in the password confirmation as well.');
+            $this->errors[] = $this->trans('The confirmation is empty: please fill in the password confirmation as well.', array(), 'Admin.Login.Notification');
         } elseif ($reset_password !== $reset_confirm) {
-            $this->errors[] = Tools::displayError('The password and its confirmation do not match. Please double check both passwords.');
+            $this->errors[] = $this->trans('The password and its confirmation do not match. Please double check both passwords.', array(), 'Admin.Login.Notification');
         } else {
             $employee = new Employee();
             if (!$employee->getByEmail($reset_email) || !$employee || $employee->id != $id_employee) { // check matching employee id with its email
-                $this->errors[] = Tools::displayError('This account does not exist.');
+                $this->errors[] = $this->trans('This account does not exist.', array(), 'Admin.Login.Notification');
             } elseif ((strtotime($employee->last_passwd_gen.'+'.Configuration::get('PS_PASSWD_TIME_BACK').' minutes') - time()) > 0) {
                 $this->errors[] = sprintf(
-                    Tools::displayError('You can reset your password every %d minute(s) only. Please try again later.'),
+                    $this->trans('You can reset your password every %d minute(s) only. Please try again later.', array(), 'Admin.Login.Notification'),
                     Configuration::get('PS_PASSWD_TIME_BACK')
                 );
             } elseif ($employee->getValidResetPasswordToken() !== $reset_token_value) {
                 // To update password, we must have the temporary reset token that matches.
-                $this->errors[] = Tools::displayError('Your password reset request expired. Please start again.');
+                $this->errors[] = $this->trans('Your password reset request expired. Please start again.', array(), 'Admin.Login.Notification');
             }
         }
 
@@ -348,7 +348,7 @@ class AdminLoginControllerCore extends AdminController
 
                 $result = $employee->update();
                 if (!$result) {
-                    $this->errors[] = Tools::displayError('An error occurred while attempting to change your password.');
+                    $this->errors[] = $this->trans('An error occurred while attempting to change your password.', array(), 'Admin.Login.Notification');
                 } else {
                     $employee->removeResetPasswordToken(); // Delete temporary reset token
                     $employee->update();
@@ -360,7 +360,7 @@ class AdminLoginControllerCore extends AdminController
             } else {
                 die(Tools::jsonEncode(array(
                     'hasErrors' => true,
-                    'errors' => array(Tools::displayError('An error occurred while attempting to change your password.'))
+                    'errors' => array($this->trans('An error occurred while attempting to change your password.', array(), 'Admin.Login.Notification'))
                 )));
             }
         } elseif (Tools::isSubmit('ajax')) {

--- a/controllers/admin/AdminManufacturersController.php
+++ b/controllers/admin/AdminManufacturersController.php
@@ -844,7 +844,7 @@ class AdminManufacturersControllerCore extends AdminController
         }
 
         if (!$res) {
-            $this->errors[] = Tools::displayError('Unable to resize one or more of your pictures.');
+            $this->errors[] = $this->trans('Unable to resize one or more of your pictures.', array(), 'Admin.Catalog.Notification');
         }
 
         return $res;

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -355,7 +355,7 @@ class AdminMetaControllerCore extends AdminController
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_ && Tools::isSubmit('submitOptionsmeta')
             && (Tools::getValue('domain') != Configuration::get('PS_SHOP_DOMAIN') || Tools::getValue('domain_ssl') != Configuration::get('PS_SHOP_DOMAIN_SSL'))) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
 
@@ -370,7 +370,7 @@ class AdminMetaControllerCore extends AdminController
             }
 
             if (!$defaultLangIsValidated && !$englishLangIsValidated) {
-                $this->errors[] = Tools::displayError('The URL rewrite field must be filled in either the default or English language.');
+                $this->errors[] = $this->trans('The URL rewrite field must be filled in either the default or English language.', array(), 'Admin.Notifications.Error');
                 return false;
             }
 
@@ -405,7 +405,7 @@ class AdminMetaControllerCore extends AdminController
     public function generateRobotsFile()
     {
         if (!$write_fd = @fopen($this->rb_file, 'w')) {
-            $this->errors[] = sprintf(Tools::displayError('Cannot write into file: %s. Please check write permissions.'), $this->rb_file);
+            $this->errors[] = $this->trans('Cannot write into file: %filename%. Please check write permissions.', array( '%filename' => $this->rb_file), 'Admin.Notifications.Error');
         } else {
             Hook::exec('actionAdminMetaBeforeWriteRobotsFile', array(
                 'rb_data' => &$this->rb_data
@@ -606,7 +606,7 @@ class AdminMetaControllerCore extends AdminController
                 $this->url->update();
                 Configuration::updateGlobalValue('PS_SHOP_DOMAIN', $value);
             } else {
-                $this->errors[] = Tools::displayError('This domain is not valid.');
+                $this->errors[] = $this->trans('This domain is not valid.', array(), 'Admin.Notifications.Error');
             }
         }
     }
@@ -626,7 +626,7 @@ class AdminMetaControllerCore extends AdminController
                 $this->url->update();
                 Configuration::updateGlobalValue('PS_SHOP_DOMAIN_SSL', $value);
             } else {
-                $this->errors[] = Tools::displayError('The SSL domain is not valid.');
+                $this->errors[] = $this->trans('The SSL domain is not valid.', array(), 'Admin.Notifications.Error');
             }
         }
     }

--- a/controllers/admin/AdminNotFoundController.php
+++ b/controllers/admin/AdminNotFoundController.php
@@ -44,7 +44,7 @@ class AdminNotFoundControllerCore extends AdminController
 
     public function initContent()
     {
-        $this->errors[] = Tools::displayError('Controller not found');
+        $this->errors[] = $this->trans('Controller not found', array(), 'Admin.Notifications.Error');
         $tpl_vars['controller'] = Tools::getvalue('controllerUri', Tools::getvalue('controller'));
         $this->context->smarty->assign($tpl_vars);
         parent::initContent();

--- a/controllers/admin/AdminPaymentPreferencesController.php
+++ b/controllers/admin/AdminPaymentPreferencesController.php
@@ -124,7 +124,7 @@ class AdminPaymentPreferencesControllerCore extends AdminController
                 $this->action = 'group';
             }
         } else {
-            $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+            $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
         }
     }
 

--- a/controllers/admin/AdminPdfController.php
+++ b/controllers/admin/AdminPdfController.php
@@ -42,7 +42,7 @@ class AdminPdfControllerCore extends AdminController
         if ($access['view'] === '1' && ($action = Tools::getValue('submitAction'))) {
             $this->action = $action;
         } else {
-            $this->errors[] = Tools::displayError('You do not have permission to view this.');
+            $this->errors[] = $this->trans('You do not have permission to view this.', array(), 'Admin.Notifications.Error');
         }
     }
 
@@ -60,7 +60,7 @@ class AdminPdfControllerCore extends AdminController
         } elseif (Tools::isSubmit('id_order_invoice')) {
             $this->generateInvoicePDFByIdOrderInvoice(Tools::getValue('id_order_invoice'));
         } else {
-            die(Tools::displayError('The order ID -- or the invoice order ID -- is missing.'));
+            die($this->trans('The order ID -- or the invoice order ID -- is missing.', array(), 'Admin.OrdersCustomers.Notification'));
         }
     }
 
@@ -70,7 +70,7 @@ class AdminPdfControllerCore extends AdminController
         $order = new Order((int)$order_slip->id_order);
 
         if (!Validate::isLoadedObject($order)) {
-            die(Tools::displayError('The order cannot be found within your database.'));
+            die($this->trans('The order cannot be found within your database.', array(), 'Admin.OrdersCustomers.Notification'));
         }
 
         $order->products = OrderSlip::getOrdersSlipProducts($order_slip->id, $order);
@@ -87,7 +87,7 @@ class AdminPdfControllerCore extends AdminController
             $order = Order::getByDelivery((int)Tools::getValue('id_delivery'));
             $this->generateDeliverySlipPDFByIdOrder((int)$order->id);
         } else {
-            die(Tools::displayError('The order ID -- or the invoice order ID -- is missing.'));
+            die($this->trans('The order ID -- or the invoice order ID -- is missing.', array(), 'Admin.OrdersCustomers.Notification'));
         }
     }
 
@@ -96,7 +96,7 @@ class AdminPdfControllerCore extends AdminController
         $order_invoice_collection = OrderInvoice::getByDateInterval(Tools::getValue('date_from'), Tools::getValue('date_to'));
 
         if (!count($order_invoice_collection)) {
-            die(Tools::displayError('No invoice was found.'));
+            die($this->trans('No invoice was found.', array(), 'Admin.OrdersCustomers.Notification'));
         }
 
         $this->generatePDF($order_invoice_collection, PDF::TEMPLATE_INVOICE);
@@ -112,7 +112,7 @@ class AdminPdfControllerCore extends AdminController
         }
 
         if (!count($order_invoice_collection)) {
-            die(Tools::displayError('No invoice was found.'));
+            die($this->trans('No invoice was found.', array(), 'Admin.OrdersCustomers.Notification'));
         }
 
         $this->generatePDF($order_invoice_collection, PDF::TEMPLATE_INVOICE);
@@ -122,7 +122,7 @@ class AdminPdfControllerCore extends AdminController
     {
         $id_order_slips_list = OrderSlip::getSlipsIdByDate(Tools::getValue('date_from'), Tools::getValue('date_to'));
         if (!count($id_order_slips_list)) {
-            die(Tools::displayError('No order slips were found.'));
+            die($this->trans('No order slips were found.', array(), 'Admin.OrdersCustomers.Notification'));
         }
 
         $order_slips = array();
@@ -138,7 +138,7 @@ class AdminPdfControllerCore extends AdminController
         $order_invoice_collection = OrderInvoice::getByDeliveryDateInterval(Tools::getValue('date_from'), Tools::getValue('date_to'));
 
         if (!count($order_invoice_collection)) {
-            die(Tools::displayError('No invoice was found.'));
+            die($this->trans('No invoice was found.', array(), 'Admin.OrdersCustomers.Notification'));
         }
 
         $this->generatePDF($order_invoice_collection, PDF::TEMPLATE_DELIVERY_SLIP);
@@ -147,14 +147,14 @@ class AdminPdfControllerCore extends AdminController
     public function processGenerateSupplyOrderFormPDF()
     {
         if (!Tools::isSubmit('id_supply_order')) {
-            die(Tools::displayError('The supply order ID is missing.'));
+            die($this->trans('The supply order ID is missing.', array(), 'Admin.OrdersCustomers.Notification'));
         }
 
         $id_supply_order = (int)Tools::getValue('id_supply_order');
         $supply_order = new SupplyOrder($id_supply_order);
 
         if (!Validate::isLoadedObject($supply_order)) {
-            die(Tools::displayError('The supply order cannot be found within your database.'));
+            die($this->trans('The supply order cannot be found within your database.', array(), 'Admin.OrdersCustomers.Notification'));
         }
 
         $this->generatePDF($supply_order, PDF::TEMPLATE_SUPPLY_ORDER_FORM);
@@ -185,7 +185,7 @@ class AdminPdfControllerCore extends AdminController
     {
         $order = new Order((int)$id_order);
         if (!Validate::isLoadedObject($order)) {
-            die(Tools::displayError('The order cannot be found within your database.'));
+            die($this->trans('The order cannot be found within your database.', array(), 'Admin.OrdersCustomers.Notification'));
         }
 
         $order_invoice_list = $order->getInvoicesCollection();
@@ -197,7 +197,7 @@ class AdminPdfControllerCore extends AdminController
     {
         $order_invoice = new OrderInvoice((int)$id_order_invoice);
         if (!Validate::isLoadedObject($order_invoice)) {
-            die(Tools::displayError('The order invoice cannot be found within your database.'));
+            die($this->trans('The order invoice cannot be found within your database.', array(), 'Admin.OrdersCustomers.Notification'));
         }
 
         Hook::exec('actionPDFInvoiceRender', array('order_invoice_list' => array($order_invoice)));

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -720,7 +720,7 @@ class AdminPerformanceControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
 
@@ -728,13 +728,13 @@ class AdminPerformanceControllerCore extends AdminController
         if (Tools::isSubmit('submitAddServer')) {
             if ($this->access('add')) {
                 if (!Tools::getValue('memcachedIp')) {
-                    $this->errors[] = Tools::displayError('The Memcached IP is missing.');
+                    $this->errors[] = $this->trans('The Memcached IP is missing.', array(), 'Admin.Parameters.Notification');
                 }
                 if (!Tools::getValue('memcachedPort')) {
-                    $this->errors[] = Tools::displayError('The Memcached port is missing.');
+                    $this->errors[] = $this->trans('The Memcached port is missing.', array(), 'Admin.Parameters.Notification');
                 }
                 if (!Tools::getValue('memcachedWeight')) {
-                    $this->errors[] = Tools::displayError('The Memcached weight is missing.');
+                    $this->errors[] = $this->trans('The Memcached weight is missing.', array(), 'Admin.Parameters.Notification');
                 }
                 if (!count($this->errors)) {
                     if (CacheMemcache::addServer(pSQL(Tools::getValue('memcachedIp')),
@@ -742,11 +742,11 @@ class AdminPerformanceControllerCore extends AdminController
                         (int)Tools::getValue('memcachedWeight'))) {
                         Tools::redirectAdmin(self::$currentIndex.'&token='.Tools::getValue('token').'&conf=4');
                     } else {
-                        $this->errors[] = Tools::displayError('The Memcached server cannot be added.');
+                        $this->errors[] = $this->trans('The Memcached server cannot be added.', array(), 'Admin.Parameters.Notification');
                     }
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to add this.');
+                $this->errors[] = $this->trans('You do not have permission to add this.', array(), 'Admin.Notifications.Error');
             }
         }
 
@@ -755,10 +755,10 @@ class AdminPerformanceControllerCore extends AdminController
                 if (CacheMemcache::deleteServer((int)Tools::getValue('deleteMemcachedServer'))) {
                     Tools::redirectAdmin(self::$currentIndex.'&token='.Tools::getValue('token').'&conf=4');
                 } else {
-                    $this->errors[] = Tools::displayError('There was an error when attempting to delete the Memcached server.');
+                    $this->errors[] = $this->trans('There was an error when attempting to delete the Memcached server.', array(), 'Admin.Parameters.Notification');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
             }
         }
 
@@ -777,7 +777,7 @@ class AdminPerformanceControllerCore extends AdminController
                 Configuration::updateValue('PS_SMARTY_LOCAL', Tools::getValue('smarty_local', 0));
                 $redirectAdmin = true;
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
 
@@ -798,7 +798,7 @@ class AdminPerformanceControllerCore extends AdminController
                 Configuration::updateValue('PS_FEATURE_FEATURE_ACTIVE', (bool)Tools::getValue('feature'));
                 $redirectAdmin = true;
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
 
@@ -807,7 +807,13 @@ class AdminPerformanceControllerCore extends AdminController
                 $theme_cache_directory = _PS_ALL_THEMES_DIR_.$this->context->shop->theme_directory.'/cache/';
                 @mkdir($theme_cache_directory, 0777, true);
                 if (((bool)Tools::getValue('PS_CSS_THEME_CACHE') || (bool)Tools::getValue('PS_JS_THEME_CACHE')) && !is_writable($theme_cache_directory)) {
-                    $this->errors[] = sprintf(Tools::displayError('To use Smart Cache directory %s must be writable.'), realpath($theme_cache_directory));
+                    $this->errors[] = $this->trans(
+                        'To use Smart Cache, the directory %directorypath% must be writable.',
+                        array(
+                            '%directorypath%' => realpath($theme_cache_directory)
+                        ),
+                        'Admin.Parameters.Notification'
+                    );
                 }
 
                 if ($tmp = (int)Tools::getValue('PS_CSS_THEME_CACHE')) {
@@ -830,7 +836,7 @@ class AdminPerformanceControllerCore extends AdminController
                     !Configuration::updateValue('PS_JS_HTML_THEME_COMPRESSION', (int)Tools::getValue('PS_JS_HTML_THEME_COMPRESSION')) ||
                     !Configuration::updateValue('PS_JS_DEFER', (int)Tools::getValue('PS_JS_DEFER')) ||
                     !Configuration::updateValue('PS_HTACCESS_CACHE_CONTROL', (int)Tools::getValue('PS_HTACCESS_CACHE_CONTROL'))) {
-                    $this->errors[] = Tools::displayError('Unknown error.');
+                    $this->errors[] = $this->trans('Unknown error.', array(), 'Admin.Notifications.Error');
                 } else {
                     $redirectAdmin = true;
                     if (Configuration::get('PS_HTACCESS_CACHE_CONTROL')) {
@@ -846,20 +852,20 @@ class AdminPerformanceControllerCore extends AdminController
                     }
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
 
         if ((bool)Tools::getValue('media_server_up') && !defined('_PS_HOST_MODE_')) {
             if ($this->access('edit')) {
                 if (Tools::getValue('_MEDIA_SERVER_1_') != null && !Validate::isFileName(Tools::getValue('_MEDIA_SERVER_1_'))) {
-                    $this->errors[] = Tools::displayError('Media server #1 is invalid');
+                    $this->errors[] = $this->trans('Media server #1 is invalid', array(), 'Admin.Parameters.Notification');
                 }
                 if (Tools::getValue('_MEDIA_SERVER_2_') != null && !Validate::isFileName(Tools::getValue('_MEDIA_SERVER_2_'))) {
-                    $this->errors[] = Tools::displayError('Media server #2 is invalid');
+                    $this->errors[] = $this->trans('Media server #2 is invalid', array(), 'Admin.Parameters.Notification');
                 }
                 if (Tools::getValue('_MEDIA_SERVER_3_') != null && !Validate::isFileName(Tools::getValue('_MEDIA_SERVER_3_'))) {
-                    $this->errors[] = Tools::displayError('Media server #3 is invalid');
+                    $this->errors[] = $this->trans('Media server #3 is invalid', array(), 'Admin.Parameters.Notification');
                 }
                 if (!count($this->errors)) {
                     $base_urls = array();
@@ -893,7 +899,7 @@ class AdminPerformanceControllerCore extends AdminController
                     }
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
         if ((bool)Tools::getValue('ciphering_up') && Configuration::get('PS_CIPHER_ALGORITHM') != (int)Tools::getValue('PS_CIPHER_ALGORITHM')) {
@@ -903,7 +909,7 @@ class AdminPerformanceControllerCore extends AdminController
                 $new_settings = $prev_settings;
                 if ($algo) {
                     if (!function_exists('mcrypt_encrypt')) {
-                        $this->errors[] = Tools::displayError('The "Mcrypt" PHP extension is not activated on this server.');
+                        $this->errors[] = $this->trans('The "Mcrypt" PHP extension is not activated on this server.', array(), 'Admin.Parameters.Notification');
                     } else {
                         if (!strstr($new_settings, '_RIJNDAEL_KEY_')) {
                             $key_size = mcrypt_get_key_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
@@ -934,11 +940,11 @@ class AdminPerformanceControllerCore extends AdminController
                         Configuration::updateValue('PS_CIPHER_ALGORITHM', $algo);
                         $redirectAdmin = true;
                     } else {
-                        $this->errors[] = Tools::displayError('The settings file cannot be overwritten.');
+                        $this->errors[] = $this->trans('The settings file cannot be overwritten.', array(), 'Admin.Parameters.Notification');
                     }
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
 
@@ -955,35 +961,41 @@ class AdminPerformanceControllerCore extends AdminController
                     );
                 } else {
                     $cache_active = false;
-                    $this->errors[] = Tools::displayError('The caching system is missing.');
+                    $this->errors[] = $this->trans('The caching system is missing.', array(), 'Admin.Parameters.Notification');
                 }
                 if ($cache_active) {
                     if ($caching_system == 'CacheMemcache' && !extension_loaded('memcache')) {
-                        $this->errors[] = Tools::displayError('To use Memcached, you must install the Memcache PECL extension on your server.').'
+                        $this->errors[] = $this->trans('To use Memcached, you must install the Memcache PECL extension on your server.', array(), 'Admin.Parameters.Notification').'
 							<a href="http://www.php.net/manual/en/memcache.installation.php">http://www.php.net/manual/en/memcache.installation.php</a>';
                     } elseif ($caching_system == 'CacheMemcached' && !extension_loaded('memcached')) {
-                        $this->errors[] = Tools::displayError('To use Memcached, you must install the Memcached PECL extension on your server.').'
+                        $this->errors[] = $this->trans('To use Memcached, you must install the Memcached PECL extension on your server.', array(), 'Admin.Parameters.Notification').'
 							<a href="http://www.php.net/manual/en/memcached.installation.php">http://www.php.net/manual/en/memcached.installation.php</a>';
                     } elseif ($caching_system == 'CacheApc'  && !extension_loaded('apc') && !extension_loaded('apcu')) {
-                        $this->errors[] = Tools::displayError('To use APC cache, you must install the APC PECL extension on your server.').'
+                        $this->errors[] = $this->trans('To use APC cache, you must install the APC PECL extension on your server.', array(), 'Admin.Parameters.Notification').'
 							<a href="http://fr.php.net/manual/fr/apc.installation.php">http://fr.php.net/manual/fr/apc.installation.php</a>';
                     } elseif ($caching_system == 'CacheXcache' && !extension_loaded('xcache')) {
-                        $this->errors[] = Tools::displayError('To use Xcache, you must install the Xcache extension on your server.').'
+                        $this->errors[] = $this->trans('To use Xcache, you must install the Xcache extension on your server.', array(), 'Admin.Parameters.Notification').'
 							<a href="http://xcache.lighttpd.net">http://xcache.lighttpd.net</a>';
                     } elseif ($caching_system == 'CacheXcache' && !ini_get('xcache.var_size')) {
-                        $this->errors[] = Tools::displayError('To use Xcache, you must configure "xcache.var_size" for the Xcache extension (recommended value 16M to 64M).').'
+                        $this->errors[] = $this->trans('To use Xcache, you must configure "xcache.var_size" for the Xcache extension (recommended value 16M to 64M).', array(), 'Admin.Parameters.Notification').'
 							<a href="http://xcache.lighttpd.net/wiki/XcacheIni">http://xcache.lighttpd.net/wiki/XcacheIni</a>';
                     } elseif ($caching_system == 'CacheFs') {
                         if (!is_dir(_PS_CACHEFS_DIRECTORY_)) {
                             @mkdir(_PS_CACHEFS_DIRECTORY_, 0777, true);
                         } elseif (!is_writable(_PS_CACHEFS_DIRECTORY_)) {
-                            $this->errors[] = sprintf(Tools::displayError('To use CacheFS, the directory %s must be writable.'), realpath(_PS_CACHEFS_DIRECTORY_));
+                            $this->errors[] = $this->trans(
+                                'To use CacheFS, the directory %directorypath% must be writable.',
+                                array(
+                                    '%directorypath%' => realpath(_PS_CACHEFS_DIRECTORY_)
+                                ),
+                                'Admin.Parameters.Notification'
+                            );
                         }
                     }
 
                     if ($caching_system == 'CacheFs') {
                         if (!($depth = Tools::getValue('ps_cache_fs_directory_depth'))) {
-                            $this->errors[] = Tools::displayError('Please set a directory depth.');
+                            $this->errors[] = $this->trans('Please set a directory depth.', array(), 'Admin.Parameters.Notification');
                         }
                         if (!count($this->errors)) {
                             CacheFs::deleteCacheDirectory();
@@ -1009,11 +1021,11 @@ class AdminPerformanceControllerCore extends AdminController
                         }
                         $redirectAdmin = true;
                     } else {
-                        $this->errors[] = Tools::displayError('The settings file cannot be overwritten.');
+                        $this->errors[] = $this->trans('The settings file cannot be overwritten.', array(), 'Admin.Parameters.Notification');
                     }
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
 
@@ -1076,7 +1088,7 @@ class AdminPerformanceControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            die(Tools::displayError('This functionality has been disabled.'));
+            die($this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error'));
         }
         /* PrestaShop demo mode*/
         if (Tools::isSubmit('action') && Tools::getValue('action') == 'test_server') {

--- a/controllers/admin/AdminProfilesController.php
+++ b/controllers/admin/AdminProfilesController.php
@@ -91,7 +91,7 @@ class AdminProfilesControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
         /* PrestaShop demo mode*/

--- a/controllers/admin/AdminQuickAccessesController.php
+++ b/controllers/admin/AdminQuickAccessesController.php
@@ -146,7 +146,7 @@ class AdminQuickAccessesControllerCore extends AdminController
             if ($this->access('edit')) {
                 $this->action = 'newWindow';
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
 
@@ -185,7 +185,7 @@ class AdminQuickAccessesControllerCore extends AdminController
             $this->beforeAdd($this->object);
 
             if (method_exists($this->object, 'add') && !$this->object->add()) {
-                $this->errors[] = Tools::displayError('An error occurred while creating an object.').
+                $this->errors[] = $this->trans('An error occurred while creating an object.', array(), 'Admin.Notifications.Error').
                     ' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
             }
             /* voluntary do affectation here */
@@ -234,12 +234,12 @@ class AdminQuickAccessesControllerCore extends AdminController
             if ($object->toggleNewWindow()) {
                 $this->redirect_after = self::$currentIndex.'&conf=5&token='.$this->token;
             } else {
-                $this->errors[] = Tools::displayError('An error occurred while updating new window property.');
+                $this->errors[] = $this->trans('An error occurred while updating new window property.', array(), 'Admin.Parameters.Notification');
             }
         } else {
-            $this->errors[] = Tools::displayError('An error occurred while updating the new window property for this object.').
+            $this->errors[] = $this->trans('An error occurred while updating the new window property for this object.', array(), 'Admin.Parameters.Notification').
                 ' <b>'.$this->table.'</b> '.
-                Tools::displayError('(cannot load object)');
+                $this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
         }
 
         return $object;

--- a/controllers/admin/AdminRangePriceController.php
+++ b/controllers/admin/AdminRangePriceController.php
@@ -141,11 +141,11 @@ class AdminRangePriceControllerCore extends AdminController
         $id = (int)Tools::getValue('id_'.$this->table);
         if (Tools::getValue('submitAdd'.$this->table)) {
             if (Tools::getValue('delimiter1') >= Tools::getValue('delimiter2')) {
-                $this->errors[] = Tools::displayError('Invalid range');
+                $this->errors[] = $this->trans('Invalid range', array(), 'Admin.Notifications.Error');
             } elseif (!$id && RangePrice::rangeExist((int)Tools::getValue('id_carrier'), (float)Tools::getValue('delimiter1'), (float)Tools::getValue('delimiter2'))) {
-                $this->errors[] = Tools::displayError('The range already exists');
+                $this->errors[] = $this->trans('The range already exists', array(), 'Admin.Shipping.Notification');
             } elseif (RangePrice::isOverlapping((int)Tools::getValue('id_carrier'), (float)Tools::getValue('delimiter1'), (float)Tools::getValue('delimiter2'), ($id ? (int)$id : null))) {
-                $this->errors[] = Tools::displayError('Error: Ranges are overlapping');
+                $this->errors[] = $this->trans('Error: Ranges are overlapping', array(), 'Admin.Shipping.Notification');
             } elseif (!count($this->errors)) {
                 parent::postProcess();
             }

--- a/controllers/admin/AdminRangeWeightController.php
+++ b/controllers/admin/AdminRangeWeightController.php
@@ -138,11 +138,11 @@ class AdminRangeWeightControllerCore extends AdminController
         
         if (Tools::getValue('submitAdd'.$this->table)) {
             if (Tools::getValue('delimiter1') >= Tools::getValue('delimiter2')) {
-                $this->errors[] = Tools::displayError('Invalid range');
+                $this->errors[] = $this->trans('Invalid range', array(), 'Admin.Notifications.Error');
             } elseif (!$id && RangeWeight::rangeExist((int)Tools::getValue('id_carrier'), (float)Tools::getValue('delimiter1'), (float)Tools::getValue('delimiter2'))) {
-                $this->errors[] = Tools::displayError('The range already exists');
+                $this->errors[] = $this->trans('The range already exists', array(), 'Admin.Shipping.Notification');
             } elseif (RangeWeight::isOverlapping((int)Tools::getValue('id_carrier'), (float)Tools::getValue('delimiter1'), (float)Tools::getValue('delimiter2'), ($id ? (int)$id : null))) {
-                $this->errors[] = Tools::displayError('Error: Ranges are overlapping');
+                $this->errors[] = $this->trans('Error: Ranges are overlapping', array(), 'Admin.Shipping.Notification');
             } elseif (!count($this->errors)) {
                 parent::postProcess();
             }

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -170,7 +170,7 @@ class AdminRequestSqlControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
         return parent::postProcess();
@@ -184,7 +184,7 @@ class AdminRequestSqlControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            die(Tools::displayError('This functionality has been disabled.'));
+            die($this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error'));
         }
         if ($table = Tools::GetValue('table')) {
             $request_sql = new RequestSql();
@@ -364,7 +364,7 @@ class AdminRequestSqlControllerCore extends AdminController
                         readfile($export_dir.$file);
                         die();
                     } else {
-                        $this->errors[] = Tools::DisplayError('The file is too large and can not be downloaded. Please use the LIMIT clause in this query.');
+                        $this->errors[] = $this->trans('The file is too large and can not be downloaded. Please use the LIMIT clause in this query.', array(), 'Admin.Parameters.Notification');
                     }
                 }
             }
@@ -382,13 +382,22 @@ class AdminRequestSqlControllerCore extends AdminController
             switch ($key) {
                 case 'checkedFrom':
                     if (isset($e[$key]['table'])) {
-                        $this->errors[] = sprintf(Tools::displayError('The "%s" table does not exist.'), $e[$key]['table']);
-                    } elseif (isset($e[$key]['attribut'])) {
-                        $this->errors[] = sprintf(
-                            Tools::displayError('The "%1$s" attribute does not exist in the "%2$s" table.'),
-                            $e[$key]['attribut'][0],
-                            $e[$key]['attribut'][1]
+                        $this->errors[] = $this->trans(
+                            'The "%tablename%" table does not exist.',
+                            array(
+                                '%tablename%' => $e[$key]['table'],
+                            ),
+                            'Admin.Parameters.Notification'
                         );
+                    } elseif (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                                'The "%attribute%" attribute does not exist in the "%table%" table.',
+                                array(
+                                    '%attribute%' => $e[$key]['attribut'][0],
+                                    '%table%' => $e[$key]['attribut'][1],
+                                ),
+                                'Admin.Parameters.Notification'
+                            );
                     } else {
                         $this->errors[] = Tools::displayError('Undefined "checkedFrom" error');
                     }
@@ -396,15 +405,24 @@ class AdminRequestSqlControllerCore extends AdminController
 
                 case 'checkedSelect':
                     if (isset($e[$key]['table'])) {
-                        $this->errors[] = sprintf(Tools::displayError('The "%s" table does not exist.'), $e[$key]['table']);
+                        $this->errors[] = $this->trans(
+                            'The "%tablename%" table does not exist.',
+                            array(
+                                '%tablename%' => $e[$key]['table'],
+                            ),
+                            'Admin.Parameters.Notification'
+                        );
                     } elseif (isset($e[$key]['attribut'])) {
-                        $this->errors[] = sprintf(
-                            Tools::displayError('The "%1$s" attribute does not exist in the "%2$s" table.'),
-                            $e[$key]['attribut'][0],
-                            $e[$key]['attribut'][1]
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Parameters.Notification'
                         );
                     } elseif (isset($e[$key]['*'])) {
-                        $this->errors[] = Tools::displayError('The "*" operator cannot be used in a nested query.');
+                        $this->errors[] = $this->trans('The "*" operator cannot be used in a nested query.', array(), 'Admin.Parameters.Notification');
                     } else {
                         $this->errors[] = Tools::displayError('Undefined "checkedSelect" error');
                     }
@@ -412,12 +430,21 @@ class AdminRequestSqlControllerCore extends AdminController
 
                 case 'checkedWhere':
                     if (isset($e[$key]['operator'])) {
-                        $this->errors[] = sprintf(Tools::displayError('The operator "%s" is incorrect.'), $e[$key]['operator']);
+                        $this->errors[] = $this->trans(
+                            'The operator "%s" is incorrect.',
+                            array(
+                                '%operator%' => $e[$key]['operator'],
+                            ),
+                            'Admin.Parameters.Notification'
+                        );
                     } elseif (isset($e[$key]['attribut'])) {
-                        $this->errors[] = sprintf(
-                            Tools::displayError('The "%1$s" attribute does not exist in the "%2$s" table.'),
-                            $e[$key]['attribut'][0],
-                            $e[$key]['attribut'][1]
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Parameters.Notification'
                         );
                     } else {
                         $this->errors[] = Tools::displayError('Undefined "checkedWhere" error');
@@ -426,12 +453,21 @@ class AdminRequestSqlControllerCore extends AdminController
 
                 case 'checkedHaving':
                     if (isset($e[$key]['operator'])) {
-                        $this->errors[] = sprintf(Tools::displayError('The "%s" operator is incorrect.'), $e[$key]['operator']);
+                        $this->errors[] = $this->trans(
+                            'The "%operator%" operator is incorrect.',
+                            array(
+                                '%operator%' => $e[$key]['operator']
+                            ),
+                            'Admin.Parameters.Notification'
+                        );
                     } elseif (isset($e[$key]['attribut'])) {
-                        $this->errors[] = sprintf(
-                            Tools::displayError('The "%1$s" attribute does not exist in the "%2$s" table.'),
-                            $e[$key]['attribut'][0],
-                            $e[$key]['attribut'][1]
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Parameters.Notification'
                         );
                     } else {
                         $this->errors[] = Tools::displayError('Undefined "checkedHaving" error');
@@ -440,10 +476,13 @@ class AdminRequestSqlControllerCore extends AdminController
 
                 case 'checkedOrder':
                     if (isset($e[$key]['attribut'])) {
-                        $this->errors[] = sprintf(
-                            Tools::displayError('The "%1$s" attribute does not exist in the "%2$s" table.'),
-                            $e[$key]['attribut'][0],
-                            $e[$key]['attribut'][1]
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Parameters.Notification'
                         );
                     } else {
                         $this->errors[] = Tools::displayError('Undefined "checkedOrder" error');
@@ -452,10 +491,13 @@ class AdminRequestSqlControllerCore extends AdminController
 
                 case 'checkedGroupBy':
                     if (isset($e[$key]['attribut'])) {
-                        $this->errors[] = sprintf(
-                            Tools::displayError('The "%1$s" attribute does not exist in the "%2$s" table.'),
-                            $e[$key]['attribut'][0],
-                            $e[$key]['attribut'][1]
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Parameters.Notification'
                         );
                     } else {
                         $this->errors[] = Tools::displayError('Undefined "checkedGroupBy" error');
@@ -463,27 +505,30 @@ class AdminRequestSqlControllerCore extends AdminController
                 break;
 
                 case 'checkedLimit':
-                    $this->errors[] = Tools::displayError('The LIMIT clause must contain numeric arguments.');
+                    $this->errors[] = $this->trans('The LIMIT clause must contain numeric arguments.', array(), 'Admin.Parameters.Notification');
                 break;
 
                 case 'returnNameTable':
                     if (isset($e[$key]['reference'])) {
-                        $this->errors[] = sprintf(
-                            Tools::displayError('The "%1$s" reference does not exist in the "%2$s" table.'),
-                            $e[$key]['reference'][0],
-                            $e[$key]['attribut'][1]
+                        $this->errors[] = $this->trans(
+                            'The "%reference%" reference does not exist in the "%table%" table.',
+                            array(
+                                '%reference%' => $e[$key]['reference'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Parameters.Notification'
                         );
                     } else {
-                        $this->errors[] = Tools::displayError('When multiple tables are used, each attribute must refer back to a table.');
+                        $this->errors[] = $this->trans('When multiple tables are used, each attribute must refer back to a table.', array(), 'Admin.Parameters.Notification');
                     }
                 break;
 
                 case 'testedRequired':
-                    $this->errors[] = sprintf(Tools::displayError('%s does not exist.'), $e[$key]);
+                    $this->errors[] = sprintf($this->trans('"%s" does not exist.', array(), 'Admin.Notifications.Error'), $e[$key]);
                 break;
 
                 case 'testedUnauthorized':
-                    $this->errors[] = sprintf(Tools::displayError('Is an unauthorized keyword.'), $e[$key]);
+                    $this->errors[] = sprintf($this->trans('Is an unauthorized keyword.', array(), 'Admin.Parameters.Notification'), $e[$key]);
                 break;
             }
         }

--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -37,7 +37,7 @@ class AdminReturnControllerCore extends AdminController
         $this->colorOnBackground = true;
 
         parent::__construct();
-        
+
         $this->_select = 'ors.color, orsl.`name`, o.`id_shop`';
         $this->_join = 'LEFT JOIN '._DB_PREFIX_.'order_return_state ors ON (ors.`id_order_return_state` = a.`state`)';
         $this->_join .= 'LEFT JOIN '._DB_PREFIX_.'order_return_state_lang orsl ON (orsl.`id_order_return_state` = a.`state` AND orsl.`id_lang` = '.(int)$this->context->language->id.')';
@@ -214,19 +214,19 @@ class AdminReturnControllerCore extends AdminController
                             if (OrderReturn::deleteOrderReturnDetail($id_order_return, $id_order_detail, (int)(Tools::getValue('id_customization', 0)))) {
                                 Tools::redirectAdmin(self::$currentIndex.'&conf=4token='.$this->token);
                             } else {
-                                $this->errors[] = Tools::displayError('An error occurred while deleting the details of your order return.');
+                                $this->errors[] = $this->trans('An error occurred while deleting the details of your order return.', array(), 'Admin.OrdersCustomers.Notification');
                             }
                         } else {
-                            $this->errors[] = Tools::displayError('You need at least one product.');
+                            $this->errors[] = $this->trans('You need at least one product.', array(), 'Admin.OrdersCustomers.Notification');
                         }
                     } else {
-                        $this->errors[] = Tools::displayError('The order return is invalid.');
+                        $this->errors[] = $this->trans('The order return is invalid.', array(), 'Admin.OrdersCustomers.Notification');
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('The order return content is invalid.');
+                    $this->errors[] = $this->trans('The order return content is invalid.', array(), 'Admin.OrdersCustomers.Notification');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
             }
         } elseif (Tools::isSubmit('submitAddorder_return') || Tools::isSubmit('submitAddorder_returnAndStay')) {
             if ($this->access('edit')) {
@@ -253,10 +253,10 @@ class AdminReturnControllerCore extends AdminController
                         }
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('No order return ID has been specified.');
+                    $this->errors[] = $this->trans('No order return ID has been specified.', array(), 'Admin.OrdersCustomers.Notification');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
         parent::postProcess();

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -36,7 +36,7 @@ class AdminSearchControllerCore extends AdminController
     {
         return 'ROLE_MOD_TAB_ADMINSEARCHCONF_';
     }
-    
+
     public function postProcess()
     {
         $this->context = Context::getContext();
@@ -112,7 +112,7 @@ class AdminSearchControllerCore extends AdminController
                             $this->_list['orders'][] = $row;
                         }
                     } elseif ($searchType == 3) {
-                        $this->errors[] = Tools::displayError('No order was found with this ID:').' '.Tools::htmlentitiesUTF8($this->query);
+                        $this->errors[] = $this->trans('No order was found with this ID:', array(), 'Admin.OrdersCustomers.Notification').' '.Tools::htmlentitiesUTF8($this->query);
                     }
                 }
             }
@@ -122,7 +122,7 @@ class AdminSearchControllerCore extends AdminController
                 if (Validate::isOrderInvoiceNumber($this->query) && ($invoice = OrderInvoice::getInvoiceByNumber($this->query))) {
                     Tools::redirectAdmin($this->context->link->getAdminLink('AdminPdf').'&submitAction=generateInvoicePDF&id_order='.(int)($invoice->id_order));
                 }
-                $this->errors[] = Tools::displayError('No invoice was found with this ID:').' '.Tools::htmlentitiesUTF8($this->query);
+                $this->errors[] = $this->trans('No invoice was found with this ID:', array(), 'Admin.OrdersCustomers.Notification').' '.Tools::htmlentitiesUTF8($this->query);
             }
 
             /* Cart */
@@ -130,7 +130,7 @@ class AdminSearchControllerCore extends AdminController
                 if ((int)$this->query && Validate::isUnsignedInt((int)$this->query) && ($cart = new Cart($this->query)) && Validate::isLoadedObject($cart)) {
                     Tools::redirectAdmin('index.php?tab=AdminCarts&id_cart='.(int)($cart->id).'&viewcart'.'&token='.Tools::getAdminToken('AdminCarts'.(int)(Tab::getIdFromClassName('AdminCarts')).(int)$this->context->employee->id));
                 }
-                $this->errors[] = Tools::displayError('No cart was found with this ID:').' '.Tools::htmlentitiesUTF8($this->query);
+                $this->errors[] = $this->trans('No cart was found with this ID:', array(), 'Admin.OrdersCustomers.Notification').' '.Tools::htmlentitiesUTF8($this->query);
             }
             /* IP */
             // 6 - but it is included in the customer block
@@ -153,7 +153,7 @@ class AdminSearchControllerCore extends AdminController
     public function searchIP()
     {
         if (!ip2long(trim($this->query))) {
-            $this->errors[] = Tools::displayError('This is not a valid IP address:').' '.Tools::htmlentitiesUTF8($this->query);
+            $this->errors[] = $this->trans('This is not a valid IP address:', array(), 'Admin.Parameters.Notification').' '.Tools::htmlentitiesUTF8($this->query);
             return;
         }
         $this->_list['customers'] = Customer::searchByIp($this->query);

--- a/controllers/admin/AdminShippingController.php
+++ b/controllers/admin/AdminShippingController.php
@@ -165,15 +165,15 @@ class AdminShippingControllerCore extends AdminController
                         $carrier->addDeliveryPrice($priceList);
                         Tools::redirectAdmin(self::$currentIndex.'&conf=6&id_carrier='.$carrier->id.'&token='.$this->token);
                     } else {
-                        $this->errors[] = Tools::displayError('An error occurred while attempting to update fees (cannot load carrier object).');
+                        $this->errors[] = $this->trans('An error occurred while attempting to update fees (cannot load carrier object).', array(), 'Admin.Shipping.Notification');
                     }
                 } elseif (isset($id_carrier2)) {
                     $_POST['id_carrier'] = $id_carrier2;
                 } else {
-                    $this->errors[] = Tools::displayError('An error occurred while attempting to update fees (cannot load carrier object).');
+                    $this->errors[] = $this->trans('An error occurred while attempting to update fees (cannot load carrier object).', array(), 'Admin.Shipping.Notification');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         } else {
             return parent::postProcess();

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -260,7 +260,7 @@ class AdminShopControllerCore extends AdminController
         if (Tools::isSubmit('submitAddshopAndStay') || Tools::isSubmit('submitAddshop')) {
             $shop_group = new ShopGroup((int)Tools::getValue('id_shop_group'));
             if ($shop_group->shopNameExists(Tools::getValue('name'), (int)Tools::getValue('id_shop'))) {
-                $this->errors[] = Tools::displayError('You cannot have two shops with the same name in the same group.');
+                $this->errors[] = $this->trans('You cannot have two shops with the same name in the same group.', array(), 'Admin.Parameters.Notification');
             }
         }
 
@@ -285,7 +285,7 @@ class AdminShopControllerCore extends AdminController
     public function processDelete()
     {
         if (!Validate::isLoadedObject($object = $this->loadObject())) {
-            $this->errors[] = Tools::displayError('Unable to load this shop.');
+            $this->errors[] = $this->trans('Unable to load this shop.', array(), 'Admin.Parameters.Notification');
         } elseif (!Shop::hasDependency($object->id)) {
             $result = Category::deleteCategoriesFromShop($object->id) && parent::processDelete();
             Tools::generateHtaccess();
@@ -662,7 +662,7 @@ class AdminShopControllerCore extends AdminController
             $this->copyFromPost($object, $this->table);
             $this->beforeAdd($object);
             if (!$object->add()) {
-                $this->errors[] = Tools::displayError('An error occurred while creating an object.').
+                $this->errors[] = $this->trans('An error occurred while creating an object.', array(), 'Admin.Notifications.Error').
                     ' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
             }
             /* voluntary do affectation here */

--- a/controllers/admin/AdminShopGroupController.php
+++ b/controllers/admin/AdminShopGroupController.php
@@ -319,9 +319,9 @@ class AdminShopGroupControllerCore extends AdminController
             $object = $this->loadObject();
 
             if (ShopGroup::getTotalShopGroup() == 1) {
-                $this->errors[] = Tools::displayError('You cannot delete or disable the last shop group.');
+                $this->errors[] = $this->trans('You cannot delete or disable the last shop group.', array(), 'Admin.Notifications.Error');
             } elseif ($object->haveShops()) {
-                $this->errors[] = Tools::displayError('You cannot delete or disable a shop group in use.');
+                $this->errors[] = $this->trans('You cannot delete or disable a shop group in use.', array(), 'Admin.Notifications.Error');
             }
 
             if (count($this->errors)) {

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -405,17 +405,17 @@ class AdminShopUrlControllerCore extends AdminController
                 if (Validate::isLoadedObject($object = $this->loadObject())) {
                     /** @var ShopUrl $object */
                     if ($object->main) {
-                        $this->errors[] = Tools::displayError('You cannot disable the Main URL.');
+                        $this->errors[] = $this->trans('You cannot disable the Main URL.', array(), 'Admin.Notifications.Error');
                     } elseif ($object->toggleStatus()) {
                         Tools::redirectAdmin(self::$currentIndex.'&conf=5&token='.$token);
                     } else {
-                        $this->errors[] = Tools::displayError('An error occurred while updating the status.');
+                        $this->errors[] = $this->trans('An error occurred while updating the status.', array(), 'Admin.Notifications.Error');
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.').' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                    $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         } elseif (Tools::isSubmit('main'.$this->table) && Tools::getValue($this->identifier)) {
             if ($this->access('edit')) {
@@ -425,13 +425,13 @@ class AdminShopUrlControllerCore extends AdminController
                         $result = $object->setMain();
                         Tools::redirectAdmin(self::$currentIndex.'&conf=4&token='.$token);
                     } else {
-                        $this->errors[] = Tools::displayError('You cannot change a main URL to a non-main URL. You have to set another URL as your Main URL for the selected shop.');
+                        $this->errors[] = $this->trans('You cannot change a main URL to a non-main URL. You have to set another URL as your Main URL for the selected shop.', array(), 'Admin.Notifications.Error');
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.').' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                    $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         } else {
             $result = parent::postProcess();
@@ -449,12 +449,18 @@ class AdminShopUrlControllerCore extends AdminController
         /** @var ShopUrl $object */
         $object = $this->loadObject(true);
         if ($object->canAddThisUrl(Tools::getValue('domain'), Tools::getValue('domain_ssl'), Tools::getValue('physical_uri'), Tools::getValue('virtual_uri'))) {
-            $this->errors[] = Tools::displayError('A shop URL that uses this domain already exists.');
+            $this->errors[] = $this->trans('A shop URL that uses this domain already exists.', array(), 'Admin.Notifications.Error');
         }
 
         $unallowed = str_replace('/', '', Tools::getValue('virtual_uri'));
         if ($unallowed == 'c' || $unallowed == 'img' || is_numeric($unallowed)) {
-            $this->errors[] = sprintf(Tools::displayError('A shop virtual URL can not be "%s"'), $unallowed);
+            $this->errors[] = $this->trans(
+                'A shop virtual URL can not be "%URL%"',
+                array(
+                    '%URL%' => $unallowed,
+                ),
+                'Admin.Notifications.Error'
+            );
         }
         $return = parent::processSave();
         if (!$this->errors) {
@@ -472,11 +478,11 @@ class AdminShopUrlControllerCore extends AdminController
         $object = $this->loadObject(true);
 
         if ($object->canAddThisUrl(Tools::getValue('domain'), Tools::getValue('domain_ssl'), Tools::getValue('physical_uri'), Tools::getValue('virtual_uri'))) {
-            $this->errors[] = Tools::displayError('A shop URL that uses this domain already exists.');
+            $this->errors[] = $this->trans('A shop URL that uses this domain already exists.', array(), 'Admin.Notifications.Error');
         }
 
         if (Tools::getValue('main') && !Tools::getValue('active')) {
-            $this->errors[] = Tools::displayError('You cannot disable the Main URL.');
+            $this->errors[] = $this->trans('You cannot disable the Main URL.', array(), 'Admin.Notifications.Error');
         }
 
         return parent::processAdd();
@@ -494,11 +500,11 @@ class AdminShopUrlControllerCore extends AdminController
         $object = $this->loadObject(true);
 
         if ($object->main && !Tools::getValue('main')) {
-            $this->errors[] = Tools::displayError('You cannot change a main URL to a non-main URL. You have to set another URL as your Main URL for the selected shop.');
+            $this->errors[] = $this->trans('You cannot change a main URL to a non-main URL. You have to set another URL as your Main URL for the selected shop.', array(), 'Admin.Notifications.Error');
         }
 
         if (($object->main || Tools::getValue('main')) && !Tools::getValue('active')) {
-            $this->errors[] = Tools::displayError('You cannot disable the Main URL.');
+            $this->errors[] = $this->trans('You cannot disable the Main URL.', array(), 'Admin.Notifications.Error');
         }
 
         return parent::processUpdate();

--- a/controllers/admin/AdminStatesController.php
+++ b/controllers/admin/AdminStatesController.php
@@ -221,12 +221,12 @@ class AdminStatesControllerCore extends AdminController
         // Idiot-proof controls
         if (!Tools::getValue('id_'.$this->table)) {
             if (Validate::isStateIsoCode(Tools::getValue('iso_code')) && State::getIdByIso(Tools::getValue('iso_code'), Tools::getValue('id_country'))) {
-                $this->errors[] = Tools::displayError('This ISO code already exists. You cannot create two states with the same ISO code.');
+                $this->errors[] = $this->trans('This ISO code already exists. You cannot create two states with the same ISO code.', array(), 'Admin.International.Notification');
             }
         } elseif (Validate::isStateIsoCode(Tools::getValue('iso_code'))) {
             $id_state = State::getIdByIso(Tools::getValue('iso_code'), Tools::getValue('id_country'));
             if ($id_state && $id_state != Tools::getValue('id_'.$this->table)) {
-                $this->errors[] = Tools::displayError('This ISO code already exists. You cannot create two states with the same ISO code.');
+                $this->errors[] = $this->trans('This ISO code already exists. You cannot create two states with the same ISO code.', array(), 'Admin.International.Notification');
             }
         }
 
@@ -239,15 +239,15 @@ class AdminStatesControllerCore extends AdminController
                         if ($object->delete()) {
                             Tools::redirectAdmin(self::$currentIndex.'&conf=1&token='.(Tools::getValue('token') ? Tools::getValue('token') : $this->token));
                         }
-                        $this->errors[] = Tools::displayError('An error occurred during deletion.');
+                        $this->errors[] = $this->trans('An error occurred during deletion.', array(), 'Admin.Notifications.Error');
                     } else {
-                        $this->errors[] = Tools::displayError('This state was used in at least one address. It cannot be removed.');
+                        $this->errors[] = $this->trans('This state was used in at least one address. It cannot be removed.', array(), 'Admin.International.Notification');
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('An error occurred while deleting the object.').' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                    $this->errors[] = $this->trans('An error occurred while deleting the object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
                 }
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
             }
         }
 

--- a/controllers/admin/AdminStatsTabController.php
+++ b/controllers/admin/AdminStatsTabController.php
@@ -51,7 +51,7 @@ abstract class AdminStatsTabControllerCore extends AdminPreferencesControllerCor
             }
             $this->content .= $this->renderView();
         }
-        
+
         $this->content .= $this->displayMenu();
         $this->content .= $this->displayCalendar();
         $this->content .= $this->displayStats();
@@ -97,7 +97,7 @@ abstract class AdminStatsTabControllerCore extends AdminPreferencesControllerCor
             $identifier = 'module';
             $id = Tools::getValue('module');
         }
-        
+
         $action = Context::getContext()->link->getAdminLink('AdminStats');
         $action .= ($action && $table ? '&'.Tools::safeOutput($action) : '');
         $action .= ($identifier && $id ? '&'.Tools::safeOutput($identifier).'='.(int)$id : '');
@@ -172,7 +172,7 @@ abstract class AdminStatsTabControllerCore extends AdminPreferencesControllerCor
 
         return $tpl->fetch();
     }
-    
+
     public function checkModulesNames($a, $b)
     {
         return (bool)($a['displayName'] > $b['displayName']);
@@ -205,7 +205,7 @@ abstract class AdminStatsTabControllerCore extends AdminPreferencesControllerCor
             if (!isset($module_instance)) {
                 $module_instance = Module::getInstanceByName($module_name);
             }
-                
+
             if ($module_instance && $module_instance->active) {
                 $hook = Hook::exec('displayAdminStatsModules', null, $module_instance->id);
             }
@@ -223,9 +223,9 @@ abstract class AdminStatsTabControllerCore extends AdminPreferencesControllerCor
     public function postProcess()
     {
         $this->context = Context::getContext();
-        
+
         $this->processDateRange();
-        
+
         if (Tools::getValue('submitSettings')) {
             if ($this->access('edit')) {
                 self::$currentIndex .= '&module='.Tools::getValue('module');
@@ -233,16 +233,16 @@ abstract class AdminStatsTabControllerCore extends AdminPreferencesControllerCor
                 Configuration::updateValue('PS_STATS_GRID_RENDER', Tools::getValue('PS_STATS_GRID_RENDER', Configuration::get('PS_STATS_GRID_RENDER')));
                 Configuration::updateValue('PS_STATS_OLD_CONNECT_AUTO_CLEAN', Tools::getValue('PS_STATS_OLD_CONNECT_AUTO_CLEAN', Configuration::get('PS_STATS_OLD_CONNECT_AUTO_CLEAN')));
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             }
         }
     }
-    
+
     public function processDateRange()
     {
         if (Tools::isSubmit('submitDatePicker')) {
             if ((!Validate::isDate($from = Tools::getValue('datepickerFrom')) || !Validate::isDate($to = Tools::getValue('datepickerTo'))) || (strtotime($from) > strtotime($to))) {
-                $this->errors[] = Tools::displayError('The specified date is invalid.');
+                $this->errors[] = $this->trans('The specified date is invalid.', array(), 'Admin.Stats.Notification');
             }
         }
         if (Tools::isSubmit('submitDateDay')) {
@@ -281,11 +281,11 @@ abstract class AdminStatsTabControllerCore extends AdminPreferencesControllerCor
             }
         }
     }
-    
+
     public function ajaxProcessSetDashboardDateRange()
     {
         $this->processDateRange();
-        
+
         if ($this->isXmlHttpRequest()) {
             if (is_array($this->errors) && count($this->errors)) {
                 die(json_encode(array(

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -373,24 +373,24 @@ class AdminStoresControllerCore extends AdminController
 
             /* If the selected country contains states, then a state have to be selected */
             if ((int)$country->contains_states && !$id_state) {
-                $this->errors[] = Tools::displayError('An address located in a country containing states must have a state selected.');
+                $this->errors[] = $this->trans('An address located in a country containing states must have a state selected.', array(), 'Admin.Parameters.Notification');
             }
 
             $latitude = (float)Tools::getValue('latitude');
             $longitude = (float)Tools::getValue('longitude');
 
             if (empty($latitude) || empty($longitude)) {
-                $this->errors[] = Tools::displayError('Latitude and longitude are required.');
+                $this->errors[] = $this->trans('Latitude and longitude are required.', array(), 'Admin.Parameters.Notification');
             }
 
             $postcode = Tools::getValue('postcode');
             /* Check zip code format */
             if ($country->zip_code_format && !$country->checkZipCode($postcode)) {
-                $this->errors[] = Tools::displayError('Your Zip/postal code is incorrect.').'<br />'.Tools::displayError('It must be entered as follows:').' '.str_replace('C', $country->iso_code, str_replace('N', '0', str_replace('L', 'A', $country->zip_code_format)));
+                $this->errors[] = $this->trans('Your Zip/postal code is incorrect.', array(), 'Admin.Notifications.Error').'<br />'.$this->trans('It must be entered as follows:', array(), 'Admin.Notifications.Error').' '.str_replace('C', $country->iso_code, str_replace('N', '0', str_replace('L', 'A', $country->zip_code_format)));
             } elseif (empty($postcode) && $country->need_zip_code) {
-                $this->errors[] = Tools::displayError('A Zip/postal code is required.');
+                $this->errors[] = $this->trans('A Zip/postal code is required.', array(), 'Admin.Notifications.Error');
             } elseif ($postcode && !Validate::isPostCode($postcode)) {
-                $this->errors[] = Tools::displayError('The Zip/postal code is invalid.');
+                $this->errors[] = $this->trans('The Zip/postal code is invalid.', array(), 'Admin.Notifications.Error');
             }
             /* Store hours */
             $_POST['hours'] = array();
@@ -563,7 +563,7 @@ class AdminStoresControllerCore extends AdminController
 						AND `id_state` = '.(int)Tools::getValue('PS_SHOP_STATE_ID');
             $isStateOk = Db::getInstance()->getValue($sql);
             if ($isStateOk != 1) {
-                $this->errors[] = Tools::displayError('The specified state is not located in this country.');
+                $this->errors[] = $this->trans('The specified state is not located in this country.', array(), 'Admin.Parameters.Notification');
             }
         }
     }

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -443,7 +443,7 @@ class AdminSuppliersControllerCore extends AdminController
     {
         // checks access
         if (Tools::isSubmit('submitAdd'.$this->table) && !($this->access('add'))) {
-            $this->errors[] = Tools::displayError('You do not have permission to add suppliers.');
+            $this->errors[] = $this->trans('You do not have permission to add suppliers.', array(), 'Admin.Catalog.Notification');
             return parent::postProcess();
         }
 
@@ -479,7 +479,7 @@ class AdminSuppliersControllerCore extends AdminController
                 foreach ($validation as $item) {
                     $this->errors[] = $item;
                 }
-                $this->errors[] = Tools::displayError('The address is not correct. Please make sure all of the required fields are completed.');
+                $this->errors[] = $this->trans('The address is not correct. Please make sure all of the required fields are completed.', array(), 'Admin.Catalog.Notification');
             } else {
                 if (Tools::isSubmit('id_address') && Tools::getValue('id_address') > 0) {
                     $address->update();

--- a/controllers/admin/AdminTabsController.php
+++ b/controllers/admin/AdminTabsController.php
@@ -267,7 +267,7 @@ class AdminTabsControllerCore extends AdminController
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
         /* PrestaShop demo mode*/
@@ -278,13 +278,13 @@ class AdminTabsControllerCore extends AdminController
             }
         } elseif (Tools::getValue('position') && !Tools::isSubmit('submitAdd'.$this->table)) {
             if ($this->access('edit') !== '1') {
-                $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
             } elseif (!Validate::isLoadedObject($object = new Tab((int)Tools::getValue($this->identifier)))) {
-                $this->errors[] = Tools::displayError('An error occurred while updating the status for an object.').
-                    ' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error').
+                    ' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
             }
             if (!$object->updatePosition((int)Tools::getValue('way'), (int)Tools::getValue('position'))) {
-                $this->errors[] = Tools::displayError('Failed to update the position.');
+                $this->errors[] = $this->trans('Failed to update the position.', array(), 'Admin.Notifications.Error');
             } else {
                 Tools::redirectAdmin(self::$currentIndex.'&conf=5&token='.Tools::getAdminTokenLite('AdminTabs'));
             }
@@ -309,7 +309,7 @@ class AdminTabsControllerCore extends AdminController
                         $this->action = 'bulk'.$bulk_action;
                         $this->boxes = Tools::getValue($this->list_id.'Box');
                     } else {
-                        $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                        $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
                     }
                     break;
                 } elseif (Tools::isSubmit('submitBulk')) {
@@ -317,7 +317,7 @@ class AdminTabsControllerCore extends AdminController
                         $this->action = 'bulk'.Tools::getValue('select_submitBulk');
                         $this->boxes = Tools::getValue($this->list_id.'Box');
                     } else {
-                        $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                        $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
                     }
                     break;
                 }

--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -380,19 +380,19 @@ class AdminTaxRulesGroupControllerCore extends AdminController
             if ($this->access('delete')) {
                 $this->action = 'delete_tax_rule';
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
             }
         } elseif (Tools::isSubmit('submitBulkdeletetax_rule')) {
             if ($this->access('delete')) {
                 $this->action = 'bulk_delete_tax_rules';
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to delete this.');
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
             }
         } elseif (Tools::getValue('action') == 'create_rule') {
             if ($this->access('add')) {
                 $this->action = 'create_rule';
             } else {
-                $this->errors[] = Tools::displayError('You do not have permission to add this.');
+                $this->errors[] = $this->trans('You do not have permission to add this.', array(), 'Admin.Notifications.Error');
             }
         } else {
             parent::initProcess();
@@ -427,7 +427,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
             $first = true;
             foreach ($this->selected_states as $id_state) {
                 if ($tax_rules_group->hasUniqueTaxRuleForCountry($id_country, $id_state, $id_rule)) {
-                    $this->errors[] = Tools::displayError('A tax rule already exists for this country/state with tax only behavior.');
+                    $this->errors[] = $this->trans('A tax rule already exists for this country/state with tax only behavior.', array(), 'Admin.International.Notification');
                     continue;
                 }
                 $tr = new TaxRule();
@@ -454,7 +454,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
                             if ($zip_code) {
                                 if (!$country->checkZipCode($zip_code)) {
                                     $this->errors[] = sprintf(
-                                        Tools::displayError('The Zip/postal code is invalid. It must be typed as follows: %s for %s.'),
+                                        $this->trans('The Zip/postal code is invalid. It must be typed as follows: %s for %s.', array(), 'Admin.International.Notification'),
                                         str_replace('C', $country->iso_code, str_replace('N', '0', str_replace('L', 'A', $country->zip_code_format))), $country->name
                                     );
                                 }
@@ -476,7 +476,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
                     $tr->id_tax_rules_group = (int)$tax_rules_group->id;
 
                     if (!$tr->save()) {
-                        $this->errors[] = Tools::displayError('An error has occurred: Cannot save the current tax rule.');
+                        $this->errors[] = $this->trans('An error has occurred: Cannot save the current tax rule.', array(), 'Admin.International.Notification');
                     }
                 }
             }

--- a/controllers/admin/AdminTaxesController.php
+++ b/controllers/admin/AdminTaxesController.php
@@ -255,12 +255,12 @@ class AdminTaxesControllerCore extends AdminController
                         $result = $object->update(false, false);
 
                         if (!$result) {
-                            $this->errors[] = Tools::displayError('An error occurred while updating an object.').' <b>'.$this->table.'</b>';
+                            $this->errors[] = $this->trans('An error occurred while updating an object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b>';
                         } elseif ($this->postImage($object->id)) {
                             Tools::redirectAdmin(self::$currentIndex.'&id_'.$this->table.'='.$object->id.'&conf=4'.'&token='.$this->token);
                         }
                     } else {
-                        $this->errors[] = Tools::displayError('An error occurred while updating an object.').' <b>'.$this->table.'</b> '.Tools::displayError('(cannot load object)');
+                        $this->errors[] = $this->trans('An error occurred while updating an object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b> '.$this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
                     }
                 }
 
@@ -270,7 +270,7 @@ class AdminTaxesControllerCore extends AdminController
                     $object = new $this->className();
                     $this->copyFromPost($object, $this->table);
                     if (!$object->add()) {
-                        $this->errors[] = Tools::displayError('An error occurred while creating an object.').' <b>'.$this->table.'</b>';
+                        $this->errors[] = $this->trans('An error occurred while creating an object.', array(), 'Admin.Notifications.Error').' <b>'.$this->table.'</b>';
                     } elseif (($_POST['id_'.$this->table] = $object->id /* voluntary */) && $this->postImage($object->id) && $this->_redirect) {
                         Tools::redirectAdmin(self::$currentIndex.'&id_'.$this->table.'='.$object->id.'&conf=3'.'&token='.$this->token);
                     }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -109,7 +109,7 @@ class AdminTranslationsControllerCore extends AdminController
             if (method_exists($this, $method_name)) {
                 $this->content = $this->initForm($method_name);
             } else {
-                $this->errors[] = sprintf(Tools::displayError('"%s" does not exist.'), $this->type_selected);
+                $this->errors[] = sprintf($this->trans('"%s" does not exist.', array(), 'Admin.Notifications.Error'), $this->type_selected);
                 $this->content = $this->initMain();
             }
         } else {
@@ -297,9 +297,9 @@ class AdminTranslationsControllerCore extends AdminController
 
         if ($file_path && !file_exists($file_path)) {
             if (!file_exists(dirname($file_path)) && !mkdir(dirname($file_path), 0777, true)) {
-                throw new PrestaShopException(sprintf(Tools::displayError('Directory "%s" cannot be created'), dirname($file_path)));
+                throw new PrestaShopException(sprintf($this->trans('Directory "%s" cannot be created', array(), 'Admin.Notifications.Error'), dirname($file_path)));
             } elseif (!touch($file_path)) {
-                throw new PrestaShopException(sprintf(Tools::displayError('File "%s" cannot be created'), $file_path));
+                throw new PrestaShopException(sprintf($this->trans('File "%s" cannot be created', array(), 'Admin.Notifications.Error'), $file_path));
             }
         }
 
@@ -352,7 +352,7 @@ class AdminTranslationsControllerCore extends AdminController
                 $this->redirect();
             }
         } else {
-            throw new PrestaShopException(sprintf(Tools::displayError('Cannot write this file: "%s"'), $file_path));
+            throw new PrestaShopException(sprintf($this->trans('Cannot write this file: "%s"', array(), 'Admin.Notifications.Error'), $file_path));
         }
     }
 
@@ -479,7 +479,7 @@ class AdminTranslationsControllerCore extends AdminController
             throw new PrestaShopException('File "'.$path.'" does not exist and cannot be created in '.$dir);
         }
         if (!is_writable($path)) {
-            $this->displayWarning(sprintf(Tools::displayError('This file must be writable: %s'), $path));
+            $this->displayWarning(sprintf($this->trans('This file must be writable: %s', array(), 'Admin.Notifications.Error'), $path));
         }
     }
 
@@ -506,9 +506,9 @@ class AdminTranslationsControllerCore extends AdminController
                 @unlink($file_name);
                 exit;
             }
-            $this->errors[] = Tools::displayError('An error occurred while creating archive.');
+            $this->errors[] = $this->trans('An error occurred while creating archive.', array(), 'Admin.International.Notification');
         }
-        $this->errors[] = Tools::displayError('Please select a language and a theme.');
+        $this->errors[] = $this->trans('Please select a language and a theme.', array(), 'Admin.International.Notification');
     }
 
     public static function checkAndAddMailsFiles($iso_code, $files_list)
@@ -668,7 +668,7 @@ class AdminTranslationsControllerCore extends AdminController
                             }
 
                             if (!Validate::isGenericName($tab->name[(int)$id_lang])) {
-                                $errors[] = sprintf(Tools::displayError('Tab "%s" is not valid'), $tab->name[(int)$id_lang]);
+                                $errors[] = sprintf($this->trans('Tab "%s" is not valid', array(), 'Admin.International.Notification'), $tab->name[(int)$id_lang]);
                             } else {
                                 $tab->update();
                             }
@@ -724,7 +724,7 @@ class AdminTranslationsControllerCore extends AdminController
     public function submitImportLang()
     {
         if (!isset($_FILES['file']['tmp_name']) || !$_FILES['file']['tmp_name']) {
-            $this->errors[] = Tools::displayError('No file has been selected.');
+            $this->errors[] = $this->trans('No file has been selected.', array(), 'Admin.Notifications.Error');
         } else {
             require_once(_PS_TOOL_DIR_.'tar/Archive_Tar.php');
             $gz = new Archive_Tar($_FILES['file']['tmp_name'], true);
@@ -747,10 +747,10 @@ class AdminTranslationsControllerCore extends AdminController
 
                         if (preg_match('@^[0-9a-z-_/\\\\]+\.php$@i', $file2check['filename'])) {
                             if (!@filemtime($sandbox.$file2check['filename']) || !AdminTranslationsController::checkTranslationFile(file_get_contents($sandbox.$file2check['filename']))) {
-                                $this->errors[] = sprintf(Tools::displayError('Validation failed for: %s'), $file2check['filename']);
+                                $this->errors[] = sprintf($this->trans('Validation failed for: %s', array(), 'Admin.International.Notification'), $file2check['filename']);
                             }
                         } elseif (!preg_match('@mails[0-9a-z-_/\\\\]+\.(html|tpl|txt)$@i', $file2check['filename'])) {
-                            $this->errors[] = sprintf(Tools::displayError('Unidentified file found: %s'), $file2check['filename']);
+                            $this->errors[] = sprintf($this->trans('Unidentified file found: %s', array(), 'Admin.International.Notification'), $file2check['filename']);
                         }
                     }
                     Tools::deleteDirectory($sandbox, true);
@@ -761,7 +761,7 @@ class AdminTranslationsControllerCore extends AdminController
                 foreach ($files_paths as $files_path) {
                     $path = dirname($files_path);
                     if (is_dir(_PS_TRANSLATIONS_DIR_.'../'.$path) && !is_writable(_PS_TRANSLATIONS_DIR_.'../'.$path) && !in_array($path, $tmp_array)) {
-                        $this->errors[] = (!$i++? Tools::displayError('The archive cannot be extracted.').' ' : '').Tools::displayError('The server does not have permissions for writing.').' '.sprintf(Tools::displayError('Please check rights for %s'), $path);
+                        $this->errors[] = (!$i++? $this->trans('The archive cannot be extracted.', array(), 'Admin.International.Notification').' ' : '').$this->trans('The server does not have permissions for writing.', array(), 'Admin.Notifications.Error').' '.sprintf($this->trans('Please check rights for %s', array(), 'Admin.Notifications.Error'), $path);
                         $tmp_array[] = $path;
                     }
                 }
@@ -772,7 +772,7 @@ class AdminTranslationsControllerCore extends AdminController
 
                 if ($error = $gz->extractList($files_paths, _PS_TRANSLATIONS_DIR_.'../')) {
                     if (is_object($error) && !empty($error->message)) {
-                        $this->errors[] = Tools::displayError('The archive cannot be extracted.'). ' '.$error->message;
+                        $this->errors[] = $this->trans('The archive cannot be extracted.', array(), 'Admin.International.Notification'). ' '.$error->message;
                     } else {
                         foreach ($files_list as $file2check) {
                             if (pathinfo($file2check['filename'], PATHINFO_BASENAME) == 'index.php' && file_put_contents(_PS_TRANSLATIONS_DIR_.'../'.$file2check['filename'], Tools::getDefaultIndexContent())) {
@@ -810,9 +810,9 @@ class AdminTranslationsControllerCore extends AdminController
                         $this->redirect(false, (isset($conf) ? $conf : '15'));
                     }
                 }
-                $this->errors[] = Tools::displayError('The archive cannot be extracted.');
+                $this->errors[] = $this->trans('The archive cannot be extracted.', array(), 'Admin.International.Notification');
             } else {
-                $this->errors[] = sprintf(Tools::displayError('ISO CODE invalid "%1$s" for the following file: "%2$s"'), $iso_code, $filename);
+                $this->errors[] = sprintf($this->trans('ISO CODE invalid "%1$s" for the following file: "%2$s"', array(), 'Admin.International.Notification'), $iso_code, $filename);
             }
         }
     }
@@ -884,7 +884,7 @@ class AdminTranslationsControllerCore extends AdminController
 
                     if ($error = $gz->extractList(AdminTranslationsController::filesListToPaths($files_list), _PS_TRANSLATIONS_DIR_.'../')) {
                         if (is_object($error) && !empty($error->message)) {
-                            $this->errors[] = Tools::displayError('The archive cannot be extracted.'). ' '.$error->message;
+                            $this->errors[] = $this->trans('The archive cannot be extracted.', array(), 'Admin.International.Notification'). ' '.$error->message;
                         } else {
                             if (!Language::checkAndAddLanguage($arr_import_lang[0])) {
                                 $conf = 20;
@@ -900,7 +900,7 @@ class AdminTranslationsControllerCore extends AdminController
                                 }
                             }
                             if (!unlink($file)) {
-                                $this->errors[] = sprintf(Tools::displayError('Cannot delete the archive %s.'), $file);
+                                $this->errors[] = sprintf($this->trans('Cannot delete the archive %s.', array(), 'Admin.International.Notification'), $file);
                             }
 
                             //fetch cldr datas for the new imported locale
@@ -911,7 +911,7 @@ class AdminTranslationsControllerCore extends AdminController
                             $this->redirect(false, (isset($conf) ? $conf : '15'));
                         }
                     } else {
-                        $this->errors[] = sprintf(Tools::displayError('Cannot decompress the translation file for the following language: %s'), $arr_import_lang[0]);
+                        $this->errors[] = sprintf($this->trans('Cannot decompress the translation file for the following language: %s', array(), 'Admin.International.Notification'), $arr_import_lang[0]);
                         $checks= array();
                         foreach ($files_list as $f) {
                             if (isset($f['filename'])) {
@@ -925,20 +925,20 @@ class AdminTranslationsControllerCore extends AdminController
 
                         $checks = array_unique($checks);
                         foreach ($checks as $check) {
-                            $this->errors[] = sprintf(Tools::displayError('Please check rights for folder and files in %s'), $check);
+                            $this->errors[] = sprintf($this->trans('Please check rights for folder and files in %s', array(), 'Admin.Notifications.Error'), $check);
                         }
                         if (!unlink($file)) {
-                            $this->errors[] = sprintf(Tools::displayError('Cannot delete the archive %s.'), $file);
+                            $this->errors[] = sprintf($this->trans('Cannot delete the archive %s.', array(), 'Admin.International.Notification'), $file);
                         }
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('The server does not have permissions for writing.').' '.sprintf(Tools::displayError('Please check rights for %s'), dirname($file));
+                    $this->errors[] = $this->trans('The server does not have permissions for writing.', array(), 'Admin.Notifications.Error').' '.sprintf($this->trans('Please check rights for %s', array(), 'Admin.Notifications.Error'), dirname($file));
                 }
             } else {
-                $this->errors[] = Tools::displayError('Language not found.');
+                $this->errors[] = $this->trans('Language not found.', array(), 'Admin.International.Notification');
             }
         } else {
-            $this->errors[] = Tools::displayError('Invalid parameter.');
+            $this->errors[] = $this->trans('Invalid parameter.', array(), 'Admin.Notifications.Error');
         }
     }
 
@@ -1398,7 +1398,7 @@ class AdminTranslationsControllerCore extends AdminController
         if (($theme = Tools::getValue('theme')) && !is_array($theme)) {
             $theme_exists = $this->theme_exists($theme);
             if (!$theme_exists) {
-                throw new PrestaShopException(sprintf(Tools::displayError('Invalid theme "%s"'), Tools::safeOutput($theme)));
+                throw new PrestaShopException(sprintf($this->trans('Invalid theme "%s"', array(), 'Admin.International.Notification'), Tools::safeOutput($theme)));
             }
             $this->theme_selected = Tools::safeOutput($theme);
         }
@@ -1420,7 +1420,7 @@ class AdminTranslationsControllerCore extends AdminController
             $iso_code = Tools::getValue('lang') ? Tools::getValue('lang') : Tools::getValue('iso_code');
 
             if (!Validate::isLangIsoCode($iso_code) || !in_array($iso_code, $this->all_iso_lang)) {
-                throw new PrestaShopException(sprintf(Tools::displayError('Invalid iso code "%s"'), Tools::safeOutput($iso_code)));
+                throw new PrestaShopException(sprintf($this->trans('Invalid iso code "%s"', array(), 'Admin.International.Notification'), Tools::safeOutput($iso_code)));
             }
 
             $this->lang_selected = new Language((int)Language::getIdByIso($iso_code));
@@ -1492,7 +1492,7 @@ class AdminTranslationsControllerCore extends AdminController
 
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
-            $this->errors[] = Tools::displayError('This functionality has been disabled.');
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
             return;
         }
         /* PrestaShop demo mode */
@@ -1502,25 +1502,25 @@ class AdminTranslationsControllerCore extends AdminController
                 if ($this->access('add')) {
                     $this->submitCopyLang();
                 } else {
-                    $this->errors[] = Tools::displayError('You do not have permission to add this.');
+                    $this->errors[] = $this->trans('You do not have permission to add this.', array(), 'Admin.Notifications.Error');
                 }
             } elseif (Tools::isSubmit('submitExport')) {
                 if ($this->access('add')) {
                     $this->submitExportLang();
                 } else {
-                    $this->errors[] = Tools::displayError('You do not have permission to add this.');
+                    $this->errors[] = $this->trans('You do not have permission to add this.', array(), 'Admin.Notifications.Error');
                 }
             } elseif (Tools::isSubmit('submitImport')) {
                 if ($this->access('add')) {
                     $this->submitImportLang();
                 } else {
-                    $this->errors[] = Tools::displayError('You do not have permission to add this.');
+                    $this->errors[] = $this->trans('You do not have permission to add this.', array(), 'Admin.Notifications.Error');
                 }
             } elseif (Tools::isSubmit('submitAddLanguage')) {
                 if ($this->access('add')) {
                     $this->submitAddLang();
                 } else {
-                    $this->errors[] = Tools::displayError('You do not have permission to add this.');
+                    $this->errors[] = $this->trans('You do not have permission to add this.', array(), 'Admin.Notifications.Error');
                 }
             } elseif (Tools::isSubmit('submitTranslationsPdf')) {
                 if ($this->access('edit')) {
@@ -1531,19 +1531,19 @@ class AdminTranslationsControllerCore extends AdminController
                         $this->writeTranslationFile(true);
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                    $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
                 }
             } elseif (Tools::isSubmit('submitTranslationsBack') || Tools::isSubmit('submitTranslationsErrors') || Tools::isSubmit('submitTranslationsFields') || Tools::isSubmit('submitTranslationsFront')) {
                 if ($this->access('edit')) {
                     $this->writeTranslationFile();
                 } else {
-                    $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                    $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
                 }
             } elseif (Tools::isSubmit('submitTranslationsMails') || Tools::isSubmit('submitTranslationsMailsAndStay')) {
                 if ($this->access('edit')) {
                     $this->submitTranslationsMails();
                 } else {
-                    $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                    $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
                 }
             } elseif (Tools::isSubmit('submitTranslationsModules')) {
                 if ($this->access('edit')) {
@@ -1568,7 +1568,7 @@ class AdminTranslationsControllerCore extends AdminController
                         }
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                    $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
                 }
             }
         } catch (PrestaShopException $e) {
@@ -1650,11 +1650,11 @@ class AdminTranslationsControllerCore extends AdminController
                     if ($module_name_pipe_pos) {
                         $module_name = substr($mail_name, 0, $module_name_pipe_pos);
                         if (!Validate::isModuleName($module_name)) {
-                            throw new PrestaShopException(sprintf(Tools::displayError('Invalid module name "%s"'), Tools::safeOutput($module_name)));
+                            throw new PrestaShopException(sprintf($this->trans('Invalid module name "%s"', array(), 'Admin.International.Notification'), Tools::safeOutput($module_name)));
                         }
                         $mail_name = substr($mail_name, $module_name_pipe_pos + 1);
                         if (!Validate::isTplName($mail_name)) {
-                            throw new PrestaShopException(sprintf(Tools::displayError('Invalid mail name "%s"'), Tools::safeOutput($mail_name)));
+                            throw new PrestaShopException(sprintf($this->trans('Invalid mail name "%s"', array(), 'Admin.International.Notification'), Tools::safeOutput($mail_name)));
                         }
                     }
 
@@ -1683,11 +1683,11 @@ class AdminTranslationsControllerCore extends AdminController
                             $path = str_replace('{module}', $module_name, $path);
                         }
                         if (!file_exists($path) && !mkdir($path, 0777, true)) {
-                            throw new PrestaShopException(sprintf(Tools::displayError('Directory "%s" cannot be created'), dirname($path)));
+                            throw new PrestaShopException(sprintf($this->trans('Directory "%s" cannot be created', array(), 'Admin.International.Notification'), dirname($path)));
                         }
                         file_put_contents($path.$mail_name.'.'.$type_content, Tools::purifyHTML($content, array('{', '}'), true));
                     } else {
-                        throw new PrestaShopException(Tools::displayError('Your HTML email templates cannot contain JavaScript code.'));
+                        throw new PrestaShopException($this->trans('Your HTML email templates cannot contain JavaScript code.', array(), 'Admin.International.Notification'));
                     }
                 }
             }
@@ -1738,7 +1738,7 @@ class AdminTranslationsControllerCore extends AdminController
             }
         }
         if (!is_writable($dir.DIRECTORY_SEPARATOR.$file)) {
-            $this->displayWarning(Tools::displayError('This file must be writable:').' '.$dir.'/'.$file);
+            $this->displayWarning($this->trans('This file must be writable:', array(), 'Admin.Notifications.Error').' '.$dir.'/'.$file);
         }
         include($dir.DIRECTORY_SEPARATOR.$file);
         return $$var;
@@ -1797,7 +1797,7 @@ class AdminTranslationsControllerCore extends AdminController
     public function initFormFront()
     {
         if (!$this->theme_exists(Tools::getValue('theme'))) {
-            $this->errors[] = sprintf(Tools::displayError('Invalid theme "%s"'), Tools::getValue('theme'));
+            $this->errors[] = sprintf($this->trans('Invalid theme "%s"', array(), 'Admin.International.Notification'), Tools::getValue('theme'));
             return;
         }
 
@@ -2158,10 +2158,10 @@ class AdminTranslationsControllerCore extends AdminController
     public function getListModules()
     {
         if (!Tools::file_exists_cache($this->translations_informations['modules']['dir'])) {
-            throw new PrestaShopException(Tools::displayError('Fatal error: The module directory does not exist.').'('.$this->translations_informations['modules']['dir'].')');
+            throw new PrestaShopException($this->trans('Fatal error: The module directory does not exist.', array(), 'Admin.Notifications.Error').'('.$this->translations_informations['modules']['dir'].')');
         }
         if (!is_writable($this->translations_informations['modules']['dir'])) {
-            throw new PrestaShopException(Tools::displayError('The module directory must be writable.'));
+            throw new PrestaShopException($this->trans('The module directory must be writable.', array(), 'Admin.International.Notification'));
         }
 
         $modules = array();
@@ -2406,7 +2406,7 @@ class AdminTranslationsControllerCore extends AdminController
                 }
             }
         } else {
-            $this->warnings[] = sprintf(Tools::displayError('A mail directory exists for the "%1$s" language, but not for the default language (%3$s) in %2$s'),
+            $this->warnings[] = sprintf($this->trans('A mail directory exists for the "%1$s" language, but not for the default language (%3$s) in %2$s', array(), 'Admin.International.Notification'),
                 $this->lang_selected->iso_code, str_replace(_PS_ROOT_DIR_, '', dirname($dir)), $default_language);
         }
         return $arr_return;
@@ -2939,7 +2939,7 @@ class AdminTranslationsControllerCore extends AdminController
             fwrite($fd, "\n?>");
             fclose($fd);
         } else {
-            throw new PrestaShopException(sprintf(Tools::displayError('Cannot write language file for email subjects. Path is: %s'), $path));
+            throw new PrestaShopException(sprintf($this->trans('Cannot write language file for email subjects. Path is: %s', array(), 'Admin.International.Notification'), $path));
         }
     }
 
@@ -3133,7 +3133,7 @@ class AdminTranslationsControllerCore extends AdminController
 
         $this->checkDirAndCreate($i18n_file);
         if ((!file_exists($i18n_file) && !is_writable($i18n_dir)) && !is_writable($i18n_file)) {
-            $this->errors[] = sprintf(Tools::displayError('Cannot write into the "%s"'), $i18n_file);
+            $this->errors[] = sprintf($this->trans('Cannot write into the "%s"', array(), 'Admin.International.Notification'), $i18n_file);
         }
 
         @include($i18n_file);

--- a/controllers/admin/AdminWebserviceController.php
+++ b/controllers/admin/AdminWebserviceController.php
@@ -246,10 +246,10 @@ class AdminWebserviceControllerCore extends AdminController
     public function postProcess()
     {
         if (Tools::getValue('key') && strlen(Tools::getValue('key')) < 32) {
-            $this->errors[] = Tools::displayError('Key length must be 32 character long.');
+            $this->errors[] = $this->trans('Key length must be 32 character long.', array(), 'Admin.Parameters.Notification');
         }
         if (WebserviceKey::keyExists(Tools::getValue('key')) && !Tools::getValue('id_webservice_account')) {
-            $this->errors[] = Tools::displayError('This key already exists.');
+            $this->errors[] = $this->trans('This key already exists.', array(), 'Admin.Parameters.Notification');
         }
         return parent::postProcess();
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The former Tools::displayError('Blabla') syntax prevented such strings to be parsed by the new translation system. So we changed it to have the new trans method. And of course added domains and updated some variables at the same time. It's only for admin controllers so far. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | n/a |
| How to test? | See if these errors are still displayed + should be in Crowdin once it's all updated. |

And.... good luck for the review!! :grimacing:
