### PR TITLE
Handle error if installation starts with PHP < 5.4

### DIFF
--- a/install-dev/index.php
+++ b/install-dev/index.php
@@ -25,8 +25,8 @@
  */
 
 
-if (!extension_loaded('SimpleXML')) {
-    header('Location: missing_extension.html');
+if (!extension_loaded('SimpleXML') || PHP_VERSION_ID < 50400) {
+    require_once dirname(__FILE__).'/missing_extension.php';
     exit();
 }
 

--- a/install-dev/missing_extension.php
+++ b/install-dev/missing_extension.php
@@ -78,7 +78,10 @@
       max-width: 580px;
       width: 580px;
       margin: 0 auto;
-      text-align: center;
+    }
+
+    .container p {
+        text-align: center;
     }
 
     input::-moz-focus-inner {
@@ -90,8 +93,22 @@
 <body>
 <div class="container">
   <h2>We can't start installation :(</h2>
-  <p><p>PrestaShop installation requires at least the <b>SimpleXML extension</b> to be enabled. <br><br>
-    Contact your web host provider to enable it.</p>
+
+  <ol>
+    <?php if (!extension_loaded('SimpleXML')): ?>
+    <li>
+        PrestaShop installation requires at least the <b>SimpleXML extension</b> to be enabled.
+    </li>
+    <?php endif; ?>
+    <?php if (PHP_VERSION_ID < 50400): ?>
+      <li>
+          PrestaShop requires at least PHP 5.4 or newer versions.
+          <i>You can install PrestaShop 1.6 if you can't update your version of PHP.</i>
+      </li>
+    <?php endif; ?>
+  </ol>
+
+  <p>You can contact your web host provider to fix theses requirements.</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | If we try to install PrestaShop 1.7 with PHP < 5.4, we should be aware that this is impossible |
| Type? | improvement |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | No need. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
