### PR TITLE
Fix focus issue on tinymce editor

### DIFF
--- a/js/tiny_mce/plugins/placeholder/plugin.min.js
+++ b/js/tiny_mce/plugins/placeholder/plugin.min.js
@@ -1,44 +1,57 @@
-tinymce.PluginManager.add('placeholder', function(editor) {
-    editor.on('init', function() {
-        var label = new Label;
+tinymce.PluginManager.add('placeholder', function (editor) {
+  editor.on('init', function () {
+    var label = new Label;
 
-        onBlur();
+    onBlur();
 
-        tinymce.DOM.bind(label.el, 'click', onFocus);
-        editor.on('focus', onFocus);
-        editor.on('blur', onBlur);
-        editor.on('change', onBlur);
+    tinymce.DOM.bind(label.el, 'click', onFocus);
+    editor.on('focus', onFocus);
+    editor.on('blur', onBlur);
+    editor.on('change', onBlur);
 
-        function onFocus(){
-            label.hide();
-            tinyMCE.execCommand('mceFocus', false, editor);
-        }
-
-        function onBlur(){
-            if(editor.getContent() == '') {
-                label.show();
-            }else{
-                label.hide();
-            }
-        }
-    });
-
-    var Label = function(){
-        // Create label el
-        this.text = editor.getElement().getAttribute("placeholder");
-        this.contentAreaContainer = editor.getContentAreaContainer();
-
-        tinymce.DOM.setStyle(this.contentAreaContainer, 'position', 'relative');
-
-        attrs = {style: {position: 'absolute', top: 0, left: 0, bottom: 0, color: '#6c868e', 'font-style': 'italic', padding: '1%', width:'98%', overflow: 'hidden', 'white-space': 'normal'} };
-        this.el = tinymce.DOM.add( this.contentAreaContainer, "div", attrs, this.text );
+    function onFocus() {
+      label.hide();
+      editor.execCommand('mceFocus', false);
     }
 
-    Label.prototype.hide = function(){
-        tinymce.DOM.setStyle( this.el, 'display', 'none' );
+    function onBlur() {
+      if (editor.getContent() == '') {
+        label.show();
+      } else {
+        label.hide();
+      }
     }
+  });
 
-    Label.prototype.show = function(){
-        tinymce.DOM.setStyle( this.el, 'display', '' );
-    }
+  var Label = function () {
+    // Create label el
+    this.text = editor.getElement().getAttribute("placeholder");
+    this.contentAreaContainer = editor.getContentAreaContainer();
+
+    tinymce.DOM.setStyle(this.contentAreaContainer, 'position', 'relative');
+
+    attrs = {
+      style: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        bottom: 0,
+        color: '#6c868e',
+        'font-style': 'italic',
+        padding: '1%',
+        width: '98%',
+        overflow: 'hidden',
+        'white-space': 'normal'
+      }
+    };
+    this.el = tinymce.DOM.add(this.contentAreaContainer, "div", attrs, this.text);
+  }
+
+  Label.prototype.hide = function () {
+    tinymce.DOM.setStyle(this.el, 'display', 'none');
+  }
+
+  Label.prototype.show = function () {
+    tinymce.DOM.setStyle(this.el, 'display', '');
+  }
 });


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR fixes the focus in tinymce editor. Now it takes only one click to get the focus. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1050 |
| How to test? | In back-office, on a new product page, try to add a short description. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
