### PR TITLE
Enabled loading of active theme translations

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -344,12 +344,18 @@ class ContextCore
             $this->translator->addLoader('xlf', new XliffFileLoader);
             $this->translator->addLoader('db', new SqlTranslationLoader);
 
+            $locations = array(_PS_ROOT_DIR_.'/app/Resources/translations');
+            $activeThemeLocation = _PS_ROOT_DIR_.'/themes/'.$this->shop->theme_name.'/translations';
+            if (is_dir($activeThemeLocation)) {
+                $locations[] = $activeThemeLocation;
+            }
+
             $finder = Finder::create()
                 ->files()
                 ->filter(function (\SplFileInfo $file) {
                     return 2 === substr_count($file->getBasename(), '.') && preg_match('/\.\w+$/', $file->getBasename());
                 })
-                ->in(_PS_ROOT_DIR_.'/app/Resources/translations')
+                ->in($locations)
             ;
 
             foreach ($finder as $file) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Translations from active theme should be loaded in front office |
| Type? | new feature |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Copy paste classic theme and rename it classic 2 (and update config file too). If you add a new translation key, it should be loaded. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
