### PR TITLE
Introduce Parent/Child theme feature

### DIFF
--- a/classes/Smarty/SmartyResourceParent.php
+++ b/classes/Smarty/SmartyResourceParent.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * 2007-2015 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Override module templates easily.
+ *
+ * @since 1.7.0.0
+ */
+class SmartyResourceParentCore extends Smarty_Resource_Custom
+{
+    public function __construct(array $paths)
+    {
+        $this->paths = $paths;
+    }
+
+    /**
+     * Fetch a template.
+     *
+     * @param string $name   template name
+     * @param string $source template source
+     * @param int    $mtime  template modification timestamp (epoch)
+     */
+    protected function fetch($name, &$source, &$mtime)
+    {
+        foreach ($this->paths as $path) {
+            if (Tools::file_exists_cache($file = $path.$name)) {
+                if (_PS_MODE_DEV_) {
+                    $source = implode('', array(
+                        '<!-- begin '.$file.' -->',
+                        file_get_contents($file),
+                        '<!-- end '.$file.' -->',
+                    ));
+                } else {
+                    $source = file_get_contents($file);
+                }
+                $mtime = filemtime($file);
+
+                return;
+            }
+        }
+    }
+}

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -789,17 +789,26 @@ class FrontControllerCore extends Controller
      */
     public function setMedia()
     {
-        $this->addCSS(array(
+        $cssFileList = array();
+        $parent = $this->context->shop->theme->get('parent');
+
+        if ($parent && $this->context->shop->theme->get('assets.use_parent_assets')) {
+            $cssFileList = array(
+                _PS_ALL_THEMES_DIR_.$parent.'/assets/css/theme.css',
+                _PS_ALL_THEMES_DIR_.$parent.'/assets/css/custom.css',
+            );
+        }
+
+        $cssFileList = array_merge($cssFileList, array(
             _THEME_CSS_DIR_.'theme.css',
             _THEME_CSS_DIR_.'custom.css',
         ));
 
         if ($this->context->language->is_rtl) {
-            $this->addCSS(array(
-                _THEME_CSS_DIR_.'rtl.css',
-            ));
+            $cssFileList[] = _THEME_CSS_DIR_.'rtl.css';
         }
 
+        $this->addCSS($cssFileList);
         $this->addJS(array(
             _THEMES_DIR_.'core.js',
             _THEME_JS_DIR_.'theme.js',

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2140,7 +2140,13 @@ abstract class ModuleCore
         } elseif (Tools::file_exists_cache(_PS_THEME_DIR_.'modules/'.$module_name.'/views/templates/hook/'.$template)) {
             return _PS_THEME_DIR_.'modules/'.$module_name.'/views/templates/hook/'.$template;
         } elseif (Tools::file_exists_cache(_PS_THEME_DIR_.'modules/'.$module_name.'/views/templates/front/'.$template)) {
-            return _PS_THEME_DIR_.'modules/'.$module_name.'/views/templates/front/'.$template;
+            return _PS_THEME_DIR_ . 'modules/' . $module_name . '/views/templates/front/' . $template;
+        } elseif (Tools::file_exists_cache(_PS_PARENT_THEME_DIR_.'modules/'.$module_name.'/'.$template)) {
+            return _PS_PARENT_THEME_DIR_.'modules/'.$module_name.'/'.$template;
+        } elseif (Tools::file_exists_cache(_PS_PARENT_THEME_DIR_.'modules/'.$module_name.'/views/templates/hook/'.$template)) {
+            return _PS_PARENT_THEME_DIR_.'modules/'.$module_name.'/views/templates/hook/'.$template;
+        } elseif (Tools::file_exists_cache(_PS_PARENT_THEME_DIR_.'modules/'.$module_name.'/views/templates/front/'.$template)) {
+            return _PS_PARENT_THEME_DIR_.'modules/'.$module_name.'/views/templates/front/'.$template;
         } elseif (Tools::file_exists_cache(_PS_MODULE_DIR_.$module_name.'/views/templates/hook/'.$template)) {
             return false;
         } elseif (Tools::file_exists_cache(_PS_MODULE_DIR_.$module_name.'/views/templates/front/'.$template)) {

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -114,6 +114,8 @@ try {
     $e->displayMessage();
 }
 define('_THEME_NAME_', $context->shop->theme->getName());
+define('_PARENT_THEME_NAME_', $context->shop->theme->get('parent') ?: '');
+
 define('__PS_BASE_URI__', $context->shop->getBaseURI());
 
 /* Include all defines related to base uri and theme name */

--- a/config/defines_uri.inc.php
+++ b/config/defines_uri.inc.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2015 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -27,6 +27,11 @@
 /* Theme URLs */
 define('_PS_DEFAULT_THEME_NAME_', 'classic');
 define('_PS_THEME_DIR_', _PS_ROOT_DIR_.'/themes/'._THEME_NAME_.'/');
+if (_PARENT_THEME_NAME_) {
+    define('_PS_PARENT_THEME_DIR_', _PS_ROOT_DIR_.'/themes/'._PARENT_THEME_NAME_.'/');
+} else {
+    define('_PS_PARENT_THEME_DIR_', '');
+}
 define('_THEMES_DIR_', __PS_BASE_URI__.'themes/');
 define('_THEME_DIR_', _THEMES_DIR_._THEME_NAME_.'/');
 define('_THEME_IMG_DIR_', _THEME_DIR_.'assets/img/');

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -25,17 +25,28 @@
  */
 global $smarty;
 
-$smarty->setTemplateDir(array(
-    _PS_THEME_DIR_.'templates',
-));
-$smarty->addPluginsDir(array(
-    _PS_THEME_DIR_.'plugins',
-));
+$template_dirs = array(_PS_THEME_DIR_.'templates');
+$plugin_dirs = array(_PS_THEME_DIR_.'plugins');
+if (_PARENT_THEME_NAME_) {
+    $template_dirs[] = _PS_PARENT_THEME_DIR_.'templates';
+    $plugin_dirs[] = _PS_PARENT_THEME_DIR_.'plugins';
+}
 
-$smarty->registerResource('module', new SmartyResourceModule(array(
-    'theme' => _PS_THEME_DIR_.'modules/',
-    'modules' => _PS_MODULE_DIR_,
-)));
+$smarty->setTemplateDir($template_dirs);
+$smarty->addPluginsDir($plugin_dirs);
+
+$module_resources = array('theme' => _PS_THEME_DIR_.'modules/');
+if (_PS_PARENT_THEME_DIR_) {
+    $module_resources['parent'] = _PS_PARENT_THEME_DIR_.'templates/';
+}
+$module_resources['modules'] = _PS_MODULE_DIR_;
+$smarty->registerResource('module', new SmartyResourceModule($module_resources));
+
+$parent_resources = array();
+if (_PS_PARENT_THEME_DIR_) {
+    $parent_resources['parent'] = _PS_PARENT_THEME_DIR_.'templates/';
+}
+$smarty->registerResource('parent', new SmartyResourceParent($parent_resources));
 
 if (Configuration::get('PS_JS_HTML_THEME_COMPRESSION')) {
     $smarty->registerFilter('output', 'smartyPackJSinHTML');

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
 use PrestaShop\PrestaShop\Core\Addon\AddonInterface;
 use Shudrum\Component\ArrayFinder\ArrayFinder;
+use Symfony\Component\Yaml\Yaml;
 
 class Theme implements AddonInterface
 {
@@ -35,8 +36,19 @@ class Theme implements AddonInterface
 
     public function __construct(array $attributes)
     {
+        if (isset($attributes['parent'])) {
+            $parentAttributes = Yaml::parse(file_get_contents(_PS_ALL_THEMES_DIR_.'/'.$attributes['parent'].'/config/theme.yml'));
+            $parentAttributes['preview'] = $attributes['physical_uri'].'themes/'.$attributes['parent'].'/preview.png';
+            $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/').'/';
+            $attributes = array_merge($parentAttributes, $attributes);
+        }
+
         $attributes['directory'] = rtrim($attributes['directory'], '/').'/';
-        $attributes['preview'] = $attributes['physical_uri'].'themes/'.$attributes['name'].'/preview.png';
+
+        $childPreview = $attributes['physical_uri'].'themes/'.$attributes['name'].'/preview.png';
+        if (file_exists($childPreview)) {
+            $attributes['preview'] = $childPreview;
+        }
 
         $this->attributes = new ArrayFinder($attributes);
     }

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -46,6 +46,11 @@ class Theme implements AddonInterface
         return $this->attributes->get($attr, $default);
     }
 
+    public function has($attr)
+    {
+        return $this->attributes->offsetExists($attr);
+    }
+
     public function getName()
     {
         return $this->attributes->get('name');

--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -96,16 +96,16 @@ class ThemeValidator
     private function hasRequiredFiles(Theme $theme)
     {
         $themeName = $theme->getName();
-        $parentdir = realpath($theme->getDirectory().'/../'.$theme->get('parent')).'/';
-        $parentfile = false;
+        $parentDir = realpath($theme->getDirectory().'/../'.$theme->get('parent')).'/';
+        $parentFile = false;
 
         foreach ($this->getRequiredFiles() as $file) {
-            $childfile = $theme->getDirectory().$file;
+            $childFile = $theme->getDirectory().$file;
             if ($theme->get('parent')) {
-                $parentfile = $parentdir.$file;
+                $parentFile = $parentDir.$file;
             }
 
-            if (!file_exists($childfile) && !file_exists($parentfile)) {
+            if (!file_exists($childFile) && !file_exists($parentFile)) {
                 if (!array_key_exists($themeName, $this->errors)) {
                     $this->errors[$themeName] = array();
                 }

--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -96,9 +96,16 @@ class ThemeValidator
     private function hasRequiredFiles(Theme $theme)
     {
         $themeName = $theme->getName();
+        $parentdir = realpath($theme->getDirectory().'/../'.$theme->get('parent')).'/';
+        $parentfile = false;
 
         foreach ($this->getRequiredFiles() as $file) {
-            if (!file_exists($theme->getDirectory().$file)) {
+            $childfile = $theme->getDirectory().$file;
+            if ($theme->get('parent')) {
+                $parentfile = $parentdir.$file;
+            }
+
+            if (!file_exists($childfile) && !file_exists($parentfile)) {
                 if (!array_key_exists($themeName, $this->errors)) {
                     $this->errors[$themeName] = array();
                 }

--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
-use Shudrum\Component\ArrayFinder\ArrayFinder;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class ThemeValidator
@@ -45,7 +44,8 @@ class ThemeValidator
         $this->translator = $translator;
     }
 
-    public function getErrors($themeName) {
+    public function getErrors($themeName)
+    {
         return array_key_exists($themeName, $this->errors) ? $this->errors[$themeName] : false;
     }
 
@@ -55,19 +55,19 @@ class ThemeValidator
             && $this->hasRequiredProperties($theme);
     }
 
-    private function hasRequiredProperties($theme)
+    private function hasRequiredProperties(Theme $theme)
     {
-        $attributes = new ArrayFinder($theme->get(null));
         $themeName = $theme->getName();
 
         foreach ($this->getRequiredProperties() as $prop) {
-            if (!$attributes->offsetExists($prop)) {
-
+            if (!$theme->has($prop)) {
                 if (!array_key_exists($themeName, $this->errors)) {
                     $this->errors[$themeName] = array();
                 }
 
-                $this->errors[$themeName] = $this->translator->trans('An error occurred. The information "%s" is missing.', array($prop), 'Admin.Design.Notification');
+                $this->errors[$themeName] = $this->translator->trans(
+                    'An error occurred. The information "%s" is missing.', array($prop), 'Admin.Design.Notification'
+                );
             }
         }
 
@@ -93,13 +93,12 @@ class ThemeValidator
         );
     }
 
-    private function hasRequiredFiles($theme)
+    private function hasRequiredFiles(Theme $theme)
     {
         $themeName = $theme->getName();
 
         foreach ($this->getRequiredFiles() as $file) {
             if (!file_exists($theme->getDirectory().$file)) {
-
                 if (!array_key_exists($themeName, $this->errors)) {
                     $this->errors[$themeName] = array();
                 }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Here it is! You can create child theme very easily and unleash the power of PrestaShop new themes! <span class="emoji-outer emoji-sizer"><span class="emoji-inner" style="background: url(chrome-extension://immhpnclomdloikkpcefncmfgjbkojmh/emoji-data/sheet_apple_64.png);background-position:20% 92.5%;background-size:4100%" title="tada"></span></span> |
| Type? | new feature |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Read [this doc](https://github.com/PrestaShop/docs/blob/master/themes/smarty/parent-child-feature.rst) (to be updated and detailed soon). Create a child theme, only the `config/theme.yml` is needed and below is the minimal content required |

``` yaml
name: childtheme
parent: classic
display_name: Child Theme

assets:
  use_parent_assets: true

```
