### PR TITLE
Fix country list for wrong iso code

### DIFF
--- a/install-dev/classes/language.php
+++ b/install-dev/classes/language.php
@@ -116,12 +116,15 @@ class InstallLanguage
     {
         if (!is_array($this->countries)) {
             $this->countries = array();
-            $filename = _PS_INSTALL_LANGS_PATH_.$this->language_code.'/data/country.xml';
-            if (file_exists($filename)) {
-                if ($xml = @simplexml_load_file($filename)) {
-                    foreach ($xml->country as $country) {
-                        $this->countries[strtolower((string)$country['id'])] = (string)$country->name;
-                    }
+            $filename = _PS_INSTALL_LANGS_PATH_.substr($this->language_code, 0, 2).'/data/country.xml';
+
+            if (!file_exists($filename)) {
+                $filename = _PS_INSTALL_LANGS_PATH_.'en/data/country.xml';
+            }
+
+            if ($xml = @simplexml_load_file($filename)) {
+                foreach ($xml->country as $country) {
+                    $this->countries[strtolower((string)$country['id'])] = (string)$country->name;
                 }
             }
         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | All old languages have `language_code` on 2 letters, more recent languages use starndard locale. I updated the file path accordingly and fell back on english if not provided. |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Install in Turkish because it's an available install language but there is no country list provided. |
