### PR TITLE
Introduce new hook Finder and hook displayProductExtraContent

### DIFF
--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -47,7 +47,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
         $assignedVars = array(
             'payment_options' => $this
                 ->paymentOptionsFinder
-                ->getPaymentOptionsForTemplate(),
+                ->present(),
             'conditions_to_approve' => $this
                 ->conditionsToApproveFinder
                 ->getConditionsToApproveForTemplate(),

--- a/classes/checkout/PaymentOptionsFinder.php
+++ b/classes/checkout/PaymentOptionsFinder.php
@@ -2,10 +2,10 @@
 
 use PrestaShop\PrestaShop\Core\Payment\PaymentOptionFormDecorator;
 use PrestaShop\PrestaShop\Core\Payment\PaymentOption;
-use PrestaShopBundle\Service\Hook\Finder;
+use PrestaShopBundle\Service\Hook\HookFinder;
 
-class PaymentOptionsFinderCore extends Finder
-{    
+class PaymentOptionsFinderCore extends HookFinder
+{   
     public function find() //getPaymentOptions()
     {
         // Payment options coming from intermediate, deprecated version of the Advanced API

--- a/classes/checkout/PaymentOptionsFinder.php
+++ b/classes/checkout/PaymentOptionsFinder.php
@@ -2,13 +2,15 @@
 
 use PrestaShop\PrestaShop\Core\Payment\PaymentOptionFormDecorator;
 use PrestaShop\PrestaShop\Core\Payment\PaymentOption;
+use PrestaShopBundle\Service\Hook\Finder;
 
-class PaymentOptionsFinderCore
-{
-    public function getPaymentOptions()
+class PaymentOptionsFinderCore extends Finder
+{    
+    public function find() //getPaymentOptions()
     {
         // Payment options coming from intermediate, deprecated version of the Advanced API
-        $rawDisplayPaymentEUOptions = Hook::exec('displayPaymentEU', array(), null, true);
+        $this->hookName = 'displayPaymentEU';
+        $rawDisplayPaymentEUOptions = parent::find();
 
         if (!is_array($rawDisplayPaymentEUOptions)) {
             $rawDisplayPaymentEUOptions = array();
@@ -20,13 +22,16 @@ class PaymentOptionsFinderCore
         );
 
         // Payment options coming from regular Advanced API
-        $advancedPaymentOptions = Hook::exec('advancedPaymentOptions', array(), null, true);
+        $this->hookName = 'advancedPaymentOptions';
+        $advancedPaymentOptions = parent::find();
         if (!is_array($advancedPaymentOptions)) {
             $advancedPaymentOptions = array();
         }
 
         // Payment options coming from regular Advanced API
-        $newOption = Hook::exec('paymentOptions', array(), null, true);
+        $this->hookName = 'paymentOptions';
+        $this->expectedInstanceClasses = array('PrestaShop\PrestaShop\Core\Payment\PaymentOption');
+        $newOption = parent::find();
         if (!is_array($newOption)) {
             $newOption = array();
         }
@@ -42,7 +47,7 @@ class PaymentOptionsFinderCore
         return $paymentOptions;
     }
 
-    public function getPaymentOptionsForTemplate()
+    public function present() //getPaymentOptionsForTemplate()
     {
         $id = 0;
 
@@ -62,6 +67,6 @@ class PaymentOptionsFinderCore
 
                 return $formattedOption;
             }, $options);
-        }, $this->getPaymentOptions());
+        }, $this->find());
     }
 }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -25,6 +25,7 @@
  */
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Core\Product\ProductExtraContentFinder;
 use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
@@ -291,6 +292,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             }
 
             $product_for_template = $this->getTemplateVarProduct();
+            
+            // Hook displayProductExtraContent
+            $extraContentFinder = new ProductExtraContentFinder();
+            $productExtraContent = $extraContentFinder->getPresentedProductExtraContent($this->product);
 
             $this->context->smarty->assign(array(
                 'priceDisplay' => $priceDisplay,
@@ -301,6 +306,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'product' => $product_for_template,
                 'displayUnitPrice' => (!empty($this->product->unity) && $this->product->unit_price_ratio > 0.000000) ? true : false,
                 'product_manufacturer' => new Manufacturer((int) $this->product->id_manufacturer, $this->context->language->id),
+                'productExtraContent' => $productExtraContent,
             ));
 
             // Assign attribute groups to the template

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -292,10 +292,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             }
 
             $product_for_template = $this->getTemplateVarProduct();
-            
-            // Hook displayProductExtraContent
-            $extraContentFinder = new ProductExtraContentFinder();
-            $productExtraContent = $extraContentFinder->getPresentedProductExtraContent($this->product);
 
             $this->context->smarty->assign(array(
                 'priceDisplay' => $priceDisplay,
@@ -306,7 +302,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'product' => $product_for_template,
                 'displayUnitPrice' => (!empty($this->product->unity) && $this->product->unit_price_ratio > 0.000000) ? true : false,
                 'product_manufacturer' => new Manufacturer((int) $this->product->id_manufacturer, $this->context->language->id),
-                'productExtraContent' => $productExtraContent,
             ));
 
             // Assign attribute groups to the template
