### PR TITLE
Clear the cache before trying to update the DB schema

### DIFF
--- a/src/PrestaShopBundle/Service/Cache/Refresh.php
+++ b/src/PrestaShopBundle/Service/Cache/Refresh.php
@@ -72,6 +72,21 @@ class Refresh
     public function addCacheClear()
     {
         $this->commands[] = array(
+            'command' => 'doctrine:cache:clear-metadata',
+            '--flush' => true,
+        );
+
+        $this->commands[] = array(
+            'command' => 'doctrine:cache:clear-query',
+            '--flush' => true,
+        );
+
+        $this->commands[] = array(
+            'command' => 'doctrine:cache:clear-result',
+            '--flush' => true,
+        );
+
+        $this->commands[] = array(
             'command' => 'cache:clear',
             '--no-warmup' => true,
         );
@@ -82,6 +97,7 @@ class Refresh
      */
     public function addDoctrineSchemaUpdate()
     {
+        $this->addCacheClear();
         $this->commands[] = array(
             'command' => 'doctrine:schema:update',
             '--force' => true,


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | The doctrine cache needs to be flushed before SchemaUpdate in case the parameters have been updated |
| Type? | bug fix |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | With apc activated : do an install with a first db_prefix, a second install with a different db_prefix, the first db_prefix will still be used for doctrine tables. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
