### PR TITLE
Fix credit split pdf generation

### DIFF
--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -41,6 +41,7 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
     {
         $this->order_slip = $order_slip;
         $this->order = new Order((int)$order_slip->id_order);
+        $this->id_cart = $this->order->id_cart;
 
         $products = OrderSlip::getOrdersSlipProducts($this->order_slip->id, $this->order);
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The credit slip pdf wasn't generated because an undefined instance variable was used |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1322 |
| How to test? | <ul><li>FO: Buy a product</li><li>BO: Return it</li><li>BO: Add a partial refund for this order</li><li>FO: Go to your credit slips</li><li>FO: Open the pdf</li><li>Shouldn't break</li></ul> |
