### PR TITLE
Call address form templates without extension

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -130,7 +130,7 @@ class FrontControllerCore extends Controller
     public static $initialized = false;
 
     /**
-     * @var array Holds current customer's groups.
+     * @var array Holds current customer's groups
      */
     protected static $currentCustomerGroups;
 
@@ -529,10 +529,10 @@ class FrontControllerCore extends Controller
      * @param string       $string       Term or expression in english
      * @param false|string $specific     Specific name, only for ModuleFrontController
      * @param string|null  $class        Name of the class
-     * @param bool         $addslashes   If set to true, the return value will pass through addslashes(). Otherwise, stripslashes().
+     * @param bool         $addslashes   If set to true, the return value will pass through addslashes(). Otherwise, stripslashes()
      * @param bool         $htmlentities If set to true(default), the return value will pass through htmlentities($string, ENT_QUOTES, 'utf-8')
      *
-     * @return string The translation if available, or the english default text.
+     * @return string The translation if available, or the english default text
      */
     protected function l($string, $specific = false, $class = null, $addslashes = false, $htmlentities = true)
     {
@@ -1726,7 +1726,7 @@ class FrontControllerCore extends Controller
         header('Content-Type: application/json');
         $this->ajaxDie(Tools::jsonEncode(array(
             'address_form' => $this->render(
-                'customer/_partials/address-form.tpl',
+                'customer/_partials/address-form',
                 $addressForm->getTemplateVariables()
             ),
         )));


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Templates are now called without extension. I fixed all front controllers but I forget the parent classe. Please not you still need extension for `smartyOutput` method. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |
