### PR TITLE
Fixed display of payment methods active modules

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl
@@ -24,7 +24,7 @@
 *}
 <tr>
 	<td class="fixed-width-sm center">
-		<img class="img-thumbnail" alt="{$module->name}" src="{if isset($module->image_absolute)}{$module->image_absolute}{else}{$smarty.const._MODULE_DIR_}{$module->name}/{$module->logo}{/if}" />
+		<img class="img-thumbnail" alt="{$module->name}" src="{$smarty.const._MODULE_DIR_}{$module->name}/{$module->logo}" />
 	</td>
 	<td>
 		<div id="anchor{$module->name|ucfirst}" title="{$module->displayName}">

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4099,10 +4099,6 @@ class AdminControllerCore extends Controller
         if ((Tools::getValue('module_name') == $module->name || in_array($module->name, explode('|', Tools::getValue('modules_list')))) && (int)Tools::getValue('conf') > 0) {
             unset($obj);
         }
-
-        if (!empty($module->image) && false !== strpos($module->image, '../img')) {
-            $module->image_absolute = str_replace('../', _PS_BASE_URL_.__PS_BASE_URI__, $module->image);
-        }
     }
 
     /** @var array */

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -322,11 +322,6 @@ class Module implements ModuleInterface
             .DIRECTORY_SEPARATOR.'logo.png')) {
             $this->set('logo', 'logo.png');
         }
-
-        $img = $this->get('img');
-        if (!empty($img)) {
-            $this->set('image_absolute', $this->get('img'));
-        }
     }
 
     public function canBeUpgraded()

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig
@@ -3,11 +3,7 @@
     <img
       class="img-thumbnail"
       alt="{{ module.attributes.name }}"
-      src="{% if module.attributes.image_absolute is not empty %}
-        {{ module.attributes.image_absolute }}
-        {% else %}
-          {{ constant('_MODULE_DIR_') ~ module.attributes.name ~ '/' ~ module.attributes.logo }}
-        {% endif %}"
+      src="{{ constant('_MODULE_DIR_') ~ module.attributes.name ~ '/' ~ module.attributes.logo }}"
     />
   </td>
   <td>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Module try to get an "image_absolute" property that doesnt even exists in module, let's make things simple and stupid, and finaly, work as expected. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1424 |
| How to test? | Access Payment > Payment methods page in Back office. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
