### PR TITLE
Only send real file to copy() on CLDR install

### DIFF
--- a/src/Core/Cldr/Update.php
+++ b/src/Core/Cldr/Update.php
@@ -162,7 +162,7 @@ class Update extends Repository
         $files = @scandir($rootPath.'supplemental');
 
         foreach ($files as $file) {
-            if ($file != '.' && $file != '..') {
+            if (is_file($file)) {
                 $newFileName = 'supplemental--'.pathinfo($file)['filename'];
                 if (!file_exists($this->cldrCacheFolder.DIRECTORY_SEPARATOR.$newFileName)) {
                     copy(
@@ -188,7 +188,7 @@ class Update extends Repository
             return;
         }
         foreach ($files as $file) {
-            if ($file != '.' && $file != '..') {
+            if (is_file($file)) {
                 $newFileName = 'main--'.$locale.'--'.pathinfo($file)['filename'];
                 if (!file_exists($this->cldrCacheFolder . DIRECTORY_SEPARATOR . $newFileName)) {
                     copy(


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Install can fail if /translations/cldr/datas/*/ directory contains any other directory (like .AppleDouble for example).<br/>Instead of excluding directory like ".'" or "..", we should check if it's a real file. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Clone repo using the current develop branch, go to the Apple Finder and browse PS directory, try to install (fail at step 3). |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
