### PR TITLE
Fix module listing to upgrade

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module_card.js
+++ b/admin-dev/themes/default/js/bundle/module/module_card.js
@@ -21,7 +21,7 @@ var AdminModuleCard = function () {
     this.moduleActionMenuEnableMobileLinkSelector = 'a.module_action_menu_enable_mobile';
     this.moduleActionMenuDisableMobileLinkSelector = 'a.module_action_menu_disable_mobile';
     this.moduleActionMenuResetLinkSelector = 'a.module_action_menu_reset';
-    this.moduleActionMenuUpdateLinkSelector = 'a.module_action_menu_update';
+    this.moduleActionMenuUpdateLinkSelector = 'a.module_action_menu_upgrade';
     this.moduleItemListSelector = '.module-item-list';
     this.moduleItemGridSelector = '.module-item-grid';
 

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -139,8 +139,7 @@ class AdminModuleDataProvider implements ModuleInterface
                 } else {
                     unset($urls['enable_mobile']);
                 }
-                if ($addon->database->get('installed') == 0 || version_compare($addon->database->get('version'), $addon->disk->get('version'), '<=')
-                    && version_compare($addon->attributes->get('version'), $addon->database->get('version'), '<=')) {
+                if (!$addon->canBeUpgraded()) {
                     unset(
                         $urls['upgrade']
                     );

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -122,16 +122,21 @@ class AdminModuleDataProvider implements ModuleInterface
                     $url_active = 'configure';
                     unset(
                         $urls['enable'],
-                        $urls['install'],
-                        $urls['upgrade']
+                        $urls['install']
                     );
                 } else {
                     $url_active = 'disable';
                     unset(
-                        $urls['upgrade'],
                         $urls['install'],
                         $urls['enable'],
                         $urls['configure']
+                    );
+                }
+                if ($addon->canBeUpgraded()) {
+                    $url_active = 'upgrade';
+                } else {
+                    unset(
+                        $urls['upgrade']
                     );
                 }
                 if ($addon->database->get('active_on_mobile') == 0) {

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -144,7 +144,7 @@ class Module implements ModuleInterface
         $this->disk->add($disk);
         $this->database->add($database);
 
-        $version = $this->disk->get('is_valid') ?
+        $version = is_null($this->attributes->get('version')) && $this->disk->get('is_valid') ?
             $this->disk->get('version') :
             $this->attributes->get('version');
 

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -328,4 +328,13 @@ class Module implements ModuleInterface
             $this->set('image_absolute', $this->get('img'));
         }
     }
