### PR TITLE
Provided with theme translations and overrides

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -240,7 +240,7 @@
 			</div>
 		</div>
 	</form>
-	<form action="{url entity=sf route=admin_international_translations_extract_theme }" method="post" enctype="multipart/form-data" class="form-horizontal">
+	<form action="{url entity=sf route=admin_international_translations_export_theme }" method="post" enctype="multipart/form-data" class="form-horizontal">
 		<div class="panel">
 			<h3>
 				<i class="icon-upload"></i>

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -345,23 +345,20 @@ class ContextCore
         if (null === $this->translator) {
             $this->translator = new Translator($this->language->locale, null, _PS_CACHE_DIR_, false);
             $this->translator->addLoader('xlf', new XliffFileLoader());
-            $this->translator->addLoader('db', new SqlTranslationLoader());
 
-            $locations = array(_PS_ROOT_DIR_.'/app/Resources/translations');
-
+            $sqlTranslationLoader = new SqlTranslationLoader();
             if (!is_null($this->shop)) {
-                $activeThemeLocation = _PS_ROOT_DIR_.'/themes/'.$this->shop->theme_name.'/translations';
-                if (is_dir($activeThemeLocation)) {
-                    $locations[] = $activeThemeLocation;
-                }
+                $sqlTranslationLoader->setTheme($this->shop->theme);
             }
+
+            $this->translator->addLoader('db', $sqlTranslationLoader);
 
             $finder = Finder::create()
                 ->files()
                 ->filter(function (\SplFileInfo $file) {
                     return 2 === substr_count($file->getBasename(), '.') && preg_match('/\.\w+$/', $file->getBasename());
                 })
-                ->in($locations)
+                ->in($this->getTranslationResourcesDirectories())
             ;
 
             foreach ($finder as $file) {
@@ -375,5 +372,22 @@ class ContextCore
         }
 
         return $this->translator;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getTranslationResourcesDirectories()
+    {
+        $locations = array(_PS_ROOT_DIR_ . '/app/Resources/translations');
+
+        if (!is_null($this->shop)) {
+            $activeThemeLocation = _PS_ROOT_DIR_ . '/themes/' . $this->shop->theme_name . '/translations';
+            if (is_dir($activeThemeLocation)) {
+                $locations[] = $activeThemeLocation;
+            }
+        }
+
+        return $locations;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -60,7 +60,19 @@ class TranslationsController extends FrameworkBundleAdminController
         $catalogue = $this->getTranslationsCatalogue($request);
         $translationsTree = $this->makeTranslationsTree($catalogue);
 
-        return array('translationsTree' => $translationsTree);
+        return array(
+            'translationsTree' => $translationsTree,
+            'theme' => $this->getSelectedTheme($request)
+        );
+    }
+
+    private function getSelectedTheme(Request $request)
+    {
+        if ($request->get('type') === 'themes') {
+            return $request->get('selected-theme');
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -114,6 +126,7 @@ class TranslationsController extends FrameworkBundleAdminController
 
         $themeExtractor = $this->get('prestashop.translations.theme_extractor');
         $themeExtractor
+            ->setThemeProvider($this->get('prestashop.translation.theme_provider'))
             ->setOutputPath($tmpFolderPath)
             ->enableOverridingFromDatabase()
             ->extract($theme, $locale)
@@ -149,6 +162,7 @@ class TranslationsController extends FrameworkBundleAdminController
                 'lang' => $lang,
                 'domain' => $requestParams['domain'],
                 'key' => $requestParams['translation_key'],
+                'theme' => $requestParams['theme']
             ));
 
         if (is_null($translation)) {
@@ -157,6 +171,7 @@ class TranslationsController extends FrameworkBundleAdminController
             $translation->setLang($lang);
             $translation->setKey(htmlspecialchars_decode($requestParams['translation_key'], ENT_QUOTES));
             $translation->setTranslation($requestParams['translation_value']);
+            $translation->setTheme($requestParams['theme']);
         } else {
             $translation->setTranslation($requestParams['translation_value']);
         }
@@ -213,60 +228,32 @@ class TranslationsController extends FrameworkBundleAdminController
         $type = $request->get('type');
         $theme = $request->get('selected-theme');
 
-        $translator = $this->container->get('translator');
-
-        $factory = ($theme !== 'classic' && $theme !== null) ?
-            $this->get('ps.theme_translations_factory') :
-            $this->get('ps.translations_factory')
-        ;
+        $factory = $this->get('ps.translations_factory');
+        if ($theme !== 'classic' && $this->requiresThemeTranslationsFactory($theme, $type)) {
+            $factory = $this->get('ps.theme_translations_factory');
+        }
 
         $locale = $this->langToLocale($lang);
 
-        if (!is_null($theme) && 'themes' === $type) {
+        if ($this->requiresThemeTranslationsFactory($theme, $type)) {
             if ('classic' === $theme) {
                 $type = 'front';
             } else {
                 $type = $theme;
-                $this->synchronizeTheme($theme, $locale);
             }
         }
 
-        $translations = $factory->createTranslationsArray($type, $locale);
+        return $factory->createTranslationsArray($type, $locale);
+    }
 
-        if (!is_null($translations)) {
-            return $translations;
-        }
-
-        // if type is not found, return all keys
-        $finder = new Finder();
-        $translationFiles = $finder->files()->in($this->getResourcesDirectory().'/translations/'.$locale);
-
-        $translationLocale = str_replace('-', '_', $locale);
-
-        if (count($translationFiles) === 0) {
-            throw new \Exception('There is no translation file available');
-        }
-
-        foreach ($translationFiles as $file) {
-            $translator->addResource('xlf', $file->getPathname(), $translationLocale, $file->getBasename('.xlf'));
-        }
-
-        $catalogue = $translator->getCatalogue($translationLocale)->all();
-        $databaseCatalogue = $this->getTranslationsInDatabase($locale);
-
-        foreach ($databaseCatalogue as $domain => $messages) {
-            foreach ($messages as $translationKey => $translationValue) {
-                $catalogue[$domain][$translationKey] = array(
-                    // Xliff-based translation stored for reset action
-                    'xlf' => $catalogue[$domain][$translationKey],
-                    'db' => $translationValue,
-                );
-            }
-        }
-
-        ksort($catalogue);
-
-        return $catalogue;
+    /**
+     * @param $theme
+     * @param $type
+     * @return bool
+     */
+    private function requiresThemeTranslationsFactory($theme, $type)
+    {
+        return $type === 'themes' && !is_null($theme);
     }
 
     /**
@@ -362,16 +349,16 @@ class TranslationsController extends FrameworkBundleAdminController
 
     /**
      * @param $locale
-     *
+     * @param $theme
      * @return array
      */
-    protected function getTranslationsInDatabase($locale)
+    protected function getTranslationsInDatabase($locale, $theme = null)
     {
-        $entityManager = $this->getDoctrine()->getManager();
-        $translations = $entityManager->getRepository('PrestaShopBundle:Translation')
-            ->findBy(array(
-                'lang' => $this->findLanguageByLocale($locale),
-            ));
+        $translationRepository = $this->get('prestashop.core.admin.translation.repository');
+        $translations = $translationRepository->findByLanguageAndTheme(
+            $this->findLanguageByLocale($locale),
+            $theme
+        );
 
         $translationsMap = array();
         array_map(function ($translation) use (&$translationsMap, $locale) {
@@ -384,29 +371,5 @@ class TranslationsController extends FrameworkBundleAdminController
         }, $translations);
 
         return $translationsMap;
-    }
-
-    private function synchronizeTheme($themeName, $locale)
-    {
-        $theme = $this
-            ->get('prestashop.core.addon.theme.repository')
-            ->getInstanceByName($themeName)
-        ;
-
-        $path = $this->getParameter('themes_dir').'/'.$themeName.'/translations';
-        $this->get('filesystem')->remove($path);
-        $this->get('filesystem')->mkdir($path);
-
-        $this->get('prestashop.translations.theme_extractor')
-            ->setOutputPath($path)
-            ->extract($theme, $locale)
-        ;
-
-        $translationFilesPath = $path.'/'.$locale;
-        Flattenizer::flatten($translationFilesPath, $translationFilesPath, $locale, false);
-
-        foreach ($this->get('finder')->directories()->depth('== 0')->in($translationFilesPath) as $folder) {
-            $this->get('filesystem')->remove($folder);
-        }
     }
 }

