### PR TITLE
Fixed bug when prestashop xml md5 is not valid

### DIFF
--- a/controllers/admin/AdminInformationController.php
+++ b/controllers/admin/AdminInformationController.php
@@ -167,7 +167,7 @@ class AdminInformationControllerCore extends AdminController
     {
         $this->file_list = array('missing' => array(), 'updated' => array());
         $xml = @simplexml_load_file(_PS_API_URL_.'/xml/md5/'._PS_VERSION_.'.xml');
-        if (!$xml) {
+        if (!$xml || !isset($xml->ps_root_dir[0])) {
             die(Tools::jsonEncode($this->file_list));
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | In AdminInformationController : HTTP 500 error will be sent by XHR request. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8313 |
| How to test? | Disable the PS_MODE_DEV and an HTTP 500 error will be sent by XHR request : with this PR there is no more error. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