@@ -812,6 +807,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function getTemplateVarProduct()
     {
         $productSettings = $this->getProductPresentationSettings();
+        // Hook displayProductExtraContent
+        $extraContentFinder = new ProductExtraContentFinder();
 
         $product = $this->objectPresenter->present($this->product);
         $product['id_product'] = (int) $this->product->id;
@@ -820,6 +817,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['id_product_attribute'] = (int) Tools::getValue('id_product_attribute');
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);
+        $product['extraContent'] = $extraContentFinder->addParams(array('product' => $this->product))->present();
 
         $product_full = Product::getProductProperties($this->context->language->id, $product, $this->context);
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -357,5 +357,8 @@
     <hook id="validateCustomerFormFields">
       <name>validateCustomerFormFields</name><title>Customer registration form validation</title><description>This hook is called to a module when it has sent addtionnal fields with additionalCustomerFormFields</description>
     </hook>
+    <hook id="displayProductExtraContent">
+      <name>displayProductExtraContent</name><title>Display extra content on the product page</title><description>This hook expects ProductExtraContent instances, which will be properly displayed by the template on the product page.</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -162,6 +162,13 @@ DELETE FROM `PREFIX_configuration` WHERE `name` IN ('PS_STORES_DISPLAY_FOOTER', 
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('actionValidateCustomerAddressForm', 'Customer address form validation', 'This hook is called when a customer submit its address form', '1');
 
 /* PHP:add_quick_access_tab(); */;
+<<<<<<< HEAD
+||||||| merged common ancestors
+
+=======
+<<<<<<< HEAD
+
+>>>>>>> CO: Introduce new hook displayProductExtraContent
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('displayAfterCarrier', 'After carriers list', 'This hook is displayed after the carrier list in Front Office', '1');
 
 DELETE FROM `PREFIX_hook` WHERE `name` IN ('displayProductTab', 'displayProductTabContent', 'displayBeforePayment');
@@ -176,3 +183,4 @@ DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_HTML_THEME_COMPRESSION';
 
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('validateCustomerFormFields', 'Customer registration form validation', 'This hook is called to a module when it has sent addtionnal fields with additionalCustomerFormFields', '1');
 
+INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('displayProductExtraContent', 'Display extra content on the product page', 'This hook expects ProductExtraContent instances, which will be properly displayed by the template on the product page.', '1');

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -162,13 +162,6 @@ DELETE FROM `PREFIX_configuration` WHERE `name` IN ('PS_STORES_DISPLAY_FOOTER', 
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('actionValidateCustomerAddressForm', 'Customer address form validation', 'This hook is called when a customer submit its address form', '1');
 
 /* PHP:add_quick_access_tab(); */;
-<<<<<<< HEAD
-||||||| merged common ancestors
-
-=======
-<<<<<<< HEAD
-
->>>>>>> CO: Introduce new hook displayProductExtraContent
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('displayAfterCarrier', 'After carriers list', 'This hook is displayed after the carrier list in Front Office', '1');
 
 DELETE FROM `PREFIX_hook` WHERE `name` IN ('displayProductTab', 'displayProductTabContent', 'displayBeforePayment');

--- a/src/Adapter/HookManager.php
+++ b/src/Adapter/HookManager.php
@@ -51,11 +51,19 @@ class HookManager
         $use_push = false,
         $id_shop = null
     ) {
-        try {
-            return \HookCore::exec($hook_name, $hook_args, $id_module, $array_return, $check_exceptions, $use_push, $id_shop);
-        } catch (\Exception $e) {
-            $logger = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('logger');
-            $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()));
+        global $kernel;
+        if (!is_null($kernel)) {
+            // If the Symfony kernel is instanciated, we use it for the event fonctionnality
+            $hookDispatcher = $kernel->getContainer()->get('prestashop.hook.dispatcher');
+            return $hookDispatcher->renderForParameters($hook_name, $hook_args)->getContent();
+        }
+        else {
+            try {
+                return \HookCore::exec($hook_name, $hook_args, $id_module, $array_return, $check_exceptions, $use_push, $id_shop);
+            } catch (\Exception $e) {
+                $logger = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('logger');
+                $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()));
+            }
         }
     }
 }

--- a/src/Core/Payment/PaymentOption.php
+++ b/src/Core/Payment/PaymentOption.php
@@ -25,6 +25,8 @@
  */
 namespace PrestaShop\PrestaShop\Core\Payment;
 
