### PR TITLE
Fix Addons catalog display & call the 1.7 themes API

### DIFF
--- a/admin-dev/themes/new-theme/template/controllers/addons_catalog/content.tpl
+++ b/admin-dev/themes/new-theme/template/controllers/addons_catalog/content.tpl
@@ -1,0 +1,29 @@
+{*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+* @author    PrestaShop SA <contact@prestashop.com>
+* @copyright 2007-2015 PrestaShop SA
+* @license   http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+* International Registered Trademark & Property of PrestaShop SA
+*}
+{if $display_addons_content}
+	{$addons_content}
+{else}
+	<iframe class="clearfix" style="margin:0px;padding:0px;width:100%;height:920px;overflow:hidden;border:none" src="//addons.prestashop.com/iframe/search.php?isoLang={$iso_lang}&amp;isoCurrency={$iso_currency}&amp;isoCountry={$iso_country}&amp;parentUrl={$parent_domain}"></iframe>
+{/if}

--- a/admin-dev/themes/new-theme/template/controllers/addons_catalog/index.php
+++ b/admin-dev/themes/new-theme/template/controllers/addons_catalog/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../');
+exit;

--- a/controllers/admin/AdminAddonsCatalogController.php
+++ b/controllers/admin/AdminAddonsCatalogController.php
@@ -29,7 +29,7 @@ class AdminAddonsCatalogControllerCore extends AdminController
     public function __construct()
     {
         $this->bootstrap = true;
-        parent::__construct();
+        parent::__construct('', 'new-theme');
     }
 
     public function initContent()
@@ -52,5 +52,21 @@ class AdminAddonsCatalogControllerCore extends AdminController
         ));
 
         parent::initContent();
+    }
+
+    /**
+     * Prevent the requirement of a not displayed template helper
+     */
+    protected function initTabModuleList()
+    {
+        return true;
+    }
+
+    /**
+     * Prevent the requirement of a not displayed template helper
+     */
+    public function renderModulesList($tracking_source = false)
+    {
+        return true;
     }
 }

--- a/controllers/admin/AdminThemesCatalogController.php
+++ b/controllers/admin/AdminThemesCatalogController.php
@@ -39,7 +39,7 @@ class AdminThemesCatalogControllerCore extends AdminController
         $iso_currency = $this->context->currency->iso_code;
         $iso_country = $this->context->country->iso_code;
         $activity = Configuration::get('PS_SHOP_ACTIVITY');
-        $addons_url = 'http://addons.prestashop.com/iframe/search-1.6.php?psVersion='._PS_VERSION_.'&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain.'&onlyThemes=1';
+        $addons_url = 'http://addons.prestashop.com/iframe/search-1.7.php?psVersion='._PS_VERSION_.'&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain.'&onlyThemes=1';
         $addons_content = Tools::file_get_contents($addons_url);
 
         $this->context->smarty->assign(array(

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -198,7 +198,7 @@ class AdminThemesControllerCore extends AdminController
         $iso_currency = $this->context->currency->iso_code;
         $iso_country = $this->context->country->iso_code;
         $activity = Configuration::get('PS_SHOP_ACTIVITY');
-        $addons_url = Tools::getCurrentUrlProtocolPrefix().'addons.prestashop.com/iframe/search-1.6.php?psVersion='._PS_VERSION_.'&onlyThemes=1&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain;
+        $addons_url = Tools::getCurrentUrlProtocolPrefix().'addons.prestashop.com/iframe/search-1.7.php?psVersion='._PS_VERSION_.'&onlyThemes=1&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain;
 
         die(Tools::file_get_contents($addons_url));
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Call the right Addons API for themes catalog and use the new BO theme to display modules catalog in order to be able to use the UI Kit. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
