### PR TITLE
Modules translation page modified 

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
@@ -56,12 +56,45 @@
 			<p>{l s='Expressions to translate:'} <span class="badge">{l s='%d' sprintf=[$count]}</span></p>
 			<p>{l s='Total missing expressions:'} <span class="badge">{l s='%d' sprintf=[$missing_translations]}</p>
 		</div>
+		<form action="{$url_submit_installed_module|escape:'html':'UTF-8'}" method="post" enctype="multipart/form-data" class="form-horizontal">
+			<div class="panel">
+				<input type="hidden" name="langue" value="{$lang}" />
+				<input type="hidden" name="type" value="{$type}" />
+				<input type="hidden" name="theme" value="{$theme}" />
+				<input type="hidden" name="controller" value="AdminTranslations" />
+				<h3>
+					<i class="icon-file-text"></i>
+					{l s='Modify translations'}
+				</h3>
+				<p class="alert alert-info">
+					{l s='Here you can modify translations for all installed module.'}<br />
+				</p>
+				<div class="form-group">
+					<label class="control-label col-lg-3" for="translations-languages">{l s='Select your module'}</label>
+					<div class="col-lg-4">
+						<select name="module" id="installed_module">
+							<option value="">{l s='Module'}</option>
+							{foreach from=$installed_modules key=key item=module}
+								<option value="{$module}">{$module}</option>
+							{/foreach}
+						</select>
+					</div>
+					<input type="hidden" name="token" value="{$token|escape:'html':'UTF-8'}" />
+				</div>
+				<div class="panel-footer">
+					<button type="submit" class="btn btn-default pull-right" id="submitSelect{$type|ucfirst}" name="submitSelect{$type|ucfirst}">
+						<i class="process-icon-edit"></i> {l s='Modify translation'}
+					</button>
+				</div>
+			</div>
+		</form>
 
 		<form method="post" id="{$table}_form" action="{$url_submit|escape:'html':'UTF-8'}" class="form-horizontal">
 			<div class="panel">
 				<input type="hidden" name="lang" value="{$lang}" />
 				<input type="hidden" name="type" value="{$type}" />
 				<input type="hidden" name="theme" value="{$theme}" />
+				<input type="hidden" name="module" value="{$module_name}" />
 				<div id="BoxUseSpecialSyntax">
 					<div class="alert alert-warning">
 						<p>

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -174,9 +174,6 @@ class TranslateCore
                 if (file_exists($file)) {
                     include_once($file);
                     $_MODULES = !empty($_MODULES) ? $_MODULES + $_MODULE : $_MODULE; //we use "+" instead of array_merge() because array merge erase existing values.
-                } else {
-                    // create an empty file
-                    @touch($file);
                 }
             }
             $translations_merged[$name] = true;

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1382,7 +1382,7 @@ class AdminModulesControllerCore extends AdminController
         parent::initModal();
 
         $this->context->smarty->assign(array(
-            'trad_link' => 'index.php?tab=AdminTranslations&token='.Tools::getAdminTokenLite('AdminTranslations').'&type=modules&lang=',
+            'trad_link' => 'index.php?tab=AdminTranslations&token='.Tools::getAdminTokenLite('AdminTranslations').'&type=modules&module='.$_REQUEST['configure'].'&lang=',
             'module_languages' => Language::getLanguages(false),
             'module_name' => Tools::getValue('module_name'),
         ));

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1382,7 +1382,7 @@ class AdminModulesControllerCore extends AdminController
         parent::initModal();
 
         $this->context->smarty->assign(array(
-            'trad_link' => 'index.php?tab=AdminTranslations&token='.Tools::getAdminTokenLite('AdminTranslations').'&type=modules&module='.$_REQUEST['configure'].'&lang=',
+            'trad_link' => 'index.php?tab=AdminTranslations&token='.Tools::getAdminTokenLite('AdminTranslations').'&type=modules&module='.Tools::getValue('configure').'&lang=',
             'module_languages' => Language::getLanguages(false),
             'module_name' => Tools::getValue('module_name'),
         ));

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1564,9 +1564,9 @@ class AdminTranslationsControllerCore extends AdminController
         $conf = !$conf ? 4 : $conf;
         $url_base = self::$currentIndex.'&token='.$this->token.'&conf='.$conf;
         if($modify_translation) {
-            Tools::redirectAdmin(self::$currentIndex.'&token='.$this->token.'&lang='.$_REQUEST['langue'].'&type='.$this->type_selected.'&module='.$_REQUEST['module'].'&theme='.$this->theme_selected);
+            Tools::redirectAdmin(self::$currentIndex.'&token='.$this->token.'&lang='.Tools::getValue('langue').'&type='.$this->type_selected.'&module='.Tools::getValue('module').'&theme='.$this->theme_selected);
         } elseif ($save_and_stay) {
-            Tools::redirectAdmin($url_base.'&lang='.$this->lang_selected->iso_code.'&type='.$this->type_selected.'&module='.$_REQUEST['module'].'&theme='.$this->theme_selected);
+            Tools::redirectAdmin($url_base.'&lang='.$this->lang_selected->iso_code.'&type='.$this->type_selected.'&module='.Tools::getValue('module').'&theme='.$this->theme_selected);
         } else {
             Tools::redirectAdmin($url_base);
         }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -147,6 +147,7 @@ class AdminTranslationsControllerCore extends AdminController
             'theme' => $this->theme_selected,
             'post_limit_exceeded' => $this->post_limit_exceed,
             'url_submit' => self::$currentIndex.'&submitTranslations'.ucfirst($this->type_selected).'=1&token='.$this->token,
