### PR TITLE
Made footer compatible with legal compliance module

### DIFF
--- a/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -1,7 +1,7 @@
-<div class="col-md-6 links">
+<div class="col-md-4 links">
   <div class="row">
   {foreach $linkBlocks as $linkBlock}
-    <div class="col-md-4 wrapper">
+    <div class="col-md-6 wrapper">
       <h3 class="h3 hidden-sm-down">{$linkBlock.title}</h3>
       {assign var=_expand_id value=10|mt_rand:100000}
       <div class="title clearfix hidden-md-up" data-target="#footer_sub_menu_{$_expand_id}" data-toggle="collapse">


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | "develop" |
| Description? | Fix footer broken after installation of legal compliance module |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1129 |
| How to test? | Install legal compliance module and check footer integration See also https://github.com/PrestaShop/ps_linklist/pull/16 and https://github.com/PrestaShop/ps_legalcompliance/pull/21 |
