### PR TITLE
Remove getCurrentUrtrans() typo (fix BOOM-1214).

### DIFF
--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -624,7 +624,7 @@ class AdminModulesControllerCore extends AdminController
                     } else {
                         $module->disable();
                     }
-                    Tools::redirectAdmin($this->getCurrentUrtrans('enable', array(), 'Admin.Actions'));
+                    Tools::redirectAdmin($this->trans('enable', array(), 'Admin.Actions'));
                 }
             } else {
                 $this->errors[] = Tools::displayError('Cannot load the module\'s object.');
@@ -952,7 +952,7 @@ class AdminModulesControllerCore extends AdminController
                                 $this->context->smarty->assign(array(
                                     'module' => $module,
                                     'display_multishop_checkbox' => true,
-                                    'current_url' => $this->getCurrentUrtrans('enable', array(), 'Admin.Actions'),
+                                    'current_url' => $this->trans('enable', array(), 'Admin.Actions'),
                                     'shop_context' => $shop_context,
                                 ));
                             }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | getCurrentUrtrans() seems to have been used instead of trans(). |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1214 |
| How to test? | Try to configure a module (see Forge ticket). |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
