### PR TITLE
Bring back addon card on search

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -27,9 +27,12 @@ var AdminModuleController = function() {
    * @type {Array}
    */
   this.modulesList = [];
+  this.addonsCardGrid = null;
+  this.addonsCardList = null;
 
   // Selectors into vars to make it easier to change them while keeping same code logic
   this.moduleItemGridSelector = '.module-item-grid';
+  this.moduleItemListSelector = '.module-item-list';
   this.categorySelectorLabelSelector = '.module-category-selector-label';
   this.categorySelector = '.module-category-selector';
   this.categoryItemSelector = '.module-category-menu';
@@ -65,6 +68,7 @@ var AdminModuleController = function() {
   // Selectors for Module Import and Addons connect
   this.addonsConnectModalBtnSelector = '#page-header-desc-configuration-addons_connect';
   this.addonsLogoutModalBtnSelector = '#page-header-desc-configuration-addons_logout';
+  this.addonsImportModalBtnSelector = '#page-header-desc-configuration-add_module';
   this.dropZoneModalSelector = '#module-modal-import';
   this.dropZoneImportZoneSelector = '#importDropzone';
   this.addonsConnectModalSelector = '#module-modal-addons-connect';
@@ -134,11 +138,10 @@ var AdminModuleController = function() {
   };
 
   this.onModuleDisabled = function() {
-    var globalModuleSelector = this.getModuleGlobalSelector();
     var moduleItemSelector = this.getModuleItemSelector();
     var self = this;
 
-    $(globalModuleSelector).each(function() {
+    $('.modules-list').each(function() {
       var totalForCurrentSelector = $(this).find(moduleItemSelector+':visible').length;
       self.updateTotalResults(totalForCurrentSelector, $(this));
     });
@@ -175,7 +178,7 @@ var AdminModuleController = function() {
 
         var stylesheet = document.styleSheets[0];
         var stylesheetRule = '{display: none}';
-        var moduleGlobalSelector = self.getModuleGlobalSelector();
+        var moduleGlobalSelector = '.modules-list';
         var requiredSelectorCombination = moduleGlobalSelector + ', .module-sorting-menu ';
 
         if (stylesheet.insertRule) {
@@ -197,6 +200,7 @@ var AdminModuleController = function() {
           });
           $(requiredSelectorCombination).fadeIn(800);
           $('[data-toggle="popover"]').popover();
+          self.initCurrentDisplay();
           self.fetchModulesList();
         });
 
@@ -243,6 +247,8 @@ var AdminModuleController = function() {
         $this.remove();
       });
     });
+    self.addonsCardGrid = $(this.addonItemGridSelector);
+    self.addonsCardList = $(this.addonItemListSelector);
     this.updateModuleVisibility();
   };
 
@@ -302,6 +308,13 @@ var AdminModuleController = function() {
           currentModule.container.append(currentModule.domObject);
         }
       }
+    }
+    if (this.currentTagsList.length) {
+        if ('grid' === this.currentDisplay) {
+            $(".modules-list").append(this.addonsCardGrid);
+        } else {
+            $(".modules-list").append(this.addonsCardList);
+        }
     }
 
     this.updateTotalResults();
@@ -416,7 +429,7 @@ var AdminModuleController = function() {
   };
 
   this.initAddModuleAction = function () {
-    var addModuleButton = $('#page-header-desc-configuration-add_module');
+    var addModuleButton = $(this.addonsImportModalBtnSelector);
     addModuleButton.attr('data-toggle', 'modal');
     addModuleButton.attr('data-target', this.dropZoneModalSelector);
   };
