### PR TITLE
Tooltips are now cleared when moving to another tab

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -69,6 +69,12 @@ $(document).ready(function() {
     locale: iso_user,
     format: 'YYYY-MM-DD'
   });
+
+  /** tooltips should be hidden when we move to another tab */
+  $('#form-nav').on('click','.nav-item', function clearTooltipsAndPopovers() {
+    $('[data-toggle="tooltip"]').tooltip('hide');
+    $('[data-toggle="popover"]').popover('hide');
+  });
 });
 
 /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
@@ -51,25 +51,16 @@
       <div class="row">
         <div class="col-md-12">
           <div class="pull-right">
-            <a id="desc-product-export" class="list-toolbar-btn" href="{{ path('admin_product_export_action') }}">
-              <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{{ "Export"|trans({}, 'Admin.Actions') }}" data-html="true" data-placement="top">
-                <i class="material-icons">cloud_upload</i>
-              </span>
+            {{ ps.tooltip(("Export"|trans({}, 'Admin.Actions')), 'cloud_upload') }}
             </a>
             <a id="desc-product-import" class="list-toolbar-btn" href="{{ import_link }}">
-              <span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{{ "Import"|trans({}, 'Admin.Actions') }}" data-html="true" data-placement="top">
-                <i class="material-icons">cloud_download</i>
-              </span>
+              {{ ps.tooltip(("Import"|trans({}, 'Admin.Actions')), 'cloud_download') }}
             </a>
             <a id="desc-product-show-sql" class="list-toolbar-btn" href="javascript:void(0);" onclick="showLastSqlQuery();">
-              <span class="label-tooltip" data-toggle="tooltip" data-original-title="{{ "Show SQL query"|trans({}, 'Admin.Actions') }}" data-html="true" data-placement="top">
-                <i class="material-icons">code</i>
-              </span>
+              {{ ps.tooltip(("Show SQL query"|trans({}, 'Admin.Actions')), 'code') }}
             </a>
             <a id="desc-product-sql-manager" class="list-toolbar-btn" href="javascript:void(0);" onclick="sendLastSqlQuery(createSqlQueryName());">
-              <span class="label-tooltip" data-toggle="tooltip" data-original-title="{{ "Export to SQL Manager"|trans({}, 'Admin.Actions') }}" data-html="true" data-placement="top">
-                <i class="material-icons">storage</i>
-              </span>
+              {{ ps.tooltip(("Export to SQL Manager"|trans({}, 'Admin.Actions')), 'storage') }}
             </a>
           </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -5,3 +5,9 @@
 {% macro check(variable) %}
   {{ variable is defined and variable|length > 0 ? variable : false }}
 {% endmacro %}
+
+{% macro tooltip(text, icon, position) %}
+  <span data-toggle="tooltip" class="label-tooltip" data-original-title="{{ text }}" data-html="true" data-placement="{{ position|default('top') }}">
+    <i class="material-icons">{{ icon }}</i>
+  </span>
+{% endmacro %}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | We need to clear tooltip display between tabs in Product page. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-738 |
| How to test? | Enable some tooltips and then move to another tab in Product page. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
