### PR TITLE
[WS] Fix fatal error when uploading product image

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -1056,7 +1056,6 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 if ($file['size'] > $this->imgMaxUploadSize) {
                     throw new WebserviceException(sprintf('The image size is too large (maximum allowed is %d KB)', ($this->imgMaxUploadSize / 1000)), array(72, 400));
                 }
-                require_once(_PS_CORE_DIR_.'/images.inc.php');
                 if ($error = ImageManager::validateUpload($file)) {
                     throw new WebserviceException('Image upload error : '.$error, array(76, 400));
                 }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The line "require_once(_PS_CORE_DIR_.'/images.inc.php');" was giving a fatal error since that file does not exist in 1.7. Removing it works fine. |
| Type? | bug fix |
| Category? | WS |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL. |
| How to test? | Please indicate how to best verify that this PR is correct. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
