### PR TITLE
CSV Import: Prevent default category reset when already defined (1.7)

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1788,14 +1788,6 @@ class AdminImportControllerCore extends AdminController
             }
 
             $product->id_category = array_values(array_unique($product->id_category));
-
-            // Will update default category if category column is not ignored AND if there is categories that are set in the import file row.
-            if (isset($product->id_category[0])) {
-                $product->id_category_default = (int)$product->id_category[0];
-            } else {
-                $defaultProductShop = new Shop($product->id_shop_default);
-                $product->id_category_default = Category::getRootCategory(null, Validate::isLoadedObject($defaultProductShop)?$defaultProductShop:null)->id;
-            }
         }
 
         // Will update default category if there is none set here. Home if no category at all.


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Redundant code causes the default category of a product to be reset, even when it already has a default category and the default is not given in the CSV. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8501 |
| How to test? | Download the CSV from the ticket, change the product ID, link the columns (product ID, price) and check if the default category doesn't get reset anymore. |
