### PR TITLE
Fixed hardcoded group id in getNewProducts

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2283,7 +2283,7 @@ class ProductCore extends ObjectModel
         if (Group::isFeatureActive()) {
             $groups = FrontController::getCurrentCustomerGroups();
             $sql_groups = ' AND EXISTS(SELECT 1 FROM `'._DB_PREFIX_.'category_product` cp
-				JOIN `'._DB_PREFIX_.'category_group` cg ON (cp.id_category = cg.id_category AND cg.`id_group` '.(count($groups) ? 'IN ('.implode(',', $groups).')' : '= 1').')
+				JOIN `'._DB_PREFIX_.'category_group` cg ON (cp.id_category = cg.id_category AND cg.`id_group` '.(count($groups) ? 'IN ('.implode(',', $groups).')' : '= '.(int)Configuration::get('PS_UNIDENTIFIED_GROUP')).')
 				WHERE cp.`id_product` = p.`id_product`)';
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Use configuration option for default group of unidentified customers instead of using a hardcoded value ;) |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | \- change default group in AdminGroupsController with an id != 1 for unindentified customers <br/>\- assign categories only visible for this group<br/>\- new products in blocknewproducts of thoses categories should appear even if not logged to a customer account |

Use configuration PS_UNIDENTIFIED_GROUP for unidentified customers group instead of hardcoded value
