### PR TITLE
Improved product type selector

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -63,6 +63,13 @@ var combinations = (function() {
   return {
     'init': function() {
       var _this = this;
+      var showVariationsSelector = $('#show_variations_selector input');
+      var productTypeSelector = $('#form_step1_type_product');
+      var combinationsList = $('#accordion_combinations .combination');
+
+      if (combinationsList.length > 0) {
+        productTypeSelector.prop('disabled', true);
+      }
 
       /** delete combination */
       $(document).on('click', '#accordion_combinations .delete', function(e) {
@@ -125,12 +132,16 @@ var combinations = (function() {
       });
 
       /** Combinations fields display management */
-      $('#show_variations_selector input').change(function() {
+      showVariationsSelector.change(function() {
         displayFieldsManager.refresh();
 
         if ($(this).val() === '0') {
+          // enable the top header selector
+          // we want to use a "Simple product" without any combinations
+          productTypeSelector.prop('disabled', false);
+
           //if combination(s) exists, alert user for deleting it
-          if ($('#accordion_combinations .combination').length > 0) {
+          if (combinationsList.length > 0) {
             modalConfirmation.create(translate_javascripts['Are you sure to disable variations ? they will all be deleted'], null, {
               onCancel: function() {
                 $('#show_variations_selector input[value="1"]').attr('checked', true);
@@ -141,7 +152,7 @@ var combinations = (function() {
                   type: 'GET',
                   url: $('#accordion_combinations').attr('data-action-delete-all') + '/' + $('#form_id_product').val(),
                   success: function(response) {
-                    $('#accordion_combinations .combination').remove();
+                    combinationsList.remove();
                     displayFieldsManager.refresh();
                   },
                   error: function(response) {
@@ -151,6 +162,10 @@ var combinations = (function() {
               }
             }).show();
           }
+        }else {
+          // this means we have or we want to have combinations
+          // disable the product type selector
+          productTypeSelector.prop('disabled', true);
         }
       });
 

--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -136,15 +136,11 @@ var combinations = (function() {
         displayFieldsManager.refresh();
 
         if ($(this).val() === '0') {
-          // enable the top header selector
-          // we want to use a "Simple product" without any combinations
-          productTypeSelector.prop('disabled', false);
-
           //if combination(s) exists, alert user for deleting it
           if (combinationsList.length > 0) {
             modalConfirmation.create(translate_javascripts['Are you sure to disable variations ? they will all be deleted'], null, {
               onCancel: function() {
-                $('#show_variations_selector input[value="1"]').attr('checked', true);
+                $('#show_variations_selector input[value="1"]').prop('checked', true);
                 displayFieldsManager.refresh();
               },
               onContinue: function() {
@@ -159,6 +155,9 @@ var combinations = (function() {
                     showErrorMessage(jQuery.parseJSON(response.responseText).message);
                   },
                 });
+                // enable the top header selector
+                // we want to use a "Simple product" without any combinations
+                productTypeSelector.prop('disabled', false);
               }
             }).show();
           }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Disallow the product type selector when the product have combinations, because combinations are only available for a standard product. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-621 |
| How to test? | Create a product and generate some combinations, the selector in the header should be disabled. If you change the option in Combinations selector and select "Simple product option", you can delete all combinations and the product type selector will be available. |

![capt](https://cloud.githubusercontent.com/assets/1247388/17622789/b5412b08-609c-11e6-8467-05f845a777b8.png)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
