### PR TITLE
Duplicate entry insert to specific price table when duplicating product 

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -155,7 +155,9 @@ class SpecificPriceCore extends ObjectModel
 			FROM `'._DB_PREFIX_.'specific_price`
 			WHERE `id_product` = '.(int)$id_product.'
 			AND id_product_attribute='.(int)$id_product_attribute.'
-			AND id_cart='.(int)$id_cart);
+			AND id_cart='.(int)$id_cart.'
+            AND id_specific_price_rule = 0'
+           );
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.x |
| Description? | Duplicate entry insert to specific price table when duplicating product <br/> the error looks like "Duplicate entry ‘1034-0-0-0-2016-07-21 00:00:00-2016-08-31 00:00:00-1-0-0-0-0-1-2’ for key ‘id_product_2’  " |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | yes |
| Deprecations? | no |
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL. |
| How to test? | create a "Catalog Price Rules" then duplicating a product |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
