### PR TITLE
Moved array_walk for $parameters

### DIFF
--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -101,9 +101,6 @@ class InstallModelInstall extends InstallAbstractModel
             $database_host = implode(':', $splits);
         }
 
-        array_walk($parameters['parameters'], function (&$param) {
-            $param = str_replace('%', '%%', $param);
-        });
         $key = \PhpEncryption::createNewRandomKey();
 
         $parameters = array(
@@ -123,6 +120,10 @@ class InstallModelInstall extends InstallAbstractModel
                 'locale' => $this->language->getLanguage()->getLocale(),
             )
         );
+        
+        array_walk($parameters['parameters'], function (&$param) {
+            $param = str_replace('%', '%%', $param);
+        });
 
         $parameters = array_replace_recursive(
             Yaml::parse(file_get_contents(_PS_ROOT_DIR_.'/app/config/parameters.yml.dist')),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | $parameters['parameters'] is used in array_walk before ir is defined defined |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | - |
| How to test? | The error not allow to install PrestaShop because show a warining in first step "Creating parameters file", now with this modifications installs ok. |
