### PR TITLE
Fix the popover font

### DIFF
--- a/themes/classic/assets/css/theme.css
+++ b/themes/classic/assets/css/theme.css
@@ -3935,7 +3935,6 @@ button.close {
   display: block;
   max-width: 276px;
   padding: 1px;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
   letter-spacing: normal;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The font in the popover of the menu should be Open Sans |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1373 |
| How to test? | <ul><li>BO: Create some nested categories</li><li>FO: Hover the name of one of the categories in the header</li><li>FO: The font in the popover should be Open Sans</li></ul> |