--- a/src/PrestaShopBundle/Entity/Lang.php
+++ b/src/PrestaShopBundle/Entity/Lang.php
@@ -5,10 +5,8 @@ namespace PrestaShopBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Lang
- *
  * @ORM\Table()
- * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\LangRepository")
+ * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\LangRepository")
  */
 class Lang
 {

--- a/src/PrestaShopBundle/Entity/LangRepository.php
+++ b/src/PrestaShopBundle/Entity/LangRepository.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace PrestaShopBundle\Entity;
-
-use Doctrine\ORM\EntityRepository;
-
-class LangRepository extends EntityRepository
-{
-}

--- a/src/PrestaShopBundle/Entity/Repository/LangRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LangRepository.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class LangRepository extends EntityRepository
+{
+    /**
+     * @param $isoCode
+     * @return array
+     */
+    public function getLocaleByIsoCode($isoCode)
+    {
+        return $this->findOneBy(array('isoCode' => $isoCode))
+            ->getLocale();
+    }
+}

--- a/src/PrestaShopBundle/Entity/Repository/TranslationRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/TranslationRepository.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * 2007-2016 PrestaShop.
  *
@@ -20,36 +19,37 @@
  * needs please refer to http://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2016 PrestaShop SA
+ * @copyright 2007-2015 PrestaShop SA
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Translation\Factory;
+namespace PrestaShopBundle\Entity\Repository;
 
-use Symfony\Component\Translation\MessageCatalogue;
+use Doctrine\ORM\EntityRepository;
 
-interface TranslationsFactoryInterface
+class TranslationRepository extends EntityRepository
 {
-    const DEFAULT_LOCALE = 'en_US';
-
     /**
-     * Generates extract of global Catalogue, using domain's identifiers.
-     *
-     * @param string $identifier Domain identifier
-     * @param string $locale     Locale identifier
-     *
-     * @return MessageCatalogue
+     * @param $language
+     * @param $theme
+     * @return array
      */
-    public function createCatalogue($identifier, $locale = self::DEFAULT_LOCALE);
+    public function findByLanguageAndTheme($language, $theme = null)
+    {
+        $queryBuilder = $this->createQueryBuilder('t');
+        $queryBuilder->where('lang = :language');
+        $queryBuilder->setParameter('language', $language);
 
-    /**
-     * Generates Translation tree in Back Office.
-     *
-     * @param string $domainIdentifier Domain identifier
-     * @param string $locale           Locale identifier
-     *
-     * @return array Translation tree structure
-     */
-    public function createTranslationsArray($domainIdentifier, $locale = self::DEFAULT_LOCALE);
+        if (!is_null($theme)) {
+            $queryBuilder->andWhere('theme = :theme');
+            $queryBuilder->setParameter('theme', $theme);
+        } else {
+            $queryBuilder->andWhere('theme IS NULL');
+        }
+
+        $query = $queryBuilder->getQuery();
+
+        return $query->getResult();
+    }
 }

--- a/src/PrestaShopBundle/Entity/Translation.php
+++ b/src/PrestaShopBundle/Entity/Translation.php
@@ -7,8 +7,11 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * Translation.
  *
- * @ORM\Table(indexes={@ORM\Index(name="key", columns={"domain"})})
- * @ORM\Entity(repositoryClass="TranslationRepository")
+ * @ORM\Table(
+ *     indexes={@ORM\Index(name="key", columns={"domain"})},
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="theme", columns={"theme", "id_lang", "domain"})}
+ * )
+ * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\TranslationRepository")
  */
 class Translation
 {
@@ -49,6 +52,13 @@ class Translation
      * @ORM\Column(name="domain", type="string")
      */
     private $domain;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="theme", type="string", nullable=true)
+     */
+    private $theme;
 
     /**
      * Get id.
@@ -136,6 +146,26 @@ class Translation
     public function setDomain($domain)
     {
         $this->domain = $domain;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTheme()
+    {
+        return $this->theme;
+    }
+
+    /**
+     * @param $theme
+     *
+     * @return \PrestaShopBundle\Entity\Translation
+     */
+    public function setTheme($theme)
+    {
+        $this->theme = $theme;
 
         return $this;
     }

--- a/src/PrestaShopBundle/Resources/config/admin/routing_international.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/routing_international.yml
@@ -18,9 +18,9 @@ admin_international_translations_edit:
         translation_key: \w+
         translation_value: \w+
 
-admin_international_translations_extract_theme:
-    path: /translations/extract
+admin_international_translations_export_theme:
+    path: /translations/export
     methods:  [POST]
     defaults:
