### PR TITLE
Deprecate getOrderByCartId method, add alternative

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1080,20 +1080,47 @@ class OrderCore extends ObjectModel
     }
 
     /**
-     * Get an order by its cart id
+     * Get an order id by its cart id
      *
      * @param int $id_cart Cart id
-     * @return array Order details
+     * @return int Order id
+     *
+     * @deprecated since 1.7.1.0 Use getIdByCartId() instead
      */
     public static function getOrderByCartId($id_cart)
     {
-        $sql = 'SELECT `id_order`
-                FROM `'._DB_PREFIX_.'orders`
-                WHERE `id_cart` = '.(int)$id_cart
-                    .Shop::addSqlRestriction();
-        $result = Db::getInstance()->getRow($sql);
+        return self::getIdByCartId($id_cart);
+    }
 
-        return isset($result['id_order']) ? $result['id_order'] : false;
+    /**
+     * Get an order object by its cart id
+     *
+     * @param int $id_cart Cart id
+     * @return OrderCore
+     */
+    public static function getByCartId($id_cart)
+    {
+        $id_order = (int) self::getIdByCartId((int) $id_cart);
+
+        return ($id_order > 0) ? new self($id_order) : null;
+    }
+
+    /**
+     * Get the order id by its cart id
+     *
+     * @param int $id_cart Cart id
+     * @return int $id_order
+     */
+    public static function getIdByCartId($id_cart)
+    {
+        $sql = 'SELECT `id_order` 
+            FROM `'._DB_PREFIX_.'orders`
+            WHERE `id_cart` = '.(int) $id_cart.
+            Shop::addSqlRestriction();
+
+        $result = Db::getInstance()->getValue($sql);
+
+        return !empty($result) ? (int) $result : false;
     }
 
     /**

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -219,7 +219,7 @@ class AdminCartsControllerCore extends AdminController
         $summary = $cart->getSummaryDetails();
 
         /* Display order information */
-        $id_order = (int)Order::getOrderByCartId($cart->id);
+        $id_order = (int)Order::getIdByCartId($cart->id);
         $order = new Order($id_order);
         if (Validate::isLoadedObject($order)) {
             $tax_calculation_method = $order->getTaxCalculationMethod();

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -50,7 +50,7 @@ class OrderConfirmationControllerCore extends FrontController
         $redirectLink = 'index.php?controller=history';
 
         $this->id_module = (int) (Tools::getValue('id_module', 0));
-        $this->id_order = Order::getOrderByCartId((int) ($this->id_cart));
+        $this->id_order = Order::getIdByCartId((int) ($this->id_cart));
         $this->secure_key = Tools::getValue('key', false);
         $order = new Order((int) ($this->id_order));
 
@@ -80,7 +80,7 @@ class OrderConfirmationControllerCore extends FrontController
         }
 
         parent::initContent();
-        $order = new Order(Order::getOrderByCartId((int) ($this->id_cart)));
+        $order = new Order(Order::getIdByCartId((int) ($this->id_cart)));
         $presentedOrder = $this->order_presenter->present($order);
         $register_form = $this
             ->makeCustomerForm()


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The method name "getOrderByCartId" in the OrderCore class is confusing (there are several posts on the web supporting this statement) as it only returns the id_order (even though the Docblock states it returns an array). This should be deprecated and the 2 new methods used instead. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | yes |
| How to test? | Use the new static methods, ie. Order::getByCartId($id_cart) and Order::getIdByCartId($id_cart) |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

The method name "getOrderByCartId" is confusing (there are several posts on the web supporting this statement) as it only returns the id_order (even though the Docblock states it returns an array). This should be deprecated and the 2 new methods used instead.
