### PR TITLE
Avoid overwriting $token in global Smarty context.

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -672,7 +672,6 @@ class HelperListCore extends Helper
             'pagination' => $this->_pagination,
             'list_total' => $this->listTotal,
             'sql' => isset($this->sql) && $this->sql ? str_replace('\n', ' ', str_replace('\r', '', $this->sql)) : false,
-            'token' => $this->token,
             'table' => $this->table,
             'bulk_actions' => $this->bulk_actions,
             'show_toolbar' => $this->show_toolbar,
@@ -702,7 +701,8 @@ class HelperListCore extends Helper
             'name' => isset($name) ? $name : null,
             'name_id' => isset($name_id) ? $name_id : null,
             'row_hover' => $this->row_hover,
-            'list_id' => isset($this->list_id) ? $this->list_id : $this->table
+            'list_id' => isset($this->list_id) ? $this->list_id : $this->table,
+            'token' => $this->token,
         ), $this->tpl_vars));
 
         return $this->header_tpl->fetch();
@@ -747,7 +747,8 @@ class HelperListCore extends Helper
 
         $this->footer_tpl->assign(array_merge($this->tpl_vars, array(
             'current' => $this->currentIndex,
-            'list_id' => $this->list_id
+            'list_id' => $this->list_id,
+            'token' => $this->token,
         )));
         return $this->footer_tpl->fetch();
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Under some circumstances, `HelperList` may overwrite the `$token` variable in the global Smarty context, causing the display of the famous "cursed page" in the back-office |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL. |
| How to test? | See below |

How to reproduce this bug:
- Create a module with a hook `hookDisplayAdminProductsExtra`
- Use a `HelperList` to render a list of items, which uses a different token than the `AdminProducts` page (for example, `AdminModules`)
- The `$token` variable is changed in the global Smarty context, because `HelperList` does this: 

```
Context::getContext()->smarty->assign(array(
  'token' => $this->token,
));
```

My fix makes sure the `$token` variable stays untouched in the global Smarty context, and adds the `$token` variable to the header/content/footer templates used by the helper. 
