### PR TITLE
Add translation domains to Adv. param controllers 1

### DIFF
--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -125,7 +125,7 @@ class AdminAddressesControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->trans('Identification Number', array(), 'Admin.OrdersCustomers.Feature'),
+                    'label' => $this->trans('Identification number', array(), 'Admin.OrdersCustomers.Feature'),
                     'name' => 'dni',
                     'required' => false,
                     'col' => '4',

--- a/controllers/admin/AdminEmailsController.php
+++ b/controllers/admin/AdminEmailsController.php
@@ -47,8 +47,8 @@ class AdminEmailsControllerCore extends AdminController
 
             $this->bulk_actions = array(
                 'delete' => array(
-                    'text' => $this->l('Delete selected'),
-                    'confirm' => $this->l('Delete selected items?'),
+                    'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                    'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
                     'icon' => 'icon-trash'
                 )
             );
@@ -59,10 +59,10 @@ class AdminEmailsControllerCore extends AdminController
 
             $this->fields_list = array(
                 'id_mail' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'align' => 'center', 'class' => 'fixed-width-xs'),
-                'recipient' => array('title' => $this->l('Recipient')),
-                'template' => array('title' => $this->l('Template')),
+                'recipient' => array('title' => $this->trans('Recipient', array(), 'Admin.AdvParameters.Feature')),
+                'template' => array('title' => $this->trans('Template', array(), 'Admin.AdvParameters.Feature')),
                 'language' => array(
-                    'title' => $this->l('Language'),
+                    'title' => $this->trans('Language', array(), 'Admin.Global'),
                     'type' => 'select',
                     'color' => 'color',
                     'list' => $languages,
@@ -70,9 +70,9 @@ class AdminEmailsControllerCore extends AdminController
                     'filter_type' => 'int',
                     'order_key' => 'language'
                 ),
-                'subject' => array('title' => $this->l('Subject')),
+                'subject' => array('title' => $this->trans('Subject', array(), 'Admin.AdvParameters.Feature')),
                 'date_add' => array(
-                    'title' => $this->l('Sent'),
+                    'title' => $this->trans('Sent', array(), 'Admin.AdvParameters.Feature'),
                     'type' => 'datetime',
                 )
             );
