### PR TITLE
Rework asset management

### DIFF
--- a/admin-dev/themes/default/template/controllers/performance/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/performance/helpers/form/form.tpl
@@ -207,7 +207,7 @@
 			$('#features_detachables_up').val(1);
 		});
 
-		$('input[name="_MEDIA_SERVER_1_"], input[name="_MEDIA_SERVER_2_"], input[name="_MEDIA_SERVER_3_"]').change(function(){
+		$('input[name="_MEDIA_SERVER_1_"]').change(function(){
 			$('#media_server_up').val(1);
 		});
 

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2879,6 +2879,49 @@ exit;
     }
 
     /**
+     * Fix native uasort see: http://php.net/manual/en/function.uasort.php#114535
+     *
+     * @param $array
+     * @param $cmp_function
+     */
+    public static function uasort(&$array, $cmp_function) {
+        if(count($array) < 2) {
+            return;
+        }
+        $halfway = count($array) / 2;
+        $array1 = array_slice($array, 0, $halfway, TRUE);
+        $array2 = array_slice($array, $halfway, NULL, TRUE);
+
+        self::uasort($array1, $cmp_function);
+        self::uasort($array2, $cmp_function);
+        if(call_user_func($cmp_function, end($array1), reset($array2)) < 1) {
+            $array = $array1 + $array2;
+            return;
+        }
+        $array = array();
+        reset($array1);
+        reset($array2);
+        while(current($array1) && current($array2)) {
+            if(call_user_func($cmp_function, current($array1), current($array2)) < 1) {
+                $array[key($array1)] = current($array1);
+                next($array1);
+            } else {
+                $array[key($array2)] = current($array2);
+                next($array2);
+            }
+        }
+        while(current($array1)) {
+            $array[key($array1)] = current($array1);
+            next($array1);
+        }
+        while(current($array2)) {
+            $array[key($array2)] = current($array2);
+            next($array2);
+        }
+        return;
+    }
+
+    /**
      * Copy the folder $src into $dst, $dst is created if it do not exist
      * @param      $src
      * @param      $dst

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1998,15 +1998,11 @@ class ToolsCore
 
     public static function getMediaServer($filename)
     {
-        if (self::$_cache_nb_media_servers === null && defined('_MEDIA_SERVER_1_') && defined('_MEDIA_SERVER_2_') && defined('_MEDIA_SERVER_3_')) {
+        if (self::$_cache_nb_media_servers === null && defined('_MEDIA_SERVER_1_')) {
             if (_MEDIA_SERVER_1_ == '') {
                 self::$_cache_nb_media_servers = 0;
-            } elseif (_MEDIA_SERVER_2_ == '') {
-                self::$_cache_nb_media_servers = 1;
-            } elseif (_MEDIA_SERVER_3_ == '') {
-                self::$_cache_nb_media_servers = 2;
             } else {
-                self::$_cache_nb_media_servers = 3;
+                self::$_cache_nb_media_servers = 1;
             }
         }
 
@@ -2116,15 +2112,8 @@ class ToolsCore
 
         fwrite($write_fd, "RewriteEngine on\n");
 
-        if (!$medias && Configuration::getMultiShopValues('PS_MEDIA_SERVER_1')
-            && Configuration::getMultiShopValues('PS_MEDIA_SERVER_2')
-            && Configuration::getMultiShopValues('PS_MEDIA_SERVER_3')
-        ) {
-            $medias = array(
-                Configuration::getMultiShopValues('PS_MEDIA_SERVER_1'),
-                Configuration::getMultiShopValues('PS_MEDIA_SERVER_2'),
-                Configuration::getMultiShopValues('PS_MEDIA_SERVER_3')
-            );
+        if (!$medias && Configuration::getMultiShopValues('PS_MEDIA_SERVER_1')) {
+            $medias = array(Configuration::getMultiShopValues('PS_MEDIA_SERVER_1'));
         }
 
         $media_domains = '';

--- a/classes/assets/AbstractAssetManager.php
+++ b/classes/assets/AbstractAssetManager.php
@@ -36,25 +36,18 @@ abstract class AbstractAssetManagerCore
 
     const DEFAULT_MEDIA = 'all';
     const DEFAULT_PRIORITY = 50;
-    const JS_BOTTOM = true;
+    const DEFAULT_JS_POSITION = 'bottom';
 
     public function __construct(array $directories, ConfigurationInterface $configuration)
     {
         $this->directories = $directories;
         $this->configuration = $configuration;
+
+        $this->list = $this->getDefaultList();
     }
 
-    public function getList()
-    {
-        uasort($this->list, function ($a, $b) {
-            if ($a['priority'] === $b['priority']) {
-                return 0;
-            }
-            return ($a['priority'] < $b['priority']) ? -1 : 1;
-        });
-
-        return $this->list;
-    }
+    abstract protected function getDefaultList();
+    abstract protected function getList();
 
     protected function getFullPath($relativePath)
     {

--- a/classes/assets/AbstractAssetManager.php
+++ b/classes/assets/AbstractAssetManager.php
@@ -34,6 +34,10 @@ abstract class AbstractAssetManagerCore
     protected $list = array();
     protected $fqdn;
 
+    const DEFAULT_MEDIA = 'all';
+    const DEFAULT_PRIORITY = 50;
+    const JS_BOTTOM = true;
+
     public function __construct(array $directories, ConfigurationInterface $configuration)
     {
         $this->directories = $directories;

--- a/classes/assets/AbstractAssetManager.php
+++ b/classes/assets/AbstractAssetManager.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+use \PrestaShop\PrestaShop\Core\ConfigurationInterface;
+
+abstract class AbstractAssetManagerCore
+{
+    protected $directories;
+    protected $configuration;
+    protected $list = array();
+    protected $fqdn;
+
+    public function __construct(array $directories, ConfigurationInterface $configuration)
+    {
+        $this->directories = $directories;
+        $this->configuration = $configuration;
+    }
+
+    public function getList()
+    {
+        uasort($this->list, function ($a, $b) {
+            if ($a['position'] === $b['position']) {
+                return 0;
+            }
+            return ($a['position'] < $b['position']) ? -1 : 1;
+        });
+
+        return $this->list;
+    }
+
+    protected function getFullPath($relativePath)
+    {
+        foreach ($this->directories as $baseDir) {
+            $fullPath = realpath($baseDir.'/'.$relativePath);
+            if (is_file($fullPath)) {
+                return $fullPath;
+            }
+        }
+    }
+
+    protected function getUriFromPath($fullPath)
+    {
+        $uri = str_replace(
+            $this->configuration->get('_PS_ROOT_DIR_').'/',
+            $this->configuration->get('__PS_BASE_URI__'),
+            $fullPath
+        );
+
+        return $uri;
+    }
+
+    protected function getFQDN()
+    {
+        if (is_null($this->fqdn)) {
+            $this->fqdn = ($this->configuration->get('PS_SSL_ENABLED'))
+                ? $this->configuration->get('_PS_BASE_URL_SSL_')
+                : $this->configuration->get('_PS_BASE_URL_');
+        }
+
+        return $this->fqdn;
+    }
+}

--- a/classes/assets/AbstractAssetManager.php
+++ b/classes/assets/AbstractAssetManager.php
@@ -43,10 +43,10 @@ abstract class AbstractAssetManagerCore
     public function getList()
     {
         uasort($this->list, function ($a, $b) {
-            if ($a['position'] === $b['position']) {
+            if ($a['priority'] === $b['priority']) {
                 return 0;
             }
-            return ($a['position'] < $b['position']) ? -1 : 1;
+            return ($a['priority'] < $b['priority']) ? -1 : 1;
         });
 
         return $this->list;

--- a/classes/assets/CccReducer.php
+++ b/classes/assets/CccReducer.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class CccReducerCore
+{
+    private $cacheDir;
+    protected $filesystem;
+
+    use PrestaShop\PrestaShop\Adapter\Assets\AssetUrlGeneratorTrait;
+
+    public function __construct($cacheDir, ConfigurationInterface $configuration, Filesystem $filesystem)
+    {
+        $this->cacheDir = $cacheDir;
+        $this->configuration = $configuration;
+        $this->filesystem = $filesystem;
+
+        if (!is_dir($this->cacheDir)) {
+            $this->filesystem->mkdir($this->cacheDir);
+        }
+    }
+
+    public function reduceCss($cssFileList)
+    {
+        $files = array();
+        foreach ($cssFileList['external'] as $css) {
+            if ('all' === $css['media']) {
+                $files[] = $css['path'];
+            }
+        }
+
+        $cccFilename = 'theme-'.$this->getFileNameIdentifierFromList($files).'.css';
+        $destinationPath = $this->cacheDir.$cccFilename;
+
+        if (!$this->filesystem->exists($destinationPath)) {
+            CssMinifier::minify($files, $destinationPath);
+        }
+
+        $cssFileList['external'] = [
+            'theme-ccc' => [
+                "id" => "theme-ccc",
+                "type" => "external",
+                "path" => $destinationPath,
+                "uri" => $this->getFQDN().$this->getUriFromPath($destinationPath),
+                "media" => "all",
+                "priority" => StylesheetManager::DEFAULT_PRIORITY,
+            ]
+        ];
+
+        return $cssFileList;
+    }
+
+    private function getFileNameIdentifierFromList(array $files)
+    {
+        return substr(sha1(implode('|', $files)), 0, 6);
+    }
+}

--- a/classes/assets/CssMinifier.php
+++ b/classes/assets/CssMinifier.php
@@ -25,38 +25,18 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-use \PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use MatthiasMullie\Minify\CSS;
 
-abstract class AbstractAssetManagerCore
+class CssMinifierCore
 {
-    protected $directories;
-    protected $configuration;
-    protected $list = array();
-
-    const DEFAULT_MEDIA = 'all';
-    const DEFAULT_PRIORITY = 50;
-    const DEFAULT_JS_POSITION = 'bottom';
-
-    use PrestaShop\PrestaShop\Adapter\Assets\AssetUrlGeneratorTrait;
-
-    public function __construct(array $directories, ConfigurationInterface $configuration)
+    public static function minify(array $files, $destination)
     {
-        $this->directories = $directories;
-        $this->configuration = $configuration;
+        $minifier = new CSS();
 
-        $this->list = $this->getDefaultList();
-    }
-
-    abstract protected function getDefaultList();
-    abstract protected function getList();
-
-    protected function getFullPath($relativePath)
-    {
-        foreach ($this->directories as $baseDir) {
-            $fullPath = realpath($baseDir.'/'.$relativePath);
-            if (is_file($fullPath)) {
-                return $fullPath;
-            }
+        foreach ($files as $file) {
+            $minifier->add($file);
         }
+
+        return $minifier->minify($destination);
     }
 }

--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -30,11 +30,17 @@ class JavascriptManagerCore extends AbstractAssetManager
     protected $list;
 
     protected $valid_position = ['head', 'bottom'];
+    protected $valid_attribute = ['async', 'defer'];
 
-    public function register($id, $relativePath, $position = self::DEFAULT_JS_POSITION, $priority = self::DEFAULT_PRIORITY, $inline = false)
-    {
+    public function register($id,
+        $relativePath,
+        $position = self::DEFAULT_JS_POSITION,
+        $priority = self::DEFAULT_PRIORITY,
+        $inline = false,
+        $attribute = null
+    ) {
         if ($fullPath = $this->getFullPath($relativePath)) {
-            $this->add($id, $fullPath, $position, $priority, $inline);
+            $this->add($id, $fullPath, $position, $priority, $inline, $attribute);
         }
     }
 
@@ -64,7 +70,7 @@ class JavascriptManagerCore extends AbstractAssetManager
         return $default;
     }
 
-    protected function add($id, $fullPath, $position, $priority, $inline)
+    protected function add($id, $fullPath, $position, $priority, $inline, $attribute)
     {
         if (filesize($fullPath) === 0) {
             return;
@@ -72,6 +78,7 @@ class JavascriptManagerCore extends AbstractAssetManager
 
         $priority = is_int($priority) ? $priority : self::DEFAULT_PRIORITY;
         $position = $this->getSanitizedPosition($position);
+        $attribute = $this->getSanitizedAttribute($attribute);
         $type = ($inline) ? 'inline' : 'external';
 
         $this->list[$position][$type][$id] = array(
@@ -80,6 +87,7 @@ class JavascriptManagerCore extends AbstractAssetManager
             'path' => $fullPath,
             'uri' => $this->getFQDN().$this->getUriFromPath($fullPath),
             'priority' => $priority,
+            'attribute' => $attribute,
         );
     }
 
@@ -105,6 +113,11 @@ class JavascriptManagerCore extends AbstractAssetManager
     private function getSanitizedPosition($position)
     {
         return in_array($position, $this->valid_position, true) ? $position : self::DEFAULT_JS_POSITION;
+    }
+
+    private function getSanitizedAttribute($attribute)
+    {
+        return in_array($attribute, $this->valid_attribute, true) ? $attribute : '';
     }
 
     private function sortList()

--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -124,7 +124,7 @@ class JavascriptManagerCore extends AbstractAssetManager
     {
         foreach ($this->valid_position as $position) {
             foreach ($this->list[$position] as $type => $items) {
-                uasort($items, function ($a, $b) {
+                Tools::uasort($items, function ($a, $b) {
                     if ($a['priority'] === $b['priority']) {
                         return 0;
                     }

--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+class JavascriptManagerCore extends AbstractAssetManager
+{
+    protected $list = array(
+        'head' => array(),
+        'bottom' => array()
+    );
+
+    public function register($id, $relativePath, $bottom = true, $position = 50)
+    {
+        if ($fullPath = $this->getFullPath($relativePath)) {
+            $this->add($id, $fullPath, $bottom, $position);
+        }
+    }
+
+    protected function add($id, $fullPath, $bottom, $priority)
+    {
+        if (filesize($fullPath) === 0) {
+            return;
+        }
+
+        $position = $bottom ? 'bottom' : 'head';
+
+        $this->list[$position][$id] = array(
+            'id' => $id,
+            'uri' => $this->getFQDN().$this->getUriFromPath($fullPath),
+            'priority' => $priority,
+        );
+    }
+
+    public function getList()
+    {
+        foreach ($this->list as &$sublist) {
+            uasort($sublist, function ($a, $b) {
+                if ($a['priority'] === $b['priority']) {
+                    return 0;
+                }
+                return ($a['priority'] < $b['priority']) ? -1 : 1;
+            });
+        }
+
+        return $this->list;
+    }
+}

--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -45,6 +45,10 @@ class JavascriptManagerCore extends AbstractAssetManager
             return;
         }
 
+        if (!is_int($priority)) {
+            $priority = self::DEFAULT_PRIORITY;
+        }
+
         $position = $bottom ? 'bottom' : 'head';
 
         $this->list[$position][$id] = array(

--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -32,10 +32,10 @@ class JavascriptManagerCore extends AbstractAssetManager
         'bottom' => array()
     );
 
-    public function register($id, $relativePath, $bottom = true, $position = 50)
+    public function register($id, $relativePath, $bottom = self::JS_BOTTOM, $priority = self::DEFAULT_PRIORITY)
     {
         if ($fullPath = $this->getFullPath($relativePath)) {
-            $this->add($id, $fullPath, $bottom, $position);
+            $this->add($id, $fullPath, $bottom, $priority);
         }
     }
 

--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -38,6 +38,19 @@ class JavascriptManagerCore extends AbstractAssetManager
         }
     }
 
+    public function unregisterById($idToRemove)
+    {
+        foreach ($this->valid_position as $position) {
+            foreach ($this->list[$position] as $type => $null) {
+                foreach ($this->list[$position][$type] as $id => $item) {
+                    if ($idToRemove === $id) {
+                        unset($this->list[$position][$type]);
+                    }
+                }
+            }
+        }
+    }
+
     protected function getDefaultList()
     {
         $default = [];

--- a/classes/assets/JsMinifier.php
+++ b/classes/assets/JsMinifier.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+use MatthiasMullie\Minify\JS;
+
+class JsMinifierCore
+{
+    public static function minify(array $files, $destination)
+    {
+        $minifier = new JS();
+
+        foreach ($files as $file) {
+            $minifier->add($file);
+        }
+
+        return $minifier->minify($destination);
+    }
+}

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -51,19 +51,26 @@ class StylesheetManagerCore
         $this->configuration = $configuration;
     }
 
-    public function register($id, $relativePath, $media, $position)
+    public function register($id, $relativePath, $media, $position = 50)
     {
         if ($fullPath = $this->getFullPath($relativePath)) {
-            $this->add($id, $fullPath, $this->getMedia($media));
+            $this->add($id, $fullPath, $this->getMedia($media), $position);
         }
     }
 
     public function getStylesheetList()
     {
+        uasort($this->list, function ($a, $b) {
+            if ($a['position'] === $b['position']) {
+                return 0;
+            }
+            return ($a['position'] < $b['position']) ? -1 : 1;
+        });
+
         return $this->list;
     }
 
-    private function add($id, $fullPath, $media)
+    private function add($id, $fullPath, $media, $position)
     {
         if (filesize($fullPath) === 0) {
             return;
@@ -73,6 +80,7 @@ class StylesheetManagerCore
             'id' => $id,
             'media' => $media,
             'uri' => $this->getFQDN().$this->getUriFromPath($fullPath),
+            'position' => $position,
         );
     }
 

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -1,0 +1,103 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+use \PrestaShop\PrestaShop\Core\ConfigurationInterface;
+
+class StylesheetManagerCore
+{
+    private $directories;
+    private $configuration;
+    private $list = array();
+    private $valid_media = array(
+        'all',
+        'braille',
+        'embossed',
+        'handheld',
+        'print',
+        'projection',
+        'screen',
+        'speech',
+        'tty',
+        'tv',
+    );
+
+    public function __construct(array $directories, ConfigurationInterface $configuration)
+    {
+        $this->directories = $directories;
+        $this->configuration = $configuration;
+    }
+
+    public function register($id, $relativePath, $media, $position)
+    {
+        if ($fullPath = $this->getFullPath($relativePath)) {
+            $this->add($id, $fullPath, $this->getMedia($media));
+        }
+    }
+
+    public function getStylesheetList()
+    {
+        return $this->list;
+    }
+
+    private function add($id, $fullPath, $media)
+    {
+        if (filesize($fullPath) === 0) {
+            return;
+        }
+
+        $this->list[$id] = array(
+            'id' => $id,
+            'media' => $media,
+            'uri' => $this->getUriFromPath($fullPath),
+        );
+    }
+
+    private function getFullPath($relativePath)
+    {
+        foreach ($this->directories as $baseDir) {
+            $fullPath = realpath($baseDir.'/'.$relativePath);
+            if (is_file($fullPath)) {
+                return $fullPath;
+            }
+        }
+    }
+
+    private function getMedia($media)
+    {
+        return in_array($media, $this->valid_media) ? $media : 'all';
+    }
+
+    private function getUriFromPath($fullPath)
+    {
+        $uri = str_replace(
+            $this->configuration->get('_PS_ROOT_DIR_').'/',
+            $this->configuration->get('__PS_BASE_URI__'),
+            $fullPath
+        );
+
+        return $uri;
+    }
+}

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -39,11 +39,23 @@ class StylesheetManagerCore extends AbstractAssetManager
         'tv',
     );
 
+    protected function getDefaultList()
+    {
+        return [];
+    }
+
     public function register($id, $relativePath, $media = self::DEFAULT_MEDIA, $priority = self::DEFAULT_PRIORITY)
     {
         if ($fullPath = $this->getFullPath($relativePath)) {
             $this->add($id, $fullPath, $media, $priority);
         }
+    }
+
+    public function getList()
+    {
+        $this->sortList();
+
+        return $this->list;
     }
 
     protected function add($id, $fullPath, $media, $priority)
@@ -60,8 +72,9 @@ class StylesheetManagerCore extends AbstractAssetManager
 
         $this->list[$id] = array(
             'id' => $id,
-            'media' => $media,
+            'path' => $fullPath,
             'uri' => $this->getFQDN().$this->getUriFromPath($fullPath),
+            'media' => $media,
             'priority' => $priority,
         );
     }
@@ -69,5 +82,15 @@ class StylesheetManagerCore extends AbstractAssetManager
     private function getSanitizedMedia($media)
     {
         return in_array($media, $this->valid_media) ? $media : self::DEFAULT_MEDIA;
+    }
+
+    private function sortList()
+    {
+        uasort($this->list, function ($a, $b) {
+            if ($a['priority'] === $b['priority']) {
+                return 0;
+            }
+            return ($a['priority'] < $b['priority']) ? -1 : 1;
+        });
     }
 }

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -39,14 +39,14 @@ class StylesheetManagerCore extends AbstractAssetManager
         'tv',
     );
 
-    public function register($id, $relativePath, $media, $position = 50)
+    public function register($id, $relativePath, $media, $priority = 50)
     {
         if ($fullPath = $this->getFullPath($relativePath)) {
-            $this->add($id, $fullPath, $this->getMedia($media), $position);
+            $this->add($id, $fullPath, $this->getMedia($media), $priority);
         }
     }
 
-    protected function add($id, $fullPath, $media, $position)
+    protected function add($id, $fullPath, $media, $priority)
     {
         if (filesize($fullPath) === 0) {
             return;
@@ -56,7 +56,7 @@ class StylesheetManagerCore extends AbstractAssetManager
             'id' => $id,
             'media' => $media,
             'uri' => $this->getFQDN().$this->getUriFromPath($fullPath),
-            'position' => $position,
+            'priority' => $priority,
         );
     }
 

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -39,7 +39,7 @@ class StylesheetManagerCore extends AbstractAssetManager
         'tv',
     );
 
-    public function register($id, $relativePath, $media, $priority = 50)
+    public function register($id, $relativePath, $media = 'all', $priority = 50)
     {
         if ($fullPath = $this->getFullPath($relativePath)) {
             $this->add($id, $fullPath, $this->getMedia($media), $priority);

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -86,7 +86,7 @@ class StylesheetManagerCore extends AbstractAssetManager
 
     private function getSanitizedMedia($media)
     {
-        return in_array($media, $this->valid_media) ? $media : self::DEFAULT_MEDIA;
+        return in_array($media, $this->valid_media, true) ? $media : self::DEFAULT_MEDIA;
     }
 
     private function sortList()

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -98,7 +98,7 @@ class StylesheetManagerCore extends AbstractAssetManager
     private function sortList()
     {
         foreach ($this->list as $type => &$items) {
-            uasort(
+            Tools::uasort(
                 $items,
                 function ($a, $b) {
                     if ($a['priority'] === $b['priority']) {

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -42,7 +42,7 @@ class StylesheetManagerCore extends AbstractAssetManager
     public function register($id, $relativePath, $media = self::DEFAULT_MEDIA, $priority = self::DEFAULT_PRIORITY)
     {
         if ($fullPath = $this->getFullPath($relativePath)) {
-            $this->add($id, $fullPath, $this->getMedia($media), $priority);
+            $this->add($id, $fullPath, $media, $priority);
         }
     }
 
@@ -50,6 +50,12 @@ class StylesheetManagerCore extends AbstractAssetManager
     {
         if (filesize($fullPath) === 0) {
             return;
+        }
+
+        $media = $this->getSanitizedMedia($media);
+
+        if (!is_int($priority)) {
+            $priority = self::DEFAULT_PRIORITY;
         }
 
         $this->list[$id] = array(
@@ -60,7 +66,7 @@ class StylesheetManagerCore extends AbstractAssetManager
         );
     }
 
-    private function getMedia($media)
+    private function getSanitizedMedia($media)
     {
         return in_array($media, $this->valid_media) ? $media : self::DEFAULT_MEDIA;
     }

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -51,6 +51,11 @@ class StylesheetManagerCore extends AbstractAssetManager
         }
     }
 
+    public function unregisterById($id)
+    {
+        unset($this->list[$id]);
+    }
+
     public function getList()
     {
         $this->sortList();

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -39,7 +39,7 @@ class StylesheetManagerCore extends AbstractAssetManager
         'tv',
     );
 
-    public function register($id, $relativePath, $media = 'all', $priority = 50)
+    public function register($id, $relativePath, $media = self::DEFAULT_MEDIA, $priority = self::DEFAULT_PRIORITY)
     {
         if ($fullPath = $this->getFullPath($relativePath)) {
             $this->add($id, $fullPath, $this->getMedia($media), $priority);
@@ -62,6 +62,6 @@ class StylesheetManagerCore extends AbstractAssetManager
 
     private function getMedia($media)
     {
-        return in_array($media, $this->valid_media) ? $media : 'all';
+        return in_array($media, $this->valid_media) ? $media : self::DEFAULT_MEDIA;
     }
 }

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -24,13 +24,8 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-use \PrestaShop\PrestaShop\Core\ConfigurationInterface;
-
-class StylesheetManagerCore
+class StylesheetManagerCore extends AbstractAssetManager
 {
-    private $directories;
-    private $configuration;
-    private $list = array();
     private $valid_media = array(
         'all',
         'braille',
@@ -43,13 +38,6 @@ class StylesheetManagerCore
         'tty',
         'tv',
     );
-    private $fqdn;
-
-    public function __construct(array $directories, ConfigurationInterface $configuration)
-    {
-        $this->directories = $directories;
-        $this->configuration = $configuration;
-    }
 
     public function register($id, $relativePath, $media, $position = 50)
     {
@@ -58,19 +46,7 @@ class StylesheetManagerCore
         }
     }
 
-    public function getStylesheetList()
-    {
-        uasort($this->list, function ($a, $b) {
-            if ($a['position'] === $b['position']) {
-                return 0;
-            }
-            return ($a['position'] < $b['position']) ? -1 : 1;
-        });
-
-        return $this->list;
-    }
-
-    private function add($id, $fullPath, $media, $position)
+    protected function add($id, $fullPath, $media, $position)
     {
         if (filesize($fullPath) === 0) {
             return;
@@ -84,40 +60,8 @@ class StylesheetManagerCore
         );
     }
 
-    private function getFullPath($relativePath)
-    {
-        foreach ($this->directories as $baseDir) {
-            $fullPath = realpath($baseDir.'/'.$relativePath);
-            if (is_file($fullPath)) {
-                return $fullPath;
-            }
-        }
-    }
-
     private function getMedia($media)
     {
         return in_array($media, $this->valid_media) ? $media : 'all';
-    }
-
-    private function getUriFromPath($fullPath)
-    {
-        $uri = str_replace(
-            $this->configuration->get('_PS_ROOT_DIR_').'/',
-            $this->configuration->get('__PS_BASE_URI__'),
-            $fullPath
-        );
-
-        return $uri;
-    }
-
-    private function getFQDN()
-    {
-        if (is_null($this->fqdn)) {
-            $this->fqdn = ($this->configuration->get('PS_SSL_ENABLED'))
-                ? $this->configuration->get('_PS_BASE_URL_SSL_')
-                : $this->configuration->get('_PS_BASE_URL_');
-        }
-
-        return $this->fqdn;
     }
 }

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -43,6 +43,7 @@ class StylesheetManagerCore
         'tty',
         'tv',
     );
+    private $fqdn;
 
     public function __construct(array $directories, ConfigurationInterface $configuration)
     {
@@ -71,7 +72,7 @@ class StylesheetManagerCore
         $this->list[$id] = array(
             'id' => $id,
             'media' => $media,
-            'uri' => $this->getUriFromPath($fullPath),
+            'uri' => $this->getFQDN().$this->getUriFromPath($fullPath),
         );
     }
 
@@ -99,5 +100,16 @@ class StylesheetManagerCore
         );
 
         return $uri;
+    }
+
+    private function getFQDN()
+    {
+        if (is_null($this->fqdn)) {
+            $this->fqdn = ($this->configuration->get('PS_SSL_ENABLED'))
+                ? $this->configuration->get('_PS_BASE_URL_SSL_')
+                : $this->configuration->get('_PS_BASE_URL_');
+        }
+
+        return $this->fqdn;
     }
 }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -541,23 +541,7 @@ abstract class ControllerCore
             $html = $this->context->smarty->fetch($content, null, $this->getLayout());
         }
 
-        $html = trim($html);
-
-        if (in_array($this->controller_type, array('front', 'modulefront')) && !empty($html) && $this->getLayout()) {
-            $html = trim(str_replace(array('</body>', '</html>'), '', $html))."\n";
-
-            $this->context->smarty->assign(array(
-                $js_tag => Media::getJsDef(),
-                'js_files' =>  array(),
-                'js_inline' => array(),
-            ));
-
-            $javascript = $this->context->smarty->fetch(_PS_ALL_THEMES_DIR_.'javascript.tpl');
-
-            echo preg_replace('/(?<!\$)'.$js_tag.'/', $javascript, $html).(empty($this->ajax) ? '</body></html>' : '');
-        } else {
-            echo $html;
-        }
+        echo trim($html);
     }
 
     /**

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -544,27 +544,17 @@ abstract class ControllerCore
         $html = trim($html);
 
         if (in_array($this->controller_type, array('front', 'modulefront')) && !empty($html) && $this->getLayout()) {
-            $dom_available = extension_loaded('dom') ? true : false;
-            $defer = (bool)Configuration::get('PS_JS_DEFER');
-
-            if ($defer && $dom_available) {
-                $html = Media::deferInlineScripts($html);
-            }
             $html = trim(str_replace(array('</body>', '</html>'), '', $html))."\n";
 
             $this->context->smarty->assign(array(
                 $js_tag => Media::getJsDef(),
-                'js_files' =>  $defer ? array_unique($this->js_files) : array(),
-                'js_inline' => ($defer && $dom_available) ? Media::getInlineScript() : array()
+                'js_files' =>  array(),
+                'js_inline' => array(),
             ));
 
             $javascript = $this->context->smarty->fetch(_PS_ALL_THEMES_DIR_.'javascript.tpl');
 
-            if ($defer) {
-                echo $html.$javascript.(empty($this->ajax) ? '</body></html>' : '');
-            } else {
-                echo preg_replace('/(?<!\$)'.$js_tag.'/', $javascript, $html).(empty($this->ajax) ? '</body></html>' : '');
-            }
+            echo preg_replace('/(?<!\$)'.$js_tag.'/', $javascript, $html).(empty($this->ajax) ? '</body></html>' : '');
         } else {
             echo $html;
         }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -977,12 +977,10 @@ class FrontControllerCore extends Controller
      */
     public function addMedia($media_uri, $css_media_type = null, $offset = null, $remove = false, $check_path = true)
     {
-        Tools::displayAsDeprecated(
-            'This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() and
-            $this->registerStylesheet() to manage your assets.'
-        );
-
-        return;
+        /*
+        This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() and
+        $this->registerStylesheet() to manage your assets.
+         */
     }
 
     /**
@@ -990,12 +988,10 @@ class FrontControllerCore extends Controller
      */
     public function removeMedia($media_uri, $css_media_type = null, $check_path = true)
     {
-        Tools::displayAsDeprecated(
-            'This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() and
-            $this->registerStylesheet() to manage your assets.'
-        );
-
-        return;
+        /*
+        This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() and
+        $this->registerStylesheet() to manage your assets.
+         */
     }
 
     public function registerStylesheet($id, $relativePath, $params = array())
@@ -1048,14 +1044,10 @@ class FrontControllerCore extends Controller
      */
     public function addCSS($css_uri, $css_media_type = 'all', $offset = null, $check_path = true)
     {
-        PrestaShopLogger::addLog(
-            'A module uses FrontController::addCSS() method, it should use $this->registerStylesheet() instead',
-            3,
-            null,
-            null,
-            null,
-            true
-        );
+        /*
+        This is deprecated in PrestaShop 1.7 and has no effect in PrestaShop 1.7 theme.
+        You should use registerStylesheet($id, $path, $params)
+        */
 
         if (!is_array($css_uri)) {
             $css_uri = (array) $css_uri;
@@ -1073,14 +1065,10 @@ class FrontControllerCore extends Controller
      */
     public function removeCSS($css_uri, $css_media_type = 'all', $check_path = true)
     {
-        PrestaShopLogger::addLog(
-            'A module uses FrontController::removeCSS() method, it should use $this->unregisterStylesheet() instead',
-            3,
-            null,
-            null,
-            null,
-            true
-        );
+        /*
+        This is deprecated in PrestaShop 1.7 and has no effect in PrestaShop 1.7 theme.
+        You should use unregisterStylesheet($id)
+        */
 
         if (!is_array($css_uri)) {
             $css_uri = (array) $css_uri;
@@ -1098,14 +1086,10 @@ class FrontControllerCore extends Controller
      */
     public function addJS($js_uri, $check_path = true)
     {
-        PrestaShopLogger::addLog(
-            'A module uses FrontController::addJS() method, it should use $this->registerJavascript() instead',
-            3,
-            null,
-            null,
-            null,
-            true
-        );
+        /*
+        This is deprecated in PrestaShop 1.7 and has no effect in PrestaShop 1.7 theme.
+        You should use registerJavascript($id, $path, $params)
+        */
 
         if (!is_array($js_uri)) {
             $js_uri = (array) $js_uri;
@@ -1123,14 +1107,10 @@ class FrontControllerCore extends Controller
      */
     public function removeJS($js_uri, $check_path = true)
     {
-        PrestaShopLogger::addLog(
-            'A module uses FrontController::removeJS() method, it should use $this->unregisterJavascript() instead',
-            3,
-            null,
-            null,
-            null,
-            true
-        );
+        /*
+        This is deprecated in PrestaShop 1.7 and has no effect in PrestaShop 1.7 theme.
+        You should use unregisterJavascript($id)
+        */
 
         if (!is_array($js_uri)) {
             $js_uri = (array) $js_uri;
@@ -1149,10 +1129,10 @@ class FrontControllerCore extends Controller
      */
     public function addJquery($version = null, $folder = null, $minifier = true)
     {
-        Tools::displayAsDeprecated(
-            'This function has no effect in PrestaShop 1.7 theme. jQuery2 is register by the core
-            on every theme. Have a look at the /themes/_core folder.'
-        );
+        /*
+        This is deprecated in PrestaShop 1.7 and has no effect in PrestaShop 1.7 theme.
+        jQuery2 is register by the core on every theme. Have a look at the /themes/_core folder.
+        */
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -814,9 +814,9 @@ class FrontControllerCore extends Controller
             $this->registerStylesheet('theme-rtl', '/assets/css/rtl.css', 'all', 10);
         }
 
-        $this->registerJavascript('corejs', '/themes/core.js', true, 0);
-        $this->registerJavascript('theme-main', '/assets/js/theme.js', true, 50);
-        $this->registerJavascript('theme-custom', '/assets/js/custom.js', true, 1000);
+        $this->registerJavascript('corejs', '/themes/core.js', 'bottom', 0);
+        $this->registerJavascript('theme-main', '/assets/js/theme.js', 'bottom', 50);
+        $this->registerJavascript('theme-custom', '/assets/js/custom.js', 'bottom', 1000);
 
         // Execute Hook FrontController SetMedia
         Hook::exec('actionFrontControllerSetMedia', array());
@@ -944,12 +944,12 @@ class FrontControllerCore extends Controller
         return;
     }
 
-    public function registerStylesheet($id, $relativePath, $media = 'all', $priority = 50)
+    public function registerStylesheet($id, $relativePath, $media = AbstractAssetManager::DEFAULT_MEDIA, $priority = AbstractAssetManager::DEFAULT_PRIORITY)
     {
         $this->stylesheetManager->register($id, $relativePath, $media, $priority);
     }
 
-    public function registerJavascript($id, $relativePath, $bottom = true, $priority = 50)
+    public function registerJavascript($id, $relativePath, $bottom = AbstractAssetManagerCore::JS_BOTTOM, $priority = AbstractAssetManager::DEFAULT_PRIORITY)
     {
         $this->javascriptManager->register($id, $relativePath, $bottom, $priority);
     }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -570,7 +570,13 @@ class FrontControllerCore extends Controller
      */
     public function getJavascript()
     {
-        return $this->javascriptManager->getList();
+        $jsFileList = $this->javascriptManager->getList();
+
+        if (Configuration::get('PS_JS_THEME_CACHE')) {
+            $jsFileList = $this->cccReducer->reduceJs($jsFileList);
+        }
+
+        return $jsFileList;
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -818,6 +818,15 @@ class FrontControllerCore extends Controller
         $this->registerJavascript('theme-main', '/assets/js/theme.js', 'bottom', 50);
         $this->registerJavascript('theme-custom', '/assets/js/custom.js', 'bottom', 1000);
 
+        if (!empty($assets = $this->context->shop->theme->getPageSpecificAssets($this->php_self))) {
+            foreach ($assets['css'] as $css) {
+                $this->registerStylesheet($css['id'], $css['path'], $css['media'], $css['priority']);
+            }
+            foreach ($assets['js'] as $js) {
+                $this->registerJavascript($js['id'], $js['path'], $js['bottom'], $js['priority']);
+            }
+        }
+
         // Execute Hook FrontController SetMedia
         Hook::exec('actionFrontControllerSetMedia', array());
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -823,7 +823,7 @@ class FrontControllerCore extends Controller
                 $this->registerStylesheet($css['id'], $css['path'], $css['media'], $css['priority']);
             }
             foreach ($assets['js'] as $js) {
-                $this->registerJavascript($js['id'], $js['path'], $js['bottom'], $js['priority']);
+                $this->registerJavascript($js['id'], $js['path'], $js['bottom'], $js['priority'], $js['inline']);
             }
         }
 
@@ -958,9 +958,9 @@ class FrontControllerCore extends Controller
         $this->stylesheetManager->register($id, $relativePath, $media, $priority);
     }
 
-    public function registerJavascript($id, $relativePath, $bottom = AbstractAssetManagerCore::JS_BOTTOM, $priority = AbstractAssetManager::DEFAULT_PRIORITY)
+    public function registerJavascript($id, $relativePath, $bottom = AbstractAssetManager::DEFAULT_JS_POSITION, $priority = AbstractAssetManager::DEFAULT_PRIORITY, $inline = false)
     {
-        $this->javascriptManager->register($id, $relativePath, $bottom, $priority);
+        $this->javascriptManager->register($id, $relativePath, $bottom, $priority, $inline);
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -953,9 +953,20 @@ class FrontControllerCore extends Controller
         return;
     }
 
-    public function registerStylesheet($id, $relativePath, $media = AbstractAssetManager::DEFAULT_MEDIA, $priority = AbstractAssetManager::DEFAULT_PRIORITY)
+    public function registerStylesheet($id, $relativePath, $params = array())
     {
-        $this->stylesheetManager->register($id, $relativePath, $media, $priority);
+        if (!is_array($params)) {
+            $params = array();
+        }
+
+        $default_params = [
+            'media' => AbstractAssetManager::DEFAULT_MEDIA,
+            'priority' => AbstractAssetManager::DEFAULT_PRIORITY,
+        ];
+
+        $params = array_merge($default_params, $params);
+
+        $this->stylesheetManager->register($id, $relativePath, $params['media'], $params['priority']);
     }
 
     public function unregisterStylesheet($id)
@@ -963,9 +974,21 @@ class FrontControllerCore extends Controller
         $this->stylesheetManager->unregisterById($id);
     }
 
-    public function registerJavascript($id, $relativePath, $bottom = AbstractAssetManager::DEFAULT_JS_POSITION, $priority = AbstractAssetManager::DEFAULT_PRIORITY, $inline = false)
+    public function registerJavascript($id, $relativePath, $params = array())
     {
-        $this->javascriptManager->register($id, $relativePath, $bottom, $priority, $inline);
+        if (!is_array($params)) {
+            $params = array();
+        }
+
+        $default_params = [
+            'bottom' => AbstractAssetManager::DEFAULT_JS_POSITION,
+            'priority' => AbstractAssetManager::DEFAULT_PRIORITY,
+            'inline' => false,
+        ];
+
+        $params = array_merge($default_params, $params);
+
+        $this->javascriptManager->register($id, $relativePath, $params['bottom'], $params['priority'], $params['inline']);
     }
 
     public function unregisterJavascript($id)

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -823,7 +823,7 @@ class FrontControllerCore extends Controller
                 $this->registerStylesheet($css['id'], $css['path'], $css['media'], $css['priority']);
             }
             foreach ($assets['js'] as $js) {
-                $this->registerJavascript($js['id'], $js['path'], $js['bottom'], $js['priority'], $js['inline']);
+                $this->registerJavascript($js['id'], $js['path'], $js['bottom'], $js['priority'], $js['inline'], $js['attribute']);
             }
         }
 
@@ -981,14 +981,15 @@ class FrontControllerCore extends Controller
         }
 
         $default_params = [
-            'bottom' => AbstractAssetManager::DEFAULT_JS_POSITION,
+            'position' => AbstractAssetManager::DEFAULT_JS_POSITION,
             'priority' => AbstractAssetManager::DEFAULT_PRIORITY,
             'inline' => false,
+            'attributes' => null,
         ];
 
         $params = array_merge($default_params, $params);
 
-        $this->javascriptManager->register($id, $relativePath, $params['bottom'], $params['priority'], $params['inline']);
+        $this->javascriptManager->register($id, $relativePath, $params['position'], $params['priority'], $params['inline'], $params['attributes']);
     }
 
     public function unregisterJavascript($id)

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -958,9 +958,19 @@ class FrontControllerCore extends Controller
         $this->stylesheetManager->register($id, $relativePath, $media, $priority);
     }
 
