### PR TITLE
Removed duplicate category from breadcrumb

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -914,7 +914,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             }
         }
 
-        $breadcrumb['links'][] = $this->getCategoryPath($categoryDefault);
+        if (!$categoryDefault->is_root_category) {
+            $breadcrumb['links'][] = $this->getCategoryPath($categoryDefault);
+        }
 
         $breadcrumb['links'][] = array(
             'title' => $this->context->controller->product->name,


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The breadcrumb should not contain an empty category |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1423 |
| How to test? | Create a product, attach it to the `Home` category, check the breadcrumb. |
