### PR TITLE
Fix italian translation of  "On backorder..."

### DIFF
--- a/install-dev/langs/it/data/order_state.xml
+++ b/install-dev/langs/it/data/order_state.xml
@@ -33,11 +33,11 @@
     <template>payment_error</template>
   </order_state>
   <order_state id="On_backorder_paid">
-    <name>In attesa di rifornimento</name>
+    <name>In attesa di rifornimento (pagato)</name>
     <template>outofstock</template>
   </order_state>
   <order_state id="On_backorder_unpaid">
-    <name>In attesa di rifornimento</name>
+    <name>In attesa di rifornimento (non pagato)</name>
     <template>outofstock</template>
   </order_state>
   <order_state id='Awaiting_bank_wire_payment'>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop, 1.6.1.x |
| Description? | If you use the Italian language in the BO and select `Orders -> Statuses`, you see two identical order statuses, i.e. _In attesa di rifornimento_, while they are distict: _On backorder (paid)_ and _On backorder (unpaid)_. This patch fixes the Italian translation. |
| Type? | bug fix |
| Category? | LO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | See Description above |
