### PR TITLE
Add new hook validateCustomerFormFields

### DIFF
--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -182,14 +182,18 @@ class CustomerFormatterCore implements FormFormatterInterface
             ;
         }
 
+        // ToDo, replace the hook exec with HookFinder when the associated PR will be merged
         $additionalCustomerFormFields = Hook::exec('additionalCustomerFormFields', array(), null, true);
 
-        if (!is_array($additionalCustomerFormFields)) {
-            $additionalCustomerFormFields = array();
+        if (is_array($additionalCustomerFormFields)) {
+            foreach ($additionalCustomerFormFields as $moduleName => $additionnalFormFields) {
+                foreach ($additionnalFormFields as $formField) {
+                    $formField->moduleName = $moduleName;
+                    $format[$moduleName.'_'.$formField->getName()] = $formField;
+                }
+            }
         }
-
-        $format = array_merge($format, $additionalCustomerFormFields);
-
+        
         // TODO: TVA etc.?
 
         return $this->addConstraints($format);

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -354,5 +354,8 @@
     <hook id="displayCarrierExtraContent">
       <name>displayCarrierExtraContent</name><title>Display additionnal content for a carrier (e.g pickup points)</title><description>This hook calls only the module related to the carrier, in order to add options when needed.</description>
     </hook>
+    <hook id="validateCustomerFormFields">
+      <name>validateCustomerFormFields</name><title>Customer registration form validation</title><description>This hook is called to a module when it has sent addtionnal fields with additionalCustomerFormFields</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -173,3 +173,5 @@ INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('
 
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_CACHEFS_DIRECTORY_DEPTH';
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_CART_REDIRECT';
+
+INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('validateCustomerFormFields', 'Customer registration form validation', 'This hook is called to a module when it has sent addtionnal fields with additionalCustomerFormFields', '1');


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | A hook was recently introduced in order to display additionnal fields on the customer registration form. However, modules never had the chance to check them on form validation.  This PR brings this feature. :) |
| Type? | new feature |
| Category? | CO |
| BC breaks? | **Yep**, hook `additionalCustomerFormFields` now expects an array of `FormField` instances |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1417](http://forge.prestashop.com/browse/BOOM-1417) |
| How to test? | <p>See the commit module repository: https://github.com/Quetzacoalt91/ps_emailsubscription/commit/48c11a70190c59ceee473b317684b83d52828ec8<br/>Then, **RESET** the module.</p> |
## Results when the checkbox of ps_emailsubscription are not checked

![capture d ecran 2016-09-15 a 16 39 52](https://cloud.githubusercontent.com/assets/6768917/18557595/70c25dc2-7b67-11e6-8cf4-08dd4ec44810.png)