+    public function unregisterStylesheet($id)
+    {
+        $this->stylesheetManager->unregisterById($id);
+    }
+
     public function registerJavascript($id, $relativePath, $bottom = AbstractAssetManager::DEFAULT_JS_POSITION, $priority = AbstractAssetManager::DEFAULT_PRIORITY, $inline = false)
     {
         $this->javascriptManager->register($id, $relativePath, $bottom, $priority, $inline);
+    }
+
+    public function unregisterJavascript($id)
+    {
+        $this->javascriptManager->unregisterById($id);
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -863,7 +863,8 @@ class FrontControllerCore extends Controller
         $this->registerJavascript('theme-main', '/assets/js/theme.js', ['position' => 'bottom', 'priority' => 50]);
         $this->registerJavascript('theme-custom', '/assets/js/custom.js', ['position' => 'bottom', 'priority' => 1000]);
 
-        if (!empty($assets = $this->context->shop->theme->getPageSpecificAssets($this->php_self))) {
+        $assets = $this->context->shop->theme->getPageSpecificAssets($this->php_self);
+        if (!empty($assets)) {
             foreach ($assets['css'] as $css) {
                 $this->registerStylesheet($css['id'], $css['path'], $css);
             }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -605,12 +605,30 @@ class FrontControllerCore extends Controller
             'layout' => $this->getLayout(),
             'stylesheets' => $this->stylesheetManager->getList(),
             'javascript' => $this->javascriptManager->getList(),
+            'js_custom_vars' => Media::getJsDef(),
             'notifications' => $this->prepareNotifications(),
         ));
 
         $this->smartyOutputContent($this->template);
 
         return true;
+    }
+
+    protected function smartyOutputContent($content)
+    {
+        $this->context->cookie->write();
+
+        $html = '';
+
+        if (is_array($content)) {
+            foreach ($content as $tpl) {
+                $html .= $this->context->smarty->fetch($tpl, null, $this->getLayout());
+            }
+        } else {
+            $html = $this->context->smarty->fetch($content, null, $this->getLayout());
+        }
+
+        echo trim($html);
     }
 
     protected function prepareNotifications()

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -995,9 +995,10 @@ class FrontControllerCore extends Controller
         FrontController::addMedia($media_uri, $css_media_type, null, true, $check_path);
     }
 
