### PR TITLE
Add constraint for forbidden characters in product name

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -118,6 +118,10 @@ class ProductInformation extends CommonAbstractType
             'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [
                 'constraints' => array(
+                    new Assert\Regex(array(
+                        'pattern' => '/[<>;=#{}]/',
+                        'match'   => false,
+                    )),
                     new Assert\NotBlank(),
                     new Assert\Length(array('min' => 3, 'max' => 128))
                 ), 'attr' => ['placeholder' => $this->translator->trans('Enter your product name', [], 'Admin.Catalog.Help'), 'class' => 'edit js-edit']


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR adds a constraints to the product name. It excludes these characters "<>;=#{}" (same restriction as PS 1.6) |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1126 |
| How to test? | In BO > Catalog, add or edit a product. Try to add one of the forbidden characters in the list above. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
