### PR TITLE
Introduce a new hook to clean cache module

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -456,6 +456,7 @@ class AdminGroupsControllerCore extends AdminController
             $this->updateCategoryReduction();
             $object = parent::processSave();
             $this->updateRestrictions();
+            Hook::exec('clearModulesCache');
             return $object;
         }
     }

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -360,5 +360,8 @@
     <hook id="displayProductExtraContent">
       <name>displayProductExtraContent</name><title>Display extra content on the product page</title><description>This hook expects ProductExtraContent instances, which will be properly displayed by the template on the product page.</description>
     </hook>
+    <hook id="clearModulesCache">
+      <name>clearModulesCache</name><title>Delete cache for modules</title><description>This hook is used to delete cache for modules.</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -184,3 +184,5 @@ DELETE FROM `PREFIX_configuration` WHERE `name` IN ('PS_HTML_THEME_COMPRESSION',
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('validateCustomerFormFields', 'Customer registration form validation', 'This hook is called to a module when it has sent addtionnal fields with additionalCustomerFormFields', '1');
 
 INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('displayProductExtraContent', 'Display extra content on the product page', 'This hook expects ProductExtraContent instances, which will be properly displayed by the template on the product page.', '1');
+
+INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES ('clearModulesCache', 'Delete cache for modules', 'This hook is used to delete cache for modules.', '1');


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Introduce a new (generic) hook to clean cache of some modules when action are executed in BO |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1629 |
| How to test? | Check ps_featuredproducts after updating a customer group (discount, display prices, etc) : With https://github.com/PrestaShop/ps_featuredproducts/pull/5 |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
