### PR TITLE
Added possibility to override minimalPurchase price using new Hook

### DIFF
--- a/classes/controller/ModuleFrontController.php
+++ b/classes/controller/ModuleFrontController.php
@@ -88,6 +88,9 @@ class ModuleFrontControllerCore extends FrontController
             $currency = Currency::getCurrency((int) $this->context->cart->id_currency);
             $orderTotal = $this->context->cart->getOrderTotal();
             $minimal_purchase = Tools::convertPrice((float) Configuration::get('PS_PURCHASE_MINIMUM'), $currency);
+            Hook::exec('overrideMinimalPurchasePrice', array(
+                'minimalPurchase' => &$minimalPurchase
+            ));
             if ($this->context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS) < $minimal_purchase) {
                 Tools::redirect('index.php?controller=order&step=1');
             }

--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -15,6 +15,7 @@ use Configuration;
 use TaxConfiguration;
 use CartRule;
 use Tools;
+use Hook;
 
 class CartPresenter implements PresenterInterface
 {
@@ -327,6 +328,10 @@ class CartPresenter implements PresenterInterface
 
         $minimalPurchase = $this->priceFormatter->convertAmount((float) Configuration::get('PS_PURCHASE_MINIMUM'));
 
+        Hook::exec('overrideMinimalPurchasePrice', array(
+            'minimalPurchase' => &$minimalPurchase
+        ));
+
         // TODO: move it to a common parent, since it's copied in OrderPresenter and ProductPresenter
         $labels = array(
             'tax_short' => ($this->includeTaxes())
@@ -348,6 +353,7 @@ class CartPresenter implements PresenterInterface
             'id_address_invoice' => $cart->id_address_invoice,
             'is_virtual' => $cart->isVirtualCart(),
             'vouchers' => $this->getTemplateVarVouchers($cart),
+            'minimalPurchase' => $minimalPurchase,
             'minimalPurchaseRequired' => ($this->priceFormatter->convertAmount($productsTotalExcludingTax) < $minimalPurchase) ?
                 sprintf(
                     $this->translator->trans(


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Thanks to this change we can override minimal purchase price from a module, for example when we'd like to have minimalPurchase per customer etc. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | n/a |
| How to test? | Example module: https://gist.github.com/kpodemski/606f7e564a967e2c4c3ec677f1fb98c5 |
| Sponsor company | impSolutions

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
