### PR TITLE
Fix recommended modules popup on old theme

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -75,7 +75,7 @@
 		var employee_token = '{getAdminToken tab='AdminEmployees'}';
 		var choose_language_translate = '{l s='Choose language' js=1}';
 		var default_language = '{$default_language|intval}';
-		var admin_modules_link = '{$link->getAdminLink("AdminModulesSf")|addslashes}';
+		var admin_modules_link = '{$link->getAdminLink("AdminModulesSf", true, ['route' => "admin_module_catalog_post"])|addslashes}';
 		var tab_modules_list = '{if isset($tab_modules_list) && $tab_modules_list}{$tab_modules_list|addslashes}{/if}';
 		var update_success_msg = '{l s='Update successful' js=1}';
 		var errorLogin = '{l s='PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.' js=1}';

--- a/admin-dev/themes/new-theme/template/header.tpl
+++ b/admin-dev/themes/new-theme/template/header.tpl
@@ -44,7 +44,7 @@
     var employee_token = '{getAdminToken tab='AdminEmployees'}';
     var choose_language_translate = '{l s='Choose language' js=1}';
     var default_language = '{$default_language|intval}';
-    var admin_modules_link = '{$link->getAdminLink("AdminModulesSf")|addslashes}';
+    var admin_modules_link = '{$link->getAdminLink("AdminModulesSf", true, ['route' => "admin_module_catalog_post"])|addslashes}';
     var tab_modules_list = '{if isset($tab_modules_list) && $tab_modules_list}{$tab_modules_list|addslashes}{/if}';
     var update_success_msg = '{l s='Update successful' js=1}';
     var errorLogin = '{l s='PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.' js=1}';

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -528,6 +528,9 @@ class LinkCore
                 }
                 break;
             case 'AdminModulesSf':
+                if (array_key_exists('route', $sfRouteParams)) {
+                    return $sfRouter->generate($sfRouteParams['route'], array(), UrlGeneratorInterface::ABSOLUTE_URL);
+                }
                 // New architecture modification: temporary behavior to switch between old and new controllers.
                 return $sfRouter->generate('admin_module_catalog', array(), UrlGeneratorInterface::ABSOLUTE_URL);
         }

--- a/js/admin.js
+++ b/js/admin.js
@@ -1244,7 +1244,7 @@ function openModulesList()
 		header = $('#modules_list_container .modal-header').html();
 
 		$.ajax({
-			type: "POST",
+			type: "GET",
 			url : admin_modules_link,
 			async: true,
 			data : {

--- a/src/PrestaShopBundle/Resources/config/admin/routing_module.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/routing_module.yml
@@ -24,7 +24,7 @@ admin_module_catalog_refresh:
         _legacy_controller: AdminModules
 
 admin_module_catalog_post:
-    path:     /catalog
+    path:     /catalog/recommended
     methods:  [GET]
     defaults:
         _controller: PrestaShopBundle:Admin/Module:getPreferredModules


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The route method for the recommended modules has changed in #5942, which makes the ajax request fail on an HTTP error 405. Unfortunately, this PR does not implement the feature on the new toolbar. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Try to open the recommended modules on an old controller (i.e order). |
