### PR TITLE
Adding tooltip to minimum quantity field

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -102,7 +102,7 @@ class ProductQuantity extends CommonAbstractType
             ))
             ->add('minimal_quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
                 'required' => true,
-                'label' => $this->translator->trans('Minimum quantity', array(), 'Admin.Catalog.Feature'),
+                'label' => $this->translator->trans('Minimum quantity for sale', array(), 'Admin.Catalog.Feature'),
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Type(array('type' => 'numeric')),

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -342,6 +342,8 @@
                           </div>
                           <div class="col-md-4">
                             <label class="form-control-label">{{ form.step3.minimal_quantity.vars.label }}</label>
+                            <span class="help-box" data-toggle="popover"
+                                  data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" ></span>
                             {{ form_errors(form.step3.minimal_quantity) }}
                             {{ form_widget(form.step3.minimal_quantity) }}
                           </div>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Adding a tooltip to minimum quantity field when adding a new simple product |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1100 |
| How to test? | Just add a new simple product and open tab Quantities |
