### PR TITLE
Show availability_date for combination if exists, never use the default one for combination

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -830,7 +830,7 @@ class ProductCore extends ObjectModel
         if ($id_product_attribute === null) {
             $sql .= ' p.`available_date`';
         } else {
-            $sql .= ' IF(pa.`available_date` = "0000-00-00", p.`available_date`, pa.`available_date`) AS available_date';
+            $sql .= ' pa.`available_date`';
         }
 
         $sql .= ' FROM `'._DB_PREFIX_.'product` p';
@@ -4415,6 +4415,11 @@ class ProductCore extends ObjectModel
                 (int)$row['id_product'],
                 $id_product_attribute,
                 isset($row['cache_is_pack']) ? $row['cache_is_pack'] : null
+            );
+
+            $row['available_date'] = Product::getAvailableDate(
+                (int)$row['id_product'],
+                $id_product_attribute
             );
         }
 

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -373,7 +373,7 @@ class ProductPresenter
             if ($product['quantity'] > 0) {
                 $presentedProduct['availability_message'] = $product['available_now'];
                 $presentedProduct['availability'] = 'available';
-                $presentedProduct['availability_date'] = null;
+                $presentedProduct['availability_date'] = $product['available_date'];
             } elseif ($product['allow_oosp']) {
                 if ($product['available_later']) {
                     $presentedProduct['availability_message'] = $product['available_later'];


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Show always availability_date on the product page (description bloc) |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-341 |
| How to test? | Go to product page (with and without combination, with and without stock) and see if availability_date is on the product detail |