@@ -91,8 +91,8 @@ class AdminEmailsControllerCore extends AdminController
                 'icon' => 'icon-envelope',
                 'fields' =>    array(
                     'PS_MAIL_EMAIL_MESSAGE' => array(
-                        'title' => $this->l('Send email to'),
-                        'desc' => $this->l('Where customers send messages from the order page.'),
+                        'title' => $this->trans('Send emails to', array(), 'Admin.AdvParameters.Feature'),
+                        'desc' => $this->trans('Where customers send messages from the order page.', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isUnsignedId',
                         'type' => 'select',
                         'cast' => 'intval',
@@ -105,8 +105,8 @@ class AdminEmailsControllerCore extends AdminController
                         'type' => 'radio',
                         'required' => true,
                         'choices' => array(
-                            3 => $this->l('Never send emails (may be useful for testing purposes)'),
-                            2 => $this->l('Set my own SMTP parameters (for advanced users ONLY)')
+                            3 => $this->trans('Never send emails (may be useful for testing purposes)', array(), 'Admin.AdvParameters.Feature'),
+                            2 => $this->trans('Set my own SMTP parameters (for advanced users ONLY)', array(), 'Admin.AdvParameters.Feature')
                         )
                     ),
                     'PS_MAIL_TYPE' => array(
@@ -115,13 +115,13 @@ class AdminEmailsControllerCore extends AdminController
                         'type' => 'radio',
                         'required' => true,
                         'choices' => array(
-                            Mail::TYPE_HTML => $this->l('Send email in HTML format'),
-                            Mail::TYPE_TEXT => $this->l('Send email in text format'),
-                            Mail::TYPE_BOTH => $this->l('Both')
+                            Mail::TYPE_HTML => $this->trans('Send email in HTML format', array(), 'Admin.AdvParameters.Feature'),
+                            Mail::TYPE_TEXT => $this->trans('Send email in text format', array(), 'Admin.AdvParameters.Feature'),
+                            Mail::TYPE_BOTH => $this->trans('Both', array(), 'Admin.AdvParameters.Feature')
                         )
                     ),
                     'PS_LOG_EMAILS' => array(
-                        'title' => $this->l('Log Emails'),
+                        'title' => $this->trans('Log Emails', array(), 'Admin.AdvParameters.Feature'),
                         'validation' => 'isBool',
                         'cast' => 'intval',
                         'type' => 'bool'
@@ -133,56 +133,56 @@ class AdminEmailsControllerCore extends AdminController
                 'title' => $this->trans('Email', array(), 'Admin.Global'),
                 'fields' =>    array(
                     'PS_MAIL_DOMAIN' => array(
-                        'title' => $this->l('Mail domain name'),
-                        'hint' => $this->l('Fully qualified domain name (keep this field empty if you don\'t know).'),
+                        'title' => $this->trans('Mail domain name', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('Fully qualified domain name (keep this field empty if you don\'t know).', array(), 'Admin.AdvParameters.Help'),
                         'empty' => true, 'validation' =>
                         'isUrl',
                         'type' => 'text',
                     ),
                     'PS_MAIL_SERVER' => array(
-                        'title' => $this->l('SMTP server'),
-                        'hint' => $this->l('IP address or server name (e.g. smtp.mydomain.com).'),
+                        'title' => $this->trans('SMTP server', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('IP address or server name (e.g. smtp.mydomain.com).', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isGenericName',
                         'type' => 'text',
                     ),
                     'PS_MAIL_USER' => array(
-                        'title' => $this->l('SMTP username'),
-                        'hint' => $this->l('Leave blank if not applicable.'),
+                        'title' => $this->trans('SMTP username', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('Leave blank if not applicable.', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isGenericName',
                         'type' => 'text',
                     ),
                     'PS_MAIL_PASSWD' => array(
-                        'title' => $this->l('SMTP password'),
-                        'hint' => $this->l('Leave blank if not applicable.'),
+                        'title' => $this->trans('SMTP password', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('Leave blank if not applicable.', array(), 'Admin.AdvParameters.Help'),
                         'validation' => 'isAnything',
                         'type' => 'password',
                         'autocomplete' => false
                     ),
                     'PS_MAIL_SMTP_ENCRYPTION' => array(
-                        'title' => $this->l('Encryption'),
-                        'hint' => $this->l('Use an encrypt protocol'),
-                        'desc' => extension_loaded('openssl') ? '' : '/!\\ '.$this->l('SSL does not seem to be available on your server.'),
+                        'title' => $this->trans('Encryption'),
+                        'hint' => $this->trans('Use an encrypt protocol', array(), 'Admin.AdvParameters.Help'),
+                        'desc' => extension_loaded('openssl') ? '' : '/!\\ '.$this->trans('SSL does not seem to be available on your server.', array(), 'Admin.AdvParameters.Notification'),
                         'type' => 'select',
                         'cast' => 'strval',
                         'identifier' => 'mode',
                         'list' => array(
                             array(
                                 'mode' => 'off',
-                                'name' => $this->l('None')
+                                'name' => $this->trans('None', array(), 'Admin.AdvParameters.Feature')
                             ),
                             array(
                                 'mode' => 'tls',
-                                'name' => $this->l('TLS')
+                                'name' => $this->trans('TLS', array(), 'Admin.AdvParameters.Feature')
                             ),
                             array(
                                 'mode' => 'ssl',
-                                'name' => $this->l('SSL')
+                                'name' => $this->trans('SSL', array(), 'Admin.AdvParameters.Feature')
                             )
                         ),
                     ),
                     'PS_MAIL_SMTP_PORT' => array(
-                        'title' => $this->l('Port'),
-                        'hint' => $this->l('Port number to use.'),
+                        'title' => $this->trans('Port', array(), 'Admin.AdvParameters.Feature'),
+                        'hint' => $this->trans('Port number to use.', array(), 'Admin.AdvParameters.Feature'),
                         'validation' => 'isInt',
                         'type' => 'text',
                         'cast' => 'intval',
@@ -192,11 +192,11 @@ class AdminEmailsControllerCore extends AdminController
                 'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions'))
             ),
             'test' => array(
-                'title' =>    $this->l('Test your email configuration'),
+                'title' =>    $this->trans('Test your email configuration', array(), 'Admin.AdvParameters.Feature'),
                 'hide_multishop_checkbox' => true,
                 'fields' =>    array(
                     'PS_SHOP_EMAIL' => array(
-                        'title' => $this->l('Send a test email to'),
+                        'title' => $this->trans('Send a test email to', array(), 'Admin.AdvParameters.Feature'),
                         'type' => 'text',
                         'id' => 'testEmail',
                         'no_multishop_checkbox' => true
@@ -206,7 +206,7 @@ class AdminEmailsControllerCore extends AdminController
 					<div class="alert" id="mailResultCheck" style="display:none;"></div>
 				</div></div>',
                 'buttons' => array(
-                    array('title' => $this->l('Send a test email'),
+                    array('title' => $this->trans('Send a test email', array(), 'Admin.AdvParameters.Feature'),
                         'icon' => 'process-icon-envelope',
                         'name' => 'btEmailTest',
                         'js' => 'verifyMail()',
@@ -218,7 +218,7 @@ class AdminEmailsControllerCore extends AdminController
 
         if (!defined('_PS_HOST_MODE_')) {
             $this->fields_options['email']['fields']['PS_MAIL_METHOD']['choices'][1] =
-                $this->l('Use PHP\'s mail() function (recommended; works in most cases)');
+                $this->trans('Use PHP\'s mail() function (recommended; works in most cases)', array(), 'Admin.AdvParameters.Feature');
         }
 
         ksort($this->fields_options['email']['fields']['PS_MAIL_METHOD']['choices']);
@@ -230,12 +230,12 @@ class AdminEmailsControllerCore extends AdminController
 
         $this->addJs(_PS_JS_DIR_.'/admin/email.js');
 
-        Media::addJsDefL('textMsg', $this->l('This is a test message. Your server is now configured to send email.', null, true, false));
-        Media::addJsDefL('textSubject', $this->l('Test message -- Prestashop', null, true, false));
-        Media::addJsDefL('textSendOk', $this->l('A test email has been sent to the email address you provided.', null, true, false));
-        Media::addJsDefL('textSendError', $this->l('Error: Please check your configuration', null, true, false));
+        Media::addJsDefL('textMsg', $this->trans('This is a test message. Your server is now configured to send email.', array(), 'Admin.AdvParameters.Feature'));
+        Media::addJsDefL('textSubject', $this->trans('Test message -- Prestashop', array(), 'Admin.AdvParameters.Feature'));
+        Media::addJsDefL('textSendOk', $this->trans('A test email has been sent to the email address you provided.', array(), 'Admin.AdvParameters.Feature'));
+        Media::addJsDefL('textSendError', $this->trans('Error: Please check your configuration', array(), 'Admin.AdvParameters.Feature'));
         Media::addJsDefL('token_mail', $this->token);
-        Media::addJsDefL('errorMail', $this->l('This email address is not valid', null, true, false));
+        Media::addJsDefL('errorMail', $this->trans('This email address is not valid', array(), 'Admin.AdvParameters.Feature'));
     }
 
     public function processDelete()
@@ -254,8 +254,8 @@ class AdminEmailsControllerCore extends AdminController
         parent::initToolbar();
         $this->toolbar_btn['delete'] = array(
             'short' => 'Erase',
-            'desc' => $this->l('Erase all'),
-            'js' => 'if (confirm(\''.$this->l('Are you sure?').'\')) document.location = \''.Tools::safeOutput($this->context->link->getAdminLink('AdminEmails')).'&amp;token='.$this->token.'&amp;deletemail=1\';'
+            'desc' => $this->trans('Erase all', array(), 'Admin.AdvParameters.Feature'),
+            'js' => 'if (confirm(\''.$this->trans('Are you sure?', array(), 'Admin.Notifications.Warning').'\')) document.location = \''.Tools::safeOutput($this->context->link->getAdminLink('AdminEmails')).'&amp;token='.$this->token.'&amp;deletemail=1\';'
         );
         unset($this->toolbar_btn['new']);
     }
@@ -282,7 +282,7 @@ class AdminEmailsControllerCore extends AdminController
 
         $this->toolbar_btn['back'] = array(
             'href' => $back,
-            'desc' => $this->l('Back to the dashboard')
+            'desc' => $this->trans('Back to the dashboard', array(), 'Admin.AdvParameters.Feature')
         );
 
         // $this->content .= $this->renderOptions();

--- a/controllers/admin/AdminGendersController.php
+++ b/controllers/admin/AdminGendersController.php
@@ -46,8 +46,8 @@ class AdminGendersControllerCore extends AdminController
 
         $this->bulk_actions = array(
             'delete' => array(
-                'text' => $this->l('Delete selected'),
-                'confirm' => $this->l('Delete selected items?'),
+                'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
                 'icon' => 'icon-trash'
             )
         );
@@ -67,24 +67,24 @@ class AdminGendersControllerCore extends AdminController
                 'class' => 'fixed-width-xs'
             ),
             'name' => array(
-                'title' => $this->l('Social title'),
+                'title' => $this->trans('Social title', array(), 'Admin.ShopParameters.Feature'),
                 'filter_key' => 'b!name'
             ),
             'type' => array(
-                'title' => $this->l('Gender'),
+                'title' => $this->trans('Gender', array(), 'Admin.Global'),
                 'orderby' => false,
                 'type' => 'select',
                 'list' => array(
-                    0 => $this->l('Male'),
-                    1 => $this->l('Female'),
-                    2 => $this->l('Neutral')
+                    0 => $this->trans('Male', array(), 'Admin.ShopParameters.Feature'),
+                    1 => $this->trans('Female', array(), 'Admin.ShopParameters.Feature'),
+                    2 => $this->trans('Neutral', array(), 'Admin.ShopParameters.Feature')
                 ),
                 'filter_key' => 'a!type',
                 'callback' => 'displayGenderType',
                 'callback_object' => $this
             ),
             'image' => array(
-                'title' => $this->l('Image'),
+                'title' => $this->trans('Image', array(), 'Admin.Global'),
                 'align' => 'center',
                 'image' => 'genders',
                 'orderby' => false,
@@ -98,7 +98,7 @@ class AdminGendersControllerCore extends AdminController
         if (empty($this->display)) {
             $this->page_header_toolbar_btn['new_gender'] = array(
                 'href' => self::$currentIndex.'&addgender&token='.$this->token,
-                'desc' => $this->l('Add new social title'),
+                'desc' => $this->trans('Add new social title', array(), 'Admin.ShopParameters.Feature'),
                 'icon' => 'process-icon-new'
             );
         }
@@ -110,22 +110,22 @@ class AdminGendersControllerCore extends AdminController
     {
         $this->fields_form = array(
             'legend' => array(
-                'title' => $this->l('Social titles'),
+                'title' => $this->trans('Social titles', array(), 'Admin.ShopParameters.Feature'),
                 'icon' => 'icon-male'
             ),
             'input' => array(
                 array(
                     'type' => 'text',
-                    'label' => $this->l('Social title'),
+                    'label' => $this->trans('Social title', array(), 'Admin.Global'),
                     'name' => 'name',
                     'lang' => true,
                     'col' => 4,
-                    'hint' => $this->l('Invalid characters:').' 0-9!&lt;&gt;,;?=+()@#"�{}_$%:',
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.ShopParameters.Help').' 0-9!&lt;&gt;,;?=+()@#"�{}_$%:',
                     'required' => true
                 ),
                 array(
                     'type' => 'radio',
-                    'label' => $this->l('Gender'),
+                    'label' => $this->trans('Gender', array(), 'Admin.Global'),
                     'name' => 'type',
                     'required' => false,
                     'class' => 't',
@@ -133,40 +133,40 @@ class AdminGendersControllerCore extends AdminController
                         array(
                             'id' => 'type_male',
                             'value' => 0,
-                            'label' => $this->l('Male')
+                            'label' => $this->trans('Male', array(), 'Admin.ShopParameters.Feature')
                         ),
                         array(
                             'id' => 'type_female',
                             'value' => 1,
-                            'label' => $this->l('Female')
+                            'label' => $this->trans('Female', array(), 'Admin.ShopParameters.Feature')
                         ),
                         array(
                             'id' => 'type_neutral',
                             'value' => 2,
-                            'label' => $this->l('Neutral')
+                            'label' => $this->trans('Neutral', array(), 'Admin.ShopParameters.Feature')
                         )
                     )
                 ),
                 array(
                     'type' => 'file',
-                    'label' => $this->l('Image'),
+                    'label' => $this->trans('Image', array(), 'Admin.Global'),
                     'name' => 'image',
                     'col' => 6,
                     'value' => true
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->l('Image width'),
+                    'label' => $this->trans('Image width', array(), 'Admin.ShopParameters.Feature'),
                     'name' => 'img_width',
                     'col' => 2,
-                    'hint' => $this->l('Image width in pixels. Enter "0" to use the original size.')
+                    'hint' => $this->trans('Image width in pixels. Enter "0" to use the original size.', array(), 'Admin.ShopParameters.Help')
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->l('Image height'),
+                    'label' => $this->trans('Image height', array(), 'Admin.ShopParameters.Feature'),
                     'name' => 'img_height',
                     'col' => 2,
-                    'hint' => $this->l('Image height in pixels. Enter "0" to use the original size.')
+                    'hint' => $this->trans('Image height in pixels. Enter "0" to use the original size.', array(), 'Admin.ShopParameters.Help')
                 )
             ),
             'submit' => array(

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -86,15 +86,15 @@ class AdminImportControllerCore extends AdminController
         parent::__construct();
 
         $this->entities = array(
-            $this->l('Categories'),
-            $this->l('Products'),
-            $this->l('Combinations'),
-            $this->l('Customers'),
-            $this->l('Addresses'),
-            $this->l('Brands'),
-            $this->l('Suppliers'),
-            $this->l('Alias'),
-            $this->l('Store contacts'),
+            $this->trans('Categories', array(), 'Admin.Global'),
+            $this->trans('Products', array(), 'Admin.Global'),
+            $this->trans('Combinations', array(), 'Admin.Global'),
+            $this->trans('Customers', array(), 'Admin.Global'),
+            $this->trans('Addresses', array(), 'Admin.Global'),
+            $this->trans('Brands', array(), 'Admin.Global'),
+            $this->trans('Suppliers', array(), 'Admin.Global'),
+            $this->trans('Alias', array(), 'Admin.ShopParameters.Feature'),
+            $this->trans('Store contacts', array(), 'Admin.AdvParameters.Feature'),
         );
 
         // @since 1.5.0
@@ -102,8 +102,8 @@ class AdminImportControllerCore extends AdminController
             $this->entities = array_merge(
                 $this->entities,
                 array(
-                    $this->l('Supply Orders'),
-                    $this->l('Supply Order Details'),
+                    $this->trans('Supply Orders', array(), 'Admin.AdvParameters.Feature'),
+                    $this->trans('Supply Order Details', array(), 'Admin.AdvParameters.Feature'),
                 )
             );
         }
@@ -111,54 +111,54 @@ class AdminImportControllerCore extends AdminController
         $this->entities = array_flip($this->entities);
 
         switch ((int)Tools::getValue('entity')) {
-            case $this->entities[$this->l('Combinations')]:
+            case $this->entities[$this->trans('Combinations', array(), 'Admin.Global')]:
                 $this->required_fields = array(
                     'group',
                     'attribute'
                 );
 
                 $this->available_fields = array(
-                    'no' => array('label' => $this->l('Ignore this column')),
-                    'id_product' => array('label' => $this->l('Product ID')),
-                    'product_reference' => array('label' => $this->l('Product Reference')),
+                    'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
+                    'id_product' => array('label' => $this->trans('Product ID', array(), 'Admin.AdvParameters.Feature')),
+                    'product_reference' => array('label' => $this->trans('Product Reference', array(), 'Admin.AdvParameters.Feature')),
                     'group' => array(
-                        'label' => $this->l('Attribute (Name:Type:Position)').'*'
+                        'label' => $this->trans('Attribute (Name:Type:Position)', array(), 'Admin.AdvParameters.Feature').'*'
                     ),
                     'attribute' => array(
-                        'label' => $this->l('Value (Value:Position)').'*'
+                        'label' => $this->trans('Value (Value:Position)', array(), 'Admin.AdvParameters.Feature').'*'
                     ),
-                    'supplier_reference' => array('label' => $this->l('Supplier reference')),
+                    'supplier_reference' => array('label' => $this->trans('Supplier reference', array(), 'Admin.AdvParameters.Feature')),
                     'reference' => array('label' => $this->trans('Reference', array(), 'Admin.Global')),
-                    'ean13' => array('label' => $this->l('EAN13')),
-                    'upc' => array('label' => $this->l('UPC')),
-                    'wholesale_price' => array('label' => $this->l('Wholesale price')),
-                    'price' => array('label' => $this->l('Impact on price')),
-                    'ecotax' => array('label' => $this->l('Ecotax')),
-                    'quantity' => array('label' => $this->l('Quantity')),
-                    'minimal_quantity' => array('label' => $this->l('Minimal quantity')),
-                    'weight' => array('label' => $this->l('Impact on weight')),
-                    'default_on' => array('label' => $this->l('Default (0 = No, 1 = Yes)')),
-                    'available_date' => array('label' => $this->l('Combination availability date')),
+                    'ean13' => array('label' => $this->trans('EAN13', array(), 'Admin.AdvParameters.Feature')),
+                    'upc' => array('label' => $this->trans('UPC', array(), 'Admin.AdvParameters.Feature')),
+                    'wholesale_price' => array('label' => $this->trans('Cost price', array(), 'Admin.Catalog.Feature')),
+                    'price' => array('label' => $this->trans('Impact on price', array(), 'Admin.Catalog.Feature')),
+                    'ecotax' => array('label' => $this->trans('Ecotax', array(), 'Admin.Catalog.Feature')),
+                    'quantity' => array('label' => $this->trans('Quantity', array(), 'Admin.Global')),
+                    'minimal_quantity' => array('label' => $this->trans('Minimal quantity', array(), 'Admin.AdvParameters.Feature')),
+                    'weight' => array('label' => $this->trans('Impact on weight', array(), 'Admin.Catalog.Feature')),
+                    'default_on' => array('label' => $this->trans('Default (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Feature')),
+                    'available_date' => array('label' => $this->trans('Combination availability date', array(), 'Admin.AdvParameters.Feature')),
                     'image_position' => array(
-                        'label' => $this->l('Choose among product images by position (1,2,3...)')
+                        'label' => $this->trans('Choose among product images by position (1,2,3...)', array(),'Admin.AdvParameters.Feature' )
                     ),
-                    'image_url' => array('label' => $this->l('Image URLs (x,y,z...)')),
-                    'image_alt' => array('label' => $this->l('Image alt texts (x,y,z...)')),
+                    'image_url' => array('label' => $this->trans('Image URLs (x,y,z...)', array(), 'Admin.AdvParameters.Feature')),
+                    'image_alt' => array('label' => $this->trans('Image alt texts (x,y,z...)', array(), 'Admin.AdvParameters.Feature')),
                     'shop' => array(
-                        'label' => $this->l('ID / Name of shop'),
-                        'help' => $this->l('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.'),
+                        'label' => $this->trans('ID / Name of shop', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.', array(), 'Admin.AdvParameters.Help'),
                     ),
                     'advanced_stock_management' => array(
-                        'label' => $this->l('Advanced Stock Management'),
-                        'help' => $this->l('Enable Advanced Stock Management on product (0 = No, 1 = Yes)')
+                        'label' => $this->trans('Advanced Stock Management', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('Enable Advanced Stock Management on product (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Help')
                     ),
                     'depends_on_stock' => array(
-                        'label' => $this->l('Depends on stock'),
-                        'help' => $this->l('0 = Use quantity set in product, 1 = Use quantity from warehouse.')
+                        'label' => $this->trans('Depends on stock', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('0 = Use quantity set in product, 1 = Use quantity from warehouse.', array(), 'Admin.AdvParameters.Help')
                     ),
                     'warehouse' => array(
-                        'label' => $this->l('Warehouse'),
-                        'help' => $this->l('ID of the warehouse to set as storage.')
+                        'label' => $this->trans('Warehouse', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('ID of the warehouse to set as storage.', array(), 'Admin.AdvParameters.Help')
                     ),
                 );
 
@@ -180,26 +180,26 @@ class AdminImportControllerCore extends AdminController
                 );
                 break;
 
-            case $this->entities[$this->l('Categories')]:
+            case $this->entities[$this->trans('Categories', array(), 'Admin.Global')]:
                 $this->available_fields = array(
-                    'no' => array('label' => $this->l('Ignore this column')),
+                    'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
                     'id' => array('label' => $this->trans('ID', array(), 'Admin.Global')),
-                    'active' => array('label' => $this->l('Active (0/1)')),
+                    'active' => array('label' => $this->trans('Active (0/1)', array(), 'Admin.AdvParameters.Feature')),
                     'name' => array('label' => $this->trans('Name', array(), 'Admin.Global')),
-                    'parent' => array('label' => $this->l('Parent category')),
+                    'parent' => array('label' => $this->trans('Parent category', array(), 'Admin.Catalog.Feature')),
                     'is_root_category' => array(
-                        'label' => $this->l('Root category (0/1)'),
-                        'help' => $this->l('A category root is where a category tree can begin. This is used with multistore.')
+                        'label' => $this->trans('Root category (0/1)', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('A category root is where a category tree can begin. This is used with multistore.', array(), 'Admin.AdvParameters.Help')
                         ),
                     'description' => array('label' => $this->trans('Description', array(), 'Admin.Global')),
-                    'meta_title' => array('label' => $this->l('Meta title')),
-                    'meta_keywords' => array('label' => $this->l('Meta keywords')),
-                    'meta_description' => array('label' => $this->l('Meta description')),
-                    'link_rewrite' => array('label' => $this->l('URL rewritten')),
-                    'image' => array('label' => $this->l('Image URL')),
+                    'meta_title' => array('label' => $this->trans('Meta title', array(), 'Admin.Global')),
+                    'meta_keywords' => array('label' => $this->trans('Meta keywords', array(), 'Admin.Global')),
+                    'meta_description' => array('label' => $this->trans('Meta description', array(), 'Admin.Global')),
+                    'link_rewrite' => array('label' => $this->trans('Rewritten URL', array(),'Admin.ShopParameters.Feature')),
+                    'image' => array('label' => $this->trans('Image URL', array(), 'Admin.AdvParameters.Feature')),
                     'shop' => array(
-                        'label' => $this->l('ID / Name of shop'),
-                        'help' => $this->l('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.'),
+                        'label' => $this->trans('ID / Name of shop', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.', array(), 'Admin.AdvParameters.Help'),
                     ),
                 );
 
@@ -210,97 +210,97 @@ class AdminImportControllerCore extends AdminController
                 );
                 break;
 
-            case $this->entities[$this->l('Products')]:
+            case $this->entities[$this->trans('Products', array(), 'Admin.Global')]:
                 self::$validators['image'] = array(
                     'AdminImportController',
                     'split'
                 );
 
                 $this->available_fields = array(
-                    'no' => array('label' => $this->l('Ignore this column')),
+                    'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
                     'id' => array('label' => $this->trans('ID', array(), 'Admin.Global')),
-                    'active' => array('label' => $this->l('Active (0/1)')),
+                    'active' => array('label' => $this->trans('Active (0/1)', array(), 'Admin.AdvParameters.Feature')),
                     'name' => array('label' => $this->trans('Name', array(), 'Admin.Global')),
-                    'category' => array('label' => $this->l('Categories (x,y,z...)')),
-                    'price_tex' => array('label' => $this->l('Price tax excluded')),
-                    'price_tin' => array('label' => $this->l('Price tax included')),
-                    'id_tax_rules_group' => array('label' => $this->l('Tax rule ID')),
-                    'wholesale_price' => array('label' => $this->l('Wholesale price')),
-                    'on_sale' => array('label' => $this->l('On sale (0/1)')),
-                    'reduction_price' => array('label' => $this->l('Discount amount')),
-                    'reduction_percent' => array('label' => $this->l('Discount percent')),
-                    'reduction_from' => array('label' => $this->l('Discount from (yyyy-mm-dd)')),
-                    'reduction_to' => array('label' => $this->l('Discount to (yyyy-mm-dd)')),
-                    'reference' => array('label' => $this->l('Reference #')),
-                    'supplier_reference' => array('label' => $this->l('Supplier reference #')),
-                    'supplier' => array('label' => $this->l('Supplier')),
-                    'manufacturer' => array('label' => $this->l('Brand')),
-                    'ean13' => array('label' => $this->l('EAN13')),
-                    'upc' => array('label' => $this->l('UPC')),
-                    'ecotax' => array('label' => $this->l('Ecotax')),
-                    'width' => array('label' => $this->l('Width')),
-                    'height' => array('label' => $this->l('Height')),
-                    'depth' => array('label' => $this->l('Depth')),
-                    'weight' => array('label' => $this->l('Weight')),
-                    'quantity' => array('label' => $this->l('Quantity')),
-                    'minimal_quantity' => array('label' => $this->l('Minimal quantity')),
-                    'visibility' => array('label' => $this->l('Visibility')),
-                    'additional_shipping_cost' => array('label' => $this->l('Additional shipping cost')),
-                    'unity' => array('label' => $this->l('Unit for the unit price')),
-                    'unit_price' => array('label' => $this->l('Unit price')),
-                    'description_short' => array('label' => $this->l('Short description')),
+                    'category' => array('label' => $this->trans('Categories (x,y,z...)', array(), 'Admin.AdvParameters.Feature')),
+                    'price_tex' => array('label' => $this->trans('Price tax excluded', array(), 'Admin.AdvParameters.Feature')),
+                    'price_tin' => array('label' => $this->trans('Price tax included', array(), 'Admin.AdvParameters.Feature')),
+                    'id_tax_rules_group' => array('label' => $this->trans('Tax rule ID', array(), 'Admin.AdvParameters.Feature')),
+                    'wholesale_price' => array('label' => $this->trans('Cost price', array(), 'Admin.Catalog.Feature')),
+                    'on_sale' => array('label' => $this->trans('On sale (0/1)', array(), 'Admin.AdvParameters.Feature')),
+                    'reduction_price' => array('label' => $this->trans('Discount amount', array(), 'Admin.AdvParameters.Feature')),
+                    'reduction_percent' => array('label' => $this->trans('Discount percent', array(), 'Admin.AdvParameters.Feature')),
+                    'reduction_from' => array('label' => $this->trans('Discount from (yyyy-mm-dd)', array(), 'Admin.AdvParameters.Feature')),
+                    'reduction_to' => array('label' => $this->trans('Discount to (yyyy-mm-dd)', array(), 'Admin.AdvParameters.Feature')),
+                    'reference' => array('label' => $this->trans('Reference #', array(), 'Admin.AdvParameters.Feature')),
+                    'supplier_reference' => array('label' => $this->trans('Supplier reference #', array(), 'Admin.AdvParameters.Feature')),
+                    'supplier' => array('label' => $this->trans('Supplier', array(), 'Admin.Global')),
+                    'manufacturer' => array('label' => $this->trans('Brand', array(), 'Admin.Global')),
+                    'ean13' => array('label' => $this->trans('EAN13', array(), 'Admin.AdvParameters.Feature')),
+                    'upc' => array('label' => $this->trans('UPC', array(), 'Admin.AdvParameters.Feature')),
+                    'ecotax' => array('label' => $this->trans('Ecotax', array(), 'Admin.Catalog.Feature')),
+                    'width' => array('label' => $this->trans('Width', array(), 'Admin.Global')),
+                    'height' => array('label' => $this->trans('Height', array(), 'Admin.Global')),
+                    'depth' => array('label' => $this->trans('Depth', array(), 'Admin.Global')),
+                    'weight' => array('label' => $this->trans('Weight', array(), 'Admin.Global')),
+                    'quantity' => array('label' => $this->trans('Quantity', array(), 'Admin.Global')),
+                    'minimal_quantity' => array('label' => $this->trans('Minimal quantity', array(), 'Admin.AdvParameters.Feature')),
+                    'visibility' => array('label' => $this->trans('Visibility', array(), 'Admin.Catalog.Feature')),
+                    'additional_shipping_cost' => array('label' => $this->trans('Additional shipping cost', array(), 'Admin.AdvParameters.Feature')),
+                    'unity' => array('label' => $this->trans('Unit for the price per unit', array(), 'Admin.AdvParameters.Feature')),
+                    'unit_price' => array('label' => $this->trans('Price per unit', array(), 'Admin.AdvParameters.Feature')),
+                    'description_short' => array('label' => $this->trans('Summary', array(), 'Admin.Catalog.Feature')),
                     'description' => array('label' => $this->trans('Description', array(), 'Admin.Global')),
-                    'tags' => array('label' => $this->l('Tags (x,y,z...)')),
-                    'meta_title' => array('label' => $this->l('Meta title')),
-                    'meta_keywords' => array('label' => $this->l('Meta keywords')),
-                    'meta_description' => array('label' => $this->l('Meta description')),
-                    'link_rewrite' => array('label' => $this->l('URL rewritten')),
-                    'available_now' => array('label' => $this->l('Text when in stock')),
-                    'available_later' => array('label' => $this->l('Text when backorder allowed')),
-                    'available_for_order' => array('label' => $this->l('Available for order (0 = No, 1 = Yes)')),
-                    'available_date' => array('label' => $this->l('Product availability date')),
-                    'date_add' => array('label' => $this->l('Product creation date')),
-                    'show_price' => array('label' => $this->l('Show price (0 = No, 1 = Yes)')),
-                    'image' => array('label' => $this->l('Image URLs (x,y,z...)')),
-                    'image_alt' => array('label' => $this->l('Image alt texts (x,y,z...)')),
+                    'tags' => array('label' => $this->trans('Tags (x,y,z...)', array(), 'Admin.AdvParameters.Feature')),
+                    'meta_title' => array('label' => $this->trans('Meta title', array(), 'Admin.Global')),
+                    'meta_keywords' => array('label' => $this->trans('Meta keywords', array(), 'Admin.Global')),
+                    'meta_description' => array('label' => $this->trans('Meta description', array(), 'Admin.Global')),
+                    'link_rewrite' => array('label' => $this->trans('Rewritten URL', array(), 'Admin.AdvParameters.Feature')),
+                    'available_now' => array('label' => $this->trans('Label when in stock', array(), 'Admin.Catalog.Feature')),
+                    'available_later' => array('label' => $this->trans('Label when backorder allowed', array(), 'Admin.AdvParameters.Feature')),
+                    'available_for_order' => array('label' => $this->trans('Available for order (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Feature')),
+                    'available_date' => array('label' => $this->trans('Product availability date', array(), 'Admin.AdvParameters.Feature')),
+                    'date_add' => array('label' => $this->trans('Product creation date', array(), 'Admin.AdvParameters.Feature')),
+                    'show_price' => array('label' => $this->trans('Show price (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Feature')),
+                    'image' => array('label' => $this->trans('Image URLs (x,y,z...)', array(), 'Admin.AdvParameters.Feature')),
+                    'image_alt' => array('label' => $this->trans('Image alt texts (x,y,z...)', array(), 'Admin.AdvParameters.Feature')),
                     'delete_existing_images' => array(
-                        'label' => $this->l('Delete existing images (0 = No, 1 = Yes)')
+                        'label' => $this->trans('Delete existing images (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Feature')
                     ),
-                    'features' => array('label' => $this->l('Feature (Name:Value:Position:Customized)')),
-                    'online_only' => array('label' => $this->l('Available online only (0 = No, 1 = Yes)')),
-                    'condition' => array('label' => $this->l('Condition')),
-                    'customizable' => array('label' => $this->l('Customizable (0 = No, 1 = Yes)')),
-                    'uploadable_files' => array('label' => $this->l('Uploadable files (0 = No, 1 = Yes)')),
-                    'text_fields' => array('label' => $this->l('Text fields (0 = No, 1 = Yes)')),
-                    'out_of_stock' => array('label' => $this->l('Action when out of stock')),
-                    'is_virtual' => array('label' => $this->l('Virtual product (0 = No, 1 = Yes)')),
-                    'file_url' => array('label' => $this->l('File URL')),
+                    'features' => array('label' => $this->trans('Feature (Name:Value:Position:Customized)', array(), 'Admin.AdvParameters.Feature')),
+                    'online_only' => array('label' => $this->trans('Available online only (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Feature')),
+                    'condition' => array('label' => $this->trans('Condition', array(), 'Admin.Catalog.Feature')),
+                    'customizable' => array('label' => $this->trans('Customizable (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Feature')),
+                    'uploadable_files' => array('label' => $this->trans('Uploadable files (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Feature')),
+                    'text_fields' => array('label' => $this->trans('Text fields (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Feature')),
+                    'out_of_stock' => array('label' => $this->trans('Action when out of stock', array(), 'Admin.AdvParameters.Feature')),
+                    'is_virtual' => array('label' => $this->trans('Virtual product (0 = No, 1 = Yes)', array(), 'Admin.AdvParameters.Feature')),
+                    'file_url' => array('label' => $this->trans('File URL', array(), 'Admin.AdvParameters.Feature')),
                     'nb_downloadable' => array(
-                        'label' => $this->l('Number of allowed downloads'),
-                        'help' => $this->l('Number of downloads allowed per customer. Set to 0 for unlimited downloads.'),
+                        'label' => $this->trans('Number of allowed downloads', array(), 'Admin.Catalog.Feature'),
+                        'help' => $this->trans('Number of days this file can be accessed by customers. Set to zero for unlimited access.', array(), 'Admin.Catalog.Help'),
                     ),
-                    'date_expiration' => array('label' => $this->l('Expiration date (yyyy-mm-dd)')),
+                    'date_expiration' => array('label' => $this->trans('Expiration date (yyyy-mm-dd)', array(), 'Admin.AdvParameters.Feature')),
                     'nb_days_accessible' => array(
-                        'label' => $this->l('Number of days'),
-                        'help' => $this->l('Number of days this file can be accessed by customers. Set to zero for unlimited access.'),
+                        'label' => $this->trans('Number of days', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('Number of days this file can be accessed by customers. Set to zero for unlimited access.', array(), 'Admin.Catalog.Help'),
                     ),
                     'shop' => array(
-                        'label' => $this->l('ID / Name of shop'),
-                        'help' => $this->l('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.'),
+                        'label' => $this->trans('ID / Name of shop', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.', array(), 'Admin.AdvParameters.Help'),
                     ),
                     'advanced_stock_management' => array(
-                        'label' => $this->l('Advanced Stock Management'),
-                        'help' => $this->l('Enable Advanced Stock Management on product (0 = No, 1 = Yes).')
+                        'label' => $this->trans('Advanced Stock Management', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('Enable Advanced Stock Management on product (0 = No, 1 = Yes).', array(), 'Admin.AdvParameters.Help')
                     ),
                     'depends_on_stock' => array(
-                        'label' => $this->l('Depends on stock'),
-                        'help' => $this->l('0 = Use quantity set in product, 1 = Use quantity from warehouse.')
+                        'label' => $this->trans('Depends on stock', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('0 = Use quantity set in product, 1 = Use quantity from warehouse.', array(), 'Admin.AdvParameters.Help')
                     ),
                     'warehouse' => array(
-                        'label' => $this->l('Warehouse'),
-                        'help' => $this->l('ID of the warehouse to set as storage.')
+                        'label' => $this->trans('Warehouse', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('ID of the warehouse to set as storage.', array(), 'Admin.AdvParameters.Help')
                     ),
-                    'accessories' => array('label' => $this->l('Accessories (x,y,z...)')),
+                    'accessories' => array('label' => $this->trans('Accessories (x,y,z...)', array(), 'Admin.AdvParameters.Feature')),
                 );
 
                 self::$default_values = array(
@@ -334,28 +334,28 @@ class AdminImportControllerCore extends AdminController
                 );
                 break;
 
-            case $this->entities[$this->l('Customers')]:
+            case $this->entities[$this->trans('Customers', array(), 'Admin.Global')]:
                 //Overwrite required_fields AS only email is required whereas other entities
                 $this->required_fields = array('email', 'passwd', 'lastname', 'firstname');
 
                 $this->available_fields = array(
-                    'no' => array('label' => $this->l('Ignore this column')),
+                    'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
                     'id' => array('label' => $this->trans('ID', array(), 'Admin.Global')),
-                    'active' => array('label' => $this->l('Active  (0/1)')),
-                    'id_gender' => array('label' => $this->l('Titles ID (Mr = 1, Ms = 2, else 0)')),
-                    'email' => array('label' => $this->l('Email *')),
-                    'passwd' => array('label' => $this->l('Password *')),
-                    'birthday' => array('label' => $this->l('Birthday (yyyy-mm-dd)')),
-                    'lastname' => array('label' => $this->l('Last Name *')),
-                    'firstname' => array('label' => $this->l('First Name *')),
-                    'newsletter' => array('label' => $this->l('Newsletter (0/1)')),
-                    'optin' => array('label' => $this->l('Partner offers (0/1)')),
-                    'date_add' => array('label' => $this->l('Registration date (yyyy-mm-dd)')),
-                    'group' => array('label' => $this->l('Groups (x,y,z...)')),
-                    'id_default_group' => array('label' => $this->l('Default group ID')),
+                    'active' => array('label' => $this->trans('Active  (0/1)', array(), 'Admin.AdvParameters.Feature')),
+                    'id_gender' => array('label' => $this->trans('Titles ID (Mr = 1, Ms = 2, else 0)', array(), 'Admin.AdvParameters.Feature')),
+                    'email' => array('label' => $this->trans('Email', array(), 'Admin.Global').'*'),
+                    'passwd' => array('label' => $this->trans('Password', array(), 'Admin.Global').'*'),
+                    'birthday' => array('label' => $this->trans('Birth date (yyyy-mm-dd)', array(), 'Admin.AdvParameters.Feature')),
+                    'lastname' => array('label' => $this->trans('Last name', array(), 'Admin.Global').'*'),
+                    'firstname' => array('label' => $this->trans('First name', array(), 'Admin.Global').'*'),
+                    'newsletter' => array('label' => $this->trans('Newsletter (0/1)', array(), 'Admin.AdvParameters.Feature')),
+                    'optin' => array('label' => $this->trans('Partner offers (0/1)', array(), 'Admin.AdvParameters.Feature')),
+                    'date_add' => array('label' => $this->trans('Registration date (yyyy-mm-dd)', array(), 'Admin.AdvParameters.Feature')),
+                    'group' => array('label' => $this->trans('Groups (x,y,z...)', array(), 'Admin.AdvParameters.Feature')),
+                    'id_default_group' => array('label' => $this->trans('Default group ID', array(), 'Admin.AdvParameters.Feature')),
                     'id_shop' => array(
-                        'label' => $this->l('ID / Name of shop'),
-                        'help' => $this->l('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.'),
+                        'label' => $this->trans('ID / Name of shop', array(),'Admin.AdvParameters.Feature' ),
+                        'help' => $this->trans('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.', array(), 'Admin.AdvParameters.Help'),
                     ),
                 );
 
@@ -365,7 +365,7 @@ class AdminImportControllerCore extends AdminController
                 );
                 break;
 
-            case $this->entities[$this->l('Addresses')]:
+            case $this->entities[$this->trans('Addresses', array(), 'Admin.Global')]:
                 //Overwrite required_fields
                 $this->required_fields = array(
                     'alias',
@@ -379,28 +379,28 @@ class AdminImportControllerCore extends AdminController
                 );
 
                 $this->available_fields = array(
-                    'no' => array('label' => $this->l('Ignore this column')),
+                    'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
                     'id' => array('label' => $this->trans('ID', array(), 'Admin.Global')),
-                    'alias' => array('label' => $this->l('Alias *')),
-                    'active' => array('label' => $this->l('Active  (0/1)')),
-                    'customer_email' => array('label' => $this->l('Customer email *')),
-                    'id_customer' => array('label' => $this->l('Customer ID')),
-                    'manufacturer' => array('label' => $this->l('Brand')),
-                    'supplier' => array('label' => $this->l('Supplier')),
+                    'alias' => array('label' => $this->trans('Alias', array(), 'Admin.ShopParameters.Feature').'*'),
+                    'active' => array('label' => $this->trans('Active  (0/1)', array(), 'Admin.AdvParameters.Feature')),
+                    'customer_email' => array('label' => $this->trans('Customer email', array(), 'Admin.AdvParameters.Feature').'*'),
+                    'id_customer' => array('label' => $this->trans('Customer ID', array(), 'Admin.AdvParameters.Feature')),
+                    'manufacturer' => array('label' => $this->trans('Brand', array(), 'Admin.Global')),
+                    'supplier' => array('label' => $this->trans('Supplier', array(), 'Admin.Global')),
                     'company' => array('label' => $this->trans('Company', array(), 'Admin.Global')),
-                    'lastname' => array('label' => $this->l('Last Name *')),
-                    'firstname' => array('label' => $this->l('First Name *')),
-                    'address1' => array('label' => $this->l('Address 1 *')),
-                    'address2' => array('label' => $this->l('Address 2')),
-                    'postcode' => array('label' => $this->l('Zip/postal code *')),
-                    'city' => array('label' => $this->l('City *')),
-                    'country' => array('label' => $this->l('Country *')),
-                    'state' => array('label' => $this->l('State')),
-                    'other' => array('label' => $this->l('Other')),
-                    'phone' => array('label' => $this->l('Phone')),
-                    'phone_mobile' => array('label' => $this->l('Mobile Phone')),
-                    'vat_number' => array('label' => $this->l('VAT number')),
-                    'dni' => array('label' => $this->l('DNI/NIF/NIE')),
+                    'lastname' => array('label' => $this->trans('Last name', array(), 'Admin.Global').'*'),
+                    'firstname' => array('label' => $this->trans('First name ', array(), 'Admin.Global').'*'),
+                    'address1' => array('label' => $this->trans('Address', array(), 'Admin.Global').'*'),
+                    'address2' => array('label' => $this->trans('Address (2)', array(), 'Admin.Global')),
+                    'postcode' => array('label' => $this->trans('Zip/postal code', array(), 'Admin.Global').'*'),
+                    'city' => array('label' => $this->trans('City', array(), 'Admin.Global').'*'),
+                    'country' => array('label' => $this->trans('Country', array(), 'Admin.Global').'*'),
+                    'state' => array('label' => $this->trans('State', array(), 'Admin.Global')),
+                    'other' => array('label' => $this->trans('Other', array(), 'Admin.Global')),
+                    'phone' => array('label' => $this->trans('Phone', array(), 'Admin.Global')),
+                    'phone_mobile' => array('label' => $this->trans('Mobile Phone', array(), 'Admin.Global')),
+                    'vat_number' => array('label' => $this->trans('VAT number', array(), 'Admin.OrdersCustomers.Feature')),
+                    'dni' => array('label' => $this->trans('Identification number', array(), 'Admin.OrdersCustomers.Feature')),
                 );
 
                 self::$default_values = array(
@@ -408,8 +408,8 @@ class AdminImportControllerCore extends AdminController
                     'postcode' => 'X'
                 );
                 break;
-            case $this->entities[$this->l('Brands')]:
-            case $this->entities[$this->l('Suppliers')]:
+            case $this->entities[$this->trans('Brands', array(), 'Admin.Global')]:
+            case $this->entities[$this->trans('Suppliers', array(), 'Admin.Global')]:
                 //Overwrite validators AS name is not MultiLangField
                 self::$validators = array(
                     'description' => array('AdminImportController', 'createMultiLangField'),
@@ -420,19 +420,19 @@ class AdminImportControllerCore extends AdminController
                 );
 
                 $this->available_fields = array(
-                    'no' => array('label' => $this->l('Ignore this column')),
+                    'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
                     'id' => array('label' => $this->trans('ID', array(), 'Admin.Global')),
-                    'active' => array('label' => $this->l('Active (0/1)')),
+                    'active' => array('label' => $this->trans('Active (0/1)', array(), 'Admin.AdvParameters.Feature')),
                     'name' => array('label' => $this->trans('Name', array(), 'Admin.Global')),
                     'description' => array('label' => $this->trans('Description', array(), 'Admin.Global')),
-                    'short_description' => array('label' => $this->l('Short description')),
-                    'meta_title' => array('label' => $this->l('Meta title')),
-                    'meta_keywords' => array('label' => $this->l('Meta keywords')),
-                    'meta_description' => array('label' => $this->l('Meta description')),
-                    'image' => array('label' => $this->l('Image URL')),
+                    'short_description' => array('label' => $this->trans('Short description', array(), 'Admin.Catalog.Feature')),
+                    'meta_title' => array('label' => $this->trans('Meta title', array(), 'Admin.Global')),
+                    'meta_keywords' => array('label' => $this->trans('Meta keywords', array(), 'Admin.Global')),
+                    'meta_description' => array('label' => $this->trans('Meta description', array(), 'Admin.Global')),
+                    'image' => array('label' => $this->trans('Image URL', array(), 'Admin.AdvParameters.Feature')),
                     'shop' => array(
-                        'label' => $this->l('ID / Name of group shop'),
-                        'help' => $this->l('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.'),
+                        'label' => $this->trans('ID / Name of group shop', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.', array(), 'Admin.AdvParameters.Help'),
                     ),
                 );
 
@@ -440,24 +440,24 @@ class AdminImportControllerCore extends AdminController
                     'shop' => Shop::getGroupFromShop(Configuration::get('PS_SHOP_DEFAULT')),
                 );
                 break;
-            case $this->entities[$this->l('Alias')]:
+            case $this->entities[$this->trans('Alias', array(), 'Admin.ShopParameters.Feature')]:
                 //Overwrite required_fields
                 $this->required_fields = array(
                     'alias',
                     'search',
                 );
                 $this->available_fields = array(
-                    'no' => array('label' => $this->l('Ignore this column')),
+                    'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
                     'id' => array('label' => $this->trans('ID', array(), 'Admin.Global')),
-                    'alias' => array('label' => $this->l('Alias *')),
-                    'search' => array('label' => $this->l('Search *')),
-                    'active' => array('label' => $this->l('Active')),
+                    'alias' => array('label' => $this->trans('Alias', array(), 'Admin.ShopParameters.Feature').'*'),
+                    'search' => array('label' => $this->trans('Search', array(), 'Admin.ShopParameters.Feature').'*'),
+                    'active' => array('label' => $this->trans('Active', array(), 'Admin.Global')),
                     );
                 self::$default_values = array(
                     'active' => '1',
                 );
                 break;
-            case $this->entities[$this->l('Store contacts')]:
+            case $this->entities[$this->trans('Store contacts', array(), 'Admin.AdvParameters.Feature')]:
                 unset(self::$validators['name']);
                 self::$validators = array(
                     'hours' => array('AdminImportController', 'split')
@@ -470,27 +470,27 @@ class AdminImportControllerCore extends AdminController
                     'longitude',
                 );
                 $this->available_fields = array(
-                    'no' => array('label' => $this->l('Ignore this column')),
+                    'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
                     'id' => array('label' => $this->trans('ID', array(), 'Admin.Global')),
-                    'active' => array('label' => $this->l('Active (0/1)')),
+                    'active' => array('label' => $this->trans('Active (0/1)', array(), 'Admin.AdvParameters.Feature')),
                     'name' => array('label' => $this->trans('Name', array(), 'Admin.Global')),
-                    'address1' => array('label' => $this->l('Address').'*'),
-                    'address2' => array('label' => $this->l('Address (2)')),
+                    'address1' => array('label' => $this->trans('Address', array(), 'Admin.Global').'*'),
+                    'address2' => array('label' => $this->trans('Address (2)', array(), 'Admin.AdvParameters.Feature')),
                     'postcode' => array('label' => $this->trans('Zip/postal code', array(), 'Admin.Global')),
-                    'state' => array('label' => $this->l('State')),
+                    'state' => array('label' => $this->trans('State', array(), 'Admin.Global')),
                     'city' => array('label' => $this->trans('City', array(), 'Admin.Global').'*'),
                     'country' => array('label' => $this->trans('Country', array(), 'Admin.Global').'*'),
-                    'latitude' => array('label' => $this->l('Latitude').'*'),
-                    'longitude' => array('label' => $this->l('Longitude').'*'),
-                    'phone' => array('label' => $this->l('Phone')),
-                    'fax' => array('label' => $this->l('Fax')),
-                    'email' => array('label' => $this->l('E-mail address')),
-                    'note' => array('label' => $this->l('Note')),
-                    'hours' => array('label' => $this->l('Hours (x,y,z...)')),
-                    'image' => array('label' => $this->l('Picture URL')),
+                    'latitude' => array('label' => $this->trans('Latitude', array(), 'Admin.AdvParameters.Feature').'*'),
+                    'longitude' => array('label' => $this->trans('Longitude', array(), 'Admin.AdvParameters.Feature').'*'),
+                    'phone' => array('label' => $this->trans('Phone', array(), 'Admin.Global')),
+                    'fax' => array('label' => $this->trans('Fax', array(), 'Admin.Global')),
+                    'email' => array('label' => $this->trans('Email address', array(), 'Admin.Global')),
+                    'note' => array('label' => $this->trans('Note', array(), 'Admin.AdvParameters.Feature')),
+                    'hours' => array('label' => $this->trans('Hours (x,y,z...)', array(), 'Admin.AdvParameters.Feature')),
+                    'image' => array('label' => $this->trans('Image URL', array(), 'Admin.AdvParameters.Feature')),
                     'shop' => array(
-                        'label' => $this->l('ID / Name of shop'),
-                        'help' => $this->l('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.'),
+                        'label' => $this->trans('ID / Name of shop', array(), 'Admin.AdvParameters.Feature'),
+                        'help' => $this->trans('Ignore this field if you don\'t use the Multistore tool. If you leave this field empty, the default shop will be used.', array(), 'Admin.AdvParameters.Help'),
                     ),
                 );
                 self::$default_values = array(
@@ -502,7 +502,7 @@ class AdminImportControllerCore extends AdminController
         // @since 1.5.0
         if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
             switch ((int)Tools::getValue('entity')) {
-                case $this->entities[$this->l('Supply Orders')]:
+                case $this->entities[$this->trans('Supply Orders', array(), 'Admin.AdvParameters.Feature')]:
                     // required fields
                     $this->required_fields = array(
                         'id_supplier',
@@ -512,16 +512,16 @@ class AdminImportControllerCore extends AdminController
                     );
                     // available fields
                     $this->available_fields = array(
-                        'no' => array('label' => $this->l('Ignore this column')),
+                        'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
                         'id' => array('label' => $this->trans('ID', array(), 'Admin.Global')),
-                        'id_supplier' => array('label' => $this->l('Supplier ID *')),
-                        'id_lang' => array('label' => $this->l('Lang ID')),
-                        'id_warehouse' => array('label' => $this->l('Warehouse ID *')),
-                        'id_currency' => array('label' => $this->l('Currency ID *')),
-                        'reference' => array('label' => $this->l('Supply Order Reference *')),
-                        'date_delivery_expected' => array('label' => $this->l('Delivery Date (Y-M-D)*')),
-                        'discount_rate' => array('label' => $this->l('Discount Rate')),
-                        'is_template' => array('label' => $this->l('Template')),
+                        'id_supplier' => array('label' => $this->trans('Supplier ID *', array(), 'Admin.AdvParameters.Feature')),
+                        'id_lang' => array('label' => $this->trans('Lang ID', array(), 'Admin.AdvParameters.Feature')),
+                        'id_warehouse' => array('label' => $this->trans('Warehouse ID *', array(), 'Admin.AdvParameters.Feature')),
+                        'id_currency' => array('label' => $this->trans('Currency ID *', array(), 'Admin.AdvParameters.Feature')),
+                        'reference' => array('label' => $this->trans('Supply Order Reference *', array(), 'Admin.AdvParameters.Feature')),
+                        'date_delivery_expected' => array('label' => $this->trans('Delivery Date (Y-M-D)*', array(), 'Admin.AdvParameters.Feature')),
+                        'discount_rate' => array('label' => $this->trans('Discount rate', array(), 'Admin.AdvParameters.Feature')),
+                        'is_template' => array('label' => $this->trans('Template', array(), 'Admin.AdvParameters.Feature')),
                     );
                     // default values
                     self::$default_values = array(
@@ -531,7 +531,7 @@ class AdminImportControllerCore extends AdminController
                         'is_template' => '0',
                     );
                     break;
-                case $this->entities[$this->l('Supply Order Details')]:
+                case $this->entities[$this->trans('Supply Order Details', array(), 'Admin.AdvParameters.Feature')]:
                     // required fields
                     $this->required_fields = array(
                         'supply_order_reference',
@@ -541,14 +541,14 @@ class AdminImportControllerCore extends AdminController
                     );
                     // available fields
                     $this->available_fields = array(
-                        'no' => array('label' => $this->l('Ignore this column')),
-                        'supply_order_reference' => array('label' => $this->l('Supply Order Reference *')),
-                        'id_product' => array('label' => $this->l('Product ID *')),
-                        'id_product_attribute' => array('label' => $this->l('Product Attribute ID')),
-                        'unit_price_te' => array('label' => $this->l('Unit Price (tax excl.)*')),
-                        'quantity_expected' => array('label' => $this->l('Quantity Expected *')),
-                        'discount_rate' => array('label' => $this->l('Discount Rate')),
-                        'tax_rate' => array('label' => $this->l('Tax Rate')),
+                        'no' => array('label' => $this->trans('Ignore this column', array(), 'Admin.AdvParameters.Feature')),
+                        'supply_order_reference' => array('label' => $this->trans('Supply Order Reference *', array(), 'Admin.AdvParameters.Feature')),
+                        'id_product' => array('label' => $this->trans('Product ID *', array(), 'Admin.AdvParameters.Feature')),
+                        'id_product_attribute' => array('label' => $this->trans('Product Attribute ID', array(), 'Admin.AdvParameters.Feature')),
+                        'unit_price_te' => array('label' => $this->trans('Unit Price (tax excl.)*', array(), 'Admin.AdvParameters.Feature')),
+                        'quantity_expected' => array('label' => $this->trans('Quantity Expected *', array(), 'Admin.AdvParameters.Feature')),
+                        'discount_rate' => array('label' => $this->trans('Discount Rate', array(), 'Admin.AdvParameters.Feature')),
+                        'tax_rate' => array('label' => $this->trans('Tax Rate', array(), 'Admin.AdvParameters.Feature')),
                     );
                     // default values
                     self::$default_values = array(
@@ -592,7 +592,7 @@ class AdminImportControllerCore extends AdminController
         }
 
         if (!is_writable(AdminImportController::getPath())) {
-            $this->displayWarning($this->l('The import directory must be writable (CHMOD 755 / 777).'));
+            $this->displayWarning($this->trans('The import directory must be writable (CHMOD 755 / 777).', array(), 'Admin.AdvParameters.Notification'));
         }
 
         $files_to_import = scandir(AdminImportController::getPath());
@@ -693,10 +693,10 @@ class AdminImportControllerCore extends AdminController
         if (isset($_FILES['file']) && !empty($_FILES['file']['error'])) {
             switch ($_FILES['file']['error']) {
                 case UPLOAD_ERR_INI_SIZE:
-                    $_FILES['file']['error'] = $this->trans('The uploaded file exceeds the upload_max_filesize directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess.', array(), 'Admin.Design.Notification');
+                    $_FILES['file']['error'] = $this->trans('The uploaded file exceeds the upload_max_filesize directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess.', array(), 'Admin.AdvParameters.Notification');
                     break;
                 case UPLOAD_ERR_FORM_SIZE:
-                    $_FILES['file']['error'] = $this->trans('The uploaded file exceeds the post_max_size directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess, for example:', array(), 'Admin.Design.Notification')
+                    $_FILES['file']['error'] = $this->trans('The uploaded file exceeds the post_max_size directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess, for example:', array(), 'Admin.AdvParameters.Notification')
                     .'<br/><a href="'.$this->context->link->getAdminLink('AdminMeta').'" >
 					<code>php_value post_max_size 20M</code> '.
                     $this->trans('(click to open "Generators" page)', array(), 'Admin.AdvParameters.Notification').'</a>';
@@ -707,7 +707,7 @@ class AdminImportControllerCore extends AdminController
                     break;
                 break;
                 case UPLOAD_ERR_NO_FILE:
-                    $_FILES['file']['error'] = $this->trans('No file was uploaded.', array(), 'Admin.Notifications.Error');
+                    $_FILES['file']['error'] = $this->trans('No file was uploaded.', array(), 'Admin.AdvParameters.Notification');
                     break;
                 break;
             }
@@ -715,7 +715,7 @@ class AdminImportControllerCore extends AdminController
             $_FILES['file']['error'] = $this->trans('The extension of your file should be .csv.', array(), 'Admin.AdvParameters.Notification');
         } elseif (!@filemtime($_FILES['file']['tmp_name']) ||
             !@move_uploaded_file($_FILES['file']['tmp_name'], AdminImportController::getPath().$filename_prefix.str_replace("\0", '', $_FILES['file']['name']))) {
-            $_FILES['file']['error'] = $this->l('An error occurred while uploading / copying the file.');
+            $_FILES['file']['error'] = $this->trans('An error occurred while uploading / copying the file.', array(), 'Admin.AdvParameters.Notification');
         } else {
             @chmod(AdminImportController::getPath().$filename_prefix.$_FILES['file']['name'], 0664);
             $_FILES['file']['filename'] = $filename_prefix.str_replace('\0', '', $_FILES['file']['name']);
@@ -791,7 +791,7 @@ class AdminImportControllerCore extends AdminController
                 // Default save button - action dynamically handled in javascript
                 $this->toolbar_btn['save-import'] = array(
                     'href' => '#',
-                    'desc' => $this->l('Import .CSV data')
+                    'desc' => $this->trans('Import .CSV data', array(), 'Admin.AdvParameters.Feature')
                 );
                 break;
         }
@@ -847,7 +847,7 @@ class AdminImportControllerCore extends AdminController
             if (Tools::getValue('csv')) {
                 $this->content .= $this->renderView();
             } else {
-                $this->errors[] = $this->l('To proceed, please upload a file first.');
+                $this->errors[] = $this->trans('To proceed, please upload a file first.', array(), 'Admin.AdvParameters.Notification');
                 $this->content .= $this->renderForm();
             }
         } else {
@@ -969,7 +969,7 @@ class AdminImportControllerCore extends AdminController
                 continue;
             }
             if ($k === 'price_tin') { // Special case for Product : either one or the other. Not both.
-                $fields[$i - 1] = '<div>'.$this->available_fields[$keys[$i - 1]]['label'].'<br/>&nbsp;&nbsp;<i>'.$this->l('or').'</i>&nbsp;&nbsp; '.$field['label'].'</div>';
+                $fields[$i - 1] = '<div>'.$this->available_fields[$keys[$i - 1]]['label'].'<br/>&nbsp;&nbsp;<i>'.$this->trans('or', array(), 'Admin.AdvParameters.Help').'</i>&nbsp;&nbsp; '.$field['label'].'</div>';
             } else {
                 if (isset($field['help'])) {
                     $html = '&nbsp;<a href="#" class="help-tooltip" data-toggle="tooltip" title="'.$field['help'].'"><i class="icon-info-sign"></i></a>';
@@ -1236,7 +1236,7 @@ class AdminImportControllerCore extends AdminController
             }
 
             if (count($line) == 1 && $line[0] == null) {
-                $this->warnings[] = $this->l('There is an empty row in the file that won\'t be imported.');
+                $this->warnings[] = $this->trans('There is an empty row in the file that won\'t be imported.', array(), 'Admin.AdvParameters.Notification');
                 continue;
             }
 
@@ -1508,7 +1508,7 @@ class AdminImportControllerCore extends AdminController
             }
 
             if (count($line) == 1 && $line[0] == null) {
-                $this->warnings[] = $this->l('There is an empty row in the file that won\'t be imported.');
+                $this->warnings[] = $this->trans('There is an empty row in the file that won\'t be imported.', array(), 'Admin.AdvParameters.Notification');
                 continue;
             }
 
@@ -1942,7 +1942,7 @@ class AdminImportControllerCore extends AdminController
             if (in_array($shop, $shop_ids)) {
                 $shops[] = $shop;
             } else {
-                $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->l('Shop is not valid'));
+                $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->trans('Shop is not valid', array(), 'Admin.AdvParameters.Notification'));
             }
         }
         if (empty($shops)) {
@@ -2017,7 +2017,7 @@ class AdminImportControllerCore extends AdminController
                     $specific_price->from = (isset($info['reduction_from']) && Validate::isDate($info['reduction_from'])) ? $info['reduction_from'] : '0000-00-00 00:00:00';
                     $specific_price->to = (isset($info['reduction_to']) && Validate::isDate($info['reduction_to']))  ? $info['reduction_to'] : '0000-00-00 00:00:00';
                     if (!$validateOnly && !$specific_price->save()) {
-                        $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->l('Discount is invalid'));
+                        $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->trans('Discount is invalid', array(), 'Admin.AdvParameters.Notification'));
                     }
                 }
             }
@@ -2047,7 +2047,7 @@ class AdminImportControllerCore extends AdminController
                     foreach ($product->tags as $key => $tags) {
                         $is_tag_added = Tag::addTags($key, $product->id, $tags, $this->multiple_value_separator);
                         if (!$is_tag_added) {
-                            $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->l('Tags list is invalid'));
+                            $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->trans('Tags list is invalid', array(), 'Admin.AdvParameters.Notification'));
                             break;
                         }
                     }
@@ -2314,7 +2314,7 @@ class AdminImportControllerCore extends AdminController
             }
 
             if (count($line) == 1 && $line[0] == null) {
-                $this->warnings[] = $this->l('There is an empty row in the file that won\'t be imported.');
+                $this->warnings[] = $this->trans('There is an empty row in the file that won\'t be imported.', array(), 'Admin.AdvParameters.Notification');
                 continue;
             }
 
@@ -2787,7 +2787,7 @@ class AdminImportControllerCore extends AdminController
             }
 
             if (count($line) == 1 && $line[0] == null) {
-                $this->warnings[] = $this->l('There is an empty row in the file that won\'t be imported.');
+                $this->warnings[] = $this->trans('There is an empty row in the file that won\'t be imported.', array(), 'Admin.AdvParameters.Notification');
                 continue;
             }
 
@@ -3029,7 +3029,7 @@ class AdminImportControllerCore extends AdminController
             }
 
             if (count($line) == 1 && $line[0] == null) {
-                $this->warnings[] = $this->l('There is an empty row in the file that won\'t be imported.');
+                $this->warnings[] = $this->trans('There is an empty row in the file that won\'t be imported.', array(), 'Admin.AdvParameters.Notification');
                 continue;
             }
 
@@ -3286,7 +3286,7 @@ class AdminImportControllerCore extends AdminController
             }
 
             if (count($line) == 1 && $line[0] == null) {
-                $this->warnings[] = $this->l('There is an empty row in the file that won\'t be imported.');
+                $this->warnings[] = $this->trans('There is an empty row in the file that won\'t be imported.', array(), 'Admin.AdvParameters.Notification');
                 continue;
             }
 
@@ -3399,7 +3399,7 @@ class AdminImportControllerCore extends AdminController
             }
 
             if (count($line) == 1 && $line[0] == null) {
-                $this->warnings[] = $this->l('There is an empty row in the file that won\'t be imported.');
+                $this->warnings[] = $this->trans('There is an empty row in the file that won\'t be imported.', array(), 'Admin.AdvParameters.Notification');
                 continue;
             }
 
@@ -3483,7 +3483,7 @@ class AdminImportControllerCore extends AdminController
                 }
             }
         } else {
-            $this->errors[] = $this->l('Supplier is invalid').' ('.$supplier->name.')';
+            $this->errors[] = $this->trans('Supplier is invalid', array(), 'Admin.AdvParameters.Notification').' ('.$supplier->name.')';
             $this->errors[] = ($field_error !== true ? $field_error : '').(isset($lang_field_error) && $lang_field_error !== true ? $lang_field_error : '');
         }
     }
@@ -3508,7 +3508,7 @@ class AdminImportControllerCore extends AdminController
             }
 
             if (count($line) == 1 && $line[0] == null) {
-                $this->warnings[] = $this->l('There is an empty row in the file that won\'t be imported.');
+                $this->warnings[] = $this->trans('There is an empty row in the file that won\'t be imported.', array(), 'Admin.AdvParameters.Notification');
                 continue;
             }
 
@@ -3560,7 +3560,7 @@ class AdminImportControllerCore extends AdminController
                 );
             }
         } else {
-            $this->errors[] = $this->l('Alias is invalid').' ('.$alias->name.')';
+            $this->errors[] = $this->trans('Alias is invalid', array(), 'Admin.AdvParameters.Notification').' ('.$alias->name.')';
             $this->errors[] = ($field_error !== true ? $field_error : '').(isset($lang_field_error) && $lang_field_error !== true ? $lang_field_error : '');
         }
     }
@@ -3584,7 +3584,7 @@ class AdminImportControllerCore extends AdminController
             }
 
             if (count($line) == 1 && $line[0] == null) {
-                $this->warnings[] = $this->l('There is an empty row in the file that won\'t be imported.');
+                $this->warnings[] = $this->trans('There is an empty row in the file that won\'t be imported.', array(), 'Admin.AdvParameters.Notification');
                 continue;
             }
 