-        _controller: PrestaShopBundle:Admin/Translations:extractTheme
+        _controller: PrestaShopBundle:Admin/Translations:exportTheme
         _legacy_controller: AdminTranslations

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -1,6 +1,7 @@
 parameters:
-    translations_dir: "%kernel.root_dir%/Resources/translations"
-    themes_dir: "%kernel.root_dir%/../themes"
+    translations_dir:         "%kernel.root_dir%/Resources/translations"
+    themes_translations_dir:  "%kernel.cache_dir%/themes"
+    themes_dir:               "%kernel.root_dir%/../themes"
 
 services:
 # CORE ADMIN (prestashop.core.admin.*)
@@ -115,6 +116,8 @@ services:
     prestashop.translation.theme_translations_factory:
         class: PrestaShopBundle\Translation\Factory\ThemeTranslationsFactory
         arguments: ['@prestashop.translation.theme_provider']
+        calls:
+            - [ addProvider, ['@prestashop.translation.frontoffice_provider']]
 
     ps.theme_translations_factory:
         alias: "prestashop.translation.theme_translations_factory"
@@ -156,4 +159,9 @@ services:
         class: PrestaShopBundle\Translation\Provider\ThemeProvider
         arguments:
             - "@prestashop.translations.database_loader"
-            - "%themes_dir%"
+            - "%themes_translations_dir%"
+        properties:
+            themeResourcesDirectory:  "%themes_dir%"
+            filesystem:               "@filesystem"
+            themeRepository:          "@prestashop.core.admin.theme.repository"
+            themeExtractor:           "@prestashop.translations.theme_extractor"

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -126,7 +126,7 @@ services:
     prestashop.translation.backoffice_provider:
         class: PrestaShopBundle\Translation\Provider\BackOfficeProvider
         arguments:
-            - "@prestashop.translations.database_loader"
+            - "@prestashop.translation.database_loader"
             - "%translations_dir%"
         tags:
             - { name: "ps.translation_provider" }
@@ -134,7 +134,7 @@ services:
     prestashop.translation.frontoffice_provider:
         class: PrestaShopBundle\Translation\Provider\FrontOfficeProvider
         arguments:
-            - "@prestashop.translations.database_loader"
+            - "@prestashop.translation.database_loader"
             - "%translations_dir%"
         tags:
             - { name: "ps.translation_provider" }
@@ -142,7 +142,7 @@ services:
     prestashop.translation.mails:
         class: PrestaShopBundle\Translation\Provider\MailsProvider
         arguments:
-            - "@prestashop.translations.database_loader"
+            - "@prestashop.translation.database_loader"
             - "%translations_dir%"
         tags:
             - { name: "ps.translation_provider" }
@@ -150,7 +150,7 @@ services:
     prestashop.translation.others_provider:
             class: PrestaShopBundle\Translation\Provider\OthersProvider
             arguments:
-                - "@prestashop.translations.database_loader"
+                - "@prestashop.translation.database_loader"
                 - "%translations_dir%"
             tags:
                 - { name: "ps.translation_provider" }
@@ -158,10 +158,40 @@ services:
     prestashop.translation.theme_provider:
         class: PrestaShopBundle\Translation\Provider\ThemeProvider
         arguments:
-            - "@prestashop.translations.database_loader"
+            - "@prestashop.translation.database_loader"
             - "%themes_translations_dir%"
         properties:
             themeResourcesDirectory:  "%themes_dir%"
             filesystem:               "@filesystem"
-            themeRepository:          "@prestashop.core.admin.theme.repository"
-            themeExtractor:           "@prestashop.translations.theme_extractor"
+            themeRepository:          "@prestashop.core.addon.theme.repository"
+            themeExtractor:           "@prestashop.translation.theme_extractor"
+
+    # TRANSLATIONS
+    prestashop.translation.database_loader:
+        class: PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader
+        arguments:
+            - "@doctrine.orm.entity_manager"
+        tags:
+            - {name: translation.loader, alias: db}
+
+    prestashop.translation.theme_extractor:
+        class: PrestaShopBundle\Translation\Extractor\ThemeExtractor
+        arguments:
+            - "@prestashop.translation.extractor.smarty"
+
+
+    prestashop.translation.dumper.xliff:
+        class: PrestaShop\TranslationToolsBundle\Translation\Dumper\XliffFileDumper
+
+    prestashop.translation.theme.exporter:
+        class: PrestaShopBundle\Translation\Exporter\ThemeExporter
+        arguments:
+            - "@prestashop.translation.theme_extractor"
+            - "@prestashop.translation.theme_provider"
+            - "@prestashop.core.addon.theme.repository"
+            - "@prestashop.translation.dumper.xliff"
+            - "@prestashop.utils.zip_manager"
+            - "@filesystem"
+        properties:
+            cacheDir: "%kernel.cache_dir%"
+            exportDir: "%kernel.cache_dir%/export"

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -274,6 +274,12 @@ services:
         arguments:
             - PrestaShopBundle\Entity\Translation
 
+    prestashop.core.admin.lang.repository:
+        class: PrestaShopBundle\Entity\Repository\LangRepository
+        factory: ['@doctrine.orm.default_entity_manager', getRepository]
+        arguments:
+            - PrestaShopBundle\Entity\Lang
+
     # Managers
     prestashop.adapter.image_manager:
         class: PrestaShop\PrestaShop\Adapter\ImageManager
@@ -296,19 +302,6 @@ services:
             - "@filesystem"
             - "@finder"
             - "@translator"
-
-    # TRANSLATIONS
-    prestashop.translations.database_loader:
-        class: PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader
-        arguments:
-            - "@doctrine.orm.entity_manager"
-        tags:
-            - {name: translation.loader, alias: db}
-
-    prestashop.translations.theme_extractor:
-        class: PrestaShopBundle\Translation\Extractor\ThemeExtractor
-        arguments:
-          - "@prestashop.translation.extractor.smarty"
 
 # Addons API Client
     prestashop.addons.client_api:

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -268,6 +268,12 @@ services:
           - "@filesystem"
           - "@finder"
 
+    prestashop.core.admin.translation.repository:
+        class: PrestaShopBundle\Entity\Repository\TranslationRepository
+        factory: ['@doctrine.orm.default_entity_manager', getRepository]
+        arguments:
+            - PrestaShopBundle\Entity\Translation
+
     # Managers
     prestashop.adapter.image_manager:
         class: PrestaShop\PrestaShop\Adapter\ImageManager
@@ -303,7 +309,6 @@ services:
         class: PrestaShopBundle\Translation\Extractor\ThemeExtractor
         arguments:
           - "@prestashop.translation.extractor.smarty"
