### PR TITLE
Removed backtick from order by clause

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3373,7 +3373,7 @@ class AdminControllerCore extends Controller
             $orderBySplit = preg_split('/[.!]/', $orderBy);
             $orderBy = bqSQL($orderBySplit[0]) . '.`' . bqSQL($orderBySplit[1]) . '`';
         } elseif ($orderBy) {
-            $orderBy = '`' . bqSQL($orderBy) . '`';
+            $orderBy = bqSQL($orderBy);
         }
 
         return $orderBy;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | A column in `Order by` was invalid because of extra backtick |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | N/A |
| How to test? | Access web service in advanced parameters of the back-office |
