### PR TITLE
CO: Catch exception in GeoIp2

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -802,8 +802,13 @@ class FrontControllerCore extends Controller
             if (@filemtime(_PS_GEOIP_DIR_._PS_GEOIP_CITY_FILE_)) {
                 if (!isset($this->context->cookie->iso_code_country) || (isset($this->context->cookie->iso_code_country) && !in_array(strtoupper($this->context->cookie->iso_code_country), explode(';', Configuration::get('PS_ALLOWED_COUNTRIES'))))) {
                     $reader = new GeoIp2\Database\Reader(_PS_GEOIP_DIR_._PS_GEOIP_CITY_FILE_);
-                    $record = $reader->city(Tools::getRemoteAddr());
-
+                    try {
+                        $remoteAddr = Tools::getRemoteAddr();
+                        $record = $reader->city($remoteAddr);
+                    } catch(\GeoIp2\Exception\AddressNotFoundException $e) {
+                        $record = null;
+                        PrestaShopLogger::addLog("The IP $remoteAddr not found in the GeoIp2 Databse", 2);
+                    }
                     if (is_object($record)) {
                         if (!in_array(strtoupper($record->country->isoCode), explode(';', Configuration::get('PS_ALLOWED_COUNTRIES'))) && !FrontController::isInWhitelistForGeolocation()) {
                             if (Configuration::get('PS_GEOLOCATION_BEHAVIOR') == _PS_GEOLOCATION_NO_CATALOG_) {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -807,7 +807,7 @@ class FrontControllerCore extends Controller
                         $record = $reader->city($remoteAddr);
                     } catch(\GeoIp2\Exception\AddressNotFoundException $e) {
                         $record = null;
-                        PrestaShopLogger::addLog("The IP $remoteAddr not found in the GeoIp2 Databse", 2);
+                        PrestaShopLogger::addLog("The IP $remoteAddr not found in the GeoIp2 Databse", 3);
                     }
                     if (is_object($record)) {
                         if (!in_array(strtoupper($record->country->isoCode), explode(';', Configuration::get('PS_ALLOWED_COUNTRIES'))) && !FrontController::isInWhitelistForGeolocation()) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | Develop |
| Description? | Latest version in develop |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | NO |
| Deprecations? | no |
| How to test? | Introduce a local ip for example (192.168.33.10) |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

Fix Fatal Error when the IP is not in GeoIp2 the library.
The GeoIp2 is throwing an Exception "AddressNotFoundException"
