### PR TITLE
Fix the no duplication of category's information in all shop languages

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -134,7 +134,7 @@ class CategoryCore extends ObjectModel
 
     public function __construct($id_category = null, $id_lang = null, $id_shop = null)
     {
-        parent::__construct((int)$id_category, (int)$id_lang, (int)$id_shop);
+        parent::__construct($id_category, $id_lang, $id_shop);
         $this->id_image = ($this->id && file_exists(_PS_CAT_IMG_DIR_.(int)$this->id.'.jpg')) ? (int)$this->id : false;
         $this->image_dir = _PS_CAT_IMG_DIR_;
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When creating a new category there's no duplication for other shop languages. Casting the id_lang when calling the ObjectModel Construct set it to 1. Problem solved by removing this cast. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-973 |
| How to test? | Just add a new category and verify that it's duplicated for all your shop languages |
