### PR TITLE
Prevent display of payment return if empty

### DIFF
--- a/themes/classic/templates/checkout/order-confirmation.tpl
+++ b/themes/classic/templates/checkout/order-confirmation.tpl
@@ -63,6 +63,7 @@
     </div>
   </section>
 
+  {if ! empty($HOOK_PAYMENT_RETURN)}
   <section id="content-hook_payment_return" class="card definition-list">
     <div class="card-block">
       <div class="row">
@@ -72,6 +73,7 @@
       </div>
     </div>
   </section>
+  {/if}
 
   {if $customer.is_guest}
     <div id="registration-form" class="card">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | It should prevent display of payment return block if empty |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1203 |
| How to test? | Having `ps_wirepayment` module with payment invite display disabled, the payment return block should be empty. |

See also 
https://github.com/PrestaShop/ps_wirepayment/pull/2
https://github.com/PrestaShop/ps_legalcompliance/pull/23 
