### PR TITLE
Replaced text input by select input for page name in Meta page 

### DIFF
--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -287,11 +287,11 @@ class AdminMetaControllerCore extends AdminController
 
         $pages = array(
             'common' => array(
-                'name' => $this->trans('Default pages', array(), 'Admin.Parameters'),
+                'name' => $this->trans('Default pages', array(), 'Admin.Parameters.Feature'),
                 'query' => array(),
             ),
             'module' => array(
-                'name' => $this->trans('Modules pages', array(), 'Admin.Parameters'),
+                'name' => $this->trans('Modules pages', array(), 'Admin.Parameters.Feature'),
                 'query' => array(),
             ),
         );
@@ -316,7 +316,7 @@ class AdminMetaControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'select',
-                    'label' => $this->trans('Page', array(), 'Admin.Parameters'),
+                    'label' => $this->trans('Page', array(), 'Admin.Parameters.Feature'),
                     'name' => 'page',
 
                     'options' => array(
@@ -330,7 +330,7 @@ class AdminMetaControllerCore extends AdminController
                             'query' => 'query',
                         ),
                     ),
-                    'hint' => $this->trans('Name of the related page.', array(), 'AdminParameters'),
+                    'hint' => $this->trans('Name of the related page.', array(), 'AdminParameters.Help'),
                     'required' => true,
                 ),
                 array(

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -291,7 +291,7 @@ class AdminMetaControllerCore extends AdminController
                 'query' => array(),
             ),
             'module' => array(
-                'name' => $this->trans('Modules pages', array(), 'Admin.Parameters.Feature'),
+                'name' => $this->trans('Module pages', array(), 'Admin.Parameters.Feature'),
                 'query' => array(),
             ),
         );
@@ -316,7 +316,7 @@ class AdminMetaControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'select',
-                    'label' => $this->trans('Page', array(), 'Admin.Parameters.Feature'),
+                    'label' => $this->trans('Page name', array(), 'Admin.Parameters.Feature'),
                     'name' => 'page',
 
                     'options' => array(

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -274,6 +274,8 @@ class AdminMetaControllerCore extends AdminController
 
     public function renderForm()
     {
+        $files = Meta::getPages(true, ($this->object->page ? $this->object->page : false));
+
         $is_index = false;
         if (is_object($this->object) && is_array($this->object->url_rewrite) && count($this->object->url_rewrite)) {
             foreach ($this->object->url_rewrite as $rewrite) {
@@ -281,6 +283,25 @@ class AdminMetaControllerCore extends AdminController
                     $is_index = ($this->object->page == 'index' && empty($rewrite)) ? true : false;
                 }
             }
+        }
+
+        $pages = array(
+            'common' => array(
+                'name' => $this->trans('Default pages', array(), 'Admin.Parameters'),
+                'query' => array(),
+            ),
+            'module' => array(
+                'name' => $this->trans('Modules pages', array(), 'Admin.Parameters'),
+                'query' => array(),
+            ),
+        );
+
+        foreach ($files as $name => $file) {
+            $k = (preg_match('#^module-#', $file)) ? 'module' : 'common';
+            $pages[$k]['query'][] = array(
+                'id' => $file,
+                'page' => $name,
+            );
         }
 
         $this->fields_form = array(
@@ -294,10 +315,23 @@ class AdminMetaControllerCore extends AdminController
                     'name' => 'id_meta',
                 ),
                 array(
-                    'type' => 'text',
-                    'label' => $this->l('Page name'),
+                    'type' => 'select',
+                    'label' => $this->trans('Page', array(), 'Admin.Parameters'),
                     'name' => 'page',
-                    'disabled' => true,
+
+                    'options' => array(
+                        'optiongroup' => array(
+                            'label' => 'name',
+                            'query' => $pages,
+                        ),
+                        'options' => array(
+                            'id' => 'id',
+                            'name' => 'page',
+                            'query' => 'query',
+                        ),
+                    ),
+                    'hint' => $this->trans('Name of the related page.', array(), 'AdminParameters'),
+                    'required' => true,
                 ),
                 array(
                     'type' => 'text',


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR replaces text input by select input for the page name field, same as PS 1.6 |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1074 |
| How to test? | In BO > Shop Parameters > Traffic, add a new page. The select list should contain available pages. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
