### PR TITLE
FO: Always display available_date on the product page

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -354,7 +354,7 @@ class ProductPresenter
             if ($product['quantity'] > 0) {
                 $presentedProduct['availability_message'] = $product['available_now'];
                 $presentedProduct['availability'] = 'available';
-                $presentedProduct['availability_date'] = null;
+                $presentedProduct['availability_date'] = $product['available_date'];
             } elseif ($product['allow_oosp']) {
                 if ($product['available_later']) {
                     $presentedProduct['availability_message'] = $product['available_later'];
@@ -388,7 +388,7 @@ class ProductPresenter
             }
         } else {
             $presentedProduct['availability_message'] = null;
-            $presentedProduct['availability_date'] = null;
+            $presentedProduct['availability_date'] = $product['available_date'];
             $presentedProduct['availability'] = null;
         }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The availability date of a product should always be displayed on its description page if it exists |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-341 |
| How to test? | <ul><li>BO: Create a product without stock but with an availability date</li><li>FO: On the product's description page the availability date should appear</li><li>BO: Add some stock to the product</li><li>FO: The availability date should still appear on the description page</li></ul> |