@@ -549,11 +562,7 @@ var AdminModuleController = function() {
   };
 
   this.loadVariables = function () {
-    if ($('.modules-list').length) {
-      this.currentDisplay = 'list';
-    } else {
-      this.currentDisplay = 'grid';
-    }
+    this.initCurrentDisplay();
 
     // If index.php found in the current URL, we need it also in the baseAdminDir
     //noinspection JSUnresolvedVariable
@@ -566,13 +575,7 @@ var AdminModuleController = function() {
   this.getModuleItemSelector = function () {
     return this.currentDisplay == 'grid'
       ? this.moduleItemGridSelector
-      : '.module-item-list';
-  };
-
-  this.getModuleGlobalSelector = function () {
-    return this.currentDisplay == 'grid'
-      ? '.modules-grid'
-      : '.modules-list';
+      : this.moduleItemListSelector;
   };
 
   this.getBulkActionSelectedSelector = function () {
@@ -624,6 +627,15 @@ var AdminModuleController = function() {
       $(self.categoryItemSelector+'[data-category-ref="'+refCategory+'"]').click();
     });
   };
+  
+  this.initCurrentDisplay = function() {
+    var currentDisplaySwitch = $('.module-sort-active');
+    if (currentDisplaySwitch.length) {
+      this.currentDisplay = currentDisplaySwitch.attr('data-switch');
+    } else {
+      this.currentDisplay = 'list';
+    }
+  }
 
   this.initSortingDropdown = function () {
     var self = this;
@@ -762,7 +774,8 @@ var AdminModuleController = function() {
         modulesCount
       );
 
-      $('.module-addons-search').toggle(modulesCount === 0);
+      $(this.addonItemGridSelector).toggle(modulesCount !== (this.modulesList.length/2));
+      $(this.addonItemListSelector).toggle(modulesCount !== (this.modulesList.length/2));
       if (modulesCount === 0) {
         $('.module-addons-search-link').attr(
           'href',

--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -149,7 +149,6 @@
 * Addons Module Cast (List view)
 **/
 .module-addons-item-list {
-  margin-top: 0.25em;
   display: none;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
@@ -159,11 +158,9 @@
   user-select: none;
   cursor: pointer;
 
-  > .module-addons-item-wrapper-list {
-    display: table-cell;
+  .module-addons-item-wrapper-list {
     vertical-align: middle;
     text-align: center;
-    font-size: 20px;
 
     > .module-icon-addons-exit-list {
       > img {

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_grid_addons.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_grid_addons.html.twig
@@ -1,0 +1,9 @@
+<div class="module-addons-item-grid col-md-12 col-lg-6 col-xl-4">
+    <div class="module-addons-item-wrapper-grid">
+      <span class="module-icon-addons-exit-grid">
+        <img src="{{ asset('themes/default/img/preston.png') }}" alt="{{ 'Exit to PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}" />
+      </span>
+      {{ 'See all results for your search on'|trans({}, 'Admin.Modules.Feature') }}<br/>
+      <a class="url" href="#">{{ 'PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}</a>
+    </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list_addons.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list_addons.html.twig
@@ -1,0 +1,11 @@
+<div class="module-item-list module-addons-item-list col-md-12">
+    <div class="container-fluid">
+        <div class="module-addons-item-wrapper-list">
+          <span class="module-icon-addons-exit-list">
+            <img src="{{ asset('themes/default/img/preston.png') }}" alt="{{ 'Exit to PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}" />
+          </span>
+          {{ 'See all results for your search on'|trans({}, 'Admin.Modules.Feature') }}<br/>
+          <a class="url" href="#">{{ 'PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}</a>
+        </div>
+    </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
@@ -1,29 +1,18 @@
-{% if display_type is not defined %}
-  {% set display_type = 'grid' %}
-{% endif %}
-
 <div id="modules-list-container-{{ id }}" class="row modules-list">
   {% if app.request.attributes.get('_route') == 'admin_module_catalog_refresh' %}
     {% for module in modules %}
-      {% include 'PrestaShopBundle:Admin/Module/Includes:card_grid.html.twig' with { 'display_type': display_type, 'module': module, 'origin': origin|default('none') } %}
+      {% include 'PrestaShopBundle:Admin/Module/Includes:card_grid.html.twig' with { 'module': module, 'origin': origin|default('none') } %}
     {% endfor %}
   {% endif %}
   {% for module in modules %}
     {% block addon_card %}
-      {% include 'PrestaShopBundle:Admin/Module/Includes:card_list.html.twig' with { 'display_type': display_type, 'module': module, 'origin': origin|default('none') } %}
+      {% include 'PrestaShopBundle:Admin/Module/Includes:card_list.html.twig' with { 'module': module, 'origin': origin|default('none') } %}
     {% endblock %}
   {% endfor %}
   {% block addon_search_card %}
     {% if requireAddonsSearch is defined and requireAddonsSearch == true %}
-      <div class="module-addons-item-{{ display_type }}">
-        <div class="module-addons-item-wrapper-{{ display_type }}">
-          <span class="module-icon-addons-exit-{{ display_type }}">
-            <img src="{{ asset('themes/default/img/preston.png') }}" alt="{{ 'Exit to PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}" />
-          </span>
-          {{ 'See all results for your search on'|trans({}, 'Admin.Modules.Feature') }}<br/>
-          <a class="url" href="#">{{ 'PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}</a>
-        </div>
-      </div>
+      {% include 'PrestaShopBundle:Admin/Module/Includes:card_grid_addons.html.twig'%}
+      {% include 'PrestaShopBundle:Admin/Module/Includes:card_list_addons.html.twig'%}
     {% endif %}
   {% endblock %}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
@@ -8,14 +8,6 @@
                     data-content="{{ "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'Admin.Modules.Help') }}">
                 </span>
             </div>
-            <p class="module-addons-search">
-                <a class='module-addons-search-link' href="#">
-                    {{ 'See all results for this search on Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}
-                    <span>
-                        <i class="icon-signout"></i>
-                    </span>
-                </a>
-            </p>
         </div>
         <div class="col-lg-6">
             <div class="module-sorting module-sorting-display pull-right">


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When the merchant search on the module page, a redirection card is supposed to be displayed to redirect him to the marketplace. This PR brings back the feature. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1430](http://forge.prestashop.com/browse/BOOM-1430) |
| How to test? | Search on the module page, and check if a card suggest you to be redirected to the marketplace. |
