### PR TITLE
Fixed upload, update & delete product image

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1318,7 +1318,6 @@ var attachmentProduct = (function() {
  * images product management
  */
 var imagesProduct = (function() {
-  var id_product = $('#form_id_product').val();
   var dropZoneElem = $('#product-images-dropzone');
   var expanderElem = $('#product-images-container .dropzone-expander');
 
@@ -1387,7 +1386,7 @@ var imagesProduct = (function() {
       });
 
       var dropzoneOptions = {
-        url: dropZoneElem.attr('url-upload') + '/' + id_product,
+        url: dropZoneElem.attr('url-upload'),
         paramName: 'form[file]',
         maxFilesize: dropZoneElem.attr('data-max-size'),
         addRemoveLinks: true,

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1535,7 +1535,7 @@ var formImagesProduct = (function() {
       dropZoneElem.find(".dz-preview.active").removeClass("active");
       dropZoneElem.find(".dz-preview[data-id='"+id+"']").addClass("active");
       $.ajax({
-        url: dropZoneElem.attr('url-update') + '/' + id,
+        url: dropZoneElem.find(".dz-preview[data-id='"+id+"']").attr('url-update'),
         success: function(response) {
           formZoneElem.find('#product-images-form').html(response);
         },
@@ -1548,7 +1548,7 @@ var formImagesProduct = (function() {
     'send': function(id) {
       $.ajax({
         type: 'POST',
-        url: dropZoneElem.attr('url-update') + '/' + id,
+        url: dropZoneElem.find(".dz-preview[data-id='"+id+"']").attr('url-update'),
         data: formZoneElem.find('textarea, input').serialize(),
         beforeSend: function() {
           formZoneElem.find('.actions button').prop('disabled', 'disabled');
@@ -1583,7 +1583,7 @@ var formImagesProduct = (function() {
       modalConfirmation.create(translate_javascripts['Are you sure to delete this?'], null, {
         onContinue: function() {
           $.ajax({
-            url: dropZoneElem.attr('url-delete') + '/' + id,
+            url: dropZoneElem.find('.dz-preview[data-id="' + id + '"]').attr('url-delete'),
             complete: function() {
               formZoneElem.find('.close').click();
               dropZoneElem.find('.dz-preview[data-id="' + id + '"]').remove();

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -120,7 +120,13 @@
                     </div>
 
                     <div id="product-images-container" class="m-b-2">
-                      <div id="product-images-dropzone" class="panel dropzone ui-sortable col-md-12" url-upload="{{ path('admin_product_image_upload') }}" url-position="{{ path('admin_product_image_positions') }}" url-update="{{ path('admin_product_image_form') }}" url-delete="{{ path('admin_product_image_delete') }}" data-max-size="{{ 'PS_ATTACHMENT_MAXIMUM_SIZE'|configuration }}">
+                      <div id="product-images-dropzone" class="panel dropzone ui-sortable col-md-12"
+                           url-upload="{{ path('admin_product_image_upload', {'idProduct': id_product}) }}"
+                           url-position="{{ path('admin_product_image_positions') }}"
+                           url-update="{{ path('admin_product_image_form') }}"
+                           url-delete="{{ path('admin_product_image_delete') }}"
+                           data-max-size="{{ 'PS_ATTACHMENT_MAXIMUM_SIZE'|configuration }}"
+                      >
                         <div id="product-images-dropzone-error" class="text-danger"></div>
                         <div class="dz-default dz-message openfilemanager">
                             <i class="material-icons">add_a_photo</i><br/>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -123,8 +123,6 @@
                       <div id="product-images-dropzone" class="panel dropzone ui-sortable col-md-12"
                            url-upload="{{ path('admin_product_image_upload', {'idProduct': id_product}) }}"
                            url-position="{{ path('admin_product_image_positions') }}"
-                           url-update="{{ path('admin_product_image_form') }}"
-                           url-delete="{{ path('admin_product_image_delete') }}"
                            data-max-size="{{ 'PS_ATTACHMENT_MAXIMUM_SIZE'|configuration }}"
                       >
                         <div id="product-images-dropzone-error" class="text-danger"></div>
@@ -142,7 +140,11 @@
                               <div><span>+</span></div>
                             </div>
                           {% for image in form.step1.vars.value.images %}
-                            <div class="dz-preview dz-processing dz-image-preview dz-complete ui-sortable-handle" data-id="{{ image.id }}">
+                            <div class="dz-preview dz-processing dz-image-preview dz-complete ui-sortable-handle"
+                                 data-id="{{ image.id }}"
+                                 url-delete="{{ path('admin_product_image_delete', {'idImage': image.id}) }}"
+                                 url-update="{{ path('admin_product_image_form', {'idImage': image.id}) }}"
+                            >
                               <div class="dz-image bg" style="background-image: url('{{ image.base_image_url }}-home_default.{{ image.format }}');"></div>
                               <div class="dz-details">
                                 <div class="dz-size"><span data-dz-size=""></span></div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fixed all process for image product (upload, update, delete) |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1579 |
| How to test? | Try to play with image process! |

Thank's to @mickaelandrieu after him PR : https://github.com/PrestaShop/PrestaShop/pull/5912 It's report (a lot) bugs because some logic isn't good

Most of time, it's JS issue.
An url : `admin_product_image_form:     path:     /product/image/form/{idImage}`

In the twig :
`url-update="{{ path('admin_product_image_form') }}"`

In the JS, the url is constructed manually : 
 `url: dropZoneElem.find('foo').attr('url-update') + '/' + id`

Before, it was working but it's not good. Now with token, we have to construct good url at the begining

So, as possible : 
Twig : 
`url-update="{{ path('admin_product_image_form', {'idImage': image.id}) }}"`
JS : 
 `url: dropZoneElem.find('foo').attr('url-update')`
