### PR TITLE
Removed availability date from product page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -159,12 +159,14 @@
       {{ form_errors(form.available_later) }}
       {{ form_widget(form.available_later) }}
     </div>
-
+    
+    {% if not has_combinations %}
     <div class="col-md-4 ">
       <label class="form-control-label">{{ form.available_date.vars.label }}</label>
       {{ form_errors(form.available_date) }}
       {{ form_widget(form.available_date) }}
     </div>
+    {% endif %}
 
   </div>
 </div>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The BO product page should not contain the availability date field for product iwth combinations |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1366 |
| How to test? | Check the existence of the availability date field for product with combinations |
