### PR TITLE
Fixed infinitely spinning save buttons in product admin edit/create

### DIFF
--- a/js/admin/products.js
+++ b/js/admin/products.js
@@ -183,7 +183,7 @@ function ProductTabsManager(){
 					clearTimeout(tabs_running_timeout);
 					return false;
 				}
-				else if (!self.has_error_loading_tabs && (self.stack_done.length === self.tabs_to_preload.length)) {
+				else if (!self.has_error_loading_tabs) {
 						$('[name="submitAddproductAndStay"]').each(function() {
 							$(this).prop('disabled', false).find('i').removeClass('process-icon-loading').addClass('process-icon-save');
 						});


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

This is a port of of @vnikiti's #5949 to the `1.6.1.x` branch.

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This pull request fixes an infinite spinning Save button on product admin reported in multiple PrestaShop forum thread and StackOverflow: http://stackoverflow.com/questions/34726844/prestashop-endless-spinning-product-save-button |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | n/a |
| How to test? | Go to product admin and try to add a product. Make sure that product save button is not disabled and not spinning. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