-    public function registerStylesheet($id, $relativePath, $media, $position = 50)
+    public function registerStylesheet($id, $relativePath, $media, $priority = 50)
     {
-        $this->stylesheetManager->register($id, $relativePath, $media, $position);
+        $this->stylesheetManager->register($id, $relativePath, $media, $priority);
+    }
 
         return $this;
     }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -928,7 +928,7 @@ class FrontControllerCore extends Controller
     }
 
     /**
-     * @deprecated 1.7 this method has not effect with PrestaShop 1.7+
+     * @deprecated 1.7 use $this->registerJavascript() and $this->registerStylesheet() to manage your assets.
      */
     public function addMedia($media_uri, $css_media_type = null, $offset = null, $remove = false, $check_path = true)
     {
@@ -974,15 +974,28 @@ class FrontControllerCore extends Controller
     }
 
     /**
-     * @deprecated 1.7 This function has no effect in PrestaShop 1.7 theme, use $this->registerStylesheet() instead
+     * @deprecated 1.7 This function shouldn't be used, use $this->registerStylesheet() instead
      */
     public function addCSS($css_uri, $css_media_type = 'all', $offset = null, $check_path = true)
     {
-        Tools::displayAsDeprecated(
-            'This function has no effect in PrestaShop 1.7 theme, use $this->registerStylesheet() instead'
+        PrestaShopLogger::addLog(
+            'A module uses FrontController::addCSS() method, it should use $this->registerStylesheet() instead',
+            3,
+            null,
+            null,
+            null,
+            true
         );
 
-        return;
+        if (!is_array($css_uri)) {
+            $css_uri = (array) $css_uri;
+        }
+
+        foreach ($css_uri as $legacy_uri) {
+            if ($uri = $this->getAssetUriFromLegacyDeprecatedMethod($legacy_uri)) {
+                $this->registerStylesheet(sha1($uri), $uri, $css_media_type, 80);
+            }
+        }
     }
 
     /**
@@ -990,11 +1003,24 @@ class FrontControllerCore extends Controller
      */
     public function removeCSS($css_uri, $css_media_type = 'all', $check_path = true)
     {
-        Tools::displayAsDeprecated(
-            'This function has no effect in PrestaShop 1.7 theme, use $this->unregisterStylesheet() instead'
+        PrestaShopLogger::addLog(
+            'A module uses FrontController::removeCSS() method, it should use $this->unregisterStylesheet() instead',
+            3,
+            null,
+            null,
+            null,
+            true
         );
 
-        return;
+        if (!is_array($css_uri)) {
+            $css_uri = (array) $css_uri;
+        }
+
+        foreach ($css_uri as $legacy_uri) {
+            if ($uri = $this->getAssetUriFromLegacyDeprecatedMethod($legacy_uri)) {
+                $this->unregisterStylesheet(sha1($uri));
+            }
+        }
     }
 
     /**
@@ -1002,11 +1028,24 @@ class FrontControllerCore extends Controller
      */
     public function addJS($js_uri, $check_path = true)
     {
-        Tools::displayAsDeprecated(
-            'This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() instead'
+        PrestaShopLogger::addLog(
+            'A module uses FrontController::addJS() method, it should use $this->registerJavascript() instead',
+            3,
+            null,
+            null,
+            null,
+            true
         );
 
-        return;
+        if (!is_array($js_uri)) {
+            $js_uri = (array) $js_uri;
+        }
+
+        foreach ($js_uri as $legacy_uri) {
+            if ($uri = $this->getAssetUriFromLegacyDeprecatedMethod($legacy_uri)) {
+                $this->registerJavascript(sha1($uri), $uri, 'bottom', 80);
+            }
+        }
     }
 
     /**
@@ -1014,15 +1053,29 @@ class FrontControllerCore extends Controller
      */
     public function removeJS($js_uri, $check_path = true)
     {
-        Tools::displayAsDeprecated(
-            'This function has no effect in PrestaShop 1.7 theme, use $this->unregisterJavascript() instead'
+        PrestaShopLogger::addLog(
+            'A module uses FrontController::removeJS() method, it should use $this->unregisterJavascript() instead',
+            3,
+            null,
+            null,
+            null,
+            true
         );
 
-        return;
+        if (!is_array($js_uri)) {
+            $js_uri = (array) $js_uri;
+        }
+
+        foreach ($js_uri as $legacy_uri) {
+            if ($uri = $this->getAssetUriFromLegacyDeprecatedMethod($legacy_uri)) {
+                $this->unregisterJavascript(sha1($uri));
+            }
+        }
     }
 
     /**
-     * @deprecated 1.7
+     * @deprecated 1.7  This function has no effect in PrestaShop 1.7 theme. jQuery2 is register by the core on every theme.
+     *                  Have a look at the /themes/_core folder.
      */
     public function addJquery($version = null, $folder = null, $minifier = true)
     {
@@ -1030,8 +1083,6 @@ class FrontControllerCore extends Controller
             'This function has no effect in PrestaShop 1.7 theme. jQuery2 is register by the core
             on every theme. Have a look at the /themes/_core folder.'
         );
-
-        return;
     }
 
     /**
@@ -1735,5 +1786,18 @@ class FrontControllerCore extends Controller
     public function getRestrictedCountry()
     {
         return $this->restrictedCountry;
+    }
+
+    public function getAssetUriFromLegacyDeprecatedMethod($legacy_uri)
+    {
+        $success = preg_match('/modules\/.*/', $legacy_uri, $matches);
+        if (!$success) {
+            Tools::displayAsDeprecated(
+                'Backward compatiblity for this method couldn\'t be handled. Use $this->registerJavascript() instead'
+            );
+            return false;
+        } else {
+            return $matches[0];
+        }
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -605,9 +605,6 @@ class FrontControllerCore extends Controller
             'layout' => $this->getLayout(),
             'stylesheets' => $this->stylesheetManager->getList(),
             'javascript' => $this->javascriptManager->getList(),
-            'css_files' => $this->css_files,
-            'js_files' => ($this->getLayout() && (bool) Configuration::get('PS_JS_DEFER')) ? array() : $this->js_files,
-            'js_defer' => (bool) Configuration::get('PS_JS_DEFER'),
             'notifications' => $this->prepareNotifications(),
         ));
 
@@ -922,85 +919,29 @@ class FrontControllerCore extends Controller
     }
 
     /**
-     * Adds a media file(s) (CSS, JS) to page header.
-     *
-     * @param string|array $media_uri      Path to file, or an array of paths like: array(array(uri => media_type), ...)
-     * @param string|null  $css_media_type CSS media type
-     * @param int|null     $offset
-     * @param bool         $remove         If True, removes media files
-     * @param bool         $check_path     If true, checks if files exists
-     *
-     * @return true|void
+     * @deprecated 1.7 this method has not effect with PrestaShop 1.7+
      */
     public function addMedia($media_uri, $css_media_type = null, $offset = null, $remove = false, $check_path = true)
     {
-        if (!is_array($media_uri)) {
-            if ($css_media_type) {
-                $media_uri = array($media_uri => $css_media_type);
-            } else {
-                $media_uri = array($media_uri);
-            }
-        }
+        Tools::displayAsDeprecated(
+            'This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() and
+            $this->registerStylesheet() to manage your assets.'
+        );
 
-        $list_uri = array();
-        foreach ($media_uri as $file => $media) {
-            if (!Validate::isAbsoluteUrl($media)) {
-                $different = 0;
-                $different_css = 0;
-                $type = 'css';
-                if (!$css_media_type) {
-                    $type = 'js';
-                    $file = $media;
-                }
-                if (strpos($file, __PS_BASE_URI__.'modules/') === 0) {
-                    $override_path = str_replace(__PS_BASE_URI__.'modules/', _PS_ROOT_DIR_.'/themes/'._THEME_NAME_.'/modules/', $file, $different);
-                    if (strrpos($override_path, $type.'/'.basename($file)) !== false) {
-                        $override_path_css = str_replace($type.'/'.basename($file), basename($file), $override_path, $different_css);
-                    }
-
-                    if ($different && @filemtime($override_path)) {
-                        $file = str_replace(__PS_BASE_URI__.'modules/', __PS_BASE_URI__.'themes/'._THEME_NAME_.'/modules/', $file, $different);
-                    } elseif ($different_css && @filemtime($override_path_css)) {
-                        $file = $override_path_css;
-                    }
-                    if ($css_media_type) {
-                        $list_uri[$file] = $media;
-                    } else {
-                        $list_uri[] = $file;
-                    }
-                } else {
-                    $list_uri[$file] = $media;
-                }
-            } else {
-                $list_uri[$file] = $media;
-            }
-        }
-
-        if ($remove) {
-            if ($css_media_type) {
-                return parent::removeCSS($list_uri, $css_media_type);
-            }
-
-            return parent::removeJS($list_uri);
-        }
-
-        if ($css_media_type) {
-            return parent::addCSS($list_uri, $css_media_type, $offset, $check_path);
-        }
-
-        return parent::addJS($list_uri, $check_path);
+        return;
     }
 
     /**
-     * Removes media file(s) from page header.
-     *
-     * @param string|array $media_uri      Path to file, or an array paths of like: array(array(uri => media_type), ...)
-     * @param string|null  $css_media_type CSS media type
-     * @param bool         $check_path     If true, checks if files exists
+     * @deprecated 1.7 this method has not effect with PrestaShop 1.7+
      */
     public function removeMedia($media_uri, $css_media_type = null, $check_path = true)
     {
-        FrontController::addMedia($media_uri, $css_media_type, null, true, $check_path);
+        Tools::displayAsDeprecated(
+            'This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() and
+            $this->registerStylesheet() to manage your assets.'
+        );
+
+        return;
     }
 
     public function registerStylesheet($id, $relativePath, $media = 'all', $priority = 50)