@@ -3711,7 +3711,7 @@ class AdminImportControllerCore extends AdminController
                 );
             }
         } else {
-            $this->errors[] = $this->l('Store is invalid').' ('.$store->name.')';
+            $this->errors[] = $this->trans('Store is invalid', array(), 'Admin.AdvParameters.Notification').' ('.$store->name.')';
             $this->errors[] = ($field_error !== true ? $field_error : '').(isset($lang_field_error) && $lang_field_error !== true ? $lang_field_error : '');
         }
     }
@@ -3781,33 +3781,33 @@ class AdminImportControllerCore extends AdminController
         $error = '';
         // checks parameters
         if (!Supplier::supplierExists($id_supplier)) {
-            $error = sprintf($this->l('Supplier ID (%d) is not valid (at line %d).'), $id_supplier, $current_line + 1);
+            $error = sprintf($this->trans('Supplier ID (%d) is not valid (at line %d).', array(), 'Admin.AdvParameters.Notification'), $id_supplier, $current_line + 1);
         }
         if (!Language::getLanguage($id_lang)) {
-            $error = sprintf($this->l('Lang ID (%d) is not valid (at line %d).'), $id_lang, $current_line + 1);
+            $error = sprintf($this->trans('Lang ID (%d) is not valid (at line %d).', array(), 'Admin.AdvParameters.Notification'), $id_lang, $current_line + 1);
         }
         if (!Warehouse::exists($id_warehouse)) {
-            $error = sprintf($this->l('Warehouse ID (%d) is not valid (at line %d).'), $id_warehouse, $current_line + 1);
+            $error = sprintf($this->trans('Warehouse ID (%d) is not valid (at line %d).', array(), 'Admin.AdvParameters.Notification'), $id_warehouse, $current_line + 1);
         }
         if (!Currency::getCurrency($id_currency)) {
-            $error = sprintf($this->l('Currency ID (%d) is not valid (at line %d).'), $id_currency, $current_line + 1);
+            $error = sprintf($this->trans('Currency ID (%d) is not valid (at line %d).', array(), 'Admin.AdvParameters.Notification'), $id_currency, $current_line + 1);
         }
         if (empty($supply_order->reference) && SupplyOrder::exists($reference)) {
-            $error = sprintf($this->l('Reference (%s) already exists (at line %d).'), $reference, $current_line + 1);
+            $error = sprintf($this->trans('Reference (%s) already exists (at line %d).', array(), 'Admin.AdvParameters.Notification'), $reference, $current_line + 1);
         }
         if (!empty($supply_order->reference) && ($supply_order->reference != $reference && SupplyOrder::exists($reference))) {
-            $error = sprintf($this->l('Reference (%s) already exists (at line %d).'), $reference, $current_line + 1);
+            $error = sprintf($this->trans('Reference (%s) already exists (at line %d).', array(), 'Admin.AdvParameters.Notification'), $reference, $current_line + 1);
         }
         if (!Validate::isDateFormat($date_delivery_expected)) {
-            $error = sprintf($this->l('Date format (%s) is not valid (at line %d). It should be: %s.'), $date_delivery_expected, $current_line + 1, $this->l('YYYY-MM-DD'));
+            $error = sprintf($this->trans('Date format (%s) is not valid (at line %d). It should be: %s.', array(), 'Admin.AdvParameters.Notification'), $date_delivery_expected, $current_line + 1, $this->trans('YYYY-MM-DD', array(), 'Admin.AdvParameters.Notification'));
         } elseif (new DateTime($date_delivery_expected) <= new DateTime('yesterday')) {
-            $error = sprintf($this->l('Date (%s) cannot be in the past (at line %d). Format: %s.'), $date_delivery_expected, $current_line + 1, $this->l('YYYY-MM-DD'));
+            $error = sprintf($this->trans('Date (%s) cannot be in the past (at line %d). Format: %s.', array(), 'Admin.AdvParameters.Notification'), $date_delivery_expected, $current_line + 1, $this->trans('YYYY-MM-DD', array(), 'Admin.AdvParameters.Notification'));
         }
         if ($discount_rate < 0 || $discount_rate > 100) {
-            $error = sprintf($this->l('Discount rate (%d) is not valid (at line %d). %s.'), $discount_rate, $current_line + 1, $this->l('Format: Between 0 and 100'));
+            $error = sprintf($this->trans('Discount rate (%d) is not valid (at line %d). %s.', array(), 'Admin.AdvParameters.Notification'), $discount_rate, $current_line + 1, $this->trans('Format: Between 0 and 100', array(), 'Admin.AdvParameters.Notification'));
         }
         if ($supply_order->id > 0 && !$supply_order->isEditable()) {
-            $error = sprintf($this->l('Supply Order (%d) is not editable (at line %d).'), $supply_order->id, $current_line + 1);
+            $error = sprintf($this->trans('Supply Order (%d) is not editable (at line %d).', array(), 'Admin.AdvParameters.Notification'), $supply_order->id, $current_line + 1);
         }
 
         // if no errors, sets supply order
