### PR TITLE
Removed theme and admin menu orientation fields

### DIFF
--- a/controllers/admin/AdminEmployeesController.php
+++ b/controllers/admin/AdminEmployeesController.php
@@ -322,37 +322,6 @@ class AdminEmployeesControllerCore extends AdminController
                     'name' => 'name'
                 )
             ),
-            array(
-                'type' => 'select',
-                'label' => $this->l('Theme'),
-                'name' => 'bo_theme_css',
-                'options' => array(
-                    'query' => $this->themes,
-                    'id' => 'id',
-                    'name' => 'name'
-                ),
-                'onchange' => 'var value_array = $(this).val().split("|"); $("link").first().attr("href", "themes/" + value_array[0] + "/css/" + value_array[1]);',
-                'hint' => $this->l('Back office theme.')
-            ),
-            array(
-                'type' => 'radio',
-                'label' => $this->l('Admin menu orientation'),
-                'name' => 'bo_menu',
-                'required' => false,
-                'is_bool' => true,
-                'values' => array(
-                    array(
-                        'id' => 'bo_menu_on',
-                        'value' => 0,
-                        'label' => $this->l('Top')
-                    ),
-                    array(
-                        'id' => 'bo_menu_off',
-                        'value' => 1,
-                        'label' => $this->l('Left')
-                    )
-                )
-            )
         ));
 
         if ((int)$this->access('edit') && !$this->restrict_edition) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Remove theme and admin menu orientation fields from `Edit employee` form |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1384 |
| How to test? | Open `Edit employee` form and check theme and admin orientation fields availability |
