### PR TITLE
Fix the ecotax display

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -136,6 +136,13 @@ class CombinationCore extends ObjectModel
         return true;
     }
 
+    public static function resetEcoTax()
+    {
+        return ObjectModel::updateMultishopTable('combination', array(
+            'ecotax' => 0,
+        ));
+    }
+
     /**
      * Delete from Supplier
      *

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4473,7 +4473,7 @@ class ProductCore extends ObjectModel
         if (isset(self::$_pricesLevel2[$id_product . '-' . $id_shop][$row['id_product_attribute']]['attribute_ecotax'])) {
             $cached_combination_ecotax = self::$_pricesLevel2[$id_product . '-' . $id_shop][$row['id_product_attribute']]['attribute_ecotax'];
 
-            if ((float)$cached_combination_ecotax > 0) {
+            if (0 < (float) $cached_combination_ecotax) {
                 $row['ecotax'] = $cached_combination_ecotax;
             }
         }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3007,7 +3007,7 @@ class ProductCore extends ObjectModel
             $sql->innerJoin('product_shop', 'product_shop', '(product_shop.id_product=p.id_product AND product_shop.id_shop = '.(int)$id_shop.')');
             $sql->where('p.`id_product` = '.(int)$id_product);
             if (Combination::isFeatureActive()) {
-                $sql->select('IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute, product_attribute_shop.`price` AS attribute_price, product_attribute_shop.default_on');
+                $sql->select('IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute, product_attribute_shop.`price` AS attribute_price, product_attribute_shop.default_on, product_attribute_shop.`ecotax` AS attribute_ecotax');
                 $sql->leftJoin('product_attribute_shop', 'product_attribute_shop', '(product_attribute_shop.id_product = p.id_product AND product_attribute_shop.id_shop = '.(int)$id_shop.')');
             } else {
                 $sql->select('0 as id_product_attribute');
@@ -3020,7 +3020,8 @@ class ProductCore extends ObjectModel
                     $array_tmp = array(
                         'price' => $row['price'],
                         'ecotax' => $row['ecotax'],
-                        'attribute_price' => (isset($row['attribute_price']) ? $row['attribute_price'] : null)
+                        'attribute_price' => (isset($row['attribute_price']) ? $row['attribute_price'] : null),
+                        'attribute_ecotax' => (isset($row['attribute_ecotax']) ? $row['attribute_ecotax'] : null)
                     );
                     self::$_pricesLevel2[$cache_id_2][(int)$row['id_product_attribute']] = $array_tmp;
 
@@ -3081,9 +3082,6 @@ class ProductCore extends ObjectModel
         // Eco Tax
         if (($result['ecotax'] || isset($result['attribute_ecotax'])) && $with_ecotax) {
             $ecotax = $result['ecotax'];
-            if (isset($result['attribute_ecotax']) && $result['attribute_ecotax'] > 0) {
-                $ecotax = $result['attribute_ecotax'];
-            }
 
             if ($id_currency) {
                 $ecotax = Tools::convertPrice($ecotax, $id_currency);
@@ -4469,6 +4467,16 @@ class ProductCore extends ObjectModel
         }
 
         $row = Product::getTaxesInformations($row, $context);
+
+        $id_product = (isset($row['id']) ? $row['id'] : $row['id_product']);
+        $id_shop = (isset($row['id_shop']) ? $row['id_shop'] : $row['id_shop_default']);
+        if (isset(self::$_pricesLevel2[$id_product . '-' . $id_shop][$row['id_product_attribute']]['attribute_ecotax'])) {
+            $cached_combination_ecotax = self::$_pricesLevel2[$id_product . '-' . $id_shop][$row['id_product_attribute']]['attribute_ecotax'];
+
+            if ((float)$cached_combination_ecotax > 0) {
+                $row['ecotax'] = $cached_combination_ecotax;
+            }
+        }
 
         $row['ecotax_rate'] = (float)Tax::getProductEcotaxRate($context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
 

--- a/controllers/admin/AdminTaxesController.php
+++ b/controllers/admin/AdminTaxesController.php
@@ -289,6 +289,7 @@ class AdminTaxesControllerCore extends AdminController
             // Reset ecotax
             if ($value == 0) {
                 Product::resetEcoTax();
+                Combination::resetEcoTax();
             }
 
             Configuration::updateValue('PS_USE_ECOTAX', (int)$value);

--- a/src/Adapter/CombinationDataProvider.php
+++ b/src/Adapter/CombinationDataProvider.php
@@ -103,7 +103,7 @@ class CombinationDataProvider
             'attribute_price_display' => $this->cldrRepository->getPrice($combination['price'], $this->context->getContext()->currency->iso_code),
             'final_price' => $this->tools->bcadd($product->price, $combination['price'], CommonAbstractType::PRESTASHOP_DECIMALS),
             'attribute_priceTI' => '',
-            'attribute_ecotax' => $combination['ecotax'],
+            'attribute_ecotax' => \Tools::ps_round($combination['ecotax'] * (1 + \Tax::getProductEcotaxRate() / 100), 2),
             'attribute_weight_impact' => $attribute_weight_impact,
             'attribute_weight' => $combination['weight'],
             'attribute_unit_impact' => $attribute_unity_price_impact,

--- a/src/Adapter/Product/ProductDataProvider.php
+++ b/src/Adapter/Product/ProductDataProvider.php
@@ -69,6 +69,7 @@ class ProductDataProvider
                 $linkRewrite = $product->link_rewrite[$id_lang ? $id_lang : key($product->link_rewrite)];
             }
 
+            $product->ecotax = \Tools::ps_round($product->ecotax * (1 + \Tax::getProductEcotaxRate() / 100), 2);
             $cover = \ProductCore::getCover($product->id);
             $product->image = \Context::getContext()->link->getImageLink($linkRewrite, $cover ? $cover['id_image'] : '', 'home_default');
         }

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -158,10 +158,16 @@ class ProductPresenter
 
     private function addEcotaxInformation(
         array $presentedProduct,
+        ProductPresentationSettings $settings,
         array $product
     ) {
+        $value = $product['ecotax'];
+        if ($settings->include_taxes) {
+            $value *= 1 + $product['ecotax_rate'] / 100;
+        }
+
         $presentedProduct['ecotax'] = array(
-            'value' => $this->priceFormatter->format($product['ecotax']),
+            'value' => $this->priceFormatter->format($value),
             'amount' => $product['ecotax'],
             'rate' => $product['ecotax_rate'],
         );
@@ -573,6 +579,7 @@ class ProductPresenter
         if (isset($product['ecotax'])) {
             $presentedProduct = $this->addEcotaxInformation(
                 $presentedProduct,
+                $settings,
                 $product
             );
         }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -417,6 +417,12 @@ class ProductController extends FrameworkBundleAdminController
                 foreach ((array)$postData as $postKey => $postValue) {
                     if (preg_match('/^combination_.*/', $postKey)) {
                         $combinations[$postKey] = $postValue;
+                        if (0 < (float) $combinations[$postKey]['attribute_ecotax']) {
+                            $combinations[$postKey]['attribute_ecotax'] = \Tools::ps_round(
+                                $combinations[$postKey]['attribute_ecotax'] / (1 + \Tax::getProductEcotaxRate() / 100),
+                                2
+                            );
+                        }
                     }
                 }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The ecotax display should follow the configuration (Tax incl/excl) and the combinations should be able to have their own ecotaxes |
| Type? | bug fix |
| Category? | BO / FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1506 |
| How to test? | <ul><li>BO: Enable the ecotax</li><li>BO: Create a product and give it 1$ of ecotax</li><li>BO: Refresh the page. The ecotax should not have changed</li><li>FO: Go to the product page</li><li>FO: The ecotax should be 1$</li><li>BO: Add combinations to the product</li><li>BO: Give one of them an ecotax of 2$</li><li>FO: Go to the product page</li><li>FO: One of the combinations should have an ecotax of 2$ while the others have an ecotax of 1$</li></ul> |
