### PR TITLE
Fix bad discount computation when multiple tax rates involved

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -989,7 +989,9 @@ class CartRuleCore extends ObjectModel
                             || in_array($product['id_product'].'-0', $selected_products)) {
                             $price = $product['price'];
                             if ($use_tax) {
-                                $price *= (1 + $context->cart->getAverageProductsTaxRate());
+                                $infos = Product::getTaxesInformations($product, $context);
+                                $tax_rate = $infos['rate'] / 100;
+                                $price *= (1 + $tax_rate);
                             }
 
                             $selected_products_reduction += $price * $product['cart_quantity'];


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Fix bad discount computation when multiple tax rates involved. Cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/4351 |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |

(cherry picked from commit 79492aebcdbc85da1974a2ffd63215457712ac90)
