### PR TITLE
Fixed Employees back-office default page

### DIFF
--- a/controllers/admin/AdminEmployeesController.php
+++ b/controllers/admin/AdminEmployeesController.php
@@ -151,7 +151,11 @@ class AdminEmployeesControllerCore extends AdminController
                 $this->tabs_list[$tab['id_tab']] = $tab;
                 foreach (Tab::getTabs($this->context->language->id, $tab['id_tab']) as $children) {
                     if (Tab::checkTabRights($children['id_tab'])) {
-                        $this->tabs_list[$tab['id_tab']]['children'][] = $children;
+                        foreach (Tab::getTabs($this->context->language->id, $children['id_tab']) as $subchild) {
+                            if (Tab::checkTabRights($subchild['id_tab'])) {
+                                $this->tabs_list[$tab['id_tab']]['children'][] = $subchild;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR fixes the list of default page available in employee preferences |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1265 |
| How to test? | Change the default page in employee page to Orders for example |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
