### PR TITLE
Module page small fixes

### DIFF
--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -433,12 +433,19 @@ class ModuleManager implements AddonManagerInterface
      */
     public function getError($name)
     {
+        $message = null;
         $module = $this->moduleRepository->getModule($name);
         if ($module->hasValidInstance()) {
             $errors = $module->getInstance()->getErrors();
-            return array_pop($errors);
+            $message = array_pop($errors);
         }
 
-        return null;
+        if (empty($message)) {
+            $message = $this->translator->trans('Unfortunately, the module did not return additional details.',
+                array(),
+                'Admin.Modules.Notification');
+        }
+        
+        return $message;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/AddonsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AddonsController.php
@@ -21,6 +21,7 @@ class AddonsController extends Controller
     {
         $addonsProvider = $this->container->get('prestashop.core.admin.data_provider.addons_interface');
         $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
+        $translator = $this->container->get('translator');
         $response = new JsonResponse();
 
         // Parameters needed in order to authenticate the merchant : login and password
@@ -44,7 +45,9 @@ class AddonsController extends Controller
         } catch (Exception $e) {
             $response->setData([
                 'success' => 0,
-                'message' => $e->getMessage(),
+                'message' => $translator->trans('PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.',
+                        array(),
+                        'Admin.Notifications.Error'),
             ]);
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -523,9 +523,12 @@ class ModuleController extends FrameworkBundleAdminController
                     'Admin.Modules.Notification');
                 $installation_response['is_configurable'] = (bool) $this->get('prestashop.core.admin.module.repository')->getModule($module_name)->attributes->get('is_configurable');
             } else {
+                $error = $moduleManager->getError($file_uploaded->getPathname());
                 $installation_response['msg'] = $translator->trans(
-                    'Installation of module %module% failed.',
-                    array('%module%' => $module_name),
+                    'Installation of module %module% failed. %error%',
+                    array(
+                        '%module%' => $module_name,
+                        '%error%' => $error, ),
                     'Admin.Modules.Notification');
             }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -65,7 +65,7 @@
             {% endif %}
             {% if customerBenefits %}
               <li class="nav-item">
-                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#additional-{{ name }}">{{ 'Benefits'|trans({}, 'Admin.Modules.Feature') }}</a>
+                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#customer_benefits-{{ name }}">{{ 'Benefits'|trans({}, 'Admin.Modules.Feature') }}</a>
               </li>
             {% endif %}
             {% if features %}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR add generic and default messages on the module page and fixes a tab of the read more panel |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | <ul><li>[BOOM-659](http://forge.prestashop.com/browse/BOOM-659)</li><li>[BOOM-911](http://forge.prestashop.com/browse/BOOM-911)</li><li>[BOOM-1648](http://forge.prestashop.com/browse/BOOM-1648)</li></ul> |
| How to test? | Make your addons authentication fail, install a module which returns false on install and look at the red more of the module "easy pack pro" |
