### PR TITLE
Improve compatibility between PHP 7.1 and PrestaShop

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -604,7 +604,11 @@ class HookCore extends ObjectModel
 
         // Look on modules list
         $altern = 0;
-        $output = '';
+        if ($array_return) {
+            $output = array();
+        } else {
+            $output = '';
+        }
 
         if ($disable_non_native_modules && !isset(Hook::$native_module)) {
             Hook::$native_module = Module::getNativeModuleList();

--- a/classes/db/DbQuery.php
+++ b/classes/db/DbQuery.php
@@ -39,7 +39,7 @@ class DbQueryCore
     protected $query = array(
         'type'   => 'SELECT',
         'select' => array(),
-        'from'   => '',
+        'from'   => array(),
         'join'   => array(),
         'where'  => array(),
         'group'  => array(),


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When gettig the homepage with a server running PHP 7.1 (which seems to be more strict), a fatal error was thrown because a string variable used as an array. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Switch on PHP 7.1 and go to the homepage. You should not have the following issue. |

**Fatal error:** Uncaught Error: [] operator not supported for strings in /Users/tNabord/Documents/github/PrestaShop/classes/db/DbQuery.php:96 Stack trace: #0 /Users/tNabord/Documents/github/PrestaShop/src/Adapter/EntityMapper.php(46): DbQueryCore->from('shop', 'a') #1 /Users/tNabord/Documents/github/PrestaShop/classes/ObjectModel.php(233): PrestaShop\PrestaShop\Adapter\EntityMapper->load('1', NULL, Object(Shop), Array, NULL, true) #2 /Users/tNabord/Documents/github/PrestaShop/classes/shop/Shop.php(135): ObjectModelCore->__construct('1', NULL, NULL) #3 /Users/tNabord/Documents/github/PrestaShop/classes/shop/Shop.php(414): ShopCore->__construct('1') #4 /Users/tNabord/Documents/github/PrestaShop/config/config.inc.php(112): ShopCore::initialize() #5 /Users/tNabord/Documents/github/PrestaShop/index.php(27): require('/Users/tNabord/...') #6 {main} thrown in /Users/tNabord/Documents/github/PrestaShop/classes/db/DbQuery.php on line 96
