### PR TITLE
Payments/Carriers preferences applied also on non PS carriers

### DIFF
--- a/controllers/admin/AdminPaymentPreferencesController.php
+++ b/controllers/admin/AdminPaymentPreferencesController.php
@@ -258,7 +258,7 @@ class AdminPaymentPreferencesControllerCore extends AdminController
                           'identifier' => 'id_country',
                           'icon' => 'icon-globe',
                     ),
-                    array('items' => Carrier::getCarriers($this->context->language->id),
+                    array('items' => Carrier::getCarriers($this->context->language->id, false, false, false, null, Carrier::ALL_CARRIERS),
                         'title' => $this->trans('Carrier restrictions', array(), 'Admin.Payment.Feature'),
                         'desc' => $this->trans('Please mark each checkbox for the carrier, or carrier, for which you want the payment module(s) to be available.', array(), 'Admin.Payment.Help'),
                         'name_id' => 'reference',


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In Payments preferences, Carrier restrictions can be applied only on PS carriers. It adds the other ones |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1323 |
| How to test? | Add a carrier module and see if you can set that restriction on it |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
