### PR TITLE
Display missing hook (displayCustomerAccountForm)

### DIFF
--- a/themes/classic/templates/customer/_partials/customer-form.tpl
+++ b/themes/classic/templates/customer/_partials/customer-form.tpl
@@ -8,6 +8,7 @@
           {form_field field=$field}
         {/block}
       {/foreach}
+      {$hook_create_account_form nofilter}
     {/block}
   </section>
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The displayCustomerAccountForm hook was computed [here](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/form/CustomerForm.php#L131) but was never displayed |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Hook a module on this hook and check that it is displayed on the account form |
