### PR TITLE
Removed search param orderway duplication

### DIFF
--- a/themes/default-bootstrap/js/global.js
+++ b/themes/default-bootstrap/js/global.js
@@ -53,7 +53,7 @@ $(document).ready(function(){
 				url += requestSortProducts ;
 				if (typeof splitData[0] !== 'undefined' && splitData[0])
 				{
-					url += ( requestSortProducts.indexOf('?') < 0 ? '?' : '&') + 'orderby=' + splitData[0] + (splitData[1] ? '&orderway=' + splitData[1] : '');
+					url += ( requestSortProducts.indexOf('?') < 0 ? '?' : '&') + 'orderby=' + splitData[0];
 					if (typeof splitData[1] !== 'undefined' && splitData[1])
 						url += '&orderway=' + splitData[1];
 				}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Removed orderway param duplication from product's list sorting. 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | In product's list after changing "Sort by" param orderway gets duplicated in url.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
