### PR TITLE
Faceted Search SEO Implements most crucial Google Guidelines

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -21,3 +21,4 @@ Disallow: /tools/
 Disallow: /translations/
 Disallow: /upload/
 Disallow: /webservice/
+Disallow: /*?q=*

--- a/themes/classic/templates/_partials/pagination.tpl
+++ b/themes/classic/templates/_partials/pagination.tpl
@@ -10,7 +10,7 @@
             <span class="spacer">&hellip;</span>
           {else}
             <a
-              rel="nofollow"
+              rel="{if $page.type === 'previous'}prev{elseif $page.type === 'next'}next{else}nofollow{/if}"
               href="{$page.url}"
               class="{if $page.type === 'previous'}previous {elseif $page.type === 'next'}next {/if}{['disabled' => !$page.clickable, 'js-search-link' => true]|classnames}"
             >

--- a/themes/classic/templates/catalog/_partials/facets.tpl
+++ b/themes/classic/templates/catalog/_partials/facets.tpl
@@ -60,6 +60,7 @@
                       <a
                         href="{$filter.nextEncodedFacetsURL}"
                         class="_gray-darker search-link js-search-link"
+                        rel="nofollow"
                       >
                         {$filter.label}
                         {if $filter.magnitude}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `develop` |
| Description? | Better SEO with reduced facets search space. |
| Type? | bug fix |
| Category? | FO |
# Problem Description

Right now google will index one million times the first page of each category but never get to page two, using up all of your crawl budget to index useless results under many URLS.

For instance, all the demo products exist in sizes S, M, and L, so they are available on the URLs S, M, L, S+M, S+L, M+L, (etc. with the other facets and combinations thereof), leading to an exponentially big set of indexed URLs for the same content. This does not lead to the creation of duplicate content thanks to the use of canonical links, but will nonetheless very likely hurt SEO performance.

It also means that tools such as ScreamingFrog are unable to complete a crawl even of the default installation of PrestaShop with just 7 products.
# Proposed Solution

In order to address the issue, this PR:
-  makes pagination links crawlable, using the [google-recommended](https://webmasters.googleblog.com/2011/09/pagination-with-relnext-and-relprev.html) "prev" and "next" rel attributes of links
- disables the crawling of faceted search filters (do not worry, product pages are still reachable via pagination, so the whole site is still indexed - only in _finite_ time :))
- further ensures that non-authoritative versions of result pages (i.e. pages with the q URL parameter) are not indexed thanks to a new rule in robots.txt

The changes made to classic are also proposed in a [PR for the StarterTheme](https://github.com/PrestaShop/StarterTheme/pull/122).
