### PR TITLE
Let developer export themes easily

### DIFF
--- a/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
@@ -57,7 +57,7 @@
 											</div>
 										</div>
 									</div>
-									<img class="center-block img-thumbnail" src="{$theme->get('preview')}" alt="{$theme->getName()}" />
+									<img class="center-block img-thumbnail" src="{$link->getBaseLink()}{$theme->get('preview')}" alt="{$theme->getName()}" />
 								</div>
 							</div>
 						</div>
@@ -80,7 +80,7 @@
 
 			<div class="col-md-3">
 				<a href="{$base_url}" class="_blank">
-					<img class="center-block img-thumbnail" src="{$cur_theme->get('preview')}" alt="{$cur_theme->getName()}" />
+					<img class="center-block img-thumbnail" src="{$link->getBaseLink()}{$cur_theme->get('preview')}" alt="{$cur_theme->getName()}" />
 				</a>
 			</div>
 

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -25,6 +25,7 @@
  */
 
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeExporter;
 use PrestaShop\PrestaShop\Core\Shop\LogoUploader;
 
 /**
@@ -139,6 +140,11 @@ class AdminThemesControllerCore extends AdminController
                 'desc' => $this->trans('Add new theme', array(), 'Admin.Design.Feature'),
                 'icon' => 'process-icon-new'
             );
+            $this->page_header_toolbar_btn['export_theme'] = array(
+                'href' => self::$currentIndex.'&action=exporttheme&token='.$this->token,
+                'desc' => $this->trans('Export current theme', array(), 'Admin.Design.Feature'),
+                'icon' => 'process-icon-export'
+            );
 
             if ($this->context->mode) {
                 unset($this->toolbar_btn['new']);
@@ -218,7 +224,19 @@ class AdminThemesControllerCore extends AdminController
      */
     public function postProcess()
     {
-        if (Tools::isSubmit('submitAddconfiguration')) {
+        if ('exporttheme' === Tools::getValue('action')) {
+            $exporter = new ThemeExporter(
+                new \PrestaShop\PrestaShop\Adapter\Configuration($this->context->shop),
+                new \Symfony\Component\Filesystem\Filesystem(),
+                new \Symfony\Component\Finder\Finder()
+            );
+            $path = $exporter->export($this->context->shop->theme);
+            $this->confirmations[] = $this->trans(
+                'Your theme has been correctly exported: %path%',
+                ['%path%' => $path],
+                'Admin.Notifications.Success'
+            );
+        } elseif (Tools::isSubmit('submitAddconfiguration')) {
             try {
                 if ($filename = Tools::getValue('theme_archive_server')) {
                     $path = _PS_ALL_THEMES_DIR_.$filename;

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -38,7 +38,7 @@ class Theme implements AddonInterface
     {
         if (isset($attributes['parent'])) {
             $parentAttributes = Yaml::parse(file_get_contents(_PS_ALL_THEMES_DIR_.'/'.$attributes['parent'].'/config/theme.yml'));
-            $parentAttributes['preview'] = $attributes['physical_uri'].'themes/'.$attributes['parent'].'/preview.png';
+            $parentAttributes['preview'] = 'themes/'.$attributes['parent'].'/preview.png';
             $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/').'/';
             $attributes = array_merge($parentAttributes, $attributes);
         }
@@ -46,7 +46,7 @@ class Theme implements AddonInterface
         $attributes['directory'] = rtrim($attributes['directory'], '/').'/';
 
         if (file_exists(_PS_ALL_THEMES_DIR_.$attributes['name'].'/preview.png')) {
-            $attributes['preview'] = $attributes['physical_uri'].'themes/'.$attributes['name'].'/preview.png';
+            $attributes['preview'] = 'themes/'.$attributes['name'].'/preview.png';
         }
 
         $this->attributes = new ArrayFinder($attributes);

--- a/src/Core/Addon/Theme/ThemeExporter.php
+++ b/src/Core/Addon/Theme/ThemeExporter.php
@@ -1,0 +1,100 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+namespace PrestaShop\PrestaShop\Core\Addon\Theme;
+
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use ZipArchive;
+
+class ThemeExporter
+{
+    protected $configuration;
+    protected $fileSystem;
+    protected $finder;
+
+    public function __construct(ConfigurationInterface $configuration, Filesystem $fileSystem, Finder $finder)
+    {
+        $this->configuration = $configuration;
+        $this->fileSystem = $fileSystem;
+        $this->finder = $finder;
+    }
+
+    public function export(Theme $theme)
+    {
+        $cacheDir = $this->configuration->get('_PS_CACHE_DIR_').'/export-'.$theme->getName().'-'.time().'/';
+
+        $this->copyTheme($theme->getDirectory(), $cacheDir);
+        $this->copyModuleDependencies((array) $theme->get('dependencies.modules'), $cacheDir);
+
+        $finalFile = $this->configuration->get('_PS_ALL_THEMES_DIR_').'/'.$theme->getName().'.zip';
+        $this->createZip($cacheDir, $finalFile);
+
+        $this->fileSystem->remove($cacheDir);
+
+        return realpath($finalFile);
+    }
+
+    private function copyTheme($themeDir, $cacheDir)
+    {
+        $this->fileSystem->mirror($themeDir, $cacheDir);
+    }
+
+    private function copyModuleDependencies(array $moduleList, $cacheDir)
+    {
+        if (empty($moduleList)) {
+            return;
+        }
+
+        $dependencyDir = $cacheDir.'/dependencies/modules/';
+        $this->fileSystem->mkdir($dependencyDir);
+        $moduleDir = $this->configuration->get('_PS_MODULE_DIR_');
+
+        foreach ($moduleList as $moduleName) {
+            $this->fileSystem->mirror($moduleDir.$moduleName, $dependencyDir.$moduleName);
+        }
+    }
+
+    private function createZip($sourceDir, $destinationFileName)
+    {
+        $zip = new ZipArchive();
+        $zip->open($destinationFileName, ZipArchive::CREATE);
+
+        $finderClassName = get_class($this->finder);
+        $this->finder = $finderClassName::create();
+        $files = $this->finder
+            ->files()
+            ->in($sourceDir)
+            ->exclude(['node_modules']);
+
+        foreach ($files as $file) {
+            $zip->addFile($file->getRealpath(), $file->getRelativePathName());
+        }
+
+        return $zip->close();
+    }
+}

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -324,7 +324,7 @@ class ThemeManager implements AddonManagerInterface
         }
 
         $themePath = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_').$theme->getName();
-        if (file_exists($themePath)) {
+        if ($this->filesystem->exists($themePath)) {
             throw new PrestaShopException(
                 'There is already a theme named '.$theme->getName().' in your themes/ folder. Remove it if you want to continue.'
             );
@@ -347,7 +347,7 @@ class ThemeManager implements AddonManagerInterface
     public function saveTheme($theme)
     {
         $jsonConfigFolder = $this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$theme->getName();
-        if (!file_exists($jsonConfigFolder) && !is_dir($jsonConfigFolder)) {
+        if (!$this->filesystem->exists($jsonConfigFolder) && !is_dir($jsonConfigFolder)) {
             mkdir($jsonConfigFolder, 0777, true);
         }
 

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -291,8 +291,10 @@ class ThemeManager implements AddonManagerInterface
 
     private function installFromZip($source)
     {
-        $sandboxPath = $this->getSandboxPath();
+        $finderClass = get_class($this->finder);
+        $this->finder = $finderClass::create();
 
+        $sandboxPath = $this->getSandboxPath();
         Tools::ZipExtract($source, $sandboxPath);
 
         $directories = $this->finder->directories()

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -38,6 +38,7 @@ use Tools;
 use Shop;
 use Employee;
 use Exception;
+use PrestaShopException;
 
 class ThemeManager implements AddonManagerInterface
 {
@@ -297,54 +298,39 @@ class ThemeManager implements AddonManagerInterface
         $sandboxPath = $this->getSandboxPath();
         Tools::ZipExtract($source, $sandboxPath);
 
-        $directories = $this->finder->directories()
-                                    ->in($sandboxPath)
-                                    ->depth('== 0')
-                                    ->exclude(array('__MACOSX'))
-                                    ->ignoreVCS(true);
-
-        if (iterator_count($directories->directories()) > 1) {
-            $this->filesystem->remove($sandboxPath);
-            throw new Exception('Invalid theme zip');
-        }
-
-        $directories = iterator_to_array($directories);
-        $theme_name = basename(current($directories)->getFileName());
-
-        $theme_data = (new Parser())->parse(file_get_contents($sandboxPath.$theme_name.'/config/theme.yml'));
-        $theme_data['directory'] = $sandboxPath.$theme_name;
-        if (!$this->themeValidator->isValid(new Theme($theme_data))) {
+        $theme_data = (new Parser())->parse(file_get_contents($sandboxPath.'/config/theme.yml'));
+        $theme_data['directory'] = $sandboxPath;
+        $theme = new Theme($theme_data);
+        if (!$this->themeValidator->isValid($theme)) {
             $this->filesystem->remove($sandboxPath);
             throw new Exception('This theme is not valid for PrestaShop 1.7');
         }
 
         $module_root_dir = $this->appConfiguration->get('_PS_MODULE_DIR_');
-        $modules_parent_dir = $sandboxPath.$theme_name.'/dependencies/modules';
+        $modules_parent_dir = $sandboxPath.'/dependencies/modules';
         if ($this->filesystem->exists($modules_parent_dir)) {
             $module_dirs = $this->finder->directories()
                                         ->in($modules_parent_dir)
-                                        ->depth('== 0')
-                                        ->exclude($theme_name);
+                                        ->depth('== 0');
 
             foreach (iterator_to_array($module_dirs) as $dir) {
                 $destination = $module_root_dir.basename($dir->getFileName());
                 if (!$this->filesystem->exists($destination)) {
                     $this->filesystem->mkdir($destination);
-                    $this->filesystem->mirror(
-                        $dir->getPathName(),
-                        $destination
-                    );
+                    $this->filesystem->mirror($dir->getPathName(), $destination);
                 }
             }
             $this->filesystem->remove($modules_parent_dir);
         }
 
-        $themePath = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_').$theme_name;
+        $themePath = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_').$theme->getName();
+        if (file_exists($themePath)) {
+            throw new PrestaShopException(
+                'There is already a theme named '.$theme->getName().' in your themes/ folder. Remove it if you want to continue.'
+            );
+        }
         $this->filesystem->mkdir($themePath);
-        $this->filesystem->mirror(
-            $sandboxPath.$theme_name,
-            $themePath
-        );
+        $this->filesystem->mirror($sandboxPath, $themePath);
         $this->filesystem->remove($sandboxPath);
     }
 

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Module\HookConfigurator;
 use PrestaShop\PrestaShop\Core\Image\ImageTypeRepository;
 use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Parser;
@@ -55,6 +56,7 @@ class ThemeManager implements AddonManagerInterface
         Shop $shop,
         ConfigurationInterface $configuration,
         ThemeValidator $themeValidator,
+        TranslatorInterface $translator,
         Employee $employee,
         Filesystem $filesystem,
         Finder $finder,
@@ -65,6 +67,7 @@ class ThemeManager implements AddonManagerInterface
         $this->shop = $shop;
         $this->appConfiguration = $configuration;
         $this->themeValidator = $themeValidator;
+        $this->translator = $translator;
         $this->employee = $employee;
         $this->filesystem = $filesystem;
         $this->finder = $finder;
@@ -303,7 +306,9 @@ class ThemeManager implements AddonManagerInterface
         $theme = new Theme($theme_data);
         if (!$this->themeValidator->isValid($theme)) {
             $this->filesystem->remove($sandboxPath);
-            throw new Exception('This theme is not valid for PrestaShop 1.7');
+            throw new PrestaShopException(
+                $this->translator->trans('This theme is not valid for PrestaShop 1.7', [], 'Admin.Design.Notification')
+            );
         }
 
         $module_root_dir = $this->appConfiguration->get('_PS_MODULE_DIR_');
@@ -326,7 +331,13 @@ class ThemeManager implements AddonManagerInterface
         $themePath = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_').$theme->getName();
         if ($this->filesystem->exists($themePath)) {
             throw new PrestaShopException(
-                'There is already a theme named '.$theme->getName().' in your themes/ folder. Remove it if you want to continue.'
+                $this->translator->trans(
+                    'There is already a theme named '
+                    .$theme->getName()
+                    .' in your themes/ folder. Remove it if you want to continue.',
+                    [],
+                    'Admin.Design.Notification'
+                )
             );
         }
         $this->filesystem->mkdir($themePath);

--- a/src/Core/Addon/Theme/ThemeManagerBuilder.php
+++ b/src/Core/Addon/Theme/ThemeManagerBuilder.php
@@ -79,6 +79,7 @@ class ThemeManagerBuilder
 
         return new ThemeRepository(
             new Configuration($shop),
+            new Filesystem(),
             $shop
         );
     }

--- a/src/Core/Addon/Theme/ThemeManagerBuilder.php
+++ b/src/Core/Addon/Theme/ThemeManagerBuilder.php
@@ -53,6 +53,7 @@ class ThemeManagerBuilder
             $this->context->shop,
             new Configuration($this->context->shop),
             new ThemeValidator($this->context->getTranslator()),
+            $this->context->getTranslator(),
             $this->context->employee,
             new Filesystem(),
             new Finder(),

--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -31,17 +31,20 @@ use PrestaShop\PrestaShop\Core\Addon\AddonListFilterType;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterStatus;
 use PrestaShop\PrestaShop\Core\Addon\AddonRepositoryInterface;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Parser;
 use Shop;
 
 class ThemeRepository implements AddonRepositoryInterface
 {
     private $appConfiguration;
+    private $filesystem;
     private $shop;
 
-    public function __construct(ConfigurationInterface $configuration, Shop $shop = null)
+    public function __construct(ConfigurationInterface $configuration, Filesystem $filesystem, Shop $shop = null)
     {
         $this->appConfiguration = $configuration;
+        $this->filesystem = $filesystem;
         $this->shop = $shop;
     }
 
@@ -49,13 +52,15 @@ class ThemeRepository implements AddonRepositoryInterface
     {
         $dir = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_').$name;
 
-        $jsonConfiguration = $this->shop
-            ? $this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json'
-            : '';
+        if ($this->shop) {
+            $jsonConf = $this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json';
+        } else {
+            $jsonConf = '';
+        }
 
-        if (file_exists($jsonConfiguration)) {
+        if ($this->filesystem->exists($jsonConf)) {
             $data = $this->getConfigFromFile(
-                $jsonConfiguration,
+                $jsonConf,
                 $name
             );
         } else {
@@ -125,7 +130,7 @@ class ThemeRepository implements AddonRepositoryInterface
 
     private function getConfigFromFile($file, $name)
     {
-        if (!file_exists($file)) {
+        if (!$this->filesystem->exists($file)) {
             throw new \PrestaShopException(sprintf('[ThemeRepository] Theme configuration file not found for theme `%s`.', $name));
         }
 

--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -63,7 +63,6 @@ class ThemeRepository implements AddonRepositoryInterface
         }
 
         $data['directory'] = $dir;
-        $data['physical_uri'] = $this->shop->physical_uri;
 
         return new Theme($data);
     }

--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -39,7 +39,7 @@ class ThemeRepository implements AddonRepositoryInterface
     private $appConfiguration;
     private $shop;
 
-    public function __construct(ConfigurationInterface $configuration, Shop $shop)
+    public function __construct(ConfigurationInterface $configuration, Shop $shop = null)
     {
         $this->appConfiguration = $configuration;
         $this->shop = $shop;
@@ -49,7 +49,10 @@ class ThemeRepository implements AddonRepositoryInterface
     {
         $dir = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_').$name;
 
-        $jsonConfiguration = $this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json';
+        $jsonConfiguration = $this->shop
+            ? $this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json'
+            : '';
+
         if (file_exists($jsonConfiguration)) {
             $data = $this->getConfigFromFile(
                 $jsonConfiguration,

--- a/src/PrestaShopBundle/Command/ExportThemeCommand.php
+++ b/src/PrestaShopBundle/Command/ExportThemeCommand.php
@@ -1,0 +1,65 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+namespace PrestaShopBundle\Command;
+
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Parser;
+
+class ExportThemeCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('prestashop:theme:export')
+            ->setDescription('Create zip to distribute theme with its dependencies')
+            ->addArgument('theme', InputArgument::REQUIRED, 'Theme to export directory name.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $repository = $this->getContainer()->get('prestashop.core.addon.theme.repository');
+        $theme = $repository->getInstanceByName($input->getArgument('theme'));
+
+        $themeExporter = $this->getContainer()->get('prestashop.core.addon.theme.exporter');
+        $path = $themeExporter->export($theme);
+
+        $formatter = $this->getHelper('formatter');
+        $translator = $this->getContainer()->get('translator');
+        $successMsg = $translator->trans(
+            'Your theme has been correctly exported: %path%',
+            ['%path%' => $path],
+            'Admin.Notifications.Success'
+        );
+        $formattedBlock = $formatter->formatBlock($successMsg, 'info', true);
+        $output->writeln($formattedBlock);
+    }
+}

--- a/src/PrestaShopBundle/Command/ExportThemeCommand.php
+++ b/src/PrestaShopBundle/Command/ExportThemeCommand.php
@@ -57,7 +57,7 @@ class ExportThemeCommand extends ContainerAwareCommand
         $successMsg = $translator->trans(
             'Your theme has been correctly exported: %path%',
             ['%path%' => $path],
-            'Admin.Notifications.Success'
+            'Admin.Design.Notification'
         );
         $formattedBlock = $formatter->formatBlock($successMsg, 'info', true);
         $output->writeln($formattedBlock);

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -129,7 +129,7 @@ class ModuleController extends FrameworkBundleAdminController
         $modulesProvider = $this->get('prestashop.core.admin.data_provider.module_interface');
         $shopService = $this->get('prestashop.adapter.shop.context');
         $moduleRepository = $this->get('prestashop.core.admin.module.repository');
-        $themeRepository = $this->get('prestashop.core.admin.theme.repository');
+        $themeRepository = $this->get('prestashop.core.addon.theme.repository');
 
         // Retrieve current shop
         $shopID = $shopService->getContextShopID();

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -98,7 +98,7 @@ class TranslationsController extends FrameworkBundleAdminController
             ->getLocale()
         ;
 
-        $theme = $this->get('prestashop.core.admin.theme.repository')
+        $theme = $this->get('prestashop.core.addon.theme.repository')
             ->getInstanceByName($themeName)
         ;
 
@@ -389,7 +389,7 @@ class TranslationsController extends FrameworkBundleAdminController
     private function synchronizeTheme($themeName, $locale)
     {
         $theme = $this
-            ->get('prestashop.core.admin.theme.repository')
+            ->get('prestashop.core.addon.theme.repository')
             ->getInstanceByName($themeName)
         ;
 

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -256,7 +256,16 @@ services:
 
     prestashop.core.addon.theme.repository:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository
-        arguments: ["@prestashop.adapter.legacy.configuration", "@=service('prestashop.adapter.legacy.context').getContext().shop"]
+        arguments:
+          - "@prestashop.adapter.legacy.configuration"
+          - "@=service('prestashop.adapter.legacy.context').getContext().shop"
+
+    prestashop.core.addon.theme.exporter:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeExporter
+        arguments:
+          - "@prestashop.adapter.legacy.configuration"
+          - "@filesystem"
+          - "@finder"
 
     # Managers
     prestashop.adapter.image_manager:

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -254,7 +254,7 @@ services:
             - "@prestashop.adapter.legacy.logger"
             - "@translator"
 
-    prestashop.core.admin.theme.repository:
+    prestashop.core.addon.theme.repository:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository
         arguments: ["@prestashop.adapter.legacy.configuration", "@=service('prestashop.adapter.legacy.context').getContext().shop"]
 

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -6,12 +6,12 @@ services:
     finder:
         class: Symfony\Component\Finder\Finder
         shared: false
-        
+
     guzzle.cache.provider:
         class: Doctrine\Common\Cache\FilesystemCache
         arguments:
             - "%kernel.cache_dir%/guzzle"
-        
+
     guzzle.cache:
         class: Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\DoctrineAdapter
         arguments:
@@ -258,6 +258,7 @@ services:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository
         arguments:
           - "@prestashop.adapter.legacy.configuration"
+          - "@filesystem"
           - "@=service('prestashop.adapter.legacy.context').getContext().shop"
 
     prestashop.core.addon.theme.exporter:

--- a/tests/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
@@ -29,6 +29,7 @@ use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use Phake;
 use Shop;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ThemeRepositoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -44,6 +45,7 @@ class ThemeRepositoryTest extends \PHPUnit_Framework_TestCase
         /* @var \PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository */
         $this->repository = new ThemeRepository(
             new Configuration($shop),
+            new Filesystem(),
             $shop
         );
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In Prestashop 1.6 you could export your theme using a button in the backoffice. Unfortunately, it was exporting all settings. We removed it last year and introduce the `config/theme.yml` file to write all settings explicitly. With this PR, the theme export feature is back! |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Export your theme with the command (see below) |
## How to use it

This command exists to make your theme developer's life easier. Go in your terminal and `cd` into your PrestaShop root directory.

```
php app/console prestashop:theme:export themeToExportDirectoryName
```
## How to bundle custom modules with your theme

If you made a custom module for your themes, you need to bundle it with your theme. This command will do it automatically as long as you declare your module as a dependency in your `config/theme.yml` under the key `dependencies.modules`.

For example:

``` yml
name: exampletheme
display_name: Example Theme

dependencies:
  modules:
    - ps_customexamplemodule
    - ps_customex2
```
# Screenshot

![1____sites_ps-develop__bash_](https://cloud.githubusercontent.com/assets/1525636/19471547/017a56b4-9524-11e6-9d44-b207ab2d2fbb.png)

![themes_ _develop_branch](https://cloud.githubusercontent.com/assets/1525636/19471560/2012397a-9524-11e6-944c-6fbf7753743e.png)
