### PR TITLE
Fix module import

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -491,7 +491,7 @@ var AdminModuleController = function() {
 
     // @see: dropzone.js
     Dropzone.options.importDropzone = {
-      url: 'import',
+      url: 'import' + window.location.search,
       acceptedFiles: '.zip, .tar',
       // The name that will be used to transfer the file
       paramName: 'file_uploaded',


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `develop` |
| Description? | Module upload was broken due to a missing token. I have no idea where to look for the token as the `token` variable wasn't available within the scope, so I just took `window.location.search`. Is that going to be the final solution? It sounds strange to me. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |
