### PR TITLE
Fixed wrong order detail updated

### DIFF
--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -722,7 +722,7 @@ function init()
 			var element_list = $('.customized-' + $(this).parent().parent().find('.edit_product_id_order_detail').val());
 			query = 'ajax=1&token='+token+'&action=editProductOnOrder&id_order='+id_order+'&';
 			if (element_list.length)
-				query += element_list.parent().parent().find('input:visible, select:visible, .edit_product_id_order_detail').serialize();
+				query += element_list.find('input:visible, select:visible, .edit_product_id_order_detail').serialize();
 			else
 				query += element.parent().parent().find('input:visible, select:visible, .edit_product_id_order_detail').serialize();
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When editing a customized product that is not the last row of the table, the requested order detail is not the one updated. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | 1. Create an order with a customized product (text message or file) and any another product, in that order. 2. In the back-end, go to the order detail. 3. Update the quantity or the price of the customized product. 4. Refresh the page. |

**Explanation**
As all .edit_product_id_order_detail of the table are sent, the id_order_detail posted is overridden over and over and the last order detail will be edited.
**Fix**
Only send inputs values of the edited rows.
