### PR TITLE
Bring back forgotten hooks

### DIFF
--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -1,6 +1,9 @@
 {extends file='checkout/_partials/steps/checkout-step.tpl'}
 
 {block name='step_content'}
+
+  {hook h='displayPaymentTop'}
+
   <div class="payment-options">
     {foreach from=$payment_options item="module_options"}
       {foreach from=$module_options item="option"}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | During the migration to Symphony or the starter theme, some hooks have been forgotten. This PR brings back many of them. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-982](http://forge.prestashop.com/browse/BOOM-982), [BOOM-715](http://forge.prestashop.com/browse/BOOM-715) |
| How to test? | Get a module with the necessary hooks and check if the code is properly executed (or displayed) |
