### PR TITLE
Fix undefined shipping data on virtual cart

### DIFF
--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -280,15 +280,17 @@ class CartPresenter implements PresenterInterface
 
         if (!$cart->isVirtualCart()) {
             $shippingCost = $cart->getTotalShippingCost(null, $this->includeTaxes());
-            $subtotals['shipping'] = array(
-                'type' => 'shipping',
-                'label' => $this->translator->trans('Shipping', array(), 'Shop.Theme.Checkout'),
-                'amount' => $shippingCost,
-                'value' => $shippingCost != 0
-                    ? $this->priceFormatter->format($shippingCost)
-                    : $this->translator->trans('Free', array(), 'Shop.Theme.Checkout'),
-            );
+        } else {
+            $shippingCost = 0;
         }
+        $subtotals['shipping'] = array(
+            'type' => 'shipping',
+            'label' => $this->translator->trans('Shipping', array(), 'Shop.Theme.Checkout'),
+            'amount' => $shippingCost,
+            'value' => $shippingCost != 0
+                ? $this->priceFormatter->format($shippingCost)
+                : $this->translator->trans('Free', array(), 'Shop.Theme.Checkout'),
+        );
 
         $subtotals['tax'] = null;
         if (Configuration::get('PS_TAX_DISPLAY')) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When a cart has only virtual products, adding to the cart threw a 500 HTTP error because of an undefined shipping attribute. This PR set a default value for virtual carts. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1192](http://forge.prestashop.com/browse/BOOM-1192) |
| How to test? | Add a virtual product in an **EMPTY** cart. The modal must appear successfully with a free shipping. |
