### PR TITLE
[-] FO: Product Page not showing modules in left column in two column…

### DIFF
--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -31,11 +31,7 @@
 
           {block name="left_column"}
             <div id="left-column" class="col-xs-12 col-sm-4 col-md-3">
-              {if $page.page_name == 'product'}
-                {hook h='displayLeftColumnProduct'}
-              {else}
-                {hook h="displayLeftColumn"}
-              {/if}
+              {hook h="displayLeftColumn"}             
             </div>
           {/block}
 
@@ -49,11 +45,7 @@
 
           {block name="right_column"}
             <div id="right-column" class="col-xs-12 col-sm-4 col-md-3">
-              {if $page.page_name == 'product'}
-                {hook h='displayRightColumnProduct'}
-              {else}
-                {hook h="displayRightColumn"}
-              {/if}
+              {hook h="displayRightColumn"}              
             </div>
           {/block}
         </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | Product page not showing modules in left column when a two column layout is set. |
| Type? | [-] |
| Category? | FO |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1584 |
| How to test? | Select 2 column small left in themes choose layout section for Products. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

… layout
