### PR TITLE
Display gift wrapping on Order confirmation

### DIFF
--- a/src/Adapter/Order/OrderPresenter.php
+++ b/src/Adapter/Order/OrderPresenter.php
@@ -154,13 +154,30 @@ class OrderPresenter implements PresenterInterface
         }
 
         $tax = $order->total_paid_tax_incl - $order->total_paid_tax_excl;
-        $subtotals['tax'] = null;
+        $subtotals['tax'] = array(
+            'type' => 'tax',
+            'label' => null,
+            'amount' => null,
+            'value' => '',
+        );
         if ((float) $tax && Configuration::get('PS_TAX_DISPLAY')) {
             $subtotals['tax'] = array(
                 'type' => 'tax',
                 'label' => $this->translator->trans('Tax', array(), 'Shop.Theme.Checkout'),
                 'amount' => $tax,
                 'value' => $this->priceFormatter->format($tax),
+            );
+        }
+
+        if ($order->gift) {
+            $giftWrapping = ($this->includeTaxes())
+                ? $order->total_wrapping_tax_incl
+                : $order->total_wrapping_tax_incl;
+            $subtotals['gift_wrapping'] = array(
+                'type' => 'gift_wrapping',
+                'label' => $this->translator->trans('Gift wrapping', array(), 'Shop.Theme.Checkout'),
+                'amount' => $giftWrapping,
+                'value' => $this->priceFormatter->format($giftWrapping),
             );
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Gift wrapping line was missing from order confirmation page. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1040 |
| How to test? | Easy: enable the feature in back office, checkout a product with the feature enabled and see the result: wow ! |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
