### PR TITLE
Fix children feature length

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -339,7 +339,7 @@ var featuresCollection = (function() {
 
   /** Add a feature */
   function add() {
-    var newForm = collectionHolder.attr('data-prototype').replace(/__name__/g, collectionHolder.children().length);
+    var newForm = collectionHolder.attr('data-prototype').replace(/__name__/g, collectionHolder.children('.row').length);
     collectionHolder.append(newForm);
     prestaShopUiKit.initSelects();
   }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix children feature length which caused wrong id in form. With the mobile view introducing `<hr>` there are too many children now and the count is wrong. We need to filter the children by class. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
