### PR TITLE
Refresh KPI when needed in new BO theme

### DIFF
--- a/admin-dev/themes/new-theme/template/helpers/kpi/kpi.tpl
+++ b/admin-dev/themes/new-theme/template/helpers/kpi/kpi.tpl
@@ -24,9 +24,9 @@
 *}
 
 {if isset($href) && $href}
-  <a href="{$href|escape:'html':'UTF-8'}" id="{$id|escape:'html':'UTF-8'}" class="kpi-container">
+  <a href="{$href|escape:'html':'UTF-8'}" id="{$id|escape:'html':'UTF-8'}" class="kpi-container box-stats">
 {else}
-  <div id="{$id|escape:'html':'UTF-8'}" class="kpi-container">
+  <div id="{$id|escape:'html':'UTF-8'}" class="kpi-container box-stats">
 {/if}
   <div class="kpi-content -{$color|escape}" data-original-title="{$tooltip|escape}" data-toggle="tooltip">
     {if isset($icon) && $icon}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | A class was missing in the new BO template, preventing any refresh. The template has been updated to fix them. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-217](http://forge.prestashop.com/browse/BOOM-217) |
| How to test? | Go to the product list in the back office. The KPI must have their data up to date. |
