### PR TITLE
Add hooks for legal compliance in cart shipping subtotal

### DIFF
--- a/themes/classic/modules/ps_shoppingcart/modal.tpl
+++ b/themes/classic/modules/ps_shoppingcart/modal.tpl
@@ -33,7 +33,7 @@
                 <p class="cart-products-count">{l s='There is %product_count% item in your cart.' sprintf=['%product_count%' =>$cart.products_count] d='Shop.Theme.Checkout'}</p>
               {/if}
               <p><strong>{l s='Total products:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.subtotals.products.value}</p>
-              <p><strong>{l s='Total shipping:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.subtotals.shipping.value}</p>
+              <p><strong>{l s='Total shipping:' d='Shop.Theme.Checkout'}</strong>&nbsp;{$cart.subtotals.shipping.value} {hook h='displayCheckoutSubtotalDetails' subtotal=$cart.subtotals.shipping}</p>
               {if $cart.subtotals.tax}
               	<p><strong>{$cart.subtotals.tax.label}</strong>&nbsp;{$cart.subtotals.tax.value}</p>
               {/if}

--- a/themes/classic/templates/checkout/_partials/cart-detailed-totals.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-totals.tpl
@@ -12,6 +12,9 @@
             {/if}
           </span>
           <span class="value">{$subtotal.value}</span>
+          {if $subtotal.type === 'shipping'}
+              <div><small class="value">{hook h='displayCheckoutSubtotalDetails' subtotal=$subtotal}</small></div>
+          {/if}
         </div>
       {/if}
     {/foreach}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In order to follow the German legal compliance, we need to add a **(Under conditions)** when the shipping cost is estimated free. To do this, I added a new hook in the template on which 'ps_legalcompliance' will register. |
| Type? | improvement |
| Category? | FO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1195](http://forge.prestashop.com/browse/BOOM-1195) |
| How to test? | Get the PR PrestaShop/ps_legalcompliance#25 too, install the module (or reinstall it if already installed), and add a product to the cart in the front office. If the shipping cost is free a label (under condition) will appear near the 'Free'. |