@@ -3838,7 +3838,7 @@ class AdminImportControllerCore extends AdminController
 
             // errors
             if (!$res) {
-                $this->errors[] = sprintf($this->l('Supply Order could not be saved (at line %d).'), $current_line + 1);
+                $this->errors[] = sprintf($this->trans('Supply Order could not be saved (at line %d).', array(), 'Admin.AdvParameters.Notification'), $current_line + 1);
             }
         } else {
             $this->errors[] = $error;
@@ -3904,7 +3904,7 @@ class AdminImportControllerCore extends AdminController
         if (array_key_exists('supply_order_reference', $info) && pSQL($info['supply_order_reference']) && SupplyOrder::exists(pSQL($info['supply_order_reference']))) {
             $supply_order = SupplyOrder::getSupplyOrderByReference(pSQL($info['supply_order_reference']));
         } else {
-            $this->errors[] = sprintf($this->l('Supply Order (%s) could not be loaded (at line %d).'), $info['supply_order_reference'], $current_line + 1);
+            $this->errors[] = sprintf($this->trans('Supply Order (%s) could not be loaded (at line %d).', array(), 'Admin.AdvParameters.Notification'), $info['supply_order_reference'], $current_line + 1);
         }
 
         if (empty($this->errors)) {
@@ -3922,7 +3922,7 @@ class AdminImportControllerCore extends AdminController
             // checks if one product/attribute is there only once
             if (isset($products[$id_product][$id_product_attribute])) {
                 $this->errors[] = sprintf(
-                    $this->l('Product/Attribute (%d/%d) cannot be added twice (at line %d).'),
+                    $this->trans('Product/Attribute (%d/%d) cannot be added twice (at line %d).', array(), 'Admin.AdvParameters.Notification'),
                     $id_product,
                     $id_product_attribute,
                     $current_line + 1
@@ -3934,32 +3934,32 @@ class AdminImportControllerCore extends AdminController
             // checks parameters
             if (false === ($supplier_reference = ProductSupplier::getProductSupplierReference($id_product, $id_product_attribute, $supply_order->id_supplier))) {
                 $this->errors[] = sprintf(
-                    $this->l('Product (%d/%d) is not available for this order (at line %d).'),
+                    $this->trans('Product (%d/%d) is not available for this order (at line %d).', array(), 'Admin.AdvParameters.Notification'),
                     $id_product,
                     $id_product_attribute,
                     $current_line + 1
                 );
             }
             if ($unit_price_te < 0) {
-                $this->errors[] = sprintf($this->l('Unit Price (tax excl.) (%d) is not valid (at line %d).'), $unit_price_te, $current_line + 1);
+                $this->errors[] = sprintf($this->trans('Unit Price (tax excl.) (%d) is not valid (at line %d).', array(), 'Admin.AdvParameters.Notification'), $unit_price_te, $current_line + 1);
             }
             if ($quantity_expected < 0) {
-                $this->errors[] = sprintf($this->l('Quantity Expected (%d) is not valid (at line %d).'), $quantity_expected, $current_line + 1);
+                $this->errors[] = sprintf($this->trans('Quantity Expected (%d) is not valid (at line %d).', array(), 'Admin.AdvParameters.Notification'), $quantity_expected, $current_line + 1);
             }
             if ($discount_rate < 0 || $discount_rate > 100) {
                 $this->errors[] = sprintf(
-                    $this->l('Discount rate (%d) is not valid (at line %d). %s.'),
+                    $this->trans('Discount rate (%d) is not valid (at line %d). %s.', array(), 'Admin.AdvParameters.Notification'),
                     $discount_rate,
                     $current_line + 1,
-                    $this->l('Format: Between 0 and 100')
+                    $this->trans('Format: Between 0 and 100', array(), 'Admin.AdvParameters.Notification')
                 );
             }
             if ($tax_rate < 0 || $tax_rate > 100) {
                 $this->errors[] = sprintf(
-                    $this->l('Quantity Expected (%d) is not valid (at line %d).'),
+                    $this->trans('Quantity Expected (%d) is not valid (at line %d).', array(), 'Admin.AdvParameters.Notification'),
                     $tax_rate,
                     $current_line + 1,
-                    $this->l('Format: Between 0 and 100')
+                    $this->trans('Format: Between 0 and 100', array(), 'Admin.AdvParameters.Notification')
                 );
             }
 
@@ -4103,7 +4103,7 @@ class AdminImportControllerCore extends AdminController
     protected function truncateTables($case)
     {
         switch ((int)$case) {
-            case $this->entities[$this->l('Categories')]:
+            case $this->entities[$this->trans('Categories', array(), 'Admin.Global')]:
                 Db::getInstance()->execute('
 					DELETE FROM `'._DB_PREFIX_.'category`
 					WHERE id_category NOT IN ('.(int)Configuration::get('PS_HOME_CATEGORY').
@@ -4123,7 +4123,7 @@ class AdminImportControllerCore extends AdminController
                     }
                 }
                 break;
-            case $this->entities[$this->l('Products')]:
+            case $this->entities[$this->trans('Products', array(), 'Admin.Global')]:
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'product`');
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'product_shop`');
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'feature_product`');
@@ -4164,7 +4164,7 @@ class AdminImportControllerCore extends AdminController
                     mkdir(_PS_PROD_IMG_DIR_);
                 }
                 break;
-            case $this->entities[$this->l('Combinations')]:
+            case $this->entities[$this->trans('Combinations', array(), 'Admin.Global')]:
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'attribute`');
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'attribute_impact`');
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'attribute_lang`');
@@ -4178,13 +4178,13 @@ class AdminImportControllerCore extends AdminController
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'product_attribute_image`');
                 Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'stock_available` WHERE id_product_attribute != 0');
                 break;
