### PR TITLE
Introduced front office translation provider

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -36,8 +36,6 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
-use Symfony\Component\Translation\MessageCatalogue;
-
 /**
  * Admin controller for the International pages.
  */

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -197,10 +197,17 @@ class TranslationsController extends FrameworkBundleAdminController
     {
         $lang = $request->request->get('lang');
         $type = $request->request->get('type');
+        $theme = $request->request->get('selected-theme');
 
         $translator = $this->container->get('translator');
 
         $locale = $this->langToLocale($lang);
+
+        if (!is_null($theme)) {
+            if ('classic' === $theme) {
+                $type = 'front';
+            }
+        }
 
         $translations = $this->get('ps.translations_factory')->createTranslationsArray($type, $locale);
 

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -107,3 +107,11 @@ services:
             - "%translations_dir%"
         tags:
             - { name: "ps.translation_provider" }
+
+    prestashop.translation.frontoffice_provider:
+        class: PrestaShopBundle\Translation\Provider\FrontOfficeProvider
+        arguments:
+            - "@prestashop.translations.database_loader"
+            - "%translations_dir%"
+        tags:
+            - { name: "ps.translation_provider" }

--- a/src/PrestaShopBundle/Tests/Translation/Provider/FrontOfficeProviderTest.php
+++ b/src/PrestaShopBundle/Tests/Translation/Provider/FrontOfficeProviderTest.php
@@ -26,11 +26,11 @@
 
 namespace PrestaShopBundle\Tests\Translation\Provider;
 
-use PrestaShopBundle\Translation\Provider\BackOfficeProvider;
+use PrestaShopBundle\Translation\Provider\FrontOfficeProvider;
 
-class BackOfficeProviderTest extends \PHPUnit_Framework_TestCase
+class FrontOfficeProviderTest extends \PHPUnit_Framework_TestCase
 {
-    // @see /resources/translations/en-US/AdminActions.en-US.xlf
+    // @see /resources/translations/en-US/ShopNotificationsWarning.en-US.xlf
     private $provider;
     private static $resourcesDir;
 
@@ -41,21 +41,24 @@ class BackOfficeProviderTest extends \PHPUnit_Framework_TestCase
         ;
 
         self::$resourcesDir = __DIR__.'/../../resources/translations';
-        $this->provider = new BackOfficeProvider($loader, self::$resourcesDir);
+        $this->provider = new FrontOfficeProvider($loader, self::$resourcesDir);
     }
 
     public function testGetMessageCatalogue()
     {
-        // The xliff file contains 38 keys
+        // The xliff file contains 6 keys
         $expectedReturn = $this->provider->getMessageCatalogue();
         $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
 
         // Check integrity of translations
-        $this->assertArrayHasKey('AdminActions.en-US', $expectedReturn->all());
-        $translations = $expectedReturn->all('AdminActions.en-US');
+        $this->assertArrayHasKey('ShopNotificationsWarning.en-US', $expectedReturn->all());
 
-        $this->assertCount(38, $translations);
-        $this->assertArrayHasKey('Download file', $translations);
-        $this->assertSame('Download file', $translations['Download file']);
+        // we retrieve only the ShopNotificationsWarning domain, not others
+        $this->assertCount(1, $expectedReturn->all());
+        $translations = $expectedReturn->all('ShopNotificationsWarning.en-US');
+
+        $this->assertCount(6, $translations);
+        $this->assertArrayHasKey('You do not have any vouchers.', $translations);
+        $this->assertSame('You do not have any vouchers.', $translations['You do not have any vouchers.']);
     }
 }

