### PR TITLE
 Fixed Product::getPricesDrop SQL query

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2586,7 +2586,7 @@ class ProductCore extends ObjectModel
 		LEFT JOIN `'._DB_PREFIX_.'manufacturer` m ON (m.`id_manufacturer` = p.`id_manufacturer`)
 		WHERE product_shop.`active` = 1
 		AND product_shop.`show_price` = 1
-		'.($front ? ' AND p.`visibility` IN ("both", "catalog")' : '').'
+		'.($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '').'
 		'.((!$beginning && !$ending) ? ' AND p.`id_product` IN ('.((is_array($tab_id_product) && count($tab_id_product)) ? implode(', ', $tab_id_product) : 0).')' : '').'
 		'.$sql_groups.'
 		ORDER BY '.(isset($order_by_prefix) ? pSQL($order_by_prefix).'.' : '').pSQL($order_by).' '.pSQL($order_way).'


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR is a rebase of #6370. The visibility of the product is in the product_shop table and not in the product table. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? |  |

In getPricesDrop, changed 'visibility' to use 'product_shop.'  instead of 'p.visibility', since you set the visibility of the product in the product_shop and not in the product table.

Line 2589 :
`'.($front ? ' AND p.`visibility` IN ("both", "catalog")' : '').'`

Changed to :
`'.($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '').'`
