### PR TITLE
Add two new hooks actionAttributeCombinationSave/Delete

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -218,6 +218,10 @@ class CombinationCore extends ObjectModel
         $result = Db::getInstance()->delete('product_attribute_combination', '`id_product_attribute` = '.(int) $this->id);
         $result &= Db::getInstance()->delete('cart_product', '`id_product_attribute` = '.(int) $this->id);
         $result &= Db::getInstance()->delete('product_attribute_image', '`id_product_attribute` = '.(int) $this->id);
+        
+        if ($result) {
+            Hook::exec('actionAttributeCombinationDelete', array('id_product_attribute' => (int)$this->id));
+        }
 
         return $result;
     }
@@ -240,6 +244,9 @@ class CombinationCore extends ObjectModel
 				INSERT INTO `'._DB_PREFIX_.'product_attribute_combination` (`id_attribute`, `id_product_attribute`)
 				VALUES '.implode(',', $sqlValues)
             );
+            if ($result) {
+                Hook::exec('actionAttributeCombinationSave', array('id_product_attribute' => (int)$this->id, 'id_attributes' => $idsAttribute));
+            }
         }
 
         return $result;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Unfortunately, the generic hooks `action<object>AddAfter` etc. are not called when we add product combinations. This PR add them. |
| Type? | new feature |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1491](http://forge.prestashop.com/browse/BOOM-1491) |
| How to test? | Implement the functions `hookActionAttributeCombinationSave` and/or `hookActionAttributeCombinationDelete` and check they are properly called when you generate product combinations. |

Note: These hooks have not been added to the files `1.7.0.0.sql` and `hook.xml`, which is expected for performance reasons. If a module is hooked on them, they should be called anyway.
