### PR TITLE
When combination have no images, display all available for the product

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -59,21 +59,18 @@ class ImageRetriever
                 $image['associatedVariants'] = [];
             }
 
-            /* If product have combinations, we need to filter */
-            if (
-                in_array($productAttributeId, $image['associatedVariants'])
-                && count($imageToCombinations) > 0
-            ) {
-                return $image;
-            }
-            
-            /* If product have no combinations, return all images */
-            if (0 === count($imageToCombinations)) {
-                return $image;
-            }
+            return $image;
         }, $images);
 
-        return array_filter($images);
+        $filteredImages = array();
+
+        foreach ($images as $image) {
+            if (in_array($productAttributeId, $image['associatedVariants'])) {
+                $filteredImages[] = $image;
+            }
+        }
+
+        return (0 === count($filteredImages)) ? $images : $filteredImages;
     }
 
     public function getImage($object, $id_image)


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When combination have no images, display all available for the product (previously, causes a 500 error) |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Create 2 combinations with images, then a third with no images. In front office, visit each of them and check if the display is consistent with the behavior selected in back office. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
