### PR TITLE
CO: Keep sending email if legacy lang file not found

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -321,10 +321,6 @@ class MailCore extends ObjectModel
                 include_once($themePath.'mails/'.$iso.'/lang.php');
             } elseif (file_exists(_PS_MAIL_DIR_.$iso.'/lang.php')) {
                 include_once(_PS_MAIL_DIR_.$iso.'/lang.php');
-            } else {
-                Tools::dieOrLog(Tools::displayError('Error - The language file is missing for:').' '.$iso, $die);
-
-                return false;
             }
 
             /* Create mail and attach differents parts */


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When legacy files aren't found, we should keep sending the email since email trads are moving to `trans()` method |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1609 |
| How to test? |  |
