### PR TITLE
Fix multilang link rewrite import

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1579,8 +1579,10 @@ class AdminImportControllerCore extends AdminController
                 );
             }
 
-            if (!($match_ref || $force_ids) || !(is_array($product->link_rewrite) && count($product->link_rewrite) && !empty($product->link_rewrite[$id_lang]))) {
+            if (!(is_array($product->link_rewrite) && count($product->link_rewrite))) {
                 $product->link_rewrite = AdminImportController::createMultiLangField($link_rewrite);
+            } else {
+                $product->link_rewrite[(int)$id_lang] = $link_rewrite;
             }
 
             // replace the value of separator by coma


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `1.6.1.x` |
| Description? | Previously PrestaShop would always change the rewrite link for every product. This behavior is now limited only to new products. In case of a product update, the link_rewrite will only be changed for the selected language regardless of the match reference or force ID setting. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8272  http://forge.prestashop.com/browse/PSCSX-3013  http://forge.prestashop.com/browse/PSCSX-4212  http://forge.prestashop.com/browse/PSCSX-4428  http://forge.prestashop.com/browse/PSCSX-3154  http://forge.prestashop.com/browse/PSCSX-3821 |
| How to test? | Import CSV with product ID of an existing product and link_rewrite, import this for a particular language and it should not override the product URLs of the other languages. |