@@ -1014,62 +955,78 @@ class FrontControllerCore extends Controller
     }
 
     /**
-     * Add one or several CSS for front, checking if css files are overridden in theme/css/modules/ directory.
-     *
-     * @see Controller::addCSS()
-     *
-     * @param array|string $css_uri        $media_uri Path to file, or an array of paths like: array(array(uri => media_type), ...)
-     * @param string       $css_media_type CSS media type
-     * @param int|null     $offset
-     * @param bool         $check_path     If true, checks if files exists
-     *
-     * @return true|void
+     * @deprecated 1.7 This function has no effect in PrestaShop 1.7 theme, use $this->registerStylesheet() instead
      */
     public function addCSS($css_uri, $css_media_type = 'all', $offset = null, $check_path = true)
     {
-        return FrontController::addMedia($css_uri, $css_media_type, $offset, false, $check_path);
+        Tools::displayAsDeprecated(
+            'This function has no effect in PrestaShop 1.7 theme, use $this->registerStylesheet() instead'
+        );
+
+        return;
     }
 
     /**
-     * Removes CSS file(s) from page header.
-     *
-     * @param array|string $css_uri        $media_uri Path to file, or an array of paths like: array(array(uri => media_type), ...)
-     * @param string       $css_media_type CSS media type
-     * @param bool         $check_path     If true, checks if files exists
+     * @deprecated 1.7 This function has no effect in PrestaShop 1.7 theme, use $this->unregisterStylesheet() instead
      */
     public function removeCSS($css_uri, $css_media_type = 'all', $check_path = true)
     {
-        return FrontController::removeMedia($css_uri, $css_media_type, $check_path);
+        Tools::displayAsDeprecated(
+            'This function has no effect in PrestaShop 1.7 theme, use $this->unregisterStylesheet() instead'
+        );
+
+        return;
     }
 
     /**
-     * Add one or several JS files for front, checking if js files are overridden in theme/js/modules/ directory.
-     *
-     * @see Controller::addJS()
-     *
-     * @param array|string $js_uri     Path to file, or an array of paths
-     * @param bool         $check_path If true, checks if files exists
-     *
-     * @return true|void
+     * @deprecated 1.7 This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() instead
      */
     public function addJS($js_uri, $check_path = true)
     {
-        if (_PS_MODE_DEV_ && Tools::getValue('debug-disable-javascript')) {
-            return;
-        }
+        Tools::displayAsDeprecated(
+            'This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() instead'
+        );
 
-        return Frontcontroller::addMedia($js_uri, null, null, false, $check_path);
+        return;
     }
 
     /**
-     * Removes JS file(s) from page header.
-     *
-     * @param array|string $js_uri     Path to file, or an array of paths
-     * @param bool         $check_path If true, checks if files exists
+     * @deprecated 1.7 This function has no effect in PrestaShop 1.7 theme, use $this->unregisterJavascript() instead
      */
     public function removeJS($js_uri, $check_path = true)
     {
-        return FrontController::removeMedia($js_uri, null, $check_path);
+        Tools::displayAsDeprecated(
+            'This function has no effect in PrestaShop 1.7 theme, use $this->unregisterJavascript() instead'
+        );
+
+        return;
+    }
+
+    /**
+     * @deprecated 1.7
+     */
+    public function addJquery($version = null, $folder = null, $minifier = true)
+    {
+        Tools::displayAsDeprecated(
+            'This function has no effect in PrestaShop 1.7 theme. jQuery2 is register by the core
+            on every theme. Have a look at the /themes/_core folder.'
+        );
+
+        return;
+    }
+
+    /**
+     * @deprecated 1.7
+     */
+    public function addJqueryUI($component, $theme = 'base', $check_dependencies = true)
+    {
+        Tools::displayAsDeprecated(
+            'This function has no effect in PrestaShop 1.7 theme, manage your dependencies in your
+            themes and modules and don\'t rely on PrestaShop embeded libraries. Use $this->registerJavascript() and
+            $this->registerStylesheet() to manage your assets.'
+        );
+
+        return;
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -980,11 +980,12 @@ class FrontControllerCore extends Controller
         $default_params = [
             'media' => AbstractAssetManager::DEFAULT_MEDIA,
             'priority' => AbstractAssetManager::DEFAULT_PRIORITY,
+            'inline' => false,
         ];
 
         $params = array_merge($default_params, $params);
 
-        $this->stylesheetManager->register($id, $relativePath, $params['media'], $params['priority']);
+        $this->stylesheetManager->register($id, $relativePath, $params['media'], $params['priority'], $params['inline']);
     }
 
     public function unregisterStylesheet($id)

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -594,7 +594,7 @@ class FrontControllerCore extends Controller
 
         $this->context->smarty->assign(array(
             'layout' => $this->getLayout(),
-            'stylesheets' => $this->stylesheetManager->getStylesheetList(),
+            'stylesheets' => $this->stylesheetManager->getList(),
             'css_files' => $this->css_files,
             'js_files' => ($this->getLayout() && (bool) Configuration::get('PS_JS_DEFER')) ? array() : $this->js_files,
             'js_defer' => (bool) Configuration::get('PS_JS_DEFER'),

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -161,6 +161,11 @@ class FrontControllerCore extends Controller
     protected $stylesheetManager;
 
     /**
+     * @var object JavascriptManager
+     */
+    protected $javascriptManager;
+
+    /**
      * Controller constructor.
      *
      * @global bool $useSSL SSL connection flag
@@ -189,6 +194,10 @@ class FrontControllerCore extends Controller
         $this->cart_presenter = new CartPresenter();
         $this->templateFinder = new TemplateFinder($this->context->smarty->getTemplateDir(), '.tpl');
         $this->stylesheetManager = new StylesheetManager(
+            array(_PS_THEME_DIR_, _PS_PARENT_THEME_DIR_, _PS_ROOT_DIR_),
+            new ConfigurationAdapter()
+        );
+        $this->javascriptManager = new JavascriptManager(
             array(_PS_THEME_DIR_, _PS_PARENT_THEME_DIR_, _PS_ROOT_DIR_),
             new ConfigurationAdapter()
         );
@@ -595,6 +604,7 @@ class FrontControllerCore extends Controller
         $this->context->smarty->assign(array(
             'layout' => $this->getLayout(),
             'stylesheets' => $this->stylesheetManager->getList(),
+            'javascript' => $this->javascriptManager->getList(),
             'css_files' => $this->css_files,
             'js_files' => ($this->getLayout() && (bool) Configuration::get('PS_JS_DEFER')) ? array() : $this->js_files,
             'js_defer' => (bool) Configuration::get('PS_JS_DEFER'),
@@ -807,11 +817,9 @@ class FrontControllerCore extends Controller
             $this->registerStylesheet('theme-rtl', '/assets/css/rtl.css', 'all', 10);
         }
 
-        $this->addJS(array(
-            _THEMES_DIR_.'core.js',
-            _THEME_JS_DIR_.'theme.js',
-            _THEME_JS_DIR_.'custom.js',
-        ));
+        $this->registerJavascript('corejs', '/themes/core.js', true, 0);
+        $this->registerJavascript('theme-main', '/assets/js/theme.js', true, 50);
+        $this->registerJavascript('theme-custom', '/assets/js/custom.js', true, 1000);
 
         // Execute Hook FrontController SetMedia
         Hook::exec('actionFrontControllerSetMedia', array());
@@ -1000,7 +1008,9 @@ class FrontControllerCore extends Controller
         $this->stylesheetManager->register($id, $relativePath, $media, $priority);
     }
 
-        return $this;
+    public function registerJavascript($id, $relativePath, $bottom = true, $priority = 50)
+    {
+        $this->javascriptManager->register($id, $relativePath, $bottom, $priority);
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1003,7 +1003,7 @@ class FrontControllerCore extends Controller
         FrontController::addMedia($media_uri, $css_media_type, null, true, $check_path);
     }
 
-    public function registerStylesheet($id, $relativePath, $media, $priority = 50)
+    public function registerStylesheet($id, $relativePath, $media = 'all', $priority = 50)
     {
         $this->stylesheetManager->register($id, $relativePath, $media, $priority);
     }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1160,13 +1160,25 @@ class FrontControllerCore extends Controller
      */
     public function addJqueryUI($component, $theme = 'base', $check_dependencies = true)
     {
-        Tools::displayAsDeprecated(
-            'This function has no effect in PrestaShop 1.7 theme, manage your dependencies in your
-            themes and modules and don\'t rely on PrestaShop embeded libraries. Use $this->registerJavascript() and
-            $this->registerStylesheet() to manage your assets.'
-        );
+        /*
+        This is deprecated in PrestaShop 1.7
+        Manage your dependencies in your themes/modules and don\'t rely on PrestaShop embedded libraries.
+        Use $this->registerJavascript() and $this->registerStylesheet() to manage your assets
+        */
+        if (isset(Media::$jquery_ui_dependencies[$component])) {
+            foreach (Media::$jquery_ui_dependencies[$component]['dependencies'] as $dependency) {
+                $this->addJqueryUI($dependency);
+            }
+        }
 
-        return;
+        // backward compat'
+        $css_theme_path = '/js/jquery/ui/themes/'.$theme.'/jquery.ui.theme.css';
+        $css_path = '/js/jquery/ui/themes/'.$theme.'/jquery.'.$component.'.css';
+        $js_path = '/js/jquery/ui/jquery.'.$component.'.min.js';
+
+        $this->registerStylesheet('legacy-ui-theme', $css_theme_path, ['media' => 'all', 'priority' => 95]);
+        $this->registerStylesheet('legacy-'.$component, $css_path, ['media' => 'all', 'priority' => 90]);
+        $this->registerJavascript('legacy-'.$component, $js_path, ['position' => 'bottom', 'priority' => 90]);
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -825,23 +825,23 @@ class FrontControllerCore extends Controller
      */
     public function setMedia()
     {
-        $this->registerStylesheet('theme-main', '/assets/css/theme.css', 'all', 0);
-        $this->registerStylesheet('theme-custom', '/assets/css/custom.css', 'all', 1000);
+        $this->registerStylesheet('theme-main', '/assets/css/theme.css', ['media' => 'all', 'priority' => 0]);
+        $this->registerStylesheet('theme-custom', '/assets/css/custom.css', ['media' => 'all', 'priority' => 1000]);
 
         if ($this->context->language->is_rtl) {
-            $this->registerStylesheet('theme-rtl', '/assets/css/rtl.css', 'all', 10);
+            $this->registerStylesheet('theme-rtl', '/assets/css/rtl.css', ['media' => 'all', 'priority' => 10]);
         }
 
-        $this->registerJavascript('corejs', '/themes/core.js', 'bottom', 0);
-        $this->registerJavascript('theme-main', '/assets/js/theme.js', 'bottom', 50);
-        $this->registerJavascript('theme-custom', '/assets/js/custom.js', 'bottom', 1000);
+        $this->registerJavascript('corejs', '/themes/core.js', ['position' => 'bottom', 'priority' => 0]);
+        $this->registerJavascript('theme-main', '/assets/js/theme.js', ['position' => 'bottom', 'priority' => 50]);
+        $this->registerJavascript('theme-custom', '/assets/js/custom.js', ['position' => 'bottom', 'priority' => 1000]);
 
         if (!empty($assets = $this->context->shop->theme->getPageSpecificAssets($this->php_self))) {
             foreach ($assets['css'] as $css) {
-                $this->registerStylesheet($css['id'], $css['path'], $css['media'], $css['priority']);
+                $this->registerStylesheet($css['id'], $css['path'], $css);
             }
             foreach ($assets['js'] as $js) {
-                $this->registerJavascript($js['id'], $js['path'], $js['bottom'], $js['priority'], $js['inline'], $js['attribute']);
+                $this->registerJavascript($js['id'], $js['path'], $js);
             }
         }
 
@@ -1036,7 +1036,7 @@ class FrontControllerCore extends Controller
 
         foreach ($css_uri as $legacy_uri) {
             if ($uri = $this->getAssetUriFromLegacyDeprecatedMethod($legacy_uri)) {
-                $this->registerStylesheet(sha1($uri), $uri, $css_media_type, 80);
+                $this->registerStylesheet(sha1($uri), $uri, ['media' => $css_media_type, 'priority' => 80]);
             }
         }
     }
@@ -1086,7 +1086,7 @@ class FrontControllerCore extends Controller
 
         foreach ($js_uri as $legacy_uri) {
             if ($uri = $this->getAssetUriFromLegacyDeprecatedMethod($legacy_uri)) {
-                $this->registerJavascript(sha1($uri), $uri, 'bottom', 80);
+                $this->registerJavascript(sha1($uri), $uri, ['position' => 'bottom', 'priority' => 80]);
             }
         }
     }

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -383,7 +383,7 @@ class ShopCore extends ObjectModel
         }
 
         $http_host = Tools::getHttpHost();
-        $all_media = array_merge(Configuration::getMultiShopValues('PS_MEDIA_SERVER_1'), Configuration::getMultiShopValues('PS_MEDIA_SERVER_2'), Configuration::getMultiShopValues('PS_MEDIA_SERVER_3'));
+        $all_media = Configuration::getMultiShopValues('PS_MEDIA_SERVER_1');
 
         if ((!$id_shop && defined('_PS_ADMIN_DIR_')) || Tools::isPHPCLI() || in_array($http_host, $all_media)) {
             // If in admin, we can access to the shop without right URL

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "geoip2/geoip2": "~2.4.2",
     "doctrine/doctrine-bundle": "1.5.2",
     "mrclay/minify": "~2.3.0",
+    "matthiasmullie/minify": "~1.3.0",
     "jakeasmith/http_build_url": "^1",
     "mobiledetect/mobiledetectlib": "~2.8.22",
     "symfony/swiftmailer-bundle": "2.3.11",

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -253,9 +253,3 @@ define('_PS_OS_COD_VALIDATION_', Configuration::get('PS_OS_COD_VALIDATION'));
 if (!defined('_MEDIA_SERVER_1_')) {
     define('_MEDIA_SERVER_1_', Configuration::get('PS_MEDIA_SERVER_1'));
 }
-if (!defined('_MEDIA_SERVER_2_')) {
-    define('_MEDIA_SERVER_2_', Configuration::get('PS_MEDIA_SERVER_2'));
-}
-if (!defined('_MEDIA_SERVER_3_')) {
-    define('_MEDIA_SERVER_3_', Configuration::get('PS_MEDIA_SERVER_3'));
-}

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -784,7 +784,6 @@ class AdminPerformanceControllerCore extends AdminController
                     } else {
                         Configuration::updateValue('PS_MEDIA_SERVERS', 0);
                     }
-                    rewriteSettingsFile($base_urls, null, null);
                     Configuration::updateValue('PS_MEDIA_SERVER_1', Tools::getValue('_MEDIA_SERVER_1_'));
                     Configuration::updateValue('PS_MEDIA_SERVER_2', Tools::getValue('_MEDIA_SERVER_2_'));
                     Configuration::updateValue('PS_MEDIA_SERVER_3', Tools::getValue('_MEDIA_SERVER_3_'));

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -382,23 +382,6 @@ class AdminPerformanceControllerCore extends AdminController
                         )
                     )
                 ),
