### PR TITLE
Faster loading pages combination product

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -4399,7 +4399,10 @@ class AdminProductsControllerCore extends AdminController
                     $attributes = Attribute::getAttributes($this->context->language->id, true);
                     foreach ($attributes as $k => $attribute) {
                         $attribute_js[$attribute['id_attribute_group']][$attribute['id_attribute']] = $attribute['name'];
-                        natsort($attribute_js[$attribute['id_attribute_group']]);
+                    }
+
+                    foreach(array_keys($attribute_js) as $k) {
+                        natsort($attribute_js[$k]);
                     }
 
                     $currency = $this->context->currency;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This change greatly speeds the load tab "combinations" on page "product". This is particularly evident if any group attributes a large number of values. In the old cycle, at each iteration in the array is placed a new value attribute and the sorting of the array. If values, e.g., 1000, the array is sorted 1000 times! This is terrible! After, 1 times is enough. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | You can add about 2500 values for one of the attributes. After this, go to any product and see "Combinations" tab is loaded with some speed. <br> Below I will give an example. |

I added about 2500 values (the more, the more evident). http://pasteboard.co/7MQBA35vv.png
With old code - http://pasteboard.co/7MT2hQlWh.png (20 sec)
And with new code - http://pasteboard.co/7MUzlF483.png (0.8 sec)
