### PR TITLE
Default value for non existing request params should be null

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -408,20 +408,20 @@ class ToolsCore
     * Get a value from $_POST / $_GET
     * if unavailable, take a default value
     *
-    * @param string $key Value key
-    * @param mixed $default_value (optional)
-    * @return mixed Value
+    * @param string     $key          Value key
+    * @param mixed|null $defaultValue (optional)
+    * @return mixed|null Value
     */
-    public static function getValue($key, $default_value = false)
+    public static function getValue($key, $defaultValue = null)
     {
         if (!isset($key) || empty($key) || !is_string($key)) {
-            return false;
+            return $defaultValue;
         }
 
         if (getenv('kernel.environment') === 'test' && self::$request instanceof Request) {
-            $value = self::$request->request->get($key, self::$request->query->get($key, $default_value));
+            $value = self::$request->request->get($key, self::$request->query->get($key, $defaultValue));
         } else {
-            $value = (isset($_POST[$key]) ? $_POST[$key] : (isset($_GET[$key]) ? $_GET[$key] : $default_value));
+            $value = (isset($_POST[$key]) ? $_POST[$key] : (isset($_GET[$key]) ? $_GET[$key] : $defaultValue));
         }
 
         if (is_string($value)) {

--- a/tests/Unit/classes/ToolsCoreTest.php
+++ b/tests/Unit/classes/ToolsCoreTest.php
@@ -66,7 +66,7 @@ class ToolsCoreTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('world', Tools::getValue('hello'));
     }
 
-    public function testGetValueAcceptsOnlyTruthyStringsAsKeys()
+    public function testGetValueReturnsDefaultValueWhenKeyIsEmptyOrNull()
     {
         $this->setPostAndGet(array(
             '' => true,
@@ -74,9 +74,9 @@ class ToolsCoreTest extends PHPUnit_Framework_TestCase
             null => true
         ));
 
-        $this->assertEquals(false, Tools::getValue('', true));
+        $this->assertEquals('default', Tools::getValue('', 'default'));
         $this->assertEquals(true, Tools::getValue(' '));
-        $this->assertEquals(false, Tools::getValue(null, true));
+        $this->assertEquals('default', Tools::getValue(null, 'default'));
     }
 
     public function testGetValueStripsNullCharsFromReturnedStringsExamples()


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | `(array)false` gets casted into `array(0 => false)`, which is not empty. Casting `null` to array is gives empty `array()`, which is what you want if you're expecting a POSTed array param. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Maybe |
| Deprecations? | No |
| How to test? | `(array)Tools::getValue('notexists')` |
