### PR TITLE
Fix the caption display language on the product page

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1546,6 +1546,7 @@ var formImagesProduct = (function() {
         url: dropZoneElem.find(".dz-preview[data-id='"+id+"']").attr('url-update'),
         success: function(response) {
           formZoneElem.find('#product-images-form').html(response);
+          form.switchLanguage($('#form_switch_language').val());
         },
         complete: function() {
           toggleColDropzone(false);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The caption language should always match the one of the BO |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1638 |
| How to test? | <ul><li>Install PrestaShop in FR and EN</li><li>Open a product with some images</li><li>Add a caption to some of these images</li><li>Set the language to FR</li><li>You should not see the caption on any image unless you set the language back to EN</li></ul> |
