### PR TITLE
Added sync feature on theme translations

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -5,7 +5,7 @@ imports:
 services:
     finder:
         class: Symfony\Component\Finder\Finder
-        public: false
+        shared: false
 
     main.warmer.cache_warmer:
         class: PrestaShopBundle\Cache\CacheWarmer


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | We should be able to sync our translations files easily |
| Type? | improvement |
| Category? | BO |
| How to test? | <ul><li>Add a translation in template</li><li>F5 on tree</li><li>Celebrate</li></ul> |

![plop](https://cloud.githubusercontent.com/assets/1247388/18204910/95ef6d94-711f-11e6-8e1c-830ec226832b.png)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
