### PR TITLE
Include CMS category index in URL

### DIFF
--- a/controllers/admin/AdminCmsContentController.php
+++ b/controllers/admin/AdminCmsContentController.php
@@ -113,6 +113,8 @@ class AdminCmsContentControllerCore extends AdminController
                     $cat_bar_index = preg_replace('/&'.$tab.'Orderby=([a-z _]*)&'.$tab.'Orderway=([a-z]*)/i', '', self::$currentIndex);
                 }
             }
+            // Include CMS category index in URL (in order to maintain it when reordering list of CMS pages)
+            self::$currentIndex .= '&id_cms_category='.(int)$id_cms_category;            
             $this->context->smarty->assign(array(
                 'cms_breadcrumb' => getPath($cat_bar_index, $id_cms_category, '', '', 'cms'),
                 'page_header_toolbar_btn' => $this->page_header_toolbar_btn,


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Include CMS category index in URL ($currentIndex) in order to maintain the current CMS category when reordering list of CMS pages when seeing a single (non root) CMS category |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | (none) |
| How to test? | Go to CMS pages admin; select a single CMS category with pages in it; try to reorder the list of available pages using the up/down arrows => should stay in the same CMS category |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/6014)
<!-- Reviewable:end -->