-          - "@prestashop.translation.theme_provider"
 
 # Addons API Client
     prestashop.addons.client_api:

--- a/src/PrestaShopBundle/Resources/views/Admin/Translations/include/form-edit-message.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Translations/include/form-edit-message.html.twig
@@ -6,11 +6,16 @@
     <p><strong>Translation key:</strong> <verbatim>{{ translation_key }}</verbatim></p>
     <div class="form-group row{% if not is_translated %} has-warning{% endif %}">
         <div class="col-lg-12">
-            <textarea class="form-control{% if not is_translated %} form-control-warning{% endif %}" rows="3" name="translation_value">{{ edited_translation_value }}</textarea>
+            <textarea class="form-control{% if not is_translated %} form-control-warning{% endif %}"
+                      rows="3"
+                      name="translation_value">
+                {{- edited_translation_value -}}
+            </textarea>
         </div>
         <input type="hidden" name="domain" value="{{ domain }}"/>
         <input type="hidden" name="locale" value="{{ locale }}"/>
         <input type="hidden" name="default" value="{{ default_translation_value }}"/>
+        <input type="hidden" name="theme" value="{{ theme }}"/>
         <input type="hidden" name="translation_key" value="{{ translation_key }}"/>
     </div>
     <div class="col-md-offset-1">

--- a/src/PrestaShopBundle/Resources/views/Admin/Translations/list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Translations/list.html.twig
@@ -11,10 +11,10 @@
         <input class="btn btn-default btn-sm" type="reset" value="{{ 'Reset'|trans({}, 'Admin.Actions') }}">
     </form>
     <div id="jetsContent">
-        {{ getTranslationsForms(translationsTree)|raw }}
+        {{ getTranslationsForms(translationsTree, theme)|raw }}
     </div>
 </div>
 <div class="translation-page">
-    {{ getTranslationsTree(translationsTree)|raw }}
+    {{ getTranslationsTree(translationsTree, theme)|raw }}
 </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Tests/Translation/Exporter/ThemeExporterTest.php
