### PR TITLE
Deleted variable already defined

### DIFF
--- a/config/defines_uri.inc.php
+++ b/config/defines_uri.inc.php
@@ -46,7 +46,6 @@ define('_THEME_STORE_DIR_', _PS_IMG_.'st/');
 define('_THEME_LANG_DIR_', _PS_IMG_.'l/');
 define('_THEME_COL_DIR_', _PS_IMG_.'co/');
 define('_THEME_GENDERS_DIR_', _PS_IMG_.'genders/');
-define('_SUPP_DIR_', _PS_IMG_.'su/');
 define('_PS_PROD_IMG_', _PS_IMG_.'p/');
 
 /* Other URLs */


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Deleted variable already defined |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |

Please, try to find this variable in code, I didn't find her anywhere.
Défined 5 line above : `define('_THEME_SUP_DIR_', _PS_IMG_.'su/');`

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
