### PR TITLE
Product images in front office are now filtered by combination

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -482,11 +482,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
                         if (is_array($combination_images[$row['id_product_attribute']])) {
                             foreach ($combination_images[$row['id_product_attribute']] as $tmp) {
-                                if (isset($current_cover)) {
-                                    if ($tmp['id_image'] == $current_cover['id_image']) {
-                                        $combinations[$row['id_product_attribute']]['id_image'] = $id_image = (int) $tmp['id_image'];
-                                        break;
-                                    }
+                                if ($tmp['id_image'] == $current_cover['id_image']) {
+                                    $combinations[$row['id_product_attribute']]['id_image'] = $id_image = (int) $tmp['id_image'];
+                                    break;
                                 }
                             }
                         }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -476,12 +476,17 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                                 $current_cover = $image;
                             }
                         }
+                        if (!isset($current_cover)) {
+                            $current_cover = array_values($this->context->smarty->tpl_vars['product']->value['images'])[0];
+                        }
 
                         if (is_array($combination_images[$row['id_product_attribute']])) {
                             foreach ($combination_images[$row['id_product_attribute']] as $tmp) {
-                                if ($tmp['id_image'] == $current_cover['id_image']) {
-                                    $combinations[$row['id_product_attribute']]['id_image'] = $id_image = (int) $tmp['id_image'];
-                                    break;
+                                if (isset($current_cover)) {
+                                    if ($tmp['id_image'] == $current_cover['id_image']) {
+                                        $combinations[$row['id_product_attribute']]['id_image'] = $id_image = (int) $tmp['id_image'];
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -497,7 +502,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                                     $this->context->smarty->assign('images', $product_images);
                                 }
                             }
+
                             $cover = $current_cover;
+
                             if (isset($cover) && is_array($cover) && isset($product_images) && is_array($product_images)) {
                                 $product_images[$cover['id_image']]['cover'] = 0;
                                 if (isset($product_images[$id_image])) {

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -59,7 +59,16 @@ class ImageRetriever
                 $image['associatedVariants'] = [];
             }
 
-            if (in_array($productAttributeId, $image['associatedVariants'])) {
+            /* If product have combinations, we need to filter */
+            if (
+                in_array($productAttributeId, $image['associatedVariants'])
+                && count($imageToCombinations) > 0
+            ) {
+                return $image;
+            }
+            
+            /* If product have no combinations, return all images */
+            if (0 === count($imageToCombinations)) {
                 return $image;
             }
         }, $images);

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -18,6 +18,7 @@ class ImageRetriever
 
     public function getProductImages(array $product, Language $language)
     {
+        $productAttributeId = $product['id_product_attribute'];
         $productInstance = new Product(
             $product['id_product'],
             false,
@@ -42,7 +43,11 @@ class ImageRetriever
             }
         }
 
-        $images = array_map(function (array $image) use ($productInstance, $imageToCombinations) {
+        $images = array_map(function (array $image) use (
+            $productInstance,
+            $imageToCombinations,
+            $productAttributeId
+        ) {
             $image =  array_merge($this->getImage(
                 $productInstance,
                 $image['id_image']
@@ -54,10 +59,12 @@ class ImageRetriever
                 $image['associatedVariants'] = [];
             }
 
-            return $image;
+            if (in_array($productAttributeId, $image['associatedVariants'])) {
+                return $image;
+            }
         }, $images);
 
-        return $images;
+        return array_filter($images);
     }
 
     public function getImage($object, $id_image)

--- a/src/Core/Product/AbstractProductPresenter.php
+++ b/src/Core/Product/AbstractProductPresenter.php
@@ -64,8 +64,8 @@ abstract class AbstractProductPresenter
         }
 
         if (!isset($presentedProduct['cover'])) {
-            if (isset($presentedProduct['images'][0])) {
-                $presentedProduct['cover'] = $presentedProduct['images'][0];
+            if (count($presentedProduct['images']) > 0) {
+                $presentedProduct['cover'] = array_values($presentedProduct['images'])[0];
             } else {
                 $presentedProduct['cover'] = null;
             }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Previously, all images are displayed in front office, regardless the pictures choosen for each combination. Now the front office is consistent with the back office |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1023 |
| How to test? | Select images in Product with combinations, then check the front office is consistent with the back office. |

![blue_combination](https://cloud.githubusercontent.com/assets/1247388/17478263/d22fb516-5d6a-11e6-9274-f832fa31aeb1.PNG)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
