### PR TITLE
Hide id_guest field if it is disabled in configuration 

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_content.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_content.tpl
@@ -103,6 +103,12 @@
 						{$tr.$key|string_format:"%.2f"}
 					{elseif isset($params.type) && $params.type == 'percent'}
 						{$tr.$key} {l s='%'}
+					{elseif isset($params.type) && $params.type == 'bool'}
+            {if $tr.$key == 1}
+              {l s='Yes' d='Admin.Global'}
+            {elseif $tr.$key == 0 && $tr.$key != ''}
+              {l s='No' d='Admin.Global'}
+            {/if}
 					{* If type is 'editable', an input is created *}
 					{elseif isset($params.type) && $params.type == 'editable' && isset($tr.id)}
 						<input type="text" name="{$key}_{$tr.id}" value="{$tr.$key|escape:'html':'UTF-8'}" class="{$key}" />

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -95,15 +95,18 @@ class AdminCartsControllerCore extends AdminController
                 'class' => 'fixed-width-lg',
                 'filter_key' => 'a!date_add'
             ),
-            'id_guest' => array(
+        );
+
+        if (Configuration::get('PS_GUEST_CHECKOUT_ENABLED')) {
+            $this->fields_list['id_guest'] = array(
                 'title' => $this->trans('Online', array(), 'Admin.Global'),
                 'align' => 'text-center',
                 'type' => 'bool',
                 'havingFilter' => true,
                 'class' => 'fixed-width-xs',
-                'icon' => array(0 => 'icon-', 1 => 'icon-user')
-            )
-        );
+            );
+        }
+
         $this->shopLinkType = 'shop';
 
         $this->bulk_actions = array(


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Hide id_guest field if it is disabled in configuration + add boolean field into list template |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Enable and disable guest order & show cart page |

From : https://github.com/PrestaShop/PrestaShop/pull/6189
