### PR TITLE
Avoid escaped quotes in blockreassurance module

### DIFF
--- a/themes/classic/modules/blockreassurance/views/templates/hook/blockreassurance.tpl
+++ b/themes/classic/modules/blockreassurance/views/templates/hook/blockreassurance.tpl
@@ -28,8 +28,8 @@
       {foreach from=$elements item=element}
         <li>
           <div class="block-reassurance-item">
-            <img src="{$element.image}" alt="{$element.text}">
-            <span class="h6">{$element.text}</span>
+            <img src="{$element.image}" alt="{$element.text nofilter}">
+            <span class="h6">{$element.text nofilter}</span>
           </div>
         </li>
       {/foreach}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | we don't need to escape text from this module |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | n/a |
| How to test? | Before and after screenshots below |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

Before:
![image](https://cloud.githubusercontent.com/assets/2137763/18065880/1f9ea79a-6e36-11e6-9063-60b271e6fb13.png)

After:
![image](https://cloud.githubusercontent.com/assets/2137763/18065894/2fb76464-6e36-11e6-8e9c-0ddafd23b826.png)
