### PR TITLE
Fixed rendering condition of default groups form in AdminGroupsController

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -299,7 +299,6 @@ GitHub contributors:
 - romainberger
 - runningz
 - Remi Gaillard
-- Robin Rozo
 - s-duval
 - Sacha
 - Sacha FROMENT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -299,6 +299,7 @@ GitHub contributors:
 - romainberger
 - runningz
 - Remi Gaillard
+- Robin Rozo
 - s-duval
 - Sacha
 - Sacha FROMENT

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -101,7 +101,7 @@ class AdminGroupsControllerCore extends AdminController
         $this->_use_found_rows = false;
 
         $groups = Group::getGroups(Context::getContext()->language->id, true);
-        if (Shop::isFeatureActive()) {
+        if (Group::isFeatureActive()) {
             $this->fields_options = array(
                 'general' => array(
                     'title' =>    $this->l('Default groups options'),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fixed the rendering condition of default groups options form in AdminGroupsController. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Go to AdminGroupsController. The default groups options form should be rendered if group feature is enabled. |
