### PR TITLE
Re-add lost API call for module download from the marketplace

### DIFF
--- a/src/Adapter/Addons/AddonsDataProvider.php
+++ b/src/Adapter/Addons/AddonsDataProvider.php
@@ -60,7 +60,7 @@ class AddonsDataProvider implements AddonsInterface
 
         // Module downloading
         try {
-            $module_data = $this->request('module', $params);
+            $module_data = $this->request('module_download', $params);
         } catch (Exception $e) {
             if (!$this->isAddonsAuthenticated()) {
                 throw new Exception('Error sent by Addons. You may need to be logged.', 0, $e);
@@ -150,6 +150,14 @@ class AddonsDataProvider implements AddonsInterface
                 break;
             case 'check_module':
                 $post_data .= '&method=check&module_name='.urlencode($params['module_name']).'&module_key='.urlencode($params['module_key']);
+                break;
+            case 'module_download':
+                $post_data .= '&method=module&id_module='.urlencode($params['id_module']);
+                if (isset($params['username_addons']) && isset($params['password_addons'])) {
+                    $post_data .= '&username='.urlencode($params['username_addons']).'&password='.urlencode($params['password_addons']);
+                } else {
+                    $protocols[] = 'http';
+                }
                 break;
             case 'module':
                 return $this->marketplaceClient->getModule($params['id_module']);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR fix a misunderstanding between two API calls to the marketplace. One is supposed to get module details (in JSON), the other one the module Zip content (binary). We bring back the second one in another name. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Install a module available on the Marketplace. You should NOT have an error `Cannot store module content in temporary folder !` |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
