### PR TITLE
Added a check on directories filled in open_basedir option

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -122,7 +122,7 @@ class PhpIniRequirement extends Requirement
      *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
      * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
      *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
-     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
+     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally
      * @param string|null   $testMessage       The message for testing the requirement (when null and $evaluation is a boolean a default message is derived)
      * @param string|null   $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
      * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
@@ -224,7 +224,7 @@ class RequirementCollection implements IteratorAggregate
      *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
      * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
      *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
-     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
+     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally
      * @param string        $testMessage       The message for testing the requirement (when null and $evaluation is a boolean a default message is derived)
      * @param string        $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
      * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
@@ -242,7 +242,7 @@ class RequirementCollection implements IteratorAggregate
      *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
      * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
      *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
-     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
+     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally
      * @param string        $testMessage       The message for testing the requirement (when null and $evaluation is a boolean a default message is derived)
      * @param string        $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
      * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
@@ -510,6 +510,15 @@ class SymfonyRequirements extends RequirementCollection
             );
         }
 
+        if (!empty(ini_get('open_basedir'))) {
+            $this->addPhpIniRequirement(
+                'open_basedir',
+                'checkOpenBaseDirValidity',
+                false,
+                'open_basedir should only contains readable and writable paths to allow uploads.'
+            );
+        }
+
         if (extension_loaded('xdebug')) {
             $this->addPhpIniRequirement(
                 'xdebug.show_exception_trace', false, true
@@ -760,5 +769,26 @@ class SymfonyRequirements extends RequirementCollection
             default:
                 return (int) $size;
         }
+    }
+
+    private function checkOpenBaseDirValidity()
+    {
+        $openBaseDir = ini_get('open_basedir');
+
+        if (0 === strpos(strtolower(PHP_OS), 'win')) {
+            $separator = ';';
+        } else {
+            $separator = ':';
+        }
+
+        $directories = preg_split($separator, $openBaseDir);
+
+        foreach ($directories as $directory) {
+            if (!(is_readable($directory) && is_writable($directory))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -139,7 +139,6 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                     'title' => $this->translator->trans('Recommended PHP parameters', array(), 'Install'),
                     'success' => $this->tests['optional']['success'],
                     'checks' => array(
-                        'new_phpversion' => sprintf($this->translator->trans('You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!'), phpversion()),
                         'fopen' => $this->translator->trans('Cannot open external URLs', array(), 'Install'),
                         'gz' => $this->translator->trans('GZIP compression is not activated', array(), 'Install'),
                         'mbstring' => $this->translator->trans('Mbstring extension is not enabled', array(), 'Install'),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | `open_basedir` default value is null, and allow every path to be required. But some hosting providers set up some paths. We need to check in this case if theses paths are both readable and writable during installation because we use theses paths for our uploads. |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1325 |
| How to test? | Hmm, it's complicated. |
