### PR TITLE
Add a new hook after store data update

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -535,6 +535,7 @@ class AdminStoresControllerCore extends AdminController
                 Configuration::updateValue('PS_SHOP_COUNTRY_ID', $value);
                 Configuration::updateValue('PS_SHOP_COUNTRY', pSQL($country->name));
             }
+            Hook::exec('actionUpdateStoresAfter');
         }
     }
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -357,5 +357,8 @@
     <hook id="actionValidateCustomerAddressForm">
       <name>actionValidateCustomerAddressForm</name><title>Customer address form validation</title><description>This hook is called when a customer submit its address form</description>
     </hook>
+    <hook id="actionUpdateStoresAfter">
+      <name>actionUpdateStoresAfter</name><title>Stores update</title><description>This hook is called after the stores update</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -160,3 +160,4 @@ INSERT INTO  `PREFIX_configuration` (`id_configuration` ,`id_shop_group` ,`id_sh
 DELETE FROM `PREFIX_configuration` WHERE `name` IN ('PS_STORES_DISPLAY_FOOTER', 'PS_STORES_SIMPLIFIED', 'PS_STORES_CENTER_LAT', 'PS_STORES_CENTER_LONG', 'PS_STORES_DISPLAY_SITEMAP');
 
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('actionValidateCustomerAddressForm', 'Customer address form validation', 'This hook is called when a customer submit its address form', '1');
+INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('actionUpdateStoresAfter', 'Stores update', 'This hook is called after the stores update', '1');


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Add a new hook after store data update so ps_contactinfo can use it to clear its cache |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1312 |
| How to test? | Take this PR and this one: https://github.com/PrestaShop/ps_contactinfo/pull/5. Reset the module and try to change your contact settings, it should be displayed now. |
