### PR TITLE
Fixed module cache with 2 systems

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2280,8 +2280,12 @@ abstract class ModuleCore
     protected function getCurrentSubTemplate($template, $cache_id = null, $compile_id = null)
     {
         if (!isset($this->current_subtemplate[$template.'_'.$cache_id.'_'.$compile_id])) {
+            if (false === strpos($template, 'module:')) {
+                $template = $this->getTemplatePath($template);
+            }
+
             $this->current_subtemplate[$template.'_'.$cache_id.'_'.$compile_id] = $this->context->smarty->createTemplate(
-                $this->getTemplatePath($template),
+                $template,
                 $cache_id,
                 $compile_id,
                 $this->smarty
@@ -2326,8 +2330,10 @@ abstract class ModuleCore
     public function isCached($template, $cache_id = null, $compile_id = null)
     {
         Tools::enableCache();
-        $new_tpl = $this->getTemplatePath($template);
-        $is_cached = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->isCached($new_tpl, $cache_id, $compile_id);
+        if (false === strpos($template, 'module:')) {
+            $template = $this->getTemplatePath($template);
+        }
+        $is_cached = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->isCached($template, $cache_id, $compile_id);
         Tools::restoreCacheSettings();
         return $is_cached;
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fixed module cache with 2 systems |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Test cache for 2 modules. One with $this->display, One with $this->fetch |

ping @julienbourdeau  @maximebiloe @aleeks

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
