### PR TITLE
Added hook actionOutputHTMLBefore

### DIFF
--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -561,13 +561,13 @@ abstract class ControllerCore
             $javascript = $this->context->smarty->fetch(_PS_ALL_THEMES_DIR_.'javascript.tpl');
 
             if ($defer) {
-                echo $html.$javascript.(empty($this->ajax) ? '</body></html>' : '');
+                $html .= $javascript.(empty($this->ajax) ? '</body></html>' : '');
             } else {
-                echo preg_replace('/(?<!\$)'.$js_tag.'/', $javascript, $html).(empty($this->ajax) ? '</body></html>' : '');
+                $html = preg_replace('/(?<!\$)'.$js_tag.'/', $javascript, $html).(empty($this->ajax) ? '</body></html>' : '');
             }
-        } else {
-            echo $html;
         }
+        Hook::exec('actionOutputHTMLBefore',  array('html' => &$html));
+        echo $html;
     }
 
     /**

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -363,5 +363,8 @@
     <hook id="displayProductExtraContent">
       <name>displayProductExtraContent</name><title>Display extra content on the product page</title><description>This hook expects ProductExtraContent instances, which will be properly displayed by the template on the product page.</description>
     </hook>
+    <hook id="actionOutputHTMLBefore">
+      <name>actionOutputHTMLBefore</name><title>Before HTML output</title><description>This hook is called before HTML is sent to browser so you can manipulate it ('html' parameter is passed by reference)</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -188,3 +188,4 @@ INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('
 DELETE FROM `PREFIX_configuration` WHERE `name` IN ('PS_LOGO_MOBILE', 'SHOP_LOGO_MOBILE_HEIGHT', 'SHOP_LOGO_MOBILE_WIDTH');
 
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('displayNavFullWidth', 'Navigation', 'This hook displays full width navigation menu at the top of your pages', '1');
+INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('actionOutputHTMLBefore', 'Before HTML output', 'This hook is called before HTML is sent to browser so you can manipulate it (html parameter is passed by reference)', '1');


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | "develop" |
| Description? | Add a hook "actionOutputHTMLBefore" to allow modules to cache or manipulate HTML before sending it to the browser |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Create a module that manipulates the HTML |
