### PR TITLE
Take order state unremovable flag into account

### DIFF
--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -37,15 +37,17 @@ class AdminStatusesControllerCore extends AdminController
         $this->lang = true;
         $this->deleted = false;
         $this->colorOnBackground = false;
-        $this->bulk_actions = array('delete' => array('text' => $this->l('Delete selected'), 'confirm' => $this->l('Delete selected items?')));
-        $this->context = Context::getContext();
+        
         $this->multishop_context = Shop::CONTEXT_ALL;
         $this->imageType = 'gif';
         $this->fieldImageSettings = array(
             'name' => 'icon',
             'dir' => 'os'
         );
+
         parent::__construct();
+
+        $this->bulk_actions = array('delete' => array('text' => $this->l('Delete selected'), 'confirm' => $this->l('Delete selected items?')));
     }
 
     public function init()
@@ -211,7 +213,7 @@ class AdminStatusesControllerCore extends AdminController
         //init and render the first list
         $this->addRowAction('edit');
         $this->addRowAction('delete');
-        $this->addRowActionSkipList('delete', range(1, 14));
+        $this->addRowActionSkipList('delete', $this->getUnremovableStatuses());
         $this->bulk_actions = array(
             'delete' => array(
                 'text' => $this->l('Delete selected'),
@@ -237,6 +239,13 @@ class AdminStatusesControllerCore extends AdminController
         $lists .= parent::renderList();
 
         return $lists;
+    }
+
+    protected function getUnremovableStatuses()
+    {
+        return array_map(function ($row) {
+            return (int) $row['id_order_state'];
+        }, Db::getInstance()->executeS('SELECT id_order_state FROM '._DB_PREFIX_.'order_state WHERE unremovable = 1'));
     }
 
     protected function checkFilterForOrdersReturnsList()


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | this is rework of #5831 - i can agree with original PR, if we're going to add some unremovable statuses by hand someone could delete them from BO, this PR has also fix for a bug with a `trans()` method |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1520 |
| Sponsor company | impSolutions

btw. i was looking for Order Statuses tab so so long...
