### PR TITLE
CO: Fix getImageLink for watermark module

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -408,7 +408,7 @@ class LinkCore
         $not_default = false;
 
         // Check if module is installed, enabled, customer is logged in and watermark logged option is on
-        if (Configuration::get('WATERMARK_LOGGED') && (Module::isInstalled('watermark') && Module::isEnabled('watermark')) && isset(Context::getContext()->customer->id)) {
+        if (($type != '') && Configuration::get('WATERMARK_LOGGED') && (Module::isInstalled('watermark') && Module::isEnabled('watermark')) && isset(Context::getContext()->customer->id)) {
             $type .= '-'.Configuration::get('WATERMARK_HASH');
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | If watermark module is enable Link::getImageLink doesn't return a valid link for original picture. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Enable watermark,  Link::getImageLink('my-picture', 12) return http://example.com/12--EZEJSDSD/my-picture.jpg instead of http://example.com/12/my-picture.jpg |
