### PR TITLE
Remove extra tag block closed

### DIFF
--- a/themes/classic/templates/index.tpl
+++ b/themes/classic/templates/index.tpl
@@ -8,5 +8,3 @@
         {/block}
       </section>
     {/block}
-
-{/block}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Checking the index.tpl and the rest of files I think that exist an extra close block tag. I haven't found the open tag for this one. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | - |
| How to test? | Removing this tag all works ok, Home, product-list and cart area. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
