### PR TITLE
Reset country in address page after error

### DIFF
--- a/themes/default-bootstrap/js/tools/statesManagement.js
+++ b/themes/default-bootstrap/js/tools/statesManagement.js
@@ -90,6 +90,10 @@ function bindZipcode()
 function bindStateInputAndUpdate()
 {
 	$('.id_state, .dni, .postcode').css({'display':'none'});
+
+	if (typeof idSelectedCountry !== 'undefined' && idSelectedCountry)
+		$('#id_country option[value=' + idSelectedCountry + ']').prop('selected', true);
+
 	updateState();
 	updateNeedIDNumber();
 	updateZipCode();


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | When an error occurs in the address page, the page gets reloaded, but the country field does not get reset. |
| Type? | bug fix |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Add or edit an address from the front office, first by selecting one country, but not filling up a mandatory field (phone?), then change country and try again to fail the form, this time the country won't be selected. |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
