### PR TITLE
Fix $with_quotes ignored in ObjectModel::formatValue

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -396,7 +396,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
             case self::TYPE_DATE:
                 if (!$value) {
-                    return '0000-00-00';
+                    $value = '0000-00-00';
                 }
 
                 if ($with_quotes) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | $with_quotes argument is ignored when a date is empty in ObjectModel::formatValue |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | look at the code |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

See #6034 for discussion about this PR
