### PR TITLE
Fixed newsletter, optin, shop columns

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_content.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_content.tpl
@@ -145,7 +145,7 @@
 			{/block}
 		{/foreach}
 
-	{if $shop_link_type}
+	{if $multishop_active && $shop_link_type}
 		<td title="{$tr.shop_name}">
 			{if isset($tr.shop_short_name)}
 				{$tr.shop_short_name}

--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -285,7 +285,7 @@
 						</span>
 					</th>
 					{/foreach}
-					{if $shop_link_type}
+					{if $multishop_active && $shop_link_type}
 						<th>
 							<span class="title_box">
 							{if $shop_link_type == 'shop'}
@@ -368,7 +368,7 @@
 						</th>
 					{/foreach}
 
-					{if $shop_link_type}
+					{if $multishop_active && $shop_link_type}
 						<th>--</th>
 					{/if}
 					{if $has_actions || $show_filters}

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -332,8 +332,13 @@ class HelperListCore extends Helper
             }
         }
 
+        $showShopColumn = $this->shopLinkType;
+
+        $isMultiShopActive = Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');
+
         $this->content_tpl->assign(array_merge($this->tpl_vars, array(
-            'shop_link_type' => $this->shopLinkType,
+            'shop_link_type' => $showShopColumn,
+            'multishop_active' => $isMultiShopActive,
             'name' => isset($name) ? $name : null,
             'position_identifier' => $this->position_identifier,
             'identifier' => $this->identifier,
@@ -716,6 +721,8 @@ class HelperListCore extends Helper
             'filters_has_value' => (bool)$has_value
         ));
 
+        $isMultiShopActive = Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');
+
         $this->header_tpl->assign(array_merge(array(
             'ajax' => $ajax,
             'title' => array_key_exists('title', $this->tpl_vars) ? $this->tpl_vars['title'] : $this->title,
@@ -730,6 +737,7 @@ class HelperListCore extends Helper
             'identifier' => $this->identifier,
             'id_cat' => $id_cat,
             'shop_link_type' => $this->shopLinkType,
+            'multishop_active' => $isMultiShopActive,
             'has_actions' => !empty($this->actions),
             'table_id' => isset($this->table_id) ? $this->table_id : null,
             'table_dnd' => isset($table_dnd) ? $table_dnd : null,

--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -126,16 +126,12 @@ class AdminCustomersControllerCore extends AdminController
             'newsletter' => array(
                 'title' => $this->trans('Newsletter', array(), 'Admin.Global'),
                 'align' => 'text-center',
-                'type' => 'bool',
                 'callback' => 'printNewsIcon',
-                'orderby' => false
             ),
             'optin' => array(
                 'title' => $this->trans('Partner offers', array(), 'Admin.OrdersCustomers.Feature'),
                 'align' => 'text-center',
-                'type' => 'bool',
                 'callback' => 'printOptinIcon',
-                'orderby' => false
             ),
             'date_add' => array(
                 'title' => $this->trans('Registration', array(), 'Admin.OrdersCustomers.Feature'),


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Optin and newsletter could not be toggled for each customer |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1614 |
| How to test? | Clicking on newsletter or optin (partners offers) icons make them active and remove shop column when multishop is disabled |
