### PR TITLE
Make encryption system backward compatible with old 0.98 openssl versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ after_script:
   - google-chrome --version
 
 after_failure:
+  - openssl version
   - curl http://localhost/prestashop.unit.test/
   - cat /etc/apache2/envvars
   - cat /etc/apache2/sites-available/prestashop.conf

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2015 PrestaShop
+ * 2007-2015 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -23,7 +23,6 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
 class CookieCore
 {
     /** @var array Contain cookie content in a key => value format */
@@ -55,7 +54,7 @@ class CookieCore
     protected $_secure = false;
 
     /**
-     * Get data if the cookie exists and else initialize an new one
+     * Get data if the cookie exists and else initialize an new one.
      *
      * @param $name string Cookie name before encrypting
      * @param $path string
@@ -64,7 +63,7 @@ class CookieCore
     {
         $this->_content = array();
         $this->_standalone = $standalone;
-        $this->_expire = is_null($expire) ? time() + 1728000 : (int)$expire;
+        $this->_expire = is_null($expire) ? time() + 1728000 : (int) $expire;
         $this->_path = trim(($this->_standalone ? '' : Context::getContext()->shop->physical_uri).$path, '/\\').'/';
         if ($this->_path{0} != '/') {
             $this->_path = '/'.$this->_path;
@@ -78,12 +77,11 @@ class CookieCore
         $this->_salt = $this->_standalone ? str_pad('', 8, md5('ps'.__FILE__)) : _COOKIE_IV_;
 
         if ($this->_standalone) {
-            $asciiSafeString = \Defuse\Crypto\Encoding::saveBytesToChecksummedAsciiSafeString('ps17', str_pad('', 32, __FILE__));
-            $this->cipherTool = new PhpEncryption($asciiSafeString);
+            $this->cipherTool = new PhpEncryption(str_pad('', 32, __FILE__));
         }
         $this->cipherTool = new PhpEncryption(_NEW_COOKIE_KEY_);
 
-        $this->_secure = (bool)$secure;
+        $this->_secure = (bool) $secure;
 
         $this->update();
     }
@@ -125,23 +123,25 @@ class CookieCore
         if (!$domain) {
             $domain = $out[4];
         }
+
         return $domain;
     }
 
     /**
-     * Set expiration date
+     * Set expiration date.
      *
      * @param int $expire Expiration time from now
      */
     public function setExpire($expire)
     {
-        $this->_expire = (int)($expire);
+        $this->_expire = (int) ($expire);
     }
 
     /**
-     * Magic method wich return cookie data from _content array
+     * Magic method wich return cookie data from _content array.
      *
      * @param string $key key wanted
+     *
      * @return string value corresponding to the key
      */
     public function __get($key)
@@ -150,9 +150,10 @@ class CookieCore
     }
 
     /**
-     * Magic method which check if key exists in the cookie
+     * Magic method which check if key exists in the cookie.
      *
      * @param string $key key wanted
+     *
      * @return bool key existence
      */
     public function __isset($key)
@@ -161,10 +162,11 @@ class CookieCore
     }
 
     /**
-     * Magic method which adds data into _content array
+     * Magic method which adds data into _content array.
      *
-     * @param string $key Access key for the value
-     * @param mixed $value Value corresponding to the key
+     * @param string $key   Access key for the value
+     * @param mixed  $value Value corresponding to the key
+     *
      * @throws Exception
      */
     public function __set($key, $value)
@@ -182,7 +184,7 @@ class CookieCore
     }
 
     /**
-     * Magic method wich delete data into _content array
+     * Magic method wich delete data into _content array.
      *
      * @param string $key key wanted
      */
@@ -195,9 +197,10 @@ class CookieCore
     }
 
     /**
-     * Check customer informations saved into cookie and return customer validity
+     * Check customer informations saved into cookie and return customer validity.
      *
      * @deprecated as of version 1.5 use Customer::isLogged() instead
+     *
      * @return bool customer validity
      */
     public function isLogged($withGuest = false)
@@ -208,32 +211,34 @@ class CookieCore
         }
 
         /* Customer is valid only if it can be load and if cookie password is the same as database one */
