### PR TITLE
Avoid JS error outside of product page

### DIFF
--- a/admin-dev/themes/new-theme/js/product-page/combination.js
+++ b/admin-dev/themes/new-theme/js/product-page/combination.js
@@ -3,6 +3,10 @@ import $ from 'jquery';
 export default function() {
   $(document).ready(function() {
     let $jsCombinationsList = $('.js-combinations-list');
+    // If we are not on the product page, return
+    if (0 === $jsCombinationsList.length) {
+        return;
+    }
     let idsProductAttribute = $jsCombinationsList.data('ids-product-attribute').toString().split(',');
     let idsCount = idsProductAttribute.length;
     let currentCount = 0;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix JS error when outside of the product page<br/>![capture du 2016-08-01 12-10-22](https://cloud.githubusercontent.com/assets/6768917/17290965/81463fdc-57e1-11e6-99a6-ed1dcaad62b2.png) |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Get the PR, rebuild the JS assets with `npm run build` in the folder admin-dev/themes/new-theme and see if the error disappear. |
