### PR TITLE
Fix misuse of getimagesize returned informations

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -107,13 +107,14 @@ class ImageManagerCore
 
         $memory_limit = Tools::getMemoryLimit();
         // memory_limit == -1 => unlimited memory
-        if (function_exists('memory_get_usage') && (int)$memory_limit != -1) {
+        if (isset($infos['bits']) && function_exists('memory_get_usage') && (int)$memory_limit != -1) {
             $current_memory = memory_get_usage();
-            $channel = isset($infos['channels']) ? ($infos['channels'] / 8) : 1;
+            $bits = $infos['bits'] / 8;
+            $channel = isset($infos['channels']) ? $infos['channels'] : 1;
 
             // Evaluate the memory required to resize the image: if it's too much, you can't resize it.
             // For perfs, avoid computing static maths formulas in the code. pow(2, 16) = 65536 ; 1024 * 1024 = 1048576
-            if (($infos[0] * $infos[1] * $infos['bits'] * $channel + 65536) * 1.8 + $current_memory > $memory_limit - 1048576) {
+            if (($infos[0] * $infos[1] * $bits * $channel + 65536) * 1.8 + $current_memory > $memory_limit - 1048576) {
                 return false;
             }
         }


### PR DESCRIPTION
| Questions | Answer |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Some misuse of getimagesize returned informations |
| Category | CO |
| Type? | bugfix |
| BC breaks? | No |
| Deprecations? | No |

Some misuse of getimagesize returned informations:
- from documentation, the "bits" entry can be missing (so added a check on it)
- the number of channels were divide by 8 and the number of bits used as is... the final value was the same when the channels entry is present but not when it is missing. |
