### PR TITLE
Delete legacy code related to Discounts

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -420,25 +420,6 @@ class CartRuleCore extends ObjectModel
             $result = $result_bak;
         }
 
-        // Retrocompatibility with 1.4 discounts
-        // TODO: remove? We're at 1.7 now
-        foreach ($result as &$cart_rule) {
-            $cart_rule['value'] = 0;
-            $cart_rule['minimal'] = Tools::convertPriceFull($cart_rule['minimum_amount'], new Currency($cart_rule['minimum_amount_currency']), Context::getContext()->currency);
-            $cart_rule['cumulable'] = !$cart_rule['cart_rule_restriction'];
-            $cart_rule['id_discount_type'] = false;
-            if ($cart_rule['free_shipping']) {
-                $cart_rule['id_discount_type'] = Discount::FREE_SHIPPING;
-            } elseif ($cart_rule['reduction_percent'] > 0) {
-                $cart_rule['id_discount_type'] = Discount::PERCENT;
-                $cart_rule['value'] = $cart_rule['reduction_percent'];
-            } elseif ($cart_rule['reduction_amount'] > 0) {
-                $cart_rule['id_discount_type'] = Discount::AMOUNT;
-                $cart_rule['value'] = $cart_rule['reduction_amount'];
-            }
-        }
-        unset($cart_rule);
-
         return $result;
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When a voucher is set on "highlight", shopping cart is KO |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | yes, probably with 1.4 |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1531 |
| How to test? | details on Forge |
| Sponsor company | impSolutions

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

Overal i have found two ways to solve this problem, first, remove this code, second add constants to `CartRule` class, i'm not sure if we really need this BC code here, i think this compatibility stuff could be done while upgrade, but it's something to be tested when someone will start to work on updater :+1: 
