### PR TITLE
Auto-fill filename input for virtual product

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -714,7 +714,7 @@ var form = (function() {
     }
     seo.onSave();
     updateMissingTranslatedNames();
-    
+
     var data = $('input, textarea, select', elem).not(':input[type=button], :input[type=submit], :input[type=reset]').serialize();
     if (target == '_blank' && redirect) {
       var openBlank = window.open('about:blank', target, '');
@@ -782,7 +782,7 @@ var form = (function() {
     $('div.translations.tabbable > div > div.tab-pane:not(.translation-label-' + iso_code + ')').removeClass('active');
     $('div.translations.tabbable > div > div.tab-pane.translation-label-' + iso_code).addClass('active');
   }
-  
+
   function updateMissingTranslatedNames() {
       var namesDiv = $('#form_step1_names');
       var defaultLanguageValue = null;
@@ -1008,6 +1008,22 @@ var virtualProduct = (function() {
               $('#form_step3_virtual_product_nb_days').val(0);
             }
           });
+        }
+      });
+
+      $('#form_step3_virtual_product_file').change(function(e) {
+        if ($(this)[0].files !== undefined) {
+          var files = $(this)[0].files;
+          var name  = '';
+
+          $.each(files, function(index, value) {
+            name += value.name + ', ';
+          });
+          $('#form_step3_virtual_product_name').val(name.slice(0, -2));
+        } else {
+          // Internet Explorer 9 Compatibility
+          var name = $(this).val().split(/[\\/]/);
+          $('#form_step3_virtual_product_name').val(name[name.length - 1]);
         }
       });
 
@@ -1674,7 +1690,7 @@ var seo = (function() {
         var id_lang = elem.attr('name').match(/\d+/g)[1];
         $('#form_step5_link_rewrite_' + id_lang).val(str2url(elem.val(), 'UTF-8'));
     };
-  
+
 
   return {
     'init': function() {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Auto fills "Filename" inputs with the name of file to be uploaded. It will prevent employees from setting a filename without extension (same behaviour as PS 1.6). |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1193 |
| How to test? | Create or edit a virtual product. In "Virtual product" tab, select a file. It should auto fill the input with filename + extension. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
