### PR TITLE
Fix the discount amount in product details page

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4299,7 +4299,7 @@ class ProductCore extends ObjectModel
         }
 
         // Tax
-        $usetax = Tax::excludeTaxeOption();
+        $usetax = !Tax::excludeTaxeOption();
 
         $cache_key = $row['id_product'].'-'.$id_product_attribute.'-'.$id_lang.'-'.(int)$usetax;
         if (isset($row['id_product_pack'])) {

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -118,7 +118,7 @@ class ProductPresenter
             $presentedProduct['discount_percentage_absolute'] = round(100 * $product['specific_prices']['reduction']).'%';
             // TODO: Fix issue with tax calculation
             $presentedProduct['discount_amount'] = $this->priceFormatter->format(
-                $product['specific_prices']['reduction']
+                $product['reduction']
             );
             $regular_price = $product['price_without_reduction'];
         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In FO, when a product has a discount, the label "SAVE X€" that explain the discount amount is always Tax excluded. Fixed by getting the right PS_TAX. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1209 |
| How to test? | Just open a product details which have a discount (€) tax excluded. |
