### PR TITLE
Use "on" instead of live in colorpicker plugin

### DIFF
--- a/js/jquery/plugins/jquery.colorpicker.js
+++ b/js/jquery/plugins/jquery.colorpicker.js
@@ -38,7 +38,7 @@
 
     if ($('#css_disabled_color_picker').length < 1) $('head').prepend('<style id="css_disabled_color_picker" type="text/css">.mColorPicker[disabled] + span, .mColorPicker[disabled="disabled"] + span, .mColorPicker[disabled="true"] + span {filter:alpha(opacity=50);-moz-opacity:0.5;-webkit-opacity:0.5;-khtml-opacity: 0.5;opacity: 0.5;}</style>');
 
-    $('.mColorPicker').live('keyup', function () {
+    $('.mColorPicker').on('keyup', function () {
   
       try {
   
@@ -50,7 +50,7 @@
       } catch (r) {}
     });
 
-    $('.mColorPickerTrigger').live('click', function () {
+    $('.mColorPickerTrigger').on('click', function () {
 
       $.fn.mColorPicker.colorShow($(this).attr('id').replace('icp_', ''));
     });


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Using .live() results in an error because it's undefined |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