-                array(
-                    'type' => 'switch',
-                    'label' => $this->trans('Move JavaScript to the end', array(), 'Admin.AdvParameters.Feature'),
-                    'name' => 'PS_JS_DEFER',
-                    'values' => array(
-                        array(
-                            'id' => 'PS_JS_DEFER_1',
-                            'value' => 1,
-                            'label' => $this->trans('Move JavaScript to the end of the HTML document', array(), 'Admin.AdvParameters.Feature')
-                        ),
-                        array(
-                            'id' => 'PS_JS_DEFER_0',
-                            'value' => 0,
-                            'label' => $this->trans('Keep JavaScript in HTML at its original position', array(), 'Admin.AdvParameters.Feature')
-                        )
-                    )
-                ),
 
             ),
             'submit' => array(
@@ -430,7 +413,6 @@ class AdminPerformanceControllerCore extends AdminController
         $this->fields_value['PS_CSS_THEME_CACHE'] = Configuration::get('PS_CSS_THEME_CACHE');
         $this->fields_value['PS_JS_THEME_CACHE'] = Configuration::get('PS_JS_THEME_CACHE');
         $this->fields_value['PS_HTACCESS_CACHE_CONTROL'] = Configuration::get('PS_HTACCESS_CACHE_CONTROL');
-        $this->fields_value['PS_JS_DEFER'] = Configuration::get('PS_JS_DEFER');
         $this->fields_value['ccc_up'] = 1;
     }
 
