### PR TITLE
Added PS_MAINTENANCE_TEXT key in database

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -820,5 +820,8 @@ Country</value>
     <configuration id="PS_ORDER_RECALCULATE_SHIPPING" name="PS_ORDER_RECALCULATE_SHIPPING">
       <value>1</value>
     </configuration>
+    <configuration id="PS_MAINTENANCE_TEXT" name="PS_MAINTENANCE_TEXT">
+      <value/>
+    </configuration>
   </entities>
 </entity_configuration>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | A configuration key was missing in installation, causing maintenance text to not be translatable |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | Does it break backward compatibility? yes/no |
| How to test? | ShopParameters > General > Maintenance => play with differents languages. <br> **You MUST install again your shop** |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
