### PR TITLE
Contact page : select order_reference optional

### DIFF
--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -1,6 +1,16 @@
 <section class="contact-form">
   <form action="#" method="post">
 
+    {if $notifications}
+      <div class="col-xs-12 alert {if $notifications.nw_error}alert-danger{else}alert-success{/if}">
+        <ul>
+          {foreach $notifications.messages as $notif}
+            <li>{$notif}</li>
+          {/foreach}
+        </ul>
+      </div>
+    {/if}
+
     <section class="form-fields">
 
       <div class="form-group row">

--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -38,11 +38,15 @@
           <label class="col-md-3 form-control-label">{l s='Order reference' d='Shop.Forms.Labels'}</label>
           <div class="col-md-6">
             <select name="id_order" class="form-control form-control-select">
+              <option value="">{l s='Select reference' d='Shop.Forms.Help'}</option>
               {foreach from=$contact.orders item=order}
                 <option value="{$order.id_order}">{$order.reference}</option>
               {/foreach}
             </select>
           </div>
+          <span class="col-md-3 form-control-comment">
+            {l s='optional' d='Shop.Forms.Help'}
+          </span>
         </div>
       {/if}
 

--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -58,7 +58,7 @@
                 <p>{$conditions}</p>
               {/if}
               {if $msg}
-                <p class="text-warning notification {if $nw_error}notification-error{else}notification-success{/if}">
+                <p class="alert {if $nw_error}alert-danger{else}alert-success{/if}">
                   {$msg}
                 </p>
               {/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Make order_reference select optional on the contact page (empty option value) |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-710 |
| How to test? | Go to the contact page, & see order_reference select (account with orders and without orders) |
