### PR TITLE
Added missing maintenance / debug indicator

### DIFF
--- a/controllers/admin/AdminAccessController.php
+++ b/controllers/admin/AdminAccessController.php
@@ -107,6 +107,8 @@ class AdminAccessControllerCore extends AdminController
      */
     public function initContent()
     {
+        parent::initContent();
+
         $this->display = 'edit';
         $this->initTabModuleList();
         if (!$this->loadObject(true)) {
@@ -156,7 +158,7 @@ class AdminAccessControllerCore extends AdminController
             $enabled = (int)Tools::getValue('enabled');
             $id_tab = (int)Tools::getValue('id_tab');
             $id_profile = (int)Tools::getValue('id_profile');
-            
+
             die($access->updateLgcAccess((int)$id_profile, $id_tab, $perm, $enabled));
         }
     }

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -462,6 +462,8 @@ class AdminAttributesGroupsControllerCore extends AdminController
      */
     public function initContent()
     {
+        parent::initContent();
+
         // toolbar (save, cancel, new, ..) - show toolbar even if combinations are not active
         $this->initTabModuleList();
         $this->initToolbar();

--- a/controllers/admin/AdminCmsContentController.php
+++ b/controllers/admin/AdminCmsContentController.php
@@ -81,6 +81,8 @@ class AdminCmsContentControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         $this->renderPageHeaderToolbar();
 

--- a/controllers/admin/AdminDeliverySlipController.php
+++ b/controllers/admin/AdminDeliverySlipController.php
@@ -123,6 +123,8 @@ class AdminDeliverySlipControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         $this->initPageHeaderToolbar();
         $this->show_toolbar = false;

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -407,6 +407,8 @@ class AdminFeaturesControllerCore extends AdminController
      */
     public function initContent()
     {
+        parent::initContent();
+
         // toolbar (save, cancel, new, ..) - show toolbar even if features are not active
         $this->initTabModuleList();
         $this->initToolbar();

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -843,6 +843,8 @@ class AdminImportControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         // toolbar (save, cancel, new, ..)
         $this->initToolbar();

--- a/controllers/admin/AdminInvoicesController.php
+++ b/controllers/admin/AdminInvoicesController.php
@@ -226,6 +226,8 @@ class AdminInvoicesControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->display = 'edit';
         $this->initTabModuleList();
         $this->initToolbar();

--- a/controllers/admin/AdminLocalizationController.php
+++ b/controllers/admin/AdminLocalizationController.php
@@ -376,6 +376,8 @@ class AdminLocalizationControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         if (!$this->loadObject(true)) {
             return;

--- a/controllers/admin/AdminManufacturersController.php
+++ b/controllers/admin/AdminManufacturersController.php
@@ -743,6 +743,8 @@ class AdminManufacturersControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         // toolbar (save, cancel, new, ..)
         $this->initToolbar();

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1414,6 +1414,8 @@ class AdminModulesControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         if (Tools::isSubmit('addnewmodule') && $this->context->mode == Context::MODE_HOST) {
             $this->display = 'add';
             $this->context->smarty->assign(array('iso_code' => $this->context->language->iso_code));

--- a/controllers/admin/AdminModulesPositionsController.php
+++ b/controllers/admin/AdminModulesPositionsController.php
@@ -230,6 +230,8 @@ class AdminModulesPositionsControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         $this->addjqueryPlugin('sortable');
         $this->initPageHeaderToolbar();

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -608,6 +608,8 @@ class AdminPerformanceControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         $this->initToolbar();
         $this->initPageHeaderToolbar();

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -276,6 +276,8 @@ class AdminRequestSqlControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+        
         $this->initTabModuleList();
         // toolbar (save, cancel, new, ..)
         $this->initToolbar();

--- a/controllers/admin/AdminSlipController.php
+++ b/controllers/admin/AdminSlipController.php
@@ -164,6 +164,8 @@ class AdminSlipControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         $this->initToolbar();
         $this->initPageHeaderToolbar();

--- a/controllers/admin/AdminStatsTabController.php
+++ b/controllers/admin/AdminStatsTabController.php
@@ -36,6 +36,8 @@ abstract class AdminStatsTabControllerCore extends AdminPreferencesControllerCor
 
     public function initContent()
     {
+        parent::initContent();
+
         if ($this->ajax) {
             return;
         }

--- a/controllers/admin/AdminTrackingController.php
+++ b/controllers/admin/AdminTrackingController.php
@@ -55,6 +55,8 @@ class AdminTrackingControllerCore extends AdminController
 
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         $this->initPageHeaderToolbar();
 

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -101,6 +101,8 @@ class AdminTranslationsControllerCore extends AdminController
      */
     public function initContent()
     {
+        parent::initContent();
+
         $this->initTabModuleList();
         $this->initPageHeaderToolbar();
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Some back-office pages are missing debug / maintenance mode indicator |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1553 |
| How to test? | Go to pages mentioned in the ticket to check the presence of indicators |
