### PR TITLE
Fix work authorization for (back|front)-office. After transition from RC1 to RC2.

### DIFF
--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -67,13 +67,18 @@ namespace PrestaShopBundle\Install {
             $root_dir = realpath(__DIR__ . '/../../../');
 
             $phpParametersFilepath = $root_dir . '/app/config/parameters.php';
+            $addNewCookieKey = false;
             if (file_exists($phpParametersFilepath)) {
-                if ($event !== null) {
-                    $event->getIO()->write('parameters file already exists!');
-                    $event->getIO()->write('Finished...');
+                $default_parameters = require $phpParametersFilepath;
+                if (!array_key_exists('new_cookie_key', $default_parameters['parameters'])) {
+                    $addNewCookieKey = true;
+                } else {
+                    if ($event !== null) {
+                        $event->getIO()->write('parameters file already exists!');
+                        $event->getIO()->write('Finished...');
+                    }
+                    return false;
                 }
-
-                return false;
             }
 
             if (!file_exists($phpParametersFilepath) && !file_exists($root_dir.'/app/config/parameters.yml')
@@ -96,8 +101,21 @@ namespace PrestaShopBundle\Install {
                 return true;
             };
             $fileMigrated = false;
-            $default_parameters = Yaml::parse(file_get_contents($root_dir . '/app/config/parameters.yml.dist'));
+            if (!$addNewCookieKey) {
+                $default_parameters = Yaml::parse(file_get_contents($root_dir . '/app/config/parameters.yml.dist'));
+            }
             $default_parameters['parameters']['new_cookie_key'] = PhpEncryption::createNewRandomKey();
+
+            if ($addNewCookieKey) {
+                $exportPhpConfigFile($default_parameters, $phpParametersFilepath);
+                if ($event !== null) {
+                    $event->getIO()->write("parameters file already exists!");
+                    $event->getIO()->write("add new parameter 'new_cookie_key'");
+                    $event->getIO()->write("Finished...");
+                }
+                return false;
+            }
+
             if (file_exists($root_dir . '/' . self::SETTINGS_FILE)) {
                 $tmp_settings = file_get_contents($root_dir . '/' . self::SETTINGS_FILE);
             } else {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | After transition from RC1 to RC2, MIgrate::migrateSettingsFile() do not set 'new_cookie_key', since the file parametr.php already exists. Every time a new key is generated (config/bootstrap.php:129) for PhpEncryption. What breaks authorization, as a cookie is not valid. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | The file app/config/parameters.php will contain 'new_cookie_key', after `composer install` in RC2 |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/6681)
<!-- Reviewable:end -->
