### PR TITLE
Fix the quick links

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -126,7 +126,7 @@
 							<ul class="dropdown-menu">
 								{foreach $quick_access as $quick}
 									<li {if $link->matchQuickLink({$quick.link})}{assign "matchQuickLink" $quick.id_quick_access}class="active"{/if}>
-										<a href="{$baseAdminUrl}{$quick.link|escape:'html':'UTF-8'}"{if $quick.new_window} class="_blank"{/if}>
+										<a href="{$quick.link|escape:'html':'UTF-8'}"{if $quick.new_window} class="_blank"{/if}>
 											{if isset($quick.icon)}
 												<i class="icon-{$quick.icon} icon-fw"></i>
 											{else}

--- a/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
@@ -5,7 +5,7 @@
   </span>
   <div class="ps-dropdown-menu dropdown-menu" aria-labelledby="quick-access">
     {foreach $quick_access as $quick}
-      <a href="{$baseAdminUrl}{$quick.link|escape:'html':'UTF-8'}" class="dropdown-item" data-item="{$quick.name}">{$quick.name}</a></li>
+      <a href="{$quick.link|escape:'html':'UTF-8'}" class="dropdown-item" data-item="{$quick.name}">{$quick.name}</a></li>
     {/foreach}
     <hr>
     {if isset($matchQuickLink)}
@@ -28,7 +28,7 @@
       data-rand="{1|rand:200}"
       data-icon="{$quick_access_current_link_icon}"
       data-method="add"
-      data-url="{$link->getQuickLink($smarty.server['REQUEST_URI'])}"
+      data-url="{$smarty.server['REQUEST_URI']}"
       data-post-link="{$link->getAdminLink('AdminQuickAccesses')}"
       data-prompt-text="{l s='Please name this shortcut:' js=1}"
       data-link="{$quick_access_current_link_name|truncate:32}"

--- a/install-dev/data/xml/quick_access.xml
+++ b/install-dev/data/xml/quick_access.xml
@@ -12,7 +12,7 @@
       <link>index.php?controller=AdminCartRules&amp;addcart_rule</link>
     </quick_access>
     <quick_access id="New_product" new_window="0">
-      <link>product/new</link>
+      <link>index.php/product/new</link>
     </quick_access>
     <quick_access id="New_category" new_window="0">
       <link>index.php?controller=AdminCategories&amp;addcategory</link>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The new theme should not break the quick access links |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-957 |
| How to test? | <ul><li>Go to some page</li><li>Create a new quick access link</li><li>Go to another page</li><li>Click on the quick access link</li><li>You should have been redirected to the good page</li></ul> |
