### PR TITLE
Fix Db PDO getBestEngine

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -367,10 +367,11 @@ class DbPDOCore extends Db
         $result = $this->link->query($sql);
         if (!$result) {
             $value = 'MyISAM';
-        }
-        $row = $result->fetch();
-        if (!$row || strtolower($row['Value']) != 'yes') {
-            $value = 'MyISAM';
+        } else {
+            $row = $result->fetch();
+            if (!$row || strtolower($row['Value']) != 'yes') {
+                $value = 'MyISAM';
+            }
         }
 
         /* MySQL >= 5.6 */


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `1.6.1.x` |
| Description? | When database is not innoDB, we try to fetch() a boolean result... so, avoid fetch() on null query result. This is a fix that has been applied to 1.7, but has not been applied to 1.6 |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |
