### PR TITLE
Fixed missing button when adding countries in a taxe rule

### DIFF
--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -82,6 +82,12 @@ class AdminTaxRulesGroupControllerCore extends AdminController
                 'icon' => 'process-icon-new'
             );
         }
+        if ($this->display === "edit") {
+            $this->page_header_toolbar_btn['new'] = array(
+                'href' => '#',
+                'desc' => $this->trans('Add a new tax rule', array(), 'Admin.International.Feature')
+            );
+        }
 
         parent::initPageHeaderToolbar();
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Button "Add a new tax rule" was missing when modifying a rules tax to add countries. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1598 |
| How to test? | Go to rules taxes Tab and modify one, you will see the button on the top of the page |

Cherry-picked from https://github.com/PrestaShop/PrestaShop/pull/6585
Thanks @fatmaBouchekoua 
