### PR TITLE
Orders amount currency fixed

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -660,7 +660,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                 foreach ($orders as $key => $order) {
                     if ($order['valid']) {
                         $orders_ok[] = $order;
-                        $total_ok += $order['total_paid_real'];
+                        $total_ok += $order['total_paid_real']/$order['conversion_rate'];
                     }
                     $orders[$key]['date_add'] = Tools::displayDate($order['date_add']);
                     $orders[$key]['total_paid_real'] = Tools::displayPrice($order['total_paid_real'], new Currency((int)$order['id_currency']));

--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -750,7 +750,7 @@ class AdminCustomersControllerCore extends AdminController
 
             if ($order['valid']) {
                 $orders_ok[] = $order;
-                $total_ok += $order['total_paid_real_not_formated'];
+                $total_ok += $order['total_paid_real_not_formated']/$order['conversion_rate'];
             } else {
                 $orders_ko[] = $order;
             }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | If a shop is multi-currency and customer pays in an other than the default, the valid orders amount is displaying the amount with default currency ISO code. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | No? |
| Deprecations? | No? |
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7738 |
| How to test? | Customer pays 100 EURO, default store currency is DKK = displaying customers valid order is worth 100 DKK, instead of 100 EURO - since stores can have many currencies i figured out it was best to convert the orders back to the default currency instead of guessing the most valid currency for each customer.<br><br>This PR was submitted to develop 21-02-2016 for fixing 1.6.1.X. Since then, Develop branch has been marked marked for 1.7 and this is why i submit it again as a new PR targeting 1.6.1.X - https://github.com/PrestaShop/PrestaShop/pull/5053 |
