### PR TITLE
Hide id_guest if disabled in configuration

### DIFF
--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -104,6 +104,11 @@ class AdminCartsControllerCore extends AdminController
                 'icon' => array(0 => 'icon-', 1 => 'icon-user')
             )
         );
+
+        if (!Configuration::get('PS_GUEST_CHECKOUT_ENABLED')) {
+            unset($this->fields_list['id_guest']);
+        }
+
         $this->shopLinkType = 'shop';
 
         $this->bulk_actions = array(


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Hide id_guest field if it is disabled in configuration |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | - |
| How to test? | In cart list in back office id_guest must be hide if guest checkout is disabled |
