### PR TITLE
Fix product select type re-enabled when product has no combination

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -160,6 +160,9 @@ var combinations = (function() {
                 productTypeSelector.prop('disabled', false);
               }
             }).show();
+          } else {
+            // enable the top header selector if no combination(s) exists
+            productTypeSelector.prop('disabled', false);
           }
         }else {
           // this means we have or we want to have combinations


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix select product_type in BO (product form) when change combination options (simple/combination), select product_type was disabled and never enabled after |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1282 |
| How to test? | Change combination options in BO (product form) and see select product_type behavior (disabled/enabled) |
