### PR TITLE
Restore from class_index out of sync situation (1.7)

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2792,6 +2792,15 @@ abstract class ModuleCore
 
             // Make a reflection of the override class and the module override class
             $override_file = file($override_path);
+            if (empty($override_file)) {
+                // class_index was out of sync, so we just create a new override on the fly
+                $override_file = array(
+                    "<?php\n",
+                    "class {$classname} extends {$classname}Core\n",
+                    "{\n",
+                    "}\n",
+                );
+            }
             $override_file = array_diff($override_file, array("\n"));
             eval(preg_replace(array('#^\s*<\?(?:php)?#', '#class\s+'.$classname.'\s+extends\s+([a-z0-9_]+)(\s+implements\s+([a-z0-9_]+))?#i'), array(' ', 'class '.$classname.'OverrideOriginal'.$uniq), implode('', $override_file)));
             $override_class = new ReflectionClass($classname.'OverrideOriginal'.$uniq);


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | `develop` |
| Description? | Before adding an override, PrestaShop opens the previous file (if it is still being referred to from `class_index.php`) and adds the override(s) to it. But if the file does not physically exist while it still is in the `class_index` it will cause a fatal error. This can be solved by initializing an empty override file on the fly. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Install a module with an override. Remove the whole override file. Try to reset the module. It should be possible again after applying this PR. |
