### PR TITLE
Fixed translation BO Emails

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -118,8 +118,8 @@
         <label class="control-label col-lg-3" for="selected-emails">{l s='Select the type of email content'}</label>
         <div class="col-lg-4">
           <select name="selected-emails">
-            <option value="subject" data-controller="sf">{l s='Emails subject'}</option>
-            <option value="body" data-controller="legacy">{l s='Emails body'}</option>
+            <option value="subject" data-controller="sf">{l s='Subject'}</option>
+            <option value="body" data-controller="legacy">{l s='Body'}</option>
           </select>
         </div>
       </div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -30,10 +30,15 @@
 			getE('translation_lang').value = id_lang;
 
       var formTranslation = $('form#typeTranslationForm');
-      if ('legacy' === $('#type option:selected').data('controller')) {
-        formTranslation.attr('action', formTranslation.data('legacyaction'));
+      var typeOption = $('#type option:selected');
+
+      if ('mails' == $('#type option:selected').val()) {
+        typeOption = $('#ps_email_selector select[name="selected-emails"] option:selected');
       }
-      else {
+
+      if ('legacy' === typeOption.data('controller')) {
+        formTranslation.attr('action', formTranslation.data('legacyaction'));
+      } else {
         formTranslation.attr('action', formTranslation.data('sfaction'));
       }
 
@@ -42,16 +47,26 @@
 
 		$(document).ready(function() {
       var themeSelector = $('#ps_theme_selector');
+      var emailSelector = $('#ps_email_selector');
 
       themeSelector.hide();
+      emailSelector.hide();
 
-      $('#type').on('change', function (event) {
-        var selectedValue = $(this).val();
+      $('#type').on('change', function () {
+        if ('mails' === $(this).val()) {
+          emailSelector.show();
+        } else {
+          emailSelector.hide();
+        }
 
-        themeSelector.toggle('themes' === selectedValue);
+        if (1 === $('#type option:selected').data('choicetheme')) {
+          themeSelector.show();
+        } else {
+          themeSelector.hide();
+        }
       });
 
-			$('#modify-translations').click(function(e) {
+			$('#modify-translations').click(function() {
 				var languages = $('#translations-languages option');
 				var i;
 				var selectedLanguage;
@@ -94,8 +109,17 @@
         <div class="col-lg-4">
           <select name="type" id="type">
             {foreach $translations_type as $type => $array}
-                {if $array.name}<option value="{$type}" data-controller="{if $array.sf_controller}sf{else}legacy{/if}">{$array.name}</option>{/if}
+                {if $array.name}<option value="{$type}" data-controller="{if $array.sf_controller}sf{else}legacy{/if}" data-choicetheme="{$array.choice_theme}">{$array.name}</option>{/if}
             {/foreach}
+          </select>
+        </div>
+      </div>
+      <div class="form-group" id="ps_email_selector">
+        <label class="control-label col-lg-3" for="selected-emails">{l s='Select the type of email content'}</label>
+        <div class="col-lg-4">
+          <select name="selected-emails">
+            <option value="subject" data-controller="sf">{l s='Emails subject'}</option>
+            <option value="body" data-controller="legacy">{l s='Emails body'}</option>
           </select>
         </div>
       </div>

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1342,14 +1342,6 @@ class AdminTranslationsControllerCore extends AdminController
                 'sf_controller' => true,
                 'choice_theme' => true,
             ),
-            'others' => array(
-                'name' => $this->trans('Other translations', array(), 'Admin.International.Feature'),
-                'var' => '_OTHERS',
-                'dir' => '',
-                'file' => '',
-                'sf_controller' => true,
-                'choice_theme' => false,
-            ),
             'mails' => array(
                 'name' => $this->trans('Email translations', array(), 'Admin.International.Feature'),
                 'var' => '_LANGMAIL',
@@ -1357,6 +1349,14 @@ class AdminTranslationsControllerCore extends AdminController
                 'file' => 'lang.php',
                 'sf_controller' => false,
                 'choice_theme' => true,
+            ),
+            'others' => array(
+                'name' => $this->trans('Other translations', array(), 'Admin.International.Feature'),
+                'var' => '_OTHERS',
+                'dir' => '',
+                'file' => '',
+                'sf_controller' => true,
+                'choice_theme' => false,
             ),
             'modules' => array(
                 'dir' => _PS_MODULE_DIR_,

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1332,6 +1332,7 @@ class AdminTranslationsControllerCore extends AdminController
                 'dir' => _PS_TRANSLATIONS_DIR_.$this->lang_selected->iso_code.'/',
                 'file' => 'admin.php',
                 'sf_controller' => true,
+                'choice_theme' => false,
             ),
             'themes' => array(
                 'name' => $this->trans('Themes translations', array(), 'Admin.International.Feature'),
@@ -1339,6 +1340,7 @@ class AdminTranslationsControllerCore extends AdminController
                 'dir' => '',
                 'file' => '',
                 'sf_controller' => true,
+                'choice_theme' => true,
             ),
             'others' => array(
                 'name' => $this->trans('Other translations', array(), 'Admin.International.Feature'),
@@ -1346,13 +1348,15 @@ class AdminTranslationsControllerCore extends AdminController
                 'dir' => '',
                 'file' => '',
                 'sf_controller' => true,
+                'choice_theme' => false,
             ),
             'mails' => array(
-                'name' => $this->trans('Email templates translations', array(), 'Admin.International.Feature'),
+                'name' => $this->trans('Email translations', array(), 'Admin.International.Feature'),
                 'var' => '_LANGMAIL',
                 'dir' => _PS_MAIL_DIR_.$this->lang_selected->iso_code.'/',
                 'file' => 'lang.php',
                 'sf_controller' => false,
+                'choice_theme' => true,
             ),
             'modules' => array(
                 'dir' => _PS_MODULE_DIR_,
@@ -1590,7 +1594,6 @@ class AdminTranslationsControllerCore extends AdminController
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>#title</title>
 </head>
 <body>
     #content
@@ -1659,12 +1662,8 @@ class AdminTranslationsControllerCore extends AdminController
                         // replace correct end of line
                         $content = str_replace("\r\n", PHP_EOL, $content);
 
-                        $title = '';
-                        if (Tools::getValue('title_'.$group_name.'_'.$mail_name)) {
-                            $title = Tools::getValue('title_'.$group_name.'_'.$mail_name);
-                        }
                         $string_mail = $this->getMailPattern();
-                        $content = str_replace(array('#title', '#content'), array($title, $content), $string_mail);
+                        $content = str_replace(array('#content'), array($content), $string_mail);
 
                         // Magic Quotes shall... not.. PASS!
                         if (_PS_MAGIC_QUOTES_GPC_) {
@@ -2594,13 +2593,6 @@ class AdminTranslationsControllerCore extends AdminController
         $name_for_module = $name_for_module ? $name_for_module.'|' : '';
         return '<div class="block-mail" >
                     <div class="mail-form">
-                        <div class="form-group">
-                            <label class="control-label col-lg-3">'.$this->trans('HTML "title" tag', array(), 'Admin.International.Feature').'</label>
-                            <div class="col-lg-9">
-                                <input class="form-control" type="text" name="title_'.$group_name.'_'.$mail_name.'" value="'.(isset($title[$lang]) ? $title[$lang] : '').'" />
-                                <p class="help-block">'.(isset($title['en']) ? $title['en'] : '').'</p>
-                            </div>
-                        </div>
                         <div class="thumbnail email-html-frame" data-email-src="'.$url.'"></div>
                     </div>
                 </div>';
@@ -2764,12 +2756,10 @@ class AdminTranslationsControllerCore extends AdminController
         }
 
         $core_mails = $this->getMailFiles($i18n_dir, 'core_mail');
-        $core_mails['subject'] = $this->getSubjectMailContent($i18n_dir);
 
         foreach ($modules_has_mails as $module_name => $module_path) {
             $module_path = rtrim($module_path, '/');
             $module_mails[$module_name] = $this->getMailFiles($module_path.'/mails/'.$this->lang_selected->iso_code.'/', 'module_mail');
-            $module_mails[$module_name]['subject'] = $core_mails['subject'];
             $module_mails[$module_name]['display'] = $this->displayMailContent($module_mails[$module_name], $subject_mail, $this->lang_selected, Tools::strtolower($module_name), $module_name, $module_name);
         }
 
@@ -2905,31 +2895,6 @@ class AdminTranslationsControllerCore extends AdminController
         }
 
         return $subject_mail;
-    }
-
-    /**
-     * @param $directory : name of directory
-     * @return array
-     */
-    protected function getSubjectMailContent($directory)
-    {
-        $subject_mail_content = array();
-
-        if (Tools::file_exists_cache($directory.'/lang.php')) {
-            // we need to include this even if already included (no include once)
-            include($directory.'/lang.php');
-            foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
-                $this->total_expression++;
-                $subject = str_replace('\n', ' ', $subject);
-                $subject = str_replace("\\'", "\'", $subject);
-
-                $subject_mail_content[$key]['trad'] = htmlentities($subject, ENT_QUOTES, 'UTF-8');
-                $subject_mail_content[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
-            }
-        } else {
-            $this->errors[] = sprintf($this->trans('Email subject translation file not found in "%s".', array(), 'Admin.International.Notification'), $directory);
-        }
-        return $subject_mail_content;
     }
 
     protected function writeSubjectTranslationFile($sub, $path)

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -136,13 +136,21 @@ services:
         tags:
             - { name: "ps.translation_provider" }
 
-    prestashop.translation.others_provider:
-        class: PrestaShopBundle\Translation\Provider\OthersProvider
+    prestashop.translation.mails:
+        class: PrestaShopBundle\Translation\Provider\MailsProvider
         arguments:
             - "@prestashop.translations.database_loader"
             - "%translations_dir%"
         tags:
             - { name: "ps.translation_provider" }
+
+    prestashop.translation.others_provider:
+            class: PrestaShopBundle\Translation\Provider\OthersProvider
+            arguments:
+                - "@prestashop.translations.database_loader"
+                - "%translations_dir%"
+            tags:
+                - { name: "ps.translation_provider" }
 
     prestashop.translation.theme_provider:
         class: PrestaShopBundle\Translation\Provider\ThemeProvider

--- a/src/PrestaShopBundle/Translation/Provider/BackOfficeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/BackOfficeProvider.php
@@ -83,7 +83,8 @@ class BackOfficeProvider extends AbstractProvider implements UseDefaultCatalogue
         return $defaultCatalogue;
     }
 
-    /**{@inheritdoc}
+    /**
+     * {@inheritdoc}
      */
     public function getDefaultResourceDirectory()
     {

--- a/src/PrestaShopBundle/Translation/Provider/FrontOfficeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/FrontOfficeProvider.php
@@ -83,7 +83,8 @@ class FrontOfficeProvider extends AbstractProvider implements UseDefaultCatalogu
         return $defaultCatalogue;
     }
 
-    /**{@inheritdoc}
+    /**
+     * {@inheritdoc}
      */
     public function getDefaultResourceDirectory()
     {

--- a/src/PrestaShopBundle/Translation/Provider/MailsProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/MailsProvider.php
@@ -81,7 +81,8 @@ class MailsProvider extends AbstractProvider implements UseDefaultCatalogueInter
         return $defaultCatalogue;
     }
 
-    /**{@inheritdoc}
+    /**
+     * {@inheritdoc}
      */
     public function getDefaultResourceDirectory()
     {

--- a/src/PrestaShopBundle/Translation/Provider/MailsProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/MailsProvider.php
@@ -36,7 +36,7 @@ class MailsProvider extends AbstractProvider implements UseDefaultCatalogueInter
     public function getTranslationDomains()
     {
         return array(
-            'EmailsBody*',
+            'EmailsSubject*',
         );
     }
 
@@ -46,7 +46,7 @@ class MailsProvider extends AbstractProvider implements UseDefaultCatalogueInter
     public function getFilters()
     {
         return array(
-            '#EmailsBody*#',
+            '#EmailsSubject*#',
         );
     }
 

--- a/src/PrestaShopBundle/Translation/Provider/MailsProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/MailsProvider.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author     PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2016 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation\Provider;
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+class MailsProvider extends AbstractProvider implements UseDefaultCatalogueInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains()
+    {
+        return array(
+            'EmailsBody*',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            '#EmailsBody*#',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        return 'mails';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultCatalogue($empty = true)
+    {
+        $defaultCatalogue = new MessageCatalogue($this->getLocale());
+
+        foreach ($this->getFilters() as $filter) {
+            $filteredCatalogue = $this->getCatalogueFromPaths(
+                array($this->getDefaultResourceDirectory()),
+                $this->getLocale(),
+                $filter
+            );
+            $defaultCatalogue->addCatalogue($filteredCatalogue);
+        }
+
+        if ($empty) {
+            $defaultCatalogue = $this->emptyCatalogue($defaultCatalogue);
+        }
+
+        return $defaultCatalogue;
+    }
+
+    /**{@inheritdoc}
+     */
+    public function getDefaultResourceDirectory()
+    {
+        return $this->resourceDirectory.'/default';
+    }
+}

--- a/src/PrestaShopBundle/Translation/Provider/OthersProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/OthersProvider.php
@@ -77,7 +77,8 @@ class OthersProvider extends AbstractProvider implements UseDefaultCatalogueInte
         return $defaultCatalogue;
     }
 
-    /**{@inheritdoc}
+    /**
+     * {@inheritdoc}
      */
     public function getDefaultResourceDirectory()
     {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | Fixed translation BO Emails |
| Description? | BO |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | . |
| How to test? | @AlexEven |

=> Email translations should display 2 sections, body and subjects, according to new domains and new ways of working in 1.7.
=> You should have a theme selector to modify emails from a given theme.
