### PR TITLE
Do not display empty module categories

### DIFF
--- a/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
@@ -78,10 +78,12 @@ class CategoriesProvider
                     }
                 }
 
-                $categories['categories']->subMenu[$categoryName] = $this->createMenuObject($categoryName,
-                    $categoryName,
-                    $moduleIds
-                );
+                if (count($moduleIds)) {
+                    $categories['categories']->subMenu[$categoryName] = $this->createMenuObject($categoryName,
+                        $categoryName,
+                        $moduleIds
+                    );
+                }
             }
 
             usort($categories['categories']->subMenu, function ($a, $b) {
@@ -104,16 +106,13 @@ class CategoriesProvider
     public function getParentCategory($categoryName)
     {
         foreach ($this->getCategories() as $parentCategory) {
-            if ($parentCategory->name === $categoryName) {
-                return $categoryName;
-            }
-
             foreach ($parentCategory->categories as $childCategory) {
                 if ($childCategory->name === $categoryName) {
                     return $parentCategory->name;
                 }
             }
         }
+        return $categoryName;
     }
 
     /**


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | On the module page, we should have a category list with empty ones. If a category has no associated module, do not display it. The merchant will be able to focus on the other ones. |
| Type? | improvement |
| Category? | BO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | / |
| How to test? | Go to the module page, and check the category list. You should only have categories with at least ONE module. |
