### PR TITLE
Fixed translator selector behavior

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -222,7 +222,7 @@ class TranslationsController extends FrameworkBundleAdminController
 
         $locale = $this->langToLocale($lang);
 
-        if (!is_null($theme)) {
+        if (!is_null($theme) && 'themes' === $type) {
             if ('classic' === $theme) {
                 $type = 'front';
             } else {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Regardless the option you choose, you were always redirect to "Classic theme/Front office" translations |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | part of http://forge.prestashop.com/browse/BOOM-1441 |
| How to test? | You can know access to Back office provider, and "Others" will return empty page mainly because ... Others provider is not done at this moment... |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
