### PR TITLE
Remove zip file after serving it when export translations

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -114,6 +114,7 @@ class TranslationsController extends FrameworkBundleAdminController
         $this->get('prestashop.utils.zip_manager')->createArchive($zipFile, $folderPath);
 
         $response = new BinaryFileResponse($zipFile);
+        $response->deleteFileAfterSend(true);
 
         return $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT);
     }

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -36,8 +36,6 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
-use Symfony\Component\Translation\MessageCatalogue;
-
 /**
  * Admin controller for the International pages.
  */


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Previously, the zip files stayed in cache folder. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Use export button in International > Translations > Themes section, then check the zip file is not present in cache folder. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
