### PR TITLE
Stop relying on rewritten URL to resize images

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -271,6 +271,11 @@ class ImageManagerCore
         Hook::exec('actionOnImageResizeAfter', array('dst_file' => $destinationFile, 'file_type' => $fileType));
         @imagedestroy($srcImage);
 
+        file_put_contents(
+            dirname($destinationFile) . DIRECTORY_SEPARATOR . 'fileType',
+            $fileType
+        );
+
         return $writeFile;
     }
 
@@ -433,7 +438,7 @@ class ImageManagerCore
         if ($file['error']) {
             return sprintf(Tools::displayError('Error while uploading image; please change your server\'s settings. (Error code: %s)'), $file['error']);
         }
-        
+
         return false;
     }
 

--- a/controllers/front/PageNotFoundController.php
+++ b/controllers/front/PageNotFoundController.php
@@ -38,68 +38,8 @@ class PageNotFoundControllerCore extends FrontController
     {
         header('HTTP/1.1 404 Not Found');
         header('Status: 404 Not Found');
-
-        if (preg_match('/\.(gif|jpe?g|png|ico)$/i', parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))) {
-            $this->context->cookie->disallowWriting();
-            if (!isset($_SERVER['REDIRECT_URL'])) {
-                $_SERVER['REDIRECT_URL'] = '';
-                if (preg_match('@^'.__PS_BASE_URI__.'([0-9]+)\-([_a-zA-Z0-9-]+)(/[_a-zA-Z0-9-]+)?\.jpg$@', $_SERVER['REQUEST_URI'], $matches)) {
-                    $_SERVER['REDIRECT_URL'] = __PS_BASE_URI__.'p/'.Image::getImgFolderStatic($matches[0]).'/'.$matches[0].'-'.$matches[1].'.jpg';
-                }
-            }
-            if (preg_match('#/p[0-9/]*/([0-9]+)\-([_a-zA-Z]*)\.(png|jpe?g|gif)$#', $_SERVER['REDIRECT_URL'], $matches)) {
-                // Backward compatibility since we suffixed the template image with _default
-                if (Tools::strtolower(substr($matches[2], -8)) != '_default') {
-                    header('Location: '.$this->context->link->getImageLink('', $matches[1], $matches[2]), true, 302);
-                    exit;
-                } else {
-                    $image_type = ImageType::getByNameNType($matches[2], 'products');
-                    if ($image_type && count($image_type)) {
-                        $root = _PS_PROD_IMG_DIR_;
-                        $folder = Image::getImgFolderStatic($matches[1]);
-                        $file = $matches[1];
-                        $ext = '.'.$matches[3];
-
-                        if (file_exists($root.$folder.$file.$ext)) {
-                            if (ImageManager::resize($root.$folder.$file.$ext, $root.$folder.$file.'-'.$matches[2].$ext, (int) $image_type['width'], (int) $image_type['height'])) {
-                                header('HTTP/1.1 200 Found');
-                                header('Status: 200 Found');
-                                header('Content-Type: image/jpg');
-                                readfile($root.$folder.$file.'-'.$matches[2].$ext);
-                                exit;
-                            }
-                        }
-                    }
-                }
-            } elseif (preg_match('#/c/([0-9]+)\-([_a-zA-Z]*)\.(png|jpe?g|gif)$#', $_SERVER['REDIRECT_URL'], $matches)) {
-                $image_type = ImageType::getByNameNType($matches[2], 'categories');
-                if ($image_type && count($image_type)) {
-                    $root = _PS_CAT_IMG_DIR_;
-                    $file = $matches[1];
-                    $ext = '.'.$matches[3];
-
-                    if (file_exists($root.$file.$ext)) {
-                        if (ImageManager::resize($root.$file.$ext, $root.$file.'-'.$matches[2].$ext, (int) $image_type['width'], (int) $image_type['height'])) {
-                            header('HTTP/1.1 200 Found');
-                            header('Status: 200 Found');
-                            header('Content-Type: image/jpg');
-                            readfile($root.$file.'-'.$matches[2].$ext);
-                            exit;
-                        }
-                    }
-                }
-            }
-
-            header('Content-Type: image/gif');
-            readfile(_PS_IMG_DIR_.'404.gif');
-            exit;
-        } elseif (in_array(Tools::strtolower(substr($_SERVER['REQUEST_URI'], -3)), array('.js', 'css'))) {
-            $this->context->cookie->disallowWriting();
-            exit;
-        }
-
+        $this->context->cookie->disallowWriting();
         parent::initContent();
-
         $this->setTemplate('errors/404');
     }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | reliable image resizing |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | limited, but likely |
| How to test? | install PrestaShop in a ton of LAMP variants and check you have images on FO with and without URL rewriting enabled both in PrestaShop and on the server |
# Problem Description

Right now, PrestaShop is relying on the ability of the server to rewrite URLs in order to resize images on the fly when an image in the correct format is not found.

This is flaky, because no 2 servers handle rewritten URLs the same way. For instance, if you use php-fpm, right now you won't have any images  on your front-office.
# Proposed Solution

Instead of generating images on the fly when the browser requests them, I generate them on the fly when the template requests them. This doesn't make any assumptions on the presence or absence of URL rewriting. Images are still resized only once, but in a more reliable way.

As a bonus, we can cut a huge amount of rather contrived code from PageNotFoundController. The code in PageNotFoundController could be kept and the fix would still be relevant, but I'd rather clean some things up along the way :) It's of course higher risk, but IMHO worth it.
