### PR TITLE
Fix id_carrier check on module

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3028,7 +3028,7 @@ class CartCore extends ObjectModel
             $module = Module::getInstanceByName($module_name);
 
             if (Validate::isLoadedObject($module)) {
-                if (array_key_exists('id_carrier', $module)) {
+                if (property_exists($module, 'id_carrier')) {
                     $module->id_carrier = $carrier->id;
                 }
                 if ($carrier->need_range) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `develop` |
| Description? | Should use `property_exists` instead of `array_key_exists`. The current "hack" somehow still works, but we aren't checking an array, but rather an object instead. In order to future-proof the code we should use the right method. I even consider it a bug, because by the grace of PHP it still works, but this could end one day :wink: |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | N/A |
| How to test? | Generate a CarrierModule @ https://validator.prestashop.com and check if the module still works |
