### PR TITLE
Fixed reset behavior on Product form

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -613,6 +613,14 @@ var specificPrices = (function() {
       }
     });
   }
+  
+  /**
+   * Because all "forms" are encapsulated in a global form, we just can't use reset button
+   * Reset all subform inputs values
+   */
+  function resetForm() {
+    $('#specific_price_form input').val('');
+  }
 
   return {
     'init': function() {
@@ -622,7 +630,8 @@ var specificPrices = (function() {
         $(this).hide();
       });
 
-      $('#specific_price_form .js-cancel').click(function () {
+      $('#specific_price_form .js-cancel').click(function() {
+        resetForm();
         $('#specific-price > a').click();
         $('#specific-price .add').click().show();
         productPriceField.prop('disabled', true);
@@ -630,7 +639,7 @@ var specificPrices = (function() {
 
       $('#specific_price_form .js-save').click(function () {
         add($(this));
-        $('#specific_price_form').reset();
+        resetForm();
       });
 
       $(document).on('click', '#js-specific-price-list .js-delete', function (e) {
@@ -671,7 +680,7 @@ var specificPrices = (function() {
     },
     'refreshCombinationsList': function() {
       refreshCombinationsList();
-    }
+    },
   };
 })();
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -187,10 +187,15 @@ class ProductSpecificPrice extends CommonAbstractType
             'label' => $this->translator->trans('Apply', array(), 'Admin.Actions'),
             'attr' => array('class' => 'btn-primary-outline js-save'),
         ))
-        ->add('cancel', 'Symfony\Component\Form\Extension\Core\Type\ResetType', array(
+        ->add('cancel', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
             'label' => $this->translator->trans('Cancel', array(), 'Admin.Actions'),
             'attr' => array('class' => 'btn-default-outline js-cancel'),
         ));
+        //
+        // ResetType can't be used because the product page is wrapped
+        // inside a big form: reset a specific price form the "right" way
+        // will reset the global form.
+        //
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | We can't use button with type `reset` in product page, except if we want to reset the complete global form, this contribution is about reset the specific price rule form _only_. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | ping @vincentbz  :- ) |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
