### PR TITLE
Return default value on empty Marketplace categories response

### DIFF
--- a/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
@@ -23,6 +23,7 @@
  *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *  International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Service\DataProvider\Marketplace;
 
 use GuzzleHttp\Client;
@@ -100,7 +101,7 @@ class ApiClient
 
         $responseArray = json_decode($response);
 
-        return $responseArray->module;
+        return isset($responseArray->module) ? $responseArray->module : array();
     }
 
     public function getModule($moduleId)


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When the API call to the marketplace fails or returns nothing, we now return a default value (empty array) in order to avoid a warning message. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | To reproduce the error, the marketplace should be non-working. You can also try to disconnect your computer from internet. |

![capture d ecran 2016-09-16 a 09 35 33](https://cloud.githubusercontent.com/assets/6768917/18580075/536dd4c4-7bf1-11e6-895c-5f1afdf57f6c.png)
