### PR TITLE
Improved module display on user groups

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -79,6 +79,8 @@ class HookCore extends ObjectModel
      */
     protected static $_hook_modules_cache_exec = null;
 
+    const MODULE_LIST_BY_HOOK_KEY = 'hook_module_exec_list_';
+
     public function add($autodate = true, $null_values = false)
     {
         Cache::clean('hook_idsbyname');
@@ -429,7 +431,7 @@ class HookCore extends ObjectModel
     public static function getHookModuleExecList($hook_name = null)
     {
         $context = Context::getContext();
-        $cache_id = 'hook_module_exec_list_'.(isset($context->shop->id) ? '_'.$context->shop->id : '').((isset($context->customer)) ? '_'.$context->customer->id : '');
+        $cache_id = self::MODULE_LIST_BY_HOOK_KEY.(isset($context->shop->id) ? '_'.$context->shop->id : '').((isset($context->customer)) ? '_'.$context->customer->id : '');
         if (!Cache::isStored($cache_id) || $hook_name == 'displayPayment' || $hook_name == 'displayPaymentEU' || $hook_name == 'paymentOptions' || $hook_name == 'displayBackOfficeHeader') {
             $frontend = true;
             $groups = array();

--- a/classes/helper/HelperTreeCategories.php
+++ b/classes/helper/HelperTreeCategories.php
@@ -391,7 +391,7 @@ class HelperTreeCategoriesCore extends TreeCore
 
         $html = '';
         foreach ($data as $item) {
-            if (array_key_exists('children', $item)
+            if (is_array($item) && array_key_exists('children', $item)
                 && !empty($item['children'])) {
                 $html .= $this->getContext()->smarty->createTemplate(
                     $this->getTemplateFile($this->getNodeFolderTemplate()),

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2496,7 +2496,7 @@ abstract class ModuleCore
     }
 
     /**
-     * Get Unauthorized modules for a client group
+     * Get authorized modules for a client group
      *
      * @param int $group_id
      * @return array|null

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -505,6 +505,10 @@ class AdminGroupsControllerCore extends AdminController
         if (is_array($auth_modules)) {
             $return &= Group::addModulesRestrictions($id_group, $auth_modules, $shops);
         }
+
+        // update module list by hook cache
+        Cache::delete(Hook::MODULE_LIST_BY_HOOK_KEY.'*');
+
         return $return;
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The feature is OK but because of cache we may think this does not works as expected. Also, if 1 and only 1 group of customer allow the displaying of a module, it will be displayed despite another group disable it: this is the same behavior as 1.6.1.5. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-691 |
| How to test? | Create a new group in Customer Settings and affect a group to a customer, play with differents enable/disable on slider on language selector modules (the easiest to see for you) according to each group rules. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
