### PR TITLE
Edition of Locale in Localization -> Languages

### DIFF
--- a/controllers/admin/AdminLanguagesController.php
+++ b/controllers/admin/AdminLanguagesController.php
@@ -78,6 +78,11 @@ class AdminLanguagesControllerCore extends AdminController
                 'align' => 'center',
                 'class' => 'fixed-width-xs'
             ),
+            'locale' => array(
+                'title' => $this->l('Locale'),
+                'align' => 'center',
+                'class' => 'fixed-width-xs'
+            ),
             'date_format_lite' => array(
                 'title' => $this->l('Date format')
             ),
@@ -164,6 +169,14 @@ class AdminLanguagesControllerCore extends AdminController
                     'hint' => $this->l('IETF language tag (e.g. en-US, pt-BR).')
                     /* TO DO - ajouter les liens dans le hint ? */
                     /*'desc' => $this->l('IETF language tag (e.g. en-US, pt-BR).').' '.sprintf('<a href="http://en.wikipedia.org/wiki/IETF_language_tag" target="_blank">%s <img src="../img/admin/external_link.png" class="icon-top" /></a>', $this->l('IETF on Wikipedia'))*/
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Language locale'),
+                    'name' => 'locale',
+                    'required' => true,
+                    'maxlength' => 5,
+                    'hint' => $this->l('Five-letter ISO code (e.g. fr-FR, en-EN, de-DE).')
                 ),
                 array(
                     'type' => 'text',


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Possibility to change locale directly from BO, thanks to this change i wouldn't have problems with rc0, also - in my opinion locale should be required as it's required by `TemplateFinder` |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Well, rc0 doesn't work with two installed languages |
| How to test? | Try to edit locale in Localization -> Languages |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
