### PR TITLE
BO: Changed query word because "virtual" is reserved in mysql 5.7 and higher

### DIFF
--- a/controllers/admin/AdminAttachmentsController.php
+++ b/controllers/admin/AdminAttachmentsController.php
@@ -43,8 +43,8 @@ class AdminAttachmentsControllerCore extends AdminController
         $this->addRowAction('view');
         $this->addRowAction('delete');
 
-        $this->_select = 'IFNULL(virtual.products, 0) as products';
-        $this->_join = 'LEFT JOIN (SELECT id_attachment, COUNT(*) as products FROM '._DB_PREFIX_.'product_attachment GROUP BY id_attachment) virtual ON a.id_attachment = virtual.id_attachment';
+        $this->_select = 'IFNULL(virtualp.products, 0) as products';
+        $this->_join = 'LEFT JOIN (SELECT id_attachment, COUNT(*) as products FROM '._DB_PREFIX_.'product_attachment GROUP BY id_attachment) virtualp ON a.id_attachment = virtualp.id_attachment';
         $this->_use_found_rows = false;
 
         parent::__construct();
@@ -70,7 +70,7 @@ class AdminAttachmentsControllerCore extends AdminController
             'products' => array(
                 'title' => $this->trans('Associated with', array(), 'Admin.Catalog.Feature'),
                 'suffix' => $this->trans('product(s)', array(), 'Admin.Catalog.Feature'),
-                'filter_key' => 'virtual!products',
+                'filter_key' => 'virtualp!products',
             ),
         );
 


### PR DESCRIPTION
Description? 
Changed query word because "virtual" is reserved in mysql 5.7 and higher

Type?          bug fix 
Category?    BO
BC breaks?    no
Deprecations? no
Fixed ticket? no idea
How to test?  install mysql 5.7 or higher and then in BO go to catalog > attachments
