### PR TITLE
CO: Add new hook displayAfterProductThumb

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -360,5 +360,8 @@
     <hook id="displayProductExtraContent">
       <name>displayProductExtraContent</name><title>Display extra content on the product page</title><description>This hook expects ProductExtraContent instances, which will be properly displayed by the template on the product page.</description>
     </hook>
+    <hook id="displayAfterProductThumbs">
+      <name>displayAfterProductThumbs</name><title>Display extra content below product thums</title><description>This hook displays new elements below product images ex. additonal media</description>
+    </hook>      
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -361,7 +361,7 @@
       <name>displayProductExtraContent</name><title>Display extra content on the product page</title><description>This hook expects ProductExtraContent instances, which will be properly displayed by the template on the product page.</description>
     </hook>
     <hook id="displayAfterProductThumbs">
-      <name>displayAfterProductThumbs</name><title>Display extra content below product thums</title><description>This hook displays new elements below product images ex. additonal media</description>
+      <name>displayAfterProductThumbs</name><title>Display extra content below product thumbs</title><description>This hook displays new elements below product images ex. additonal media</description>
     </hook>      
   </entities>
 </entity_hook>

--- a/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -28,4 +28,5 @@
       </ul>
     </div>
   {/block}
+  {hook h='displayAfterProductThumbs'}
 </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | There was 0 hooks on left side of product page. This PR change that |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | This PR requires a module hooked on displayAfterProductThumbs. |
