### PR TITLE
Fix for "Advanced EU Compliance"

### DIFF
--- a/themes/default-bootstrap/order-payment-advanced.tpl
+++ b/themes/default-bootstrap/order-payment-advanced.tpl
@@ -74,7 +74,7 @@
                                 <span class="payment_option_cta">
                                     {$paymentOption->getCallToActionText()}
                                 </span>
-                                <span class="pull-right payment_option_selected">
+                                <span class="pull-right payment_option_selected" style="display: none;">
                                     <i class="icon-check"></i>
                                 </span>
                             </a>


### PR DESCRIPTION
Without this fix: Every payment option is selected by default.
With this fix: No payment option is selected by default
**Please test it if you merge it.**