### PR TITLE
Remove SwiftMailerBundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -12,7 +12,6 @@ class AppKernel extends Kernel
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             // PrestaShop Core bundle

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     "doctrine/orm": "~2.5.3",
     "ext-zip": "*",
     "doctrine/doctrine-bundle": "1.5.2",
-    "symfony/swiftmailer-bundle": "2.3.11",
     "swiftmailer/swiftmailer": "5.4.1",
     "symfony/monolog-bundle": "2.8.2",
     "sensio/distribution-bundle": "4.0.6",


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `develop` |
| Description? | Remove the `SwiftMailerBundle`. It was added to the kernel and composer, but stays unused, because we don't use dependency injection. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |
