### PR TITLE
Fix trans() parameters number in AdminStores

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -71,7 +71,7 @@ class AdminStoresControllerCore extends AdminController
 
         $this->fields_options = array(
             'general' => array(
-                'title' => $this->trans('Parameters', 'Admin.ShopParameters.Feature'),
+                'title' => $this->trans('Parameters', array(), 'Admin.ShopParameters.Feature'),
                 'fields' => array(
                     'PS_STORES_DISPLAY_FOOTER' => array(
                         'title' => $this->trans('Display in the footer', array(), 'Admin.ShopParameters.Feature'),


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix trans() parameters number in AdminStores |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1232 |
| How to test? | Just go to the page 😉 |
