### PR TITLE
Removed used vouchers from highlight panel

### DIFF
--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -349,6 +349,18 @@ class CartPresenter implements PresenterInterface
         );
 
         $discounts = $cart->getDiscounts();
+        $vouchers = $this->getTemplateVarVouchers($cart);
+
+        $cartRulesIds = array_flip(array_map(
+            function ($voucher) {
+               return $voucher['id_cart_rule'];
+            },
+            $vouchers['added']
+        ));
+
+        $discounts = array_filter($discounts, function ($discount) use ($cartRulesIds) {
+            return !array_key_exists($discount['id_cart_rule'], $cartRulesIds);
+        });
 
         return array(
             'products' => $products,
@@ -360,7 +372,7 @@ class CartPresenter implements PresenterInterface
             'id_address_delivery' => $cart->id_address_delivery,
             'id_address_invoice' => $cart->id_address_invoice,
             'is_virtual' => $cart->isVirtualCart(),
-            'vouchers' => $this->getTemplateVarVouchers($cart),
+            'vouchers' => $vouchers,
             'discounts' => $discounts,
             'minimalPurchase' => $minimalPurchase,
             'minimalPurchaseRequired' => ($this->priceFormatter->convertAmount($productsTotalExcludingTax) < $minimalPurchase) ?

--- a/themes/classic/templates/checkout/_partials/cart-voucher.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-voucher.tpl
@@ -6,7 +6,7 @@
           {foreach from=$cart.vouchers.added item=voucher}
             <li class="cart-summary-line">
               <span class="label">{$voucher.name}</span>
-              <a href="{$voucher.delete_url}" data-link-action="remove-voucher"><i class="material-icons">{l s='delete' d='Shop.Theme.Actions'}</i></a>
+              <a href="{$voucher.delete_url}" data-link-action="remove-voucher"><i class="material-icons">&#xE872;</i></a>
               <div class="pull-xs-right">
                 {$voucher.reduction_formatted}
               </div>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Already used vouchers should not be highlighted again |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1535 |
| How to test? | Add a highlighted discount code to a cart and check if it is still highlighted after refresh |
