### PR TITLE
Fix legacy ISO code for spanish

### DIFF
--- a/app/Resources/legacy-to-standard-locales.json
+++ b/app/Resources/legacy-to-standard-locales.json
@@ -16,7 +16,7 @@
   "de": "de-DE",
   "el": "el-GR",
   "en": "en-US",
-  "es-ES": "es-ES",
+  "es": "es-ES",
   "et": "et-EE",
   "eu": "eu-ES",
   "fa": "fa-IR",


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The legacy code is not ok, then if you try to translate Spanish in BO location area, it shows a message error on getLangToLocalesMapping because es not found. |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | With Spanish language installed, try to translate in Translations area. |
