### PR TITLE
Add cURL check at installation

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -77,6 +77,7 @@ class ConfigurationTestCore
                 ),
                 'phpversion' => false,
                 'apache_mod_rewrite' => false,
+                'curl' => false,
                 'gd' => false,
                 'pdo_mysql' => false,
                 'config_dir' => 'config',
@@ -182,6 +183,11 @@ class ConfigurationTestCore
         }
 
         return true;
+    }
+    
+    public static function test_curl()
+    {
+        return extension_loaded('curl');
     }
 
     public static function test_gd()

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "doctrine/common": "~2.5.3",
     "doctrine/orm": "~2.5.3",
     "twig/twig": "~1.26.0",
+    "ext-curl": "*",
     "ext-intl": "*",
     "ext-zip": "*",
     "geoip2/geoip2": "~2.4.2",

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -95,6 +95,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                         'phpversion' => $this->translator->trans('PHP 5.4 or later is not enabled', array(), 'Install'),
                         'upload' => $this->translator->trans('Cannot upload files', array(), 'Install'),
                         'system' => $this->translator->trans('Cannot create new files and folders', array(), 'Install'),
+                        'curl' => $this->translator->trans('cURL extension is not enabled', array(), 'Install'),
                         'gd' => $this->translator->trans('GD library is not installed', array(), 'Install'),
                         'openssl' => $this->translator->trans('PHP OpenSSL extension is not loaded', array(), 'Install'),
                         'pdo_mysql' => $this->translator->trans('PDO MySQL extension is not loaded', array(), 'Install'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the installation wizard, if the cURL extension is missing, no error message is thrown on the compatibility step.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | [BOOM-1712](http://forge.prestashop.com/browse/BOOM-1712)
| How to test?  | Disable the cURL extension on your PHP instance, and launch the installation wizard. You should be warned that PrestaShop requires cURL to be installed.
