### PR TITLE
Remove self to make OrderInvoice overridable

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -122,7 +122,7 @@ class OrderInvoiceCore extends ObjectModel
     {
         $order = new Order($this->id_order);
 
-        $this->shop_address = self::getCurrentFormattedShopAddress($order->id_shop);
+        $this->shop_address = OrderInvoice::getCurrentFormattedShopAddress($order->id_shop);
 
         return parent::add();
     }
@@ -897,7 +897,7 @@ class OrderInvoiceCore extends ObjectModel
         $shop_ids = Shop::getShops(false, null, true);
         $db = Db::getInstance();
         foreach ($shop_ids as $id_shop) {
-            $address = self::getCurrentFormattedShopAddress($id_shop);
+            $address = OrderInvoice::getCurrentFormattedShopAddress($id_shop);
             $escaped_address = $db->escape($address, true, true);
 
             $db->execute('UPDATE `'._DB_PREFIX_.'order_invoice` INNER JOIN `'._DB_PREFIX_.'orders` USING (`id_order`)


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | OrderInvoice.php has static calls of the form self:: that make that class not overridable |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | create a class in override/classes/order/OrderInvoice.php that extends OrderOverrideCore and defines `public static function getCurrentFormattedShopAddress($id_shop = null)` |