+++ b/src/PrestaShopBundle/Tests/Translation/Exporter/ThemeExporterTest.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author 	PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2016 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Tests\Translation\Exporter;
+
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\TranslationToolsBundle\Translation\Dumper\XliffFileDumper;
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\Util\Flattenizer;
+use PrestaShopBundle\Translation\Exporter\ThemeExporter;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class ThemeExporterTest extends \PHPUnit_Framework_TestCase
+{
+    const THEME_NAME = 'theme';
+
+    const LOCALE = 'ab-CD';
+
+    /**
+     * @var ThemeExporter
+     */
+    private $themeExporter;
+
+    private $extractorMock;
+
+    private $providerMock;
+
+    private $repositoryMock;
+
+    private $dumperMock;
+
+    private $zipManagerMock;
+
+    private $filesystemMock;
+
+    private $finderMock;
+
+    public function setUp()
+    {
+        $this->mockThemeExtractor();
+
+        $this->mockThemeProvider();
+
+        $this->mockThemeRepository();
+
+        $this->dumperMock = new XliffFileDumper();
+
+        $this->zipManagerMock = $this->getMockBuilder('\PrestaShopBundle\Utils\ZipManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockFilesystem();
+
+        $this->mockFinder();
+
+        $this->themeExporter = new ThemeExporter(
+            $this->extractorMock,
+            $this->providerMock,
+            $this->repositoryMock,
+            $this->dumperMock,
+            $this->zipManagerMock,
+            new Filesystem()
+        );
+
+        $this->themeExporter->finder = $this->finderMock;
+        $cacheDir = dirname(__FILE__) . '/' .
+            str_repeat('../', 5) .
+            'app/cache/test';
+        $this->themeExporter->exportDir = $cacheDir . '/export';
+        $this->themeExporter->cacheDir = $cacheDir;
+    }
+
+    public function testCreateZipArchive()
+    {
+        $this->themeExporter->createZipArchive(self::THEME_NAME, self::LOCALE);
+
+        $loader = new XliffFileLoader();
+        $archiveContentsParentDir = $this->themeExporter->exportDir . '/' . self::THEME_NAME . '/' . self::LOCALE;
+
+        $finder = Finder::create();
+        $catalogue = new MessageCatalogue(self::LOCALE, array());
+
+        foreach ($finder->in($archiveContentsParentDir)->files() as $file) {
+            $catalogue->addCatalogue(
+                $loader->load(
+                    $file->getPathname(),
+                    self::LOCALE,
+                    $file->getBasename('.' . $file->getExtension())
+                )
+            );
+        }
+
+        $messages = $catalogue->all();
+        $domain = 'ShopActions.' . self::LOCALE;
+        $this->assertArrayHasKey($domain, $messages);
+
+        $this->assertArrayHasKey('Edit Product', $messages[$domain]);
+        $this->assertArrayHasKey('Add Product', $messages[$domain]);
+        $this->assertArrayHasKey('Delete Product', $messages[$domain]);
+
+        $this->assertArrayHasKey('Override Me', $messages[$domain]);
+        $this->assertSame('Overridden' , $messages[$domain]['Override Me']);
+
+        $this->assertArrayHasKey('Override Me Twice', $messages[$domain]);
+        $this->assertSame('Overridden Twice', $messages[$domain]['Override Me Twice']);
+    }
+
+    protected function mockThemeExtractor()
+    {
+        $this->extractorMock = $this->getMockBuilder('\PrestaShopBundle\Translation\Extractor\ThemeExtractor')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->extractorMock->method('setOutputPath')
+            ->willReturn($this->extractorMock);
+    }
+
+    protected function mockThemeRepository()
+    {
+        $this->repositoryMock = $this->getMockBuilder('\PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->repositoryMock->method('getInstanceByName')
+            ->willReturn(new Theme(array(
+                'directory' => '',
+                'name' => self::THEME_NAME
+            )));
+    }
+
+    protected function mockFilesystem()
+    {
+        $this->filesystemMock = $this->getMockBuilder('\Symfony\Component\Filesystem\Filesystem')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->filesystemMock->method('mkdir')
+            ->willReturn(null);
+
+        Flattenizer::$filesystem = $this->filesystemMock;
+    }
+
+    protected function mockFinder()
+    {
+        $this->finderMock = $this->getMockBuilder('\Symfony\Component\Finder\Finder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->finderMock->method('in')
+            ->willReturn($this->finderMock);
+
+        $this->finderMock->method('files')
+            ->willReturn(array());
+
+        Flattenizer::$finder = $this->finderMock;
+    }
+
+    protected function mockThemeProvider()
+    {
+        $this->providerMock = $this->getMockBuilder('\PrestaShopBundle\Translation\Provider\ThemeProvider')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->providerMock->method('getCatalogueFromPaths')
+            ->willReturn(new MessageCatalogue(
+                self::LOCALE,
+                array(
+                    'ShopActions.' . self::LOCALE => array(
+                        'Add Product' => 'Add',
+                        'Override Me' => '',
+                        'Override Me Twice' => '',
+                    )
+                )
+            ));
+
+        $this->providerMock->method('getThemeCatalogue')
+            ->willReturn(new MessageCatalogue(
+                self::LOCALE,
+                array(
+                    'ShopActions.' . self::LOCALE => array(
+                        'Edit Product' => 'Edit',
+                        'Override Me' => 'Overridden',
+                        'Override Me Twice' => 'Overridden Once',
+                    )
+                )
+            ))
+        ;
+
+        $this->providerMock->method('getDatabaseCatalogue')
+            ->willReturn(new MessageCatalogue(
+                self::LOCALE,
+                array(
+                    'ShopActions' => array(
+                        'Delete Product' => 'Delete',
+                        'Override Me Twice' => 'Overridden Twice',
+                    )
+                )
+            ))
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Tests/Translation/Extractor/ThemeExtractorTest.php
+++ b/src/PrestaShopBundle/Tests/Translation/Extractor/ThemeExtractorTest.php
@@ -55,7 +55,7 @@ class ThemeExtractorTest extends KernelTestCase
 
         $this->container = self::$kernel->getContainer();
         $this->filesystem = new Filesystem();
-        $this->themeExtractor = $this->container->get('prestashop.translations.theme_extractor');
+        $this->themeExtractor = $this->container->get('prestashop.translation.theme_extractor');
     }
 
     public function tearDown()

--- a/src/PrestaShopBundle/Tests/Translation/Provider/ThemeProviderTest.php
+++ b/src/PrestaShopBundle/Tests/Translation/Provider/ThemeProviderTest.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Tests\Translation\Provider;
 
 use PrestaShopBundle\Translation\Provider\ThemeProvider;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ThemeProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -41,6 +42,7 @@ class ThemeProviderTest extends \PHPUnit_Framework_TestCase
 
         self::$resourcesDir = __DIR__.'/../../resources/themes/fakeTheme2';
         $this->provider = new ThemeProvider($loader, self::$resourcesDir);
+        $this->provider->filesystem = new Filesystem();
     }
 
     public function testGetMessageCatalogue()

--- a/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
+++ b/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author     PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2016 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation\Exporter;
+
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
+use PrestaShop\TranslationToolsBundle\Translation\Dumper\XliffFileDumper;
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\Util\Flattenizer;
+use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
+use PrestaShopBundle\Translation\Provider\ThemeProvider;
+use PrestaShopBundle\Utils\ZipManager;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class ThemeExporter
+{
+    private $themeExtractor;
+
+    private $themeProvider;
+
+    private $zipManager;
+
+    private $themeRepository;
+
+    private $dumper;
+
+    private $filesystem;
+
+    public $cacheDir;
+
+    public $exportDir;
+
+    public function __construct(
+        ThemeExtractor $themeExtractor,
+        ThemeProvider $themeProvider,
+        ThemeRepository $themeRepository,
+        XliffFileDumper $dumper,
+        ZipManager $zipManager,
+        Filesystem $filesystem
+    )
+    {
+        $this->themeExtractor = $themeExtractor;
+        $this->themeExtractor
+            ->setThemeProvider($themeProvider);
+
+        $this->themeProvider = $themeProvider;
+        $this->themeRepository = $themeRepository;
+        $this->dumper = $dumper;
+        $this->zipManager = $zipManager;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * @param $themeName
+     * @param $locale
+     * @return string
+     */
+    public function createZipArchive($themeName, $locale)
+    {
+        $this->themeProvider->setLocale($locale);
+
+        $mergedTranslations = $this->getCatalogueExtractedFromTemplates($themeName, $locale);
+        try {
+            $themeCatalogue = $this->themeProvider->getThemeCatalogue();
+        } catch (\Exception $exception) {
+            $themeCatalogue = new MessageCatalogue($locale, array());
+        }
+        $databaseCatalogue = $this->themeProvider->getDatabaseCatalogue($themeName);
+        $databaseCatalogue = $this->addLocaleToDomain($locale, $databaseCatalogue);
+
+        $mergedTranslations->addCatalogue($themeCatalogue);
+        $mergedTranslations->addCatalogue($databaseCatalogue);
+
+        $this->updateCatalogueMetadata($mergedTranslations);
+
+        $archiveParentDirectory = $this->makeArchiveParentDirectory($themeName, $locale);
+
+        // Clean up previously exported archives
+        $this->filesystem->remove($archiveParentDirectory);
+        $this->filesystem->mkdir($archiveParentDirectory);
+
+        $this->dumper->dump($mergedTranslations, array(
+            'path' => $archiveParentDirectory,
+            'default_locale' => $locale
+        ));
+
+        $this->renameCatalogues($locale, $archiveParentDirectory);
+
+        $zipFilename = $this->makeZipFilename($themeName, $locale);
+        $this->zipManager->createArchive($zipFilename, $archiveParentDirectory);
+
+        return $zipFilename;
+    }
+
+    /**
+     * @param $themeName
+     * @param $locale
+     * @return \Symfony\Component\Translation\MessageCatalogue
+     */
+    protected function getCatalogueExtractedFromTemplates($themeName, $locale)
+    {
+        $tmpFolderPath = $this->getTemporaryExtractionFolder($themeName);
+        $folderPath = $this->getFlattenizationFolder($themeName);
+
+        $this->filesystem->mkdir($folderPath);
+        $this->filesystem->mkdir($tmpFolderPath);
+
+        $theme = $this->themeRepository->getInstanceByName($themeName);
+        $this->themeExtractor
+            ->setOutputPath($tmpFolderPath)
+            ->extract($theme, $locale);
+
+        Flattenizer::flatten($tmpFolderPath . '/' . $locale, $folderPath . '/' . $locale, $locale);
+
+        return $this->themeProvider->getCatalogueFromPaths($folderPath, $locale, '*');
+    }
+
+    /**
+     * @param $locale
+     * @param $archiveParentDirectory
+     */
+    protected function renameCatalogues($locale, $archiveParentDirectory)
+    {
+        $finder = Finder::create();
+
+        foreach ($finder->in($archiveParentDirectory . '/' . $locale)->files() as $file) {
+            $parentDirectoryParts = explode('/', dirname($file));
+            $destinationFilenameParts = array(
+                $archiveParentDirectory,
+                $parentDirectoryParts[count($parentDirectoryParts) - 1] . '.' . $locale . '.xlf'
+            );
+            $this->filesystem->rename($file->getPathname(), implode('/', $destinationFilenameParts));
+        }
+
+        $this->filesystem->remove($archiveParentDirectory . '/' . $locale);
+    }
+
+    public function cleanArtifacts($themeName)
+    {
+        $this->filesystem->remove($this->getFlattenizationFolder($themeName));
+        $this->filesystem->remove($this->getTemporaryExtractionFolder($themeName));
+    }
+
+    /**
+     * @param $themeName
+     * @return string
+     */
+    protected function getTemporaryExtractionFolder($themeName)
+    {
+        return $this->cacheDir . '/' . $themeName . '-tmp';
+    }
+
+    /**
+     * @param $themeName
+     * @return string
+     */
+    protected function getFlattenizationFolder($themeName)
+    {
+        return $this->cacheDir . '/' . $themeName;
+    }
+
+    /**
+     * @param $themeName
+     * @return string
+     */
+    protected function getExportDir($themeName)
+    {
+        return $this->exportDir . '/' . $themeName;
+    }
+
+    /**
+     * @param $themeName
+     * @param $locale
+     * @return string
+     */
+    protected function makeZipFilename($themeName, $locale)
+    {
+        $zipFilenameParts = array(
+            $this->exportDir,
+            $themeName,
+            $locale,
+            $themeName . '.' . $locale . '.zip'
+        );
+
+        return implode(DIRECTORY_SEPARATOR, $zipFilenameParts);
+    }
+
+    /**
+     * @param $themeName
+     * @param $locale
+     * @return string
+     */
+    protected function makeArchiveParentDirectory($themeName, $locale)
+    {
+        $zipFilename = $this->makeZipFilename($themeName, $locale);
+
+        return dirname($zipFilename);
+    }
+
+    /**
+     * @param MessageCatalogue $mergedTranslations
+     */
+    protected function updateCatalogueMetadata(MessageCatalogue $mergedTranslations)
+    {
+        foreach ($mergedTranslations->all() as $domain => $messages) {
+            foreach ($messages as $translationKey => $translationValue) {
+                $metadata = $mergedTranslations->getMetadata($translationKey, $domain);
+                if (is_null($metadata) || !array_key_exists('file', $metadata)) {
+                    $mergedTranslations->setMetadata($translationKey, array('line' => '', 'file' => ''), $domain);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $locale
+     * @param MessageCatalogue $databaseCatalogue
+     * @return MessageCatalogue
+     */
+    protected function addLocaleToDomain($locale, MessageCatalogue $databaseCatalogue)
+    {
+        $catalogue = new MessageCatalogue($locale, array());
+        foreach ($databaseCatalogue->all() as $domain => $messages) {
+            $catalogue->add($messages, $domain . '.' . $locale);
+        }
+
+        return $catalogue;
+    }
+}

--- a/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
+++ b/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
@@ -50,14 +50,17 @@ class ThemeExtractor
 
     private $overrideFromDatabase = false;
 
-    public function __construct(
-        SmartyExtractor $smartyExtractor,
-        ThemeProvider $themeProvider
-    )
+    public function __construct(SmartyExtractor $smartyExtractor)
     {
         $this->smartyExtractor = $smartyExtractor;
-        $this->themeProvider = $themeProvider;
         $this->dumpers[] = new XliffFileDumper();
+    }
+
+    public function setThemeProvider(ThemeProvider $themeProvider)
+    {
+        $this->themeProvider = $themeProvider;
+
+        return $this;
     }
 
     public function extract(Theme $theme, $locale = 'en-US')
@@ -68,7 +71,7 @@ class ThemeExtractor
 
         $options = array('path' => $themeDirectory);
         $this->smartyExtractor->extract($themeDirectory, $this->catalog);
-        
+
         if ($this->overrideFromDatabase) {
             $this->overrideFromDatabase($theme->getName(), $locale, $this->catalog);
         }
@@ -85,9 +88,13 @@ class ThemeExtractor
 
         throw new \LogicException(sprintf('The format %s is not supported.', $this->format));
     }
-    
+
     private function overrideFromDatabase($themeName, $locale, &$catalogue)
     {
+        if (is_null($this->themeProvider)) {
+            throw new \Exception('Theme provider is required.');
+        }
+
         $databaseCatalogue = $this->themeProvider
             ->setLocale($locale)
             ->setThemeName($themeName)

--- a/src/PrestaShopBundle/Translation/Factory/TranslationsFactory.php
+++ b/src/PrestaShopBundle/Translation/Factory/TranslationsFactory.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Translation\Factory;
 use PrestaShopBundle\Translation\Provider\AbstractProvider;
 use PrestaShopBundle\Translation\Provider\UseDefaultCatalogueInterface;
 use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
 
 /**
  * This class returns a collection of translations, using locale and identifier.
@@ -47,6 +48,8 @@ class TranslationsFactory implements TranslationsFactoryInterface
      * @param string $locale           Locale identifier
      *
      * @return MessageCatalogue A MessageCatalogue instance
+     *
+     * @throws ProviderNotFoundException
      */
     public function createCatalogue($domainIdentifier, $locale = 'en_US')
     {
@@ -64,23 +67,23 @@ class TranslationsFactory implements TranslationsFactoryInterface
      *
      * @param string $domainIdentifier Domain identifier
      * @param string $locale           Locale identifier
+     * @param string $theme            Theme name
      *
      * @return array Translation tree structure
+     *
+     * @throws ProviderNotFoundException
      */
-    public function createTranslationsArray($domainIdentifier, $locale = 'en_US')
+    public function createTranslationsArray($domainIdentifier, $locale = 'en_US', $theme = null)
     {
         foreach ($this->providers as $provider) {
             if ($domainIdentifier === $provider->getIdentifier()) {
                 $provider->setLocale($locale);
 
                 $catalogue = $provider->getXliffCatalogue();
-
-                if ($provider instanceof UseDefaultCatalogueInterface) {
-                    $catalogue = $this->getTranslationsWithSources($provider, $catalogue);
-                }
+                $catalogue = $this->addDefaultTranslations($provider, $catalogue);
 
                 $translations = $catalogue->all();
-                $databaseCatalogue = $provider->getDatabaseCatalogue()->all();
+                $databaseCatalogue = $provider->getDatabaseCatalogue($theme)->all();
 
                 foreach ($translations as $domain => $messages) {
                     $databaseDomain = str_replace('.'.$locale, '', $domain);
@@ -107,14 +110,26 @@ class TranslationsFactory implements TranslationsFactoryInterface
         throw new ProviderNotFoundException($domainIdentifier);
     }
 
-    private function getTranslationsWithSources(AbstractProvider $provider, MessageCatalogue $catalogue)
+    /**
+     * @param AbstractProvider $provider
+     * @param MessageCatalogueInterface $catalogue
+     * @return MessageCatalogueInterface
+     */
+    private function addDefaultTranslations(AbstractProvider $provider, MessageCatalogueInterface $catalogue)
     {
-        $defaultCatalogue = $provider->getDefaultCatalogue();
-        $defaultCatalogue->addCatalogue($catalogue);
+        if (!$provider instanceof UseDefaultCatalogueInterface) {
+            return $catalogue;
+        }
 
-        return $defaultCatalogue;
+        $catalogueWithDefault = $provider->getDefaultCatalogue();
+        $catalogueWithDefault->addCatalogue($catalogue);
+
+        return $catalogueWithDefault;
     }
 
+    /**
+     * @param AbstractProvider $provider
+     */
     public function addProvider(AbstractProvider $provider)
     {
         $this->providers[] = $provider;

--- a/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
@@ -37,7 +37,7 @@ class DatabaseTranslationLoader implements LoaderInterface
     protected $entityManager;
 
     /**
-     * @param EntityManagerInterface $em
+     * @param EntityManagerInterface $entityManager
      */
     public function __construct(EntityManagerInterface $entityManager)
     {
@@ -47,7 +47,7 @@ class DatabaseTranslationLoader implements LoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load($resource, $locale, $domain = 'messages')
+    public function load($resource, $locale, $domain = 'messages', $theme = null)
     {
         $lang = $this->entityManager
             ->getRepository('PrestaShopBundle:Lang')
@@ -63,6 +63,15 @@ class DatabaseTranslationLoader implements LoaderInterface
             ->where('t.lang =:lang')
             ->setParameter('lang', $lang)
         ;
+
+        if (!is_null($theme)) {
+            $queryBuilder
+                ->andWhere('t.theme = :theme')
+                ->setParameter('theme', $theme)
+            ;
+        } else {
+            $queryBuilder->andWhere('t.theme IS NULL');
+        }
 
         if ($domain !== '*') {
             $queryBuilder->andWhere('REGEXP(t.domain, :domain) = true')

--- a/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
@@ -36,8 +36,10 @@ abstract class AbstractProvider implements ProviderInterface
     const DEFAULT_LOCALE = 'en-US';
 
     private $databaseLoader;
+
     protected $resourceDirectory;
-    private $locale;
+
+    protected $locale;
 
     public function __construct(LoaderInterface $databaseLoader, $resourceDirectory)
     {
@@ -137,14 +139,15 @@ abstract class AbstractProvider implements ProviderInterface
     /**
      * Get the Catalogue from database only.
      *
+     * @param null $theme
      * @return MessageCatalogue A MessageCatalogue instance
      */
-    public function getDatabaseCatalogue()
+    public function getDatabaseCatalogue($theme = null)
     {
         $databaseCatalogue = new MessageCatalogue($this->locale);
 
         foreach ($this->getTranslationDomains() as $translationDomain) {
-            $domainCatalogue = $this->getDatabaseLoader()->load(null, $this->locale, $translationDomain);
+            $domainCatalogue = $this->getDatabaseLoader()->load(null, $this->locale, $translationDomain, $theme);
 
             if ($domainCatalogue instanceof MessageCatalogue) {
                 $databaseCatalogue->addCatalogue($domainCatalogue);

--- a/src/PrestaShopBundle/Translation/Provider/FrontOfficeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/FrontOfficeProvider.php
@@ -30,6 +30,8 @@ use Symfony\Component\Translation\MessageCatalogue;
 
 class FrontOfficeProvider extends AbstractProvider implements UseDefaultCatalogueInterface
 {
+    const DEFAULT_THEME_NAME = 'classic';
+
     /**
      * {@inheritdoc}
      */
@@ -84,7 +86,19 @@ class FrontOfficeProvider extends AbstractProvider implements UseDefaultCatalogu
     }
 
     /**
-     * {@inheritdoc}
+     * @param null $themeName
+     * @return MessageCatalogue
+     */
+    public function getDatabaseCatalogue($themeName = null)
+    {
+        if (is_null($themeName)) {
+            $themeName = self::DEFAULT_THEME_NAME;
+        }
+
+        return parent::getDatabaseCatalogue($themeName);
+    }
+
+    /**{@inheritdoc}
      */
     public function getDefaultResourceDirectory()
     {

--- a/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
@@ -112,8 +112,16 @@ class ThemeProvider extends AbstractProvider
     {
         return array(
             $this->getResourceDirectory(),
-            $this->getResourceDirectory($this->themeResourcesDirectory)
+            $this->getThemeResourcesDirectory(),
         );
+    }
+
+    /**
+     * @return string
+     */
+    public function getThemeResourcesDirectory()
+    {
+        return $this->getResourceDirectory($this->themeResourcesDirectory);
     }
 
     /**
@@ -163,5 +171,13 @@ class ThemeProvider extends AbstractProvider
         foreach ($finder->directories()->depth('== 0')->in($translationFilesPath) as $folder) {
             $this->filesystem->remove($folder);
         }
+    }
+
+    /**
+     * @return \Symfony\Component\Translation\MessageCatalogue
+     */
+    public function getThemeCatalogue()
+    {
+        return $this->getCatalogueFromPaths($this->getThemeResourcesDirectory(), $this->locale, '*');
     }
 }

--- a/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
@@ -26,9 +26,30 @@
 
 namespace PrestaShopBundle\Translation\Provider;
 
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\Util\Flattenizer;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
 class ThemeProvider extends AbstractProvider
 {
     private $themeName;
+
+    public $themeResourcesDirectory;
+
+    /**
+     * @var Filesystem
+     */
+    public $filesystem;
+
+    /**
+     * @var \PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository
+     */
+    public $themeRepository;
+
+    /**
+     * @var \PrestaShopBundle\Translation\Extractor\ThemeExtractor
+     */
+    public $themeExtractor;
 
     /**
      * {@inheritdoc}
@@ -60,7 +81,6 @@ class ThemeProvider extends AbstractProvider
     public function getMessageCatalogue()
     {
         $xlfCatalogue = $this->getXliffCatalogue();
-
         $databaseCatalogue = $this->getDatabaseCatalogue();
 
         // Merge database catalogue to xliff catalogue
@@ -70,11 +90,30 @@ class ThemeProvider extends AbstractProvider
     }
 
     /**
+     * @param null $baseDir
      * @return string Path to app/themes/{themeName}/translations/{locale}
      */
-    public function getResourceDirectory()
+    public function getResourceDirectory($baseDir = null)
     {
-        return $this->resourceDirectory.'/'.$this->themeName.'/translations/'.$this->getLocale();
+        if (is_null($baseDir)) {
+            $baseDir = $this->resourceDirectory;
+        }
+
+        $resourceDirectory = $baseDir.'/'.$this->themeName.'/translations/'.$this->getLocale();
+        $this->filesystem->mkdir($resourceDirectory);
+
+        return $resourceDirectory;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDirectories()
+    {
+        return array(
+            $this->getResourceDirectory(),
+            $this->getResourceDirectory($this->themeResourcesDirectory)
+        );
     }
 
     /**
@@ -87,5 +126,42 @@ class ThemeProvider extends AbstractProvider
         $this->themeName = $themeName;
 
         return $this;
+    }
+
+    /**
+     * @param null $themeName
+     * @return \Symfony\Component\Translation\MessageCatalogue
+     */
+    public function getDatabaseCatalogue($themeName = null)
+    {
+        if (is_null($themeName)) {
+            $themeName = $this->themeName;
+        }
+
+        return parent::getDatabaseCatalogue($themeName);
+    }
+
+    public function synchronizeTheme()
+    {
+        $theme = $this->themeRepository->getInstanceByName($this->themeName);
+
+        $path = $this->resourceDirectory.'/'.$this->themeName.'/translations';
+
+        $this->filesystem->remove($path);
+        $this->filesystem->mkdir($path);
+
+        $this->themeExtractor
+            ->setOutputPath($path)
+            ->setThemeProvider($this)
+            ->extract($theme, $this->locale)
+        ;
+
+        $translationFilesPath = $path.'/'.$this->locale;
+        Flattenizer::flatten($translationFilesPath, $translationFilesPath, $this->locale, false);
+
+        $finder = Finder::create();
+        foreach ($finder->directories()->depth('== 0')->in($translationFilesPath) as $folder) {
+            $this->filesystem->remove($folder);
+        }
     }
 }

--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
@@ -32,6 +32,13 @@ use Symfony\Component\Translation\MessageCatalogue;
 
 trait TranslationFinderTrait
 {
+    /**
+     * @param $paths
+     * @param $locale
+     * @param null $pattern
+     * @return MessageCatalogue
+     * @throws \Exception
+     */
     public function getCatalogueFromPaths($paths, $locale, $pattern = null)
     {
         $messageCatalogue = new MessageCatalogue($locale);

--- a/src/PrestaShopBundle/Translation/Provider/UseDefaultCatalogueInterface.php
+++ b/src/PrestaShopBundle/Translation/Provider/UseDefaultCatalogueInterface.php
@@ -34,9 +34,9 @@ interface UseDefaultCatalogueInterface
      *
      * @param bool $empty if true, empty the catalogue
      *
-     * @return string[] Return a default catalogue with all keys
+     * @return \Symfony\Component\Translation\MessageCatalogueInterface Return a default catalogue with all keys
      */
-    public function getDefaultCatalogue($empty);
+    public function getDefaultCatalogue($empty = true);
 
     /**
      * @return string Path to app/Resources/translations/default/{locale}

--- a/src/PrestaShopBundle/Twig/TranslationsExtension.php
+++ b/src/PrestaShopBundle/Twig/TranslationsExtension.php
@@ -41,8 +41,20 @@ class TranslationsExtension extends \Twig_Extension
      */
     public $logger;
 
+    /**
+     * @var ContainerInterface
+     */
     private $container;
+
+    /**
+     * @var RouterInterface
+     */
     private $router;
+
+    /**
+     * @var string
+     */
+    private $theme;
 
     public function __construct(ContainerInterface $container, RouterInterface $router)
     {
@@ -67,13 +79,15 @@ class TranslationsExtension extends \Twig_Extension
      * Returns concatenated edit translation forms.
      *
      * @param array $translationsTree
+     * @param null $themeName
      *
      * @return string
      */
-    public function getTranslationsForms(array $translationsTree)
+    public function getTranslationsForms(array $translationsTree, $themeName = null)
     {
         $output = '';
         $viewProperties = $this->getSharedEditFormViewProperties();
+        $this->theme = $themeName;
 
         foreach ($translationsTree as $topLevelDomain => $tree) {
             $output .= $this->concatenateEditTranslationForm($tree, $viewProperties);
@@ -115,11 +129,14 @@ class TranslationsExtension extends \Twig_Extension
      * Returns a tree of translations key values.
      *
      * @param array $translationsTree
+     * @param null $themeName
      *
      * @return string
      */
-    public function getTranslationsTree(array $translationsTree)
+    public function getTranslationsTree(array $translationsTree, $themeName = null)
     {
+        $this->theme = $themeName;
+
         $output = '';
         end($translationsTree);
         list($lastTranslationDomain) = each($translationsTree);
@@ -220,7 +237,9 @@ class TranslationsExtension extends \Twig_Extension
         $defaultTranslationValue = $this->getDefaultTranslationValue($properties['translation_key'], $domain, $locale,
             $translationValue);
 
-        return $this->container->get('templating')->render('PrestaShopBundle:Admin:Translations/include/form-edit-message.html.twig', array(
+        return $this->container->get('templating')->render(
+            'PrestaShopBundle:Admin:Translations/include/form-edit-message.html.twig',
+            array(
                 'default_translation_value' => $defaultTranslationValue,
                 'domain' => $domain,
                 'edited_translation_value' => $translationValue,
@@ -233,6 +252,7 @@ class TranslationsExtension extends \Twig_Extension
                 'notification_success' => $properties['notification_success'],
                 'translation_key' => $properties['translation_key'],
                 'hash' => $this->getTranslationHash($domain, $properties['translation_key']),
+                'theme' => $this->theme,
             )
         );
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Theme translations lack messages from Shop\* and Module\* domains and should not be removed and replaced with extractions from templates. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1633 |
| How to test? | Translations should contain messages from default catalogues, Shop_, Module_ domains, parsed templates and theme translations directory in this order |
