### PR TITLE
Use trans() instead of Mail::l() to translate email subject

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1059,10 +1059,17 @@ class CustomerCore extends ObjectModel
                 '{email}' => $this->email,
             );
 
+            $language = new Language((int) $idLang);
+
             Mail::Send(
                 (int) $idLang,
                 'guest_to_customer',
-                Mail::l('Your guest account has been transformed into a customer account', (int) $idLang),
+                Context::getContext()->getTranslator()->trans(
+                    'Your guest account has been transformed into a customer account',
+                    array(),
+                    'Emails.Subject',
+                    $language->locale
+                ),
                 $vars,
                 $this->email,
                 $this->firstname.' '.$this->lastname,

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -610,6 +610,7 @@ abstract class PaymentModuleCore extends Module
                             if ($voucher->add()) {
                                 // If the voucher has conditions, they are now copied to the new voucher
                                 CartRule::copyConditions($cart_rule['obj']->id, $voucher->id);
+                                $orderLanguage = new Language((int) $order->id_lang);
 
                                 $params = array(
                                     '{voucher_amount}' => Tools::displayPrice($voucher->reduction_amount, $this->context->currency, false),
@@ -622,7 +623,12 @@ abstract class PaymentModuleCore extends Module
                                 Mail::Send(
                                     (int)$order->id_lang,
                                     'voucher',
-                                    sprintf(Mail::l('New voucher for your order %s', (int)$order->id_lang), $order->reference),
+                                    Context::getContext()->getTranslator()->trans(
+                                        'New voucher for your order %s',
+                                        array($order->reference),
+                                        'Emails.Subject',
+                                        $orderLanguage->locale
+                                    ),
                                     $params,
                                     $this->context->customer->email,
                                     $this->context->customer->firstname.' '.$this->context->customer->lastname,
@@ -811,11 +817,18 @@ abstract class PaymentModuleCore extends Module
                             PrestaShopLogger::addLog('PaymentModule::validateOrder - Mail is about to be sent', 1, null, 'Cart', (int)$id_cart, true);
                         }
 
+                        $orderLanguage = new Language((int) $order->id_lang);
+
                         if (Validate::isEmail($this->context->customer->email)) {
                             Mail::Send(
                                 (int)$order->id_lang,
                                 'order_conf',
-                                Mail::l('Order confirmation', (int)$order->id_lang),
+                                Context::getContext()->getTranslator()->trans(
+                                    'Order confirmation',
+                                    array(),
+                                    'Emails.Subject',
+                                    $orderLanguage->locale
+                                ),
                                 $data,
                                 $this->context->customer->email,
                                 $this->context->customer->firstname.' '.$this->context->customer->lastname,

--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-class    PrestaShopLoggerCore extends ObjectModel
+class PrestaShopLoggerCore extends ObjectModel
 {
     /** @var int Log id */
     public $id_log;
@@ -82,10 +82,16 @@ class    PrestaShopLoggerCore extends ObjectModel
     public static function sendByMail($log)
     {
         if ((int)Configuration::get('PS_LOGS_BY_EMAIL') <= (int)$log->severity) {
+            $language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
             Mail::Send(
                 (int)Configuration::get('PS_LANG_DEFAULT'),
                 'log_alert',
-                Mail::l('Log: You have a new alert from your shop', (int)Configuration::get('PS_LANG_DEFAULT')),
+                Context::getContext()->getTranslator()->trans(
+                    'Log: You have a new alert from your shop',
+                    array(),
+                    'Emails.Subject',
+                    $language->locale
+                ),
                 array(),
                 Configuration::get('PS_SHOP_EMAIL')
             );

--- a/classes/form/CustomerPersister.php
+++ b/classes/form/CustomerPersister.php
@@ -184,12 +184,16 @@ class CustomerPersisterCore
         return Mail::Send(
             $this->context->language->id,
             'account',
-            Mail::l('Welcome!'),
-            [
+            $this->translator->trans(
+                'Welcome!',
+                array(),
+                'Emails.Subject'
+            ),
+            array(
                 '{firstname}' => $customer->firstname,
                 '{lastname}' => $customer->lastname,
                 '{email}' => $customer->email,
-            ],
+            ),
             $customer->email,
             $customer->firstname.' '.$customer->lastname
         );

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -155,10 +155,16 @@ class OrderHistoryCore extends ObjectModel
                 );
                 // If there is at least one downloadable file
                 if (!empty($assign)) {
+                    $orderLanguage = new Language((int) $order->id_lang);
                     Mail::Send(
                         (int)$order->id_lang,
                         'download_product',
-                        Mail::l('The virtual product that you bought is available for download', $order->id_lang),
+                        Context::getContext()->getTranslator()->trans(
+                            'The virtual product that you bought is available for download',
+                            array(),
+                            'Emails.Subject',
+                            $orderLanguage->locale
+                        ),
                         $data,
                         $customer->email,
                         $customer->firstname.' '.$customer->lastname,
@@ -193,7 +199,7 @@ class OrderHistoryCore extends ObjectModel
                     $employee = null;
                 }
             }
-            
+
 
             // foreach products of the order
             foreach ($order->getProductsDetail() as $product) {

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -364,7 +364,12 @@ class AdminCustomerThreadsControllerCore extends AdminController
                     if (Mail::Send(
                         $this->context->language->id,
                         'forward_msg',
-                        Mail::l('Fwd: Customer message', $this->context->language->id),
+                        $this->trans(
+                            'Fwd: Customer message',
+                            array(),
+                            'Emails.Subject',
+                            $this->context->language->locale
+                        ),
                         $params,
                         $employee->email,
                         $employee->firstname.' '.$employee->lastname,
@@ -387,7 +392,12 @@ class AdminCustomerThreadsControllerCore extends AdminController
                     if (Mail::Send(
                         $this->context->language->id,
                         'forward_msg',
-                        Mail::l('Fwd: Customer message', $this->context->language->id),
+                        $this->trans(
+                            'Fwd: Customer message',
+                            array(),
+                            'Emails.Subject',
+                            $this->context->language->locale
+                        ),
                         $params, $email, null,
                         $current_employee->email, $current_employee->firstname.' '.$current_employee->lastname,
                         null, null, _PS_MAIL_DIR_, true)) {
@@ -440,10 +450,20 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         $from_email = null;
                     }
 
+                    $language = new Language((int) $ct->id_lang);
+
                     if (Mail::Send(
                         (int)$ct->id_lang,
                         'reply_msg',
-                        sprintf(Mail::l('An answer to your message is available #ct%1$s #tc%2$s', $ct->id_lang), $ct->id, $ct->token),
+                        $this->trans(
+                            'An answer to your message is available #ct%thread_id% #tc%thread_token%',
+                            array(
+                                '%thread_id%' => $ct->id,
+                                '%thread_token%' => $ct->token,
+                            ),
+                            'Emails.Subject',
+                            $language->locale
+                        ),
                         $params, Tools::getValue('msg_email'), null, $from_email, $from_name, $file_attachment, null,
                         _PS_MAIL_DIR_, true, $ct->id_shop)) {
                         $ct->status = 'closed';

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -4490,11 +4490,18 @@ class AdminImportControllerCore extends AdminController
                     '{lastname}' => $this->context->employee->lastname,
                     '{filename}' => Tools::getValue('csv')
                 );
+
+                $employeeLanguage = new Language((int) $this->context->employee->id_lang);
                 // Mail send in last step because in case of failure, does NOT throw an error.
                 $mailSuccess = @Mail::Send(
                     (int)$this->context->employee->id_lang,
                     'import',
-                    Mail::l('Import complete', (int)$this->context->employee->id_lang),
+                    $this->trans(
+                        'Import complete',
+                        array(),
+                        'Emails.Subject',
+                        $employeeLanguage->locale
+                    ),
                     $templateVars,
                     $this->context->employee->email,
                     $this->context->employee->firstname . ' ' . $this->context->employee->lastname,

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -279,7 +279,23 @@ class AdminLoginControllerCore extends AdminController
                 '{url}' => $admin_url.'&id_employee='.(int)$employee->id.'&reset_token='.$employee->reset_password_token
             );
 
-            if (Mail::Send($employee->id_lang, 'employee_password', Mail::l('Your new password', $employee->id_lang), $params, $employee->email, $employee->firstname.' '.$employee->lastname)) {
+            $employeeLanguage = new Language((int) $employee->id_lang);
+
+            if (
+                Mail::Send(
+                    $employee->id_lang,
+                    'employee_password',
+                    $this->trans(
+                        'Your new password',
+                        array(),
+                        'Emails.Subject',
+                        $employeeLanguage->locale
+                    ),
+                    $params,
+                    $employee->email,
+                    $employee->firstname.' '.$employee->lastname
+                )
+            ) {
                 // Update employee only if the mail can be sent
                 Shop::setContext(Shop::CONTEXT_SHOP, (int)min($employee->getAssociatedShops()));
                 die(Tools::jsonEncode(array(
@@ -342,7 +358,23 @@ class AdminLoginControllerCore extends AdminController
                 '{firstname}' => $employee->firstname,
             );
 
-            if (Mail::Send($employee->id_lang, 'password', Mail::l('Your new password', $employee->id_lang), $params, $employee->email, $employee->firstname.' '.$employee->lastname)) {
+            $employeeLanguage = new Language((int) $this->context->employee->id_lang);
+
+            if (
+                Mail::Send(
+                    $employee->id_lang,
+                    'password',
+                    $this->trans(
+                        'Your new password',
+                        array(),
+                        'Emails.Subject',
+                        $employeeLanguage->locale
+                    ),
+                    $params,
+                    $employee->email,
+                    $employee->firstname.' '.$employee->lastname
+                )
+            ) {
                 // Update employee only if the mail can be sent
                 Shop::setContext(Shop::CONTEXT_SHOP, (int)min($employee->getAssociatedShops()));
 

--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -241,6 +241,7 @@ class AdminReturnControllerCore extends AdminController
                     $orderReturn = new OrderReturn($id_order_return);
                     $order = new Order($orderReturn->id_order);
                     $customer = new Customer($orderReturn->id_customer);
+                    $orderLanguage = new Language((int) $order->id_lang);
                     $orderReturn->state = (int)(Tools::getValue('state'));
                     if ($orderReturn->save()) {
                         $orderReturnState = new OrderReturnState($orderReturn->state);
@@ -249,9 +250,26 @@ class AdminReturnControllerCore extends AdminController
                         '{firstname}' => $customer->firstname,
                         '{id_order_return}' => $id_order_return,
                         '{state_order_return}' => (isset($orderReturnState->name[(int)$order->id_lang]) ? $orderReturnState->name[(int)$order->id_lang] : $orderReturnState->name[(int)Configuration::get('PS_LANG_DEFAULT')]));
-                        Mail::Send((int)$order->id_lang, 'order_return_state', Mail::l('Your order return status has changed', $order->id_lang),
-                            $vars, $customer->email, $customer->firstname.' '.$customer->lastname, null, null, null,
-                            null, _PS_MAIL_DIR_, true, (int)$order->id_shop);
+                        Mail::Send(
+                            (int)$order->id_lang,
+                            'order_return_state',
+                            $this->trans(
+                                'Your order return status has changed',
+                                array(),
+                                'Emails.Subject',
+                                $orderLanguage->locale
+                            ),
+                            $vars,
+                            $customer->email,
+                            $customer->firstname.' '.$customer->lastname,
+                            null,
+                            null,
+                            null,
+                            null,
+                            _PS_MAIL_DIR_,
+                            true,
+                            (int)$order->id_shop
+                        );
 
                         if (Tools::isSubmit('submitAddorder_returnAndStay')) {
                             Tools::redirectAdmin(self::$currentIndex.'&conf=4&token='.$this->token.'&updateorder_return&id_order_return='.(int)$id_order_return);

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -112,7 +112,11 @@ class OrderDetailControllerCore extends FrontController
                         Mail::Send(
                             $this->context->language->id,
                             'order_customer_comment',
-                            Mail::l('Message from a customer'),
+                            $this->trans(
+                                'Message from a customer',
+                                array(),
+                                'Emails.Subject'
+                            ),
                             array(
                                 '{lastname}' => $customer->lastname,
                                 '{firstname}' => $customer->firstname,

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -76,7 +76,20 @@ class PasswordControllerCore extends FrontController
                     '{url}' => $this->context->link->getPageLink('password', true, null, 'token='.$customer->secure_key.'&id_customer='.(int) $customer->id.'&reset_token='.$customer->reset_password_token),
                 );
 
-                if (Mail::Send($this->context->language->id, 'password_query', Mail::l('Password query confirmation'), $mailParams, $customer->email, $customer->firstname.' '.$customer->lastname)) {
+                if (
+                    Mail::Send(
+                        $this->context->language->id,
+                        'password_query',
+                        $this->trans(
+                            'Password query confirmation',
+                            array(),
+                            'Emails.Subject'
+                        ),
+                        $mailParams,
+                        $customer->email,
+                        $customer->firstname.' '.$customer->lastname
+                    )
+                ) {
                     $this->success[] = $this->trans('If this email address has been registered in our shop, you will receive a link to reset your password at %email%.', array('%email%', $customer->email), 'Shop.Notifications.Success');
                     $this->setTemplate('customer/password-infos');
                 } else {
@@ -148,7 +161,20 @@ class PasswordControllerCore extends FrontController
                                 '{firstname}' => $customer->firstname
                             ];
 
-                            if (Mail::Send($this->context->language->id, 'password', Mail::l('Your new password'), $mail_params, $customer->email, $customer->firstname.' '.$customer->lastname)) {
+                            if (
+                                Mail::Send(
+                                    $this->context->language->id,
+                                    'password',
+                                    $this->trans(
+                                        'Your new password',
+                                        array(),
+                                        'Emails.Subject'
+                                    ),
+                                    $mail_params,
+                                    $customer->email,
+                                    $customer->firstname.' '.$customer->lastname
+                                )
+                            ) {
                                 $this->context->smarty->assign([
                                     'customer_email' => $customer->email
                                 ]);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Use trans() instead of Mail::l() to be able to translate email subject |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
