### PR TITLE
Add JSON, SimpleXML and DOM extensions as install requirements

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -79,11 +79,13 @@ class ConfigurationTestCore
                 'apache_mod_rewrite' => false,
                 'curl' => false,
                 'gd' => false,
+                'json' => false,
                 'pdo_mysql' => false,
                 'config_dir' => 'config',
                 'files' => false,
                 'mails_dir' => 'mails',
                 'openssl' => 'false',
+                'simplexml' => false,
                 'zip' => false,
             ));
         }
@@ -194,6 +196,11 @@ class ConfigurationTestCore
     {
         return function_exists('imagecreatetruecolor');
     }
+    
+    public static function test_json()
+    {
+        return extension_loaded('json');
+    }
 
     public static function test_gz()
     {
@@ -202,6 +209,11 @@ class ConfigurationTestCore
         }
 
         return false;
+    }
+
+    public static function test_simplexml()
+    {
+        return extension_loaded('SimpleXML');
     }
 
     public static function test_zip()

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -97,8 +97,10 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                         'system' => $this->translator->trans('Cannot create new files and folders', array(), 'Install'),
                         'curl' => $this->translator->trans('cURL extension is not enabled', array(), 'Install'),
                         'gd' => $this->translator->trans('GD library is not installed', array(), 'Install'),
+                        'json' => $this->translator->trans('JSON extension is not loaded', array(), 'Install'),
                         'openssl' => $this->translator->trans('PHP OpenSSL extension is not loaded', array(), 'Install'),
                         'pdo_mysql' => $this->translator->trans('PDO MySQL extension is not loaded', array(), 'Install'),
+                        'simplexml' => $this->translator->trans('SimpleXML extension is not loaded', array(), 'Install'),
                         'zip' => $this->translator->trans('ZIP extension is not enabled', array(), 'Install'),
                     )
                 ),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On some Linux distributions, some basic extensions are missing from PHP. We add them as requirements in the installation wizard.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | [BOOM-1734](http://forge.prestashop.com/browse/BOOM-1734)
| How to test?  | On a basic PHP environment, JSON, SimpleXml and DOM will be marked as required by the installation wizard if missing.