### PR TITLE
Allow product save after specific price creation

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -145,7 +145,6 @@ class ProductSpecificPrice extends CommonAbstractType
             'required' => false,
             'label' => $this->translator->trans('Starting at', array(), 'Admin.Catalog.Feature'),
             'constraints' => array(
-                new Assert\NotBlank(),
                 new Assert\Type(array('type' => 'numeric')),
             ),
         ))


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | After creation of new specific price on product, we couldnt save entire product form, because Server also try to validate again the specific price form. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1253 |
| How to test? | On product page (back office), create a new specific price rule, then try to click on save button in bottom bar. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
