### PR TITLE
Add js strings of module page to translations

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -335,7 +335,7 @@ var AdminModuleController = function() {
 
     body.on('change', this.bulkActionDropDownSelector, function() {
       if (0 === $(self.getBulkCheckboxesCheckedSelector()).length) {
-          $.growl.warning({message: "You need to select at least one module to use the bulk action."});
+          $.growl.warning({message: translate_javascripts['Bulk Action - One module minimum']});
           return;
       }
       self.lastBulkAction = $(this).find(':checked').attr('value');
@@ -605,7 +605,7 @@ var AdminModuleController = function() {
       var menuCategoryToTrigger = $(self.categoryItemSelector+'[data-category-ref="' + refCategory + '"]');
 
       if (!menuCategoryToTrigger.length) {
-        alert('No category with ref ('+refMenu+') seems to exists!');
+        console.warn('No category with ref ('+refMenu+') seems to exist!');
         return false;
       }
 
@@ -661,7 +661,7 @@ var AdminModuleController = function() {
     // Maybe useful to implement this kind of things later if intended to
     // use this functionality elsewhere but "manage my module" section
     if (typeof bulkActionToUrl[requestedBulkAction] === "undefined") {
-      console.error('Request bulk action "'+requestedBulkAction+'" does not exist');
+      $.growl.error({message: translate_javascripts['Bulk Action - Request not found'].replace('[1]', requestedBulkAction)});
       return false;
     }
 
@@ -692,13 +692,15 @@ var AdminModuleController = function() {
           if (urlElement.length > 0) {
             module_card_controller.requestToController(urlActionSegment, urlElement, forceDeletion);
           } else {
-            $.growl.error({message: "Action " + urlActionSegment + " not available for module " + moduleTechName + ". Skipped."});
+            $.growl.error({message: translate_javascripts["Bulk Action - Request not available for module"]
+                        .replace('[1]', urlActionSegment)
+                        .replace('[2]', moduleTechName)});
           }
         }
       });
 
     } else {
-      console.warn('Request bulk action "' + requestedBulkAction + '" can\'t be performed if you don\'t select at least 1 module');
+      console.warn(translate_javascripts['Bulk Action - One module minimum']);
       return false;
     }
   };
@@ -796,7 +798,7 @@ var AdminModuleController = function() {
         self.currentTagsList = [];
         self.updateModuleVisibility();
       },
-      inputPlaceholder: 'Search modules: keyword, name, author...',
+      inputPlaceholder: translate_javascripts['Search - placeholder'],
       closingCross: true,
       context: self,
       clearAllBtn: true,

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig
@@ -22,3 +22,7 @@
 </div>
 
 <hr class="top-menu-separator"/>
+
+{% set js_translatable = {
+"Search - placeholder": "Search modules: keyword, name, author..."|trans({}, 'Admin.Modules.Help'),
+}|merge(js_translatable) %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -84,3 +84,9 @@
         </div>
     </div>
 {% endblock %}
+
+{% set js_translatable = {
+"Bulk Action - One module minimum": "You need to select at least one module to use the bulk action."|trans({}, 'Admin.Modules.Notification'),
+"Bulk Action - Request not found": 'The action "[1]" is not available, impossible to perform your request.'|trans({}, 'Admin.Modules.Notification'),
+"Bulk Action - Request not available for module": "The action [1] is not available for module [2]. Skipped."|trans({}, 'Admin.Modules.Notification'),
+}|merge(js_translatable) %}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Woups, many strings in JS were missing from the translated data. This PR add them. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Without the strings being translated, this gonna be difficult to tests them. But at least, they should still appear in English. |
