### PR TITLE
Hook:exec should always return an array when array_return = true

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -610,7 +610,11 @@ class HookCore extends ObjectModel
         // If no modules associated to hook_name or recompatible hook name, we stop the function
 
         if (!$module_list = Hook::getHookModuleExecList($hook_name)) {
-            return '';
+            if ($array_return) {
+                return array();
+            } else {
+                return '';
+            }
         }
 
         // Check if hook exists


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Hook:exec should always return an array when array_return = true |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |
