### PR TITLE
Display unit price according to tax config

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -762,6 +762,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     public function getTemplateVarProduct()
     {
+        $productSettings = $this->getProductPresentationSettings();
+
         $product = $this->objectPresenter->present($this->product);
         $product['id_product'] = (int) $this->product->id;
         $product['out_of_stock'] = (int) $this->product->out_of_stock;
@@ -783,8 +785,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->trans('Items', array(), 'Shop.Theme.Catalog') : $this->trans('Item', array(), 'Shop.Theme.Catalog');
         $product_full['quantity_discounts'] = $this->quantity_discounts;
 
-        if ($product_full['price'] && $product_full['unit_price_ratio'] > 0) {
-            $product_full['unit_price'] = $product_full['price'] / $product_full['unit_price_ratio'];
+        if ($product_full['unit_price_ratio'] > 0) {
+            $unitPrice = ($productSettings->include_taxes) ? $product_full['price'] : $product_full['price_tax_exc'];
+            $product_full['unit_price'] = $unitPrice / $product_full['unit_price_ratio'];
         }
 
         $group_reduction = GroupReduction::getValueForProduct($this->product->id, (int) Group::getCurrent()->id);
@@ -796,7 +799,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $presenter = $this->getProductPresenter();
 
         return $presenter->present(
-            $this->getProductPresentationSettings(),
+            $productSettings,
             $product_full,
             $this->context->language
         );


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Display unit price according to tax configuration |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-805 |
| How to test? | display price tax included and excluded (change for a customer group for example) and see of the unit price is displayed correctly |
