### PR TITLE
Ensured product has default combination

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1401,7 +1401,21 @@ class ProductCore extends ObjectModel
             }
         }
 
+
         return $res;
+    }
+
+    public function sortCombinationByAttributePosition($combinations, $langId)
+    {
+        $attributes = [];
+        foreach ($combinations as $combinationId) {
+            $attributeCombination = $this->getAttributeCombinationsById($combinationId, $langId);
+            $attributes[$attributeCombination[0]["position"]][$combinationId] = $attributeCombination[0];
+        }
+
+        ksort($attributes);
+
+        return $attributes;
     }
 
     /**


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The first generated product combination has is marked as default |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1617 |
| How to test? | Generate combinations and see if the first generated combination has been ticked as default |
