### PR TITLE
Fixed link to product in order

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/_customized_data.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_customized_data.tpl
@@ -35,7 +35,7 @@
 			{if isset($product['image']) && $product['image']->id|intval}{$product['image_tag']}{else}--{/if}
 		</td>
 		<td>
-			<a href="{$link->getAdminLink('AdminProducts')|escape:'html':'UTF-8'}&amp;id_product={$product['product_id']|intval}&amp;updateproduct&amp;token={getAdminToken tab='AdminProducts'}">
+			<a href="{$link->getAdminLink('AdminProducts', true, ['id_product' => $product['product_id']|intval, 'updateproduct' => '1'])|escape:'html':'UTF-8'}">
 			<span class="productName">{$product['product_name']} - {l s='Customized'}</span><br />
 			{if ($product['product_reference'])}{l s='Reference number:'} {$product['product_reference']}<br />{/if}
 			{if ($product['product_supplier_reference'])}{l s='Supplier reference:'} {$product['product_supplier_reference']}{/if}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The link to a product with customization in back-office order redirects to the catalogue |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1630 |
| How to test? | Make a new order containing a product with customization and check the product link in the back-office order is valid. |
