### PR TITLE
Handle no limit for post_max_size in file uploads

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2845,14 +2845,18 @@ exit;
      */
     public static function getMaxUploadSize($max_size = 0)
     {
-        $post_max_size = Tools::convertBytes(ini_get('post_max_size'));
-        $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
+        $values = array(Tools::convertBytes(ini_get('upload_max_filesize')));
+
         if ($max_size > 0) {
-            $result = min($post_max_size, $upload_max_filesize, $max_size);
-        } else {
-            $result = min($post_max_size, $upload_max_filesize);
+            $values[] = $max_size;
         }
-        return $result;
+
+        $post_max_size = Tools::convertBytes(ini_get('post_max_size'));
+        if ($post_max_size > 0) {
+            $values[] = $post_max_size;
+        }
+
+        return min($values);
     }
 
     /**


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR is a rebase of #3851. It fixes a wrong max file upload value to be returned when `post_max_size` is set to 0. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Set `post_max_size = 0` in your php.ini and try to upload a file heavier than your value in `upload_max_filesize`. |
