### PR TITLE
Avoid SSL certificate problem on local env

### DIFF
--- a/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
@@ -45,6 +45,7 @@ class ApiClient
         $this->setIsoLang($isoLang)
             ->setIsoCode($isoCode)
             ->setVersion(_PS_VERSION_)
+            ->setSslVerification(!_PS_MODE_DEV_)
         ;
     }
 
@@ -206,5 +207,10 @@ class ApiClient
         $this->queryParameters['password'] = $password;
 
         return $this;
+    }
+
+    public function setSslVerification($verify)
+    {
+        return $this->addonsApiClient->setDefaultOption('verify', $verify);
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | I didn't have ssl setup on one of my env's and i couldn't see Modules because of cURL ssl certificate error, this PR set SSL verification to false if shop is in debug mode |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1522 |
| How to test? | try to see Modules Catalog without having proper ssl certificate setup locally |
