### PR TITLE
Use array key in case of missing product type in module catalog

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -255,13 +255,17 @@ class AdminModuleDataProvider implements ModuleInterface
                     // so we know whether is bought
 
                     $addons = $this->addonsDataProvider->request($action, $params);
-                    foreach ($addons as $addon) {
+                    foreach ($addons as $addonsType => $addon) {
                         $addon->origin = $action;
                         $addon->origin_filter_value = $action_filter_value;
                         $addon->categoryParent = $this->categoriesProvider
                             ->getParentCategory($addon->categoryName)
                         ;
-                        $addon->productType = $addon->product_type;
+                        if (! isset($addon->product_type)) {
+                            $addon->productType = isset($addonsType)?rtrim($addonsType, 's'):'module';
+                        } else {
+                            $addon->productType = $addon->product_type;
+                        }
                         $listAddons[$addon->name] = $addon;
                     }
                 }
@@ -320,7 +324,8 @@ class AdminModuleDataProvider implements ModuleInterface
     private function registerModuleCache($file, $data)
     {
         try {
-            $cache = (new ConfigCacheFactory(true))->cache($this->cache_dir.$file, function () {});
+            $cache = (new ConfigCacheFactory(true))->cache($this->cache_dir.$file, function () {
+            });
             $cache->write(json_encode($data));
 
             return $cache->getPath();


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When the maketplace API do not send the product type as an attribute, we can find the information in the array key |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Clear your cache and load the catalog again. It should be loaded without error. |
