### PR TITLE
Fix uncaught IOException on module deletion

### DIFF
--- a/src/Adapter/Module/ModuleDataUpdater.php
+++ b/src/Adapter/Module/ModuleDataUpdater.php
@@ -27,6 +27,7 @@ namespace PrestaShop\PrestaShop\Adapter\Module;
 
 use PrestaShopBundle\Service\DataProvider\Admin\AddonsInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 class ModuleDataUpdater
 {

--- a/src/Adapter/Module/ModuleZipManager.php
+++ b/src/Adapter/Module/ModuleZipManager.php
@@ -144,7 +144,9 @@ class ModuleZipManager
         $this->filesystem->mkdir($modulePath);
         $this->filesystem->mirror(
             $sandboxPath.$name,
-            $modulePath
+            $modulePath,
+            null,
+            array('override' => true)
         );
         $this->filesystem->remove($sandboxPath);
     }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When we try to remove module files, it cannot work sometime. But the exception thrown was not properly caught because of a missing namespace. This PR fixes it. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | On Windows, try to upload a module with a .git folder inside the zip, created by someone else on another computer. You should not have permission issue when trying to remove the module, but the message should be properly presented (not a exception caught by symfony) |
