### PR TITLE
Sorted modules by popularity in descending order

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
@@ -28,7 +28,7 @@
                   <option value="name">{{ 'Name'|trans({}, 'Admin.Global') }}</option>
                   <option value="price">{{ 'Increasing Price'|trans({}, 'Admin.Modules.Feature') }}</option>
                   <option value="price-desc">{{ 'Decreasing Price'|trans({}, 'Admin.Modules.Feature') }}</option>
-                  <option value="scoring">{{ 'Popularity'|trans({}, 'Admin.Modules.Feature') }}</option>
+                  <option value="scoring-desc">{{ 'Popularity'|trans({}, 'Admin.Modules.Feature') }}</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Sort modules by popularity in descending order |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1428 |
| How to test? | Go to `Modules > Modules & Services`, select `Popularity` as sorting criteria and check that addons have been sorted in decreasing popularity order |
