### PR TITLE
Configured Twig autoescape option

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -49,6 +49,7 @@ monolog:
 
 # Twig Configuration
 twig:
+    autoescape:       "name"
     debug:            "%kernel.debug%"
     strict_variables: "%kernel.debug%"
     form_themes:


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Set Twig autoescape option (`filename` has been deprecated with Twig 1.27) |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | N/A |
| How to test? | Run unit tests (they should not raise any deprecation warning) |
