### PR TITLE
Drop ALL the tables during install, even with foreign key contraints

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2024,13 +2024,6 @@ CREATE TABLE `PREFIX_cms_shop` (
 	KEY `id_shop` (`id_shop`)
 ) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8 COLLATION;
 
-CREATE TABLE `PREFIX_lang_shop` (
-`id_lang` INT( 11 ) UNSIGNED NOT NULL,
-`id_shop` INT( 11 ) UNSIGNED NOT NULL,
-  PRIMARY KEY (`id_lang`, `id_shop`),
-	KEY `id_shop` (`id_shop`)
-) ENGINE=ENGINE_TYPE  DEFAULT CHARSET=utf8 COLLATION;
-
 CREATE TABLE `PREFIX_currency_shop` (
 `id_currency` INT( 11 ) UNSIGNED NOT NULL,
 `id_shop` INT( 11 ) UNSIGNED NOT NULL,

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -269,6 +269,7 @@ class InstallModelInstall extends InstallAbstractModel
     public function clearDatabase($truncate = false)
     {
         $instance = Db::getInstance();
+        $instance->execute('SET FOREIGN_KEY_CHECKS=0');
         $sqlRequest = (($truncate) ? 'TRUNCATE' : 'DROP TABLE');
         foreach ($instance->executeS('SHOW TABLES') as $row) {
             $table = current($row);
@@ -277,6 +278,7 @@ class InstallModelInstall extends InstallAbstractModel
             }
         }
         $instance->execute(rtrim($sqlRequest, ','));
+        $instance->execute('SET FOREIGN_KEY_CHECKS=1');
     }
 
     /**

--- a/src/PrestaShopBundle/Entity/Lang.php
+++ b/src/PrestaShopBundle/Entity/Lang.php
@@ -76,11 +76,29 @@ class Lang
      * @ORM\Column(name="is_rtl", type="boolean")
      */
     private $isRtl;
-    
+
     /**
      * @ORM\OneToMany(targetEntity="Translation", mappedBy="lang")
      */
     private $translations;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="PrestaShopBundle\Entity\Shop", cascade={"remove", "persist"})
+     * @ORM\JoinTable(
+     *      joinColumns={@ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", onDelete="CASCADE")},
+     *      inverseJoinColumns={@ORM\JoinColumn(name="id_shop", referencedColumnName="id_shop")}
+     * )
+     *
+     */
+    private $shops;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->shops = new ArrayCollection();
+    }
 
     /**
      * Get id
@@ -259,9 +277,9 @@ class Lang
     {
         return $this->isRtl;
     }
-    
+
     /**
-     * 
+     *
      * @return string
      */
     public function getLocale()
@@ -270,14 +288,48 @@ class Lang
     }
 
     /**
-     * 
+     *
      * @param string $locale
      * @return Lang
      */
     public function setLocale($locale)
     {
         $this->locale = $locale;
-        
+
         return $this;
+    }
+
+    /**
+     * Add shop
+     *
+     * @param \PrestaShopBundle\Entity\Shop $shop
+     *
+     * @return Attribute
+     */
+    public function addShop(\PrestaShopBundle\Entity\Shop $shop)
+    {
+        $this->shops[] = $shop;
+
+        return $this;
+    }
+
+    /**
+     * Remove shop
+     *
+     * @param \PrestaShopBundle\Entity\Shop $shop
+     */
+    public function removeShop(\PrestaShopBundle\Entity\Shop $shop)
+    {
+        $this->shops->removeElement($shop);
+    }
+
+    /**
+     * Get shops
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getShops()
+    {
+        return $this->shops;
     }
 }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When you reinstalled PrestaShop, even if you checked "Drop database", three tables were not deleted due to foreign key contraints. It's now solved. In the same time, I moved the `ps_lang_shop` to Doctrine. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Just install PrestaShop twice with the same database and check if you can change language in Front Office. |
