### PR TITLE
Fix filtering on state in monitoring BO page

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -313,7 +313,7 @@
 								--
 							{else}
 								{if $params.type == 'bool'}
-									<select class="filter fixed-width-sm center" name="{$list_id}Filter_{$key}">
+									<select class="filter fixed-width-sm center" name="{$list_id}Filter_{if isset($params.filter_key)}{$params.filter_key}{else}{$key}{/if}">
 										<option value="">-</option>
 										<option value="1" {if $params.value == 1} selected="selected" {/if}>{l s='Yes'}</option>
 										<option value="0" {if $params.value == 0 && $params.value != ''} selected="selected" {/if}>{l s='No'}</option>

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -593,7 +593,11 @@ class HelperListCore extends Helper
                 $params['type'] = 'text';
             }
 
-            $value_key = $prefix.$this->list_id.'Filter_'.(array_key_exists('filter_key', $params) && $key != 'active' ? $params['filter_key'] : $key);
+            $value_key = $prefix.$this->list_id.'Filter_'.(array_key_exists('filter_key', $params) ? $params['filter_key'] : $key);
+            if ($key == 'active' && strpos($key, '!') !== false) {
+                $keys = explode('!', $params['filter_key']);
+                $value_key = $keys[1];
+            }
             $value = Context::getContext()->cookie->{$value_key};
             if (!$value && Tools::getIsset($value_key)) {
                 $value = Tools::getValue($value_key);

--- a/controllers/admin/AdminTrackingController.php
+++ b/controllers/admin/AdminTrackingController.php
@@ -146,7 +146,7 @@ class AdminTrackingControllerCore extends AdminController
             'id_product' => array('title' => $this->l('ID'), 'class' => 'fixed-width-xs', 'align' => 'center'),
             'reference' => array('title' => $this->l('Reference')),
             'name' => array('title' => $this->l('Name'), 'filter_key' => 'b!name'),
-            'active' => array('title' => $this->l('Status'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs')
+            'active' => array('title' => $this->l('Status'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs', 'filter_key' => 'a!active')
         );
 
         $this->clearFilters();
@@ -190,7 +190,7 @@ class AdminTrackingControllerCore extends AdminController
             'id_product' => array('title' => $this->l('ID'), 'class' => 'fixed-width-xs', 'align' => 'center'),
             'reference' => array('title' => $this->l('Reference')),
             'name' => array('title' => $this->l('Name')),
-            'active' => array('title' => $this->l('Status'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs')
+            'active' => array('title' => $this->l('Status'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs', 'filter_key' => 'a!active')
         );
         $this->clearFilters();
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `1.6.1.x` |
| Description? | You can't filter on status on the monitoring BO page. This PR adds support for bool filters on `HelperList` and adds `filter_key`s in order to solve the problem. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8345 |
| How to test? | When I go on "catalog" and "monitoring", and on the section "LIST OF PRODUCTS WITH ATTRIBUTES BUT WITHOUT AVAILABLE QUANTITIES FOR SALE"', when I select "yes" or "no" on the column "status", i get this error : "Unknown column 'sa.active' in 'where clause'". |
## Summary of fix

In order to properly filter `HelperList`s with an `active` column and joined tables, PrestaShop needs to allow the `filter_key` to be set for boolean values. In order to keep it backwards compatible, the `HelperList` still looks in `$this->fields_list['active']` for the actual value of the `active` column.
