### PR TITLE
Update StoresController.php

### DIFF
--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -286,7 +286,7 @@ class StoresControllerCore extends FrontController
 
         if (!Configuration::get('PS_STORES_SIMPLIFIED')) {
             $default_country = new Country((int)Tools::getCountry());
-            $this->addJS('http'.((Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE')) ? 's' : '').'://maps.google.com/maps/api/js?sensor=true&region='.substr($default_country->iso_code, 0, 2));
+            $this->addJS('http'.((Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE')) ? 's' : '').'://maps.google.com/maps/api/js?'.substr($default_country->iso_code, 0, 2));
             $this->addJS(_THEME_JS_DIR_.'stores.js');
         }
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | PrestaShop 1.6 (bugfixes only). |
| Description? | The sensor parameter is no longer required for the Google Maps JavaScript API |
| Type? | bug fix |
| Category? | CO delete sensor parameter |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

SensorNotRequired
The sensor parameter is no longer required for the Google Maps JavaScript API. It won't prevent the Google Maps JavaScript API from working correctly, but we recommend that you remove the sensor parameter from the script element.
