### PR TITLE
Fix "back" link in module configuration page

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/configure.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/configure.tpl
@@ -56,7 +56,7 @@
 	<div class="btn-toolbar">
 		<ul class="nav nav-pills pull-right">
 			<li>
-				<a id="desc-module-back" class="toolbar_btn" href="javascript: window.history.back();" title="{l s='Back'}">
+				<a id="desc-module-back" class="toolbar_btn" href="{url entity='sf' route='admin_module_manage'}">
 					<i class="process-icon-back"></i>
 					<div>{l s='Back'}</div>
 				</a>


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Back button in module page is based on browser history so have no effect most of the time. The button will know redirect to module list. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1114 |
| How to test? |  |
