### PR TITLE
Fix advanced stock manager that prevented admin from removing stock quantity

### DIFF
--- a/classes/stock/StockManager.php
+++ b/classes/stock/StockManager.php
@@ -363,10 +363,10 @@ class StockManagerCore implements StockManagerInterface
                         );
 
                         while ($row = Db::getInstance()->nextRow($resource)) {
-                            // break - in FIFO mode, we have to retreive the oldest positive mvts for which there are left quantities
+                            // continue - in FIFO mode, we have to retreive the oldest positive mvts for which there are left quantities
                             if ($warehouse->management_type == 'FIFO') {
                                 if ($row['qty'] == 0) {
-                                    break;
+                                    continue;
                                 }
                             }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Fix advanced stock manager that prevented admin from removing stock quantity. Cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/4552 |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
