### PR TITLE
Fix the auto scroll when an error appears on the page

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -870,7 +870,7 @@ var form = (function() {
         /** scroll to 1st error */
         if ($('.has-danger').first().offset()) {
           $('html, body').animate({
-            scrollTop: $('.has-danger').first().offset().top - $('.page-head').height() - $('.navbar-header').height()
+            scrollTop: $('.has-danger').first().offset().top - $('nav.main-header').height()
           }, 500);
         }
       },


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The window should scroll to the top of the field where an error is present |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1184 |
| How to test? | <ul><li>Go to the new product page</li><li>Scroll to the bottom of the page</li><li>Click on Save</li><li>You should have scrolled atop of the name field</li></ul> |
