### PR TITLE
Fixed modules sorting by access date

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -235,6 +235,7 @@ var AdminModuleController = function() {
           type: $this.attr('data-type'),
           price: parseFloat($this.attr('data-price')),
           active: parseInt($this.attr('data-active')),
+          access: $this.attr('data-last-access'),
           display: $this.hasClass('module-item-list') ? 'list' : 'grid',
           container: container
         });
@@ -247,8 +248,8 @@ var AdminModuleController = function() {
   this.updateModuleVisibility = function() {
     var self = this;
 
-    // Modules ordering
-    if (self.currentSorting !== null) {
+    if (self.currentSorting) {
+      // Modules sorting
       var order = 'asc';
       var key = self.currentSorting;
       if (key.split('-').length > 1) {
@@ -625,6 +626,8 @@ var AdminModuleController = function() {
 
   this.initSortingDropdown = function () {
     var self = this;
+
+    self.currentSorting = $(this.moduleSortingDropdownSelector).find(':checked').attr('value');
 
     $('body').on('change', this.moduleSortingDropdownSelector, function() {
       self.currentSorting = $(this).find(':checked').attr('value');

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -15,6 +15,7 @@
   data-type="{{ module.attributes.productType }}"
   data-price="{{ module.attributes.price.raw }}"
   data-active="{{ isModuleActive }}"
+  data-last-access="{{ module.database.last_access_date }}"
 >
   <div class="container-fluid">
     <div class="module-item-wrapper-list row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -44,7 +44,7 @@
                             <select class="c-select c-select-sm">
                               <option value="" disabled>- {{ 'Sort by'|trans({}, 'Admin.Actions') }} -</option>
                               <option value="name">{{ 'Name'|trans({}, 'Admin.Global') }}</option>
-                              <option value="access-date" selected>{{ 'Last access'|trans({}, 'Admin.Modules.Feature') }}</option>
+                              <option value="access-desc" selected>{{ 'Last access'|trans({}, 'Admin.Modules.Feature') }}</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In Modules, we should see modules sorted by access date by default |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1300 |
| How to test? | Selecting `last access` in the back-office should result in modules sorting by access date. |
