### PR TITLE
Empty carrier if stock in unavailable warehouse

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1982,8 +1982,6 @@ class CartCore extends ObjectModel
                 if (count($warehouse_list) == 0) {
                     $warehouse_list = Warehouse::getProductWarehouseList($product['id_product'], $product['id_product_attribute']);
                 }
-                // Does the product is in stock ?
-                // If yes, get only warehouse where the product is in stock
 
                 $warehouse_in_stock = array();
                 $manager = StockManagerFactory::getManager();
@@ -2002,7 +2000,6 @@ class CartCore extends ObjectModel
                 }
 
                 if (!empty($warehouse_in_stock)) {
-                    $warehouse_list = $warehouse_in_stock;
                     $product['in_stock'] = true;
                 } else {
                     $product['in_stock'] = false;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | If I have a warehouse in USA with stock and another one in Europe without stock, it makes no sense to limit the warehouses to the ones with stock if the delivery address is not available for the warehouses with stock.<br><br>If delivery is in Europe, I want the order to be placed in Europe, product marked as out of stock and it should appear in the supplier order list<br><br>This doesn't happen since before checking if the warehouse is suitable for sending the product, we are removing from the available warehouses the ones without stock.<br><br>Because the warehouses are limited by stock before checking if the carriers from a certain warehouse is suitable for delivery to customer address, an order without carries may be created. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | 1. Activate advanced stock<br>2. De-activate order splitting<br>3. add 2 carries, 1 for USA and 1 for Europe<br>4. add 2 warehouses, 1 attached to the USA carrier and the other for the Europe carrier<br>5. Give 1 product stock in the USA warehouse<br>6. Give another product stock in the Europe warehouse<br>7. Place an order with both products to a destination in Europe<br>8. Look at the resulting splitted orders. One for each warehouse. One with the product with stock in Europe , shipping with the Europe carrier and product leaving from Europe warehouse. Another with the product with stock in USA, **with no carrier** and product marked as using the USA warehouse. |
