### PR TITLE
Displayed modal on combinations deletion

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -62,10 +62,10 @@ var combinations = (function() {
 
   return {
     'init': function() {
-      var _this = this;
       var showVariationsSelector = $('#show_variations_selector input');
       var productTypeSelector = $('#form_step1_type_product');
-      var combinationsList = $('#accordion_combinations .combination');
+      var combinationsListSelector = '#accordion_combinations .combination';
+      var combinationsList = $(combinationsListSelector);
 
       if (combinationsList.length > 0) {
         productTypeSelector.prop('disabled', true);
@@ -134,6 +134,7 @@ var combinations = (function() {
       /** Combinations fields display management */
       showVariationsSelector.change(function() {
         displayFieldsManager.refresh();
+        combinationsList = $(combinationsListSelector);
 
         if ($(this).val() === '0') {
           //if combination(s) exists, alert user for deleting it


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Display confirmation modal window on combinations deletoin |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1497 |
| How to test? | After having created a product, generate combinations.Switching to `Simple Product` should trigger the display of a confirmation modal window |
