### PR TITLE
Fix module install from an upload

### DIFF
--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -124,7 +124,11 @@ class ModuleManager implements AddonManagerInterface
         }
 
         if (! $this->moduleProvider->isOnDisk($name)) {
-            $this->moduleUpdater->setModuleOnDiskFromAddons($name);
+            if (!empty($source)) {
+                $this->moduleZipManager->storeInModulesFolder($source);
+            } else {
+                $this->moduleUpdater->setModuleOnDiskFromAddons($name);
+            }
         }
 
         $module = $this->moduleRepository->getModule($name);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When a module was installed from a ZIP, the module manager was only trying for it in the Marketplace, not on the temporary folder. Thanks @Shiryu75 for noticing. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Installing a module with an upload must now work. Before, it was always failing. |
