### PR TITLE
Use module_name to get error on upload (debug branch)

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -523,7 +523,7 @@ class ModuleController extends FrameworkBundleAdminController
                     'Admin.Modules.Notification');
                 $installation_response['is_configurable'] = (bool) $this->get('prestashop.core.admin.module.repository')->getModule($module_name)->attributes->get('is_configurable');
             } else {
-                $error = $moduleManager->getError($file_uploaded->getPathname());
+                $error = $moduleManager->getError($module_name);
                 $installation_response['msg'] = $translator->trans(
                     'Installation of module %module% failed. %error%',
                     array(


### PR DESCRIPTION
This PR is a rebase / squash of #6773 

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Get error message during module installation. Get error with path, it doesn't work ...  Use the module name instead. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Add "$this->_errors[] = Tools::displayError('Doh !');" in an install module method <br /> Install the module. <br /> "Doh!" Should be written when you click on "What happened?" |
