### PR TITLE
Fix link to product in shopping cart

### DIFF
--- a/themes/default-bootstrap/shopping-cart.tpl
+++ b/themes/default-bootstrap/shopping-cart.tpl
@@ -549,7 +549,7 @@
 				<span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span>
 			</a>
 		{/if}
-		<a href="{if (isset($smarty.server.HTTP_REFERER) && ($smarty.server.HTTP_REFERER == $link->getPageLink('order', true) || $smarty.server.HTTP_REFERER == $link->getPageLink('order-opc', true) || strstr($smarty.server.HTTP_REFERER, 'step='))) || !isset($smarty.server.HTTP_REFERER)}{$link->getPageLink('index')}{else}{$smarty.server.HTTP_REFERER|escape:'html':'UTF-8'|secureReferrer}{/if}" class="button-exclusive btn btn-default" title="{l s='Continue shopping'}">
+		<a href="{if (isset($smarty.server.HTTP_REFERER) && ($smarty.server.HTTP_REFERER == $link->getPageLink('order', true) || $smarty.server.HTTP_REFERER == $link->getPageLink('order-opc', true) || strstr($smarty.server.HTTP_REFERER, 'step='))) || !isset($smarty.server.HTTP_REFERER)}{$link->getPageLink('index')}{else}{$smarty.server.HTTP_REFERER|replace:'&content_only=1':''|escape:'html':'UTF-8'|secureReferrer}{/if}" class="button-exclusive btn btn-default" title="{l s='Continue shopping'}">
 			<i class="icon-chevron-left"></i>{l s='Continue shopping'}
 		</a>
 	</p>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `1.6.1.x` |
| Description? | Looks like we have us a nasty bug here. The continue shopping button sometimes links to the quick view version of a product page, which makes the customer unable to navigate any further on the site. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Source is this forum topic: https://www.prestashop.com/forums/topic/553647-major-bug-in-default-theme |
| How to test? | This should no longer occur: |
|  | 1. Go to frontpage. |
|  | 2. Click on a products "Quick View" |
|  | 3. Select your color etc. Click on "Add to cart" |
|  | 4. You are automaticly taken to the cart. |
|  | 5. Click on the bottom left link "Continue Shopping" -> |
|  | 6 BANG!!!.. you are in some way taken back to the quick view but in Full screen. and no links or menu is shown so no way to go anywhere. |
