### PR TITLE
Make the buttons and dropdown aligned in the module page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -14,9 +14,7 @@
         {% else %}{{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}{% endif %}
       </a>
   {% else %}
-    <div class="module-quick-action-grid">
-      <a class="btn btn-primary-reverse btn-primary-outline btn-sm light-button module_action_menu_{{ url_active }}" href="{{ urls[url_active] }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">{{ url_active|capitalize|replace({'_': " "}) }}</a>
-    </div>
+      <a class="module-quick-action-grid btn btn-primary-reverse btn-primary-outline btn-sm light-button module_action_menu_{{ url_active }}" href="{{ urls[url_active] }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">{{ url_active|capitalize|replace({'_': " "}) }}</a>
       {% if urls|length > 1 %}
           <button type="button" class="btn btn-primary-outline  btn-sm dropdown-toggle light-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="caret"></span>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | We remove an div block, which prevents a button to be stuck with a dropdown button. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | You must see your module page as follow: |

![capture du 2016-08-08 12-04-59](https://cloud.githubusercontent.com/assets/6768917/17478927/88dc4a1e-5d6f-11e6-9e2a-d1b8646b07a6.png)
