### PR TITLE
transformToCustomer not moves the default group from Guest to Cus…

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1055,7 +1055,8 @@ class CustomerCore extends ObjectModel
         $this->is_guest = 0;
         $this->passwd = $crypto->encrypt($password, _COOKIE_KEY_);
         $this->cleanGroups();
-        $this->addGroups(array(Configuration::get('PS_CUSTOMER_GROUP'))); // add default customer group
+        $this->addGroups(array(Configuration::get('PS_CUSTOMER_GROUP')));
+        $this->id_default_group = Configuration::get('PS_CUSTOMER_GROUP');
         if ($this->update()) {
             $vars = array(
                 '{firstname}' => $this->firstname,


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | transformToCustomer not moves the default group from Guest to Customer Group. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | [BOOM-1582](http://forge.prestashop.com/browse/BOOM-1582) |
| How to test? | Create a new order with a Guest account, in Back Office change this user to Customer. Only "Customer" account must be selected on Customer list Group and Customer Default Group must be "Customer" |
