### PR TITLE
Disable SmartyDev in BO

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -28,7 +28,7 @@ define('_PS_SMARTY_DIR_', _PS_VENDOR_DIR_.'prestashop/smarty/');
 global $smarty;
 if (Configuration::get('PS_SMARTY_LOCAL')) {
     $smarty = new SmartyCustom();
-} elseif (_PS_MODE_DEV_) {
+} elseif (_PS_MODE_DEV_ && !defined('_PS_ADMIN_DIR_')) {
     $smarty = new SmartyDev();
 } else {
     $smarty = new Smarty();


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | We had to remove the name in the template printed in the dom in BO since it was breaking many ajax call. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1180 |
| How to test? | Try to complete a BO order |
