### PR TITLE
Prevent smartyTranslate to escape HTML tags when they are needed

### DIFF
--- a/admin-dev/themes/default/template/controllers/backup/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/controllers/backup/helpers/list/list_header.tpl
@@ -68,7 +68,7 @@
 		{if $host_mode}
 		<div class="alert alert-info">
 			<h4>{l s='How to restore a database backup'}</h4>
-			{l s='If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>', '[2]' => '<a class="_blank" href="http://addons.prestashop.com/support/16298-support-essentiel-plan.html">', '[/2]' => '</a>']}
+			{l s='If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>', '[2]' => '<a class="_blank" href="http://addons.prestashop.com/support/16298-support-essentiel-plan.html">', '[/2]' => '</a>']}
 			<br />
 			{l s='Our team will take care of restoring your database safely.'}
 			<br />

--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
@@ -71,7 +71,7 @@
 						<div class="col-sm-6">
 							<p>
 							{if $count_ok}
-								{l s='[1]%1$d[/1] order(s) validated for a total amount of [2]%2$s[/2]' sprintf=[$count_ok, $total_ok] sprintf=['[1]' => '<span class="badge">', '[/1]' => '</span>', '[2]' => '<span class="badge badge-success">', '[/2]' => '</span>']}
+								{l s='[1]%count%[/1] order(s) validated for a total amount of [2]%total%[/2]' html=true sprintf=['%count%' => $count_ok, '%total%' => $total_ok, '[1]' => '<span class="badge">', '[/1]' => '</span>', '[2]' => '<span class="badge badge-success">', '[/2]' => '</span>']}
 							{else}
 								{l s="No orders validated for the moment"}
 							{/if}

--- a/admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl
@@ -74,13 +74,13 @@
 
 		<p>{l s="A module that hasn't been verified may be dangerous and could add hidden functionalities like backdoors, ads, hidden links, spam, etc. Don’t worry, this alert is simply a warning."}</p>
 
-		<p>{l s="PrestaShop, being an open-source software, has an awesome community with a long history of developing and sharing high quality modules. Before installing this module, making sure its author is a known community member is always a good idea (by checking [1]our forum[/1] for instance)." sprintf=['[1]' => '<a href="https://www.prestashop.com/forums/">', '[/1]' => '</a>']}</p>
+		<p>{l s="PrestaShop, being an open-source software, has an awesome community with a long history of developing and sharing high quality modules. Before installing this module, making sure its author is a known community member is always a good idea (by checking [1]our forum[/1] for instance)." html=true sprintf=['[1]' => '<a href="https://www.prestashop.com/forums/">', '[/1]' => '</a>']}</p>
 
 		<h4>{l s='What Should I Do?'}</h4>
 
 		<p>{l s="If you trust or find the author of this module to be an active community member, you can proceed with the installation."}</p>
 
-		<p>{l s="Otherwise you can look for similar modules on the official marketplace. [1]Click here to browse PrestaShop Addons[/1]." sprintf=['[1]' => '<a class="catalog-link" href="#">', '[/1]' => '</a>']}</p>
+		<p>{l s="Otherwise you can look for similar modules on the official marketplace. [1]Click here to browse PrestaShop Addons[/1]." html=true sprintf=['[1]' => '<a class="catalog-link" href="#">', '[/1]' => '</a>']}</p>
 
 	</div>
 

--- a/admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl
@@ -59,6 +59,6 @@
 
 		<p>{l s='You can search for similar modules on the official marketplace.'}</p>
 
-		<p>{l s="[1]Click here to browse our catalog on PrestaShop Addons[/1]." sprintf=['[1]' => '<a class="catalog-link" href="#">', '[/1]' => '</a>']}
+		<p>{l s="[1]Click here to browse our catalog on PrestaShop Addons[/1]." html=true sprintf=['[1]' => '<a class="catalog-link" href="#">', '[/1]' => '</a>']}
 	</div>
 </div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
@@ -69,9 +69,9 @@
 					{l s='You MUST use this syntax in your translations. Here are a few examples:'}
 				</p>
 				<ul>
