### PR TITLE
Be able to extract theme translations in Back Office

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -197,7 +197,7 @@
 			</div>
 		</div>
 	</form>
-	<form action="{$url_submit|escape:'html':'UTF-8'}" method="post" enctype="multipart/form-data" class="form-horizontal">
+	<form action="index.php/international/translations/extract" method="post" enctype="multipart/form-data" class="form-horizontal">
 		<div class="panel">
 			<h3>
 				<i class="icon-upload"></i>
@@ -220,7 +220,7 @@
 			<div class="form-group">
 				<label class="control-label col-lg-3" for="export-theme">{l s='Select your theme'}</label>
 				<div class="col-lg-4">
-					<select name="theme" id="export-theme">
+					<select name="theme-name" id="export-theme">
 						{foreach $themes as $theme}
 							<option value="{$theme->getName()}" {if $current_theme_name ==$theme->getName()}selected=selected{/if}>{$theme->getName()}</option>
 						{/foreach}

--- a/src/PrestaShopBundle/Resources/config/admin/routing_international.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/routing_international.yml
@@ -18,3 +18,9 @@ admin_international_translations_edit:
         translation_key: \w+
         translation_value: \w+
 
+admin_international_translations_extract_theme:
+    path: /translations/extract
+    methods:  [POST]
+    defaults:
+        _controller: PrestaShopBundle:Admin/Translations:extractTheme
+        _legacy_controller: AdminTranslations

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -85,3 +85,7 @@ services:
         class: PrestaShopBundle\Security\Admin\EmployeeProvider
         arguments:
             - "@prestashop.adapter.legacy.context"
+
+    #UTILS
+    prestashop.utils.zip_manager:
+        class: PrestaShopBundle\Utils\ZipManager

--- a/src/PrestaShopBundle/Utils/ZipManager.php
+++ b/src/PrestaShopBundle/Utils/ZipManager.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PrestaShopBundle\Utils;
+
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+
+class ZipManager
+{
+    public function createArchive($filename, $folder)
+    {
+        $zip = new \ZipArchive();
+
+        $zip->open($filename, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($folder),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        foreach ($files as $name => $file) {
+            if (!$file->isDir()) {
+                $filePath = $file->getRealPath();
+                $relativePath = substr($filename, strlen($folder) + 1);
+
+                $zip->addFile($filePath, $relativePath);
+            }
+        }
+
+        $zip->close();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | We can now get a zip file containing all translation files from a theme (using the new xliff format, of course). <br> _Note this feature will need to be improved once we can be able to override translations in database._ |
| Type? | new feature |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | part of http://forge.prestashop.com/browse/BOOM-1248 |
| How to test? | Select a locale and a theme, and click on "Export" action button |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
