### PR TITLE
Add PHP polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,10 @@
     "prestashop/trackingfront": "dev-master",
     "prestashop/welcome": "dev-master",
     "prestashop/dashtrends": "dev-master",
-    "beberlei/DoctrineExtensions": "^1.0"
+    "beberlei/DoctrineExtensions": "^1.0",
+    "symfony/polyfill-php55": "^1.2",
+    "symfony/polyfill-php56": "^1.2",
+    "symfony/polyfill-php70": "^1.2"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.5",


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | `develop`
| Description?  | Now that PrestaShop has been ported to Symfony it's time to reap the rewards. Add Symfony polyfills for PHP 5.5, 5.6 and 7.0 functions to make module development easier. These are tiny libs and only register global functions when needed, thus more efficient than using `Tools::whatever()`. With these libraries in place we might be able to remove several `Tools::` thingies in the future.   
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 