### PR TITLE
Escaped percentage in parameters

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -84,6 +84,9 @@ if ($lastParametersModificationTime) {
     }
 
     $config = require_once _PS_CACHE_DIR_ . 'appParameters.php';
+    array_walk($config['parameters'], function (&$param) {
+        $param = str_replace('%%', '%', $param);
+    });
 
     $database_host = $config['parameters']['database_host'];
 

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -102,26 +102,30 @@ class InstallModelInstall extends InstallAbstractModel
         }
 
         $key = \Defuse\Crypto\Key::createNewRandomKey();
-
-        $parameters  = array_replace_recursive(
-            Yaml::parse(file_get_contents(_PS_ROOT_DIR_.'/app/config/parameters.yml.dist')),
-            array(
-                'parameters' => array(
-                    'database_host' => $database_host,
-                    'database_port' => $database_port,
-                    'database_user' => $database_user,
-                    'database_password' => $database_password,
-                    'database_name' => $database_name,
-                    'database_prefix' => $database_prefix,
-                    'database_engine' =>  $database_engine,
-                    'cookie_key' => $cookie_key,
-                    'cookie_iv' =>  $cookie_iv,
-                    'new_cookie_key' => $key->saveToAsciiSafeString(),
-                    'ps_creation_date' => date('Y-m-d'),
-                    'secret' => $secret,
-                    'locale' => $this->language->getLanguage()->getLocale(),
-                )
+        $parameters = array(
+            'parameters' => array(
+                'database_host' => $database_host,
+                'database_port' => $database_port,
+                'database_user' => $database_user,
+                'database_password' => $database_password,
+                'database_name' => $database_name,
+                'database_prefix' => $database_prefix,
+                'database_engine' =>  $database_engine,
+                'cookie_key' => $cookie_key,
+                'cookie_iv' =>  $cookie_iv,
+                'new_cookie_key' => $key->saveToAsciiSafeString(),
+                'ps_creation_date' => date('Y-m-d'),
+                'secret' => $secret,
+                'locale' => $this->language->getLanguage()->getLocale(),
             )
+        );
+        array_walk($parameters['parameters'], function (&$param) {
+            $param = str_replace('%', '%%', $param);
+        });
+
+        $parameters = array_replace_recursive(
+            Yaml::parse(file_get_contents(_PS_ROOT_DIR_.'/app/config/parameters.yml.dist')),
+            $parameters
         );
 
         $settings_content = "<?php\n";


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Parameters containing percentage symbols fails installation |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | N/A |
| How to test? | Add a parameter containing the percentage symbol to parameters.php like database password. The percentage symbol should be escaped with another percentage symbol |