+            'url_submit_installed_module' => self::$currentIndex.'&submitSelect'.ucfirst($this->type_selected).'=1&token='.$this->token,
             'toggle_button' => $this->displayToggleButton(),
             'textarea_sized' => AdminTranslationsControllerCore::TEXTAREA_SIZED
         );
@@ -1543,6 +1544,8 @@ class AdminTranslationsControllerCore extends AdminController
                 } else {
                     $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
                 }
+            }elseif (Tools::isSubmit('submitSelectModules')){
+                $this->redirect(false,false,true);
             }
         } catch (PrestaShopException $e) {
             $this->errors[] = $e->getMessage();
@@ -1554,13 +1557,16 @@ class AdminTranslationsControllerCore extends AdminController
      *
      * @param bool $save_and_stay : true if the user has clicked on the button "save and stay"
      * @param bool $conf : id of confirmation message
+     * @param bool $modify_translation : true if the user has clicked on the button "Modify translation"
      */
-    protected function redirect($save_and_stay = false, $conf = false)
+    protected function redirect($save_and_stay = false, $conf = false, $modify_translation = false)
     {
         $conf = !$conf ? 4 : $conf;
         $url_base = self::$currentIndex.'&token='.$this->token.'&conf='.$conf;
-        if ($save_and_stay) {
-            Tools::redirectAdmin($url_base.'&lang='.$this->lang_selected->iso_code.'&type='.$this->type_selected.'&theme='.$this->theme_selected);
+        if($modify_translation){
+            Tools::redirectAdmin(self::$currentIndex.'&token='.$this->token.'&lang='.$_REQUEST['langue'].'&type='.$this->type_selected.'&module='.$_REQUEST['module'].'&theme='.$this->theme_selected);
+        } elseif ($save_and_stay) {
+            Tools::redirectAdmin($url_base.'&lang='.$this->lang_selected->iso_code.'&type='.$this->type_selected.'&module='.$_REQUEST['module'].'&theme='.$this->theme_selected);
         } else {
             Tools::redirectAdmin($url_base);
         }
@@ -2971,7 +2977,7 @@ class AdminTranslationsControllerCore extends AdminController
         $initial_root_dir = $root_dir;
         foreach ($modules as $module) {
             $root_dir = $initial_root_dir;
-            if ($module{0} == '.') {
+            if (isset($module{0}) && $module{0} == '.') {
                 continue;
             }
 
@@ -3020,8 +3026,11 @@ class AdminTranslationsControllerCore extends AdminController
      */
     public function initFormModules()
     {
-        // Get list of modules
-        $modules = $this->getListModules();
+        // Get list of installed modules
+        $installed_modules = $this->getListModules();
+
+        // get selected module
+        $modules[0] = Tools::getValue('module');
 
         if (!empty($modules)) {
             // Get all modules files and include all translation files
@@ -3038,7 +3047,9 @@ class AdminTranslationsControllerCore extends AdminController
                 'textarea_sized' => AdminTranslationsControllerCore::TEXTAREA_SIZED,
                 'cancel_url' => $this->context->link->getAdminLink('AdminTranslations'),
                 'modules_translations' => isset($this->modules_translations) ? $this->modules_translations : array(),
-                'missing_translations' => $this->missing_translations
+                'missing_translations' => $this->missing_translations,
+                'module_name' => $modules[0],
+                'installed_modules' => $installed_modules
             ));
 
             $this->initToolbar();

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1544,7 +1544,7 @@ class AdminTranslationsControllerCore extends AdminController
                 } else {
                     $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
                 }
-            }elseif (Tools::isSubmit('submitSelectModules')){
+            } elseif (Tools::isSubmit('submitSelectModules')){
                 $this->redirect(false,false,true);
             }
         } catch (PrestaShopException $e) {
@@ -1563,7 +1563,7 @@ class AdminTranslationsControllerCore extends AdminController
     {
         $conf = !$conf ? 4 : $conf;
         $url_base = self::$currentIndex.'&token='.$this->token.'&conf='.$conf;
-        if($modify_translation){
+        if($modify_translation) {
             Tools::redirectAdmin(self::$currentIndex.'&token='.$this->token.'&lang='.$_REQUEST['langue'].'&type='.$this->type_selected.'&module='.$_REQUEST['module'].'&theme='.$this->theme_selected);
         } elseif ($save_and_stay) {
             Tools::redirectAdmin($url_base.'&lang='.$this->lang_selected->iso_code.'&type='.$this->type_selected.'&module='.$_REQUEST['module'].'&theme='.$this->theme_selected);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When trying to translate one module, you will be redirected to a page that contains the form of all the installed module to translate and sometimes get this error : Your PHP configuration limits the maximum number of fields on a form 1000 for max_input_vars. The new in this PR that the translation page will contains only the form of the selected module. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Go to Module & Service -> installed modules -> configure one installed module then click on Translate button -> choose a language and then you will be redirected to the translation page which contains a form to translate the selected module and a select button to choose another module to translate in the same language. |
