### PR TITLE
Fixed Product::getPricesDrop SQL query 

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2586,7 +2586,7 @@ class ProductCore extends ObjectModel
 		LEFT JOIN `'._DB_PREFIX_.'manufacturer` m ON (m.`id_manufacturer` = p.`id_manufacturer`)
 		WHERE product_shop.`active` = 1
 		AND product_shop.`show_price` = 1
-		'.($front ? ' AND p.`visibility` IN ("both", "catalog")' : '').'
+		'.($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '').'
 		'.((!$beginning && !$ending) ? ' AND p.`id_product` IN ('.((is_array($tab_id_product) && count($tab_id_product)) ? implode(', ', $tab_id_product) : 0).')' : '').'
 		'.$sql_groups.'
 		ORDER BY '.(isset($order_by_prefix) ? pSQL($order_by_prefix).'.' : '').pSQL($order_by).' '.pSQL($order_way).'


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The visibility of the product is in the product_shop table and not in the product table. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? |  |

In getPricesDrop, changed 'visibility' to use 'product_shop.'  instead of 'p.visibility', since you set the visibility of the product in the product_shop and not in the product table.

Line 2589 :
`'.($front ? ' AND p.`visibility` IN ("both", "catalog")' : '').'`

Changed to :
`'.($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '').'`

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
