### PR TITLE
Fix admin tabs saving

### DIFF
--- a/controllers/admin/AdminTabsController.php
+++ b/controllers/admin/AdminTabsController.php
@@ -315,9 +315,6 @@ class AdminTabsControllerCore extends AdminController
                     break;
                 }
             }
-        } elseif (Tools::isSubmit('submitAdd'.$this->table) && ($class_name = Tools::getValue('class_name')) && !class_exists($class_name.'Controller')) {
-            $this->errors[] = sprintf(Tools::displayError('The class name \'%sController\' cannot be found.'), $class_name);
-            return parent::postProcess();
         } else {
             // Temporary add the position depend of the selection of the parent category
             if (!Tools::isSubmit('id_tab')) { // @todo Review


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | https://github.com/PrestaShop/PrestaShop/pull/4439/ introduce a bug in BO > Admin > admin Tabs, you can not now modify a tab |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Go to  BO > Admin > admin Tabs, and try to save any of tabs ( like catalog for example) |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