+use PrestaShopBundle\Service\Hook\HookContentClassInterface;
+
 /**
  * We define 4 types of payment options:
  *
@@ -33,7 +35,7 @@ namespace PrestaShop\PrestaShop\Core\Payment;
  * - the "embedded" kind: you write your credit card info in a form that is on your site and not inside an iframe (e.g. stripe)
  * - the "iframe" kind: payment form is displayed on your website but inside an iframe (e.g. atos)
  */
-class PaymentOption
+class PaymentOption implements HookContentClassInterface
 {
     /**
      * This text will be displayed

--- a/src/Core/Product/ProductExtraContent.php
+++ b/src/Core/Product/ProductExtraContent.php
@@ -48,37 +48,55 @@ class ProductExtraContent
      * For some reason, you may need to have a class on the div generated,
      * or to be able to set an anchor.
      * 
-     * @var string
+     * @var array
      */
-    private $attr = '';
+    private $attr = array(
+        'id' => '',
+        'class' => '',
+    );
 
-    function getTitle() {
+    public function getTitle()
+    {
         return $this->title;
     }
 
-    function getContent() {
+    public function getContent()
+    {
         return $this->content;
     }
 
-    function getAttr() {
+    public function getAttr()
+    {
         return $this->attr;
     }
 
-    function setTitle($title) {
+    public function setTitle($title) {
         $this->title = $title;
         return $this;
     }
 
-    function setContent($content) {
+    public function setContent($content)
+    {
         $this->content = $content;
         return $this;
     }
-
-    function setAttr($attr) {
-        $this->attr = $attr;
+    
+    public function addAttr($attr)
+    {
+        $this->attr = array_merge($this->attr, $attr);
         return $this;
     }
 
+    public function setAttr($attr)
+    {
+        // We declare default values for if and class which
+        // could be mandatory in the template
+        $this->attr = array_merge(array(
+            'id' => '',
+            'class' => '',
+        ), $attr);
+        return $this;
+    }
     
     public function toArray()
     {

--- a/src/Core/Product/ProductExtraContent.php
+++ b/src/Core/Product/ProductExtraContent.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShop\PrestaShop\Core\Product;
+
+class ProductExtraContent
+{
+    /**
+     * Title of the content. This can be used in the template
+     * e.g as a tab name or an anchor.
+     * 
+     * @var string
+     */
+    private $title;
+
+
+    /**
+     * Content in HTML to display.
+     * This is the main attribute of this class.
+     *
+     * @var string
+     */
+    private $content;
+    
+    /**
+     * For some reason, you may need to have a class on the div generated,
+     * or to be able to set an anchor.
+     * 
+     * @var string
+     */
+    private $attr = '';
+
+    function getTitle() {
+        return $this->title;
+    }
+
+    function getContent() {
+        return $this->content;
+    }
+
+    function getAttr() {
+        return $this->attr;
+    }
+
+    function setTitle($title) {
+        $this->title = $title;
+        return $this;
+    }
+
+    function setContent($content) {
+        $this->content = $content;
+        return $this;
+    }
+
+    function setAttr($attr) {
+        $this->attr = $attr;
+        return $this;
+    }
+
+    
+    public function toArray()
+    {
+        return array(
+            'title' => $this->title,
+            'content' => $this->content,
+            'attr' => $this->attr,
+        );
+    }
+
+}

--- a/src/Core/Product/ProductExtraContent.php
+++ b/src/Core/Product/ProductExtraContent.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2015 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -23,6 +23,7 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShop\PrestaShop\Core\Product;
 
 class ProductExtraContent
@@ -35,7 +36,6 @@ class ProductExtraContent
      */
     private $title;
 
-
     /**
      * Content in HTML to display.
      * This is the main attribute of this class.
@@ -43,7 +43,7 @@ class ProductExtraContent
      * @var string
      */
     private $content;
-    
+
     /**
      * For some reason, you may need to have a class on the div generated,
      * or to be able to set an anchor.
@@ -70,20 +70,24 @@ class ProductExtraContent
         return $this->attr;
     }
 
-    public function setTitle($title) {
+    public function setTitle($title)
+    {
         $this->title = $title;
+
         return $this;
     }
 
     public function setContent($content)
     {
         $this->content = $content;
+
         return $this;
     }
-    
+
     public function addAttr($attr)
     {
         $this->attr = array_merge($this->attr, $attr);
+
         return $this;
     }
 
@@ -95,9 +99,10 @@ class ProductExtraContent
             'id' => '',
             'class' => '',
         ), $attr);
+
         return $this;
     }
-    
+
     public function toArray()
     {
         return array(
@@ -106,5 +111,4 @@ class ProductExtraContent
             'attr' => $this->attr,
         );
     }
-
 }

--- a/src/Core/Product/ProductExtraContent.php
+++ b/src/Core/Product/ProductExtraContent.php
@@ -26,7 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Core\Product;
 
-class ProductExtraContent
+use PrestaShopBundle\Service\Hook\HookContentClassInterface;
+
+class ProductExtraContent implements HookContentClassInterface
 {
     /**
      * Title of the content. This can be used in the template

--- a/src/Core/Product/ProductExtraContentFinder.php
+++ b/src/Core/Product/ProductExtraContentFinder.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShop\PrestaShop\Core\Product;
+
+/**
+ * This class gets the extra content to display on the product page
+ * from the modules hooked on productExtraContent
+ */
+class ProductExtraContentFinder {
+    /**
+     * Execute hook to get all addionnal product content, and check if valid
+     * (not empty and only instances of class ProductExtraContent).
+     * 
+     * @param \Product $product
+     * @return array
+     * @throws \Exception
+     */
+    public function getProductExtraContent(\Product $product)
+    {
+        $extraContent = \Hook::exec('displayProductExtraContent', array('product' => $product), null, true);
+        if (!is_array($extraContent)) {
+            $extraContent = array();
+        }
+        foreach ($extraContent as $moduleName => $moduleExtraContents) {
+            foreach ($moduleExtraContents as $content) {
+                if (!$content instanceof ProductExtraContent) {
+                    throw new \Exception('The module '.$moduleName.' did not return expected ProductExtraContent object.');
+                }
+            }
+        }
+        return $extraContent;
+    }
+    
+    /**
+     * Present all product extra content for templates
+     * @param \Product $product
+     * @return array
+     */
+    public function getPresentedProductExtraContent(\Product $product)
+    {
+        $extraContent = $this->getProductExtraContent($product);
+        $presentedExtraContent = array();
+        
+        foreach ($extraContent as $moduleExtraContents) {
+            foreach ($moduleExtraContents as $content) {
+                $presentedExtraContent[] = $content->toArray();
+            }
+        }
+        
+        return $presentedExtraContent;
+    }
+}

--- a/src/Core/Product/ProductExtraContentFinder.php
+++ b/src/Core/Product/ProductExtraContentFinder.php
@@ -26,13 +26,13 @@
 
 namespace PrestaShop\PrestaShop\Core\Product;
 
-use PrestaShopBundle\Service\Hook\Finder;
+use PrestaShopBundle\Service\Hook\HookFinder;
 
 /**
  * This class gets the extra content to display on the product page
  * from the modules hooked on displayProductExtraContent.
  */
-class ProductExtraContentFinder extends Finder
+class ProductExtraContentFinder extends HookFinder
 {
     protected $hookName = 'displayProductExtraContent';
     protected $expectedInstanceClasses = array('PrestaShop\PrestaShop\Core\Product\ProductExtraContent');

--- a/src/Core/Product/ProductExtraContentFinder.php
+++ b/src/Core/Product/ProductExtraContentFinder.php
@@ -25,51 +25,31 @@
  */
 namespace PrestaShop\PrestaShop\Core\Product;
 
+use PrestaShopBundle\Service\Hook\Finder;
+
 /**
  * This class gets the extra content to display on the product page
- * from the modules hooked on productExtraContent
+ * from the modules hooked on displayProductExtraContent
  */
-class ProductExtraContentFinder {
+class ProductExtraContentFinder extends Finder {
+    
+    protected $hookName = 'displayProductExtraContent';
+    protected $expectedInstanceClasses = array('PrestaShop\PrestaShop\Core\Product\ProductExtraContent');
+    
     /**
      * Execute hook to get all addionnal product content, and check if valid
      * (not empty and only instances of class ProductExtraContent).
      * 
-     * @param \Product $product
      * @return array
      * @throws \Exception
      */
-    public function getProductExtraContent(\Product $product)
+    public function find()
     {
-        $extraContent = \Hook::exec('displayProductExtraContent', array('product' => $product), null, true);
-        if (!is_array($extraContent)) {
-            $extraContent = array();
-        }
-        foreach ($extraContent as $moduleName => $moduleExtraContents) {
-            foreach ($moduleExtraContents as $content) {
-                if (!$content instanceof ProductExtraContent) {
-                    throw new \Exception('The module '.$moduleName.' did not return expected ProductExtraContent object.');
-                }
-            }
-        }
-        return $extraContent;
-    }
-    
-    /**
-     * Present all product extra content for templates
-     * @param \Product $product
-     * @return array
-     */
-    public function getPresentedProductExtraContent(\Product $product)
-    {
-        $extraContent = $this->getProductExtraContent($product);
-        $presentedExtraContent = array();
-        
-        foreach ($extraContent as $moduleExtraContents) {
-            foreach ($moduleExtraContents as $content) {
-                $presentedExtraContent[] = $content->toArray();
-            }
+        // Check first that we have a product to send as params
+        if (!array_key_exists('product', $this->params) || !$this->params['product'] instanceof \Product) {
+            throw new \Exception('Required product param not found.');
         }
         
-        return $presentedExtraContent;
+        return parent::find();
     }
 }

--- a/src/Core/Product/ProductExtraContentFinder.php
+++ b/src/Core/Product/ProductExtraContentFinder.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2016 PrestaShop
+ * 2007-2016 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -23,24 +23,26 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShop\PrestaShop\Core\Product;
 
 use PrestaShopBundle\Service\Hook\Finder;
 
 /**
  * This class gets the extra content to display on the product page
- * from the modules hooked on displayProductExtraContent
+ * from the modules hooked on displayProductExtraContent.
  */
-class ProductExtraContentFinder extends Finder {
-    
+class ProductExtraContentFinder extends Finder
+{
     protected $hookName = 'displayProductExtraContent';
     protected $expectedInstanceClasses = array('PrestaShop\PrestaShop\Core\Product\ProductExtraContent');
-    
+
     /**
      * Execute hook to get all addionnal product content, and check if valid
      * (not empty and only instances of class ProductExtraContent).
      * 
      * @return array
+     *
      * @throws \Exception
      */
     public function find()
@@ -49,7 +51,7 @@ class ProductExtraContentFinder extends Finder {
         if (!array_key_exists('product', $this->params) || !$this->params['product'] instanceof \Product) {
             throw new \Exception('Required product param not found.');
         }
-        
+
         return parent::find();
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -52,6 +52,9 @@ services:
         calls:
             - [addSubscriber, ["@prestashop.adapter.legacy.hook.subscriber"]]
             - [addSubscriber, ["@prestashop.adapter.legacy.block.helper.subscriber"]]
+            
+    prestashop.hook.finder:
+        class: PrestaShopBundle\Service\Hook\HookFinder
 
     # EVENT HANDLER
     prestashop.handler.log:

--- a/src/PrestaShopBundle/Service/Hook/Finder.php
+++ b/src/PrestaShopBundle/Service/Hook/Finder.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShopBundle\Service\Hook;
+
+/**
+ * This class declares the functions needed to get structured data
+ * from the modules, by asking them to follow a specific class.
+ */
+class Finder {
+    /**
+     * In order to not return wrong things to the caller, we ask for an
+     * instance of specific classes.
+     * Please note it must implement the function toArray()
+     * 
+     * @var string
+     */
+    protected $expectedInstanceClasses = array();
+    
+    /**
+     * Because we cannot send the same parameters between two different finders,
+     * we need a attribute. It will be sent to the Hook::exec() function.
+     * 
+     * @var array 
+     */
+    protected $params = array();
+    
+    /**
+     * The hook to call
+     * 
+     * @var string
+     */
+    protected $hookName;
+    
+    /**
+     * Execute hook specified in params and check if the result matches the expected classes if asked.
+     * 
+     * @return array Content returned by modules
+     * @throws \Exception if class doesn't match interface or expected classes
+     */
+    public function find()
+    {
+        $hookContent = \Hook::exec($this->hookName, $this->params, null, true);
+        if (!is_array($hookContent)) {
+            $hookContent = array();
+        }
+        // Check data returned if asked
+        if (count($this->expectedInstanceClasses)) {
+            foreach ($hookContent as $moduleName => $moduleContents) {
+                foreach ($moduleContents as $content) {
+                    if (is_object($content) && !in_array(get_class($content), $this->expectedInstanceClasses)) {
+                        throw new \Exception('The module '.$moduleName.' did not return expected class. Was '.get_class($content).' instead of '. implode(' or ', $this->expectedInstanceClasses).'.');
+                    } else if (!is_object($content)) {
+                        throw new \Exception('The module '.$moduleName.' did not return expected type. Was '.gettype($content).' instead of '. implode(' or ', $this->expectedInstanceClasses).'.');
+                    }
+                }
+            }
+        }
+        return $hookContent;
+    }
+    
+    /**
+     * Present all extra content for templates, meaning converting them as arrays
+     * 
+     * @return array
+     */
+    public function present()
+    {
+        $hookContent = $this->find();
+        $presentedContents = array();
+        
+        foreach ($hookContent as $moduleName => $moduleContents) {
+            foreach ($moduleContents as $content) {
+                $presentedContent = $content->toArray();
+                $presentedContent['moduleName'] = $moduleName;
+                $presentedContents[] = $presentedContent;
+            }
+        }
+        
+        return $presentedContents;
+    }
+    
+    /**
+     * This array contains all the classes expected to be returned
+     * by the modules on Hook::exec
+     * 
+     * @return array
+     */
+    public function getExpectedInstanceClasses()
+    {
+        return $this->expectedInstanceClasses;
+    }
+
+    /**
+     * The hook going to be called when firing find()
+     * @return string
+     */
+    public function getHookName()
+    {
+        return $this->hookName;
+    }
+    
+    /**
+     * The $params sent to Hook::exec()
+     * @return array
+     */
+    public function getParams()
+    {
+        return $this->params;
+    }
+    
+    /**
+     * Add an instance of class to be returned by the hook without
+     * erasing the other values.
+     * 
+     * @param string|array $expectedInstanceClasses
+     * @return \PrestaShopBundle\Service\Hook\Finder
+     */
+    public function addExpectedInstanceClasses($expectedInstanceClasses)
+    {
+        if (is_array($expectedInstanceClasses)) {
+            array_merge($this->expectedInstanceClasses, $expectedInstanceClasses);
+        } else {
+            $this->expectedInstanceClasses[] = $expectedInstanceClasses;
+        }
+        return $this;
+    }
+
+    /**
+     * Replace all expected classes and types
+     * 
+     * @param array $expectedInstanceClasses
+     * @return \PrestaShopBundle\Service\Hook\Finder
+     */
+    public function setExpectedInstanceClasses($expectedInstanceClasses)
+    {
+        $this->expectedInstanceClasses = $expectedInstanceClasses;
+        return $this;
+    }
+
+    /**
+     * Change the hook to be called
+     * 
+     * @param string $hookName
+     * @return \PrestaShopBundle\Service\Hook\Finder
+     */
+    public function setHookName($hookName)
+    {
+        $this->hookName = $hookName;
+        return $this;
+    }
+    
+    /**
+     * Add a hook param without erasing all the other values
+     * @param array $params
+     * @return \PrestaShopBundle\Service\Hook\Finder
+     */
+    public function addParams($params)
+    {
+        $this->params = array_merge($this->params, $params);
+        return $this;
+    }
+
+    /**
+     * Replace the params array
+     * @param array $params
+     * @return \PrestaShopBundle\Service\Hook\Finder
+     */
+    public function setParams($params)
+    {
+        $this->params = $params;
+        return $this;
+    }
+}

--- a/src/PrestaShopBundle/Service/Hook/Finder.php
+++ b/src/PrestaShopBundle/Service/Hook/Finder.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2016 PrestaShop
+ * 2007-2016 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -23,41 +23,44 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Service\Hook;
 
 /**
  * This class declares the functions needed to get structured data
  * from the modules, by asking them to follow a specific class.
  */
-class Finder {
+class Finder
+{
     /**
      * In order to not return wrong things to the caller, we ask for an
      * instance of specific classes.
-     * Please note it must implement the function toArray()
+     * Please note it must implement the function toArray().
      * 
      * @var string
      */
     protected $expectedInstanceClasses = array();
-    
+
     /**
      * Because we cannot send the same parameters between two different finders,
      * we need a attribute. It will be sent to the Hook::exec() function.
      * 
-     * @var array 
+     * @var array
      */
     protected $params = array();
-    
+
     /**
-     * The hook to call
+     * The hook to call.
      * 
      * @var string
      */
     protected $hookName;
-    
+
     /**
      * Execute hook specified in params and check if the result matches the expected classes if asked.
      * 
      * @return array Content returned by modules
+     *
      * @throws \Exception if class doesn't match interface or expected classes
      */
     public function find()
@@ -71,18 +74,19 @@ class Finder {
             foreach ($hookContent as $moduleName => $moduleContents) {
                 foreach ($moduleContents as $content) {
                     if (is_object($content) && !in_array(get_class($content), $this->expectedInstanceClasses)) {
-                        throw new \Exception('The module '.$moduleName.' did not return expected class. Was '.get_class($content).' instead of '. implode(' or ', $this->expectedInstanceClasses).'.');
-                    } else if (!is_object($content)) {
-                        throw new \Exception('The module '.$moduleName.' did not return expected type. Was '.gettype($content).' instead of '. implode(' or ', $this->expectedInstanceClasses).'.');
+                        throw new \Exception('The module '.$moduleName.' did not return expected class. Was '.get_class($content).' instead of '.implode(' or ', $this->expectedInstanceClasses).'.');
+                    } elseif (!is_object($content)) {
+                        throw new \Exception('The module '.$moduleName.' did not return expected type. Was '.gettype($content).' instead of '.implode(' or ', $this->expectedInstanceClasses).'.');
                     }
                 }
             }
         }
+
         return $hookContent;
     }
-    
+
     /**
-     * Present all extra content for templates, meaning converting them as arrays
+     * Present all extra content for templates, meaning converting them as arrays.
      * 
      * @return array
      */
@@ -90,7 +94,7 @@ class Finder {
     {
         $hookContent = $this->find();
         $presentedContents = array();
-        
+
         foreach ($hookContent as $moduleName => $moduleContents) {
             foreach ($moduleContents as $content) {
                 $presentedContent = $content->toArray();
@@ -98,13 +102,13 @@ class Finder {
                 $presentedContents[] = $presentedContent;
             }
         }
-        
+
         return $presentedContents;
     }
-    
+
     /**
      * This array contains all the classes expected to be returned
-     * by the modules on Hook::exec
+     * by the modules on Hook::exec.
      * 
      * @return array
      */
@@ -114,28 +118,31 @@ class Finder {
     }
 
     /**
-     * The hook going to be called when firing find()
+     * The hook going to be called when firing find().
+     *
      * @return string
      */
     public function getHookName()
     {
         return $this->hookName;
     }
-    
+
     /**
-     * The $params sent to Hook::exec()
+     * The $params sent to Hook::exec().
+     *
      * @return array
      */
     public function getParams()
     {
         return $this->params;
     }
-    
+
     /**
      * Add an instance of class to be returned by the hook without
      * erasing the other values.
      * 
      * @param string|array $expectedInstanceClasses
+     *
      * @return \PrestaShopBundle\Service\Hook\Finder
      */
     public function addExpectedInstanceClasses($expectedInstanceClasses)
@@ -145,52 +152,63 @@ class Finder {
         } else {
             $this->expectedInstanceClasses[] = $expectedInstanceClasses;
         }
+
         return $this;
     }
 
     /**
-     * Replace all expected classes and types
+     * Replace all expected classes and types.
      * 
      * @param array $expectedInstanceClasses
+     *
      * @return \PrestaShopBundle\Service\Hook\Finder
      */
     public function setExpectedInstanceClasses($expectedInstanceClasses)
     {
         $this->expectedInstanceClasses = $expectedInstanceClasses;
+
         return $this;
     }
 
     /**
-     * Change the hook to be called
+     * Change the hook to be called.
      * 
      * @param string $hookName
+     *
      * @return \PrestaShopBundle\Service\Hook\Finder
      */
     public function setHookName($hookName)
     {
         $this->hookName = $hookName;
+
         return $this;
     }
-    
+
     /**
-     * Add a hook param without erasing all the other values
+     * Add a hook param without erasing all the other values.
+     *
      * @param array $params
+     *
      * @return \PrestaShopBundle\Service\Hook\Finder
      */
     public function addParams($params)
     {
         $this->params = array_merge($this->params, $params);
+
         return $this;
     }
 
     /**
-     * Replace the params array
+     * Replace the params array.
+     *
      * @param array $params
+     *
      * @return \PrestaShopBundle\Service\Hook\Finder
      */
     public function setParams($params)
     {
         $this->params = $params;
+
         return $this;
     }
 }

--- a/src/PrestaShopBundle/Service/Hook/Finder.php
+++ b/src/PrestaShopBundle/Service/Hook/Finder.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShopBundle\Service\Hook;
 
+use PrestaShopBundle\Service\Hook\HookContentClassInterface;
+
 /**
  * This class declares the functions needed to get structured data
  * from the modules, by asking them to follow a specific class.
@@ -69,15 +71,21 @@ class Finder
         if (!is_array($hookContent)) {
             $hookContent = array();
         }
-        // Check data returned if asked
-        if (count($this->expectedInstanceClasses)) {
-            foreach ($hookContent as $moduleName => $moduleContents) {
-                foreach ($moduleContents as $content) {
-                    if (is_object($content) && !in_array(get_class($content), $this->expectedInstanceClasses)) {
-                        throw new \Exception('The module '.$moduleName.' did not return expected class. Was '.get_class($content).' instead of '.implode(' or ', $this->expectedInstanceClasses).'.');
-                    } elseif (!is_object($content)) {
-                        throw new \Exception('The module '.$moduleName.' did not return expected type. Was '.gettype($content).' instead of '.implode(' or ', $this->expectedInstanceClasses).'.');
-                    }
+        
+        foreach ($hookContent as $moduleName => $moduleContents) {
+            foreach ($moduleContents as $content) {
+                if (!$content instanceof HookContentClassInterface) {
+                    throw new \Exception('The class returned must implement HookContentClassInterface');
+                }
+                
+                // Check data returned if asked
+                if (!count($this->expectedInstanceClasses)) {
+                    continue;
+                }
+                if (is_object($content) && !in_array(get_class($content), $this->expectedInstanceClasses)) {
+                    throw new \Exception('The module '.$moduleName.' did not return expected class. Was '.get_class($content).' instead of '.implode(' or ', $this->expectedInstanceClasses).'.');
+                } elseif (!is_object($content)) {
+                    throw new \Exception('The module '.$moduleName.' did not return expected type. Was '.gettype($content).' instead of '.implode(' or ', $this->expectedInstanceClasses).'.');
                 }
             }
         }

--- a/src/PrestaShopBundle/Service/Hook/HookContentClassInterface.php
+++ b/src/PrestaShopBundle/Service/Hook/HookContentClassInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author 	PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2016 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShopBundle\Service\Hook;
+
+interface HookContentClassInterface {
+    public function toArray();
+}

--- a/src/PrestaShopBundle/Service/Hook/HookFinder.php
+++ b/src/PrestaShopBundle/Service/Hook/HookFinder.php
@@ -26,13 +26,13 @@
 
 namespace PrestaShopBundle\Service\Hook;
 
-use PrestaShopBundle\Service\Hook\HookContentClassInterface;
+use PrestaShop\PrestaShop\Adapter\HookManager;
 
 /**
  * This class declares the functions needed to get structured data
  * from the modules, by asking them to follow a specific class.
  */
-class Finder
+class HookFinder
 {
     /**
      * In order to not return wrong things to the caller, we ask for an
@@ -67,7 +67,7 @@ class Finder
      */
     public function find()
     {
-        $hookContent = \Hook::exec($this->hookName, $this->params, null, true);
+        $hookContent = (new HookManager())->exec($this->hookName, $this->params, null, true);
         if (!is_array($hookContent)) {
             $hookContent = array();
         }

--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -131,7 +131,7 @@
                   <a class="nav-link" data-toggle="tab" href="#attachments">{l s='Attachments' d='Shop.Theme.Catalog'}</a>
                 </li>
                 {/if}
-                {foreach from=$productExtraContent item=extra key=extraKey}
+                {foreach from=$product.extraContent item=extra key=extraKey}
                 <li class="nav-item">
                   <a class="nav-link" data-toggle="tab" href="#extra-{$extraKey}">{$extra.title}</a>
                 </li>
@@ -166,7 +166,7 @@
                    </div>
                  {/if}
                {/block}
-               {foreach from=$productExtraContent item=extra key=extraKey}
+               {foreach from=$product.extraContent item=extra key=extraKey}
                <div class="tab-pane fade in {$extra.attr}" id="extra-{$extraKey}">
                    {$extra.content nofilter}
                </div>

--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -167,7 +167,7 @@
                  {/if}
                {/block}
                {foreach from=$product.extraContent item=extra key=extraKey}
-               <div class="tab-pane fade in {$extra.attr}" id="extra-{$extraKey}">
+               <div class="tab-pane fade in {$extra.attr.class}" id="extra-{$extraKey}" {foreach $extra.attr as $key => $val} {$key}="{$val}"{/foreach}>
                    {$extra.content nofilter}
                </div>
                {/foreach}

--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -131,6 +131,11 @@
                   <a class="nav-link" data-toggle="tab" href="#attachments">{l s='Attachments' d='Shop.Theme.Catalog'}</a>
                 </li>
                 {/if}
+                {foreach from=$productExtraContent item=extra key=extraKey}
+                <li class="nav-item">
+                  <a class="nav-link" data-toggle="tab" href="#extra-{$extraKey}">{$extra.title}</a>
+                </li>
+                {/foreach}
               </ul>
 
               <div class="tab-content" id="tab-content">
@@ -161,6 +166,11 @@
                    </div>
                  {/if}
                {/block}
+               {foreach from=$productExtraContent item=extra key=extraKey}
+               <div class="tab-pane fade in {$extra.attr}" id="extra-{$extraKey}">
+                   {$extra.content nofilter}
+               </div>
+               {/foreach}
             </div>
           </div>
         </div>


### PR DESCRIPTION
- [ ] Tests to add
- [x] Define Hook\Finder as a service and remove legacy calls from the class
- [x] Objects returned to hooks must implement an interface with toArray()
- [x] Add object check in Finder

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | <p>This PR introduce a new hook which replaces the old displayProductTab & displayProductTabContent : displayProductExtraContent. It allows module developper to only care about the content they want to display, NOT how it will be included in the template.<br/>In the Classic theme, the nav tabs are used to separate each extra contents.<br/>In the StarterTheme, they will be directly displayed under the product description.</p> |
| Type? | new feature |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Yes |
| Fixed ticket? | / |
| How to test? | I will make a module for this hook, or you can make yours by copy-pasting the example. |
## StarterTheme backport

https://github.com/PrestaShop/StarterTheme/pull/117
## Example of module code

``` php
    /**
    * Display additionnal content on the product page.
    * @param $param array The product object
    * @return array Instances of ProductExtraContent
    */
    public function hookDisplayProductExtraContent($params)
    {
        $array = array();
        $array[] = (new PrestaShop\PrestaShop\Core\Product\ProductExtraContent())
                ->setTitle('Catch phrase')
                ->setContent('Look at my <b>horse</b>, my horse is <i>amazing</i> !');
        $array[] = (new PrestaShop\PrestaShop\Core\Product\ProductExtraContent())
                ->setTitle('Picture test')
                ->setContent('<img src="https://66.media.tumblr.com/a7d7323885509fa85478fd30af784af9/tumblr_n6sxu83sGe1scd4jmo1_400.gif" />');
        return $array;
    }
```
## Result

![capture d ecran 2016-09-07 a 18 21 14](https://cloud.githubusercontent.com/assets/6768917/18321903/ecedd804-7527-11e6-8201-afdfda2203ff.png)
