### PR TITLE
Use Controller::ajaxDie() method instead of die()

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -465,7 +465,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
         if ($this->ajax) {
             ob_end_clean();
             header('Content-Type: application/json');
-            die(json_encode($this->getAjaxProductSearchVariables()));
+            $this->ajaxDie(json_encode($this->getAjaxProductSearchVariables()));
         } else {
             $variables = $this->getProductSearchVariables();
             if (


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Controller::ajaxDie() method should be used instead of die() so hook "'actionAjaxDie'.$controller.$method.'Before'" can be called |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Use the faceted search and see if it's working as usual |
