### PR TITLE
Keep additionnal data in $_POST instead of dropping it

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -412,7 +412,7 @@ class ProductController extends FrameworkBundleAdminController
                 $formData['step3']['combinations'] = $combinations;
 
                 //define POST values for keeping legacy adminController skills
-                $_POST = $modelMapper->getModelData($formData, $isMultiShopContext);
+                $_POST = $modelMapper->getModelData($formData, $isMultiShopContext) + $_POST;
                 $_POST['state'] = \Product::STATE_SAVED;
 
                 $adminProductController = $adminProductWrapper->getInstance();


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When a module uses the product form to manage its additionnal data, they are lost because of a $_POST drop. This PR fixes this issue. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [Part of BOOM-661](http://forge.prestashop.com/browse/BOOM-661) & [BOOM-916](http://forge.prestashop.com/browse/BOOM-916) |
| How to test? | - |
