### PR TITLE
Check instanceof only when trying to present hook results

### DIFF
--- a/src/PrestaShopBundle/Service/Hook/HookFinder.php
+++ b/src/PrestaShopBundle/Service/Hook/HookFinder.php
@@ -77,10 +77,6 @@ class HookFinder
                 continue;
             }
             foreach ($moduleContents as $content) {
-                if (!$content instanceof HookContentClassInterface) {
-                    throw new \Exception('The class returned must implement HookContentClassInterface');
-                }
-
                 // Check data returned if asked
                 if (!count($this->expectedInstanceClasses)) {
                     continue;
@@ -108,6 +104,10 @@ class HookFinder
 
         foreach ($hookContent as $moduleName => $moduleContents) {
             foreach ($moduleContents as $content) {
+                if (!$content instanceof HookContentClassInterface) {
+                    throw new \Exception('The class returned must implement HookContentClassInterface to be presented');
+                }
+
                 $presentedContent = $content->toArray();
                 $presentedContent['moduleName'] = $moduleName;
                 $presentedContents[] = $presentedContent;


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | In the HookFinder class, we check to early if a Hook result is an instance of an interface. We could just find the results without trying to present them. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | Nope |
| Deprecations? | Nope |
| Fixed ticket? | https://github.com/firstred/mdstripe/issues/50 |
| How to test? | Implement a module registered on displayPaymentEU. Without the PR, you should get an exception 'The class returned must implement HookContentClassInterface' |