--- a/src/PrestaShopBundle/Tests/resources/translations/default/ShopNotificationsWarning.en-US.xlf
+++ b/src/PrestaShopBundle/Tests/resources/translations/default/ShopNotificationsWarning.en-US.xlf
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="controllers/front/DiscountController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3f5baf7537ec2a40ade00599a8da8c6" approved="yes">
+        <source>You do not have any vouchers.</source>
+        <target xml:lang="en">You do not have any vouchers.</target>
+        <note>Context:
+File: controllers/front/DiscountController.php:45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/GuestTrackingController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      
+    </body>
+  </file>
+  <file original="controllers/front/HistoryController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="116cb47fe026f7a3679486e086426a64" approved="yes">
+        <source>If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.</source>
+        <target xml:lang="en">If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.</target>
+        <note>Context:
+File: controllers/front/HistoryController.php:47</note>
+      </trans-unit>
+      <trans-unit id="5acc2ceeb883ba07cef2d02ea382f242" approved="yes">
+        <source>You have not placed any orders.</source>
+        <target xml:lang="en">You have not placed any orders.</target>
+        <note>Context:
+File: controllers/front/HistoryController.php:53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderReturnController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="44a9edeffb86277f007fa90d96689a6d" approved="yes">
+        <source>You must wait for confirmation before returning any merchandise.</source>
+        <target xml:lang="en">You must wait for confirmation before returning any merchandise.</target>
+        <note>Context:
+File: controllers/front/OrderReturnController.php:57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderSlipController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0ba830b7ca1513a4882ce5aac84030b8" approved="yes">
+        <source>You have not received any credit slips.</source>
+        <target xml:lang="en">You have not received any credit slips.</target>
+        <note>Context:
+File: controllers/front/OrderSlipController.php:45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/ProductController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f9ddd507fdf437437efdcb333a0f4ff0" approved="yes">
+        <source>This product is not visible to your customers.</source>
+        <target xml:lang="en">This product is not visible to your customers.</target>
+        <note>Context:
+File: controllers/front/ProductController.php:90</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/PrestaShopBundle/Tests/resources/translations/en-US/ShopNotificationsWarning.en-US.xlf
+++ b/src/PrestaShopBundle/Tests/resources/translations/en-US/ShopNotificationsWarning.en-US.xlf
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="controllers/front/DiscountController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3f5baf7537ec2a40ade00599a8da8c6" approved="yes">
+        <source>You do not have any vouchers.</source>
+        <target xml:lang="en">You do not have any vouchers.</target>
+        <note>Context:
+File: controllers/front/DiscountController.php:45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/GuestTrackingController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      
+    </body>
+  </file>
+  <file original="controllers/front/HistoryController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="116cb47fe026f7a3679486e086426a64" approved="yes">
+        <source>If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.</source>
+        <target xml:lang="en">If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.</target>
+        <note>Context:
+File: controllers/front/HistoryController.php:47</note>
+      </trans-unit>
+      <trans-unit id="5acc2ceeb883ba07cef2d02ea382f242" approved="yes">
+        <source>You have not placed any orders.</source>
+        <target xml:lang="en">You have not placed any orders.</target>
+        <note>Context:
+File: controllers/front/HistoryController.php:53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderReturnController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="44a9edeffb86277f007fa90d96689a6d" approved="yes">
+        <source>You must wait for confirmation before returning any merchandise.</source>
+        <target xml:lang="en">You must wait for confirmation before returning any merchandise.</target>
+        <note>Context:
+File: controllers/front/OrderReturnController.php:57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderSlipController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0ba830b7ca1513a4882ce5aac84030b8" approved="yes">
+        <source>You have not received any credit slips.</source>
+        <target xml:lang="en">You have not received any credit slips.</target>
+        <note>Context:
+File: controllers/front/OrderSlipController.php:45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/ProductController.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f9ddd507fdf437437efdcb333a0f4ff0" approved="yes">
+        <source>This product is not visible to your customers.</source>
+        <target xml:lang="en">This product is not visible to your customers.</target>
+        <note>Context:
+File: controllers/front/ProductController.php:90</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/PrestaShopBundle/Translation/Provider/FrontOfficeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/FrontOfficeProvider.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author     PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2016 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation\Provider;
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+class FrontOfficeProvider extends AbstractProvider implements UseDefaultCatalogueInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains()
+    {
+        return array('Shop%');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array('Shop*');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        return 'front';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultCatalogue($empty = true)
+    {
+        $defaultCatalogue = new MessageCatalogue($this->getLocale());
+
+        foreach ($this->getFilters() as $filter) {
+            $filteredCatalogue = $this->getCatalogueFromPaths(
+                array($this->getDefaultResourceDirectory()),
+                $this->getLocale(),
+                $filter
+            );
+            $defaultCatalogue->addCatalogue($filteredCatalogue);
+        }
+
+        if ($empty) {
+            $defaultCatalogue = $this->emptyCatalogue($defaultCatalogue);
+        }
+
+        return $defaultCatalogue;
+    }
+
+    /**{@inheritdoc}
+     */
+    public function getDefaultResourceDirectory()
+    {
+        return $this->resourceDirectory.'/default';
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | We continue to implement providers in order to manage translations: this time we implement all translations from Classic theme. |
| Type? | new feature |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Part of http://forge.prestashop.com/browse/BOOM-1248 |
| How to test? | In "International > Translations section, choose themes, then "classic": you should be able to access to translations and search. |

![frontofficeprovider](https://cloud.githubusercontent.com/assets/1247388/18134088/6278fac6-6f9d-11e6-8539-fc8bb9b4136c.png)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
