### PR TITLE
Show not active category in Filter by Category

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -171,7 +171,7 @@ class ProductController extends FrameworkBundleAdminController
                 null,
                 array(
                     'label' => $translator->trans('Categories', array(), 'Admin.Catalog.Feature'),
-                    'list' => $this->container->get('prestashop.adapter.data_provider.category')->getNestedCategories(),
+                    'list' => $this->container->get('prestashop.adapter.data_provider.category')->getNestedCategories(null, $this->get('prestashop.adapter.legacy.context')->getContext()->language->id, false),
                     'valid_list' => [],
                     'multiple' => false,
                 )


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Show not active categories in Filter by Category, not only active categories. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Access into your BO, having some not active categories in products list, use "Filter By Category" all categories must to appear. |
