### PR TITLE
Fixed method Order::isVirtual

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -753,17 +753,17 @@ class OrderCore extends ObjectModel
         if (count($products) < 1) {
             return false;
         }
+
         $virtual = true;
+
         foreach ($products as $product) {
-            $pd = ProductDownload::getIdFromIdProduct((int)$product['product_id']);
-            if ($pd && Validate::isUnsignedInt($pd) && $product['download_hash'] && $product['display_filename'] != '') {
-                if ($strict === false) {
-                    return true;
-                }
-            } else {
-                $virtual &= false;
+            if ($strict === false && (bool)$product['is_virtual']) {
+                return true;
             }
+
+            $virtual &= (bool)$product['is_virtual'];
         }
+
         return $virtual;
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | The current method check if the product has a download, with "download_hash" and "display_filename" to be considered as virtual; but not every virtual product has a download file, etc. So, simply check if the "is_virtual" index is set to 1 instead of using ProductDownload::getIdFromIdProduct(). |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | No |
| Deprecations? | No |
| Fixed ticket? |  |
| How to test? | Create an order with a virtual product with a download and an order with a virtual product without a download, then check with (new Order($id_order))->isVirtual(); |
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
