### PR TITLE
Removed the dumped XML container (Security issue)

### DIFF
--- a/src/PrestaShopBundle/DependencyInjection/Compiler/RemoveXmlCompiledContainerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/RemoveXmlCompiledContainerPass.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop.
+ * 2007-2016 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -23,34 +23,32 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-namespace PrestaShopBundle;
+namespace PrestaShopBundle\DependencyInjection\Compiler;
 
-use PrestaShopBundle\DependencyInjection\Compiler\RemoveXmlCompiledContainerPass;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-use PrestaShopBundle\DependencyInjection\PrestaShopExtension;
-use PrestaShopBundle\DependencyInjection\DynamicRolePass;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Symfony entry point: adds Extension, that will add other stuff.
+ * Security Compiler pass: removed app{env}{..}.xml files from cache.
  */
-class PrestaShopBundle extends Bundle
+class RemoveXmlCompiledContainerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function getContainerExtension()
+    public function process(ContainerBuilder $container)
     {
-        return new PrestaShopExtension();
-    }
+        if ($container->getParameter('kernel.debug')) {
+            $filename = $container->getParameter('debug.container.dump');
+            $filesystem = new Filesystem();
 
-    /**
-     * {@inheritdoc}
-     */
-    public function build(ContainerBuilder $container)
-    {
-        $container->addCompilerPass(new DynamicRolePass());
-        $container->addCompilerPass(new RemoveXmlCompiledContainerPass(), PassConfig::TYPE_AFTER_REMOVING);
+            try {
+                $filesystem->remove($filename);
+            } catch (IOException $e) {
+                // discard chmod failure (some filesystem may not support it)
+            }
+        }
     }
 }

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2015 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -29,7 +29,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Loader\FileLoader;
 
 /**
  * Adds main PrestaShop core services to the Symfony container.


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | If PrestaShop is used with nginx, we can access to appDevDebugProjectContainer.xml file, so all the application configuration is available. So I've removed this file. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Check the existence of file in `app/cache/dev`. |

> The PHPStorm Symfony plugin won't work anymore :/ 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
