### PR TITLE
Fix broken links related to token on module page

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -529,7 +529,7 @@ var AdminModuleController = function() {
           $(self.moduleImportProcessingSelector).finish().fadeOut(function() {
             if (responseObject.status === true) {
               if (responseObject.is_configurable === true) {
-                var configureLink = self.baseAdminDir + 'module/manage/action/configure/' + responseObject.module_name;
+                var configureLink = self.baseAdminDir + 'module/manage/action/configure/' + responseObject.module_name + window.location.search;
                 $(self.moduleImportSuccessConfigureBtnSelector).attr('href', configureLink);
                 $(self.moduleImportSuccessConfigureBtnSelector).show();
               }

--- a/admin-dev/themes/default/js/bundle/module/module_card.js
+++ b/admin-dev/themes/default/js/bundle/module/module_card.js
@@ -121,7 +121,7 @@ var AdminModuleCard = function () {
         var url = "//" + window.location.host + element.attr("href");
 
         if (forceDeletion === "true" || forceDeletion === true) {
-          url +="?deletion=true";
+          url +="&deletion=true";
         }
 
         $.ajax({


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This PR fix the compromised message when we try to configure a module just uploaded ou when we try to delete the module files on uninstallation. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | Dealed with http://forge.prestashop.com/browse/BOOM-1663 |
| How to test? | Upload a module successfully and click on the configure button. It should work. Uninstall a module AND check the file deletion checkbox. It should work too. |
