### PR TITLE
Use native round instead of 2 forced decimals

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/_customized_data.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_customized_data.tpl
@@ -78,9 +78,9 @@
 		{if $stock_management}<td class="text-center">{$product['current_stock']}</td>{/if}
 		<td class="total_product">
 		{if ($order->getTaxCalculationMethod() == $smarty.const.PS_TAX_EXC)}
-			{displayPrice price=Tools::ps_round($product['product_price'] * $product['customizationQuantityTotal'], 2) currency=$currency->id|intval}
+			{displayPrice price=($product['unit_price_tax_excl'] * $product['customizationQuantityTotal']) currency=$currency->id|intval}
 		{else}
-			{displayPrice price=Tools::ps_round($product['product_price_wt'] * $product['customizationQuantityTotal'], 2) currency=$currency->id|intval}
+			{displayPrice price=($product['unit_price_tax_incl'] * $product['customizationQuantityTotal']) currency=$currency->id|intval}
 		{/if}
 		</td>
 		<td class="cancelQuantity standard_refund_fields current-edit" style="display:none" colspan="2">
@@ -174,9 +174,9 @@
 				<td class="text-center">-</td>
 				<td class="total_product">
 					{if ($order->getTaxCalculationMethod() == $smarty.const.PS_TAX_EXC)}
-						{displayPrice price=Tools::ps_round($product['product_price'] * $customization['quantity'], 2) currency=$currency->id|intval}
+						{displayPrice price=($product['unit_price_tax_excl'] * $customization['quantity']) currency=$currency->id|intval}
 					{else}
-						{displayPrice price=Tools::ps_round($product['product_price_wt'] * $customization['quantity'], 2) currency=$currency->id|intval}
+						{displayPrice price=($product['unit_price_tax_incl'] * $customization['quantity']) currency=$currency->id|intval}
 					{/if}
 				</td>
 				<td class="cancelCheck standard_refund_fields current-edit" style="display:none">

--- a/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
@@ -129,7 +129,7 @@
 	{/if}
 	{if $stock_management}<td class="productQuantity product_stock text-center">{$product['current_stock']}</td>{/if}
 	<td class="total_product">
-		{displayPrice price=(Tools::ps_round($product_price, 2) * ($product['product_quantity'] - $product['customizationQuantityTotal'])) currency=$currency->id}
+		{displayPrice price=($product_price * ($product['product_quantity'] - $product['customizationQuantityTotal'])) currency=$currency->id}
 	</td>
 	<td colspan="2" style="display: none;" class="add_product_fields">&nbsp;</td>
 	<td class="cancelCheck standard_refund_fields current-edit" style="display:none">


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Fix incorrect round when looking at order details |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Set decimals preferences to 6, order a product that is using 6 decimals to see the result. Without the fix, prices are looking like 12,340000€ / after: 12,345678€ into the order details |
