### PR TITLE
FO: hide language selector when not needed

### DIFF
--- a/themes/classic/modules/ps_languageselector/ps_languageselector.tpl
+++ b/themes/classic/modules/ps_languageselector/ps_languageselector.tpl
@@ -22,6 +22,7 @@
 *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 *}
+{if 1 < count($languages)}
 <div id="_desktop_language_selector">
   <div class="language-selector-wrapper">
     <span class="hidden-md-up">{l s='Language:' d='Shop.Theme'}</span>
@@ -45,3 +46,4 @@
     </div>
   </div>
 </div>
+{/if}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Hide the language selector if there is only one language |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1299 |
| How to test? | <ul><li>BO: Install at least 2 languages</li><li>FO: You should see the selector</li><li>BO: Remove all the languages except one</li><li>FO: You should not see the selector</li></ul> |
