### PR TITLE
Check that $errors is defined and is an array

### DIFF
--- a/themes/classic/templates/_partials/form-errors.tpl
+++ b/themes/classic/templates/_partials/form-errors.tpl
@@ -1,4 +1,4 @@
-{if $errors|count}
+{if isset($errors) && $errors|is_array && $errors|count}
   <div class="help-block">
     <ul>
       {foreach $errors as $error}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When you use the Classic theme and want to use the form-errors template inside your module's templates, you can maybe not have the $errors variable assign with Smarty to the template. Just check if $errors is define and is an array. |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Add {include file="_partials/form-errors.tpl"} to a module template without assign $errors and test the ouput with or without this change. |