-        if ($this->logged == 1 && $this->id_customer && Validate::isUnsignedId($this->id_customer) && Customer::checkPassword((int)($this->id_customer), $this->passwd)) {
+        if ($this->logged == 1 && $this->id_customer && Validate::isUnsignedId($this->id_customer) && Customer::checkPassword((int) ($this->id_customer), $this->passwd)) {
             return true;
         }
+
         return false;
     }
 
     /**
-     * Check employee informations saved into cookie and return employee validity
+     * Check employee informations saved into cookie and return employee validity.
      *
      * @deprecated as of version 1.5 use Employee::isLoggedBack() instead
+     *
      * @return bool employee validity
      */
     public function isLoggedBack()
     {
         Tools::displayAsDeprecated();
         /* Employee is valid only if it can be load and if cookie password is the same as database one */
-        return ($this->id_employee
+        return $this->id_employee
             && Validate::isUnsignedId($this->id_employee)
-            && Employee::checkPassword((int)$this->id_employee, $this->passwd)
+            && Employee::checkPassword((int) $this->id_employee, $this->passwd)
             && (!isset($this->_content['remote_addr']) || $this->_content['remote_addr'] == ip2long(Tools::getRemoteAddr()) || !Configuration::get('PS_COOKIE_CHECKIP'))
-        );
+        ;
     }
 
     /**
      * Delete cookie
-     * As of version 1.5 don't call this function, use Customer::logout() or Employee::logout() instead;
+     * As of version 1.5 don't call this function, use Customer::logout() or Employee::logout() instead;.
      */
     public function logout()
     {
@@ -246,7 +251,7 @@ class CookieCore
     /**
      * Soft logout, delete everything links to the customer
      * but leave there affiliate's informations.
-     * As of version 1.5 don't call this function, use Customer::mylogout() instead;
+     * As of version 1.5 don't call this function, use Customer::mylogout() instead;.
      */
     public function mylogout()
     {
@@ -274,7 +279,7 @@ class CookieCore
     }
 
     /**
-     * Get cookie content
+     * Get cookie content.
      */
     public function update($nullValues = false)
     {
@@ -311,7 +316,7 @@ class CookieCore
         }
 
         //checks if the language exists, if not choose the default language
-        if (!$this->_standalone && !Language::getLanguage((int)$this->id_lang)) {
+        if (!$this->_standalone && !Language::getLanguage((int) $this->id_lang)) {
             $this->id_lang = Configuration::get('PS_LANG_DEFAULT');
             // set detect_language to force going through Tools::setCookieLanguage to figure out browser lang
             $this->detect_language = true;
@@ -319,7 +324,7 @@ class CookieCore
     }
 
     /**
-     * Encrypt and set the Cookie
+     * Encrypt and set the Cookie.
      *
      * @param string|null $cookie Cookie content
      *
@@ -333,7 +338,7 @@ class CookieCore
     }
 
     /**
-     * Encrypt and set the Cookie
+     * Encrypt and set the Cookie.
      *
      * @param string|null $cookie Cookie content
      *
@@ -365,7 +370,7 @@ class CookieCore
     }
 
     /**
-     * Save cookie with setcookie()
+     * Save cookie with setcookie().
      */
     public function write()
     {
@@ -391,7 +396,7 @@ class CookieCore
     }
 
     /**
-     * Get a family of variables (e.g. "filter_")
+     * Get a family of variables (e.g. "filter_").
      */
     public function getFamily($origin)
     {
@@ -404,12 +409,10 @@ class CookieCore
                 $result[$key] = $value;
             }
         }
+
         return $result;
     }
 
-    /**
-     *
-     */
     public function unsetFamily($origin)
     {
         $family = $this->getFamily($origin);
@@ -424,7 +427,7 @@ class CookieCore
     }
 
     /**
-     * @return String name of cookie
+     * @return string name of cookie
      */
     public function getName()
     {
@@ -432,9 +435,10 @@ class CookieCore
     }
 
     /**
-     * Check if the cookie exists
+     * Check if the cookie exists.
      *
      * @since 1.5.0
+     *
      * @return bool
      */
     public function exists()

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -128,8 +128,8 @@ if ($lastParametersModificationTime) {
         define('_NEW_COOKIE_KEY_', $config['parameters']['new_cookie_key']);
     } else {
         // Define cookie key if missing to prevent failure in composer post-install script
-        $key = \Defuse\Crypto\Key::createNewRandomKey();
-        define('_NEW_COOKIE_KEY_', $key->saveToAsciiSafeString());
+        $key = PhpEncryption::createNewRandomKey();
+        define('_NEW_COOKIE_KEY_', $key);
     }
 
     define('_PS_CREATION_DATE_', $config['parameters']['ps_creation_date']);

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -101,7 +101,11 @@ class InstallModelInstall extends InstallAbstractModel
             $database_host = implode(':', $splits);
         }
 
