### PR TITLE
Fixed bug when adding to cart from a page with different token

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -99,7 +99,7 @@ class CartControllerCore extends FrontController
                 Tools::redirect('index.php?controller=order&'.(isset($this->id_product) ? 'ipa='.$this->id_product : ''));
             }
         } elseif (!$this->isTokenValid()) {
-            if ($this->ajax) {
+            if (Tools::getValue('ajax')) {
                 $this->ajaxDie(Tools::jsonEncode(array(
                     'hasError' => true,
                     'errors' => array(Tools::displayError('Impossible to add the product to the cart. Please refresh page.')),

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -99,7 +99,14 @@ class CartControllerCore extends FrontController
                 Tools::redirect('index.php?controller=order&'.(isset($this->id_product) ? 'ipa='.$this->id_product : ''));
             }
         } elseif (!$this->isTokenValid()) {
-            Tools::redirect('index.php');
+            if ($this->ajax) {
+                $this->ajaxDie(Tools::jsonEncode(array(
+                    'hasError' => true,
+                    'errors' => array(Tools::displayError('Impossible to add the product to the cart. Please refresh page.')),
+                )));
+            } else {
+                Tools::redirect('index.php');
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Fixed bug when you tried to add a product to cart from a page with an outdated token |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | N |
| Deprecations? | N |
| Fixed ticket? |  |
| How to test? | Open one tab with the store without login. Open a new one and logged in as a customer. Try to add a product to cart from the first tab without refreshing the page. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
