### PR TITLE
Export translations when exporting theme

### DIFF
--- a/src/PrestaShopBundle/Command/ExportThemeCommand.php
+++ b/src/PrestaShopBundle/Command/ExportThemeCommand.php
@@ -26,12 +26,13 @@
 
 namespace PrestaShopBundle\Command;
 
-use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+require dirname(__FILE__) . '/../../../vendor/prestashop/smarty/Autoloader.php';
+\Smarty_Autoloader::register();
+
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Yaml\Parser;
 
 class ExportThemeCommand extends ContainerAwareCommand
 {

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -267,6 +267,8 @@ services:
           - "@prestashop.adapter.legacy.configuration"
           - "@filesystem"
           - "@finder"
+          - "@prestashop.core.admin.lang.repository"
+          - "@prestashop.translation.theme.exporter"
 
     prestashop.core.admin.translation.repository:
         class: PrestaShopBundle\Entity\Repository\TranslationRepository

--- a/src/PrestaShopBundle/Tests/Command/ExportThemeCommandTest.php
+++ b/src/PrestaShopBundle/Tests/Command/ExportThemeCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+namespace PrestaShopBundle\Tests\Command;
+
+use PrestaShopBundle\Command\ExportThemeCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ExportThemeCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExecute()
+    {
+        $command = new ExportThemeCommand();
+        $commandTester = new CommandTester($command);
+
+        $containerMock = $this->mockContainer();
+        $command->setContainer($containerMock);
+
+        $helperSetMock = $this->mockHelperSet();
+        $command->setHelperSet($helperSetMock);
+
+        $this->assertEquals(0, $commandTester->execute(array('theme'  => 'classic')));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function mockThemeRepository()
+    {
+        $themeMock = $this->getMockBuilder('\PrestaShop\PrestaShop\Core\Addon\Theme\Theme')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $themeRepositoryMock = $this->getMockBuilder('\PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $themeRepositoryMock->method('getInstanceByName')
+            ->willReturn($themeMock);
+
+        return $themeRepositoryMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function mockTranslator()
+    {
+        $translatorMock = $this->getMockBuilder('\Symfony\Component\Translation\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $translatorMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function mockThemeExporter()
+    {
+        $themeExporterMock = $this->getMockBuilder('\PrestaShop\PrestaShop\Core\Addon\Theme\ThemeExporter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $themeExporterMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function mockContainer()
+    {
+        $containerMock = $this->getMockBuilder('\Symfony\Component\DependencyInjection\Container')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $themeRepositoryMock = $this->mockThemeRepository();
+        $translatorMock = $this->mockTranslator();
+        $themeExporterMock = $this->mockThemeExporter();
+
+        $containerMock->method('get')
+            ->will($this->returnCallback(function ($serviceId) use (
+                $themeRepositoryMock,
+                $translatorMock,
+                $themeExporterMock
+            ) {
+                $services = array(
+                    'prestashop.core.addon.theme.repository' => $themeRepositoryMock,
+                    'translator' => $translatorMock,
+                    'prestashop.core.addon.theme.exporter' => $themeExporterMock
+                );
+
+                return $services[$serviceId];
+            }));
+
+        return $containerMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function mockHelperSet()
+    {
+        $helperSetMock = $this->getMockBuilder('\Symfony\Component\Console\Helper\HelperSet')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $formatterHelperMock = $this->getMockBuilder('\Symfony\Component\Console\Helper\FormatterHelper')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $helperSetMock->method('get')
+            ->with('formatter')
+            ->willReturn($formatterHelperMock);
+        return $helperSetMock;
+    }
+}

--- a/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
+++ b/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
@@ -69,7 +69,10 @@ class ThemeExtractor
         // remove the last "/"
         $themeDirectory = substr($theme->getDirectory(), 0, -1);
 
-        $options = array('path' => $themeDirectory);
+        $options = array(
+            'path' => $themeDirectory,
+            'default_locale' => $locale,
+        );
         $this->smartyExtractor->extract($themeDirectory, $this->catalog);
 
         if ($this->overrideFromDatabase) {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Export translations on theme export |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | N/A |
| How to test? | Export a theme by executing `app/console prestashop:theme:export` command (with targeted theme name as first argument) |

See also https://github.com/PrestaShop/PrestaShop/pull/6767
