### PR TITLE
Fix fatal on Best Sales

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -472,25 +472,10 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
             $this->ajaxDie(json_encode($this->getAjaxProductSearchVariables()));
         } else {
             $variables = $this->getProductSearchVariables();
-            if (
-                !empty($variables['products'])
-                || $params['entity'] === 'category'
-            ) {
-                $this->context->smarty->assign(array(
-                    'listing' => $variables,
-                ));
-                $this->setTemplate($template, $params, $locale);
-            } else {
-                header('HTTP/1.1 404 Not Found');
-                header('Status: 404 Not Found');
-                $this->php_self = 'pagenotfound';
-                $this->page_name = 'pagenotfound';
-                $this->context->smarty->assign(
-                    'title',
-                    $this->trans('No results were found for your search.', array(), 'Shop.Notifications.Error')
-                );
-                $this->setTemplate('errors/404');
-            }
+            $this->context->smarty->assign(array(
+                'listing' => $variables,
+            ));
+            $this->setTemplate($template, $params, $locale);
         }
     }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | debug (develop) |
| Description? | Fix fatal on Best Sales - Never redirect on regular 404 when no product, use the product one with the category block and search bar. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |

See #6807 also
