### PR TITLE
Added reference parameter to OrderDetailController (1.6.1.x)

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -147,13 +147,12 @@ class OrderDetailControllerCore extends FrontController
         parent::initContent();
 
         $id_order = (int)Tools::getValue('id_order');
-        $reference = Tools::getValue('reference');
-
         $id_order = $id_order && Validate::isUnsignedId($id_order) ? $id_order : false;
-        $reference = $reference && Validate::isReference($reference) ? $reference : false;
 
-        if (!$id_order && $reference) {
-            $order = Order::getByReference($reference)->getFirst();
+        if (!$id_order) {
+            $reference = Tools::getValue('reference');
+            $reference = $reference && Validate::isReference($reference) ? $reference : false;
+            $order = $reference ? Order::getByReference($reference)->getFirst() : false;
             $id_order = $order ? $order->id : false;
         }
 

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -146,7 +146,18 @@ class OrderDetailControllerCore extends FrontController
     {
         parent::initContent();
 
-        if (!($id_order = (int)Tools::getValue('id_order')) || !Validate::isUnsignedId($id_order)) {
+        $id_order = (int)Tools::getValue('id_order');
+        $reference = Tools::getValue('reference');
+
+        $id_order = $id_order && Validate::isUnsignedId($id_order) ? $id_order : false;
+        $reference = $reference && Validate::isReference($reference) ? $reference : false;
+
+        if (!$id_order && $reference) {
+            $order = Order::getByReference($reference)->getFirst();
+            $id_order = $order ? $order->id : false;
+        }
+
+        if (!$id_order) {
             $this->errors[] = Tools::displayError('Order ID required');
         } else {
             $order = new Order($id_order);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | This enables to load the order detail page directly with an order `reference` rather then an order id. If both parameters are passed, `id_order` has precedence, which is good for backwards compatibility. |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | example.com/order-detail?id_order={id_order}<br>example.com/order-detail?reference={order_reference} |

Cherry-picked 279dee43c59384ce3c479b9456c1c8c65d97f137 (develop)
