### PR TITLE
Make customer required fields translatable

### DIFF
--- a/admin-dev/themes/default/template/controllers/customers/helpers/required_fields.tpl
+++ b/admin-dev/themes/default/template/controllers/customers/helpers/required_fields.tpl
@@ -46,13 +46,13 @@
         </thead>
         <tbody>
         {foreach $table_fields as $field}
-          {if !in_array($field, $required_class_fields)}
+          {if !in_array($field.name, $required_class_fields)}
           <tr>
             <td class="noborder">
-              <input type="checkbox" name="fieldsBox[]" value="{$field}" {if in_array($field, $required_fields)} checked="checked"{/if} />
+              <input type="checkbox" name="fieldsBox[]" value="{$field.name}" {if in_array($field.name, $required_fields)} checked="checked"{/if} />
             </td>
             <td>
-              {$field}
+              {$field.label}
             </td>
           </tr>
           {/if}

--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -40,7 +40,6 @@ class AdminCustomersControllerCore extends AdminController
     {
         $this->bootstrap = true;
         $this->required_database = true;
-        $this->required_fields = array('optin');
         $this->table = 'customer';
         $this->className = 'Customer';
         $this->lang = false;
@@ -50,6 +49,13 @@ class AdminCustomersControllerCore extends AdminController
         $this->allow_export = true;
 
         parent::__construct();
+
+        $this->required_fields = array(
+            array(
+                'name' => 'optin',
+                'label' => $this->trans('Partner offers', array(), 'Admin.OrdersCustomers.Feature')
+            ),
+        );
 
         $this->addRowAction('edit');
         $this->addRowAction('view');


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Make customer required fields translatable, so we can update 'opt-in' to 'Partner offers' |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |

@AlexEven can you check the wording and domain, please?
