### PR TITLE
IN : Added Australian States which are mandatory for addresses

### DIFF
--- a/install-dev/data/xml/state.xml
+++ b/install-dev/data/xml/state.xml
@@ -954,5 +954,29 @@
     <state id="JP-19" id_country="JP" id_zone="Asia" iso_code="19" tax_behavior="0" active="1">
       <name>Yamanashi</name>
     </state>
+    <state id="AU-ACT" id_country="AU" id_zone="Oceania" iso_code="ACT" tax_behavior="0" active="1">
+      <name>Australian Capital Territory</name>
+    </state>
+    <state id="AU-NSW" id_country="AU" id_zone="Oceania" iso_code="NSW" tax_behavior="0" active="1">
+      <name>New South Wales</name>
+    </state>
+    <state id="AU-NT" id_country="AU" id_zone="Oceania" iso_code="NT" tax_behavior="0" active="1">
+      <name>Northern Territory</name>
+    </state>
+    <state id="AU-QLD" id_country="AU" id_zone="Oceania" iso_code="QLD" tax_behavior="0" active="1">
+      <name>Queensland</name>
+    </state>
+    <state id="AU-SA" id_country="AU" id_zone="Oceania" iso_code="SA" tax_behavior="0" active="1">
+      <name>South Australia</name>
+    </state>
+    <state id="AU-TAS" id_country="AU" id_zone="Oceania" iso_code="TAS" tax_behavior="0" active="1">
+      <name>Tasmania</name>
+    </state>
+    <state id="AU-VIC" id_country="AU" id_zone="Oceania" iso_code="VIC" tax_behavior="0" active="1">
+      <name>Victoria</name>
+    </state>
+    <state id="AU-WA" id_country="AU" id_zone="Oceania" iso_code="WA" tax_behavior="0" active="1">
+      <name>Western Australia</name>
+    </state>
   </entities>
 </entity_state>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | It adds the 8 australian states. They are mandatory in australian addresses so it will allow to modify the default australian address and add the state field (should be my next PR) |
| Type? | improvement |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | not yet, but it's the beginning of BOOM-1235 |
| How to test? | Reinstall and see if australian states are here |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
