### PR TITLE
Wording update - remove 'CMS' to use 'page' only

### DIFF
--- a/admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl
@@ -45,14 +45,14 @@
 		});
 		$('#active_off').bind('click', function(){
 			toggleDraftWarning(true);
-		});		
+		});
 	});
 {/block}
 
 {block name="leadin"}
 	<div style="{if $active}display:none{/if}">
 		<p class="alert alert-warning">
-			{l s='Your CMS page will be saved as a draft'}
+			{l s='Your page will be saved as a draft'}
 		</p>
 	</div>
 {/block}

--- a/controllers/admin/AdminCmsController.php
+++ b/controllers/admin/AdminCmsController.php
@@ -120,14 +120,14 @@ class AdminCmsControllerCore extends AdminController
         $this->fields_form = array(
             'tinymce' => true,
             'legend' => array(
-                'title' => $this->l('CMS Page'),
+                'title' => $this->l('Page'),
                 'icon' => 'icon-folder-close'
             ),
             'input' => array(
                 // custom template
                 array(
                     'type' => 'select_category',
-                    'label' => $this->l('CMS Category'),
+                    'label' => $this->l('Page Category'),
                     'name' => 'id_cms_category',
                     'options' => array(
                         'html' => $html_categories,

--- a/controllers/admin/AdminLocalizationController.php
+++ b/controllers/admin/AdminLocalizationController.php
@@ -301,7 +301,7 @@ class AdminLocalizationControllerCore extends AdminController
             array(
                 'id' => 'groups',
                 'val' => 'groups',
-                'name' => $this->trans('Change the behavior of the taxes displayed to the groups', array(), 'Admin.International.Feature')
+                'name' => $this->trans('Change the behavior of the price display for groups', array(), 'Admin.International.Feature')
             )
         );
 

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -714,8 +714,8 @@ class AdminMetaControllerCore extends AdminController
         $this->addFieldRoute('layered_rule', $this->trans('Route to category which has the "selected_filter" attribute for the "Layered Navigation" (blocklayered) module', array(), 'Admin.ShopParameters.Feature'));
         $this->addFieldRoute('supplier_rule', $this->trans('Route to supplier', array(), 'Admin.ShopParameters.Feature'));
         $this->addFieldRoute('manufacturer_rule', $this->trans('Route to brand', array(), 'Admin.ShopParameters.Feature'));
-        $this->addFieldRoute('cms_rule', $this->trans('Route to CMS page', array(), 'Admin.ShopParameters.Feature'));
-        $this->addFieldRoute('cms_category_rule', $this->trans('Route to CMS category', array(), 'Admin.ShopParameters.Feature'));
+        $this->addFieldRoute('cms_rule', $this->trans('Route to page', array(), 'Admin.ShopParameters.Feature'));
+        $this->addFieldRoute('cms_category_rule', $this->trans('Route to page category', array(), 'Admin.ShopParameters.Feature'));
         $this->addFieldRoute('module', $this->trans('Route to modules', array(), 'Admin.ShopParameters.Feature'));
     }
 

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -528,7 +528,7 @@ class AdminShopControllerCore extends AdminController
 
         $import_data = array(
             'carrier' => $this->l('Carriers'),
-            'cms' => $this->l('CMS pages'),
+            'cms' => $this->l('Pages'),
             'contact' => $this->l('Contact information'),
             'country' => $this->l('Countries'),
             'currency' => $this->l('Currencies'),

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -347,7 +347,7 @@ class AdminThemesControllerCore extends AdminController
                 'tabs' => array(
                     'logo' => $this->trans('Logo', array(), 'Admin.Global'),
                     'logo2' => $this->trans('Invoice & Email Logos', array(), 'Admin.Design.Feature'),
-                    'icons' => $this->trans('Icons', array(), 'Admin.Design.Feature'),
+                    'icons' => $this->trans('Favicons', array(), 'Admin.Design.Feature'),
                     ),
                 'fields' => array(
                     'PS_LOGO' => array(


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Wording update. We no longer use "CMS pages" but simply "Pages" + other minor changes. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Check content display |
