### PR TITLE
Update theme layout to handle columns

### DIFF
--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -34,20 +34,19 @@
             </div>
           {/block}
 
-          {block name="right_column"}
-            <div id="right-column" class="col-xs-12 col-sm-8 col-md-9">
-              {hook h="displayRightColumn"}
-            </div>
-          {/block}
-
           {block name="content_wrapper"}
-            <div id="content-wrapper" class="left-column right-column">
+            <div id="content-wrapper" class="left-column right-column col-sm-4 col-md-6">
               {block name="content"}
                 <p>Hello world! This is HTML5 Boilerplate.</p>
               {/block}
             </div>
           {/block}
 
+          {block name="right_column"}
+            <div id="right-column" class="col-xs-12 col-sm-4 col-md-3">
+              {hook h="displayRightColumn"}
+            </div>
+          {/block}
         </div>
       </section>
 

--- a/themes/classic/templates/layouts/layout-right-column.tpl
+++ b/themes/classic/templates/layouts/layout-right-column.tpl
@@ -3,7 +3,7 @@
 {block name='left_column'}{/block}
 
 {block name='content_wrapper'}
-  <div id="content-wrapper" class="right-column">
+  <div id="content-wrapper" class="right-column col-xs-12 col-sm-8 col-md-9">
     {block name='content'}
       <p>Hello world! This is HTML5 Boilerplate.</p>
     {/block}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The bootstrap grid was not properly applied on two theme layouts (layout-both-columns and layout-right-column). This PR fixes the issue |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1115](http://forge.prestashop.com/browse/BOOM-1115) |
| How to test? | See below and the forge issue |
### How to test

Enable i.e. the 3 columns layout.
![capture du 2016-08-23 18-42-20](https://cloud.githubusercontent.com/assets/6768917/17900902/7b8447f6-6961-11e6-9918-98cbb36861ab.png)

See a working result with 3 visible columns:
Before:
![capture du 2016-08-23 18-38-42](https://cloud.githubusercontent.com/assets/6768917/17900933/9beda2b2-6961-11e6-9a30-14b42e09da1a.png)

After:
![capture du 2016-08-23 18-38-13](https://cloud.githubusercontent.com/assets/6768917/17900939/a4242104-6961-11e6-8e3b-fbcc4905c3b5.png)
