### PR TITLE
Fixed translations tree

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -206,8 +206,7 @@ class TranslationsController extends FrameworkBundleAdminController
                 $subtree = &$subtree[$subdomain];
             }
 
-            $subtree = $messages;
-            $subtree['__camelized_domain'] = $domain;
+            $subtree['__messages'] = array($domain => $messages);
         }
 
         return $translationsTree;

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -92,7 +92,7 @@ class TranslationsController extends FrameworkBundleAdminController
             $translation = new Translation;
             $translation->setDomain($requestParams['domain']);
             $translation->setLang($lang);
-            $translation->setKey($requestParams['translation_key']);
+            $translation->setKey(htmlspecialchars_decode($requestParams['translation_key'], ENT_QUOTES));
             $translation->setTranslation($requestParams['translation_value']);
         } else {
             $translation->setTranslation($requestParams['translation_value']);

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -117,18 +117,10 @@ class TranslationsController extends FrameworkBundleAdminController
      */
     protected function clearCache()
     {
-        $realCacheDir = $this->container->getParameter('kernel.cache_dir');
-        $oldCacheDir = substr($realCacheDir, 0, -1).('~' === substr($realCacheDir, -1) ? '+' : '~');
-        $filesystem = $this->container->get('filesystem');
+        $cacheRefresh = $this->container->get('prestashop.cache.refresh');
 
         try {
-            if ($filesystem->exists($oldCacheDir)) {
-                $filesystem->remove($oldCacheDir);
-            }
-
-            $this->container->get('cache_clearer')->clear($realCacheDir);
-            $filesystem->rename($realCacheDir, $oldCacheDir);
-            $filesystem->remove($oldCacheDir);
+            $cacheRefresh->execute();
         } catch (\Exception $exception) {
             $this->container->get('logger')->error($exception->getMessage());
         }

--- a/src/PrestaShopBundle/Entity/Translation.php
+++ b/src/PrestaShopBundle/Entity/Translation.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * Translation
  *
- * @ORM\Table(indexes={@ORM\Index(name="key_domain", columns={"key", "domain"})})
+ * @ORM\Table(indexes={@ORM\Index(name="key", columns={"domain"})})
  * @ORM\Entity(repositoryClass="TranslationRepository")
  */
 class Translation
@@ -24,14 +24,14 @@ class Translation
     /**
      * @var string
      *
-     * @ORM\Column(name="`key`", type="string")
+     * @ORM\Column(name="`key`", type="text")
      */
     private $key;
 
     /**
      * @var string
      *
-     * @ORM\Column(name="translation", type="string")
+     * @ORM\Column(name="translation", type="text")
      */
     private $translation;
 

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -14,6 +14,13 @@ services:
         tags:
             - { name: kernel.cache_warmer }
 
+    prestashop.cache.refresh:
+        class: PrestaShopBundle\Service\Cache\Refresh
+        arguments:
+            - "%kernel.environment%"
+        calls:
+            - [addCacheClear, []]
+
     prestashop.database.naming_strategy:
         class: PrestaShopBundle\Service\Database\DoctrineNamingStrategy
         arguments: ["%database_prefix%"]

--- a/src/PrestaShopBundle/Twig/TranslationsExtension.php
+++ b/src/PrestaShopBundle/Twig/TranslationsExtension.php
@@ -108,7 +108,7 @@ class TranslationsExtension extends \Twig_Extension
 
                 $output .= $this->render('form-edit-message.html.twig',
                     array(
-                        'default_translation_value' => $defaultTranslationValue,
+                        'default_translation_value' => htmlspecialchars($defaultTranslationValue, ENT_QUOTES),
                         'domain' => $domain,
                         'edited_translation_value' => $translationValue,
                         'error_message' => $errorMessage,
@@ -116,7 +116,7 @@ class TranslationsExtension extends \Twig_Extension
                         'label_reset' => $resetLabel,
                         'locale' => $locale,
                         'success_message' => $successMessage,
-                        'translation_key' => $translationKey,
+                        'translation_key' => htmlspecialchars($translationKey, ENT_QUOTES),
                     )
                 );
 

--- a/src/PrestaShopBundle/Twig/TranslationsExtension.php
+++ b/src/PrestaShopBundle/Twig/TranslationsExtension.php
@@ -285,6 +285,11 @@ class TranslationsExtension extends \Twig_Extension
         if ($id) {
             $openingTag = '<span id="_' . $id . '">';
             $closingTag = '</span>';
+
+            if (2 === $level) {
+                $openingTag = '<h2>' . $openingTag;
+                $closingTag = $closingTag . '</h2>';
+            }
         }
 
         return $openingTag . $subject . $closingTag;

--- a/src/PrestaShopBundle/Twig/TranslationsExtension.php
+++ b/src/PrestaShopBundle/Twig/TranslationsExtension.php
@@ -87,8 +87,10 @@ class TranslationsExtension extends \Twig_Extension
 
             $editLabel = $this->translator->trans('Edit', array(), 'AdminActions', 'en-US');
             $resetLabel = $this->translator->trans('Reset', array(), 'AdminActions', 'en-US');
-            $successMessage = 'Translation successfully edited';
-            $errorMessage = 'Translation unsuccessfully edited';
+            $successMessage = $this->translator->trans('Translation successfully edited', array(),
+                'AdminNotificationsSuccess', 'en-US');
+            $errorMessage = $this->translator->trans('Translation unsuccessfully edited', array(),
+                'AdminNotificationsError', 'en-US');
 
             $formIndex = 0;
             $pageIndex = 1;
@@ -186,8 +188,8 @@ class TranslationsExtension extends \Twig_Extension
 
         if ($hasMessagesSubtree) {
             $output .= $this->render('button-toggle-messages-visibility.html.twig', array(
-                'label_show_messages' => 'Show messages',
-                'label_hide_messages' => 'Hide messages'
+                'label_show_messages' => $this->translator->trans('Show messages', array(), 'AdminActions', 'en-US'),
+                'label_hide_messages' => $this->translator->trans('Hide messages', array(), 'AdminActions', 'en-US')
             ));
 
             $output .= $this->getNavigation($this->parseDomain($subtree));
@@ -200,7 +202,7 @@ class TranslationsExtension extends \Twig_Extension
         if ($hasMessagesSubtree) {
             $output .= $this->render('button-go-to-pagination-bar.html.twig', array(
                 'domain' => $id,
-                'label' => 'Go to previous navigation menu',
+                'label' => $this->translator->trans('Go to previous navigation menu', array(), 'AdminActions', 'en-US'),
             ));
 
             // Close div with translation-domain class


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Some translations domains were missing from the back-office (International > Traductions). Some translations values were truncated. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Domains containing multiple words should not be split into multiple domains of the translations tree. No translation value should be truncated after edition. |
