### PR TITLE
Use _PARENT_THEME_NAME_ constant for consistency

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -27,7 +27,7 @@ global $smarty;
 
 $template_dirs = array(_PS_THEME_DIR_.'templates');
 $plugin_dirs = array(_PS_THEME_DIR_.'plugins');
-if (_PARENT_THEME_NAME_) {
+if (_PS_PARENT_THEME_DIR_) {
     $template_dirs[] = _PS_PARENT_THEME_DIR_.'templates';
     $plugin_dirs[] = _PS_PARENT_THEME_DIR_.'plugins';
 }


### PR DESCRIPTION
Undefined constant `_PARENT_THEME_NAME_` - the correct constant in the if should be `_PS_PARENT_THEME_DIR_` as used in the rest of the file.

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Undefined constant `_PARENT_THEME_NAME_` - the correct constant in the if should be `_PS_PARENT_THEME_DIR_` as used in the rest of the file. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | The warnings in webserver log should be gone. The issue was probably breaking some plugins/templates when using more themes (not sure with that). |