-            case $this->entities[$this->l('Customers')]:
+            case $this->entities[$this->trans('Customers', array(), 'Admin.Global')]:
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'customer`');
                 break;
-            case $this->entities[$this->l('Addresses')]:
+            case $this->entities[$this->trans('Addresses', array(), 'Admin.Global')]:
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'address`');
                 break;
-            case $this->entities[$this->l('Brands')]:
+            case $this->entities[$this->trans('Brands', array(), 'Admin.Global')]:
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'manufacturer`');
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'manufacturer_lang`');
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'manufacturer_shop`');
@@ -4194,7 +4194,7 @@ class AdminImportControllerCore extends AdminController
                     }
                 }
                 break;
-            case $this->entities[$this->l('Suppliers')]:
+            case $this->entities[$this->trans('Suppliers', array(), 'Admin.Global')]:
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'supplier`');
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'supplier_lang`');
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'supplier_shop`');
@@ -4204,7 +4204,7 @@ class AdminImportControllerCore extends AdminController
                     }
                 }
                 break;
-            case $this->entities[$this->l('Alias')]:
+            case $this->entities[$this->trans('Alias', array(), 'Admin.ShopParameters.Feature')]:
                 Db::getInstance()->execute('TRUNCATE TABLE `'._DB_PREFIX_.'alias`');
                 break;
         }
