### PR TITLE
Checked available cipher method

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -363,7 +363,10 @@ class ConfigurationTestCore
 
     public static function test_openssl()
     {
-        return function_exists('openssl_encrypt');
+        return extension_loaded('openssl') &&
+            in_array(\Defuse\Crypto\Core::CIPHER_METHOD, openssl_get_cipher_methods()) &&
+            function_exists('openssl_encrypt')
+        ;
     }
 
     public static function test_sessions()

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -95,7 +95,11 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                         'upload' => $this->translator->trans('Cannot upload files', array(), 'Install'),
                         'system' => $this->translator->trans('Cannot create new files and folders', array(), 'Install'),
                         'gd' => $this->translator->trans('GD library is not installed', array(), 'Install'),
-                        'openssl' => $this->translator->trans('PHP OpenSSL extension is not loaded', array(), 'Install'),
+                        'openssl' => $this->translator->trans(
+                            'OpenSSL extension is not loaded or "aes-256-ctr" cipher method is not available',
+                            array(),
+                            'Install'
+                        ),
                         'pdo_mysql' => $this->translator->trans('PDO MySQL extension is not loaded', array(), 'Install'),
                         'zip' => $this->translator->trans('ZIP extension is not enabled', array(), 'Install'),
                     )


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | test |
| Description? | `aes-256-ctr` cipher method is now required. |
| Type? | improvement |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | N/A |
| How to test? | Installing prestashop without OpenSSL extension or cipher method missing would raise an error in the installer |
