### PR TITLE
Fixes for module upgrade with zip upload

### DIFF
--- a/src/Adapter/Module/ModuleZipManager.php
+++ b/src/Adapter/Module/ModuleZipManager.php
@@ -144,7 +144,9 @@ class ModuleZipManager
         $this->filesystem->mkdir($modulePath);
         $this->filesystem->mirror(
             $sandboxPath.$name,
-            $modulePath
+            $modulePath,
+            null,
+            array('override' => true)
         );
         $this->filesystem->remove($sandboxPath);
     }

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -123,12 +123,11 @@ class ModuleManager implements AddonManagerInterface
             return $this->upgrade($name, 'latest', $source);
         }
 
-        if (! $this->moduleProvider->isOnDisk($name)) {
-            if (!empty($source)) {
-                $this->moduleZipManager->storeInModulesFolder($source);
-            } else {
-                $this->moduleUpdater->setModuleOnDiskFromAddons($name);
-            }
+        if (!empty($source)) {
+            $this->moduleZipManager->storeInModulesFolder($source);
+        }
+        else if (! $this->moduleProvider->isOnDisk($name)) {
+            $this->moduleUpdater->setModuleOnDiskFromAddons($name);
         }
 
         $module = $this->moduleRepository->getModule($name);

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -539,8 +539,7 @@ class ModuleController extends FrameworkBundleAdminController
             );
         } catch (Exception $e) {
             if (isset($module_name)) {
-                $moduleManager->uninstall($module_name);
-                $moduleManager->removeModuleFromDisk($module_name);
+                $moduleManager->disable($module_name);
             }
 
             return new JsonResponse(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR replaces the old `eval()` with the PhpParser library. It also fixes an issue when we upload a zip to upgrade a module, not applied at all.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Upload the same module multiple times. You can check the files have been properly updated by verifying their "creation date/time". 
