### PR TITLE
Add attribute ID to product update response

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -138,6 +138,9 @@ class CartControllerCore extends FrontController
         if (Configuration::isCatalogMode()) {
             return;
         }
+
+        $id_product_attribute = (int)Product::getIdProductAttributesByIdAttributes($this->id_product, Tools::getValue('group'));
+
         $url = $this->context->link->getProductLink(
             $this->id_product,
             null,
@@ -145,7 +148,7 @@ class CartControllerCore extends FrontController
             null,
             $this->context->language->id,
             null,
-            (int)Product::getIdProductAttributesByIdAttributes($this->id_product, Tools::getValue('group')),
+            $id_product_attribute,
             false,
             false,
             true,
@@ -155,7 +158,8 @@ class CartControllerCore extends FrontController
         header('Content-Type: application/json');
         $this->ajaxDie(Tools::jsonEncode([
             'success' => true,
-            'productUrl' => $url
+            'productUrl' => $url,
+            'id_product_attribute' => $id_product_attribute
         ]));
     }
 

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -26,6 +26,7 @@ $(document).ready(function () {
           reason: {
             productUrl: resp.productUrl
           },
+          id_product_attribute: resp.id_product_attribute,
           refreshUrl: $productRefresh.data('url-update'),
           eventType: eventType
         });


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Add the attribute ID so that modules can read it directly without making another ajax call |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Sample code |

```
prestashop.on('updateProduct', function(resp){
    var id_product_attribute = resp.id_product_attribute;
    //...
});
```
