### PR TITLE
Add before and after <body> hooks

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -48,6 +48,12 @@
     <hook id="actionProductUpdate">
       <name>actionProductUpdate</name><title>Product update</title><description>This hook is displayed after a product has been updated</description>
     </hook>
+    <hook id="displayAfterBodyOpeningTag">
+      <name>displayAfterBodyOpeningTag</name><title>Very top of pages</title><description>Use this hook for advertisement or modals you want to load first.</description>
+    </hook>
+    <hook id="displayBeforeBodyClosingTag">
+      <name>displayBeforeBodyClosingTag</name><title>Very bottom of pages</title><description>Use this hook for your modals or any content you want to load at the very end.</description>
+    </hook>
     <hook id="displayTop">
       <name>displayTop</name><title>Top of pages</title><description>This hook displays additional elements at the top of your pages</description>
     </hook>

--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -8,6 +8,7 @@
   </head>
 
   <body id="{$page.page_name}" class="{$page.body_classes|classnames}">
+
     {hook h='displayAfterBodyOpeningTag'}
 
     <main>
@@ -65,6 +66,8 @@
       </footer>
 
     </main>
+
+    {hook h='displayBeforeBodyClosingTag'}
 
   </body>
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | We already have `displayAfterBodyOpeningTag` in Classic. I think this is an interesting hook so I made it visible in the position page. Its sibbling `displayBeforeBodyClosingTag` is added. |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |

NOTE: Added to StarterTheme https://github.com/PrestaShop/StarterTheme/pull/112
