### PR TITLE
Fix unexpected JS behaviour when fixing price decimals on product page

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -250,11 +250,10 @@ function toggleMultiple(tab)
 
 function truncateDecimals(value, decimals)
 {
-  var numPower = Math.pow(10, decimals);
-
-  var value = ~~(value * numPower)/numPower;
-
-  return value.toFixed(decimals);
+    var numPower = Math.pow(10, decimals);
+    var tempNumber = value * numPower;
+    var roundedTempNumber = Math.floor(tempNumber);
+    return roundedTempNumber / numPower;
 }
 
 /**


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Changing the number of decimal for a too high float made JavaScript return a negative value. This PR fixes the issue. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1155](http://forge.prestashop.com/browse/BOOM-1155) |
| How to test? | Write a value greater than 7899 in the excluded taxes price. The all-taxes-included price should not be negative anymore. |
