### PR TITLE
Add missing help text on "New product" button

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -141,7 +141,8 @@ class ProductController extends FrameworkBundleAdminController
         $toolbarButtons['add'] = array(
             'href' => $this->generateUrl('admin_product_new'),
             'desc' => $translator->trans('New product', array(), 'Admin.Actions'),
-            'icon' => 'add_circle_outline'
+            'icon' => 'add_circle_outline',
+            'help' => $translator->trans('Create a new product: CTRL+P', array(), 'Admin.Catalog.Help'),
         );
 
         // Fetch product list (and cache it into view subcall to listAction)


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR adds a tooltip under "New Product" in catalog page. Tooltip contains associated shortcut |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1118 |
| How to test? | In catalog page, put your mouse on "New product" button |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
