### PR TITLE
Payments/Carriers preferences applied also on non PS carriers

### DIFF
--- a/controllers/admin/AdminPaymentPreferencesController.php
+++ b/controllers/admin/AdminPaymentPreferencesController.php
@@ -258,7 +258,7 @@ class AdminPaymentPreferencesControllerCore extends AdminController
                           'identifier' => 'id_country',
                           'icon' => 'icon-globe',
                     ),
-                    array('items' => Carrier::getCarriers($this->context->language->id),
+                    array('items' => Carrier::getCarriers($this->context->language->id, false, false, false, null, (defined('ALL_CARRIERS') ? ALL_CARRIERS : null)),
                         'title' => $this->trans('Carrier restrictions', array(), 'Admin.Payment.Feature'),
                         'desc' => $this->trans('Please mark each checkbox for the carrier, or carrier, for which you want the payment module(s) to be available.', array(), 'Admin.Payment.Help'),
                         'name_id' => 'reference',

--- a/controllers/admin/AdminPaymentPreferencesController.php
+++ b/controllers/admin/AdminPaymentPreferencesController.php
@@ -258,7 +258,7 @@ class AdminPaymentPreferencesControllerCore extends AdminController
                           'identifier' => 'id_country',
                           'icon' => 'icon-globe',
                     ),
-                    array('items' => Carrier::getCarriers($this->context->language->id, false, false, false, null, (defined('ALL_CARRIERS') ? ALL_CARRIERS : null)),
+                    array('items' => Carrier::getCarriers($this->context->language->id, false, false, false, null, Carrier::ALL_CARRIERS),
                         'title' => $this->trans('Carrier restrictions', array(), 'Admin.Payment.Feature'),
                         'desc' => $this->trans('Please mark each checkbox for the carrier, or carrier, for which you want the payment module(s) to be available.', array(), 'Admin.Payment.Help'),
                         'name_id' => 'reference',

--- a/install-dev/fixtures/fashion/data/access.xml
+++ b/install-dev/fixtures/fashion/data/access.xml
@@ -61,57 +61,75 @@
     <access id="access_3_52"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSLIP_READ"/>
     <access id="access_3_53"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSLIP_UPDATE"/>
     <access id="access_3_54"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSLIP_DELETE"/>
-    <access id="access_3_55"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTATUSES_CREATE"/>
-    <access id="access_3_56"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTATUSES_READ"/>
-    <access id="access_3_57"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTATUSES_UPDATE"/>
-    <access id="access_3_58"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTATUSES_DELETE"/>
     <!--<access id="access_3_38"  id_profile="Logistician"   id_authorization_role="Customers_1" view="1" add="1" edit="1" delete="1"/>-->
-    <access id="access_3_59"  id_profile="Logistician"   id_authorization_role="TAB_ADMINADDRESSES_CREATE"/>
-    <access id="access_3_60"  id_profile="Logistician"   id_authorization_role="TAB_ADMINADDRESSES_READ"/>
-    <access id="access_3_61"  id_profile="Logistician"   id_authorization_role="TAB_ADMINADDRESSES_UPDATE"/>
-    <access id="access_3_62"  id_profile="Logistician"   id_authorization_role="TAB_ADMINADDRESSES_DELETE"/>
-    <access id="access_3_63"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSHIPPING_CREATE"/>
-    <access id="access_3_64"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSHIPPING_READ"/>
-    <access id="access_3_65"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSHIPPING_UPDATE"/>
-    <access id="access_3_66"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSHIPPING_DELETE"/>
-    <access id="access_3_67"  id_profile="Logistician"   id_authorization_role="TAB_ADMINCARRIERS_CREATE"/>
-    <access id="access_3_68"  id_profile="Logistician"   id_authorization_role="TAB_ADMINCARRIERS_READ"/>
-    <access id="access_3_69"  id_profile="Logistician"   id_authorization_role="TAB_ADMINCARRIERS_UPDATE"/>
-    <access id="access_3_70"  id_profile="Logistician"   id_authorization_role="TAB_ADMINCARRIERS_DELETE"/>
+    <access id="access_3_55"  id_profile="Logistician"   id_authorization_role="TAB_ADMINADDRESSES_CREATE"/>
+    <access id="access_3_56"  id_profile="Logistician"   id_authorization_role="TAB_ADMINADDRESSES_READ"/>
+    <access id="access_3_57"  id_profile="Logistician"   id_authorization_role="TAB_ADMINADDRESSES_UPDATE"/>
+    <access id="access_3_58"  id_profile="Logistician"   id_authorization_role="TAB_ADMINADDRESSES_DELETE"/>
+    <access id="access_3_59"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSHIPPING_CREATE"/>
+    <access id="access_3_60"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSHIPPING_READ"/>
+    <access id="access_3_61"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSHIPPING_UPDATE"/>
+    <access id="access_3_62"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSHIPPING_DELETE"/>
+    <access id="access_3_63"  id_profile="Logistician"   id_authorization_role="TAB_ADMINCARRIERS_CREATE"/>
+    <access id="access_3_64"  id_profile="Logistician"   id_authorization_role="TAB_ADMINCARRIERS_READ"/>
+    <access id="access_3_65"  id_profile="Logistician"   id_authorization_role="TAB_ADMINCARRIERS_UPDATE"/>
+    <access id="access_3_66"  id_profile="Logistician"   id_authorization_role="TAB_ADMINCARRIERS_DELETE"/>
     <!--<access id="access_3_50"  id_profile="Logistician"   id_authorization_role="Price_Ranges" view="1" add="1" edit="1" delete="1"/>-->
     <!--<access id="access_3_51"  id_profile="Logistician"   id_authorization_role="Weight_Ranges" view="1" add="1" edit="1" delete="1"/>-->
     <!--<access id="access_3_61"  id_profile="Logistician"   id_authorization_role="Modules_1" view="1" add="0" edit="1" delete="0"/>-->
-    <access id="access_3_71"  id_profile="Logistician"   id_authorization_role="TAB_ADMINWAREHOUSES_CREATE"/>
-    <access id="access_3_72"  id_profile="Logistician"   id_authorization_role="TAB_ADMINWAREHOUSES_READ"/>
-    <access id="access_3_73"  id_profile="Logistician"   id_authorization_role="TAB_ADMINWAREHOUSES_UPDATE"/>
-    <access id="access_3_74"  id_profile="Logistician"   id_authorization_role="TAB_ADMINWAREHOUSES_DELETE"/>
-    <access id="access_3_75"  id_profile="Logistician"   id_authorization_role="TAB_ADMINPARENTSTOCKMANAGEMENT_CREATE"/>
-    <access id="access_3_76"  id_profile="Logistician"   id_authorization_role="TAB_ADMINPARENTSTOCKMANAGEMENT_READ"/>
-    <access id="access_3_77"  id_profile="Logistician"   id_authorization_role="TAB_ADMINPARENTSTOCKMANAGEMENT_UPDATE"/>
-    <access id="access_3_78"  id_profile="Logistician"   id_authorization_role="TAB_ADMINPARENTSTOCKMANAGEMENT_DELETE"/>
-    <access id="access_3_79"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKMVT_CREATE"/>
-    <access id="access_3_80"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKMVT_READ"/>
-    <access id="access_3_81"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKMVT_UPDATE"/>
-    <access id="access_3_82"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKMVT_DELETE"/>
+    <access id="access_3_67"  id_profile="Logistician"   id_authorization_role="TAB_ADMINWAREHOUSES_CREATE"/>
+    <access id="access_3_68"  id_profile="Logistician"   id_authorization_role="TAB_ADMINWAREHOUSES_READ"/>
+    <access id="access_3_69"  id_profile="Logistician"   id_authorization_role="TAB_ADMINWAREHOUSES_UPDATE"/>
+    <access id="access_3_70"  id_profile="Logistician"   id_authorization_role="TAB_ADMINWAREHOUSES_DELETE"/>
+    <access id="access_3_71"  id_profile="Logistician"   id_authorization_role="TAB_ADMINPARENTSTOCKMANAGEMENT_CREATE"/>
+    <access id="access_3_72"  id_profile="Logistician"   id_authorization_role="TAB_ADMINPARENTSTOCKMANAGEMENT_READ"/>
+    <access id="access_3_73"  id_profile="Logistician"   id_authorization_role="TAB_ADMINPARENTSTOCKMANAGEMENT_UPDATE"/>
+    <access id="access_3_74"  id_profile="Logistician"   id_authorization_role="TAB_ADMINPARENTSTOCKMANAGEMENT_DELETE"/>
+    <access id="access_3_75"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKMVT_CREATE"/>
+    <access id="access_3_76"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKMVT_READ"/>
+    <access id="access_3_77"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKMVT_UPDATE"/>
+    <access id="access_3_78"  id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKMVT_DELETE"/>
     <!--<access id="access_3_98"  id_profile="Logistician"   id_authorization_role="Stock_instant_state" view="1" add="1" edit="1" delete="1"/>-->
     <!--<access id="access_3_99"  id_profile="Logistician"   id_authorization_role="Stock_cover" view="1" add="1" edit="1" delete="1"/>-->
-    <access id="access_3_83" id_profile="Logistician"   id_authorization_role="TAB_ADMINSUPPLYORDERS_CREATE"/>
-    <access id="access_3_84" id_profile="Logistician"   id_authorization_role="TAB_ADMINSUPPLYORDERS_READ"/>
-    <access id="access_3_85" id_profile="Logistician"   id_authorization_role="TAB_ADMINSUPPLYORDERS_UPDATE"/>
-    <access id="access_3_86" id_profile="Logistician"   id_authorization_role="TAB_ADMINSUPPLYORDERS_DELETE"/>
-    <access id="access_3_87" id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKCONFIGURATION_CREATE"/>
-    <access id="access_3_88" id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKCONFIGURATION_READ"/>
-    <access id="access_3_89" id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKCONFIGURATION_UPDATE"/>
-    <access id="access_3_90" id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKCONFIGURATION_DELETE"/>
+    <access id="access_3_79" id_profile="Logistician"   id_authorization_role="TAB_ADMINSUPPLYORDERS_CREATE"/>
+    <access id="access_3_80" id_profile="Logistician"   id_authorization_role="TAB_ADMINSUPPLYORDERS_READ"/>
+    <access id="access_3_81" id_profile="Logistician"   id_authorization_role="TAB_ADMINSUPPLYORDERS_UPDATE"/>
+    <access id="access_3_82" id_profile="Logistician"   id_authorization_role="TAB_ADMINSUPPLYORDERS_DELETE"/>
+    <access id="access_3_83" id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKCONFIGURATION_CREATE"/>
+    <access id="access_3_84" id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKCONFIGURATION_READ"/>
+    <access id="access_3_85" id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKCONFIGURATION_UPDATE"/>
+    <access id="access_3_86" id_profile="Logistician"   id_authorization_role="TAB_ADMINSTOCKCONFIGURATION_DELETE"/>
+    <access id="access_3_87" id_profile="Logistician" id_authorization_role="TAB_IMPROVE_CREATE"/>
+    <access id="access_3_88" id_profile="Logistician" id_authorization_role="TAB_IMPROVE_READ"/>
+    <access id="access_3_89" id_profile="Logistician" id_authorization_role="TAB_IMPROVE_UPDATE"/>
+    <access id="access_3_90" id_profile="Logistician" id_authorization_role="TAB_IMPROVE_DELETE"/>
+    <access id="access_3_91" id_profile="Logistician" id_authorization_role="TAB_SELL_CREATE"/>
+    <access id="access_3_92" id_profile="Logistician" id_authorization_role="TAB_SELL_READ"/>
+    <access id="access_3_93" id_profile="Logistician" id_authorization_role="TAB_SELL_UPDATE"/>
+    <access id="access_3_94" id_profile="Logistician" id_authorization_role="TAB_SELL_DELETE"/>
+	<access id="access_3_95" id_profile="Logistician" id_authorization_role="TAB_ADMINPARENTMANUFACTURERS_CREATE"/>
+    <access id="access_3_96" id_profile="Logistician" id_authorization_role="TAB_ADMINPARENTMANUFACTURERS_READ"/>
+    <access id="access_3_97" id_profile="Logistician" id_authorization_role="TAB_ADMINPARENTMANUFACTURERS_UPDATE"/>
+    <access id="access_3_98" id_profile="Logistician" id_authorization_role="TAB_ADMINPARENTMANUFACTURERS_DELETE"/>
+    <access id="access_3_99" id_profile="Logistician" id_authorization_role="TAB_ADMINPARENTCUSTOMERTHREADS_CREATE"/>
+    <access id="access_3_100" id_profile="Logistician" id_authorization_role="TAB_ADMINPARENTCUSTOMERTHREADS_READ"/>
+    <access id="access_3_101" id_profile="Logistician" id_authorization_role="TAB_ADMINPARENTCUSTOMERTHREADS_UPDATE"/>
+    <access id="access_3_102" id_profile="Logistician" id_authorization_role="TAB_ADMINPARENTCUSTOMERTHREADS_DELETE"/>
     <!--<access id="access_4_2"   id_profile="Translator"    id_authorization_role="CMS_pages" view="1" add="1" edit="1" delete="1"/>-->
     <!--<access id="access_4_3"   id_profile="Translator"    id_authorization_role="CMS_categories" view="1" add="1" edit="1" delete="1"/>-->
     <!--<access id="access_4_4"   id_profile="Translator"    id_authorization_role="Combinations_generator" view="1" add="1" edit="1" delete="1"/>-->
-    <access id="access_4_1"   id_profile="Translator"    id_authorization_role="TAB_ADMINPARENTSEARCHCONF_READ"/>
+    <access id="access_4_1" id_profile="Translator" id_authorization_role="TAB_ADMINPARENTSEARCHCONF_CREATE"/>
+    <access id="access_4_39" id_profile="Translator" id_authorization_role="TAB_ADMINPARENTSEARCHCONF_READ"/>
+    <access id="access_4_40" id_profile="Translator" id_authorization_role="TAB_ADMINPARENTSEARCHCONF_UPDATE"/>
+    <access id="access_4_41" id_profile="Translator" id_authorization_role="TAB_ADMINPARENTSEARCHCONF_DELETE"/>
     <access id="access_4_2"   id_profile="Translator"    id_authorization_role="TAB_ADMINCATALOG_CREATE"/>
     <access id="access_4_3"   id_profile="Translator"    id_authorization_role="TAB_ADMINCATALOG_READ"/>
     <access id="access_4_4"   id_profile="Translator"    id_authorization_role="TAB_ADMINCATALOG_UPDATE"/>
     <access id="access_4_5"   id_profile="Translator"    id_authorization_role="TAB_ADMINCATALOG_DELETE"/>
     <access id="access_4_6"  id_profile="Translator"    id_authorization_role="TAB_ADMINPARENTLOCALIZATION_READ"/>
+    <access id="access_4_39"  id_profile="Translator"    id_authorization_role="TAB_ADMINPARENTLOCALIZATION_CREATE"/>
+    <access id="access_4_40"  id_profile="Translator"    id_authorization_role="TAB_ADMINPARENTLOCALIZATION_UPDATE"/>
+    <access id="access_4_41"  id_profile="Translator"    id_authorization_role="TAB_ADMINPARENTLOCALIZATION_DELETE"/>
     <!--<access id="access_4_16"  id_profile="Translator"    id_authorization_role="Preferences" view="1" add="0" edit="0" delete="0"/>-->
     <access id="access_4_7"  id_profile="Translator"    id_authorization_role="TAB_ADMINPRODUCTS_CREATE"/>
     <access id="access_4_8"  id_profile="Translator"    id_authorization_role="TAB_ADMINPRODUCTS_READ"/>
@@ -125,9 +143,38 @@
     <access id="access_4_16"  id_profile="Translator"    id_authorization_role="TAB_ADMINTRANSLATIONS_READ"/>
     <access id="access_4_17"  id_profile="Translator"    id_authorization_role="TAB_ADMINTRANSLATIONS_UPDATE"/>
     <access id="access_4_18"  id_profile="Translator"    id_authorization_role="TAB_ADMINTRANSLATIONS_DELETE"/>
+    <access id="access_4_19" id_profile="Translator" id_authorization_role="TAB_IMPROVE_CREATE"/>
+    <access id="access_4_20" id_profile="Translator" id_authorization_role="TAB_IMPROVE_READ"/>
+    <access id="access_4_21" id_profile="Translator" id_authorization_role="TAB_IMPROVE_UPDATE"/>
+    <access id="access_4_22" id_profile="Translator" id_authorization_role="TAB_IMPROVE_DELETE"/>
+    <access id="access_4_23" id_profile="Translator" id_authorization_role="TAB_SELL_CREATE"/>
+    <access id="access_4_24" id_profile="Translator" id_authorization_role="TAB_SELL_READ"/>
+    <access id="access_4_25" id_profile="Translator" id_authorization_role="TAB_SELL_UPDATE"/>
+    <access id="access_4_26" id_profile="Translator" id_authorization_role="TAB_SELL_DELETE"/>
+    <access id="access_4_27" id_profile="Translator" id_authorization_role="TAB_CONFIGURE_CREATE"/>
+    <access id="access_4_28" id_profile="Translator" id_authorization_role="TAB_CONFIGURE_READ"/>
+    <access id="access_4_29" id_profile="Translator" id_authorization_role="TAB_CONFIGURE_UPDATE"/>
+    <access id="access_4_30" id_profile="Translator" id_authorization_role="TAB_CONFIGURE_DELETE"/>
+    <access id="access_4_31" id_profile="Translator" id_authorization_role="TAB_ADMININTERNATIONAL_CREATE"/>
+    <access id="access_4_32" id_profile="Translator" id_authorization_role="TAB_ADMININTERNATIONAL_READ"/>
+    <access id="access_4_33" id_profile="Translator" id_authorization_role="TAB_ADMININTERNATIONAL_UPDATE"/>
+    <access id="access_4_34" id_profile="Translator" id_authorization_role="TAB_ADMININTERNATIONAL_DELETE"/>
+    <access id="access_4_35" id_profile="Translator" id_authorization_role="TAB_SHOPPARAMETERS_CREATE"/>
+    <access id="access_4_36" id_profile="Translator" id_authorization_role="TAB_SHOPPARAMETERS_READ"/>
+    <access id="access_4_37" id_profile="Translator" id_authorization_role="TAB_SHOPPARAMETERS_UPDATE"/>
+    <access id="access_4_38" id_profile="Translator" id_authorization_role="TAB_SHOPPARAMETERS_DELETE"/>
+    <access id="access_4_39" id_profile="Translator" id_authorization_role="TAB_ADMINSEARCHCONF_CREATE"/>
+    <access id="access_4_40" id_profile="Translator" id_authorization_role="TAB_ADMINSEARCHCONF_READ"/>
+    <access id="access_4_41" id_profile="Translator" id_authorization_role="TAB_ADMINSEARCHCONF_UPDATE"/>
+    <access id="access_4_42" id_profile="Translator" id_authorization_role="TAB_ADMINSEARCHCONF_DELETE"/>
+    <access id="access_4_43" id_profile="Translator" id_authorization_role="TAB_ADMINLOCALIZATION_CREATE"/>
+    <access id="access_4_44" id_profile="Translator" id_authorization_role="TAB_ADMINLOCALIZATION_READ"/>
+    <access id="access_4_45" id_profile="Translator" id_authorization_role="TAB_ADMINLOCALIZATION_UPDATE"/>
+    <access id="access_4_46" id_profile="Translator" id_authorization_role="TAB_ADMINLOCALIZATION_DELETE"/>
     <!--<access id="access_4_71"  id_profile="Translator"    id_authorization_role="CMS" view="1" add="1" edit="1" delete="1"/>-->
     <!--<access id="access_5_4"   id_profile="Salesman"      id_authorization_role="Combinations_generator" view="1" add="1" edit="1" delete="1"/>-->
     <access id="access_5_1"   id_profile="Salesman"      id_authorization_role="TAB_ADMINPARENTSEARCHCONF_READ"/>
+    <access id="access_5_87" id_profile="Salesman" id_authorization_role="TAB_ADMINSEARCHCONF_READ"/>
     <access id="access_5_2"   id_profile="Salesman"      id_authorization_role="TAB_ADMINCATALOG_CREATE"/>
     <access id="access_5_3"   id_profile="Salesman"      id_authorization_role="TAB_ADMINCATALOG_READ"/>
     <access id="access_5_4"   id_profile="Salesman"      id_authorization_role="TAB_ADMINCATALOG_UPDATE"/>
@@ -193,5 +240,37 @@
     <access id="access_5_59"  id_profile="Salesman"      id_authorization_role="TAB_ADMINREFERRERS_UPDATE"/>
     <access id="access_5_60"  id_profile="Salesman"      id_authorization_role="TAB_ADMINREFERRERS_DELETE"/>
     <access id="access_5_61" id_profile="Salesman"      id_authorization_role="TAB_ADMINSUPPLYORDERS_READ"/>
+    <access id="access_5_87" id_profile="Salesman"      id_authorization_role="TAB_ADMINSUPPLYORDERS_DELETE"/>
+    <access id="access_5_88" id_profile="Salesman"      id_authorization_role="TAB_ADMINSUPPLYORDERS_UPDATE"/>
+    <access id="access_5_89" id_profile="Salesman"      id_authorization_role="TAB_ADMINSUPPLYORDERS_CREATE"/>
+	<access id="access_5_62" id_profile="Salesman" id_authorization_role="TAB_SELL_CREATE"/>
+    <access id="access_5_63" id_profile="Salesman" id_authorization_role="TAB_SELL_READ"/>
+    <access id="access_5_64" id_profile="Salesman" id_authorization_role="TAB_SELL_UPDATE"/>
+    <access id="access_5_65" id_profile="Salesman" id_authorization_role="TAB_SELL_DELETE"/>
+    <access id="access_5_66" id_profile="Salesman" id_authorization_role="TAB_CONFIGURE_CREATE"/>
+    <access id="access_5_67" id_profile="Salesman" id_authorization_role="TAB_CONFIGURE_READ"/>
+    <access id="access_5_68" id_profile="Salesman" id_authorization_role="TAB_CONFIGURE_UPDATE"/>
+    <access id="access_5_69" id_profile="Salesman" id_authorization_role="TAB_CONFIGURE_DELETE"/>
+    <access id="access_5_70" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTMANUFACTURERS_READ"/>
+	<access id="access_5_87" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTMANUFACTURERS_CREATE"/>
+	<access id="access_5_88" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTMANUFACTURERS_UPDATE"/>
+	<access id="access_5_89" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTMANUFACTURERS_DELETE"/>
+    <access id="access_5_71" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTCUSTOMERTHREADS_CREATE"/>
+    <access id="access_5_72" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTCUSTOMERTHREADS_READ"/>
+    <access id="access_5_73" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTCUSTOMERTHREADS_UPDATE"/>
+    <access id="access_5_74" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTCUSTOMERTHREADS_DELETE"/>
+    <access id="access_5_75" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTMETA_CREATE"/>
+    <access id="access_5_76" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTMETA_READ"/>
+    <access id="access_5_77" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTMETA_UPDATE"/>
+    <access id="access_5_78" id_profile="Salesman" id_authorization_role="TAB_ADMINPARENTMETA_DELETE"/>
+    <access id="access_5_79" id_profile="Salesman" id_authorization_role="TAB_SHOPPARAMETERS_CREATE"/>
+    <access id="access_5_80" id_profile="Salesman" id_authorization_role="TAB_SHOPPARAMETERS_READ"/>
+    <access id="access_5_81" id_profile="Salesman" id_authorization_role="TAB_SHOPPARAMETERS_UPDATE"/>
+    <access id="access_5_82" id_profile="Salesman" id_authorization_role="TAB_SHOPPARAMETERS_DELETE"/>
+    <access id="access_5_83" id_profile="Salesman"  id_authorization_role="TAB_ADMINADVANCEDPARAMETERS_CREATE"/>
+    <access id="access_5_84" id_profile="Salesman"  id_authorization_role="TAB_ADMINADVANCEDPARAMETERS_READ"/>
+    <access id="access_5_85" id_profile="Salesman"  id_authorization_role="TAB_ADMINADVANCEDPARAMETERS_UPDATE"/>
+    <access id="access_5_86" id_profile="Salesman"  id_authorization_role="TAB_ADMINADVANCEDPARAMETERS_DELETE"/>
+	
   </entities>
 </entity_access>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | deveop |
| Description? | In Payments preferences, Carrier restrictions can be applied only on PS carriers. It adds the other ones |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1323 |
| How to test? | Add a carrier module and see if you can set that restriction on it |
