### PR TITLE
FO: Fix robot.txt generation.  Correction to "finish" and not "contains"

### DIFF
--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -790,7 +790,8 @@ class AdminMetaControllerCore extends AdminController
 					WHERE l.active = 1 AND m.page IN (\''.implode('\', \'', $disallow_controllers).'\')';
             if ($results = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql)) {
                 foreach ($results as $row) {
-                    $tab['Files'][$row['iso_code']][] = $row['url_rewrite'];
+                    $tab['Files'][$row['iso_code']][] = $row['url_rewrite'].'$';
+                    $tab['Files'][$row['iso_code']][] = $row['url_rewrite'].'?';
                 }
             }
         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | If an URL contains a word, the robots.txt blocks. Correction ends |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | If a product name contains the word"order" for example |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/6770)
<!-- Reviewable:end -->
