### PR TITLE
Raise errors when theme can't be enabled

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -242,8 +242,13 @@ class AdminThemesControllerCore extends AdminController
             $this->processSubmitConfigureLayouts();
             $this->redirect_after = $this->context->link->getAdminLink('AdminThemes');
         } elseif (Tools::getValue('action') == 'enableTheme') {
-            $this->theme_manager->enable(Tools::getValue('theme_name'));
-            $this->redirect_after = $this->context->link->getAdminLink('AdminThemes');
+            $isThemeEnabled = $this->theme_manager->enable(Tools::getValue('theme_name'));
+            // get errors if theme wasn't enabled
+            if (!$isThemeEnabled) {
+                $this->errors[] = $this->theme_manager->getErrors(Tools::getValue('theme_name'));
+            } else {
+                $this->redirect_after = $this->context->link->getAdminLink('AdminThemes');
+            }
         } elseif (Tools::getValue('action') == 'deleteTheme') {
             $this->theme_manager->uninstall(Tools::getValue('theme_name'));
             $this->redirect_after = $this->context->link->getAdminLink('AdminThemes');

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -225,19 +225,26 @@ class AdminThemesControllerCore extends AdminController
     public function postProcess()
     {
         if (Tools::isSubmit('submitAddconfiguration')) {
-            if ($filename = Tools::getValue('theme_archive_server')) {
-                $path = _PS_ALL_THEMES_DIR_.$filename;
-                $this->theme_manager->install($path);
-            } elseif ($filename = Tools::getValue('themearchive')) {
-                $path = _PS_ALL_THEMES_DIR_.$filename;
-                if ($this->processUploadFile($path)) {
+            try {
+                if ($filename = Tools::getValue('theme_archive_server')) {
+                    $path = _PS_ALL_THEMES_DIR_.$filename;
                     $this->theme_manager->install($path);
-                    @unlink($path);
+                } elseif ($filename = Tools::getValue('themearchive')) {
+                    $path = _PS_ALL_THEMES_DIR_.$filename;
+                    if ($this->processUploadFile($path)) {
+                        $this->theme_manager->install($path);
+                        @unlink($path);
+                    }
+                } elseif ($source = Tools::getValue('themearchiveUrl')) {
+                    $this->theme_manager->install($source);
                 }
-            } elseif ($source = Tools::getValue('themearchiveUrl')) {
-                $this->theme_manager->install($source);
+            } catch (Exception $e) {
+                $this->errors[] = $e->getMessage();
             }
-            $this->redirect_after = $this->context->link->getAdminLink('AdminThemes');
+
+            if (empty($this->errors)) {
+                $this->redirect_after = $this->context->link->getAdminLink('AdminThemes');
+            }
         } elseif (Tools::getValue('action') == 'submitConfigureLayouts') {
             $this->processSubmitConfigureLayouts();
             $this->redirect_after = $this->context->link->getAdminLink('AdminThemes');

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -211,6 +211,17 @@ class ThemeManager implements AddonManagerInterface
         return;
     }
 
+    /**
+     * Get all errors of theme install
+     *
+     * @param string $name The technical theme name
+     * @return array|false
+     */
+    public function getErrors($theme_name)
+    {
+        return $this->themeValidator->getErrors($theme_name);
+    }
+
     private function doCreateCustomHooks(array $hooks)
     {
         foreach ($hooks as $hook) {

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -190,23 +190,23 @@ class ThemeManager implements AddonManagerInterface
     /**
      * Actions to perform to restore default settings.
      *
-     * @param string $theme_name The theme name to reset
+     * @param string $themeName The theme name to reset
      *
      * @return bool True for success
      */
-    public function reset($theme_name)
+    public function reset($themeName)
     {
-        return $this->disable($theme_name) && $this->enable($theme_name);
+        return $this->disable($themeName) && $this->enable($themeName);
     }
 
     /**
      * Returns the last error, if found.
      *
-     * @param string $name The technical theme name
+     * @param string $themeName The technical theme name
      *
      * @return string|null The last error if found
      */
-    public function getError($theme_name)
+    public function getError($themeName)
     {
         return;
     }
@@ -214,12 +214,12 @@ class ThemeManager implements AddonManagerInterface
     /**
      * Get all errors of theme install
      *
-     * @param string $name The technical theme name
+     * @param string $themeName The technical theme name
      * @return array|false
      */
-    public function getErrors($theme_name)
+    public function getErrors($themeName)
     {
-        return $this->themeValidator->getErrors($theme_name);
+        return $this->themeValidator->getErrors($themeName);
     }
 
     private function doCreateCustomHooks(array $hooks)

--- a/src/Core/Addon/Theme/ThemeManagerBuilder.php
+++ b/src/Core/Addon/Theme/ThemeManagerBuilder.php
@@ -52,7 +52,7 @@ class ThemeManagerBuilder
         return new ThemeManager(
             $this->context->shop,
             new Configuration($this->context->shop),
-            new ThemeValidator(),
+            new ThemeValidator($this->context->getTranslator()),
             $this->context->employee,
             new Filesystem(),
             new Finder(),

--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -27,12 +27,23 @@
 namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
 use Shudrum\Component\ArrayFinder\ArrayFinder;
-use Context;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class ThemeValidator
 {
+    /**
+     * Translator.
+     *
+     * @var \Symfony\Component\Translation\TranslatorInterface
+     */
+    private $translator;
 
     private $errors = array();
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
 
     public function getErrors($theme_name) {
         return array_key_exists($theme_name, $this->errors) ? $this->errors[$theme_name] : false;
@@ -52,15 +63,11 @@ class ThemeValidator
         foreach ($this->getRequiredProperties() as $prop) {
             if (!$attributes->offsetExists($prop)) {
 
-                if (empty($translator)) {
-                    $translator = Context::getContext()->getTranslator();
-                }
-
                 if (!array_key_exists($themeName, $this->errors)) {
                     $this->errors[$themeName] = array();
                 }
 
-                $this->errors[$themeName] = $translator->trans('An error occurred. The information "%s" is missing.', array($prop), 'Admin.Design.Notification');
+                $this->errors[$themeName] = $this->translator->trans('An error occurred. The information "%s" is missing.', array($prop), 'Admin.Design.Notification');
             }
         }
 
@@ -93,15 +100,11 @@ class ThemeValidator
         foreach ($this->getRequiredFiles() as $file) {
             if (!file_exists($theme->getDirectory().$file)) {
 
-                if (empty($translator)) {
-                    $translator = Context::getContext()->getTranslator();
-                }
-
                 if (!array_key_exists($themeName, $this->errors)) {
                     $this->errors[$themeName] = array();
                 }
 
-                $this->errors[$themeName] = $translator->trans('An error occurred. The template "%s" is missing.', array($file), 'Admin.Design.Notification');
+                $this->errors[$themeName] = $this->translator->trans('An error occurred. The template "%s" is missing.', array($file), 'Admin.Design.Notification');
             }
         }
 

--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -27,9 +27,17 @@
 namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
 use Shudrum\Component\ArrayFinder\ArrayFinder;
+use Context;
 
 class ThemeValidator
 {
+
+    private $errors = array();
+
+    public function getErrors($theme_name) {
+        return array_key_exists($theme_name, $this->errors) ? $this->errors[$theme_name] : false;
+    }
+
     public function isValid(Theme $theme)
     {
         return $this->hasRequiredFiles($theme)
@@ -39,14 +47,24 @@ class ThemeValidator
     private function hasRequiredProperties($theme)
     {
         $attributes = new ArrayFinder($theme->get(null));
+        $themeName = $theme->getName();
 
         foreach ($this->getRequiredProperties() as $prop) {
             if (!$attributes->offsetExists($prop)) {
-                return false;
+
+                if (empty($translator)) {
+                    $translator = Context::getContext()->getTranslator();
+                }
+
+                if (!array_key_exists($themeName, $this->errors)) {
+                    $this->errors[$themeName] = array();
+                }
+
+                $this->errors[$themeName] = $translator->trans('An error occurred. The information "%s" is missing.', array($prop), 'Admin.Design.Notification');
             }
         }
 
-        return true;
+        return !array_key_exists($themeName, $this->errors);
     }
 
     public function getRequiredProperties()
@@ -70,13 +88,24 @@ class ThemeValidator
 
     private function hasRequiredFiles($theme)
     {
+        $themeName = $theme->getName();
+
         foreach ($this->getRequiredFiles() as $file) {
             if (!file_exists($theme->getDirectory().$file)) {
-                return false;
+
+                if (empty($translator)) {
+                    $translator = Context::getContext()->getTranslator();
+                }
+
+                if (!array_key_exists($themeName, $this->errors)) {
+                    $this->errors[$themeName] = array();
+                }
+
+                $this->errors[$themeName] = $translator->trans('An error occurred. The template "%s" is missing.', array($file), 'Admin.Design.Notification');
             }
         }
 
-        return true;
+        return !array_key_exists($themeName, $this->errors);
     }
 
     public function getRequiredFiles()

--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -45,8 +45,8 @@ class ThemeValidator
         $this->translator = $translator;
     }
 
-    public function getErrors($theme_name) {
-        return array_key_exists($theme_name, $this->errors) ? $this->errors[$theme_name] : false;
+    public function getErrors($themeName) {
+        return array_key_exists($themeName, $this->errors) ? $this->errors[$themeName] : false;
     }
 
     public function isValid(Theme $theme)

--- a/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Tests\Core\Addon;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeValidator;
 use Symfony\Component\Yaml\Parser;
+use Phake;
 
 class ThemeValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -37,8 +38,10 @@ class ThemeValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $translator = Phake::mock('Symfony\Component\Translation\TranslatorInterface');
+
         /* @var \PrestaShop\PrestaShop\Core\Addon\Theme\ThemeValidator */
-        $this->validator = new ThemeValidator();
+        $this->validator = new ThemeValidator($translator);
     }
 
     protected function tearDown()


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Raise errors when theme can't be enabled. Before page reload, theme wasn't enabled and we have no error |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Install a theme with a missing template (form-fields.tpl) for example |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
