### PR TITLE
Add potential email error in order bulk action message failure.

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -419,7 +419,7 @@ class AdminOrdersControllerCore extends AdminController
                                         }
                                     }
                                 } else {
-                                    $this->errors[] = $this->trans('Cannot change status for order #%d.', array('#%d' => $id_order), 'Admin.OrdersCustomers.Notification');
+                                    $this->errors[] = $this->trans('An error occurred while changing order status #%d, or we were unable to send an email to the customer.', array('#%d' => $id_order), 'Admin.OrdersCustomers.Notification');
                                 }
                             }
                         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When the order status changes, it can ask for a mail to be sent. On a single order update, the merchant is properly warned if the mail is not sent. However on a bulk action, he just read the whole update process failed (but actually it succeeded !). This PR add the potential mail issue in the error message. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | [BOOM-1368](http://forge.prestashop.com/browse/BOOM-1368) |
| How to test? | Change the status of an order with the bulk action, with an email which cannot be sent. You should be properly warned now. |
