### PR TITLE
Combination feature desactivation

### DIFF
--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -504,17 +504,19 @@ class AdminAttributesGroupsControllerCore extends AdminController
 
     public function initPageHeaderToolbar()
     {
-        if (empty($this->display)) {
-            $this->page_header_toolbar_btn['new_attribute_group'] = array(
-                'href' => self::$currentIndex.'&addattribute_group&token='.$this->token,
-                'desc' => $this->trans('Add new attribute', array(), 'Admin.Catalog.Feature'),
-                'icon' => 'process-icon-new'
-            );
-            $this->page_header_toolbar_btn['new_value'] = array(
-                'href' => self::$currentIndex.'&updateattribute&id_attribute_group='.(int)Tools::getValue('id_attribute_group').'&token='.$this->token,
-                'desc' => $this->trans('Add new value', array(), 'Admin.Catalog.Feature'),
-                'icon' => 'process-icon-new'
-            );
+        if (Combination::isFeatureActive()) {
+            if (empty($this->display)) {
+                $this->page_header_toolbar_btn['new_attribute_group'] = array(
+                    'href' => self::$currentIndex.'&addattribute_group&token='.$this->token,
+                    'desc' => $this->trans('Add new attribute', array(), 'Admin.Catalog.Feature'),
+                    'icon' => 'process-icon-new'
+                );
+                $this->page_header_toolbar_btn['new_value'] = array(
+                    'href' => self::$currentIndex.'&updateattribute&id_attribute_group='.(int)Tools::getValue('id_attribute_group').'&token='.$this->token,
+                    'desc' => $this->trans('Add new value', array(), 'Admin.Catalog.Feature'),
+                    'icon' => 'process-icon-new'
+                );
+            }
         }
 
         if ($this->display == 'view') {

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -462,33 +462,32 @@ class AdminAttributesGroupsControllerCore extends AdminController
      */
     public function initContent()
     {
-        if (!Combination::isFeatureActive()) {
-            $url = '<a href="index.php?tab=AdminPerformance&token='.Tools::getAdminTokenLite('AdminPerformance').'#featuresDetachables">'.
-                    $this->trans('Performance', array(), 'Admin.Global').'</a>';
-            $this->displayWarning(sprintf($this->trans('This feature has been disabled. You can activate it here: %s.', array('%s' => $url), 'Admin.Catalog.Notification')));
-            return;
-        }
-
-        // toolbar (save, cancel, new, ..)
+        // toolbar (save, cancel, new, ..) - show toolbar even if combinations are not active
         $this->initTabModuleList();
         $this->initToolbar();
         $this->initPageHeaderToolbar();
-        if ($this->display == 'edit' || $this->display == 'add') {
-            if (!($this->object = $this->loadObject(true))) {
-                return;
-            }
-            $this->content .= $this->renderForm();
-        } elseif ($this->display == 'editAttributes') {
-            if (!$this->object = new Attribute((int)Tools::getValue('id_attribute'))) {
-                return;
-            }
 
-            $this->content .= $this->renderFormAttributes();
-        } elseif ($this->display != 'view' && !$this->ajax) {
-            $this->content .= $this->renderList();
-            $this->content .= $this->renderOptions();
-        } elseif ($this->display == 'view' && !$this->ajax) {
-            $this->content = $this->renderView();
+        if (Combination::isFeatureActive()) {
+            if ($this->display == 'edit' || $this->display == 'add') {
+                if (!($this->object = $this->loadObject(true))) {
+                    return;
+                }
+                $this->content .= $this->renderForm();
+            } elseif ($this->display == 'editAttributes') {
+                if (!$this->object = new Attribute((int)Tools::getValue('id_attribute'))) {
+                    return;
+                }
+
+                $this->content .= $this->renderFormAttributes();
+            } elseif ($this->display != 'view' && !$this->ajax) {
+                $this->content .= $this->renderList();
+                $this->content .= $this->renderOptions();
+            } elseif ($this->display == 'view' && !$this->ajax) {
+                $this->content = $this->renderView();
+            }
+        } else {
+            $url = '<a href="index.php?tab=AdminPerformance&token='.Tools::getAdminTokenLite('AdminPerformance').'#featuresDetachables">'.$this->trans('Performance', array(), 'Admin.Global').'</a>';
+            $this->displayWarning(sprintf($this->trans('This feature has been disabled. You can activate it here: %s.', array('%s' => $url), 'Admin.Catalog.Notification')));
         }
 
         $this->context->smarty->assign(array(

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -405,11 +405,12 @@ class AdminFeaturesControllerCore extends AdminController
      */
     public function initContent()
     {
+        // toolbar (save, cancel, new, ..) - show toolbar even if features are not active
+        $this->initTabModuleList();
+        $this->initToolbar();
+        $this->initPageHeaderToolbar();
+
         if (Feature::isFeatureActive()) {
-            // toolbar (save, cancel, new, ..)
-            $this->initTabModuleList();
-            $this->initToolbar();
-            $this->initPageHeaderToolbar();
             if ($this->display == 'edit' || $this->display == 'add') {
                 if (!$this->loadObject(true)) {
                     return;
@@ -425,7 +426,6 @@ class AdminFeaturesControllerCore extends AdminController
                 if (!$this->object = new FeatureValue((int)Tools::getValue('id_feature_value'))) {
                     return;
                 }
-
                 $this->content .= $this->initFormFeatureValue();
             } elseif (!$this->ajax) {
                 // If a feature value was saved, we need to reset the values to display the list

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -190,18 +190,20 @@ class AdminFeaturesControllerCore extends AdminController
 
     public function initPageHeaderToolbar()
     {
-        if (empty($this->display)) {
-            $this->page_header_toolbar_btn['new_feature'] = array(
-                'href' => self::$currentIndex.'&addfeature&token='.$this->token,
-                'desc' => $this->trans('Add new feature', array(), 'Admin.Catalog.Feature'),
-                'icon' => 'process-icon-new'
-            );
+        if (Feature::isFeatureActive()) {
+            if (empty($this->display)) {
+                $this->page_header_toolbar_btn['new_feature'] = array(
+                    'href' => self::$currentIndex.'&addfeature&token='.$this->token,
+                    'desc' => $this->trans('Add new feature', array(), 'Admin.Catalog.Feature'),
+                    'icon' => 'process-icon-new'
+                );
 
-            $this->page_header_toolbar_btn['new_feature_value'] = array(
-                'href' => self::$currentIndex.'&addfeature_value&id_feature='.(int)Tools::getValue('id_feature').'&token='.$this->token,
-                'desc' => $this->trans('Add new feature value', array(), 'Admin.Catalog.Help'),
-                'icon' => 'process-icon-new'
-            );
+                $this->page_header_toolbar_btn['new_feature_value'] = array(
+                    'href' => self::$currentIndex.'&addfeature_value&id_feature='.(int)Tools::getValue('id_feature').'&token='.$this->token,
+                    'desc' => $this->trans('Add new feature value', array(), 'Admin.Catalog.Help'),
+                    'icon' => 'process-icon-new'
+                );
+            }
         }
 
         if ($this->display == 'view') {

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -75,4 +75,22 @@ class Configuration implements ConfigurationInterface
 
         return $this;
     }
+
+    /**
+     * Return if Feature feature is active or not
+     * @return bool
+     */
+    public function featureIsActive()
+    {
+        return \FeatureCore::isFeatureActive();
+    }
+
+    /**
+     * Return if Combination feature is active or not
+     * @return bool
+     */
+    public function combinationIsActive()
+    {
+        return  \CombinationCore::isFeatureActive();
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -501,6 +501,7 @@ class ProductController extends FrameworkBundleAdminController
             'asm_globally_activated' => $stockManager->isAsmGloballyActivated(),
             'warehouses' => ($stockManager->isAsmGloballyActivated())? $warehouseProvider->getWarehouses() : [],
             'is_multishop_context' => $isMultiShopContext,
+            'is_combination_active' => $this->get('prestashop.adapter.legacy.configuration')->combinationIsActive(),
             'showContentHeader' => false,
             'preview_link' => $preview_url,
             'preview_link_deactivate' => $preview_url_deactive,

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -215,31 +215,33 @@
                       <div class="row">
                         <div class="col-md-12">
 
-                          <div class="form-group" id="show_variations_selector">
-                            <h2>
-                              {{ "Combinations"|trans({}, 'Admin.Catalog.Feature') }}
-                              <span class="help-box" data-toggle="popover"
-                                data-content="{{ "Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?"|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                            </h2>
-                            <div class="radio">
-                              <label>
-                                <input type="radio" name="show_variations" value="0" {% if not has_combinations %}checked="checked"{% endif %}>
-                                {{ "Simple product"|trans({}, 'Admin.Catalog.Feature') }}
-                              </label>
-                            </div>
-                            <div class="radio">
-                              <label>
-                                <input type="radio" name="show_variations" value="1" {% if has_combinations %}checked="checked"{% endif %}>
-                                {{ "Product with combinations"|trans({}, 'Admin.Catalog.Feature') }}
-                              </label>
-                              <div id="product_type_combinations_shortcut">
-                                <span class="small font-secondary">
-                                  {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                                  {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').tab(\'show\');" class="btn sensitive p-x-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
-                                </span>
+                          {% if is_combination_active %}
+                            <div class="form-group" id="show_variations_selector">
+                              <h2>
+                                {{ "Combinations"|trans({}, 'Admin.Catalog.Feature') }}
+                                <span class="help-box" data-toggle="popover"
+                                  data-content="{{ "Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?"|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                              </h2>
+                              <div class="radio">
+                                <label>
+                                  <input type="radio" name="show_variations" value="0" {% if not has_combinations %}checked="checked"{% endif %}>
+                                  {{ "Simple product"|trans({}, 'Admin.Catalog.Feature') }}
+                                </label>
+                              </div>
+                              <div class="radio">
+                                <label>
+                                  <input type="radio" name="show_variations" value="1" {% if has_combinations %}checked="checked"{% endif %}>
+                                  {{ "Product with combinations"|trans({}, 'Admin.Catalog.Feature') }}
+                                </label>
+                                <div id="product_type_combinations_shortcut">
+                                  <span class="small font-secondary">
+                                    {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
+                                    {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').tab(\'show\');" class="btn sensitive p-x-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+                                  </span>
+                                </div>
                               </div>
                             </div>
-                          </div>
+                          {% endif %}
 
                           <div class="form-group">
                             <h2>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix "attributes & features" tabs display & toolbar<br /> Fix "combination" bloc on "new product" page |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1227 |
| How to test? | \- With a correct install (no corrupted product/combination), change combination & feature settings (BO > performance),<br /> - Go to "attributes & features tabs", test if is ok with settings, <br /> - Go on "new product" page and see "declinaison bloc" on the right is active or not |