-        $key = \Defuse\Crypto\Key::createNewRandomKey();
+        array_walk($parameters['parameters'], function (&$param) {
+            $param = str_replace('%', '%%', $param);
+        });
+        $key = \PhpEncryption::createNewRandomKey();
+
         $parameters = array(
             'parameters' => array(
                 'database_host' => $database_host,
@@ -113,15 +117,12 @@ class InstallModelInstall extends InstallAbstractModel
                 'database_engine' =>  $database_engine,
                 'cookie_key' => $cookie_key,
                 'cookie_iv' =>  $cookie_iv,
-                'new_cookie_key' => $key->saveToAsciiSafeString(),
+                'new_cookie_key' => $key,
                 'ps_creation_date' => date('Y-m-d'),
                 'secret' => $secret,
                 'locale' => $this->language->getLanguage()->getLocale(),
             )
         );
-        array_walk($parameters['parameters'], function (&$param) {
-            $param = str_replace('%', '%%', $param);
-        });
 
         $parameters = array_replace_recursive(
             Yaml::parse(file_get_contents(_PS_ROOT_DIR_.'/app/config/parameters.yml.dist')),

--- a/src/PrestaShopBundle/Utils/Migrate.php
+++ b/src/PrestaShopBundle/Utils/Migrate.php
@@ -15,18 +15,18 @@ class Migrate
     public static function migrateSettingsFile(Event $event = null)
     {
         if ($event !== null) {
-            $event->getIO()->write("Migrating old setting file...");
+            $event->getIO()->write('Migrating old setting file...');
         }
 
         $root_dir = realpath(__DIR__.'/../../../');
 
-
         $phpParametersFilepath = $root_dir.'/app/config/parameters.php';
         if (file_exists($phpParametersFilepath)) {
             if ($event !== null) {
-                $event->getIO()->write("parameters file already exists!");
-                $event->getIO()->write("Finished...");
+                $event->getIO()->write('parameters file already exists!');
+                $event->getIO()->write('Finished...');
             }
+
             return false;
         }
 
@@ -37,6 +37,7 @@ class Migrate
             } catch (IOException $e) {
                 return false;
             }
+
             return true;
         };
         $fileMigrated = false;
@@ -56,9 +57,9 @@ class Migrate
             file_put_contents($tmp_settings_file, $tmp_settings);
             include $tmp_settings_file;
             @unlink($tmp_settings_file);
-            $factory   = new RandomLib\Factory;
+            $factory = new RandomLib\Factory();
             $generator = $factory->getLowStrengthGenerator();
