### PR TITLE
Hide Specific References table when it's empty

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -479,13 +479,16 @@ class ProductPresenter
 
         //if the attribute's references doesn't exist then get the product's references or unset it
         foreach ($presentedProduct['specific_references'] as $key => $value) {
-            if (null === $value) {
-                if (null !== $product[$key]) {
+            if (empty($value)) {
+                if (!empty($product[$key])) {
                     $presentedProduct['specific_references'][$key] = $product[$key];
                 } else {
                     unset($presentedProduct['specific_references'][$key]);
                 }
             }
+        }
+        if(empty($presentedProduct['specific_references'])){
+            unset($presentedProduct['specific_references']);
         }
 
         return $presentedProduct;
@@ -592,6 +595,7 @@ class ProductPresenter
                 $presentedProduct
             );
         }
+        /*dump($presentedProduct);*/
         return $presentedProduct;
     }
 }

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -595,7 +595,6 @@ class ProductPresenter
                 $presentedProduct
             );
         }
-        /*dump($presentedProduct);*/
         return $presentedProduct;
     }
 }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When there's no specific references of product, we should not show the table of these references in FO |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1552 |
| How to test? | Add a new product with no specific reference and visualize it |
