### PR TITLE
Fix duplicate insert to specific price table

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -719,6 +719,7 @@ class AdminProductsControllerCore extends AdminController
             unset($product->id_product);
             $product->indexed = 0;
             $product->active = 0;
+            SpecificPriceRule::disableAnyApplication();
             if ($product->add()
             && Category::duplicateProductCategories($id_product_old, $product->id)
             && Product::duplicateSuppliers($id_product_old, $product->id)


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | "1.6.1.x" |
| Description? | when duplicating a product,it shows the error something like "Duplicate entry ‘1034-0-0-0-2016-07-21 00:00:00-2016-08-31 00:00:00-1-0-0-0-0-1-2’ for key ‘id_product_2’" ,duplicating product failed |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | yes |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | create a "catalog price rule" ,then duplicating a product |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/6469)
<!-- Reviewable:end -->
