### PR TITLE
Chrome54 is not available on webdriver.io yet (fix Travis build)

### DIFF
--- a/tests/Selenium/wdio.conf.js
+++ b/tests/Selenium/wdio.conf.js
@@ -33,7 +33,7 @@ exports.config = {
     // https://docs.saucelabs.com/reference/platforms-configurator
     //
     capabilities: [{
-        browserName: 'chrome',
+        browserName: 'firefox',
         tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
         screenResolution: "1600x1200",
         platform: "Windows 7",


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Chrome 54 has been released but is not available in webdriver.io, making a weird error in our build. Also, I've configurated an open source plan from sauce labs. |
| Type? | bug fix |
| Category? | TE |
| How to test? | Let's travis and saucelabs do it. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
