### PR TITLE
Fix customization label after resaving product

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -477,18 +477,31 @@ class AdminProductWrapper
                     $hasRequiredField = true;
                 }
 
-                //create label
-                \Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'customization_field` (`id_product`, `type`, `required`)
-                    VALUES ('.(int)$product->id.', '.(int)$customization['type'].', '.($customization['require'] ? 1 : 0).')');
-
-                $id_customization_field = (int)\Db::getInstance()->Insert_ID();
-
+                if (isset($customization['id_customization_field'])) {
+                    //create a custom field with the same old id
+                    \Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'customization_field` (`id_customization_field`,`id_product`, `type`, `required`)
+                    VALUES (
+                    ' . $customization['id_customization_field'] . ',
+                    ' . (int)$product->id . ', ' . (int)$customization['type'] . ', 
+                    ' . ($customization['require'] ? 1 : 0) . '
+                    )');
+                } else {
+                    //create a new custom field
+                    \Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'customization_field` (`id_product`, `type`, `required`)
+                    VALUES (
+                    ' . (int)$product->id . ', 
+                    ' . (int)$customization['type'] . ', 
+                    ' . ($customization['require'] ? 1 : 0) . '
+                    )');
+                    $id_customization_field = (int)\Db::getInstance()->Insert_ID();
+                }
+                
                 // Create multilingual label name
                 $langValues = '';
                 foreach (\LanguageCore::getLanguages() as $language) {
                     $name = $customization['label'][$language['id_lang']];
                     foreach ($shopList as $id_shop) {
-                        $langValues .= '('.(int)$id_customization_field.', '.(int)$language['id_lang'].', '.$id_shop .',\''.$name.'\'), ';
+                        $langValues .= '(' . (isset($customization['id_customization_field']) ? $customization['id_customization_field'] : (int)$id_customization_field) . ', ' . (int)$language['id_lang'] . ', ' . $id_shop . ',\'' . $name . '\'), ';
                     }
                 }
                 \Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'customization_field_lang` (`id_customization_field`, `id_lang`, `id_shop`, `name`) VALUES '.rtrim($langValues, ', '));

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
@@ -57,7 +57,10 @@ class ProductCustomField extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('label', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+        $builder->add('id_customization_field','Symfony\Component\Form\Extension\Core\Type\HiddenType', array(
+            'required' => false,
+        ))
+         ->add('label', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
             'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [ 'constraints' => array(
                 new Assert\NotBlank(),

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -589,6 +589,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
 
         foreach ($customizationFields as $customizationField) {
             $baseObject = [
+                'id_customization_field' => $customizationField[$this->locales[0]['id_lang']]['id_customization_field'],
                 'label' => [],
                 'type' => $customizationField[$this->locales[0]['id_lang']]['type'],
                 'require' => $customizationField[$this->locales[0]['id_lang']]['required'] == 1 ? true : false,

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_custom_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_custom_fields.html.twig
@@ -1,4 +1,6 @@
 <div class="row">
+  {{ form_errors(form.id_customization_field) }}
+  {{ form_widget(form.id_customization_field) }}
   <div class="col-md-3">
     <fieldset class="form-group">
       <label class="form-control-label">{{ form.label.vars.label }}</label>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Customization labels disappear in order details page each time product is (re)saved in BO |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1395 |
| How to test? |  |
- Order a product with customization
- Go to the order details page in the FO and click on the Customization link => label of the custom field exists 
- Edit the product you have ordred and save it
- Go back to the order details page in the FO and click on the Customization link => label of the custom field doesn't disappear ;)
