### PR TITLE
Fixed rule followed to show product prices

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -94,6 +94,8 @@ var displayFieldsManager = (function() {
         $(this).select();
       });
 
+      this.initVisibilityRule();
+
       /** Tax rule dropdown shortcut */
       $('a#tax_rule_shortcut_opener').on('click', function () {
         // lazy instantiated
@@ -113,6 +115,28 @@ var displayFieldsManager = (function() {
 
         return false;
       });
+    },
+    /**
+     * When a product is available for order, its price should be visible,
+     * whereas products unavailable for order can have their prices visible or hidden.
+     */
+    'initVisibilityRule': function () {
+      var showPriceSelector = '.js-show-price';
+      var availableForOrderSelector = '.js-available-for-order';
+
+      var applyVisibilityRule = () => {
+        var $availableForOrder = $(availableForOrderSelector + ' input');
+        var $showPrice = $(showPriceSelector + ' input');
+        var $showPriceColumn = $(showPriceSelector);
+        if ($availableForOrder.prop('checked')) {
+          $showPrice.prop('checked', true);
+          $showPriceColumn.addClass('hide');
+        } else {
+          $showPriceColumn.removeClass('hide');
+        }
+      };
+      $(availableForOrderSelector + ' .checkbox').on('click', applyVisibilityRule);
+      applyVisibilityRule();
     },
     'refresh': function () {
       this.checkAccessVariations();

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -707,10 +707,10 @@
                       <div class="col-md-7 form-group">
                           {{ form_errors(form.step6.display_options) }}
                           <div class="row">
-                            <div class="col-md-4">
+                            <div class="col-md-4 js-available-for-order">
                               {{ form_widget(form.step6.display_options.available_for_order) }}
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 js-show-price">
                               {{ form_widget(form.step6.display_options.show_price) }}
                             </div>
                             <div class="col-md-5">

--- a/tests/Unit/Core/Business/Product/ProductPresenterTest.php
+++ b/tests/Unit/Core/Business/Product/ProductPresenterTest.php
@@ -56,6 +56,7 @@ class ProductPresenterTest extends UnitTestCase
         $this->product['on_sale'] = false;
         $this->product['new'] = false;
         $this->product['pack'] = false;
+        $this->product['show_price'] = true;
         $this->language = new Language;
     }
 
@@ -119,7 +120,14 @@ class ProductPresenterTest extends UnitTestCase
     public function test_price_should_not_be_shown_if_product_not_available_for_order()
     {
         $this->product['available_for_order'] = false;
+        $this->product['show_price'] = false;
+
         $this->assertFalse($this->getPresentedProduct('show_price'));
+
+        $this->product['available_for_order'] = false;
+        $this->product['show_price'] = true;
+
+        $this->assertTrue($this->getPresentedProduct('show_price'));
     }
 
     public function test_price_is_tax_excluded()
@@ -281,6 +289,7 @@ class ProductPresenterTest extends UnitTestCase
     {
         $this->product['online_only'] = true;
         $this->product['available_for_order'] = false;
+        $this->product['show_price'] = false;
         $this->assertEquals(
             [],
             $this->getPresentedProduct('flags')


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix rule applied to show products prices |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1365 |
| How to test? | Set a product as not available for order (Catalog > Product > Options), Enable price visibility (tick `Show price` checkbox) and check price visibility in the front office |