-					<li>"{l s='There are [1]%d[/1] products' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a number.' sprintf=['%d']}</li>
-					<li>"{l s='List of pages in [1]%s[/1]' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a string.' sprintf=['%s']}</li>
-					<li>"{l s='Feature: [1]%1$s[/1] ([1]%2$d[/1] values)' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
+          <li>"{l s='There are [1]%replace%[/1] products' html=true sprintf=['%replace%' => '%d', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a number.' sprintf=['%d']}</li>
+          <li>"{l s='List of pages in [1]%replace%[/1]' html=true sprintf=['%replace%' => '%s', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a string.' sprintf=['%s']}</li>
+          <li>"{l s='Feature: [1]%1%[/1] ([1]%2%[/1] values)' html=true sprintf=['%1%' => '%1$s', '%2%' => '%2$d', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
 				</ul>
 			</div>
 		</div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
@@ -86,9 +86,9 @@
 							{l s='You MUST use this syntax in your translations. Here are several examples:'}
 						</p>
 						<ul>
-							<li>"{l s='There are [1]%d[/1] products' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a number.' sprintf=['%d']}</li>
-							<li>"{l s='List of pages in [1]%s[/1]' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a string.' sprintf=['%s']}</li>
-							<li>"{l s='Feature: [1]%1$s[/1] ([1]%2$d[/1] values)' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
+              <li>"{l s='There are [1]%replace%[/1] products' html=true sprintf=['%replace%' => '%d', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a number.' sprintf=['%d']}</li>
+              <li>"{l s='List of pages in [1]%replace%[/1]' html=true sprintf=['%replace%' => '%s', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a string.' sprintf=['%s']}</li>
+              <li>"{l s='Feature: [1]%1%[/1] ([1]%2%[/1] values)' html=true sprintf=['%1%' => '%1$s', '%2%' => '%2$d', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
 						</ul>
 					</div>
 				</div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -70,9 +70,9 @@
 							{l s='You MUST use this syntax in your translations. Here are several examples:'}
 						</p>
 						<ul>
-							<li>"{l s='There are [1]%d[/1] products' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a number.' sprintf=['%d']}</li>
-							<li>"{l s='List of pages in [1]%s[/1]' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a string.' sprintf=['%s']}</li>
-							<li>"{l s='Feature: [1]%1$s[/1] ([1]%2$d[/1] values)' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
+              <li>"{l s='There are [1]%replace%[/1] products' html=true sprintf=['%replace%' => '%d', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a number.' sprintf=['%d']}</li>
+              <li>"{l s='List of pages in [1]%replace%[/1]' html=true sprintf=['%replace%' => '%s', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a string.' sprintf=['%s']}</li>
+              <li>"{l s='Feature: [1]%1%[/1] ([1]%2%[/1] values)' html=true sprintf=['%1%' => '%1$s', '%2%' => '%2$d', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
 						</ul>
 					</div>
 				</div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
@@ -71,9 +71,9 @@
 							{l s='You MUST use this syntax in your translations. Here are several examples:'}
 						</p>
 						<ul>
-							<li>"{l s='There are [1]%d[/1] products' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a number.' sprintf=['%d']}</li>
-							<li>"{l s='List of pages in [1]%s[/1]' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a string.' sprintf=['%s']}</li>
-							<li>"{l s='Feature: [1]%1$s[/1] ([1]%2$d[/1] values)' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
+							<li>"{l s='There are [1]%replace%[/1] products' html=true sprintf=['%replace%' => '%d', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a number.' sprintf=['%d']}</li>
+							<li>"{l s='List of pages in [1]%replace%[/1]' html=true sprintf=['%replace%' => '%s', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='"%s" will be replaced by a string.' sprintf=['%s']}</li>
+							<li>"{l s='Feature: [1]%1%[/1] ([1]%2%[/1] values)' html=true sprintf=['%1%' => '%1$s', '%2%' => '%2$d', '[1]' => '<strong>', '[/1]' => '</strong>']}": {l s='The numbers enable you to reorder the variables when necessary.'}</li>
 						</ul>
 					</div>
 				</div>

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -274,7 +274,7 @@
                       {$active = ""}
                     {/if}
                   </ul>
-                  
+
                   <!-- Tab panes -->
                   <div class="tab-content">
                     {$active = "active"}
