### PR TITLE
Shows company in BO search if B2B is enabled

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -736,6 +736,10 @@ class CustomerCore extends ObjectModel
         $sql .= ' UNION ('.$sqlBase.' WHERE `lastname` LIKE \'%'.pSQL($query).'%\' '.Shop::addSqlRestriction(Shop::SHARE_CUSTOMER).')';
         $sql .= ' UNION ('.$sqlBase.' WHERE `firstname` LIKE \'%'.pSQL($query).'%\' '.Shop::addSqlRestriction(Shop::SHARE_CUSTOMER).')';
 
+        if (Configuration::get('PS_B2B_ENABLE')) {
+            $sql .= ' UNION ('.$sqlBase.' WHERE `company` LIKE \'%'.pSQL($query).'%\' '.Shop::addSqlRestriction(Shop::SHARE_CUSTOMER).')';
+        }
+
         if ($limit) {
             $sql .= ' LIMIT 0, '.(int) $limit;
         }

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -283,6 +283,7 @@ class AdminSearchControllerCore extends AdminController
             'firstname' => array('title' => $this->l('First Name'), 'align' => 'left', 'width' => 150),
             'lastname' => array('title' => $this->trans('Name', array(), 'Admin.Global'), 'align' => 'left', 'width' => 'auto'),
             'email' => array('title' => $this->l('Email address'), 'align' => 'left', 'width' => 250),
+            'company' => array('title' => $this->l('Company'), 'align' => 'left', 'width' => 150),
             'birthday' => array('title' => $this->l('Birth date'), 'align' => 'center', 'type' => 'date', 'width' => 75),
             'date_add' => array('title' => $this->l('Registration date'), 'align' => 'center', 'type' => 'date', 'width' => 75),
             'orders' => array('title' => $this->l('Orders'), 'align' => 'center', 'width' => 50),


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Allows you to search for a customer by company in the backoffice search bar, if B2B is enabled. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no? |
| Deprecations? | no |
| Fixed ticket? | -- |
| How to test? | Simply click around :). |

After discussion on the forums, this seemed like something that should be in PS by default. See [here on the forums](https://www.prestashop.com/forums/topic/558477-v1615-add-company-name-column-in-bo-search-results-page/).
