### PR TITLE
[*] CO : Quantity calculation when negative stock on combination

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -441,6 +441,7 @@ class StockAvailableCore extends ObjectModel
 			SELECT SUM(quantity) as quantity
 			FROM '._DB_PREFIX_.'stock_available
 			WHERE id_product = '.(int)$this->id_product.'
+			AND quantity > 0 
 			AND id_product_attribute <> 0 '.
             StockAvailable::addSqlShopRestriction(null, $id_shop)
         );


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | Quantity calculation when negative stock on combination |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | For exemple, if you have a product with a combination at '-1' in stock, and a combination at '1' in stock. The product quantity should be 1 and not 0 (and then should be orderable). So when you calculate the global quantity of a product, you don't have to SUM the negative quantity. |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/6824)
<!-- Reviewable:end -->
