### PR TITLE
Display 'install' on paid module when present on disk

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -145,7 +145,7 @@ class AdminModuleDataProvider implements ModuleInterface
                         $urls['upgrade']
                     );
                 }
-            } elseif (!$addon->attributes->has('origin') || in_array($addon->attributes->get('origin'), array('native', 'native_all', 'partner', 'customer'))) {
+            } elseif (!$addon->attributes->has('origin') || $addon->disk->get('is_present') == true || in_array($addon->attributes->get('origin'), array('native', 'native_all', 'partner', 'customer'))) {
                 $url_active = 'install';
                 unset(
                     $urls['uninstall'],


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When a module can be bought via the marketplace, its price is always displayed on the module page even if it is present on the disk. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? |  |
| How to test? | Copy-paste a module which has a price on the Marketplace in your disk. The button 'install' should now appear instead of its price. |
