### PR TITLE
Add new hook displayFullWidthTop

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -57,6 +57,9 @@
     <hook id="displayTop">
       <name>displayTop</name><title>Top of pages</title><description>This hook displays additional elements at the top of your pages</description>
     </hook>
+    <hook id="displayFullWidthTop">
+      <name>displayFullWidthTop</name><title>Top of pages without width limitation.</title><description>This hook displays additional elements at the top of your pages without width limitation.</description>
+    </hook>
     <hook id="displayRightColumnProduct">
       <name>displayRightColumnProduct</name><title>New elements on the product page (right column)</title><description>This hook displays new elements in the right-hand column of the product page</description>
     </hook>

--- a/themes/classic/templates/_partials/header.tpl
+++ b/themes/classic/templates/_partials/header.tpl
@@ -39,6 +39,9 @@
             <div class="clearfix"></div>
           </div>
         </div>
+        <div class="col-xs-12">
+          {hook h='displayFullWidthTop'}
+        </div>
       </div>
       <div id="mobile_top_menu_wrapper" class="row hidden-md-up" style="display:none;">
         <div class="js-top-menu mobile" id="_mobile_top_menu"></div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | For many merchant current displayTop hook maybe to narrow for displaying main menu and they have no option to display full width menu without template modification |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | This PR requires a module hooked on displayFullWidthTop. |
