### PR TITLE
Unhook email modal from afterBodyOpeningTag

### DIFF
--- a/themes/classic/config/theme.yml
+++ b/themes/classic/config/theme.yml
@@ -33,8 +33,6 @@ global_settings:
      - ps_linklist
   hooks:
     modules_to_hook:
-      displayAfterBodyOpeningTag:
-        - ps_emailsubscription
       displayNav1:
         - ps_contactinfo
       displayNav2:


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | We removed the modal from the module so classic config needs to unhook the module. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |
