### PR TITLE
CO: Set backtick on column name instead of whole SortOrder value

### DIFF
--- a/src/Core/Product/Search/SortOrder.php
+++ b/src/Core/Product/Search/SortOrder.php
@@ -122,11 +122,11 @@ class SortOrder
     public function toLegacyOrderBy($prefix = false)
     {
         if ($prefix) {
-            return $this->getLegacyPrefix() . $this->field;
+            return $this->getLegacyPrefix() . '`' . bqSQL($this->field) . '`';
         } elseif ($this->entity === 'manufacturer' && $this->field === 'name') {
-            return 'manufacturer_name';
+            return '`manufacturer_name`';
         } else {
-            return $this->field;
+            return '`'.bqSQL($this->field).'`';
         }
     }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Set the backtick only on the column name in the SQL request, instead of the whole value. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Get https://github.com/PrestaShop/ps_facetedsearch/pull/2 with this PR, and check the calatog page on the front office. The Database exception should not appear anymore. |