+
+    public function canBeUpgraded()
+    {
+        return
+            $this->database->get('installed') == 1
+            && $this->database->get('version')
+            !== 0 && version_compare($this->database->get('version'), $this->attributes->get('version'), '<')
+        ;
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -297,7 +297,7 @@ class ModuleController extends FrameworkBundleAdminController
             $warnings = $installedProduct->attributes->get('warning');
             if (!empty($warnings)) {
                 $row = 'to_configure';
-            } elseif ($installedProduct->database->get('installed') == 1 && $installedProduct->database->get('version') !== 0 && version_compare($installedProduct->database->get('version'), $installedProduct->attributes->get('version'), '<')) {
+            } elseif ($installedProduct->canBeUpgraded()) {
                 $row = 'to_update';
             } else {
                 $row = false;

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -294,7 +294,16 @@ class ModuleController extends FrameworkBundleAdminController
         }
 
         foreach ($installedProducts as $installedProduct) {
-            $warnings = $installedProduct->attributes->get('warning');
+            $warnings = array();
+            $moduleProvider = $this->get('prestashop.adapter.data_provider.module');
+            $moduleName = $installedProduct->attributes->get('name');
+
+            if ($moduleProvider->isModuleMainClassValid($moduleName)) {
+                require_once _PS_MODULE_DIR_.$moduleName.'/'.$moduleName.'.php';
+
+                $module = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get($moduleName);
+                $warnings[] = $module->warning;
+            }
             if (!empty($warnings)) {
                 $modules->to_configure[] = (object) $installedProduct;
             }

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -302,7 +302,7 @@ class ModuleController extends FrameworkBundleAdminController
                 require_once _PS_MODULE_DIR_.$moduleName.'/'.$moduleName.'.php';
 
                 $module = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get($moduleName);
-                $warnings[] = $module->warning;
+                $warnings = $module->warning;
             }
             if (!empty($warnings)) {
                 $modules->to_configure[] = (object) $installedProduct;

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -296,15 +296,11 @@ class ModuleController extends FrameworkBundleAdminController
         foreach ($installedProducts as $installedProduct) {
             $warnings = $installedProduct->attributes->get('warning');
             if (!empty($warnings)) {
-                $row = 'to_configure';
-            } elseif ($installedProduct->canBeUpgraded()) {
-                $row = 'to_update';
-            } else {
-                $row = false;
+                $modules->to_configure[] = (object) $installedProduct;
             }
 
-            if ($row) {
-                $modules->{$row}[] = (object) $installedProduct;
+            if ($installedProduct->canBeUpgraded()) {
+                $modules->to_update[] = (object) $installedProduct;
             }
         }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_manage_installed.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_manage_installed.html.twig
@@ -1,0 +1,15 @@
+{% extends "PrestaShopBundle:Admin/Module/Includes:card_list.html.twig" %}
+
+{# Twig extension for "Addons to update" part in notification page #}
+
+{# Display database version #}
+{% block addon_version %}
+  {% if module.attributes.productType == "service" %} bbb
+    {{ 'Service by '|trans({}, 'Admin.Modules.Feature') }}
+    <b>{{ module.attributes.author }}</b>
+  {% else %}
+    {{ 'v%version% - by '|trans({ '%version%' : module.database.version }, 'Admin.Modules.Feature') }}
+    <b>{{ module.attributes.author }}</b>
+  {% endif %}
+{% endblock %}
+

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_configure.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_configure.html.twig
@@ -1,4 +1,4 @@
-{% extends "PrestaShopBundle:Admin/Module/Includes:card_list.html.twig" %}
+{% extends "PrestaShopBundle:Admin/Module/Includes:card_manage_installed.html.twig" %}
 
 {# Twig extension for "Addons to configure" part in notification page #}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
@@ -9,7 +9,9 @@
     {% endfor %}
   {% endif %}
   {% for module in modules %}
-    {% include 'PrestaShopBundle:Admin/Module/Includes:card_list.html.twig' with { 'display_type': display_type, 'module': module, 'origin': origin|default('none') } %}
+    {% block addon_card %}
+      {% include 'PrestaShopBundle:Admin/Module/Includes:card_list.html.twig' with { 'display_type': display_type, 'module': module, 'origin': origin|default('none') } %}
+    {% endblock %}
   {% endfor %}
   {% block addon_search_card %}
     {% if requireAddonsSearch is defined and requireAddonsSearch == true %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_installed.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_installed.html.twig
@@ -1,0 +1,5 @@
+{% extends "PrestaShopBundle:Admin/Module/Includes:grid.html.twig" %}
+
+{% block addon_card %}
+  {% include 'PrestaShopBundle:Admin/Module/Includes:card_manage_installed.html.twig' with { 'display_type': display_type, 'module': module, 'origin': origin|default('none') } %}
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_notification_configure.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_notification_configure.html.twig
@@ -5,7 +5,6 @@
         with {
             'module': module,
             'display_type': display_type,
-            'col_lg': col_lg,
             'origin': origin|default('none')
         }
     %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_notification_update.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_notification_update.html.twig
@@ -5,7 +5,6 @@
         with {
             'module': module,
             'display_type': display_type,
-            'col_lg': col_lg,
             'origin': origin|default('none')
         }
     %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -59,7 +59,7 @@
                                 data-content="{{ "These are all the modules you’ve added to your shop, either by buying it from PrestaShop Addons, or by uploading it directly."|trans({}, 'Admin.Modules.Help') }}">
                            </span>
                    </div>
-		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules': modules.modules, 'display_type': 'list', 'origin': 'manage', 'id': 'all' } %}
+		{% include 'PrestaShopBundle:Admin/Module/Includes:grid_manage_installed.html.twig' with { 'modules': modules.modules, 'display_type': 'list', 'origin': 'manage', 'id': 'all' } %}
 
 		<hr class="top-menu-separator">
 
@@ -70,7 +70,7 @@
                                 data-content="{{ "These modules from PrestaShop are preinstalled when you set-up your shop. They cover the basics of e-commerce and comes for free."|trans({}, 'Admin.Modules.Help') }}">
                            </span>
 		</div>
-		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules': modules.native_modules, 'display_type': 'list', 'origin': 'manage', 'id': 'native' } %}
+		{% include 'PrestaShopBundle:Admin/Module/Includes:grid_manage_installed.html.twig' with { 'modules': modules.native_modules, 'display_type': 'list', 'origin': 'manage', 'id': 'native' } %}
 
 		<hr class="top-menu-separator">
 
@@ -81,7 +81,7 @@
                                 data-content="{{ "Each theme you install will come with its own set of modules. You’ll find here all the modules related to your active theme."|trans({}, 'Admin.Modules.Help') }}">
                            </span>
 		</div>
-		{% include 'PrestaShopBundle:Admin/Module/Includes:grid.html.twig' with { 'modules': modules.theme_bundle, 'display_type': 'list', 'origin': 'manage', 'id': 'theme' } %}
+		{% include 'PrestaShopBundle:Admin/Module/Includes:grid_manage_installed.html.twig' with { 'modules': modules.theme_bundle, 'display_type': 'list', 'origin': 'manage', 'id': 'theme' } %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The notifications now lists all the modules to upgrade. It is based on the database version compared to the Addons feed one. The button to upgrade has also been restored as the "Module to upgrade" layout. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1388 |
- [x] Need to display the disk version and not the feed version into "Installed modules" and "Modules to configure"
- [x] Need to display modules to configure which need an upgrade in "To configure" and "To upgrade" sections
