### PR TITLE
Fixed method getNonNativeModuleList (always returns false)

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1537,7 +1537,7 @@ abstract class ModuleCore
         }
 
         $arr_native_modules = array();
-        if (is_array($native_modules)) {
+        if (is_object($native_modules)) {
             foreach ($native_modules as $native_modules_type) {
                 if (in_array($native_modules_type['type'], array('native', 'partner'))) {
                     $arr_native_modules[] = '""';


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop & 1.6.1.x |
| Description? | simplexml_load_file function returns an object, not an array. The method expecting an array, not an object. Therefore, it will always return false. List of non-native module is always empty. <br>I have not received the text of the error. I did not get anything, when i wanted to see a list of Non-native modules with Module::getNonNativeModuleList()! |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7136 |
| How to test? | Call Module::getNonNativeModuleList() |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
