### PR TITLE
Remove deprecated getName() twig method

### DIFF
--- a/src/PrestaShopBundle/Twig/AdminExtension.php
+++ b/src/PrestaShopBundle/Twig/AdminExtension.php
@@ -114,12 +114,4 @@ class AdminExtension extends \Twig_Extension implements \Twig_Extension_GlobalsI
 
         return $globals;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'twig_admin_extension';
-    }
 }

--- a/src/PrestaShopBundle/Twig/DataFormatterExtension.php
+++ b/src/PrestaShopBundle/Twig/DataFormatterExtension.php
@@ -95,14 +95,4 @@ class DataFormatterExtension extends \Twig_Extension
         unset($array[$key]);
         return $array;
     }
-
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'twig_data_formatter_extension';
-    }
 }

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -79,16 +79,6 @@ class HookExtension extends \Twig_Extension
     }
 
     /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'twig_hook_extension';
-    }
-
-    /**
      * Calls the HookDispatcher, and dispatch a RenderingHookEvent.
      *
      * The listeners will then return html data to display in the Twig template.

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -208,14 +208,4 @@ EOF;
         return '<iframe width="560" height="315" src="'.$embedUrl.
             '" frameborder="0" allowfullscreen class="youtube-iframe m-x-auto"></iframe>';
     }
-
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'twig_layout_extension';
-    }
 }

--- a/src/PrestaShopBundle/Twig/TranslationsExtension.php
+++ b/src/PrestaShopBundle/Twig/TranslationsExtension.php
@@ -268,16 +268,6 @@ class TranslationsExtension extends \Twig_Extension
     }
 
     /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'twig_translations_extension';
-    }
-
-    /**
      * @param $subdomain
      * @param $subtree
      * @param int $level


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Remove deprecated getName() twig method. It has been deprecated in twig 1.26 |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
