### PR TITLE
Ability to know combination id at the product page

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-variants.tpl
+++ b/themes/classic/templates/catalog/_partials/product-variants.tpl
@@ -35,4 +35,5 @@
       {/if}
     </div>
   {/foreach}
+  <input type="hidden" name="idCombination" id="idCombination" value="{$product.id_product_attribute}">
 </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Ability to know combination id at the product page |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1516 |
| How to test? | Open product page and find value of the input #idCombination |
