### PR TITLE
Fixed no default message when available_later is empty and out of stock orders enabled

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -380,11 +380,8 @@ class ProductPresenter
                     $presentedProduct['availability_date'] = $product['available_date'];
                     $presentedProduct['availability'] = 'available';
                 } else {
-                    $presentedProduct['availability_message'] = $this->translator->trans(
-                        'Out of stock',
-                        array(),
-                        'Shop.Theme.Catalog'
-                    );
+                    // no default message when allow_oosp (out of stock) is enabled & available_later is empty
+                    $presentedProduct['availability_message'] = null;
                     $presentedProduct['availability_date'] = $product['available_date'];
                     $presentedProduct['availability'] = 'unavailable';
                 }

--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -20,7 +20,7 @@
           </button>
           {block name='product_availability'}
             <span id="product-availability">
-              {if $product.show_availability}
+              {if $product.show_availability && $product.availability_message}
                 {if $product.availability == 'available'}
                   <i class="material-icons product-available">&#xE5CA;</i>
                 {else}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | remove default message when available_later is empty & out of stock is enabled |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1387 |
| How to test? | Active out of stock orders, and see a product page with no quantity. available_message doesn't appear if he isn't configured |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
