### PR TITLE
CO: External JS scripts should come before local scripts when concatenated

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -660,7 +660,10 @@ class MediaCore
             $url = str_replace(_PS_CORE_DIR_.'/', __PS_BASE_URI__, $compressedJsPath);
         }
 
-        return array_merge(array($protocolLink.Tools::getMediaServer($url).$url), $jsExternalFiles);
+        return array_merge(
+            $jsExternalFiles,
+            array($protocolLink.Tools::getMediaServer($url).$url)
+        );
     }
 
     /**


### PR DESCRIPTION
When CCC is enabled, external scripts should come before local concatenated JS files. It seems that this is already true for concatenated CSS files, but not JS files.

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When CCC is enabled, external scripts should come before local concatenated JS files. It seems that this is already true for concatenated CSS files, but not JS files. If a module script is dependent on a library from CDN, the library must be loaded first. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Not really, maybe |
| Deprecations? | no |
| How to test? | Include and external JS script from CDN to a controller, enable JS CCC, see the script order. |
