### PR TITLE
Added reference to select products field

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
@@ -164,7 +164,12 @@
                     limit: 30,
                     templates: {
                         suggestion: function(item){
-                            return '<div><img src="'+ item.image +'" style="width:50px" /> '+ item.name +'</div>'
+                            return '<div>' +
+                                   '<table><tr>' +
+                                   '<td rowspan="2"><img src="'+ item.image +'" style="width:50px; margin-right: 7px;" /></td>' +
+                                   '<td>' + item.name + '</td></tr>' +
+                                   '<tr><td>REF: ' + item.ref + '</td></tr>' +
+                                   '</table></div>'
                         }
                     }
                 }).bind('typeahead:select', function(ev, suggestion) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When creating a pack and adding products into it, we can search products with the name or reference but the reference is not displayed in the products. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1198 |
| How to test? | Create a new Pack Product and search for a product with its reference. |
