### PR TITLE
Restored Smarty legacy functions for pdf

### DIFF
--- a/classes/controller/PdfFrontController.php
+++ b/classes/controller/PdfFrontController.php
@@ -1,0 +1,24 @@
+<?php
+
+abstract class PdfFrontControllerCore extends FrontController
+{
+    public function init()
+    {
+        parent::init();
+
+        /* For PDF we restore some functions from Smarty
+         * they've been removed in PrestaShop 1.7 so
+         * new themes don't use them. Although PDF haven't been
+         * reworked so every PDF controller must extend this class.
+         */
+        smartyRegisterFunction($this->context->smarty, 'function', 'convertPrice', array('Product', 'convertPrice'));
+        smartyRegisterFunction($this->context->smarty, 'function', 'convertPriceWithCurrency', array('Product', 'convertPriceWithCurrency'));
+        smartyRegisterFunction($this->context->smarty, 'function', 'displayWtPrice', array('Product', 'displayWtPrice'));
+        smartyRegisterFunction($this->context->smarty, 'function', 'displayWtPriceWithCurrency', array('Product', 'displayWtPriceWithCurrency'));
+        smartyRegisterFunction($this->context->smarty, 'function', 'displayPrice', array('Tools', 'displayPriceSmarty'));
+        smartyRegisterFunction($this->context->smarty, 'modifier', 'convertAndFormatPrice', array('Product', 'convertAndFormatPrice')); // used twice
+        smartyRegisterFunction($this->context->smarty, 'function', 'displayAddressDetail', array('AddressFormat', 'generateAddressSmarty'));
+        smartyRegisterFunction($this->context->smarty, 'function', 'getWidthSize', array('Image', 'getWidth'));
+        smartyRegisterFunction($this->context->smarty, 'function', 'getHeightSize', array('Image', 'getHeight'));
+    }
+}

--- a/controllers/front/PdfInvoiceController.php
+++ b/controllers/front/PdfInvoiceController.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-class PdfInvoiceControllerCore extends FrontController
+class PdfInvoiceControllerCore extends PdfFrontController
 {
     public $php_self = 'pdf-invoice';
     protected $display_header = false;

--- a/controllers/front/PdfInvoiceController.php
+++ b/controllers/front/PdfInvoiceController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2015 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -23,7 +23,6 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
 class PdfInvoiceControllerCore extends PdfFrontController
 {
     public $php_self = 'pdf-invoice';
@@ -41,13 +40,13 @@ class PdfInvoiceControllerCore extends PdfFrontController
             Tools::redirect('index.php?controller=authentication&back=pdf-invoice');
         }
 
-        if (!(int)Configuration::get('PS_INVOICE')) {
+        if (!(int) Configuration::get('PS_INVOICE')) {
             die(Tools::displayError('Invoices are disabled in this shop.'));
         }
 
-        $id_order = (int)Tools::getValue('id_order');
+        $id_order = (int) Tools::getValue('id_order');
         if (Validate::isUnsignedId($id_order)) {
-            $order = new Order((int)$id_order);
+            $order = new Order((int) $id_order);
         }
 
         if (!isset($order) || !Validate::isLoadedObject($order)) {

--- a/controllers/front/PdfOrderReturnController.php
+++ b/controllers/front/PdfOrderReturnController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2015 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -23,7 +23,6 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
 class PdfOrderReturnControllerCore extends PdfFrontController
 {
     public $php_self = 'pdf-order-return';
@@ -32,7 +31,7 @@ class PdfOrderReturnControllerCore extends PdfFrontController
 
     public function postProcess()
     {
-        $from_admin = (Tools::getValue('adtoken') == Tools::getAdminToken('AdminReturn'.(int)Tab::getIdFromClassName('AdminReturn').(int)Tools::getValue('id_employee')));
+        $from_admin = (Tools::getValue('adtoken') == Tools::getAdminToken('AdminReturn'.(int) Tab::getIdFromClassName('AdminReturn').(int) Tools::getValue('id_employee')));
 
         if (!$from_admin && !$this->context->customer->isLogged()) {
             Tools::redirect('index.php?controller=authentication&back=order-follow');

--- a/controllers/front/PdfOrderReturnController.php
+++ b/controllers/front/PdfOrderReturnController.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-class PdfOrderReturnControllerCore extends FrontController
+class PdfOrderReturnControllerCore extends PdfFrontController
 {
     public $php_self = 'pdf-order-return';
     protected $display_header = false;

--- a/controllers/front/PdfOrderSlipController.php
+++ b/controllers/front/PdfOrderSlipController.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-class PdfOrderSlipControllerCore extends FrontController
+class PdfOrderSlipControllerCore extends PdfFrontController
 {
     public $php_self = 'pdf-order-slip';
     protected $display_header = false;

--- a/controllers/front/PdfOrderSlipController.php
+++ b/controllers/front/PdfOrderSlipController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2015 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -23,7 +23,6 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
 class PdfOrderSlipControllerCore extends PdfFrontController
 {
     public $php_self = 'pdf-order-slip';
@@ -31,7 +30,6 @@ class PdfOrderSlipControllerCore extends PdfFrontController
     protected $display_footer = false;
 
     protected $order_slip;
-
 
     public function postProcess()
     {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | PDF still use smarty function like `{displayPrice xx}` so many smarty function have been restored |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1276 |
| How to test? |  |
