### PR TITLE
Force full SSL

### DIFF
--- a/controllers/admin/AdminPreferencesController.php
+++ b/controllers/admin/AdminPreferencesController.php
@@ -96,8 +96,7 @@ class AdminPreferencesControllerCore extends AdminController
             $fields = array(
                 'PS_SSL_ENABLED' => array(
                     'title' => $this->trans('Enable SSL', array(), 'Admin.ShopParameters.Feature'),
-                    'desc' => $this->trans('If you own an SSL certificate for your shop\'s domain name, you can activate SSL encryption (https://) for customer account identification and order processing.', array(), 'Admin.ShopParameters.Help'),
-                    'hint' => $this->trans('If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.', array(), 'Admin.ShopParameters.Help'),
+                    'desc' => $this->trans('When enabled, all the pages of your shop will be SSL-secured.', array(), 'Admin.ShopParameters.Help'),
                     'validation' => 'isBool',
                     'cast' => 'intval',
                     'type' => 'bool',
@@ -110,9 +109,8 @@ class AdminPreferencesControllerCore extends AdminController
                 'desc' => $this->trans('When enabled, all the pages of your shop will be SSL-secured.', array(), 'Admin.ShopParameters.Help'),
                 'validation' => 'isBool',
                 'cast' => 'intval',
-                'type' => 'bool',
+                'type' => 'hidden',
                 'default' => '0',
-                'disabled' => (Tools::getValue('PS_SSL_ENABLED', Configuration::get('PS_SSL_ENABLED'))) ? false : true
             );
 
             $fields = array_merge($fields, array(
@@ -241,5 +239,17 @@ class AdminPreferencesControllerCore extends AdminController
         $tab = Tab::getInstanceFromClassName('AdminShopGroup');
         $tab->active = (bool)Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');
         $tab->update();
+    }
+
+    /**
+     * Some additional processing, before processing the whole form
+     */
+    public function postProcess()
+    {
+        if (Tools::isSubmit('PS_SSL_ENABLED')) {
+            $_POST['PS_SSL_ENABLED_EVERYWHERE'] = (Tools::getValue('PS_SSL_ENABLED')) ? 1 : 0;
+        }
+
+        parent::postProcess();
     }
 }

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -86,6 +86,9 @@
   <configuration id="PS_SSL_ENABLED" name="PS_SSL_ENABLED">
     <value>0</value>
   </configuration>
+  <configuration id="PS_SSL_ENABLED_EVERYWHERE" name="PS_SSL_ENABLED_EVERYWHERE">
+    <value>0</value>
+  </configuration>
   <configuration id="PS_WEIGHT_UNIT" name="PS_WEIGHT_UNIT">
     <value>kg</value>
   </configuration>

--- a/install-dev/upgrade/php/force_ssl.php
+++ b/install-dev/upgrade/php/force_ssl.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+function force_ssl()
+{
+    $sql = new DbQuery();
+    $sql->select('*');
+    $sql->from('configuration');
+    $sql->where('`name` = \'PS_SSL_ENABLED\'');
+
+    $configurations = Db::getInstance()->executeS($sql);
+
+    foreach ($configurations as &$configuration) {
+        if ($configuration['id_shop'] === null) {
+            $configuration['id_shop'] = 'IS NULL';
+        } else {
+            $configuration['id_shop'] = '= '.(int) $configuration['id_shop'];
+        }
+        if ($configuration['id_shop_group'] === null) {
+            $configuration['id_shop_group'] = 'IS NULL';
+        } else {
+            $configuration['id_shop_group'] = '= '.(int) $configuration['id_shop_group'];
+
+            Db::getInstance()->update(
+                'configuration',
+                array(
+                    'value' => (int) $configuration['value'],
+                ),
+                '`name` = \'PS_SSL_ENABLED_EVERYWHERE\' AND `id_shop_group` '.$configuration['id_shop_group'].' AND `id_shop` '.$configuration['id_shop'],
+                1,
+                true
+            );
+        }
+    }
+}

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -204,3 +204,4 @@ DELETE FROM `PREFIX_configuration` WHERE `name` IN (
 ALTER TABLE `PREFIX_tab` ADD `icon` varchar(32) DEFAULT '';
 
 /* PHP:migrate_tabs_17(); */;
+/* PHP:force_ssl(); */;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | `develop`
| Description?  | Sites that have not enabled full SSL from January 2017 will be punished in the Google rankings (https://security.googleblog.com/2016/09/moving-towards-more-secure-web.html). Therefore it makes no sense anymore to have the hybrid option. This PR removes the possibility to enable hybrid SSL/non-SSL in a backwards compatible way. The options are now either no SSL or full SSL. Nothing in between.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | 
| How to test?  | 