### PR TITLE
Module uninstallation now can remove properties on multiple lines

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2970,19 +2970,29 @@ abstract class ModuleCore
                 if (!$override_class->hasProperty($property->getName())) {
                     continue;
                 }
+                $multiline_property_deletion = false;
 
                 // Replace the declaration line by #--remove--#
                 foreach ($override_file as $line_number => &$line_content) {
                     if (preg_match('/(public|private|protected)\s+(static\s+)?(\$)?'.$property->getName().'/i', $line_content)) {
+                        if(!preg_match("/(.*);$/i",trim($line_content))){
+                            $multiline_property_deletion = true;
+                        }
                         if (preg_match('/\* module: ('.$this->name.')/ism', $override_file[$line_number - 4])) {
                             $override_file[$line_number - 5] = $override_file[$line_number - 4] = $override_file[$line_number - 3] = $override_file[$line_number - 2] = $override_file[$line_number - 1] = '#--remove--#';
                         }
                         $line_content = '#--remove--#';
-                        break;
+                    }else if($multiline_property_deletion){
+                        if (preg_match("/(.*);$/i", trim($line_content))) {
+                            $multiline_property_deletion = false;
+                        }
+                        $line_content = '#--remove--#';
+                        if(!$multiline_property_deletion) {
+                            break;
+                        }
                     }
                 }
             }
-
             // Remove properties from override file
             foreach ($module_class->getConstants() as $constant => $value) {
                 if (!$override_class->hasConstant($constant)) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | ModuleCore::uninstall can now remove properties on multilines |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1596 |
| How to test? | create a module who override a class and keep $definition property, install module, and next uninstall it. |

don't know if the type is ok

Sorry, code is not realy sexy :(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/6541)
<!-- Reviewable:end -->
