### PR TITLE
Introduced SSL verify config parameter

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -104,3 +104,8 @@ csa_guzzle:
                 timeout: "5.0"
                 headers:
                     Accept: "application/json"
+
+prestashop:
+    addons:
+        api_client:
+            verify_ssl: ~ # true by default, declaring "addons.api_client.verify_ssl" parameter overrides its usage

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -131,6 +131,13 @@ class ModuleManagerBuilder
             _PS_VERSION_)
         ;
 
+        if (file_exists($this->getConfigDir().'/parameters.php')) {
+            $parameters = require($this->getConfigDir().'/parameters.php');
+            if (array_key_exists('addons.api_client.verify_ssl', $parameters['parameters'])) {
+                $marketPlaceClient->setSslVerification($parameters['parameters']['addons.api_client.verify_ssl']);
+            }
+        }
+
         self::$addonsDataProvider = new AddonsDataProvider($marketPlaceClient);
         self::$categoriesProvider = new CategoriesProvider($marketPlaceClient);
 
@@ -159,11 +166,16 @@ class ModuleManagerBuilder
     {
         // get the environment to load the good routing file
         $routeFileName = _PS_MODE_DEV_ === true ? 'routing_dev.yml' : 'routing.yml';
-        $routesDirectory = _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'config';
+        $routesDirectory = $this->getConfigDir();
         $locator = new FileLocator(array($routesDirectory));
         $loader = new YamlFileLoader($locator);
 
         return new Router($loader, $routeFileName);
+    }
+
+    protected function getConfigDir()
+    {
+        return _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'config';
     }
 
     /**

--- a/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
+++ b/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShopBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class AddOnsConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('prestashop');
+
+        $rootNode
+            ->children()
+                ->arrayNode('addons')
+                    ->children()
+                        ->arrayNode('api_client')
+                            ->children()
+                                ->booleanNode('verify_ssl')
+                                    ->defaultTrue()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -40,8 +40,21 @@ class PrestaShopExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        $configuration = new AddOnsConfiguration();
+        $config = $this->processConfiguration($configuration, $configs);
+
         $loader = new YamlFileLoader($container, new FileLocator(dirname(__DIR__).'/Resources/config'));
         $loader->load('services.yml');
+
+        $hasVerifySslParameter = $container->hasParameter('addons.api_client.verify_ssl');
+
+        if ($hasVerifySslParameter) {
+            $verifySsl = $container->getParameter('addons.api_client.verify_ssl');
+        } else {
+            $verifySsl = $config['addons']['api_client']['verify_ssl'];
+        }
+
+        $container->setParameter('prestashop.addons.api_client.verify_ssl', $verifySsl);
     }
 
     /**
@@ -49,6 +62,6 @@ class PrestaShopExtension extends Extension
      */
     public function getAlias()
     {
-        return 'prestashop_bundle';
+        return 'prestashop';
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -267,4 +267,6 @@ services:
             - "@csa_guzzle.client.addons_api"
             - "@=service('prestashop.adapter.legacy.context').getContext().language.iso_code"
             - "@=service('prestashop.adapter.data_provider.country').getIsoCodebyId()"
+        calls:
+            - [ "setSslVerification", ["%prestashop.addons.api_client.verify_ssl%"]]
 

--- a/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
@@ -48,6 +48,22 @@ class ApiClient
         ;
     }
 
+    public function setSslVerification($verifySsl)
+    {
+        $this->addonsApiClient->setDefaultOption('verify', $verifySsl);
+    }
+
+    /**
+     * @param Client $client
+     * @return $this
+     */
+    public function setClient(Client $client)
+    {
+        $this->addonsApiClient = $client;
+
+        return $this;
+    }
+
     public function getNativesModules()
     {
         $response = $this->setMethod('listing')

--- a/tests/Integration/PrestashopBundle/Service/DataProvider/MarketPlace/ApiClientTest.php
+++ b/tests/Integration/PrestashopBundle/Service/DataProvider/MarketPlace/ApiClientTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author 	PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2015 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Tests\Service\DataProvider\MarketPlace;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Phake;
+
+/**
+ * @group addons
+ */
+class ApiClientTest extends KernelTestCase
+{
+    protected $apiClient;
+
+    public function setUp()
+    {
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $kernel->getContainer()->set('prestashop.adapter.legacy.context', $this->mockLegacyContext());
+
+        $this->apiClient = $kernel->getContainer()->get('prestashop.addons.client_api');
+        $this->apiClient->setClient($this->mockClient());
+    }
+
+    public function testGetNativeModules()
+    {
+        $this->assertCount(0, $this->apiClient->getNativesModules());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function mockResponse()
+    {
+        $responseMock = $this->getMockBuilder('\GuzzleHttp\Message\Response')
+            ->disableOriginalConstructor()
+            ->setMethods(['getBody'])
+            ->getMock();
+
+        $responseMock->method('getBody')
+            ->willReturn(json_encode((object)['modules' => []]));
+
+        return $responseMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function mockClient()
+    {
+        $responseMock = $this->mockResponse();
+
+        $clientMock = $this->getMockBuilder('\GuzzleHttp\Client')
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMock();
+
+        $clientMock->method('get')
+            ->with($this->anything())
+            ->willReturn($responseMock);
+
+        return $clientMock;
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function mockLegacyContext()
+    {
+        $context = Phake::mock('Context');
+        $context->language = Phake::mock('Language');
+
+        $legacyContext = Phake::mock('\PrestaShop\PrestaShop\Adapter\LegacyContext');
+        Phake::when($legacyContext)->getContext()->thenReturn($context);
+
+        return $legacyContext;
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,4 +1,7 @@
 <phpunit bootstrap="bootstrap.php">
+    <php>
+        <server name="KERNEL_DIR" value="../app/" />
+    </php>
     <groups>
         <exclude>
             <group>admin</group>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Allow use of `addons.api_client.verify_ssl` parameter to prevent SSL verification |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | N/A |
| How to test? | Declare `addons.api_client.verify_ssl` in `parameters.php` to prevent SSL verification |
