### PR TITLE
Speed up AdminStatsControllerCore::getVisits() time by 30%

### DIFF
--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -58,21 +58,21 @@ class AdminStatsControllerCore extends AdminStatsTabController
         } else {
             if ($granularity == 'day') {
                 $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
-				SELECT LEFT(`date_add`, 10) as date, COUNT('.($unique ? 'DISTINCT id_guest' : '*').') as visits
+				SELECT date(`date_add`) as date, COUNT('.($unique ? 'DISTINCT id_guest' : '*').') as visits
 				FROM `'._DB_PREFIX_.'connections`
 				WHERE `date_add` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59"
 				'.Shop::addSqlRestriction().'
-				GROUP BY LEFT(`date_add`, 10)');
+				GROUP BY date(`date_add`)');
                 foreach ($result as $row) {
                     $visits[strtotime($row['date'])] = $row['visits'];
                 }
             } elseif ($granularity == 'month') {
                 $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
-				SELECT LEFT(`date_add`, 7) as date, COUNT('.($unique ? 'DISTINCT id_guest' : '*').') as visits
+				SELECT LEFT(LAST_DAY(`date_add`)) as date, COUNT('.($unique ? 'DISTINCT id_guest' : '*').') as visits
 				FROM `'._DB_PREFIX_.'connections`
 				WHERE `date_add` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59"
 				'.Shop::addSqlRestriction().'
-				GROUP BY LEFT(`date_add`, 7)');
+				GROUP BY LAST_DAY(`date_add`)');
                 foreach ($result as $row) {
                     $visits[strtotime($row['date'].'-01')] = $row['visits'];
                 }

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -68,7 +68,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
                 }
             } elseif ($granularity == 'month') {
                 $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
-				SELECT LEFT(LAST_DAY(`date_add`)) as date, COUNT('.($unique ? 'DISTINCT id_guest' : '*').') as visits
+				SELECT LEFT(LAST_DAY(`date_add`), 7) as date, COUNT('.($unique ? 'DISTINCT id_guest' : '*').') as visits
 				FROM `'._DB_PREFIX_.'connections`
 				WHERE `date_add` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59"
 				'.Shop::addSqlRestriction().'


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | By using date functions instead of string functions to do "GROUP BY", speed up getVisits() by about 30%. (benchmarked with MariaDB 10.0, with ~140k entries in the connections table.) |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | - |
| How to test? | - |
