### PR TITLE
Invalidate Product cache on time

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1046,6 +1046,9 @@ class ProductCore extends ObjectModel
         }
 
         Db::getInstance()->insert('category_product', $product_cats);
+
+        Cache::clean('Product::getProductCategories_'.(int)$this->id);
+
         return true;
     }
 
@@ -1085,6 +1088,9 @@ class ProductCore extends ObjectModel
         }
 
         SpecificPriceRule::applyAllRules(array((int)$this->id));
+
+        Cache::clean('Product::getProductCategories_'.(int)$this->id);
+
         return true;
     }
 
@@ -1110,7 +1116,11 @@ class ProductCore extends ObjectModel
                 self::cleanPositions((int)$row['id_category'], (int)$row['position']);
             }
         }
+
         SpecificPriceRule::applyAllRules(array((int)$this->id));
+
+        Cache::clean('Product::getProductCategories_'.(int)$this->id);
+
         return $return;
     }
 
@@ -1136,6 +1146,8 @@ class ProductCore extends ObjectModel
                 $return &= self::cleanPositions((int)$row['id_category'], (int)$row['position']);
             }
         }
+
+        Cache::clean('Product::getProductCategories_'.(int)$this->id);
 
         return $return;
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `develop` |
| Description? | The product categories cache isn't always invalidated when it has to be. This PR fixes it. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8457 - http://forge.prestashop.com/browse/BOOM-1013 |
| How to test? | See the following code to paste in a module hooked on `actionObjectUpdateAfter` |
### Hook example

``` php
    public function hookActionObjectUpdateAfter(Array $params)
    {
        if (isset($params['object'])) {
            if ($params['object'] instanceof Product) {
                $product = new ProductCore($params['object']->id);
//                Cache::clean('Product::getProductCategories_'.(int)$params['object']->id);
                dump($product->getCategories());
            }
        }
    }
```
