### PR TITLE
Fixed missing btn on new controllers

### DIFF
--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -73,25 +73,23 @@ class AdminLegacyLayoutControllerCore extends AdminController
 
     public function initContent()
     {
-        parent::initToolbar();
-        parent::initTabModuleList();
-        parent::initPageHeaderToolbar();
-
         $this->addHeaderToolbarBtn();
-
-        parent::initContent();
 
         $this->show_page_header_toolbar = (bool) $this->showContentHeader;
 
-        if ($this->title) {
-            $this->context->smarty->assign(array('title' => $this->title));
-        }
-
         $vars = array(
             'maintenance_mode' => !(bool)Configuration::get('PS_SHOP_ENABLE'),
+            'debug_mode' => (bool)_PS_MODE_DEV_,
             'headerTabContent' => $this->headerTabContent,
             'content' => '{$content}', //replace content by original smarty tag var
             'enableSidebar' => $this->enableSidebar,
+            'lite_display' => $this->lite_display,
+            'url_post' => self::$currentIndex.'&token='.$this->token,
+            'show_page_header_toolbar' => $this->show_page_header_toolbar,
+            'page_header_toolbar_title' => $this->page_header_toolbar_title,
+            'title' => $this->title ? $this->title : $this->page_header_toolbar_title,
+            'toolbar_btn' => $this->page_header_toolbar_btn,
+            'page_header_toolbar_btn' => $this->page_header_toolbar_btn
         );
 
         if (!empty($this->helpLink)) {

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -79,7 +79,9 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function catalogAction(Request $request, $limit = 10, $offset = 0, $orderBy = 'id_product', $sortOrder = 'asc')
     {
-        $request->getSession()->set('_locale', 'fr-FR');
+        $context = $this->get('prestashop.adapter.legacy.context')->getContext();
+        $request->getSession()->set('_locale', $context->language->locale);
+
         // Redirect to legacy controller (FIXME: temporary behavior)
         $pagePreference = $this->container->get('prestashop.core.admin.page_preference_interface');
         /* @var $pagePreference AdminPagePreferenceInterface */
@@ -174,7 +176,7 @@ class ProductController extends FrameworkBundleAdminController
                 null,
                 array(
                     'label' => $translator->trans('Categories', array(), 'Admin.Catalog.Feature'),
-                    'list' => $this->container->get('prestashop.adapter.data_provider.category')->getNestedCategories(null, $this->get('prestashop.adapter.legacy.context')->getContext()->language->id, false),
+                    'list' => $this->container->get('prestashop.adapter.data_provider.category')->getNestedCategories(null, $context->language->id, false),
                     'valid_list' => [],
                     'multiple' => false,
                 )


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fixed missing btn on new controllers |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1598 |
| How to test? | Go to catalog page and modules pages & see btn :D |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