-            $secret    = $generator->generateString(56);
+            $secret = $generator->generateString(56);
 
             if (!defined('_LEGACY_NEW_COOKIE_KEY_')) {
                 define('_LEGACY_NEW_COOKIE_KEY_', $default_parameters['parameters']['new_cookie_key']);
@@ -67,35 +68,35 @@ class Migrate
             $db_server_port = explode(':', _LEGACY_DB_SERVER_);
             if (count($db_server_port) == 1) {
                 $db_server = $db_server_port[0];
-                $db_port   = 3306;
+                $db_port = 3306;
             } else {
                 $db_server = $db_server_port[0];
-                $db_port   = $db_server_port[1];
+                $db_port = $db_server_port[1];
             }
 
             $parameters = array(
                 'parameters' => array(
-                    'database_host'     => $db_server,
-                    'database_port'     => $db_port,
-                    'database_user'     => _LEGACY_DB_USER_,
+                    'database_host' => $db_server,
+                    'database_port' => $db_port,
+                    'database_user' => _LEGACY_DB_USER_,
                     'database_password' => _LEGACY_DB_PASSWD_,
-                    'database_name'     => _LEGACY_DB_NAME_,
-                    'database_prefix'   => _LEGACY_DB_PREFIX_,
-                    'database_engine'   => _LEGACY_MYSQL_ENGINE_,
-                    'cookie_key'        => _LEGACY_COOKIE_KEY_,
-                    'cookie_iv'         => _LEGACY_COOKIE_IV_,
-                    'new_cookie_key'    => _LEGACY_NEW_COOKIE_KEY_,
-                    'ps_caching'        => _LEGACY_PS_CACHING_SYSTEM_,
-                    'ps_cache_enable'   => _LEGACY_PS_CACHE_ENABLED_,
-                    'ps_creation_date'  => _LEGACY_PS_CREATION_DATE_,
-                    'secret'            => $secret,
-                    'mailer_transport'  => 'smtp',
-                    'mailer_host'       => '127.0.0.1',
-                    'mailer_user'       => '',
-                    'mailer_password'   => ''
-                ) + $default_parameters['parameters']
+                    'database_name' => _LEGACY_DB_NAME_,
+                    'database_prefix' => _LEGACY_DB_PREFIX_,
+                    'database_engine' => _LEGACY_MYSQL_ENGINE_,
+                    'cookie_key' => _LEGACY_COOKIE_KEY_,
+                    'cookie_iv' => _LEGACY_COOKIE_IV_,
+                    'new_cookie_key' => _LEGACY_NEW_COOKIE_KEY_,
+                    'ps_caching' => _LEGACY_PS_CACHING_SYSTEM_,
+                    'ps_cache_enable' => _LEGACY_PS_CACHE_ENABLED_,
+                    'ps_creation_date' => _LEGACY_PS_CREATION_DATE_,
+                    'secret' => $secret,
+                    'mailer_transport' => 'smtp',
+                    'mailer_host' => '127.0.0.1',
+                    'mailer_user' => '',
+                    'mailer_password' => '',
+                ) + $default_parameters['parameters'],
             );
-        } else if (file_exists($root_dir.'/app/config/parameters.yml')) {
+        } elseif (file_exists($root_dir.'/app/config/parameters.yml')) {
             $parameters = Yaml::parse(file_get_contents($root_dir.'/app/config/parameters.yml'));
             if (empty($parameters['parameters'])) {
                 $parameters['parameters'] = array();
@@ -109,7 +110,7 @@ class Migrate
         if (!empty($parameters) && $exportPhpConfigFile($parameters, $phpParametersFilepath)) {
             $fileMigrated = true;
             $settings_content = "<?php\n";
-            $settings_content .= "//@deprecated 1.7";
+            $settings_content .= '//@deprecated 1.7';
 
             file_put_contents($root_dir.'/'.self::SETTINGS_FILE, $settings_content);
             file_put_contents($root_dir.'/app/config/parameters.yml', 'parameters:');
@@ -117,9 +118,9 @@ class Migrate
 
         if ($event !== null) {
             if (!$fileMigrated) {
-                $event->getIO()->write("No old config file present!");
+                $event->getIO()->write('No old config file present!');
             }
-            $event->getIO()->write("Finished...");
+            $event->getIO()->write('Finished...');
         }
     }
 }

--- a/tests/Unit/classes/PhpEncryptionLegacyEngineTest.php
+++ b/tests/Unit/classes/PhpEncryptionLegacyEngineTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\tests\Unit\classes;
+
+use PhpEncryptionLegacyEngine;
+
+class PhpEncryptionLegacyEngineTest extends \PHPUnit_Framework_TestCase
+{
+    const FOO = 'foo';
+    private $engine;
+
+    public function setUp()
+    {
+        $key = \Defuse\Crypto\Key::createNewRandomKey();
+        $this->engine = new PhpEncryptionLegacyEngine($key->saveToAsciiSafeString());
+    }
+
+    public function testEncryptAndDecrypt()
+    {
+        $encryptedValue = $this->engine->encrypt(self::FOO);
+        $this->assertSame(self::FOO, $this->engine->decrypt($encryptedValue));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Actually we can't install PrestaShop in legacy plans of web hosting platforms like OVH. They are still providing a deprecated version of OpenSSL without the new method of encryption we now use in PrestaShop (thanks to php-encryption and @firstred for the integration). So, basically we need to backward to another encryption engine in this case... |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1659 |
| How to test? | We need to build a private build and let @dSkrbic test it against popular web hosting providers. |
