### PR TITLE
Add deprecated hooks list in class

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -78,6 +78,29 @@ class HookCore extends ObjectModel
      * @deprecated 1.5.0
      */
     protected static $_hook_modules_cache_exec = null;
+    
+    /**
+     * List of all deprecated hooks
+     * @var array 
+     */
+    protected static $deprecated_hooks = array(
+        // Back office
+        'backOfficeFooter' => array('from' => '1.7.0.0'),
+        'displayBackOfficeFooter' => array('from' => '1.7.0.0'),
+        
+        // Shipping step
+        'displayCarrierList' => array('from' => '1.7.0.0'),
+        'extraCarrier' => array('from' => '1.7.0.0'),
+        
+        // Payment step
+        'hookBackBeforePayment' => array('from' => '1.7.0.0'),
+        'hookDisplayBeforePayment' => array('from' => '1.7.0.0'),
+        'hookOverrideTOSDisplay' => array('from' => '1.7.0.0'),
+        
+        // Product page
+        'displayProductTabContent' => array('from' => '1.7.0.0'),
+        'displayProductTab' => array('from' => '1.7.0.0'),
+    );
 
     public function add($autodate = true, $null_values = false)
     {
@@ -587,6 +610,13 @@ class HookCore extends ObjectModel
         // Check if hook exists
         if (!$id_hook = Hook::getIdByName($hook_name)) {
             return false;
+        }
+
+        if (array_key_exists($hook_name, self::$deprecated_hooks)) {
+            $deprecVersion = isset(self::$deprecated_hooks[$hook_name]['from'])?
+                    self::$deprecated_hooks[$hook_name]['from']:
+                    _PS_VERSION_;
+            Tools::displayAsDeprecated('The hook '. $hook_name .' is deprecated in PrestaShop v.'. $deprecVersion);
         }
 
         // Store list of executed hooks on this page

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -210,6 +210,9 @@
     <hook id="displayBeforeCarrier">
       <name>displayBeforeCarrier</name><title>Before carriers list</title><description>This hook is displayed before the carrier list in Front Office</description>
     </hook>
+    <hook id="displayAfterCarrier">
+      <name>displayAfterCarrier</name><title>After carriers list</title><description>This hook is displayed after the carrier list in Front Office</description>
+    </hook>
     <hook id="displayOrderDetail">
       <name>displayOrderDetail</name><title>Order detail</title><description>This hook is displayed within the order's details in Front Office</description>
     </hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -117,12 +117,6 @@
     <hook id="actionOrderSlipAdd">
       <name>actionOrderSlipAdd</name><title>Order slip creation</title><description>This hook is called when a new credit slip is added regarding client order</description>
     </hook>
-    <hook id="displayProductTab">
-      <name>displayProductTab</name><title>Tabs on product page</title><description>This hook is called on the product page's tab</description>
-    </hook>
-    <hook id="displayProductTabContent">
-      <name>displayProductTabContent</name><title>Tabs content on the product page</title><description>This hook is called on the product page's tab</description>
-    </hook>
     <hook id="displayShoppingCartFooter">
       <name>displayShoppingCartFooter</name><title>Shopping cart footer</title><description>This hook displays some specific information on the shopping cart's page</description>
     </hook>
@@ -176,9 +170,6 @@
     </hook>
     <hook id="actionSearch">
       <name>actionSearch</name><title>Search</title><description/>
-    </hook>
-    <hook id="displayBeforePayment">
-      <name>displayBeforePayment</name><title>Redirect during the order process</title><description>This hook redirects the user to the module instead of displaying payment modules</description>
     </hook>
     <hook id="actionCarrierUpdate">
       <name>actionCarrierUpdate</name><title>Carrier Update</title><description>This hook is called when a carrier is updated</description>

--- a/install-dev/data/xml/hook_alias.xml
+++ b/install-dev/data/xml/hook_alias.xml
@@ -113,14 +113,6 @@
       <alias>orderSlip</alias>
       <name>actionOrderSlipAdd</name>
     </hook_alias>
-    <hook_alias id="productTab">
-      <alias>productTab</alias>
-      <name>displayProductTab</name>
-    </hook_alias>
-    <hook_alias id="productTabContent">
-      <alias>productTabContent</alias>
-      <name>displayProductTabContent</name>
-    </hook_alias>
     <hook_alias id="shoppingCart">
       <alias>shoppingCart</alias>
       <name>displayShoppingCartFooter</name>
@@ -184,10 +176,6 @@
     <hook_alias id="search">
       <alias>search</alias>
       <name>actionSearch</name>
-    </hook_alias>
-    <hook_alias id="backBeforePayment">
-      <alias>backBeforePayment</alias>
-      <name>displayBeforePayment</name>
     </hook_alias>
     <hook_alias id="updateCarrier">
       <alias>updateCarrier</alias>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -162,3 +162,4 @@ DELETE FROM `PREFIX_configuration` WHERE `name` IN ('PS_STORES_DISPLAY_FOOTER', 
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('actionValidateCustomerAddressForm', 'Customer address form validation', 'This hook is called when a customer submit its address form', '1');
 
 /* PHP:add_quick_access_tab(); */;
+INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('displayAfterCarrier', 'After carriers list', 'This hook is displayed after the carrier list in Front Office', '1');

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -163,3 +163,6 @@ INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('
 
 /* PHP:add_quick_access_tab(); */;
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('displayAfterCarrier', 'After carriers list', 'This hook is displayed after the carrier list in Front Office', '1');
+
+DELETE FROM `PREFIX_hook` WHERE `name` IN ('displayProductTab', 'displayProductTabContent', 'displayBeforePayment');
+DELETE FROM `PREFIX_hook_alias` WHERE `name` IN ('displayProductTab', 'displayProductTabContent', 'displayBeforePayment');


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Some hooks are now deprecated from PS 1.7. This PR adds a variable in the Hook class in order to notify the developer if one of them will be removed. The hook displayBackOfficeFooter is the first one to be flagged as deprecated. |
| Type? | new feature |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Yes |
| Fixed ticket? | / |
| How to test? | Install a module registered in the hook backOfficeFooter, visit several pages on the backoffice and finally look at the PrestaShop log. You should have a line about the deprecated notice. |

![capture d ecran 2016-09-06 a 11 46 02](https://cloud.githubusercontent.com/assets/6768917/18270976/b45d8dd2-7427-11e6-8781-6b1b04641129.png)
