### PR TITLE
CO: Fix $with_quotes ignored for empty dates in ObjectModel::formatValue

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -396,7 +396,7 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
 
             case self::TYPE_DATE:
                 if (!$value) {
-                    return '0000-00-00';
+                    $value = '0000-00-00';
                 }
 
                 if ($with_quotes) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | $with_quotes argument is ignored when a date is empty in ObjectModel::formatValue |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | look at the code |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
