### PR TITLE
Fixed :: Access to undeclared static property: Validate::$data for PHP7

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1136,8 +1136,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             // Hack for postcode required for country which does not have postcodes
             if (!empty($value) || $value === '0' || ($field == 'postcode' && $value == '0')) {
                 if (isset($data['validate'])) {
-                    $data_validate = $data['validate'];
-                    if (!Validate::$data_validate($value) && (!empty($value) || $data['required'])) {
+                    if (!call_user_func('Validate::'.$data['validate'],$value) && (!empty($value) || $data['required'])) {
                         $errors[$field] = '<b>'.self::displayFieldName($field, get_class($this), $htmlentities).
                             '</b> '.Tools::displayError('is invalid.');
                     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fatal error: Uncaught Error: Access to undeclared static property: Validate::$data <br> fixed for PHP7 incompatibility |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Try registering a costumer from the Front office |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

Refer : http://stackoverflow.com/questions/35406163/presta-shop-errors-on-registration/39512556#39512556

Fixed :: Fatal error: Uncaught Error: Access to undeclared static property: Validate::$data
