### PR TITLE
Add clear all active product filters link

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -138,6 +138,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
             'js_enabled' => $this->ajax,
             'activeFilters' => $activeFilters,
             'sort_order' => $result->getCurrentSortOrder()->toString(),
+            'clear_all_link' => $this->updateQueryString(array('q' => null, 'page' => null))
         ));
     }
 
@@ -172,6 +173,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
 
         return $this->render('catalog/_partials/active_filters', array(
             'activeFilters' => $activeFilters,
+            'clear_all_link' => $this->updateQueryString(array('q' => null, 'page' => null))
         ));
     }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | If you want to clear all active filters in product listing page, you can use this link. Please not it's available **only** in `catalog/_partials/facets.tpl` and `catalog/_partials/active_filters`. |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |
