### PR TITLE
Parent returns child name if it is defined

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -114,7 +114,7 @@ try {
     $e->displayMessage();
 }
 define('_THEME_NAME_', $context->shop->theme->getName());
-define('_PARENT_THEME_NAME_', $context->shop->theme->get('parent') ?: '');
+define('_PARENT_THEME_NAME_', $context->shop->theme->get('parent') ? $context->shop->theme->get('parent'): false);
 
 define('__PS_BASE_URI__', $context->shop->getBaseURI());
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In new implementation for PrestaShop child theme, the name of the theme is not defined well. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | -- |
| How to test? | Create a new theme using theme child from julienbourdeau childtheme-example. And now the theme loads ok. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