@@ -729,7 +711,6 @@ class AdminPerformanceControllerCore extends AdminController
 
                 if (!Configuration::updateValue('PS_CSS_THEME_CACHE', (int)Tools::getValue('PS_CSS_THEME_CACHE')) ||
                     !Configuration::updateValue('PS_JS_THEME_CACHE', (int)Tools::getValue('PS_JS_THEME_CACHE')) ||
-                    !Configuration::updateValue('PS_JS_DEFER', (int)Tools::getValue('PS_JS_DEFER')) ||
                     !Configuration::updateValue('PS_HTACCESS_CACHE_CONTROL', (int)Tools::getValue('PS_HTACCESS_CACHE_CONTROL'))) {
                     $this->errors[] = $this->trans('Unknown error.', array(), 'Admin.Notifications.Error');
                 } else {

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -453,18 +453,6 @@ class AdminPerformanceControllerCore extends AdminController
                     'name' => '_MEDIA_SERVER_1_',
                     'hint' => $this->trans('Name of the second domain of your shop, (e.g. myshop-media-server-1.com). If you do not have another domain, leave this field blank.', array(), 'Admin.AdvParameters.Help')
                 ),
-                array(
-                    'type' => 'text',
-                    'label' => $this->trans('Media server #2', array(), 'Admin.AdvParameters.Feature'),
-                    'name' => '_MEDIA_SERVER_2_',
-                    'hint' => $this->trans('Name of the third domain of your shop, (e.g. myshop-media-server-2.com). If you do not have another domain, leave this field blank.', array(), 'Admin.AdvParameters.Help')
-                ),
-                array(
-                    'type' => 'text',
-                    'label' => $this->trans('Media server #3', array(), 'Admin.AdvParameters.Feature'),
-                    'name' => '_MEDIA_SERVER_3_',
-                    'hint' => $this->trans('Name of the fourth domain of your shop, (e.g. myshop-media-server-3.com). If you do not have another domain, leave this field blank.', array(), 'Admin.AdvParameters.Help')
-                ),
             ),
             'submit' => array(
                 'title' => $this->trans('Save', array(), 'Admin.Actions')
@@ -472,8 +460,6 @@ class AdminPerformanceControllerCore extends AdminController
         );
 
         $this->fields_value['_MEDIA_SERVER_1_'] = Configuration::get('PS_MEDIA_SERVER_1');
