### PR TITLE
Fix the invalid favicon uploading

### DIFF
--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -139,7 +139,7 @@ class LogoUploader
 
         if (isset($files[$name]['tmp_name']) && !empty($files[$name]['tmp_name'])) {
             if ($error = ImageManager::validateIconUpload($files[$name])) {
-                throw new PrestaShopException(self::NOTICE.$error);
+                throw new PrestaShopException($error);
             } elseif (!copy($_FILES[$name]['tmp_name'], $destination)) {
                 throw new PrestaShopException(sprintf(Tools::displayError('An error occurred while uploading the favicon: cannot copy file "%s" to folder "%s".'), $files[$name]['tmp_name'], $destination));
             }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The server crashed when uploading a invalid favicon because of an undefined constant |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1148 |
| How to test? | Go to Design > Themes and open the ICON tab. Try to upload an invalid favicon (a file without the .ico extension or a file that is to large). It should display an error message. |
