### PR TITLE
Clean installation files from deleted hooks

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -6,9 +6,6 @@
     <field name="description"/>
   </fields>
   <entities>
-    <hook id="displayPayment">
-      <name>displayPayment</name><title>Payment</title><description>This hook displays new elements on the payment page</description>
-    </hook>
     <hook id="actionValidateOrder">
       <name>actionValidateOrder</name><title>New orders</title><description/>
     </hook>
@@ -114,9 +111,6 @@
     <hook id="displayCustomerAccount">
       <name>displayCustomerAccount</name><title>Customer account displayed in Front Office</title><description>This hook displays new elements on the customer account page</description>
     </hook>
-    <hook id="displayCustomerIdentityForm">
-      <name>displayCustomerIdentityForm</name><title>Customer identity form displayed in Front Office</title><description>This hook displays new elements on the form to update a customer identity</description>
-    </hook>
     <hook id="actionOrderSlipAdd">
       <name>actionOrderSlipAdd</name><title>Order slip creation</title><description>This hook is called when a new credit slip is added regarding client order</description>
     </hook>
@@ -171,9 +165,6 @@
     <hook id="displayShoppingCart">
       <name>displayShoppingCart</name><title>Shopping cart - Additional button</title><description>This hook displays new action buttons within the shopping cart</description>
     </hook>
-    <hook id="actionSearch">
-      <name>actionSearch</name><title>Search</title><description/>
-    </hook>
     <hook id="actionCarrierUpdate">
       <name>actionCarrierUpdate</name><title>Carrier Update</title><description>This hook is called when a carrier is updated</description>
     </hook>
@@ -198,9 +189,6 @@
     <hook id="actionCarrierProcess">
       <name>actionCarrierProcess</name><title>Carrier process</title><description/>
     </hook>
-    <hook id="actionOrderDetail">
-      <name>actionOrderDetail</name><title>Order detail</title><description>This hook is used to set the follow-up in Smarty when an order's detail is called</description>
-    </hook>
     <hook id="displayBeforeCarrier">
       <name>displayBeforeCarrier</name><title>Before carriers list</title><description>This hook is displayed before the carrier list in Front Office</description>
     </hook>
@@ -221,9 +209,6 @@
     </hook>
     <hook id="actionCategoryDelete">
       <name>actionCategoryDelete</name><title>Category deletion</title><description>This hook is displayed when a category is deleted</description>
-    </hook>
-    <hook id="actionBeforeAuthentication">
-      <name>actionBeforeAuthentication</name><title>Before authentication</title><description>This hook is displayed before the customer's authentication</description>
     </hook>
     <hook id="displayPaymentTop">
       <name>displayPaymentTop</name><title>Top of payment page</title><description>This hook is displayed at the top of the payment page</description>
@@ -254,9 +239,6 @@
     </hook>
     <hook id="actionProductSave">
       <name>actionProductSave</name><title>Saving products</title><description>This hook is called while saving products</description>
-    </hook>
-    <hook id="actionProductListOverride">
-      <name>actionProductListOverride</name><title>Assign a products list to a category</title><description>This hook assigns a products list to a category</description>
     </hook>
     <hook id="displayAttributeGroupPostProcess">
       <name>displayAttributeGroupPostProcess</name><title>On post-process in admin attribute group</title><description>This hook is called on post-process in admin attribute group</description>
@@ -299,12 +281,6 @@
     </hook>
     <hook id="actionModuleInstallAfter">
       <name>actionModuleInstallAfter</name><title>actionModuleInstallAfter</title><description></description>
-    </hook>
-    <hook id="displayHomeTab">
-      <name>displayHomeTab</name><title>Home Page Tabs</title><description>This hook displays new elements on the homepage tabs</description>
-    </hook>
-    <hook id="displayHomeTabContent">
-      <name>displayHomeTabContent</name><title>Home Page Tabs Content</title><description>This hook displays new elements on the homepage tabs content</description>
     </hook>
     <hook id="displayTopColumn">
       <name>displayTopColumn</name><title>Top column blocks</title><description>This hook displays new elements in the top of columns</description>

--- a/install-dev/data/xml/hook_alias.xml
+++ b/install-dev/data/xml/hook_alias.xml
@@ -5,10 +5,6 @@
     <field name="name"/>
   </fields>
   <entities>
-    <hook_alias id="payment">
-      <alias>payment</alias>
-      <name>displayPayment</name>
-    </hook_alias>
     <hook_alias id="newOrder">
       <alias>newOrder</alias>
       <name>actionValidateOrder</name>
@@ -173,10 +169,6 @@
       <alias>shoppingCartExtra</alias>
       <name>displayShoppingCart</name>
     </hook_alias>
-    <hook_alias id="search">
-      <alias>search</alias>
-      <name>actionSearch</name>
-    </hook_alias>
     <hook_alias id="updateCarrier">
       <alias>updateCarrier</alias>
       <name>actionCarrierUpdate</name>
@@ -209,10 +201,6 @@
       <alias>processCarrier</alias>
       <name>actionCarrierProcess</name>
     </hook_alias>
-    <hook_alias id="orderDetail">
-      <alias>orderDetail</alias>
-      <name>actionOrderDetail</name>
-    </hook_alias>
     <hook_alias id="beforeCarrier">
       <alias>beforeCarrier</alias>
       <name>displayBeforeCarrier</name>
@@ -236,10 +224,6 @@
     <hook_alias id="categoryDeletion">
       <alias>categoryDeletion</alias>
       <name>actionCategoryDelete</name>
-    </hook_alias>
-    <hook_alias id="beforeAuthentication">
-      <alias>beforeAuthentication</alias>
-      <name>actionBeforeAuthentication</name>
     </hook_alias>
     <hook_alias id="paymentTop">
       <alias>paymentTop</alias>
@@ -280,10 +264,6 @@
     <hook_alias id="afterSaveProduct">
       <alias>afterSaveProduct</alias>
       <name>actionProductSave</name>
-    </hook_alias>
-    <hook_alias id="productListAssign">
-      <alias>productListAssign</alias>
-      <name>actionProductListOverride</name>
     </hook_alias>
     <hook_alias id="postProcessAttributeGroup">
       <alias>postProcessAttributeGroup</alias>

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -154,12 +154,25 @@ INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES
 DELETE FROM `PREFIX_hook` WHERE `name` IN (
   'displayProductTab',
   'displayProductTabContent',
-  'displayBeforePayment');
+  'displayBeforePayment',
+  'actionBeforeAuthentication',
+  'actionOrderDetail',
+  'actionProductListOverride',
+  'actionSearch',
+  'displayCustomerIdentityForm',
+  'displayHomeTab',
+  'displayHomeTabContent',
+  'displayPayment');
 
 DELETE FROM `PREFIX_hook_alias` WHERE `name` IN (
+  'beforeAuthentication',
   'displayProductTab',
   'displayProductTabContent',
-  'displayBeforePayment');
+  'displayBeforePayment',
+  'orderDetail',
+  'payment',
+  'productListAssign',
+  'search');
 
 DELETE FROM `PREFIX_configuration` WHERE `name` IN (
   '_MEDIA_SERVER_2_',


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In the build article, we specify which hook have been deleted in PrestaShop 1.7. However, they still can be found in the database. This PR removes them from the list at installation and upgrade. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1642](http://forge.prestashop.com/browse/BOOM-1642) |
| How to test? | The hooks won't be found anymore in the database, tables `ps_hooks` and `ps_hooks_alias` |
