### PR TITLE
FO : Prevent customer to view all codes 

### DIFF
--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -39,7 +39,7 @@ class DiscountControllerCore extends FrontController
     {
         parent::initContent();
 
-        $cart_rules = CartRule::getCustomerCartRules($this->context->language->id, $this->context->customer->id, true, true, true);
+        $cart_rules = CartRule::getCustomerCartRules($this->context->language->id, $this->context->customer->id, true, false, true);
         $nb_cart_rules = count($cart_rules);
 
         foreach ($cart_rules as $key => &$discount ) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | PrestaShop 1.6 (bugfixes only). |
| Description? | Prestashop 1.6.1.6, when customer logs in and go to "my vouchers", all voucher codes are listed, even the generic one. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | Does it break backward compatibility? no |
| Deprecations? | Does it deprecate an existing feature? no |
| Fixed ticket? |  |
| How to test? | Create a generic voucher codes, they should not be listed on the my voucher page. |

The discount page list all generic codes.
