### PR TITLE
Remove pdo_mysql check from optional

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -105,7 +105,6 @@ class ConfigurationTestCore
             'mcrypt' => false,
             'mbstring' => false,
             'dom' => false,
-            'pdo_mysql' => false,
         );
     }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `develop` |
| Description? | Remove `pdo_mysql` as optional. It is already in the required section. |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |
