### PR TITLE
Remove the translations of Attribute and Attribute group after deleting the language

### DIFF
--- a/src/PrestaShopBundle/Entity/AttributeGroupLang.php
+++ b/src/PrestaShopBundle/Entity/AttributeGroupLang.php
@@ -22,7 +22,7 @@ class AttributeGroupLang
     /**
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="PrestaShopBundle\Entity\Lang")
-     * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false)
+     * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false, onDelete="CASCADE" )
      */
     private $lang;
 

--- a/src/PrestaShopBundle/Entity/AttributeLang.php
+++ b/src/PrestaShopBundle/Entity/AttributeLang.php
@@ -22,7 +22,7 @@ class AttributeLang
     /**
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="PrestaShopBundle\Entity\Lang")
-     * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false)
+     * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false, onDelete="CASCADE" )
      */
     private $lang;
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Error when deleting a language due to foreign keys in Attribute and AttributeGroup. Problem solved by adding onDelete CASCADE. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1075 |
| How to test? | Just delete language and all associated translations will be removed from Database. |
