### PR TITLE
Fix product link in quick access

### DIFF
--- a/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
@@ -5,8 +5,9 @@
   </span>
   <div class="ps-dropdown-menu dropdown-menu" aria-labelledby="quick-access">
     {foreach $quick_access as $quick}
-      <a href="{$quick.link|escape:'html':'UTF-8'}" class="dropdown-item" data-item="{$quick.name}">{$quick.name}</a></li>
+      <a href="{$admin_folder}/{$quick.link|escape:'html':'UTF-8'}" class="dropdown-item" data-item="{$quick.name}">{$quick.name}</a></li>
     {/foreach}
+    {assign var="position_token" value=$link->getQuickLink($smarty.server['REQUEST_URI'])|strpos:"?_token"}
     <hr>
     {if isset($matchQuickLink)}
       <a
@@ -28,7 +29,7 @@
       data-rand="{1|rand:200}"
       data-icon="{$quick_access_current_link_icon}"
       data-method="add"
-      data-url="{$smarty.server['REQUEST_URI']}"
+      data-url="{$link->getQuickLink($smarty.server['REQUEST_URI'])|substr:0:$position_token}"
       data-post-link="{$link->getAdminLink('AdminQuickAccesses')}"
       data-prompt-text="{l s='Please name this shortcut:' js=1}"
       data-link="{$quick_access_current_link_name|truncate:32}"

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1876,6 +1876,7 @@ class AdminControllerCore extends Controller
                 'search_type' => Tools::getValue('bo_search_type'),
                 'bo_query' => Tools::safeOutput(Tools::stripslashes(Tools::getValue('bo_query'))),
                 'quick_access' => $quick_access,
+                'admin_folder' => array_reverse(explode("/", _PS_ADMIN_DIR_))[0],
                 'multi_shop' => Shop::isFeatureActive(),
                 'shop_list' => $helperShop->getRenderedShopList(),
                 'current_shop_name' => $helperShop->getCurrentShopName(),


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | test |
| Description? | New product link in quick access is not working when you are in twig template (wrong redirection) |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1598 |
| How to test? | Click the create new product button in the quick access drop-down menu. |
