### PR TITLE
Make Debug-mode notification link to debug settings page

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -301,8 +301,9 @@
               {if isset($debug_mode) && $debug_mode == true}
                 <span class="shop-state" id="debug-mode">
                   <i class="material-icons">bug_report</i>
-                  <span class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
-                    title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in debug mode.'}</strong></p><p class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' tags=['<strong>']}</p>">{l s='Debug mode'}</span>
+                  <a class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
+                    title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in debug mode.'}</strong></p><p    class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' tags=['<strong>']}</p>" href="{$link->getAdminLink('AdminPerformance')|escape:'html':'UTF-8'}">{l s='Debug mode'}
+                  </a>
                 </span>
               {/if}
               {if isset($maintenance_mode) && $maintenance_mode == true}

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -43,8 +43,9 @@
       <div class="component pull-right">
         <div class="shop-state" id="debug-mode">
           <i class="material-icons">bug_report</i>
-          <span class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
-            title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in debug mode.'}</strong></p><p class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' tags=['<strong>']}</p>">{l s='Debug mode'}</span>
+          <a class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
+              title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in debug mode.'}</strong></p><p    class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' tags=['<strong>']}</p>" href="{$link->getAdminLink('AdminPerformance')|escape:'html':'UTF-8'}">{l s='Debug mode'}
+          </a>
         </div>
       </div>
     {/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | Added a href so that the Debug notification links to the correlating settings page. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | - |
| How to test? | Access the backoffice and activate the debug mode. Then click on the Debug notification in the top right corner. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
