### PR TITLE
Module catalog version updated to 1.7

### DIFF
--- a/controllers/admin/AdminAddonsCatalogController.php
+++ b/controllers/admin/AdminAddonsCatalogController.php
@@ -39,7 +39,7 @@ class AdminAddonsCatalogControllerCore extends AdminController
         $iso_currency = $this->context->currency->iso_code;
         $iso_country = $this->context->country->iso_code;
         $activity = Configuration::get('PS_SHOP_ACTIVITY');
-        $addons_url = 'http://addons.prestashop.com/iframe/search-1.6.php?psVersion='._PS_VERSION_.'&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain;
+        $addons_url = 'http://addons.prestashop.com/iframe/search-1.7.php?psVersion='._PS_VERSION_.'&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain;
         $addons_content = Tools::file_get_contents($addons_url);
 
         $this->context->smarty->assign(array(


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The module catalog provided by the addons website is still the 1.6 version. This pull request update the call to get the 1.7 version. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Just go to the module catalog |
