### PR TITLE
Add translation domains to controllers - 4

### DIFF
--- a/controllers/admin/AdminAdminPreferencesController.php
+++ b/controllers/admin/AdminAdminPreferencesController.php
@@ -49,16 +49,16 @@ class AdminAdminPreferencesControllerCore extends AdminController
                 'icon' =>    'icon-cogs',
                 'fields' =>    array(
                     'PRESTASTORE_LIVE' => array(
-                        'title' => $this->trans('Automatically check for module updates', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('New modules and updates are displayed on the modules page.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Automatically check for module updates', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('New modules and updates are displayed on the modules page.', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool',
                         'visibility' => Shop::CONTEXT_ALL
                     ),
                     'PS_COOKIE_CHECKIP' => array(
-                        'title' => $this->trans('Check the cookie\'s IP address', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Check the IP address of the cookie in order to prevent your cookie from being stolen.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Check the cookie\'s IP address', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('Check the IP address of the cookie in order to prevent your cookie from being stolen.', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool',
@@ -66,22 +66,22 @@ class AdminAdminPreferencesControllerCore extends AdminController
                         'visibility' => Shop::CONTEXT_ALL
                     ),
                     'PS_COOKIE_LIFETIME_FO' => array(
-                        'title' => $this->trans('Lifetime of front office cookies', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Set the amount of hours during which the front office cookies are valid. After that amount of time, the customer will have to log in again.', array(), 'Admin.Parameters.Feature'),
+                        'title' => $this->trans('Lifetime of front office cookies', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('Set the amount of hours during which the front office cookies are valid. After that amount of time, the customer will have to log in again.', array(), 'Admin.AdvParameters.Feature'),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'text',
-                        'suffix' => $this->trans('hours', array(), 'Admin.Parameters.Feature'),
+                        'suffix' => $this->trans('hours', array(), 'Admin.AdvParameters.Feature'),
                         'default' => '480',
                         'visibility' => Shop::CONTEXT_ALL
                     ),
                     'PS_COOKIE_LIFETIME_BO' => array(
-                        'title' => $this->trans('Lifetime of back office cookies', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Set the amount of hours during which the back office cookies are valid. After that amount of time, the PrestaShop user will have to log in again.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Lifetime of back office cookies', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('Set the amount of hours during which the back office cookies are valid. After that amount of time, the PrestaShop user will have to log in again.', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'text',
-                        'suffix' => $this->trans('hours', array(), 'Admin.Parameters.Feature'),
+                        'suffix' => $this->trans('hours', array(), 'Admin.AdvParameters.Feature'),
                         'default' => '480',
                         'visibility' => Shop::CONTEXT_ALL
                     ),
@@ -89,61 +89,61 @@ class AdminAdminPreferencesControllerCore extends AdminController
                 'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions'))
             ),
             'upload' => array(
-                'title' =>    $this->trans('Upload quota', array(), 'Admin.Parameters.Feature'),
+                'title' =>    $this->trans('Upload quota', array(), 'Admin.AdvParameters.Feature'),
                 'icon' =>    'icon-cloud-upload',
                 'fields' => array(
                     'PS_ATTACHMENT_MAXIMUM_SIZE' => array(
-                        'title' => $this->trans('Maximum size for attachment', array(), 'Admin.Parameters.Feature'),
-                        'hint' =>  sprintf($this->trans('Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %s MB).', array(), 'Admin.Parameters.Help'), $upload_mb),
+                        'title' => $this->trans('Maximum size for attachment', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' =>  sprintf($this->trans('Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %s MB).', array(), 'Admin.AdvParameters.Help'), $upload_mb),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'text',
-                        'suffix' => $this->trans('megabytes', array(), 'Admin.Parameters.Feature'),
+                        'suffix' => $this->trans('megabytes', array(), 'Admin.AdvParameters.Feature'),
                         'default' => '2'
                     ),
                     'PS_LIMIT_UPLOAD_FILE_VALUE' => array(
-                        'title' => $this->trans('Maximum size for a downloadable product', array(), 'Admin.Parameters.Feature'),
-                        'hint' => sprintf($this->trans('Define the upload limit for a downloadable product (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %s MB).', array(), 'Admin.Parameters.Help'), $upload_mb),
+                        'title' => $this->trans('Maximum size for a downloadable product', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => sprintf($this->trans('Define the upload limit for a downloadable product (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %s MB).', array(), 'Admin.AdvParameters.Help'), $upload_mb),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'text',
-                        'suffix' => $this->trans('megabytes', array(), 'Admin.Parameters.Feature'),
+                        'suffix' => $this->trans('megabytes', array(), 'Admin.AdvParameters.Feature'),
                         'default' => '1'
                     ),
                     'PS_LIMIT_UPLOAD_IMAGE_VALUE' => array(
-                        'title' => $this->trans('Maximum size for a product\'s image', array(), 'Admin.Parameters.Feature'),
-                        'hint' => sprintf($this->trans('Define the upload limit for an image (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %s MB).', array('%s' => $upload_mb), 'Admin.Parameters.Help')),
+                        'title' => $this->trans('Maximum size for a product\'s image', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => sprintf($this->trans('Define the upload limit for an image (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %s MB).', array('%s' => $upload_mb), 'Admin.AdvParameters.Help')),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'text',
-                        'suffix' => $this->trans('megabytes', array(), 'Admin.Parameters.Feature'),
+                        'suffix' => $this->trans('megabytes', array(), 'Admin.AdvParameters.Feature'),
                         'default' => '1'
                     ),
                 ),
                 'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions'))
             ),
             'notifications' => array(
-                'title' =>    $this->trans('Notifications', array(), 'Admin.Parameters.Feature'),
+                'title' =>    $this->trans('Notifications', array(), 'Admin.AdvParameters.Feature'),
                 'icon' =>    'icon-list-alt',
-                'description' => $this->trans('Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop\'s name. They display the number of new items since you last clicked on them.', array(), 'Admin.Parameters.Help'),
+                'description' => $this->trans('Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop\'s name. They display the number of new items since you last clicked on them.', array(), 'Admin.AdvParameters.Help'),
                 'fields' =>    array(
                     'PS_SHOW_NEW_ORDERS' => array(
-                        'title' => $this->trans('Show notifications for new orders', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('This will display notifications when new orders are made in your shop.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Show notifications for new orders', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('This will display notifications when new orders are made in your shop.', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_SHOW_NEW_CUSTOMERS' => array(
-                        'title' => $this->trans('Show notifications for new customers', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('This will display notifications every time a new customer registers in your shop.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Show notifications for new customers', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('This will display notifications every time a new customer registers in your shop.', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_SHOW_NEW_MESSAGES' => array(
-                        'title' => $this->trans('Show notifications for new messages', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('This will display notifications when new messages are posted in your shop.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Show notifications for new messages', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('This will display notifications when new messages are posted in your shop.', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
@@ -161,7 +161,7 @@ class AdminAdminPreferencesControllerCore extends AdminController
         $max_size = $upload_max_size < $post_max_size ? $upload_max_size : $post_max_size;
 
         if (Tools::getValue('PS_LIMIT_UPLOAD_FILE_VALUE') > $max_size || Tools::getValue('PS_LIMIT_UPLOAD_IMAGE_VALUE') > $max_size) {
-            $this->errors[] = $this->trans('The limit chosen is larger than the server\'s maximum upload limit. Please increase the limits of your server.', array(), 'Admin.Parameters.Notification');
+            $this->errors[] = $this->trans('The limit chosen is larger than the server\'s maximum upload limit. Please increase the limits of your server.', array(), 'Admin.AdvParameters.Notification');
             return;
         }
 

--- a/controllers/admin/AdminBackupController.php
+++ b/controllers/admin/AdminBackupController.php
@@ -43,9 +43,9 @@ class AdminBackupControllerCore extends AdminController
 
         $this->fields_list = array(
             'date' => array('title' => $this->trans('Date', array(), 'Admin.Global'), 'type' => 'datetime', 'class' => 'fixed-width-lg', 'orderby' => false, 'search' => false),
-            'age' => array('title' => $this->trans('Age', array(), 'Admin.Parameters.Feature'), 'orderby' => false, 'search' => false),
+            'age' => array('title' => $this->trans('Age', array(), 'Admin.AdvParameters.Feature'), 'orderby' => false, 'search' => false),
             'filename' => array('title' => $this->trans('Filename', array(), 'Admin.Global'), 'orderby' => false, 'search' => false),
-            'filesize' => array('title' => $this->trans('File size', array(), 'Admin.Parameters.Feature'), 'class' => 'fixed-width-sm', 'orderby' => false, 'search' => false)
+            'filesize' => array('title' => $this->trans('File size', array(), 'Admin.AdvParameters.Feature'), 'class' => 'fixed-width-sm', 'orderby' => false, 'search' => false)
         );
 
         $this->bulk_actions = array('delete' => array(
@@ -55,21 +55,21 @@ class AdminBackupControllerCore extends AdminController
 
         $this->fields_options = array(
             'general' => array(
-                'title' =>    $this->trans('Backup options', array(), 'Admin.Parameters.Feature'),
+                'title' =>    $this->trans('Backup options', array(), 'Admin.AdvParameters.Feature'),
                 'fields' =>    array(
                     'PS_BACKUP_ALL' => array(
-                        'title' => $this->trans('Ignore statistics tables', array(), 'Admin.Parameters.Feature'),
-                        'desc' => $this->trans('Drop existing tables during import.', array(), 'Admin.Parameters.Help').'
+                        'title' => $this->trans('Ignore statistics tables', array(), 'Admin.AdvParameters.Feature'),
+                        'desc' => $this->trans('Drop existing tables during import.', array(), 'Admin.AdvParameters.Help').'
 							<br />'._DB_PREFIX_.'connections, '._DB_PREFIX_.'connections_page, '._DB_PREFIX_
                             .'connections_source, '._DB_PREFIX_.'guest, '._DB_PREFIX_.'statssearch',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_BACKUP_DROP_TABLE' => array(
-                        'title' => $this->trans('Drop existing tables during import', array(), 'Admin.Parameters.Feature'),
+                        'title' => $this->trans('Drop existing tables during import', array(), 'Admin.AdvParameters.Feature'),
                         'hint' => array(
-                            $this->trans('If enabled, the backup script will drop your tables prior to restoring data.', array(), 'Admin.Parameters.Help'),
-                            $this->trans('(ie. "DROP TABLE IF EXISTS")', array(), 'Admin.Parameters.Help'),
+                            $this->trans('If enabled, the backup script will drop your tables prior to restoring data.', array(), 'Admin.AdvParameters.Help'),
+                            $this->trans('(ie. "DROP TABLE IF EXISTS")', array(), 'Admin.AdvParameters.Help'),
                         ),
                         'cast' => 'intval',
                         'type' => 'bool'
@@ -155,7 +155,7 @@ class AdminBackupControllerCore extends AdminController
         }
 
         $obj = new $this->className();
-        $obj->error = $this->trans('The backup file does not exist', array(), 'Admin.Parameters.Notification');
+        $obj->error = $this->trans('The backup file does not exist', array(), 'Admin.AdvParameters.Notification');
 
         return $obj;
     }
@@ -171,14 +171,14 @@ class AdminBackupControllerCore extends AdminController
 
         // Test if the backup dir is writable
         if (!is_writable(PrestaShopBackup::getBackupPath())) {
-            $this->warnings[] = $this->trans('The "Backups" directory located in the admin directory must be writable (CHMOD 755 / 777).', array(), 'Admin.Parameters.Notification');
+            $this->warnings[] = $this->trans('The "Backups" directory located in the admin directory must be writable (CHMOD 755 / 777).', array(), 'Admin.AdvParameters.Notification');
         } elseif ($this->display == 'add') {
             if (($object = $this->loadObject())) {
                 if (!$object->add()) {
                     $this->errors[] = $object->error;
                 } else {
                     $this->context->smarty->assign(array(
-                            'conf' => $this->trans('It appears the backup was successful, however you must download and carefully verify the backup file before proceeding.', array(), 'Admin.Parameters.Notification'),
+                            'conf' => $this->trans('It appears the backup was successful, however you must download and carefully verify the backup file before proceeding.', array(), 'Admin.AdvParameters.Notification'),
                             'backup_url' => $object->getBackupURL(),
                             'backup_weight' => number_format((filesize($object->id) * 0.000001), 2, '.', '')
                         ));
@@ -246,7 +246,7 @@ class AdminBackupControllerCore extends AdminController
         $dh = @opendir(PrestaShopBackup::getBackupPath());
 
         if ($dh === false) {
-            $this->errors[] = $this->trans('Unable to open your backup directory', array(), 'Admin.Parameters.Notification');
+            $this->errors[] = $this->trans('Unable to open your backup directory', array(), 'Admin.AdvParameters.Notification');
             return;
         }
         while (($file = readdir($dh)) !== false) {

--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -40,11 +40,11 @@ class AdminCustomerPreferencesControllerCore extends AdminController
         $registration_process_type = array(
             array(
                 'value' => PS_REGISTRATION_PROCESS_STANDARD,
-                'name' => $this->trans('Only account creation', array(), 'Admin.Parameters.Feature')
+                'name' => $this->trans('Only account creation', array(), 'Admin.ShopParameters.Feature')
             ),
             array(
                 'value' => PS_REGISTRATION_PROCESS_AIO,
-                'name' => $this->trans('Standard (account creation and address creation)', array(), 'Admin.Parameters.Feature')
+                'name' => $this->trans('Standard (account creation and address creation)', array(), 'Admin.ShopParameters.Feature')
             )
         );
 
@@ -54,8 +54,8 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 'icon' =>    'icon-cogs',
                 'fields' =>    array(
                     'PS_REGISTRATION_PROCESS_TYPE' => array(
-                        'title' => $this->trans('Registration process type', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('The "Only account creation" registration option allows the customer to register faster, and create his/her address later.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Registration process type', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('The "Only account creation" registration option allows the customer to register faster, and create his/her address later.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'select',
@@ -63,45 +63,45 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                         'identifier' => 'value'
                     ),
                     'PS_CART_FOLLOWING' => array(
-                        'title' => $this->trans('Re-display cart at login', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('After a customer logs in, you can recall and display the content of his/her last shopping cart.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Re-display cart at login', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('After a customer logs in, you can recall and display the content of his/her last shopping cart.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_CUSTOMER_CREATION_EMAIL' => array(
-                        'title' => $this->trans('Send an email after registration', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Send an email with summary of the account information (email, password) after registration.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Send an email after registration', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Send an email with summary of the account information (email, password) after registration.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_PASSWD_TIME_FRONT' => array(
-                        'title' => $this->trans('Password reset delay', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Minimum time required between two requests for a password reset.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Password reset delay', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Minimum time required between two requests for a password reset.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isUnsignedInt',
                         'cast' => 'intval',
                         'size' => 5,
                         'type' => 'text',
-                        'suffix' => $this->trans('minutes', array(), 'Admin.Parameters.Feature')
+                        'suffix' => $this->trans('minutes', array(), 'Admin.ShopParameters.Feature')
                     ),
                     'PS_B2B_ENABLE' => array(
-                        'title' => $this->trans('Enable B2B mode', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Enable B2B mode', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_CUSTOMER_BIRTHDATE' => array(
-                        'title' => $this->trans('Ask for birthdate', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Display or not the birthdate field.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Ask for birthdate', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Display or not the birthdate field.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_CUSTOMER_OPTIN' => array(
-                        'title' => $this->trans('Enable partner offers', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Display or not the partner offers tick box, to receive offers from the store\'s partners.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Enable partner offers', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Display or not the partner offers tick box, to receive offers from the store\'s partners.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'

--- a/controllers/admin/AdminOrderPreferencesController.php
+++ b/controllers/admin/AdminOrderPreferencesController.php
@@ -52,50 +52,50 @@ class AdminOrderPreferencesControllerCore extends AdminController
                 'icon' =>    'icon-cogs',
                 'fields' =>    array(
                     'PS_FINAL_SUMMARY_ENABLED' => array(
-                        'title' => $this->trans('Enable final summary', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Display an overview of the addresses, shipping method and cart just before the order button (required in some European countries).', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Enable final summary', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Display an overview of the addresses, shipping method and cart just before the order button (required in some European countries).', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_GUEST_CHECKOUT_ENABLED' => array(
-                        'title' => $this->trans('Enable guest checkout', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Allow guest visitors to place an order without registering.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Enable guest checkout', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Allow guest visitors to place an order without registering.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_DISALLOW_HISTORY_REORDERING' => array(
-                        'title' => $this->trans('Disable Reordering Option', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Disable the option to allow customers to reorder in one click from the order history page (required in some European countries).', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Disable Reordering Option', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Disable the option to allow customers to reorder in one click from the order history page (required in some European countries).', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_PURCHASE_MINIMUM' => array(
-                        'title' => $this->trans('Minimum purchase total required in order to validate the order', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Set to 0 to disable this feature.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Minimum purchase total required in order to validate the order', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Set to 0 to disable this feature.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isFloat',
                         'cast' => 'floatval',
                         'type' => 'price'
                     ),
                     'PS_ALLOW_MULTISHIPPING' => array(
-                        'title' => $this->trans('Allow multishipping', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Allow the customer to ship orders to multiple addresses. This option will convert the customer\'s cart into one or more orders.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Allow multishipping', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Allow the customer to ship orders to multiple addresses. This option will convert the customer\'s cart into one or more orders.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_SHIP_WHEN_AVAILABLE' => array(
-                        'title' => $this->trans('Delayed shipping', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Allows you to delay shipping at your customers\' request.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Delayed shipping', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Allows you to delay shipping at your customers\' request.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_CONDITIONS' => array(
-                        'title' => $this->trans('Terms of service', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Require customers to accept or decline terms of service before processing an order.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Terms of service', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Require customers to accept or decline terms of service before processing an order.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool',
@@ -105,8 +105,8 @@ class AdminOrderPreferencesControllerCore extends AdminController
                         )
                     ),
                     'PS_CONDITIONS_CMS_ID' => array(
-                        'title' => $this->trans('Page for the Conditions of use', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Choose the page which contains your store\'s conditions of use.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Page for the Conditions of use', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Choose the page which contains your store\'s conditions of use.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isInt',
                         'type' => 'select',
                         'list' => $cms_tab,
@@ -117,26 +117,26 @@ class AdminOrderPreferencesControllerCore extends AdminController
                 'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions'))
             ),
             'gift' => array(
-                'title' =>    $this->trans('Gift options', array(), 'Admin.Parameters.Feature'),
+                'title' =>    $this->trans('Gift options', array(), 'Admin.ShopParameters.Feature'),
                 'icon' =>    'icon-gift',
                 'fields' =>    array(
                     'PS_GIFT_WRAPPING' => array(
-                        'title' => $this->trans('Offer gift wrapping', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Suggest gift-wrapping to customers.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Offer gift wrapping', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Suggest gift-wrapping to customers.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
                     ),
                     'PS_GIFT_WRAPPING_PRICE' => array(
-                        'title' => $this->trans('Gift-wrapping price', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Set a price for gift wrapping.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Gift-wrapping price', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Set a price for gift wrapping.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isPrice',
                         'cast' => 'floatval',
                         'type' => 'price'
                     ),
                     'PS_GIFT_WRAPPING_TAX_RULES_GROUP' => array(
-                        'title' => $this->trans('Gift-wrapping tax', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Set a tax for gift wrapping.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Gift-wrapping tax', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Set a tax for gift wrapping.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'select',
@@ -144,8 +144,8 @@ class AdminOrderPreferencesControllerCore extends AdminController
                         'identifier' => 'id_tax_rules_group'
                     ),
                     'PS_RECYCLABLE_PACK' => array(
-                        'title' => $this->trans('Offer recycled packaging', array(), 'Admin.Parameters.Feature'),
-                        'hint' => $this->trans('Suggest recycled packaging to customer.', array(), 'Admin.Parameters.Help'),
+                        'title' => $this->trans('Offer recycled packaging', array(), 'Admin.ShopParameters.Feature'),
+                        'hint' => $this->trans('Suggest recycled packaging to customer.', array(), 'Admin.ShopParameters.Help'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
@@ -172,7 +172,7 @@ class AdminOrderPreferencesControllerCore extends AdminController
         $sql = 'SELECT `id_cms` FROM `'._DB_PREFIX_.'cms`
 				WHERE id_cms = '.(int)Tools::getValue('PS_CONDITIONS_CMS_ID');
         if (Tools::getValue('PS_CONDITIONS') && (Tools::getValue('PS_CONDITIONS_CMS_ID') == 0 || !Db::getInstance()->getValue($sql))) {
-            $this->errors[] = $this->trans('Assign a valid page if you want it to be read.', array(), 'Admin.Parameters.Notification');
+            $this->errors[] = $this->trans('Assign a valid page if you want it to be read.', array(), 'Admin.ShopParameters.Notification');
         }
     }
 }

--- a/controllers/admin/AdminPreferencesController.php
+++ b/controllers/admin/AdminPreferencesController.php
@@ -42,51 +42,51 @@ class AdminPreferencesControllerCore extends AdminController
             $round_mode = array(
                 array(
                     'value' => PS_ROUND_HALF_UP,
-                    'name' => $this->l('Round up away from zero, when it is half way there (recommended)')
+                    'name' => $this->trans('Round up away from zero, when it is half way there (recommended)', array(), 'Admin.ShopParameters.Feature')
                 ),
                 array(
                     'value' => PS_ROUND_HALF_DOWN,
-                    'name' => $this->l('Round down towards zero, when it is half way there')
+                    'name' => $this->trans('Round down towards zero, when it is half way there', array(), 'Admin.ShopParameters.Feature')
                 ),
                 array(
                     'value' => PS_ROUND_HALF_EVEN,
-                    'name' => $this->l('Round towards the next even value')
+                    'name' => $this->trans('Round towards the next even value', array(), 'Admin.ShopParameters.Feature')
                 ),
                 array(
                     'value' => PS_ROUND_HALF_ODD,
-                    'name' => $this->l('Round towards the next odd value')
+                    'name' => $this->trans('Round towards the next odd value', array(), 'Admin.ShopParameters.Feature')
                 ),
                 array(
                     'value' => PS_ROUND_UP,
-                    'name' => $this->l('Round up to the nearest value')
+                    'name' => $this->trans('Round up to the nearest value', array(), 'Admin.ShopParameters.Feature')
                 ),
                 array(
                     'value' => PS_ROUND_DOWN,
-                    'name' => $this->l('Round down to the nearest value')
+                    'name' => $this->trans('Round down to the nearest value', array(), 'Admin.ShopParameters.Feature')
                 ),
             );
             $activities1 = array(
-                0 => $this->l('-- Please choose your main activity --'),
-                2 => $this->l('Animals and Pets'),
-                3 => $this->l('Art and Culture'),
-                4 => $this->l('Babies'),
-                5 => $this->l('Beauty and Personal Care'),
-                6 => $this->l('Cars'),
-                7 => $this->l('Computer Hardware and Software'),
-                8 => $this->l('Download'),
-                9 => $this->l('Fashion and accessories'),
-                10 => $this->l('Flowers, Gifts and Crafts'),
-                11 => $this->l('Food and beverage'),
-                12 => $this->l('HiFi, Photo and Video'),
-                13 => $this->l('Home and Garden'),
-                14 => $this->l('Home Appliances'),
-                15 => $this->l('Jewelry'),
-                1 => $this->l('Lingerie and Adult'),
-                16 => $this->l('Mobile and Telecom'),
-                17 => $this->l('Services'),
-                18 => $this->l('Shoes and accessories'),
-                19 => $this->l('Sport and Entertainment'),
-                20 => $this->l('Travel')
+                0 => $this->trans('-- Please choose your main activity --', array(), 'Install'),
+                2 => $this->trans('Animals and Pets', array(), 'Install'),
+                3 => $this->trans('Art and Culture', array(), 'Install'),
+                4 => $this->trans('Babies', array(), 'Install'),
+                5 => $this->trans('Beauty and Personal Care', array(), 'Install'),
+                6 => $this->trans('Cars', array(), 'Install'),
+                7 => $this->trans('Computer Hardware and Software', array(), 'Install'),
+                8 => $this->trans('Download', array(), 'Install'),
+                9 => $this->trans('Fashion and accessories', array(), 'Install'),
+                10 => $this->trans('Flowers, Gifts and Crafts', array(), 'Install'),
+                11 => $this->trans('Food and beverage', array(), 'Install'),
+                12 => $this->trans('HiFi, Photo and Video', array(), 'Install'),
+                13 => $this->trans('Home and Garden', array(), 'Install'),
+                14 => $this->trans('Home Appliances', array(), 'Install'),
+                15 => $this->trans('Jewelry', array(), 'Install'),
+                1 => $this->trans('Lingerie and Adult', array(), 'Install'),
+                16 => $this->trans('Mobile and Telecom', array(), 'Install'),
+                17 => $this->trans('Services', array(), 'Install'),
+                18 => $this->trans('Shoes and accessories', array(), 'Install'),
+                19 => $this->trans('Sport and Entertainment', array(), 'Install'),
+                20 => $this->trans('Travel', array(), 'Install')
             );
             $activities2 = array();
             foreach ($activities1 as $value => $name) {
@@ -95,9 +95,9 @@ class AdminPreferencesControllerCore extends AdminController
 
             $fields = array(
                 'PS_SSL_ENABLED' => array(
-                    'title' => $this->l('Enable SSL'),
-                    'desc' => $this->l('If you own an SSL certificate for your shop\'s domain name, you can activate SSL encryption (https://) for customer account identification and order processing.'),
-                    'hint' => $this->l('If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.'),
+                    'title' => $this->trans('Enable SSL', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('If you own an SSL certificate for your shop\'s domain name, you can activate SSL encryption (https://) for customer account identification and order processing.', array(), 'Admin.ShopParameters.Help'),
+                    'hint' => $this->trans('If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isBool',
                     'cast' => 'intval',
                     'type' => 'bool',
@@ -106,8 +106,8 @@ class AdminPreferencesControllerCore extends AdminController
             );
 
             $fields['PS_SSL_ENABLED_EVERYWHERE'] = array(
-                'title' => $this->l('Enable SSL on all pages'),
-                'desc' => $this->l('When enabled, all the pages of your shop will be SSL-secured.'),
+                'title' => $this->trans('Enable SSL on all pages', array(), 'Admin.ShopParameters.Feature'),
+                'desc' => $this->trans('When enabled, all the pages of your shop will be SSL-secured.', array(), 'Admin.ShopParameters.Help'),
                 'validation' => 'isBool',
                 'cast' => 'intval',
                 'type' => 'bool',
@@ -117,8 +117,8 @@ class AdminPreferencesControllerCore extends AdminController
 
             $fields = array_merge($fields, array(
                 'PS_TOKEN_ENABLE' => array(
-                    'title' => $this->l('Increase front office security'),
-                    'desc' => $this->l('Enable or disable token in the Front Office to improve PrestaShop\'s security.'),
+                    'title' => $this->trans('Increase front office security', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('Enable or disable token in the Front Office to improve PrestaShop\'s security.', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isBool',
                     'cast' => 'intval',
                     'type' => 'bool',
@@ -126,24 +126,24 @@ class AdminPreferencesControllerCore extends AdminController
                     'visibility' => Shop::CONTEXT_ALL
                 ),
                 'PS_ALLOW_HTML_IFRAME' => array(
-                    'title' => $this->l('Allow iframes on HTML fields'),
-                    'desc' => $this->l('Allow iframes on text fields like product description. We recommend that you leave this option disabled.'),
+                    'title' => $this->trans('Allow iframes on HTML fields', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('Allow iframes on text fields like product description. We recommend that you leave this option disabled.', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isBool',
                     'cast' => 'intval',
                     'type' => 'bool',
                     'default' => '0'
                 ),
                 'PS_USE_HTMLPURIFIER' => array(
-                    'title' => $this->l('Use HTMLPurifier Library'),
-                    'desc' => $this->l('Clean the HTML content on text fields. We recommend that you leave this option enabled.'),
+                    'title' => $this->trans('Use HTMLPurifier Library', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('Clean the HTML content on text fields. We recommend that you leave this option enabled.', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isBool',
                     'cast' => 'intval',
                     'type' => 'bool',
                     'default' => '0'
                 ),
                 'PS_PRICE_ROUND_MODE' => array(
-                    'title' => $this->l('Round mode'),
-                    'desc' => $this->l('You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.'),
+                    'title' => $this->trans('Round mode', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isInt',
                     'cast' => 'intval',
                     'type' => 'select',
@@ -151,58 +151,58 @@ class AdminPreferencesControllerCore extends AdminController
                     'identifier' => 'value'
                 ),
                 'PS_ROUND_TYPE' => array(
-                    'title' => $this->l('Round type'),
-                    'desc' => $this->l('You can choose when to round prices: either on each item, each line or the total (of an invoice, for example).'),
+                    'title' => $this->trans('Round type', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('You can choose when to round prices: either on each item, each line or the total (of an invoice, for example).', array(), 'Admin.ShopParameters.Help'),
                     'cast' => 'intval',
                     'type' => 'select',
                     'list' => array(
                         array(
-                            'name' => $this->l('Round on each item'),
+                            'name' => $this->trans('Round on each item', array(), 'Admin.ShopParameters.Feature'),
                             'id' => Order::ROUND_ITEM
                             ),
                         array(
-                            'name' => $this->l('Round on each line'),
+                            'name' => $this->trans('Round on each line', array(), 'Admin.ShopParameters.Feature'),
                             'id' => Order::ROUND_LINE
                             ),
                         array(
-                            'name' => $this->l('Round on the total'),
+                            'name' => $this->trans('Round on the total', array(), 'Admin.ShopParameters.Feature'),
                             'id' => Order::ROUND_TOTAL
                             ),
                         ),
                     'identifier' => 'id'
                 ),
                 'PS_PRICE_DISPLAY_PRECISION' => array(
-                    'title' => $this->l('Number of decimals'),
-                    'desc' => $this->l('Choose how many decimals you want to display'),
+                    'title' => $this->trans('Number of decimals', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('Choose how many decimals you want to display', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isUnsignedInt',
                     'cast' => 'intval',
                     'type' => 'text',
                     'class' => 'fixed-width-xxl'
                 ),
                 'PS_DISPLAY_SUPPLIERS' => array(
-                    'title' => $this->l('Display brands and suppliers'),
-                    'desc' => $this->l('Enable brands and suppliers pages on your front office even when their respective modules are disabled.'),
+                    'title' => $this->trans('Display brands and suppliers', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('Enable brands and suppliers pages on your front office even when their respective modules are disabled.', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isBool',
                     'cast' => 'intval',
                     'type' => 'bool'
                 ),
                 'PS_DISPLAY_BEST_SELLERS' => array(
-                    'title' => $this->l('Display best sellers'),
-                    'desc' => $this->l('Enable best sellers page on your front office even when its respective module is disabled.'),
+                    'title' => $this->trans('Display best sellers', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('Enable best sellers page on your front office even when its respective module is disabled.', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isBool',
                     'cast' => 'intval',
                     'type' => 'bool'
                 ),
                 'PS_MULTISHOP_FEATURE_ACTIVE' => array(
-                    'title' => $this->l('Enable Multistore'),
-                    'desc' => $this->l('The multistore feature allows you to manage several e-shops with one Back Office. If this feature is enabled, a "Multistore" page will be available in the "Advanced Parameters" menu.'),
+                    'title' => $this->trans('Enable Multistore', array(), 'Admin.ShopParameters.Feature'),
+                    'desc' => $this->trans('The multistore feature allows you to manage several e-shops with one Back Office. If this feature is enabled, a "Multistore" page will be available in the "Advanced Parameters" menu.', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isBool',
                     'cast' => 'intval',
                     'type' => 'bool',
                     'visibility' => Shop::CONTEXT_ALL
                 ),
                 'PS_SHOP_ACTIVITY' => array(
-                    'title' => $this->l('Main Shop Activity'),
+                    'title' => $this->trans('Main Shop Activity', array(), 'Admin.ShopParameters.Feature'),
                     'validation' => 'isInt',
                     'cast' => 'intval',
                     'type' => 'select',
@@ -215,12 +215,12 @@ class AdminPreferencesControllerCore extends AdminController
             if (!Tools::usingSecureMode() && !Configuration::get('PS_SSL_ENABLED')) {
                 $fields['PS_SSL_ENABLED']['type'] = 'disabled';
                 $fields['PS_SSL_ENABLED']['disabled'] = '<a class="btn btn-link" href="https://'.Tools::getShopDomainSsl().Tools::safeOutput($_SERVER['REQUEST_URI']).'">'.
-                    $this->l('Please click here to check if your shop supports HTTPS.').'</a>';
+                    $this->trans('Please click here to check if your shop supports HTTPS.', array(), 'Admin.ShopParameters.Feature').'</a>';
             }
 
             $this->fields_options = array(
                 'general' => array(
-                    'title' =>    $this->l('General'),
+                    'title' =>    $this->trans('General', array(), 'Admin.Global'),
                     'icon' =>    'icon-cogs',
                     'fields' =>    $fields,
                     'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions')),

--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -37,7 +37,7 @@ class AdminReturnControllerCore extends AdminController
         $this->colorOnBackground = true;
 
         parent::__construct();
-        
+
         $this->_select = 'ors.color, orsl.`name`, o.`id_shop`';
         $this->_join = 'LEFT JOIN '._DB_PREFIX_.'order_return_state ors ON (ors.`id_order_return_state` = a.`state`)';
         $this->_join .= 'LEFT JOIN '._DB_PREFIX_.'order_return_state_lang orsl ON (orsl.`id_order_return_state` = a.`state` AND orsl.`id_lang` = '.(int)$this->context->language->id.')';
@@ -45,28 +45,28 @@ class AdminReturnControllerCore extends AdminController
 
         $this->fields_list = array(
             'id_order_return' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'align' => 'center', 'width' => 25),
-            'id_order' => array('title' => $this->l('Order ID'), 'width' => 100, 'align' => 'center', 'filter_key'=>'a!id_order'),
-            'name' => array('title' => $this->l('Status'),'color' => 'color', 'width' => 'auto', 'align' => 'left'),
-            'date_add' => array('title' => $this->l('Date issued'), 'width' => 150, 'type' => 'date', 'align' => 'right', 'filter_key'=>'a!date_add'),
+            'id_order' => array('title' => $this->trans('Order ID', array(), 'Admin.OrdersCustomers.Feature'), 'width' => 100, 'align' => 'center', 'filter_key'=>'a!id_order'),
+            'name' => array('title' => $this->trans('Status', array(), 'Admin.Global'),'color' => 'color', 'width' => 'auto', 'align' => 'left'),
+            'date_add' => array('title' => $this->trans('Date issued', array(), 'Admin.OrdersCustomers.Feature'), 'width' => 150, 'type' => 'date', 'align' => 'right', 'filter_key'=>'a!date_add'),
         );
 
         $this->fields_options = array(
             'general' => array(
-                'title' =>    $this->l('Merchandise return (RMA) options'),
+                'title' =>    $this->trans('Merchandise return (RMA) options', array(), 'Admin.OrdersCustomers.Feature'),
                 'fields' =>    array(
                     'PS_ORDER_RETURN' => array(
-                        'title' => $this->l('Enable returns'),
-                        'desc' => $this->l('Would you like to allow merchandise returns in your shop?'),
+                        'title' => $this->trans('Enable returns', array(), 'Admin.OrdersCustomers.Feature'),
+                        'desc' => $this->trans('Would you like to allow merchandise returns in your shop?', array(), 'Admin.OrdersCustomers.Help'),
                         'cast' => 'intval', 'type' => 'bool'),
                     'PS_ORDER_RETURN_NB_DAYS' => array(
-                        'title' => $this->l('Time limit of validity'),
-                        'desc' => $this->l('How many days after the delivery date does the customer have to return a product?'),
+                        'title' => $this->trans('Time limit of validity', array(), 'Admin.OrdersCustomers.Feature'),
+                        'desc' => $this->trans('How many days after the delivery date does the customer have to return a product?', array(), 'Admin.OrdersCustomers.Help'),
                         'cast' => 'intval',
                         'type' => 'text',
                         'size' => '2'),
                     'PS_RETURN_PREFIX' => array(
-                        'title' => $this->l('Returns prefix'),
-                        'desc' => $this->l('Prefix used for return name (e.g. RE00001).'),
+                        'title' => $this->trans('Returns prefix', array(), 'Admin.OrdersCustomers.Feature'),
+                        'desc' => $this->trans('Prefix used for return name (e.g. RE00001).', array(), 'Admin.OrdersCustomers.Help'),
                         'size' => 6,
                         'type' => 'textLang'
                     ),
@@ -83,7 +83,7 @@ class AdminReturnControllerCore extends AdminController
     {
         $this->fields_form = array(
             'legend' => array(
-                'title' => $this->l('Return Merchandise Authorization (RMA)'),
+                'title' => $this->trans('Return Merchandise Authorization (RMA)', array(), 'Admin.OrdersCustomers.Feature'),
                 'icon' => 'icon-clipboard'
             ),
             'input' => array(
@@ -104,21 +104,21 @@ class AdminReturnControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'text_order',
-                    'label' => $this->l('Order'),
+                    'label' => $this->trans('Order', array(), 'Admin.Global'),
                     'name' => '',
                     'size' => '',
                     'required' => false,
                 ),
                 array(
                     'type' => 'free',
-                    'label' => $this->l('Customer explanation'),
+                    'label' => $this->trans('Customer explanation', array(), 'Admin.OrdersCustomers.Feature'),
                     'name' => 'question',
                     'size' => '',
                     'required' => false,
                 ),
                 array(
                     'type' => 'select',
-                    'label' => $this->l('Status'),
+                    'label' => $this->trans('Status', array(), 'Admin.Global'),
                     'name' => 'state',
                     'required' => false,
                     'options' => array(
@@ -126,23 +126,23 @@ class AdminReturnControllerCore extends AdminController
                         'id' => 'id_order_return_state',
                         'name' => 'name'
                     ),
-                    'desc' => $this->l('Merchandise return (RMA) status.')
+                    'desc' => $this->trans('Merchandise return (RMA) status.', array(), 'Admin.OrdersCustomers.Help')
                 ),
                 array(
                     'type' => 'list_products',
-                    'label' => $this->l('Products'),
+                    'label' => $this->trans('Products', array(), 'Admin.Global'),
                     'name' => '',
                     'size' => '',
                     'required' => false,
-                    'desc' => $this->l('List of products in return package.')
+                    'desc' => $this->trans('List of products in return package.', array(), 'Admin.OrdersCustomers.Help')
                 ),
                 array(
                     'type' => 'pdf_order_return',
-                    'label' => $this->l('Return slip'),
+                    'label' => $this->trans('Return slip', array(), 'Admin.OrdersCustomers.Feature'),
                     'name' => '',
                     'size' => '',
                     'required' => false,
-                    'desc' => $this->l('The link is only available after validation and before the parcel gets delivered.')
+                    'desc' => $this->trans('The link is only available after validation and before the parcel gets delivered.', array(), 'Admin.OrdersCustomers.Help')
                 ),
             ),
             'submit' => array(
@@ -168,7 +168,14 @@ class AdminReturnControllerCore extends AdminController
         $this->tpl_form_vars = array(
             'customer' => new Customer($this->object->id_customer),
             'url_customer' => 'index.php?tab=AdminCustomers&id_customer='.(int)$this->object->id_customer.'&viewcustomer&token='.Tools::getAdminToken('AdminCustomers'.(int)(Tab::getIdFromClassName('AdminCustomers')).(int)$this->context->employee->id),
-            'text_order' => sprintf($this->l('Order #%1$d from %2$s'), $order->id, Tools::displayDate($order->date_upd)),
+            'text_order' => $this->trans(
+                'Order #%id% from %date%',
+                array(
+                    '%id%' => $order->id,
+                    '%date%' => Tools::displayDate($order->date_upd)
+                ),
+                'Admin.OrdersCustomers.Feature'
+            ),
             'url_order' => 'index.php?tab=AdminOrders&id_order='.(int)$order->id.'&vieworder&token='.Tools::getAdminToken('AdminOrders'.(int)Tab::getIdFromClassName('AdminOrders').(int)$this->context->employee->id),
             'picture_folder' => _THEME_PROD_PIC_DIR_,
             'returnedCustomizations' => $returned_customizations,
@@ -191,7 +198,7 @@ class AdminReturnControllerCore extends AdminController
             $this->toolbar_btn['save-and-stay'] = array(
                 'short' => 'SaveAndStay',
                 'href' => '#',
-                'desc' => $this->l('Save and stay'),
+                'desc' => $this->trans('Save and stay', array(), 'Admin.Actions'),
                 'force_desc' => true,
             );
         }

--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -52,8 +52,8 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
         }
 
         $this->list_reduction_type = array(
-            'percentage' => $this->l('Percentage'),
-            'amount' => $this->l('Amount')
+            'percentage' => $this->trans('Percentage', array(), 'Admin.Global'),
+            'amount' => $this->trans('Amount', array(), 'Admin.Global')
         );
 
         $this->addRowAction('edit');
@@ -68,8 +68,8 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
 
         $this->bulk_actions = array(
             'delete' => array(
-                'text' => $this->l('Delete selected'),
-                'confirm' => $this->l('Delete selected items?'),
+                'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
                 'icon' => 'icon-trash'
             )
         );
@@ -90,7 +90,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                 'filter_key' => 's!name'
             ),
             'currency_name' => array(
-                'title' => $this->l('Currency'),
+                'title' => $this->trans('Currency', array(), 'Admin.Global'),
                 'align' => 'center',
                 'filter_key' => 'cu!name'
             ),
@@ -105,30 +105,30 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                 'filter_key' => 'gl!name'
             ),
             'from_quantity' => array(
-                'title' => $this->l('From quantity'),
+                'title' => $this->trans('From quantity', array(), 'Admin.Catalog.Feature'),
                 'align' => 'center',
                 'class' => 'fixed-width-xs'
             ),
             'reduction_type' => array(
-                'title' => $this->l('Reduction type'),
+                'title' => $this->trans('Reduction type', array(), 'Admin.Catalog.Feature'),
                 'align' => 'center',
                 'type' => 'select',
                 'filter_key' => 'a!reduction_type',
                 'list' => $this->list_reduction_type,
             ),
             'reduction' => array(
-                'title' => $this->l('Reduction'),
+                'title' => $this->trans('Reduction', array(), 'Admin.Catalog.Feature'),
                 'align' => 'center',
                 'type' => 'decimal',
                 'class' => 'fixed-width-xs'
             ),
             'from' => array(
-                'title' => $this->l('Beginning'),
+                'title' => $this->trans('Beginning', array(), 'Admin.Catalog.Feature'),
                 'align' => 'right',
                 'type' => 'datetime',
             ),
             'to' => array(
-                'title' => $this->l('End'),
+                'title' => $this->trans('End', array(), 'Admin.Catalog.Feature'),
                 'align' => 'right',
                 'type' => 'datetime'
             ),
@@ -140,7 +140,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
         if (empty($this->display)) {
             $this->page_header_toolbar_btn['new_specific_price_rule'] = array(
                 'href' => self::$currentIndex.'&addspecific_price_rule&token='.$this->token,
-                'desc' => $this->l('Add new catalog price rule', null, null, false),
+                'desc' => $this->trans('Add new catalog price rule', array(), 'Admin.Catalog.Feature'),
                 'icon' => 'process-icon-new'
             );
         }
@@ -172,7 +172,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
 
         $this->fields_form = array(
             'legend' => array(
-                'title' => $this->l('Catalog price rules'),
+                'title' => $this->trans('Catalog price rules', array(), 'Admin.Catalog.Feature'),
                 'icon' => 'icon-dollar'
             ),
             'input' => array(
@@ -182,7 +182,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                     'name' => 'name',
                     'maxlength' => 255,
                     'required' => true,
-                    'hint' => $this->l('Forbidden characters').' <>;=#{}'
+                    'hint' => $this->trans('Invalid characters', array(), 'Admin.Notifications.Info').' <>;=#{}'
                 ),
                 array(
                     'type' => 'select',
@@ -198,10 +198,10 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'select',
-                    'label' => $this->l('Currency'),
+                    'label' => $this->trans('Currency', array(), 'Admin.Global'),
                     'name' => 'id_currency',
                     'options' => array(
-                        'query' => array_merge(array(0 => array('id_currency' => 0, 'name' => $this->l('All currencies'))), Currency::getCurrencies(false, true, true)),
+                        'query' => array_merge(array(0 => array('id_currency' => 0, 'name' => $this->trans('All currencies', array(), 'Admin.Global'))), Currency::getCurrencies(false, true, true)),
                         'id' => 'id_currency',
                         'name' => 'name'
                     ),
@@ -211,7 +211,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                     'label' => $this->trans('Country', array(), 'Admin.Global'),
                     'name' => 'id_country',
                     'options' => array(
-                        'query' => array_merge(array(0 => array('id_country' => 0, 'name' => $this->l('All countries'))), Country::getCountries((int)$this->context->language->id)),
+                        'query' => array_merge(array(0 => array('id_country' => 0, 'name' => $this->trans('All countries', array(), 'Admin.Global'))), Country::getCountries((int)$this->context->language->id)),
                         'id' => 'id_country',
                         'name' => 'name'
                     ),
@@ -221,21 +221,21 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                     'label' => $this->trans('Group', array(), 'Admin.Global'),
                     'name' => 'id_group',
                     'options' => array(
-                        'query' => array_merge(array(0 => array('id_group' => 0, 'name' => $this->l('All groups'))), Group::getGroups((int)$this->context->language->id)),
+                        'query' => array_merge(array(0 => array('id_group' => 0, 'name' => $this->trans('All groups', array(), 'Admin.Global'))), Group::getGroups((int)$this->context->language->id)),
                         'id' => 'id_group',
                         'name' => 'name'
                     ),
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->l('From quantity'),
+                    'label' => $this->trans('From quantity', array(), 'Admin.Catalog.Feature'),
                     'name' => 'from_quantity',
                     'maxlength' => 10,
                     'required' => true,
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->l('Price (tax excl.)'),
+                    'label' => $this->trans('Price (tax excl.)', array(), 'Admin.Catalog.Feature'),
                     'name' => 'price',
                     'disabled' => ($this->object->price == -1 ? 1 : 0),
                     'maxlength' => 10,
@@ -249,7 +249,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                         'query' => array(
                             array(
                                 'id' => 'on',
-                                'name' => $this->l('Leave initial price'),
+                                'name' => $this->trans('Leave initial price', array(), 'Admin.Catalog.Feature'),
                                 'val' => '1',
                                 'checked' => '1'
                             ),
@@ -260,33 +260,33 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'datetime',
-                    'label' => $this->l('From'),
+                    'label' => $this->trans('From', array(), 'Admin.Global'),
                     'name' => 'from'
                 ),
                 array(
                     'type' => 'datetime',
-                    'label' => $this->l('To'),
+                    'label' => $this->trans('To', array(), 'Admin.Global'),
                     'name' => 'to'
                 ),
                 array(
                     'type' => 'select',
-                    'label' => $this->l('Reduction type'),
+                    'label' => $this->trans('Reduction type', array(), 'Admin.Catalog.Feature'),
                     'name' => 'reduction_type',
                     'options' => array(
-                        'query' => array(array('reduction_type' => 'amount', 'name' => $this->l('Amount')), array('reduction_type' => 'percentage', 'name' => $this->l('Percentage'))),
+                        'query' => array(array('reduction_type' => 'amount', 'name' => $this->trans('Amount', array(), 'Admin.Global')), array('reduction_type' => 'percentage', 'name' => $this->trans('Percentage', array(), 'Admin.Global'))),
                         'id' => 'reduction_type',
                         'name' => 'name'
                     ),
                 ),
                 array(
                     'type' => 'select',
-                    'label' => $this->l('Reduction with or without taxes'),
+                    'label' => $this->trans('Reduction with or without taxes', array(), 'Admin.Catalog.Feature'),
                     'name' => 'reduction_tax',
                     'align' => 'center',
                     'options' => array(
                         'query' => array(
-                                        array('lab' => $this->l('Tax included'), 'val' => 1),
-                                        array('lab' => $this->l('Tax excluded'), 'val' => 0),
+                                        array('lab' => $this->trans('Tax included', array(), 'Admin.Global'), 'val' => 1),
+                                        array('lab' => $this->trans('Tax excluded', array(), 'Admin.Global'), 'val' => 0),
                                     ),
                         'id' => 'val',
                         'name' => 'lab',
@@ -294,7 +294,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->l('Reduction'),
+                    'label' => $this->trans('Reduction', array(), 'Admin.Catalog.Feature'),
                     'name' => 'reduction',
                     'required' => true,
                 ),

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -588,14 +588,14 @@ class AdminStatsControllerCore extends AdminStatsTabController
 
             case 'percent_product_out_of_stock':
                 $value = AdminStatsController::getPercentProductOutOfStock();
-                $tooltip = sprintf($this->l('%s of your products for sale are out of stock.', null, null, false), $value);
+                $tooltip = $this->trans('%s of your products for sale are out of stock.', array($value), 'Admin.Stats.Help');
                 ConfigurationKPI::updateValue('PERCENT_PRODUCT_OUT_OF_STOCK', $value);
                 ConfigurationKPI::updateValue('PERCENT_PRODUCT_OUT_OF_STOCK_EXPIRE', strtotime('+4 hour'));
                 break;
 
             case 'product_avg_gross_margin':
                 $value = AdminStatsController::getProductAverageGrossMargin();
-                $tooltip = sprintf($this->l('Gross margin expressed in percentage assesses how cost-effectively you sell your goods. Out of $100, you will retain $%s to cover profit and expenses.', null, null, false), str_replace('%', '', $value));
+                $tooltip = $this->trans('Gross margin expressed in percentage assesses how cost-effectively you sell your goods. Out of $100, you will retain $%s to cover profit and expenses.', array(str_replace('%', '', $value)), 'Admin.Stats.Help');
                 ConfigurationKPI::updateValue('PRODUCT_AVG_GROSS_MARGIN', $value);
                 ConfigurationKPI::updateValue('PRODUCT_AVG_GROSS_MARGIN_EXPIRE', strtotime('+6 hour'));
                 break;
@@ -608,15 +608,15 @@ class AdminStatsControllerCore extends AdminStatsTabController
 
             case 'disabled_products':
                 $value = round(100 * AdminStatsController::getDisabledProducts() / AdminStatsController::getTotalProducts(), 2).'%';
-                $tooltip = sprintf($this->l('%s of your products are disabled and not visible to your customers', null, null, false), $value);
+                $tooltip = sprintf($this->trans('%s of your products are disabled and not visible to your customers', array(), 'Admin.Stats.Help'), $value);
                 ConfigurationKPI::updateValue('DISABLED_PRODUCTS', $value);
                 ConfigurationKPI::updateValue('DISABLED_PRODUCTS_EXPIRE', strtotime('+2 hour'));
                 break;
 
             case '8020_sales_catalog':
                 $value = AdminStatsController::get8020SalesCatalog(date('Y-m-d', strtotime('-30 days')), date('Y-m-d'));
-                $tooltip = sprintf($this->l('Within your catalog, %s of your products have had sales in the last 30 days', null, null, false), $value);
-                $value = sprintf($this->l('%d%% of your Catalog'), $value);
+                $tooltip = sprintf($this->trans('Within your catalog, %s of your products have had sales in the last 30 days', array(), 'Admin.Stats.Help'), $value);
+                $value = sprintf($this->trans('%d%% of your Catalog', array(), 'Admin.Stats.Feature'), $value);
                 ConfigurationKPI::updateValue('8020_SALES_CATALOG', $value);
                 ConfigurationKPI::updateValue('8020_SALES_CATALOG_EXPIRE', strtotime('+12 hour'));
                 break;
@@ -631,13 +631,13 @@ class AdminStatsControllerCore extends AdminStatsTabController
                 $value = AdminStatsController::getCustomerMainGender();
 
                 if ($value === false) {
-                    $value = $this->l('No customers', null, null, false);
+                    $value = $this->trans('No customers', array(), 'Admin.Stats.Feature');
                 } elseif ($value['type'] == 'female') {
-                    $value = sprintf($this->l('%d%% Female Customers', null, null, false), $value['value']);
+                    $value = sprintf($this->trans('%d%% Female Customers', array(), 'Admin.Stats.Feature'), $value['value']);
                 } elseif ($value['type'] == 'male') {
-                    $value = sprintf($this->l('%d%% Male Customers', null, null, false), $value['value']);
+                    $value = sprintf($this->trans('%d%% Male Customers', array(), 'Admin.Stats.Feature'), $value['value']);
                 } else {
-                    $value = sprintf($this->l('%d%% Neutral Customers', null, null, false), $value['value']);
+                    $value = sprintf($this->trans('%d%% Neutral Customers', array(), 'Admin.Stats.Feature'), $value['value']);
                 }
 
                 ConfigurationKPI::updateValue('CUSTOMER_MAIN_GENDER', array($this->context->language->id => $value));
@@ -645,7 +645,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
                 break;
 
             case 'avg_customer_age':
-                $value = sprintf($this->l('%d years', null, null, false), AdminStatsController::getAverageCustomerAge(), 1);
+                $value = sprintf($this->trans('%d years', array(), 'Admin.Stats.Feature'), AdminStatsController::getAverageCustomerAge(), 1);
                 ConfigurationKPI::updateValue('AVG_CUSTOMER_AGE', array($this->context->language->id => $value));
                 ConfigurationKPI::updateValue('AVG_CUSTOMER_AGE_EXPIRE', array($this->context->language->id => strtotime('+1 day')));
                 break;
@@ -657,7 +657,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
                 break;
 
             case 'avg_msg_response_time':
-                $value = sprintf($this->l('%.1f hours', null, null, false), AdminStatsController::getAverageMessageResponseTime(date('Y-m-d', strtotime('-31 day')), date('Y-m-d', strtotime('-1 day'))));
+                $value = sprintf($this->trans('%.1f hours', array(), 'Admin.Stats.Feature'), AdminStatsController::getAverageMessageResponseTime(date('Y-m-d', strtotime('-31 day')), date('Y-m-d', strtotime('-1 day'))));
                 ConfigurationKPI::updateValue('AVG_MSG_RESPONSE_TIME', $value);
                 ConfigurationKPI::updateValue('AVG_MSG_RESPONSE_TIME_EXPIRE', strtotime('+4 hour'));
                 break;
@@ -720,10 +720,10 @@ class AdminStatsControllerCore extends AdminStatsTabController
 
             case 'main_country':
                 if (!($row = AdminStatsController::getMainCountry(date('Y-m-d', strtotime('-30 day')), date('Y-m-d')))) {
-                    $value = $this->l('No orders', null, null, false);
+                    $value = $this->trans('No orders', array(), 'Admin.Stats.Feature');
                 } else {
                     $country = new Country($row['id_country'], $this->context->language->id);
-                    $value = sprintf($this->l('%d%% %s', null, null, false), $row['orders'], $country->name);
+                    $value = $this->trans('%d%% %s', array('%d%%' => $row['orders'], '%s' =>$country->name), 'Admin.Stats.Feature');
                 }
 
                 ConfigurationKPI::updateValue('MAIN_COUNTRY', array($this->context->language->id => $value));
@@ -793,7 +793,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 
                 case 'top_category':
                     if (!($id_category = AdminStatsController::getBestCategory(date('Y-m-d', strtotime('-1 month')), date('Y-m-d')))) {
-                        $value = $this->l('No category', null, null, false);
+                        $value = $this->trans('No category', array(), 'Admin.Stats.Feature');
                     } else {
                         $category = new Category($id_category, $this->context->language->id);
                         $value = $category->name;

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -136,7 +136,7 @@ class AdminThemesControllerCore extends AdminController
         if (empty($this->display)) {
             $this->page_header_toolbar_btn['import_theme'] = array(
                 'href' => self::$currentIndex.'&action=importtheme&token='.$this->token,
-                'desc' => $this->l('Add new theme', null, null, false),
+                'desc' => $this->trans('Add new theme', array(), 'Admin.Design.Feature'),
                 'icon' => 'process-icon-new'
             );
 
@@ -146,9 +146,9 @@ class AdminThemesControllerCore extends AdminController
         }
 
         if ($this->display == 'importtheme') {
-            $this->toolbar_title[] = $this->l('Import theme');
+            $this->toolbar_title[] = $this->trans('Import theme', array(), 'Admin.Design.Feature');
         } else {
-            $this->toolbar_title[] = $this->l('Theme');
+            $this->toolbar_title[] = $this->trans('Theme', array(), 'Admin.Design.Feature');
         }
 
         $title = implode(' '.Configuration::get('PS_NAVIGATION_PIPE').' ', $this->toolbar_title);
@@ -285,10 +285,10 @@ class AdminThemesControllerCore extends AdminController
                 break;
             case UPLOAD_ERR_INI_SIZE:
             case UPLOAD_ERR_FORM_SIZE:
-                $this->errors[] = $this->l('The uploaded file is too large.');
+                $this->errors[] = $this->trans('The uploaded file is too large.', array(), 'Admin.Design.Notification');
                 return false;
             default:
-                $this->errors[] = $this->l('Unknown error.');
+                $this->errors[] = $this->trans('Unknown error.', array(), 'Admin.Notifications.Error');
                 return false;
         }
 
@@ -301,7 +301,7 @@ class AdminThemesControllerCore extends AdminController
             true
         );
         if ($ext === false) {
-            $this->errors[] = $this->l('Invalid file format.');
+            $this->errors[] = $this->trans('Invalid file format.', array(), 'Admin.Design.Notification');
             return false;
         }
 
@@ -313,7 +313,7 @@ class AdminThemesControllerCore extends AdminController
             $_FILES['themearchive']['tmp_name'],
             _PS_ALL_THEMES_DIR_.$name
         )) {
-            $this->errors[] = $this->l('Failed to move uploaded file.');
+            $this->errors[] = $this->trans('Failed to move uploaded file.', array(), 'Admin.Design.Notification');
             return false;
         }
 
@@ -336,43 +336,48 @@ class AdminThemesControllerCore extends AdminController
 
         $this->fields_options = array(
             'appearance' => array(
-                'title' => $this->l('Your current theme'),
+                'title' => $this->trans('Your current theme', array(), 'Admin.Design.Feature'),
                 'icon' => 'icon-html5',
                 'tabs' => array(
-                    'logo' => $this->l('Logo'),
-                    'logo2' => $this->l('Invoice & Email Logos'),
-                    'icons' => $this->l('Icons'),
+                    'logo' => $this->trans('Logo', array(), 'Admin.Global'),
+                    'logo2' => $this->trans('Invoice & Email Logos', array(), 'Admin.Design.Feature'),
+                    'icons' => $this->trans('Icons', array(), 'Admin.Design.Feature'),
                     ),
                 'fields' => array(
                     'PS_LOGO' => array(
-                        'title' => $this->l('Header logo'),
-                        'hint' => $this->l('Will appear on main page. Recommended height: 52px. Maximum height on default theme: 65px.'),
+                        'title' => $this->trans('Header logo', array(), 'Admin.Design.Feature'),
+                        'hint' => $this->trans('Will appear on main page. Recommended height: %height%. Maximum height on default theme: %max_height%.',
+                            array(
+                                '%height%' => '52px',
+                                '%max_height%' => '65px'
+                            ),
+                            'Admin.Design.Help'),
                         'type' => 'file',
                         'name' => 'PS_LOGO',
                         'tab' => 'logo',
                         'thumb' => _PS_IMG_.Configuration::get('PS_LOGO')
                     ),
                     'PS_LOGO_MAIL' => array(
-                        'title' => $this->l('Mail logo'),
-                        'desc' => ((Configuration::get('PS_LOGO_MAIL') === false) ? '<span class="light-warning">'.$this->l('Warning: if no email logo is available, the main logo will be used instead.').'</span><br />' : ''),
-                        'hint' => $this->l('Will appear on email headers. If undefined, the header logo will be used.'),
+                        'title' => $this->trans('Mail logo', array(), 'Admin.Design.Feature'),
+                        'desc' => ((Configuration::get('PS_LOGO_MAIL') === false) ? '<span class="light-warning">'.$this->trans('Warning: if no email logo is available, the main logo will be used instead.', array(), 'Admin.Design.Notification').'</span><br />' : ''),
+                        'hint' => $this->trans('Will appear on email headers. If undefined, the header logo will be used.', array(), 'Admin.Design.Help'),
                         'type' => 'file',
                         'name' => 'PS_LOGO_MAIL',
                         'tab' => 'logo2',
                         'thumb' => (Configuration::get('PS_LOGO_MAIL') !== false && file_exists(_PS_IMG_DIR_.Configuration::get('PS_LOGO_MAIL'))) ? _PS_IMG_.Configuration::get('PS_LOGO_MAIL') : _PS_IMG_.Configuration::get('PS_LOGO')
                     ),
                     'PS_LOGO_INVOICE' => array(
-                        'title' => $this->l('Invoice logo'),
-                        'desc' => ((Configuration::get('PS_LOGO_INVOICE') === false) ? '<span class="light-warning">'.$this->l('Warning: if no invoice logo is available, the main logo will be used instead.').'</span><br />' : ''),
-                        'hint' => $this->l('Will appear on invoice headers.').' '.$this->l('Warning: you can use a PNG file for transparency, but it can take up to 1 second per page for processing. Please consider using JPG instead.'),
+                        'title' => $this->trans('Invoice logo', array(), 'Admin.Design.Feature'),
+                        'desc' => ((Configuration::get('PS_LOGO_INVOICE') === false) ? '<span class="light-warning">'.$this->trans('Warning: if no invoice logo is available, the main logo will be used instead.', array(), 'Admin.Design.Help').'</span><br />' : ''),
+                        'hint' => $this->trans('Will appear on invoice headers.', array(), 'Admin.Design.Help').' '.$this->trans('Warning: you can use a PNG file for transparency, but it can take up to 1 second per page for processing. Please consider using JPG instead.', array(), 'Admin.Design.Help'),
                         'type' => 'file',
                         'name' => 'PS_LOGO_INVOICE',
                         'tab' => 'logo2',
                         'thumb' => (Configuration::get('PS_LOGO_INVOICE') !== false && file_exists(_PS_IMG_DIR_.Configuration::get('PS_LOGO_INVOICE'))) ? _PS_IMG_.Configuration::get('PS_LOGO_INVOICE') : _PS_IMG_.Configuration::get('PS_LOGO')
                     ),
                     'PS_FAVICON' => array(
-                        'title' => $this->l('Favicon'),
-                        'hint' => $this->l('Will appear in the address bar of your web browser.'),
+                        'title' => $this->trans('Favicon', array(), 'Admin.Design.Feature'),
+                        'hint' => $this->trans('Will appear in the address bar of your web browser.', array(), 'Admin.Design.Help'),
                         'type' => 'file',
                         'name' => 'PS_FAVICON',
                         'tab' => 'icons',
@@ -385,7 +390,7 @@ class AdminThemesControllerCore extends AdminController
                 'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions')),
                 'buttons' => array(
                     'storeLink' => array(
-                        'title' => $this->l('Visit the theme catalog'),
+                        'title' => $this->trans('Visit the theme catalog', array(), 'Admin.Design.Feature'),
                         'icon' => 'process-icon-themes',
                         'href' => Tools::getCurrentUrlProtocolPrefix().'addons.prestashop.com/en/3-templates-prestashop'
                         .'?utm_source=back-office&utm_medium=theme-button'
@@ -400,8 +405,8 @@ class AdminThemesControllerCore extends AdminController
         $other_themes = $this->theme_repository->getListExcluding([$this->context->shop->theme->getName()]);
         if (!empty($other_themes)) {
             $this->fields_options['theme'] = array(
-                'title' => sprintf($this->l('Select a theme for the "%s" shop'), $this->context->shop->name),
-                'description' => (!$this->can_display_themes) ? $this->l('You must select a shop from the above list if you wish to choose a theme.') : '',
+                'title' => sprintf($this->trans('Select a theme for the "%s" shop', array(), 'Admin.Design.Feature'), $this->context->shop->name),
+                'description' => (!$this->can_display_themes) ? $this->trans('You must select a shop from the above list if you wish to choose a theme.', array(), 'Admin.Design.Help') : '',
                 'fields' => array(
                     'theme_for_shop' => array(
                         'type' => 'theme',
@@ -421,7 +426,7 @@ class AdminThemesControllerCore extends AdminController
             $helper = new HelperOptions($this);
             $this->setHelperDisplay($helper);
             $helper->toolbar_scroll = true;
-            $helper->title = $this->l('Theme appearance');
+            $helper->title = $this->trans('Theme appearance', array(), 'Admin.Design.Feature');
             $helper->toolbar_btn = array(
                 'save' => array(
                     'href' => '#',
@@ -450,14 +455,14 @@ class AdminThemesControllerCore extends AdminController
                 'form' => array(
                     'tinymce' => false,
                     'legend' => array(
-                        'title' => $this->l('Import from your computer'),
+                        'title' => $this->trans('Import from your computer', array(), 'Admin.Design.Feature'),
                         'icon' => 'icon-picture'
                     ),
                     'input' => array(
                         array(
                             'type' => 'file',
-                            'label' => $this->l('Zip file'),
-                            'desc' => $this->l('Browse your computer files and select the Zip file for your new theme.'),
+                            'label' => $this->trans('Zip file', array(), 'Admin.Design.Feature'),
+                            'desc' => $this->trans('Browse your computer files and select the Zip file for your new theme.', array(), 'Admin.Design.Help'),
                             'name' => 'themearchive'
                         ),
                     ),
@@ -472,14 +477,14 @@ class AdminThemesControllerCore extends AdminController
                 'form' => array(
                     'tinymce' => false,
                     'legend' => array(
-                        'title' => $this->l('Import from the web'),
+                        'title' => $this->trans('Import from the web', array(), 'Admin.Design.Feature'),
                         'icon' => 'icon-picture'
                     ),
                     'input' => array(
                         array(
                             'type' => 'text',
-                            'label' => $this->l('Archive URL'),
-                            'desc' => $this->l('Indicate the complete URL to an online Zip file that contains your new theme. For instance, "http://example.com/files/theme.zip".'),
+                            'label' => $this->trans('Archive URL', array(), 'Admin.Design.Feature'),
+                            'desc' => $this->trans('Indicate the complete URL to an online Zip file that contains your new theme. For instance, "http://example.com/files/theme.zip".', array(), 'Admin.Design.Help'),
                             'name' => 'themearchiveUrl'
                         ),
                     ),
@@ -506,15 +511,15 @@ class AdminThemesControllerCore extends AdminController
                 'form' => array(
                     'tinymce' => false,
                     'legend' => array(
-                        'title' => $this->l('Import from FTP'),
+                        'title' => $this->trans('Import from FTP', array(), 'Admin.Design.Feature'),
                         'icon' => 'icon-picture'
                     ),
                     'input' => array(
                         array(
                             'type' => 'select',
-                            'label' => $this->l('Select the archive'),
+                            'label' => $this->trans('Select the archive', array(), 'Admin.Design.Feature'),
                             'name' => 'theme_archive_server',
-                            'desc' => $this->l('This selector lists the Zip files that you uploaded in the \'/themes\' folder.'),
+                            'desc' => $this->trans('This selector lists the Zip files that you uploaded in the \'/themes\' folder.', array(), 'Admin.Design.Help'),
                             'options' => array(
                                 'id' => 'id',
                                 'name' => 'name',


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Add some more translation domains to back office controllers (and change a few existing ones) |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | n/a |
| How to test? | as usual |

I'm also introducing a change in the domains.
We had **Admin.Parameters** before, which included both "Shop Parameters" and "Advanced Parameters" sections. It's about 20 pages using the same domains.
To make it easier, I'm splitting **Admin.Parameters** in 2 domains:
- **Admin.ShopParameters**
- **Admin.AdvParameters**.

I'll update the Build article consequently (I've also introduced new domains along the way).

Let me know if unclear.

Thanks!
