### PR TITLE
Fix BDD required during install

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2307,8 +2307,11 @@ FileETag none
 
     public static function generateIndex()
     {
-        if (defined('_PS_CREATION_DATE_') && _PS_CREATION_DATE_ !== null && Configuration::get('PS_DISABLE_OVERRIDES')) {
-            PrestaShopAutoload::getInstance()->_include_override_path = false;
+        if (defined('_PS_CREATION_DATE_')) {
+            $creationDate = _PS_CREATION_DATE_;
+            if (!empty($creationDate) && Configuration::get('PS_DISABLE_OVERRIDES')) {
+                PrestaShopAutoload::getInstance()->_include_override_path = false;
+            }
         }
         PrestaShopAutoload::getInstance()->generateIndex();
     }
@@ -2884,25 +2887,26 @@ exit;
      * @param $array
      * @param $cmp_function
      */
-    public static function uasort(&$array, $cmp_function) {
-        if(count($array) < 2) {
+    public static function uasort(&$array, $cmp_function)
+    {
+        if (count($array) < 2) {
             return;
         }
         $halfway = count($array) / 2;
-        $array1 = array_slice($array, 0, $halfway, TRUE);
-        $array2 = array_slice($array, $halfway, NULL, TRUE);
+        $array1 = array_slice($array, 0, $halfway, true);
+        $array2 = array_slice($array, $halfway, null, true);
 
         self::uasort($array1, $cmp_function);
         self::uasort($array2, $cmp_function);
-        if(call_user_func($cmp_function, end($array1), reset($array2)) < 1) {
+        if (call_user_func($cmp_function, end($array1), reset($array2)) < 1) {
             $array = $array1 + $array2;
             return;
         }
         $array = array();
         reset($array1);
         reset($array2);
-        while(current($array1) && current($array2)) {
-            if(call_user_func($cmp_function, current($array1), current($array2)) < 1) {
+        while (current($array1) && current($array2)) {
+            if (call_user_func($cmp_function, current($array1), current($array2)) < 1) {
                 $array[key($array1)] = current($array1);
                 next($array1);
             } else {
@@ -2910,11 +2914,11 @@ exit;
                 next($array2);
             }
         }
-        while(current($array1)) {
+        while (current($array1)) {
             $array[key($array1)] = current($array1);
             next($array1);
         }
-        while(current($array2)) {
+        while (current($array2)) {
             $array[key($array2)] = current($array2);
             next($array2);
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix BDD required during install. As we saw with @aleeks, we generate index during install and try to load a configuration variable if the `_PS_CREATION_DATE_` is not null *BUT* it's set to an empty string.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Try to install with the default parameters.php values