@@ -282,7 +282,7 @@
                       <div class="tab-pane {$active} empty" id="orders-notifications" role="tabpanel">
                         <p class="no-notification">
                           {l s='No new order for now :('}<br>
-                          {l s='Have you checked your [1][2]abandonned carts[/2][/1]?' tags=['<strong>', '<a href="'|cat:$abandoned_cart_url|cat:'">']}<br>
+                          {l s='Have you checked your [1][2]abandonned carts[/2][/1]?' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>', '[2]' => '<a href="'|cat:$abandoned_cart_url|cat:'">', '[/2]' => '</a>']}<br>
                           {$no_order_tip}
                         </p>
                         <div class="notification-elements"></div>
@@ -324,7 +324,7 @@
                 <span class="shop-state" id="debug-mode">
                   <i class="material-icons">bug_report</i>
                   <span class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
-                    title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in debug mode.'}</strong></p><p class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}</p>">{l s='Debug mode'}</span>
+                    title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in debug mode.'}</strong></p><p class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}</p>">{l s='Debug mode'}</span>
                 </span>
               {/if}
               {if isset($maintenance_mode) && $maintenance_mode == true}

--- a/admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl
@@ -17,7 +17,7 @@
               href="#orders-notifications"
               role="tab"
             >
-              {l s='Orders[1][/1]' sprintf=['[1]' => '<span id="_nb_new_orders_">', '[/1]' => '</span>']}
+              {l s='Orders[1][/1]' html=true sprintf=['[1]' => '<span id="_nb_new_orders_">', '[/1]' => '</span>']}
             </a>
           </li>
           {$active = ""}
@@ -32,7 +32,7 @@
               href="#customers-notifications"
               role="tab"
             >
-              {l s='Customers[1][/1]' sprintf=['[1]' => '<span id="_nb_new_customers_">', '[/1]' => '</span>']}
+              {l s='Customers[1][/1]' html=true sprintf=['[1]' => '<span id="_nb_new_customers_">', '[/1]' => '</span>']}
             </a>
           </li>
           {$active = ""}
@@ -47,7 +47,7 @@
               href="#messages-notifications"
               role="tab"
             >
-              {l s='Messages[1][/1]' sprintf=['[1]' => '<span id="_nb_new_messages_">', '[/1]' => '</span>']}
+              {l s='Messages[1][/1]' html=true sprintf=['[1]' => '<span id="_nb_new_messages_">', '[/1]' => '</span>']}
             </a>
           </li>
           {$active = ""}
@@ -62,7 +62,7 @@
             <p class="no-notification">
               {l s='No new order for now :('}<br>
               {l
-              s='Have you checked your [1][2]abandonned carts[/2][/1]?'
+              s='Have you checked your [1][2]abandonned carts[/2][/1]?' html=true
               sprintf=['[1]' => '<strong>', '[/1]' => '</strong>', '[2]' => '<a href="'|cat:$abandoned_cart_url|cat:'">', '[/2]' => '</a>']
               }<br>
               {$no_order_tip}

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -46,7 +46,7 @@
         <div class="shop-state" id="debug-mode">
           <i class="material-icons">bug_report</i>
           <span class="label-tooltip" data-toggle="tooltip" data-placement="bottom" data-html="true"
-            title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in debug mode.'}</strong></p><p class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}</p>">{l s='Debug mode'}</span>
+            title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in debug mode.'}</strong></p><p class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>']}</p>">{l s='Debug mode'}</span>
         </div>
       </div>
     {/if}

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -56,7 +56,7 @@ function smartyTranslate($params, &$smarty)
 {
     $translator = Context::getContext()->getTranslator();
 
-    $htmlEntities = !isset($params['js']);
+    $htmlEntities = !isset($params['html']) && !isset($params['js']);
     $addSlashes = (isset($params['slashes']) || isset($params['js']));
     $isInPDF = isset($params['pdf']);
     $isInModule = isset($params['mod']) && !empty($params['mod']);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | smartyTranslate escape HTML tags by default. Some of these tags are needed so we should add `js=true` when calling the `l` helper. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | you should not see raw html tags in the notification center |
