### PR TITLE
Registered Localization cache warmer

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -36,7 +36,7 @@ ServiceLocator::setServiceContainerInstance($container);
 if (!file_exists(_PS_CACHE_DIR_)) {
     @mkdir(_PS_CACHE_DIR_);
     $warmer = new CacheWarmerAggregate([
-        new PrestaShopBundle\Cache\LocalizationWarmer(_PS_VERSION_, 'en') //@replace hard-coded Lang
+        new PrestaShopBundle\Cache\LocalizationCacheWarmer(_PS_VERSION_, 'en') //@replace hard-coded Lang
     ]);
     $warmer->warmUp(_PS_CACHE_DIR_);
 }

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -28,11 +28,20 @@ services:
     prestashop.security.role.dynamic_role_hierarchy:
         class:      PrestaShopBundle\Security\Role\DynamicRoleHierarchy
 
-
     prestashop.service.product:
         class: PrestaShopBundle\Service\ProductService
         arguments:
             - "@prestashop.adapter.data_provider.product"
+
+
+    # CACHE WARMERS
+    prestashop.localization.cache_warmer:
+        class: PrestaShopBundle\Cache\LocalizationCacheWarmer
+        arguments:
+          - "@=service('prestashop.adapter.data_provider.country').getIsoCodebyId()"
+          - "@filesystem"
+        tags:
+            - { name: kernel.cache_warmer }
 
     # Interfaced services to decorate
     prestashop.core.data_provider.stock_interface:


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This cache warmup is used to store in cache an updated version of localization file provided during the installation of PrestaShop (by locale) |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | You can see a `17en.xml` or `17fr.xml` file in `cache/sandbox` folder. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