@@ -4292,40 +4292,40 @@ class AdminImportControllerCore extends AdminController
             }
             Db::getInstance()->disableCache();
             switch ((int)Tools::getValue('entity')) {
-                case $this->entities[$import_type = $this->l('Categories')]:
+                case $this->entities[$import_type = $this->trans('Categories', array(), 'Admin.Global')]:
                     $doneCount += $this->categoryImport($offset, $limit, $crossStepsVariables, $validateOnly);
                     $this->clearSmartyCache();
                     break;
-                case $this->entities[$import_type = $this->l('Products')]:
+                case $this->entities[$import_type = $this->trans('Products', array(), 'Admin.Global')]:
                     if (!defined('PS_MASS_PRODUCT_CREATION')) {
                         define('PS_MASS_PRODUCT_CREATION', true);
                     }
-                    $moreStepLabels = array($this->l('Linking Accessories...'));
+                    $moreStepLabels = array($this->trans('Linking Accessories...', array(), 'Admin.AdvParameters.Notification'));
                     $doneCount += $this->productImport($offset, $limit, $crossStepsVariables, $validateOnly, $moreStep);
                     $this->clearSmartyCache();
                     break;
-                case $this->entities[$import_type = $this->l('Customers')]:
+                case $this->entities[$import_type = $this->trans('Customers', array(), 'Admin.Global')]:
                     $doneCount += $this->customerImport($offset, $limit, $validateOnly);
                     break;
-                case $this->entities[$import_type = $this->l('Addresses')]:
+                case $this->entities[$import_type = $this->trans('Addresses', array(), 'Admin.Global')]:
                     $doneCount += $this->addressImport($offset, $limit, $validateOnly);
                     break;
-                case $this->entities[$import_type = $this->l('Combinations')]:
+                case $this->entities[$import_type = $this->trans('Combinations', array(), 'Admin.Global')]:
                     $doneCount += $this->attributeImport($offset, $limit, $crossStepsVariables, $validateOnly);
                     $this->clearSmartyCache();
                     break;
-                case $this->entities[$import_type = $this->l('Brands')]:
+                case $this->entities[$import_type = $this->trans('Brands', array(), 'Admin.Global')]:
                     $doneCount += $this->manufacturerImport($offset, $limit, $validateOnly);
                     $this->clearSmartyCache();
                     break;
-                case $this->entities[$import_type = $this->l('Suppliers')]:
+                case $this->entities[$import_type = $this->trans('Suppliers', array(), 'Admin.Global')]:
                     $doneCount += $this->supplierImport($offset, $limit, $validateOnly);
                     $this->clearSmartyCache();
                     break;
-                case $this->entities[$import_type = $this->l('Alias')]:
+                case $this->entities[$import_type = $this->trans('Alias', array(), 'Admin.ShopParameters.Feature')]:
                     $doneCount += $this->aliasImport($offset, $limit, $validateOnly);
                     break;
-                case $this->entities[$import_type = $this->l('Store contacts')]:
+                case $this->entities[$import_type = $this->trans('Store contacts', array(), 'Admin.AdvParameters.Feature')]:
                     $doneCount += $this->storeContactImport($offset, $limit, $validateOnly);
                     $this->clearSmartyCache();
                     break;
@@ -4334,12 +4334,12 @@ class AdminImportControllerCore extends AdminController
             // @since 1.5.0
             if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
                 switch ((int)Tools::getValue('entity')) {
-                    case $this->entities[$import_type = $this->l('Supply Orders')]:
+                    case $this->entities[$import_type = $this->trans('Supply Orders', array(), 'Admin.AdvParameters.Feature')]:
                         if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
                             $doneCount += $this->supplyOrdersImport($offset, $limit, $validateOnly);
                         }
                         break;
-                    case $this->entities[$import_type = $this->l('Supply Order Details')]:
+                    case $this->entities[$import_type = $this->trans('Supply Order Details', array(), 'Admin.AdvParameters.Feature')]:
                         if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
                             $doneCount += $this->supplyOrdersDetailsImport($offset, $limit, $crossStepsVariables, $validateOnly);
                         }
@@ -4376,19 +4376,19 @@ class AdminImportControllerCore extends AdminController
             }
 
             if ($import_type !== false) {
-                $log_message = sprintf($this->l('%s import', 'AdminTab', false, false), $import_type);
+                $log_message = sprintf($this->trans('%s import', array(), 'Admin.AdvParameters.Notification'), $import_type);
                 if ($offset !== false && $limit !== false) {
-                    $log_message .= ' '.sprintf($this->l('(from %s to %s)', 'AdminTab', false, false), $offset, $limit);
+                    $log_message .= ' '.sprintf($this->trans('(from %s to %s)', array(), 'Admin.AdvParameters.Notification'), $offset, $limit);
                 }
                 if (Tools::getValue('truncate')) {
-                    $log_message .= ' '.$this->l('with truncate', 'AdminTab', false, false);
+                    $log_message .= ' '.$this->trans('with truncate', array(), 'Admin.AdvParameters.Notification');
                 }
                 PrestaShopLogger::addLog($log_message, 1, null, $import_type, null, true, (int)$this->context->employee->id);
             }
 
             Db::getInstance()->enableCache();
         } else {
-            $this->errors[] = $this->l('To proceed, please upload a file first.');
+            $this->errors[] = $this->trans('To proceed, please upload a file first.', array(), 'Admin.AdvParameters.Notification');
         }
     }
 
@@ -4506,10 +4506,10 @@ class AdminImportControllerCore extends AdminController
                     (int)$this->context->shop->id
                 );
                 if (!$mailSuccess) {
-                    $results['warnings'][] = $this->l('The confirmation email couldn\'t be sent, but the import is successfull. Yay!');
+                    $results['warnings'][] = $this->trans('The confirmation email couldn\'t be sent, but the import is successful. Yay!', array(), 'Admin.AdvParameters.Notification');
                 }
             } catch (\Exception $e) {
-                $results['warnings'][] = $this->l('The confirmation email couldn\'t be sent, but the import is successfull. Yay!');
+                $results['warnings'][] = $this->trans('The confirmation email couldn\'t be sent, but the import is successful. Yay!', array(), 'Admin.AdvParameters.Notification');
             }
         }
 
@@ -4523,7 +4523,7 @@ class AdminImportControllerCore extends AdminController
         $this->modals[] = array(
              'modal_id' => 'importProgress',
              'modal_class' => 'modal-md',
-             'modal_title' => $this->l('Importing...'),
+             'modal_title' => $this->trans('Importing...', array(), 'Admin.AdvParameters.Notification'),
              'modal_content' => $modal_content
          );
     }

