### PR TITLE
Added in URL method the possibility to recover the category image

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1066,6 +1066,14 @@ class LinkCore
                     $params['relative_protocol']
                 );
                 break;
+            case 'categoryImage':
+                $params = array_merge(array('selected_filters' => null), $params);
+                $link = $context->link->getCatImageLink(
+                    $params['name'],
+                    $params['id'],
+                    $params['type'] = (isset($params['type']) ? $params['type'] : null)
+                );
+                break;
             case 'cms':
                 $link = $context->link->getCMSLink(
                     new CMS($params['id'], $params['id_lang']),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Add in smarty {url (Class Link method getUrlSmarty) the posibility to recover the category image. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | - |
| How to test? | Try to use this call in smarty ->  {url entity=categoryImage id=$category.id_category name=$category.name type='small_default'}" |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
