### PR TITLE
Removed the language selector on the Product page if there is only one language

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -24,12 +24,14 @@
             <span class="help-box pull-xs-right" data-toggle="popover"
               data-content="{{ "Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?"|trans({}, 'Admin.Catalog.Help') }}"></span>
           </div>
-          <div class="col-md-1 form_switch_language {{ languages|length == 1 ? 'hide' : '' }}">
-            <select id="form_switch_language" class="form-control" data-toggle="select2">
-              {% for language in languages %}
-                <option value="{{ language.iso_code }}" {% if default_language_iso == language.iso_code %}selected="selected"{% endif %}>{{ language.iso_code }}</option>
-              {% endfor %}
-            </select>
+          <div class="col-md-1 form_switch_language">
+            <div class="{{ languages|length == 1 ? 'hide' : '' }}">
+              <select id="form_switch_language" class="form-control" data-toggle="select2">
+                {% for language in languages %}
+                  <option value="{{ language.iso_code }}" {% if default_language_iso == language.iso_code %}selected="selected"{% endif %}>{{ language.iso_code }}</option>
+                {% endfor %}
+              </select>
+            </div>
           </div>
           <div class="toolbar col-lg-2 text-md-right">
             <a class="toolbar-button btn-sales" href="{{ stats_link }}" target="_blank" title="{{ 'Sales'|trans({}, 'Admin.Global') }}"


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The language selector shouldn't appear on the product page when there is only one language available |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-642 |
| How to test? | <ul><li>BO: Install at least 2 languages</li><li>BO: Product page : You should see the selector</li><li>BO: Remove all the languages except one</li><li> BO: Product page : You should not see the selector</li></ul> |
