### PR TITLE
Display discounts by quantity table when applied to combination

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-discounts.tpl
+++ b/themes/classic/templates/catalog/_partials/product-discounts.tpl
@@ -1,5 +1,5 @@
-{if $product.quantity_discounts}
 <section class="product-discounts">
+  {if $product.quantity_discounts}
     <h3 class="h6 product-discounts-title">{l s='Volume discounts' d='Shop.Theme.Catalog'}</h3>
     <table class="table-product-discounts">
       <thead>
@@ -19,5 +19,5 @@
       {/foreach}
       </tbody>
     </table>
+  {/if}
 </section>
-{/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Display discounts by quantity table when applied to combination |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1218 |
| How to test? | Add a specific rule on a specific combination with a price fixed if you buy - lets say - 3 products. You should see the table of discounts displayed. |

![capt](https://cloud.githubusercontent.com/assets/1247388/17590070/7988c13a-5fd8-11e6-8595-33899a4b3006.png)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
