### PR TITLE
Translation files should be overriden by database when using "export theme" action

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -107,7 +107,7 @@ class TranslationsController extends FrameworkBundleAdminController
 
         $zipFile = $folderPath.'.'.$locale.'.zip';
 
-        // create the directory
+        // create the directories
         $fs = new Filesystem();
         $fs->mkdir($folderPath);
         $fs->mkdir($tmpFolderPath);
@@ -115,6 +115,7 @@ class TranslationsController extends FrameworkBundleAdminController
         $themeExtractor = $this->get('prestashop.translations.theme_extractor');
         $themeExtractor
             ->setOutputPath($tmpFolderPath)
+            ->enableOverridingFromDatabase()
             ->extract($theme, $locale)
         ;
 
@@ -222,11 +223,11 @@ class TranslationsController extends FrameworkBundleAdminController
         $locale = $this->langToLocale($lang);
 
         if (!is_null($theme)) {
-            $this->synchronizeTheme($theme, $locale);
             if ('classic' === $theme) {
                 $type = 'front';
             } else {
                 $type = $theme;
+                $this->synchronizeTheme($theme, $locale);
             }
         }
 

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -258,6 +258,7 @@ services:
         class: PrestaShopBundle\Translation\Extractor\ThemeExtractor
         arguments:
           - "@prestashop.translation.extractor.smarty"
+          - "@prestashop.translation.theme_provider"
 
 # Addons API Client
     prestashop.addons.client_api:

--- a/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
@@ -58,18 +58,22 @@ class DatabaseTranslationLoader implements LoaderInterface
             ->getRepository('PrestaShopBundle:Translation')
         ;
 
-        $translations = $translationRepository
+        $queryBuilder = $translationRepository
             ->createQueryBuilder('t')
             ->where('t.lang =:lang')
-            ->andWhere('t.domain LIKE :domain')
-            ->setParameters(array(
-                'lang' => $lang,
-                'domain' => $domain,
-            ))
-            ->getQuery()
-            ->getResult()
+            ->setParameter('lang', $lang)
         ;
 
+        if ($domain !== '*') {
+            $queryBuilder->andWhere('t.domain LIKE :domain')
+                ->setParameter('domain', $domain)
+            ;
+        }
+
+        $translations = $queryBuilder->getQuery()
+            ->getResult()
+        ;
+        
         $catalogue = new MessageCatalogue($locale);
 
         foreach ($translations as $translation) {

--- a/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
@@ -145,6 +145,7 @@ abstract class AbstractProvider implements ProviderInterface
 
         foreach ($this->getTranslationDomains() as $translationDomain) {
             $domainCatalogue = $this->getDatabaseLoader()->load(null, $this->locale, $translationDomain);
+
             if ($domainCatalogue instanceof MessageCatalogue) {
                 $databaseCatalogue->addCatalogue($domainCatalogue);
             }

--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
@@ -42,7 +42,6 @@ trait TranslationFinderTrait
             $finder->name($pattern);
         }
         $translationFiles = $finder->files()->in($paths);
-
         if (count($translationFiles) === 0) {
             throw new \Exception('There is no translation file available.');
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Theme extraction xliff files should be overriden by database values if any. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Try it with a real theme (like starter theme), not with classic because classic translations files are not stored in the classic theme. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
