### PR TITLE
Implement optionnal but specific action to display on module page

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -95,7 +95,7 @@ class AdminModuleDataProvider implements ModuleInterface
         return array_keys($this->getCatalogModules($filter));
     }
 
-    public function generateAddonsUrls(array $addons)
+    public function generateAddonsUrls(array $addons, $specific_action = null)
     {
         foreach ($addons as &$addon) {
             $urls = array();
@@ -174,7 +174,11 @@ class AdminModuleDataProvider implements ModuleInterface
             if (count($urls)) {
                 $addon->attributes->set('urls', $urls);
             }
-            $addon->attributes->set('url_active', $url_active);
+            if ($specific_action && array_key_exists($specific_action, $urls)) {
+                $addon->attributes->set('url_active', $specific_action);
+            } else {
+                $addon->attributes->set('url_active', $url_active);
+            }
 
             $categoryParent = $this->categoriesProvider->getParentCategory($addon->attributes->get('categoryName'));
             $addon->attributes->set('categoryParent', $categoryParent);

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -351,7 +351,7 @@ class ModuleController extends FrameworkBundleAdminController
         }
 
         foreach ($modules as $moduleLabel => $modulesPart) {
-            $modules->{$moduleLabel} = $modulesProvider->generateAddonsUrls($modulesPart);
+            $modules->{$moduleLabel} = $modulesProvider->generateAddonsUrls($modulesPart, str_replace("to_", "", $moduleLabel));
             $modules->{$moduleLabel} = $this->getPresentedProducts($modulesPart);
         }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | If a panel of the module page needs a specific primary action to display (i.e when upgrade and configure are both available), it is now possible. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1650](http://forge.prestashop.com/browse/BOOM-1650) |
| How to test? | You must have a module configurable which needs to be configured AND upgraded. You should see it in the notification tab, with two different main action. |
### Result

![capture d ecran 2016-10-21 a 12 54 12](https://cloud.githubusercontent.com/assets/6768917/19597711/1f81d51c-978e-11e6-9a21-127fda9a4f13.png)
