### PR TITLE
Remove z-index of ps tagger reset button

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -261,7 +261,6 @@
   position: absolute;
   color: #2eacce;
   font-size: 20px;
-  z-index: 498 !important;
   cursor: pointer;
   top: 0;
   right: 0;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When we open the help sidebar on the module page, the button to reset the search bar is still visible on the screen. This PR make it disappear when something is in front of it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | [BOOM-1708](http://forge.prestashop.com/browse/BOOM-1708]
| How to test?  | Be sure to update and compile all assets, and open the help on the module page. You should not have the cross on the middle of the panel.
