### PR TITLE
Introduced sf entity in Smarty router

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -65,7 +65,7 @@
 			});
 		});
 	</script>
-  <form method="post" action="index.php/international/translations/list" id="typeTranslationForm" class="form-horizontal">
+  <form method="post" action="{url entity=sf route=admin_international_translations_list }" id="typeTranslationForm" class="form-horizontal">
     <div class="panel">
       <h3>
         <i class="icon-file-text"></i>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -206,7 +206,7 @@
 			</div>
 		</div>
 	</form>
-	<form action="index.php/international/translations/extract" method="post" enctype="multipart/form-data" class="form-horizontal">
+	<form action="{url entity=sf route=admin_international_translations_extract_theme }" method="post" enctype="multipart/form-data" class="form-horizontal">
 		<div class="panel">
 			<h3>
 				<i class="icon-upload"></i>

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1152,7 +1152,7 @@ class LinkCore
                 break;
             case 'sf':
                 if (!array_key_exists('route', $params)) {
-                    throw new \InvalidArgumentException("You need to setup a `route` attribute.");
+                    throw new \InvalidArgumentException('You need to setup a `route` attribute.');
                 }
                 global $kernel; // sf kernel
                 if ($kernel instanceof Symfony\Component\HttpKernel\HttpKernelInterface) {
@@ -1163,7 +1163,7 @@ class LinkCore
                     }
                     $link = $sfRouter->generate($params['route'], array(), UrlGeneratorInterface::ABSOLUTE_URL);
                 }else{
-                    throw new \InvalidArgumentException("You can't use Symfony router in legacy context.");
+                    throw new \InvalidArgumentException('You can\'t use Symfony router in legacy context.');
                 }
                 break;
             default:

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1150,6 +1150,22 @@ class LinkCore
                     $params['relative_protocol']
                 );
                 break;
+            case 'sf':
+                if (!array_key_exists('route', $params)) {
+                    throw new \InvalidArgumentException("You need to setup a `route` attribute.");
+                }
+                global $kernel; // sf kernel
+                if ($kernel instanceof Symfony\Component\HttpKernel\HttpKernelInterface) {
+                    $sfRouter = $kernel->getContainer()->get('router');
+
+                    if (array_key_exists('sf-params', $params)) {
+                        return $sfRouter->generate($params['route'], $params['sf-params'], UrlGeneratorInterface::ABSOLUTE_URL);
+                    }
+                    $link = $sfRouter->generate($params['route'], array(), UrlGeneratorInterface::ABSOLUTE_URL);
+                }else{
+                    throw new \InvalidArgumentException("You can't use Symfony router in legacy context.");
+                }
+                break;
             default:
                 $link = $context->link->getPageLink(
                     $params['entity'],


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Allow to use the router from Symfony architecture in Back Office using Smarty, using the following syntax: `{url entity=sf route=admin_international_translations_list }`. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | not realy, but is a blocking issue for http://forge.prestashop.com/browse/BOOM-1561 as I can't access translations anymore. |
| How to test? | A simple review is enough. |

``` smarty
{url entity=sf route=admin_international_translations_list }
# you can also use ``sf-params`` if you need any parameter
{url entity=sf route=admin_international_translations_list sf-params=['id' => 1]}
```
