### PR TITLE
Fix detection of APCu on Performance page

### DIFF
--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -584,7 +584,7 @@ class AdminPerformanceControllerCore extends AdminController
                         array(
                             'id' => 'CacheApc',
                             'value' => 'CacheApc',
-                            'label' => $this->l('APC').(extension_loaded('apc') ? '' : $warning_apc)
+                            'label' => $this->l('APC').((extension_loaded('apc') || extension_loaded('apcu')) ? '' : $warning_apc)
                         ),
                         array(
                             'id' => 'CacheXcache',
@@ -914,7 +914,7 @@ class AdminPerformanceControllerCore extends AdminController
                     } elseif ($caching_system == 'CacheMemcached' && !extension_loaded('memcached')) {
                         $this->errors[] = Tools::displayError('To use Memcached, you must install the Memcached PECL extension on your server.').'
 							<a href="http://www.php.net/manual/en/memcached.installation.php">http://www.php.net/manual/en/memcached.installation.php</a>';
-                    } elseif ($caching_system == 'CacheApc' && !extension_loaded('apc')) {
+                    } elseif ($caching_system == 'CacheApc' && !extension_loaded('apc') && !extension_loaded('apcu')) {
                         $this->errors[] = Tools::displayError('To use APC cache, you must install the APC PECL extension on your server.').'
 							<a href="http://fr.php.net/manual/fr/apc.installation.php">http://fr.php.net/manual/fr/apc.installation.php</a>';
                     } elseif ($caching_system == 'CacheXcache' && !extension_loaded('xcache')) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `1.6.1.x` |
| Description? | PrestaShop 1.6 doesn't detect the APCu extension correctly on the Performance page, even though it has been supported for a while. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8379 |
| How to test? |  |
