### PR TITLE
Escape url like any variable

### DIFF
--- a/themes/classic/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
+++ b/themes/classic/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
@@ -30,7 +30,7 @@
         {foreach from=$nodes item=node}
           <li data-depth="{$depth}">
             {if $depth===0}
-              <a href="{$node.link nofilter}">{$node.name}</a>
+              <a href="{$node.link}">{$node.name}</a>
               {if $node.children}
                 <div class="navbar-toggler collapse-icons" data-toggle="collapse" data-target="#exCollapsingNavbar{$node.id}">
                   <i class="material-icons add">&#xE145;</i>
@@ -41,7 +41,7 @@
                 </div>
               {/if}
             {else}
-              <a class="category-sub-link" href="{$node.link nofilter}">{$node.name}</a>
+              <a class="category-sub-link" href="{$node.link}">{$node.name}</a>
               {if $node.children}
                 <span class="arrows" data-toggle="collapse" data-target="#exCollapsingNavbar{$node.id}">
                   <i class="material-icons arrow-right">&#xE315;</i>

--- a/themes/classic/modules/ps_mainmenu/ps_mainmenu.tpl
+++ b/themes/classic/modules/ps_mainmenu/ps_mainmenu.tpl
@@ -1,18 +1,11 @@
 {function name="menu" nodes=[] depth=0 parent=null}
     {if $nodes|count}
-      <ul
-        class="top-menu"
-        {if $depth == 0}id="top-menu"{/if}
-        data-depth="{$depth}"
-      >
+      <ul class="top-menu" {if $depth == 0}id="top-menu"{/if} data-depth="{$depth}">
         {foreach from=$nodes item=node}
-            <li
-              class="{$node.type}{if $node.current} current {/if}"
-              id="{$node.page_identifier}"
-            >
+            <li class="{$node.type}{if $node.current} current {/if}" id="{$node.page_identifier}">
               <a
                 class="{if $depth >= 0}dropdown-item{/if}{if $depth === 1} dropdown-submenu{/if}"
-                href="{$node.url nofilter}" data-depth="{$depth}"
+                href="{$node.url}" data-depth="{$depth}"
                 {if $node.open_in_new_window} target="_blank" {/if}
               >
                 {$node.label}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | URL were escaped where they shouldn't have. It's fixed here: https://github.com/PrestaShop/ps_mainmenu/pull/1/commits/41ad5bf998705e876e4d28ebf10860702e7f49b0#diff-a0b5d58d033617a7d976cdd5838291e8L719 hence there is no reason to keep the `nofilter` in template. |
| Type? | new feature |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-945 |
