### PR TITLE
BO: add isset($employee) if employee not exist

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -216,7 +216,7 @@
 				{* Employee *}
 				<ul id="header_employee_box">
 					<li id="employee_infos" class="dropdown">
-						<a href="{$link->getAdminLink('AdminEmployees')|escape:'html':'UTF-8'}&amp;id_employee={$employee->id|intval}&amp;updateemployee" class="employee_name dropdown-toggle" data-toggle="dropdown">
+						<a href="{$link->getAdminLink('AdminEmployees')|escape:'html':'UTF-8'}&amp;id_employee={if isset($employee)}{$employee->id|intval}{/if}&amp;updateemployee" class="employee_name dropdown-toggle" data-toggle="dropdown">
 							<span class="employee_avatar_small">
 								{if isset($employee)}
 									<img class="imgm img-thumbnail" alt="" src="{$employee->getImage()}" width="32" height="32" />
@@ -226,12 +226,14 @@
 						<ul id="employee_links" class="dropdown-menu">
 							<li>
 								<span class="employee_avatar">
+									{if isset($employee)}
 									<img class="imgm img-thumbnail" alt="" src="{$employee->getImage()}" width="96" height="96" />
+									{/if}
 								</span>
 							</li>
-							<li class="text-center text-nowrap">{$employee->firstname} {$employee->lastname}</li>
+							<li class="text-center text-nowrap">{if isset($employee)}{$employee->firstname} {$employee->lastname}{/if}</li>
 							<li class="divider"></li>
-							<li><a href="{$link->getAdminLink('AdminEmployees')|escape:'html':'UTF-8'}&amp;id_employee={$employee->id|intval}&amp;updateemployee"><i class="icon-wrench"></i> {l s='My preferences' d='Admin.Navigation.Header'}</a></li>
+							<li><a href="{$link->getAdminLink('AdminEmployees')|escape:'html':'UTF-8'}&amp;id_employee={if isset($employee)}{$employee->id|intval}{/if}&amp;updateemployee"><i class="icon-wrench"></i> {l s='My preferences' d='Admin.Navigation.Header'}</a></li>
 							{if $host_mode}
 							<li><a href="https://www.prestashop.com/cloud/" class="_blank"><i class="icon-wrench"></i> {l s='My PrestaShop account' d='Admin.Navigation.Header'}</a></li>
 							{/if}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When employee is not set, if an attribute or function is called there will be fatal error |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | File can be loaded when employee is not defined, At the line 221 there is already one check if employe is set. Because if it is not set, when getImage() is called there will be fatal error: Call to undefined method . But there is also second call to getImage() , in line 229, this time - without check, so this commit tries to address that |
