### PR TITLE
Add missing hook call for actionSubmitAccountBefore

### DIFF
--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -43,7 +43,14 @@ class AuthControllerCore extends FrontController
             ;
 
             if (Tools::isSubmit('submitCreate')) {
-                if ($register_form->submit()) {
+                $hookResult = array_reduce(
+                    Hook::exec('actionSubmitAccountBefore', array(), null, true),
+                    function ($carry, $item) {
+                        return $carry && $item;
+                    },
+                    true
+                );
+                if ($hookResult && $register_form->submit()) {
                     $should_redirect = true;
                 }
             }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | FO |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1694 |
| How to test? | hook some modules on actionSubmitAccountBefore. If there is at least one that returns false then the registration should fail. |