### PR TITLE
Automatically fill link_rewrite on new CMS category page (1.7)

### DIFF
--- a/controllers/admin/AdminCmsCategoriesController.php
+++ b/controllers/admin/AdminCmsCategoriesController.php
@@ -219,6 +219,7 @@ class AdminCmsCategoriesControllerCore extends AdminController
                     'type' => 'text',
                     'label' => $this->trans('Name', array(), 'Admin.Global'),
                     'name' => 'name',
+                    'class' => 'copyMeta2friendlyURL',
                     'required' => true,
                     'lang' => true,
                     'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info').' &lt;&gt;;=#{}'


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `develop` |
| Description? | Automatically fill the link_rewrite field when creating new CMS Category |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8378 |
| How to test? |  |
