### PR TITLE
Automatically fill link_rewrite on new CMS category page

### DIFF
--- a/controllers/admin/AdminCmsCategoriesController.php
+++ b/controllers/admin/AdminCmsCategoriesController.php
@@ -215,6 +215,7 @@ class AdminCmsCategoriesControllerCore extends AdminController
                     'type' => 'text',
                     'label' => $this->l('Name'),
                     'name' => 'name',
+                    'class' => 'copyMeta2friendlyURL',
                     'required' => true,
                     'lang' => true,
                     'hint' => $this->l('Invalid characters:').' &lt;&gt;;=#{}'


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `1.6.1.x` |
| Description? | Automatically fill the link_rewrite field when creating new CMS Category |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8378 |
| How to test? |  |