--- a/controllers/admin/AdminInformationController.php
+++ b/controllers/admin/AdminInformationController.php
@@ -108,27 +108,27 @@ class AdminInformationControllerCore extends AdminController
     public function getTestResult()
     {
         $tests_errors = array(
-            'phpversion' => $this->l('Update your PHP version.'),
-            'upload' => $this->l('Configure your server to allow file uploads.'),
-            'system' => $this->l('Configure your server to allow the creation of directories and files with write permissions.'),
-            'gd' => $this->l('Enable the GD library on your server.'),
-            'mysql_support' => $this->l('Enable the MySQL support on your server.'),
-            'config_dir' => $this->l('Set write permissions for the "config" folder.'),
-            'cache_dir' => $this->l('Set write permissions for the "cache" folder.'),
-            'sitemap' => $this->l('Set write permissions for the "sitemap.xml" file.'),
-            'img_dir' => $this->l('Set write permissions for the "img" folder and subfolders.'),
-            'log_dir' => $this->l('Set write permissions for the "log" folder and subfolders.'),
-            'mails_dir' => $this->l('Set write permissions for the "mails" folder and subfolders.'),
-            'module_dir' => $this->l('Set write permissions for the "modules" folder and subfolders.'),
-            'theme_lang_dir' => sprintf($this->l('Set the write permissions for the "themes%s/lang/" folder and subfolders, recursively.'), _THEME_NAME_),
-            'translations_dir' => $this->l('Set write permissions for the "translations" folder and subfolders.'),
-            'customizable_products_dir' => $this->l('Set write permissions for the "upload" folder and subfolders.'),
-            'virtual_products_dir' => $this->l('Set write permissions for the "download" folder and subfolders.'),
-            'fopen' => $this->l('Allow the PHP fopen() function on your server.'),
-            'gz' => $this->l('Enable GZIP compression on your server.'),
-            'files' => $this->l('Some PrestaShop files are missing from your server.'),
-            'new_phpversion' => sprintf($this->l('You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!'), phpversion()),
-            'apache_mod_rewrite' => $this->l('Enable the Apache mod_rewrite module')
+            'phpversion' => $this->trans('Update your PHP version.', array(), 'Admin.AdvParameters.Notification'),
+            'upload' => $this->trans('Configure your server to allow file uploads.', array(), 'Admin.AdvParameters.Notification'),
+            'system' => $this->trans('Configure your server to allow the creation of directories and files with write permissions.', array(), 'Admin.AdvParameters.Notification'),
+            'gd' => $this->trans('Enable the GD library on your server.', array(), 'Admin.AdvParameters.Notification'),
+            'mysql_support' => $this->trans('Enable the MySQL support on your server.', array(), 'Admin.AdvParameters.Notification'),
+            'config_dir' => $this->trans('Set write permissions for the "config" folder.', array(), 'Admin.AdvParameters.Notification'),
+            'cache_dir' => $this->trans('Set write permissions for the "cache" folder.', array(), 'Admin.AdvParameters.Notification'),
+            'sitemap' => $this->trans('Set write permissions for the "sitemap.xml" file.', array(), 'Admin.AdvParameters.Notification'),
+            'img_dir' => $this->trans('Set write permissions for the "img" folder and subfolders.', array(), 'Admin.AdvParameters.Notification'),
+            'log_dir' => $this->trans('Set write permissions for the "log" folder and subfolders.', array(), 'Admin.AdvParameters.Notification'),
+            'mails_dir' => $this->trans('Set write permissions for the "mails" folder and subfolders.', array(), 'Admin.AdvParameters.Notification'),
+            'module_dir' => $this->trans('Set write permissions for the "modules" folder and subfolders.', array(), 'Admin.AdvParameters.Notification'),
+            'theme_lang_dir' => $this->trans('Set the write permissions for the "themes%s/lang/" folder and subfolders, recursively.', array('%s' => _THEME_NAME_), 'Admin.AdvParameters.Notification'),
+            'translations_dir' => $this->trans('Set write permissions for the "translations" folder and subfolders.', array(), 'Admin.AdvParameters.Notification'),
+            'customizable_products_dir' => $this->trans('Set write permissions for the "upload" folder and subfolders.', array(), 'Admin.AdvParameters.Notification'),
+            'virtual_products_dir' => $this->trans('Set write permissions for the "download" folder and subfolders.', array(), 'Admin.AdvParameters.Notification'),
+            'fopen' => $this->trans('Allow the PHP fopen() function on your server.', array(), 'Admin.AdvParameters.Notification'),
+            'gz' => $this->trans('Enable GZIP compression on your server.', array(), 'Admin.AdvParameters.Notification'),
+            'files' => $this->trans('Some PrestaShop files are missing from your server.', array(), 'Admin.AdvParameters.Notification'),
+            'new_phpversion' => $this->trans('You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!', array('%s' => phpversion()), 'Admin.AdvParameters.Notification'),
+            'apache_mod_rewrite' => $this->trans('Enable the Apache mod_rewrite module', array(), 'Admin.AdvParameters.Notification')
         );
 
         // Functions list to test with 'test_system'

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -52,7 +52,7 @@ class AdminPerformanceControllerCore extends AdminController
     {
         $this->fields_form[0]['form'] = array(
             'legend' => array(
-                'title' => $this->l('Smarty'),
+                'title' => $this->trans('Smarty', array(), 'Admin.AdvParameters.Feature'),
                 'icon' => 'icon-briefcase'
             ),
             'input' => array(
@@ -62,32 +62,32 @@ class AdminPerformanceControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'radio',
-                    'label' => $this->l('Template compilation'),
+                    'label' => $this->trans('Template compilation', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'smarty_force_compile',
                     'values' => array(
                         array(
                             'id' => 'smarty_force_compile_'._PS_SMARTY_NO_COMPILE_,
                             'value' => _PS_SMARTY_NO_COMPILE_,
-                            'label' => $this->l('Never recompile template files'),
-                            'hint' => $this->l('This option should be used in a production environment.')
+                            'label' => $this->trans('Never recompile template files', array(), 'Admin.AdvParameters.Feature'),
+                            'hint' => $this->trans('This option should be used in a production environment.', array(), 'Admin.AdvParameters.Help')
                         ),
                         array(
                             'id' => 'smarty_force_compile_'._PS_SMARTY_CHECK_COMPILE_,
                             'value' => _PS_SMARTY_CHECK_COMPILE_,
-                            'label' => $this->l('Recompile templates if the files have been updated'),
-                            'hint' => $this->l('Templates are recompiled when they are updated. If you experience compilation troubles when you update your template files, you should use Force Compile instead of this option. It should never be used in a production environment.')
+                            'label' => $this->trans('Recompile templates if the files have been updated', array(), 'Admin.AdvParameters.Feature'),
+                            'hint' => $this->trans('Templates are recompiled when they are updated. If you experience compilation troubles when you update your template files, you should use Force Compile instead of this option. It should never be used in a production environment.', array(), 'Admin.AdvParameters.Help')
                         ),
                         array(
                             'id' => 'smarty_force_compile_'._PS_SMARTY_FORCE_COMPILE_,
                             'value' => _PS_SMARTY_FORCE_COMPILE_,
-                            'label' => $this->l('Force compilation'),
-                            'hint' => $this->l('This forces Smarty to (re)compile templates on every invocation. This is handy for development and debugging. Note: This should never be used in a production environment.')
+                            'label' => $this->trans('Force compilation', array(), 'Admin.AdvParameters.Feature'),
+                            'hint' => $this->trans('This forces Smarty to (re)compile templates on every invocation. This is handy for development and debugging. Note: This should never be used in a production environment.', array(), 'Admin.AdvParameters.Help')
                         )
                     )
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Cache'),
+                    'label' => $this->trans('Cache', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'smarty_cache',
                     'is_bool' => true,
                     'values' => array(
@@ -102,11 +102,11 @@ class AdminPerformanceControllerCore extends AdminController
                             'label' => $this->trans('No', array(), 'Admin.Global')
                         )
                     ),
-                    'hint' => $this->l('Should be enabled except for debugging.')
+                    'hint' => $this->trans('Should be enabled except for debugging.', array(), 'Admin.AdvParameters.Feature')
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Multi-front optimizations'),
+                    'label' => $this->trans('Multi-front optimizations', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'smarty_local',
                     'is_bool' => true,
                     'values' => array(
@@ -121,39 +121,39 @@ class AdminPerformanceControllerCore extends AdminController
                             'label' => $this->trans('No', array(), 'Admin.Global')
                         )
                     ),
-                    'hint' => $this->l('Should be enabled if you want to avoid to store the smarty cache on NFS.')
+                    'hint' => $this->trans('Should be enabled if you want to avoid to store the smarty cache on NFS.', array(), 'Admin.AdvParameters.Help')
                 ),
                 array(
                     'type' => 'radio',
-                    'label' => $this->l('Caching type'),
+                    'label' => $this->trans('Caching type', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'smarty_caching_type',
                     'values' => array(
                         array(
                             'id' => 'smarty_caching_type_filesystem',
                             'value' => 'filesystem',
-                            'label' => $this->l('File System').(is_writable(_PS_CACHE_DIR_.'smarty/cache') ? '' : ' '.sprintf($this->l('(the directory %s must be writable)'), realpath(_PS_CACHE_DIR_.'smarty/cache')))
+                            'label' => $this->trans('File System', array(), 'Admin.AdvParameters.Feature').(is_writable(_PS_CACHE_DIR_.'smarty/cache') ? '' : ' '.sprintf($this->trans('(the directory %s must be writable)', array(), 'Admin.AdvParameters.Notification'), realpath(_PS_CACHE_DIR_.'smarty/cache')))
                         ),
                         array(
                             'id' => 'smarty_caching_type_mysql',
                             'value' => 'mysql',
-                            'label' => $this->l('MySQL')
+                            'label' => $this->trans('MySQL', array(), 'Admin.AdvParameters.Feature')
                         ),
                     )
                 ),
                 array(
                     'type' => 'radio',
-                    'label' => $this->l('Clear cache'),
+                    'label' => $this->trans('Clear cache', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'smarty_clear_cache',
                     'values' => array(
                         array(
                             'id' => 'smarty_clear_cache_never',
                             'value' => 'never',
-                            'label' => $this->l('Never clear cache files'),
+                            'label' => $this->trans('Never clear cache files', array(), 'Admin.AdvParameters.Feature'),
                         ),
                         array(
                             'id' => 'smarty_clear_cache_everytime',
                             'value' => 'everytime',
-                            'label' => $this->l('Clear cache everytime something has been modified'),
+                            'label' => $this->trans('Clear cache everytime something has been modified', array(), 'Admin.AdvParameters.Feature'),
                         ),
                     )
                 ),
@@ -176,13 +176,13 @@ class AdminPerformanceControllerCore extends AdminController
     {
         $this->fields_form[1]['form'] = array(
             'legend' => array(
-                'title' => $this->l('Debug mode'),
+                'title' => $this->trans('Debug mode', array(), 'Admin.AdvParameters.Feature'),
                 'icon' => 'icon-bug'
             ),
             'input' => array(
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Disable non PrestaShop modules'),
+                    'label' => $this->trans('Disable non PrestaShop modules', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'native_module',
                     'class' => 't',
                     'is_bool' => true,
@@ -198,11 +198,11 @@ class AdminPerformanceControllerCore extends AdminController
                             'label' => $this->trans('Disabled', array(), 'Admin.Global')
                         )
                     ),
-                    'hint' => $this->l('Enable or disable non PrestaShop Modules.')
+                    'hint' => $this->trans('Enable or disable non PrestaShop Modules.', array(), 'Admin.AdvParameters.Feature')
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Disable all overrides'),
+                    'label' => $this->trans('Disable all overrides', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'overrides',
                     'class' => 't',
                     'is_bool' => true,
@@ -218,11 +218,11 @@ class AdminPerformanceControllerCore extends AdminController
                             'label' => $this->trans('Disabled', array(), 'Admin.Global')
                         )
                     ),
-                    'hint' => $this->l('Enable or disable all classes and controllers overrides.')
+                    'hint' => $this->trans('Enable or disable all classes and controllers overrides.', array(), 'Admin.AdvParameters.Feature')
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Debug mode'),
+                    'label' => $this->trans('Debug mode', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'debug_mode',
                     'class' => 't',
                     'is_bool' => true,
@@ -238,7 +238,7 @@ class AdminPerformanceControllerCore extends AdminController
                             'label' => $this->trans('Disabled', array(), 'Admin.Global')
                         )
                     ),
-                    'hint' => $this->l('Enable or disable debug mode.')
+                    'hint' => $this->trans('Enable or disable debug mode.', array(), 'Admin.AdvParameters.Help')
                 ),
             ),
             'submit' => array(
@@ -255,10 +255,10 @@ class AdminPerformanceControllerCore extends AdminController
     {
         $this->fields_form[2]['form'] = array(
             'legend' => array(
-                'title' => $this->l('Optional features'),
+                'title' => $this->trans('Optional features', array(), 'Admin.AdvParameters.Feature'),
                 'icon' => 'icon-puzzle-piece'
             ),
-            'description' => $this->l('Some features can be disabled in order to improve performance.'),
+            'description' => $this->trans('Some features can be disabled in order to improve performance.', array(), 'Admin.AdvParameters.Help'),
             'input' => array(
                 array(
                     'type' => 'hidden',
@@ -266,7 +266,7 @@ class AdminPerformanceControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Combinations'),
+                    'label' => $this->trans('Combinations', array(), 'Admin.Global'),
                     'name' => 'combination',
                     'is_bool' => true,
                     'disabled' => Combination::isCurrentlyUsed(),
@@ -282,12 +282,12 @@ class AdminPerformanceControllerCore extends AdminController
                             'label' => $this->trans('No', array(), 'Admin.Global')
                         )
                     ),
-                    'hint' => $this->l('Choose "No" to disable Product Combinations.'),
-                    'desc' => Combination::isCurrentlyUsed() ? $this->l('You cannot set this parameter to No when combinations are already used by some of your products') : null
+                    'hint' => $this->trans('Choose "No" to disable Product Combinations.', array(), 'Admin.AdvParameters.Help'),
+                    'desc' => Combination::isCurrentlyUsed() ? $this->trans('You cannot set this parameter to No when combinations are already used by some of your products', array(), 'Admin.AdvParameters.Help') : null
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Features'),
+                    'label' => $this->trans('Features', array(), 'Admin.Global'),
                     'name' => 'feature',
                     'is_bool' => true,
                     'values' => array(
@@ -302,11 +302,11 @@ class AdminPerformanceControllerCore extends AdminController
                             'label' => $this->trans('No', array(), 'Admin.Global')
                         )
                     ),
-                    'hint' => $this->l('Choose "No" to disable Product Features.')
+                    'hint' => $this->trans('Choose "No" to disable Product Features.', array(), 'Admin.AdvParameters.Help')
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Customer Groups'),
+                    'label' => $this->trans('Customer Groups', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'customer_group',
                     'is_bool' => true,
                     'disabled' => Group::isCurrentlyUsed(),
@@ -322,7 +322,7 @@ class AdminPerformanceControllerCore extends AdminController
                             'label' => $this->trans('No', array(), 'Admin.Global')
                         )
                     ),
-                    'hint' => $this->l('Choose "No" to disable Customer Groups.')
+                    'hint' => $this->trans('Choose "No" to disable Customer Groups.', array(), 'Admin.AdvParameters.Help')
                 )
             ),
             'submit' => array(
@@ -339,10 +339,10 @@ class AdminPerformanceControllerCore extends AdminController
     {
         $this->fields_form[3]['form'] = array(
             'legend' => array(
-                'title' => $this->l('CCC (Combine, Compress and Cache)'),
+                'title' => $this->trans('CCC (Combine, Compress and Cache)', array(), 'Admin.AdvParameters.Feature'),
                 'icon' => 'icon-fullscreen'
             ),
-            'description' => $this->l('CCC allows you to reduce the loading time of your page. With these settings you will gain performance without even touching the code of your theme. Make sure, however, that your theme is compatible with PrestaShop 1.4+. Otherwise, CCC will cause problems.'),
+            'description' => $this->trans('CCC allows you to reduce the loading time of your page. With these settings you will gain performance without even touching the code of your theme. Make sure, however, that your theme is compatible with PrestaShop 1.4+. Otherwise, CCC will cause problems.', array(), 'Admin.AdvParameters.Help'),
             'input' => array(
                 array(
                     'type' => 'hidden',
@@ -350,69 +350,69 @@ class AdminPerformanceControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Smart cache for CSS'),
+                    'label' => $this->trans('Smart cache for CSS', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'PS_CSS_THEME_CACHE',
                     'values' => array(
                         array(
                             'id' => 'PS_CSS_THEME_CACHE_1',
                             'value' => 1,
-                            'label' => $this->l('Use CCC for CSS')
+                            'label' => $this->trans('Use CCC for CSS', array(), 'Admin.AdvParameters.Feature')
                         ),
                         array(
                             'id' => 'PS_CSS_THEME_CACHE_0',
                             'value' => 0,
-                            'label' => $this->l('Keep CSS as original')
+                            'label' => $this->trans('Keep CSS as original', array(), 'Admin.AdvParameters.Feature')
                         )
                     )
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Smart cache for JavaScript'),
+                    'label' => $this->trans('Smart cache for JavaScript', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'PS_JS_THEME_CACHE',
                     'values' => array(
                         array(
                             'id' => 'PS_JS_THEME_CACHE_1',
                             'value' => 1,
-                            'label' => $this->l('Use CCC for JavaScript')
+                            'label' => $this->trans('Use CCC for JavaScript', array(), 'Admin.AdvParameters.Feature')
                         ),
                         array(
                             'id' => 'PS_JS_THEME_CACHE_0',
                             'value' => 0,
-                            'label' => $this->l('Keep JavaScript as original')
+                            'label' => $this->trans('Keep JavaScript as original', array(), 'Admin.AdvParameters.Feature')
                         )
                     )
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Compress inline JavaScript in HTML'),
+                    'label' => $this->trans('Compress inline JavaScript in HTML', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'PS_JS_HTML_THEME_COMPRESSION',
                     'values' => array(
                         array(
                             'id' => 'PS_JS_HTML_THEME_COMPRESSION_1',
                             'value' => 1,
-                            'label' => $this->l('Compress inline JavaScript in HTML after "Smarty compile" execution')
+                            'label' => $this->trans('Compress inline JavaScript in HTML after "Smarty compile" execution', array(), 'Admin.AdvParameters.Feature')
                         ),
                         array(
                             'id' => 'PS_JS_HTML_THEME_COMPRESSION_0',
                             'value' => 0,
-                            'label' => $this->l('Keep inline JavaScript in HTML as original')
+                            'label' => $this->trans('Keep inline JavaScript in HTML as original', array(), 'Admin.AdvParameters.Feature')
                         )
                     )
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Move JavaScript to the end'),
+                    'label' => $this->trans('Move JavaScript to the end', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'PS_JS_DEFER',
                     'values' => array(
                         array(
                             'id' => 'PS_JS_DEFER_1',
                             'value' => 1,
-                            'label' => $this->l('Move JavaScript to the end of the HTML document')
+                            'label' => $this->trans('Move JavaScript to the end of the HTML document', array(), 'Admin.AdvParameters.Feature')
                         ),
                         array(
                             'id' => 'PS_JS_DEFER_0',
                             'value' => 0,
-                            'label' => $this->l('Keep JavaScript in HTML at its original position')
+                            'label' => $this->trans('Keep JavaScript in HTML at its original position', array(), 'Admin.AdvParameters.Feature')
                         )
                     )
                 ),
@@ -426,9 +426,9 @@ class AdminPerformanceControllerCore extends AdminController
         if (!defined('_PS_HOST_MODE_')) {
             $this->fields_form[3]['form']['input'][] = array(
                 'type' => 'switch',
-                'label' => $this->l('Apache optimization'),
+                'label' => $this->trans('Apache optimization', array(), 'Admin.AdvParameters.Feature'),
                 'name' => 'PS_HTACCESS_CACHE_CONTROL',
-                'hint' => $this->l('This will add directives to your .htaccess file, which should improve caching and compression.'),
+                'hint' => $this->trans('This will add directives to your .htaccess file, which should improve caching and compression.', array(), 'Admin.AdvParameters.Help'),
                 'values' => array(
                     array(
                         'id' => 'PS_HTACCESS_CACHE_CONTROL_1',
@@ -456,10 +456,10 @@ class AdminPerformanceControllerCore extends AdminController
     {
         $this->fields_form[4]['form'] = array(
             'legend' => array(
-                'title' => $this->l('Media servers (use only with CCC)'),
+                'title' => $this->trans('Media servers (use only with CCC)', array(), 'Admin.AdvParameters.Feature'),
                 'icon' => 'icon-link'
             ),
-            'description' => $this->l('You must enter another domain, or subdomain, in order to use cookieless static content.'),
+            'description' => $this->trans('You must enter another domain, or subdomain, in order to use cookieless static content.', array(), 'Admin.AdvParameters.Feature'),
             'input' => array(
                 array(
                     'type' => 'hidden',
@@ -467,21 +467,21 @@ class AdminPerformanceControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->l('Media server #1'),
+                    'label' => $this->trans('Media server #1', array(), 'Admin.AdvParameters.Feature'),
                     'name' => '_MEDIA_SERVER_1_',
-                    'hint' => $this->l('Name of the second domain of your shop, (e.g. myshop-media-server-1.com). If you do not have another domain, leave this field blank.')
+                    'hint' => $this->trans('Name of the second domain of your shop, (e.g. myshop-media-server-1.com). If you do not have another domain, leave this field blank.', array(), 'Admin.AdvParameters.Help')
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->l('Media server #2'),
+                    'label' => $this->trans('Media server #2', array(), 'Admin.AdvParameters.Feature'),
                     'name' => '_MEDIA_SERVER_2_',
-                    'hint' => $this->l('Name of the third domain of your shop, (e.g. myshop-media-server-2.com). If you do not have another domain, leave this field blank.')
+                    'hint' => $this->trans('Name of the third domain of your shop, (e.g. myshop-media-server-2.com). If you do not have another domain, leave this field blank.', array(), 'Admin.AdvParameters.Help')
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->l('Media server #3'),
+                    'label' => $this->trans('Media server #3', array(), 'Admin.AdvParameters.Feature'),
                     'name' => '_MEDIA_SERVER_3_',
-                    'hint' => $this->l('Name of the fourth domain of your shop, (e.g. myshop-media-server-3.com). If you do not have another domain, leave this field blank.')
+                    'hint' => $this->trans('Name of the fourth domain of your shop, (e.g. myshop-media-server-3.com). If you do not have another domain, leave this field blank.', array(), 'Admin.AdvParameters.Help')
                 ),
             ),
             'submit' => array(
@@ -499,25 +499,40 @@ class AdminPerformanceControllerCore extends AdminController
         $phpdoc_langs = array('en', 'zh', 'fr', 'de', 'ja', 'pl', 'ro', 'ru', 'fa', 'es', 'tr');
         $php_lang = in_array($this->context->language->iso_code, $phpdoc_langs) ? $this->context->language->iso_code : 'en';
 
-        $warning_memcache = ' '.$this->l('(you must install the [a]Memcache PECL extension[/a])');
-        $warning_memcache = str_replace('[a]', '<a href="http://www.php.net/manual/'.substr($php_lang, 0, 2).'/memcache.installation.php" target="_blank">', $warning_memcache);
-        $warning_memcache = str_replace('[/a]', '</a>', $warning_memcache);
+        $warning_memcache = ' '.$this->trans('(you must install the [a]Memcache PECL extension[/a])',
+            array(
+                '[a]' => '<a href="http://www.php.net/manual/'.substr($php_lang, 0, 2).'/memcache.installation.php" target="_blank">',
+                '[/a]' => '</a>',
+            ),
+            'Admin.AdvParameters.Notification'
+        );
 
-        $warning_memcached = ' '.$this->l('(you must install the [a]Memcached PECL extension[/a])');
-        $warning_memcached = str_replace('[a]', '<a href="http://www.php.net/manual/'.substr($php_lang, 0, 2).'/memcached.installation.php" target="_blank">', $warning_memcached);
-        $warning_memcached = str_replace('[/a]', '</a>', $warning_memcached);
+        $warning_memcached = ' '.$this->trans('(you must install the [a]Memcached PECL extension[/a])',
+            array(
+                '[a]' => '<a href="http://www.php.net/manual/'.substr($php_lang, 0, 2).'/memcached.installation.php" target="_blank">',
+                '[/a]' => '</a>',
+            ),
+            'Admin.AdvParameters.Notification'
+        );
 
-        $warning_apc = ' '.$this->l('(you must install the [a]APC PECL extension[/a])');
-        $warning_apc = str_replace('[a]', '<a href="http://php.net/manual/'.substr($php_lang, 0, 2).'/apc.installation.php" target="_blank">', $warning_apc);
-        $warning_apc = str_replace('[/a]', '</a>', $warning_apc);
+        $warning_apc = ' '.$this->trans('(you must install the [a]APC PECL extension[/a])',
+            array(
+                '[a]' => '<a href="http://php.net/manual/'.substr($php_lang, 0, 2).'/apc.installation.php" target="_blank">',
+                '[/a]' => '</a>',
+            ),
+            'Admin.AdvParameters.Notification'
+        );
 
-        $warning_xcache = ' '.$this->l('(you must install the [a]Xcache extension[/a])');
-        $warning_xcache = str_replace('[a]', '<a href="http://xcache.lighttpd.net" target="_blank">', $warning_xcache);
-        $warning_xcache = str_replace('[/a]', '</a>', $warning_xcache);
+        $warning_xcache = ' '.$this->trans('(you must install the [a]Xcache extension[/a])', array(
+            '[a]' => '<a href="http://xcache.lighttpd.net" target="_blank">',
+            '[/a]' => '</a>',
+            ),
+            'Admin.AdvParameters.Notification'
+        );
 
         $this->fields_form[6]['form'] = array(
             'legend' => array(
-                'title' => $this->l('Caching'),
+                'title' => $this->trans('Caching', array(), 'Admin.AdvParameters.Feature'),
                 'icon' => 'icon-desktop'
             ),
             'input' => array(
@@ -527,7 +542,7 @@ class AdminPerformanceControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->l('Use cache'),
+                    'label' => $this->trans('Use cache', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'cache_active',
                     'is_bool' => true,
                     'values' => array(
@@ -545,28 +560,28 @@ class AdminPerformanceControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'radio',
-                    'label' => $this->l('Caching system'),
+                    'label' => $this->trans('Caching system', array(), 'Admin.AdvParameters.Feature'),
                     'name' => 'caching_system',
                     'values' => array(
                         array(
                             'id' => 'CacheMemcache',
                             'value' => 'CacheMemcache',
-                            'label' => $this->l('Memcached via PHP::Memcache').(extension_loaded('memcache') ? '' : $warning_memcache)
+                            'label' => $this->trans('Memcached via PHP::Memcache', array(), 'Admin.AdvParameters.Feature').(extension_loaded('memcache') ? '' : $warning_memcache)
                         ),
                         array(
                             'id' => 'CacheMemcached',
                             'value' => 'CacheMemcached',
-                            'label' => $this->l('Memcached via PHP::Memcached').(extension_loaded('memcached') ? '' : $warning_memcached)
+                            'label' => $this->trans('Memcached via PHP::Memcached', array(), 'Admin.AdvParameters.Feature').(extension_loaded('memcached') ? '' : $warning_memcached)
                         ),
                         array(
                             'id' => 'CacheApc',
                             'value' => 'CacheApc',
-                            'label' => $this->l('APC').((extension_loaded('apc') || extension_loaded('apcu'))? '' : $warning_apc)
+                            'label' => $this->trans('APC', array(), 'Admin.AdvParameters.Feature').((extension_loaded('apc') || extension_loaded('apcu'))? '' : $warning_apc)
                         ),
                         array(
                             'id' => 'CacheXcache',
                             'value' => 'CacheXcache',
-                            'label' => $this->l('Xcache').(extension_loaded('xcache') ? '' : $warning_xcache)
+                            'label' => $this->trans('Xcache', array(), 'Admin.AdvParameters.Feature').(extension_loaded('xcache') ? '' : $warning_xcache)
                         ),
 
                     )
@@ -622,7 +637,7 @@ class AdminPerformanceControllerCore extends AdminController
 
         $this->page_header_toolbar_btn['clear_cache'] = array(
             'href' => self::$currentIndex.'&token='.$this->token.'&empty_smarty_cache=1&empty_sf2_cache=1',
-            'desc' => $this->l('Clear cache'),
+            'desc' => $this->trans('Clear cache', array(), 'Admin.AdvParameters.Feature'),
             'icon' => 'process-icon-eraser'
         );
     }
@@ -756,9 +771,9 @@ class AdminPerformanceControllerCore extends AdminController
                         if (is_writable(_PS_ROOT_DIR_.'/.htaccess')) {
                             Tools::generateHtaccess();
                         } else {
-                            $message = $this->l('Before being able to use this tool, you need to:');
-                            $message .= '<br />- '.$this->l('Create a blank .htaccess in your root directory.');
-                            $message .= '<br />- '.$this->l('Give it write permissions (CHMOD 666 on Unix system).');
+                            $message = $this->trans('Before being able to use this tool, you need to:', array(), 'Admin.AdvParameters.Notification');
+                            $message .= '<br />- '.$this->trans('Create a blank .htaccess in your root directory.', array(), 'Admin.AdvParameters.Notification');
+                            $message .= '<br />- '.$this->trans('Give it write permissions (CHMOD 666 on Unix system).', array(), 'Admin.AdvParameters.Notification');
                             $this->errors[] = Tools::displayError($message, false);
                             Configuration::updateValue('PS_HTACCESS_CACHE_CONTROL', false);
                         }
@@ -804,9 +819,9 @@ class AdminPerformanceControllerCore extends AdminController
                         unset($this->_fieldsGeneral['_MEDIA_SERVER_3_']);
                         $redirectAdmin = true;
                     } else {
-                        $message = $this->l('Before being able to use this tool, you need to:');
-                        $message .= '<br />- '.$this->l('Create a blank .htaccess in your root directory.');
-                        $message .= '<br />- '.$this->l('Give it write permissions (CHMOD 666 on Unix system).');
+                        $message = $this->trans('Before being able to use this tool, you need to:', array(), 'Admin.AdvParameters.Notification');
+                        $message .= '<br />- '.$this->trans('Create a blank .htaccess in your root directory.', array(), 'Admin.AdvParameters.Notification');
+                        $message .= '<br />- '.$this->trans('Give it write permissions (CHMOD 666 on Unix system).', array(), 'Admin.AdvParameters.Notification');
                         $this->errors[] = Tools::displayError($message, false);
                         Configuration::updateValue('PS_HTACCESS_CACHE_CONTROL', false);
                     }
@@ -909,19 +924,19 @@ class AdminPerformanceControllerCore extends AdminController
             if (!empty($debug_mode_status)) {
                 switch ($debug_mode_status) {
                     case self::DEBUG_MODE_ERROR_COULD_NOT_BACKUP:
-                        $this->errors[] = Tools::displayError(sprintf($this->l('Error: could not write to file. Make sure that the correct permissions are set on the file %s'), _PS_ROOT_DIR_.'/config/defines.old.php'));
+                        $this->errors[] = Tools::displayError(sprintf($this->trans('Error: could not write to file. Make sure that the correct permissions are set on the file %s', array(), 'Admin.AdvParameters.Notification'), _PS_ROOT_DIR_.'/config/defines.old.php'));
                         break;
                     case self::DEBUG_MODE_ERROR_NO_DEFINITION_FOUND:
-                        $this->errors[] = Tools::displayError(sprintf($this->l('Error: could not find whether debug mode is enabled. Make sure that the correct permissions are set on the file %s'), _PS_ROOT_DIR_.'/config/defines.inc.php'));
+                        $this->errors[] = Tools::displayError(sprintf($this->trans('Error: could not find whether debug mode is enabled. Make sure that the correct permissions are set on the file %s', array(), 'Admin.AdvParameters.Notification'), _PS_ROOT_DIR_.'/config/defines.inc.php'));
                         break;
                     case self::DEBUG_MODE_ERROR_NO_WRITE_ACCESS:
-                        $this->errors[] = Tools::displayError(sprintf($this->l('Error: could not write to file. Make sure that the correct permissions are set on the file %s'), _PS_ROOT_DIR_.'/config/defines.inc.php'));
+                        $this->errors[] = Tools::displayError(sprintf($this->trans('Error: could not write to file. Make sure that the correct permissions are set on the file %s', array(), 'Admin.AdvParameters.Notification'), _PS_ROOT_DIR_.'/config/defines.inc.php'));
                         break;
                     case self::DEBUG_MODE_ERROR_NO_WRITE_ACCESS_CUSTOM:
-                        $this->errors[] = Tools::displayError(sprintf($this->l('Error: could not write to file. Make sure that the correct permissions are set on the file %s'), _PS_ROOT_DIR_.'/config/defines_custom.inc.php'));
+                        $this->errors[] = Tools::displayError(sprintf($this->trans('Error: could not write to file. Make sure that the correct permissions are set on the file %s', array(), 'Admin.AdvParameters.Notification'), _PS_ROOT_DIR_.'/config/defines_custom.inc.php'));
                         break;
                     case self::DEBUG_MODE_ERROR_NO_READ_ACCESS:
-                        $this->errors[] = Tools::displayError(sprintf($this->l('Error: could not read file. Make sure that the correct permissions are set on the file %s'), _PS_ROOT_DIR_.'/config/defines.inc.php'));
+                        $this->errors[] = Tools::displayError(sprintf($this->trans('Error: could not read file. Make sure that the correct permissions are set on the file %s', array(), 'Admin.AdvParameters.Notification'), _PS_ROOT_DIR_.'/config/defines.inc.php'));
                         break;
                     default:
                         break;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Add translations domains to controllers for Advanced Parameters section in BO. Another PR should follow. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | pouet pouet |
| How to test? | Check domains before Crowdin update. |

and a few wording updates for the Import controller.
@vincentbz: you might want to check, for your information.
