### PR TITLE
Added reference parameter to OrderDetailController

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -150,7 +150,18 @@ class OrderDetailControllerCore extends FrontController
 
         parent::initContent();
 
-        if (!($id_order = (int)Tools::getValue('id_order')) || !Validate::isUnsignedId($id_order)) {
+        $id_order = (int)Tools::getValue('id_order');
+        $reference = Tools::getValue('reference');
+
+        $id_order = $id_order && Validate::isUnsignedId($id_order) ? $id_order : false;
+        $reference = $reference && Validate::isReference($reference) ? $reference : false;
+
+        if (!$id_order && $reference) {
+            $order = Order::getByReference($reference)->getFirst();
+            $id_order = $order ? $order->id : false;
+        }
+
+        if (!$id_order) {
             $this->redirect_after = '404';
             $this->redirect();
         } else {

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -151,13 +151,12 @@ class OrderDetailControllerCore extends FrontController
         parent::initContent();
 
         $id_order = (int)Tools::getValue('id_order');
-        $reference = Tools::getValue('reference');
-
         $id_order = $id_order && Validate::isUnsignedId($id_order) ? $id_order : false;
-        $reference = $reference && Validate::isReference($reference) ? $reference : false;
 
-        if (!$id_order && $reference) {
-            $order = Order::getByReference($reference)->getFirst();
+        if (!$id_order) {
+            $reference = Tools::getValue('reference');
+            $reference = $reference && Validate::isReference($reference) ? $reference : false;
+            $order = $reference ? Order::getByReference($reference)->getFirst() : false;
             $id_order = $order ? $order->id : false;
         }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This enables to load the order detail page directly with an order `reference` rather then an order id. If both parameters are passed, `id_order` has precedence, which is good for backwards compatibility. |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | example.com/order-detail?id_order={id_order}<br>example.com/order-detail?reference={order_reference} |
