### PR TITLE
Introduce hook to override layout file

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1129,6 +1129,18 @@ class FrontControllerCore extends Controller
 
         $layout = $this->context->shop->theme->getLayoutRelativePathForPage($entity);
 
+        if ($overridden_layout = Hook::exec(
+            'overrideLayoutTemplate',
+            array(
+                'default_layout' => $layout,
+                'entity' => $entity,
+                'locale' => $this->context->language->locale,
+                'controller' => $this,
+            )
+        )) {
+            return $overridden_layout;
+        }
+
         if ((int) Tools::getValue('content_only')) {
             $layout = 'layouts/layout-content-only.tpl';
         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Introduce hook to override layout file. Since 1.7 consider layout and template as 2 different things, we need a hook to build amazing things :D |
| Type? | new feature |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Create a module that register this hook and create "hookOverrideLayoutTemplate($params)" method |

**Note**: New naming convention for hook name, this one start with `get`. Since it's neither an action nor a display hook, it made sense to me. What do you think?