-        $this->fields_value['_MEDIA_SERVER_2_'] = Configuration::get('PS_MEDIA_SERVER_2');
-        $this->fields_value['_MEDIA_SERVER_3_'] = Configuration::get('PS_MEDIA_SERVER_3');
     }
 
     public function initFieldsetCaching()
@@ -768,33 +754,21 @@ class AdminPerformanceControllerCore extends AdminController
                 if (Tools::getValue('_MEDIA_SERVER_1_') != null && !Validate::isFileName(Tools::getValue('_MEDIA_SERVER_1_'))) {
                     $this->errors[] = $this->trans('Media server #1 is invalid', array(), 'Admin.AdvParameters.Notification');
                 }
-                if (Tools::getValue('_MEDIA_SERVER_2_') != null && !Validate::isFileName(Tools::getValue('_MEDIA_SERVER_2_'))) {
-                    $this->errors[] = $this->trans('Media server #2 is invalid', array(), 'Admin.AdvParameters.Notification');
-                }
-                if (Tools::getValue('_MEDIA_SERVER_3_') != null && !Validate::isFileName(Tools::getValue('_MEDIA_SERVER_3_'))) {
-                    $this->errors[] = $this->trans('Media server #3 is invalid', array(), 'Admin.AdvParameters.Notification');
-                }
                 if (!count($this->errors)) {
                     $base_urls = array();
                     $base_urls['_MEDIA_SERVER_1_'] = Tools::getValue('_MEDIA_SERVER_1_');
-                    $base_urls['_MEDIA_SERVER_2_'] = Tools::getValue('_MEDIA_SERVER_2_');
-                    $base_urls['_MEDIA_SERVER_3_'] = Tools::getValue('_MEDIA_SERVER_3_');
-                    if ($base_urls['_MEDIA_SERVER_1_'] || $base_urls['_MEDIA_SERVER_2_'] || $base_urls['_MEDIA_SERVER_3_']) {
+                    if ($base_urls['_MEDIA_SERVER_1_']) {
                         Configuration::updateValue('PS_MEDIA_SERVERS', 1);
                     } else {
                         Configuration::updateValue('PS_MEDIA_SERVERS', 0);
                     }
                     Configuration::updateValue('PS_MEDIA_SERVER_1', Tools::getValue('_MEDIA_SERVER_1_'));
-                    Configuration::updateValue('PS_MEDIA_SERVER_2', Tools::getValue('_MEDIA_SERVER_2_'));
-                    Configuration::updateValue('PS_MEDIA_SERVER_3', Tools::getValue('_MEDIA_SERVER_3_'));
                     Tools::clearSmartyCache();
                     Media::clearCache();
 
                     if (is_writable(_PS_ROOT_DIR_.'/.htaccess')) {
-                        Tools::generateHtaccess(null, null, null, '', null, array($base_urls['_MEDIA_SERVER_1_'], $base_urls['_MEDIA_SERVER_2_'], $base_urls['_MEDIA_SERVER_3_']));
+                        Tools::generateHtaccess(null, null, null, '', null, array($base_urls['_MEDIA_SERVER_1_']));
                         unset($this->_fieldsGeneral['_MEDIA_SERVER_1_']);
-                        unset($this->_fieldsGeneral['_MEDIA_SERVER_2_']);
-                        unset($this->_fieldsGeneral['_MEDIA_SERVER_3_']);
                         $redirectAdmin = true;
                     } else {
                         $message = $this->trans('Before being able to use this tool, you need to:', array(), 'Admin.AdvParameters.Notification');

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -172,6 +172,8 @@ DELETE FROM `PREFIX_hook_alias` WHERE `name` IN (
   'displayBeforePayment');
 
 DELETE FROM `PREFIX_configuration` WHERE `name` IN (
+  '_MEDIA_SERVER_2_',
+  '_MEDIA_SERVER_3_',
   'PS_ORDER_PROCESS_TYPE',
   'PS_ADVANCED_PAYMENT_API',
   'PS_ONE_PHONE_AT_LEAST',

--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -250,8 +250,6 @@ $datas = array(
 
 if (version_compare(_PS_INSTALL_VERSION_, '1.6.0.11', '<')) {
     $datas[] = array('_MEDIA_SERVER_1_', defined('_MEDIA_SERVER_1_') ? _MEDIA_SERVER_1_ : '');
-    $datas[] = array('_MEDIA_SERVER_2_', defined('_MEDIA_SERVER_2_') ? _MEDIA_SERVER_2_ : '');
-    $datas[] = array('_MEDIA_SERVER_3_', defined('_MEDIA_SERVER_3_') ? _MEDIA_SERVER_3_ : '');
 }
 
 if (defined('_RIJNDAEL_KEY_')) {
@@ -303,7 +301,7 @@ $list = $moduleManagerRepository->getFilteredList($filter, true);
 /**
  * @var $module \PrestaShop\PrestaShop\Adapter\Module\Module
  */
-foreach($list as $moduleName => $module) {
+foreach ($list as $moduleName => $module) {
     $moduleInfo = $moduleManagerRepository->getModule($moduleName, true);
     /** @var \Symfony\Component\HttpFoundation\ParameterBag $attributes */
     $attributes = $module->attributes;

--- a/src/Adapter/Assets/AssetUrlGeneratorTrait.php
+++ b/src/Adapter/Assets/AssetUrlGeneratorTrait.php
@@ -25,38 +25,33 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-use \PrestaShop\PrestaShop\Core\ConfigurationInterface;
+namespace PrestaShop\PrestaShop\Adapter\Assets;
 
-abstract class AbstractAssetManagerCore
+trait AssetUrlGeneratorTrait
 {
-    protected $directories;
-    protected $configuration;
-    protected $list = array();
+    protected $fqdn;
 
-    const DEFAULT_MEDIA = 'all';
-    const DEFAULT_PRIORITY = 50;
-    const DEFAULT_JS_POSITION = 'bottom';
-
-    use PrestaShop\PrestaShop\Adapter\Assets\AssetUrlGeneratorTrait;
-
-    public function __construct(array $directories, ConfigurationInterface $configuration)
+    protected function getUriFromPath($fullPath)
     {
-        $this->directories = $directories;
-        $this->configuration = $configuration;
+        $uri = str_replace(
+            $this->configuration->get('_PS_ROOT_DIR_').'/',
+            $this->configuration->get('__PS_BASE_URI__'),
+            $fullPath
+        );
 
-        $this->list = $this->getDefaultList();
+        return $uri;
     }
 
-    abstract protected function getDefaultList();
-    abstract protected function getList();
-
-    protected function getFullPath($relativePath)
+    protected function getFQDN()
     {
-        foreach ($this->directories as $baseDir) {
-            $fullPath = realpath($baseDir.'/'.$relativePath);
-            if (is_file($fullPath)) {
-                return $fullPath;
+        if (is_null($this->fqdn)) {
+            if ($this->configuration->get('PS_SSL_ENABLED')) {
+                $this->fqdn = $this->configuration->get('_PS_BASE_URL_SSL_');
+            } else {
+                $this->fqdn = $this->configuration->get('_PS_BASE_URL_');
             }
         }
+
+        return $this->fqdn;
     }
 }

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -88,6 +88,14 @@ class Theme implements AddonInterface
         return $modulesToEnable;
     }
 
+    public function getPageSpecificAssets($pageId)
+    {
+        return [
+            'css' => $this->getPageSpecificCss($pageId),
+            'js' => $this->getPageSpecificJs($pageId),
+        ];
+    }
+
     public function onInstall()
     {
         return true;
@@ -177,5 +185,51 @@ class Theme implements AddonInterface
     public function getLayoutRelativePathForPage($page)
     {
         return 'layouts/'.$this->getLayoutNameForPage($page).'.tpl';
+    }
+
+    private function getPageSpecificCss($pageId)
+    {
+        $css = array_merge(
+            (array) $this->get('assets.css.all'),
+            (array) $this->get('assets.css.'.$pageId)
+        );
+        foreach ($css as $key => &$entry) {
+            // Required parameters
+            if (!isset($entry['id']) || !isset($entry['path'])) {
+                unset($css[$key]);
+                continue;
+            }
+            if (!isset($entry['media'])) {
+                $entry['media'] = \AbstractAssetManager::DEFAULT_MEDIA;
+            }
+            if (!isset($entry['priority'])) {
+                $entry['priority'] = \AbstractAssetManager::DEFAULT_PRIORITY;
+            }
+        }
+
+        return $css;
+    }
+
+    private function getPageSpecificJs($pageId)
+    {
+        $js = array_merge(
+            (array) $this->get('assets.js.all'),
+            (array) $this->get('assets.js.'.$pageId)
+        );
+        foreach ($js as $key => &$entry) {
+            // Required parameters
+            if (!isset($entry['id']) || !isset($entry['path'])) {
+                unset($js[$key]);
+                continue;
+            }
+            if (!isset($entry['bottom'])) {
+                $entry['bottom'] = \AbstractAssetManager::JS_BOTTOM;
+            }
+            if (!isset($entry['priority'])) {
+                $entry['priority'] = \AbstractAssetManager::DEFAULT_PRIORITY;
+            }
+        }
+
+        return $js;
     }
 }

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -222,14 +222,17 @@ class Theme implements AddonInterface
                 unset($js[$key]);
                 continue;
             }
-            if (!isset($entry['bottom'])) {
-                $entry['bottom'] = \AbstractAssetManager::DEFAULT_JS_POSITION;
+            if (!isset($entry['position'])) {
+                $entry['position'] = \AbstractAssetManager::DEFAULT_JS_POSITION;
             }
             if (!isset($entry['priority'])) {
                 $entry['priority'] = \AbstractAssetManager::DEFAULT_PRIORITY;
             }
             if (!isset($entry['inline'])) {
                 $entry['inline'] = false;
+            }
+            if (!isset($entry['attribute'])) {
+                $entry['attribute'] = false;
             }
         }
 

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -223,10 +223,13 @@ class Theme implements AddonInterface
                 continue;
             }
             if (!isset($entry['bottom'])) {
-                $entry['bottom'] = \AbstractAssetManager::JS_BOTTOM;
+                $entry['bottom'] = \AbstractAssetManager::DEFAULT_JS_POSITION;
             }
             if (!isset($entry['priority'])) {
                 $entry['priority'] = \AbstractAssetManager::DEFAULT_PRIORITY;
+            }
+            if (!isset($entry['inline'])) {
+                $entry['inline'] = false;
             }
         }
 

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -205,6 +205,9 @@ class Theme implements AddonInterface
             if (!isset($entry['priority'])) {
                 $entry['priority'] = \AbstractAssetManager::DEFAULT_PRIORITY;
             }
+            if (!isset($entry['inline'])) {
+                $entry['inline'] = false;
+            }
         }
 
         return $css;

--- a/themes/classic/config/theme.yml
+++ b/themes/classic/config/theme.yml
@@ -25,6 +25,28 @@ meta:
       name: Two Columns, small right column
       description: Two columns with a small right column
 
+assets:
+  # If you're using this theme as child and you want to load
+  # the parent theme assets, uncomment this line.
+#  use_parent_assets: true
+
+  # The following lines are showing how to load assets in your page
+  # Uncomment and change value to start loading css or js files
+#  css:
+#    all:
+#      - id: custom-lib-style
+#        path: assets/css/custom-lib.css
+#    product:
+#      - id: product-style
+#        path: assets/css/product.css
+#        media: all
+#        priority: 200
+#  js:
+#    cart:
+#      - id: cat-extra-lib
+#        path: assets/js/cart-lib.js
+
+
 global_settings:
   configuration:
     PS_IMAGE_QUALITY: png

--- a/themes/classic/templates/_partials/head.tpl
+++ b/themes/classic/templates/_partials/head.tpl
@@ -18,11 +18,10 @@
 <link rel="icon" type="image/vnd.microsoft.icon" href="{$shop.favicon}?{$shop.favicon_update_time}">
 <link rel="shortcut icon" type="image/x-icon" href="{$shop.favicon}?{$shop.favicon_update_time}">
 
-{if isset($css_files)}
-  {foreach from=$css_files key=css_uri item=media}
-    <link rel="stylesheet" href="{$css_uri}" type="text/css" media="{$media}">
-  {/foreach}
-{/if}
+{block name='stylesheets'}
+  {include file="_partials/stylesheets.tpl" stylesheets=$stylesheets}
+{/block}
+
 {if isset($js_defer) && !$js_defer && isset($js_files) && isset($js_def)}
   {$js_def nofilter}
   {foreach from=$js_files item=js_uri}

--- a/themes/classic/templates/_partials/head.tpl
+++ b/themes/classic/templates/_partials/head.tpl
@@ -22,12 +22,11 @@
   {include file="_partials/stylesheets.tpl" stylesheets=$stylesheets}
 {/block}
 
-{if isset($js_defer) && !$js_defer && isset($js_files) && isset($js_def)}
-  {$js_def nofilter}
-  {foreach from=$js_files item=js_uri}
-    <script type="text/javascript" src="{$js_uri}"></script>
-  {/foreach}
-{/if}
+{block name='javascript_head'}
+  {include file="_partials/javascript.tpl" files=$javascript.head}
+{/block}
+
+{$js_def nofilter}
 
 {block name='hook_header'}
   {$HOOK_HEADER nofilter}

--- a/themes/classic/templates/_partials/head.tpl
+++ b/themes/classic/templates/_partials/head.tpl
@@ -23,10 +23,8 @@
 {/block}
 
 {block name='javascript_head'}
-  {include file="_partials/javascript.tpl" javascript=$javascript.head}
+  {include file="_partials/javascript.tpl" javascript=$javascript.head vars=$js_custom_vars}
 {/block}
-
-{$js_def nofilter}
 
 {block name='hook_header'}
   {$HOOK_HEADER nofilter}

--- a/themes/classic/templates/_partials/head.tpl
+++ b/themes/classic/templates/_partials/head.tpl
@@ -23,7 +23,7 @@
 {/block}
 
 {block name='javascript_head'}
-  {include file="_partials/javascript.tpl" files=$javascript.head}
+  {include file="_partials/javascript.tpl" javascript=$javascript.head}
 {/block}
 
 {$js_def nofilter}

--- a/themes/classic/templates/_partials/javascript.tpl
+++ b/themes/classic/templates/_partials/javascript.tpl
@@ -1,0 +1,3 @@
+{foreach $files as $js}
+  <script type="text/javascript" src="{$js.uri}"></script>
+{/foreach}

--- a/themes/classic/templates/_partials/javascript.tpl
+++ b/themes/classic/templates/_partials/javascript.tpl
@@ -7,3 +7,11 @@
     {$js.content nofilter}
   </script>
 {/foreach}
+
+{if isset($vars) && $vars|@count}
+  <script type="text/javascript">
+    {foreach from=$vars key=var_name item=var_value}
+    var {$var_name} = {$var_value|json_encode nofilter};
+    {/foreach}
+  </script>
+{/if}

--- a/themes/classic/templates/_partials/javascript.tpl
+++ b/themes/classic/templates/_partials/javascript.tpl
@@ -1,3 +1,9 @@
-{foreach $files as $js}
+{foreach $javascript.external as $js}
   <script type="text/javascript" src="{$js.uri}"></script>
+{/foreach}
+
+{foreach $javascript.inline as $js}
+  <script type="text/javascript">
+    {$js.content nofilter}
+  </script>
 {/foreach}

--- a/themes/classic/templates/_partials/javascript.tpl
+++ b/themes/classic/templates/_partials/javascript.tpl
@@ -1,5 +1,5 @@
 {foreach $javascript.external as $js}
-  <script type="text/javascript" src="{$js.uri}"></script>
+  <script type="text/javascript" src="{$js.uri}" {$js.attribute}></script>
 {/foreach}
 
 {foreach $javascript.inline as $js}

--- a/themes/classic/templates/_partials/stylesheets.tpl
+++ b/themes/classic/templates/_partials/stylesheets.tpl
@@ -1,0 +1,3 @@
+{foreach $stylesheets as $stylesheet}
+  <link rel="stylesheet" href="{$stylesheet.uri}" type="text/css" media="{$stylesheet.media}">
+{/foreach}

--- a/themes/classic/templates/_partials/stylesheets.tpl
+++ b/themes/classic/templates/_partials/stylesheets.tpl
@@ -1,3 +1,9 @@
-{foreach $stylesheets as $stylesheet}
+{foreach $stylesheets.external as $stylesheet}
   <link rel="stylesheet" href="{$stylesheet.uri}" type="text/css" media="{$stylesheet.media}">
+{/foreach}
+
+{foreach $stylesheets.inline as $stylesheet}
+  <style>
+    {$stylesheet.content}
+  </style>
 {/foreach}

--- a/themes/classic/templates/checkout/checkout.tpl
+++ b/themes/classic/templates/checkout/checkout.tpl
@@ -8,6 +8,7 @@
   </head>
 
   <body id="{$page.page_name}" class="{$page.body_classes|classnames}">
+
     {hook h='displayAfterBodyOpeningTag'}
 
     <header id="header">
@@ -16,11 +17,9 @@
       {/block}
     </header>
 
-
-      {block name='notifications'}
-        {include file='_partials/notifications.tpl'}
-      {/block}
-
+    {block name='notifications'}
+      {include file='_partials/notifications.tpl'}
+    {/block}
 
     <section id="wrapper">
       <div class="container">
@@ -42,11 +41,18 @@
       {/block}
       </div>
     </section>
+
     <footer id="footer">
       {block name='footer'}
         {include file='checkout/_partials/footer.tpl'}
       {/block}
     </footer>
+
+    {hook h='displayBeforeBodyClosingTag'}
+
+    {block name='javascript_bottom'}
+      {include file="_partials/javascript.tpl" javascript=$javascript.bottom}
+    {/block}
 
   </body>
 

--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -69,6 +69,10 @@
 
     {hook h='displayBeforeBodyClosingTag'}
 
+    {block name='javascript_bottom'}
+      {include file="_partials/javascript.tpl" files=$javascript.bottom}
+    {/block}
+
   </body>
 
 </html>

--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -70,7 +70,7 @@
     {hook h='displayBeforeBodyClosingTag'}
 
     {block name='javascript_bottom'}
-      {include file="_partials/javascript.tpl" files=$javascript.bottom}
+      {include file="_partials/javascript.tpl" javascript=$javascript.bottom}
     {/block}
 
   </body>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Introduce a new asset management system to register assets (css and js). All previous method are deprecated BUT backward compatibility for `addCSS`, `addJS`, `removeCSS` and `removeJS` is maintained. I would very very strongly advise you to update your module to not rely on them. **This require new module version (PR in progress)** |
| Type? | new feature |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Try to add CSS/JS in your `theme.yml` or create a module that register assets the proper way |
## TODO
- [x] Introduce new simple method to register assets
- [x] Handle head and bottom position for javascript
- [x] Handle priority order for all assets
- [x] Allow theme developer to manage their assets in `theme.yml`
- [x] Allow module to inline JavaScript (for google analytics for example)
- [x] Allow module assets override
- [x] Work with parent theme
- [x] Ensure theme can unregister module assets by placing empty file in module override directory
- [x] Ensure CDN works (**note:** CDN 2 and 3 have been removed)
- [x] ~~Ensure all JS can be forced to load at the bottom (`PS_JS_DEFER`)~~ Feature became useless and have been removed
- [ ] Document everything
- [ ] Use new method in native modules
- [x] Ensure CCC is fully working
- [x] Allow javascript to be loaded in `async` or `defer`
- [x] Add backward compat' for `addCSS`, `addJS`, `removeCSS`, `removeJS`.
## Notes
### Example to load assets depending on pages with your `theme.yml`

``` yaml
assets:
  css:
    all:
      - id: custom-lib-style
        path: assets/css/custom-lib.css
    product:
      - id: product-style
        path: assets/css/product.css
        media: all
        priority: 200
  js:
    cart:
      - id: cat-extra-lib
        path: assets/js/cart-lib.js
```
### Prority
- By default priority is set to 50.
- Priority zero is `core.js` and `theme.css`. `theme.js` is loaded with priority 50 in order to let you load libraries before.
- `custom.css` and `custom.js` are loaded with priority 1000 since they are meant to be edited by hand and override everything.
- By default javascript is loaded at the bottom. Modules should always try to load javascript at the bottom unless there is a special need (google analytics or modernizer for example). Remember jQuery2 is provided in core.js, at the bottom of the page.
### How to register assets for a module

In your module, use the `actionFrontControllerSetMedia` hook.

Example:

``` php
    public function hookActionFrontControllerSetMedia($params)
    {
        $this->context->controller->registerStylesheet(
            'module-ps-image-slider-style',
            '/modules/'.$this->name.'/css/homeslider.css',
            ['media' => 'all']
        );
        $this->context->controller->registerJavascript(
            'module-ps-image-slider-reponsive-plugin',
            '/modules/'.$this->name.'js/responsiveslides.min.js',
            ['position' => 'bottom', 'priority' => 100]
        );
        $this->context->controller->registerJavascript(
            'module-ps-image-slider-main',
            '/modules/'.$this->name.'js/homeslider.js',
            ['position' => 'bottom', 'priority' => 110]
        );
    }
```
