### PR TITLE
Remove unused parameter for Cart::isVirtualCart()

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3569,7 +3569,7 @@ class CartCore extends ObjectModel
     *
     * @return bool true if is a virtual cart or false
     */
-    public function isVirtualCart($strict = false)
+    public function isVirtualCart()
     {
         if (!ProductDownload::isFeatureActive()) {
             return false;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Remove unused parameter into isVirtualCart method |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Nothing to test here |
