### PR TITLE
Add "No tax" option in the list of tax rules

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -80,6 +80,10 @@ class ProductPrice extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $this->tax_rules = array_merge(
+            array($this->translator->trans('No tax', [], 'Admin.Catalog.Feature') => 0),
+            $this->tax_rules
+        );
         $builder->add('price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,
             'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR adds "No tax" option in the list of tax rules, on BO Product page. Associated value is 0%. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-685 |
| How to test? | In BO, product page, try to set "No tax" either in first tab "Basic settings" or 4th tab "Pricing". |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
