### PR TITLE
Added dependency injection container in legacy

### DIFF
--- a/classes/container/LegacyCompilerPass.php
+++ b/classes/container/LegacyCompilerPass.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+
+class LegacyCompilerPass implements CompilerPassInterface
+{
+    /**
+     * Add legacy services that need to be built using Context::getContext().
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $context = Context::getContext();
+
+        $this->buildSyntheticDefinitions([
+            'configuration',
+            'context',
+            'db',
+            'shop',
+            'employee',
+        ], $container);
+
+        $container->set('context', $context);
+        $container->set('configuration', new Configuration($context->shop));
+        $container->set('db', Db::getInstance());
+        $container->set('shop', $context->shop);
+        $container->set('employee', $context->employee);
+    }
+
+    private function buildSyntheticDefinitions(array $keys, ContainerBuilder $container)
+    {
+        foreach ($keys as $key) {
+            $definition = new Definition();
+            $definition->setSynthetic(true);
+            $container->setDefinition($key, $definition);
+        }
+    }
+}

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -25,6 +25,7 @@
  */
 
 use PrestaShop\PrestaShop\Core\Cldr;
+use LegacyCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -25,7 +25,6 @@
  */
 
 use PrestaShop\PrestaShop\Core\Cldr;
-use LegacyCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
@@ -4632,7 +4631,7 @@ class AdminControllerCore extends Controller
     protected function buildContainer()
     {
         $container = new ContainerBuilder();
-        $container->addCompilerPass(new LegacyCompilerPass());
+        $container->addCompilerPass(new \LegacyCompilerPass());
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__));
         $env = _PS_MODE_DEV_ === true ? 'dev' : 'prod';
         $loader->load(_PS_CONFIG_DIR_.'services/admin/services_'. $env .'.yml');

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -26,6 +26,9 @@
 
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 use PrestaShop\PrestaShop\Core\Cldr;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Config\FileLocator;
 
 class AdminControllerCore extends Controller
 {
@@ -4626,5 +4629,17 @@ class AdminControllerCore extends Controller
         }
 
         return $this->tabSlug;
+    }
+
+    protected function buildContainer()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new LegacyCompilerPass());
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__));
+        $env = _PS_MODE_DEV_ === true ? 'dev' : 'prod';
+        $loader->load(_PS_CONFIG_DIR_.'services/admin/services_'. $env .'.yml');
+        $container->compile();
+
+        return $container;
     }
 }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -24,7 +24,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 use PrestaShop\PrestaShop\Core\Cldr;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -3760,9 +3759,7 @@ class AdminControllerCore extends Controller
                 }
                 /* Automatically hash password in MD5 */
                 if ($key == 'passwd' && !empty($value)) {
-                    /** @var \PrestaShop\PrestaShop\Core\Crypto\Hashing $crypto */
-                    $crypto = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Crypto\\Hashing');
-                    $value = $crypto->hash($value, _COOKIE_KEY_);
+                    $value = $this->get('hashing')->hash($value, _COOKIE_KEY_);
                 }
                 $object->{$key} = $value;
             }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -111,7 +111,7 @@ abstract class ControllerCore
         if (!defined('_PS_BASE_URL_SSL_')) {
             define('_PS_BASE_URL_SSL_', Tools::getShopDomainSsl(true));
         }
-        $this->buildContainer();
+        $this->container = $this->buildContainer();
     }
 
     /**

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -81,6 +81,9 @@ abstract class ControllerCore
     /** @var PrestaShopBundle\Translation\Translator */
     protected $translator;
 
+    /** @var ContainerBuilder legacy container */
+    protected $container;
+
 
     /**
      * Check if the controller is available for the current user/visitor
@@ -108,6 +111,7 @@ abstract class ControllerCore
         if (!defined('_PS_BASE_URL_SSL_')) {
             define('_PS_BASE_URL_SSL_', Tools::getShopDomainSsl(true));
         }
+        $this->buildContainer();
     }
 
     /**
@@ -626,7 +630,6 @@ abstract class ControllerCore
         }
 
         /* @deprecated deprecated since 1.6.1.1 */
-        // Hook::exec('actionBeforeAjaxDie', array('controller' => $controller, 'method' => $method, 'value' => $value));
         Hook::exec('actionAjaxDieBefore', array('controller' => $controller, 'method' => $method, 'value' => $value));
 
         /**
@@ -637,5 +640,20 @@ abstract class ControllerCore
         Hook::exec('actionAjaxDie'.$controller.$method.'Before', array('value' => $value));
 
         die($value);
+    }
+
+    /**
+     * Construct the container of dependencies
+     */
+    protected function buildContainer(){}
+
+    public function get($serviceId)
+    {
+        return $this->container->get($serviceId);
+    }
+
+    public function getParameter($parameterId)
+    {
+        return $this->container->getParameter($parameterId);
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -25,10 +25,12 @@
  */
 use PrestaShop\PrestaShop\Adapter\Cart\CartPresenter;
 use PrestaShop\PrestaShop\Adapter\ObjectPresenter;
-use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use PrestaShop\PrestaShop\Adapter\Configuration as ConfigurationAdapter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Debug\Debug;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Config\FileLocator;
 
 class FrontControllerCore extends Controller
 {
@@ -1799,7 +1801,7 @@ class FrontControllerCore extends Controller
             $this->makeCustomerFormatter(),
             new CustomerPersister(
                 $this->context,
-                new Hashing(),
+                $this->get('hashing'),
                 $this->getTranslator(),
                 $this->guestAllowed
             ),
@@ -1902,5 +1904,16 @@ class FrontControllerCore extends Controller
         } else {
             return $matches[0];
         }
+    }
+
+    protected function buildContainer()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__));
+        $env = _PS_MODE_DEV_ === true ? 'dev' : 'prod';
+        $loader->load(_PS_CONFIG_DIR_.'services/front/services_'. $env .'.yml');
+        $container->compile();
+
+        return $container;
     }
 }

--- a/config/services/admin/services_dev.yml
+++ b/config/services/admin/services_dev.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: services_prod.yml }

--- a/config/services/admin/services_prod.yml
+++ b/config/services/admin/services_prod.yml
@@ -1,0 +1,21 @@
+parameters:
+
+services:
+  sf_filesystem:
+    class: Symfony\Component\Filesystem\Filesystem
+  sf_finder:
+    class: Symfony\Component\Finder\Finder
+
+  hook_provider:
+    class: PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider
+  hook_repository:
+    class: PrestaShop\PrestaShop\Core\Module\HookRepository
+    arguments: ["@hook_provider", "@shop", "@db"]
+  hook_configurator:
+    class: PrestaShop\PrestaShop\Core\Module\HookConfigurator
+    arguments: ["@hook_repository"]
+  theme_checker:
+    class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeChecker
+  theme_manager:
+    class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager
+    arguments: ["@shop", "@configuration", "@theme_checker", "@employee", "@sf_filesystem", "@sf_finder", "@hook_configurator"]

--- a/config/services/admin/services_prod.yml
+++ b/config/services/admin/services_prod.yml
@@ -1,21 +1,28 @@
 parameters:
 
 services:
-  sf_filesystem:
-    class: Symfony\Component\Filesystem\Filesystem
-  sf_finder:
-    class: Symfony\Component\Finder\Finder
+    filesystem:
+        class: Symfony\Component\Filesystem\Filesystem
+    finder:
+        class: Symfony\Component\Finder\Finder
 
-  hook_provider:
-    class: PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider
-  hook_repository:
-    class: PrestaShop\PrestaShop\Core\Module\HookRepository
-    arguments: ["@hook_provider", "@shop", "@db"]
-  hook_configurator:
-    class: PrestaShop\PrestaShop\Core\Module\HookConfigurator
-    arguments: ["@hook_repository"]
-  theme_checker:
-    class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeChecker
-  theme_manager:
-    class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager
-    arguments: ["@shop", "@configuration", "@theme_checker", "@employee", "@sf_filesystem", "@sf_finder", "@hook_configurator"]
+    hook_provider:
+        class: PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider
+
+    hook_repository:
+        class: PrestaShop\PrestaShop\Core\Module\HookRepository
+        arguments: ["@hook_provider", "@shop", "@db"]
+
+    hook_configurator:
+        class: PrestaShop\PrestaShop\Core\Module\HookConfigurator
+        arguments: ["@hook_repository"]
+
+    theme_checker:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeChecker
+
+    theme_manager:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager
+        arguments: ["@shop", "@configuration", "@theme_checker", "@employee", "@filesystem", "@finder", "@hook_configurator"]
+
+    hashing:
+        class: PrestaShop\PrestaShop\Core\Crypto\Hashing

--- a/config/services/admin/services_prod.yml
+++ b/config/services/admin/services_prod.yml
@@ -17,12 +17,12 @@ services:
         class: PrestaShop\PrestaShop\Core\Module\HookConfigurator
         arguments: ["@hook_repository"]
 
-    theme_checker:
-        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeChecker
+    theme_validator:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeValidator
 
     theme_manager:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager
-        arguments: ["@shop", "@configuration", "@theme_checker", "@employee", "@filesystem", "@finder", "@hook_configurator"]
+        arguments: ["@shop", "@configuration", "@theme_validator", "@employee", "@filesystem", "@finder", "@hook_configurator"]
 
     hashing:
         class: PrestaShop\PrestaShop\Core\Crypto\Hashing

--- a/config/services/front/services_dev.yml
+++ b/config/services/front/services_dev.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: services_prod.yml }

--- a/config/services/front/services_prod.yml
+++ b/config/services/front/services_prod.yml
@@ -1,0 +1,5 @@
+parameters:
+
+services:
+    hashing:
+        class: PrestaShop\PrestaShop\Core\Crypto\Hashing

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -37,8 +37,6 @@ define('MAX_COLUMNS', 6);
 /** correct Mac error on eof */
 @ini_set('auto_detect_line_endings', '1');
 
-use PrestaShop\PrestaShop\Adapter\ServiceLocator;
-
 class AdminImportControllerCore extends AdminController
 {
     public static $column_mask;
@@ -2875,9 +2873,7 @@ class AdminImportControllerCore extends AdminController
         AdminImportController::arrayWalk($info, array('AdminImportController', 'fillInfo'), $customer);
 
         if ($customer->passwd) {
-            /** @var \PrestaShop\PrestaShop\Core\Crypto\Hashing $crypto */
-            $crypto = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Crypto\\Hashing');
-            $customer->passwd = $crypto->hash($customer->passwd, _COOKIE_KEY_);
+            $customer->passwd = $this->get('hashing')->hash($customer->passwd, _COOKIE_KEY_);
         }
 
         $id_shop_list = explode($this->multiple_value_separator, $customer->id_shop);

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -24,7 +24,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 use PrestaShop\PrestaShop\Adapter\CoreException;
 
 class AdminLoginControllerCore extends AdminController
@@ -351,10 +350,7 @@ class AdminLoginControllerCore extends AdminController
         }
 
         if (!count($this->errors)) {
-            /** @var \PrestaShop\PrestaShop\Core\Crypto\Hashing $crypto */
-            $crypto = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Crypto\\Hashing');
-
-            $employee->passwd = $crypto->hash($reset_password, _COOKIE_KEY_);
+            $employee->passwd = $this->get('hashing')->hash($reset_password, _COOKIE_KEY_);
             $employee->last_passwd_gen = date('Y-m-d H:i:s', time());
 
             $params = array(

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -148,14 +148,7 @@ class PasswordControllerCore extends FrontController
                     if ($customer->getValidResetPasswordToken() !== Tools::getValue('reset_token')) {
                         $this->errors[] = $this->trans('The password change request expired. You should ask for a new one.', array(), 'Shop.Notifications.Error');
                     } else {
-                        try {
-                            $crypto = new Hashing();
-                        } catch (\PrestaShop\PrestaShop\Adapter\CoreException $e) {
-                            $this->errors[] = $this->trans('An error occurred with your account, which prevents us from updating the new password. Please report this issue using the contact form.', array(), 'Shop.Notifications.Error');
-                            return false;
-                        }
-
-                        $customer->passwd = $crypto->hash($password = Tools::getValue('passwd'), _COOKIE_KEY_);
+                        $customer->passwd = $this->get('hashing')->hash($password = Tools::getValue('passwd'), _COOKIE_KEY_);
                         $customer->last_passwd_gen = date('Y-m-d H:i:s', time());
 
                         if ($customer->update()) {

--- a/src/Adapter/ServiceLocator.php
+++ b/src/Adapter/ServiceLocator.php
@@ -27,6 +27,11 @@ namespace PrestaShop\PrestaShop\Adapter;
 
 use \PrestaShop\PrestaShop\Core\Foundation\IoC\Container;
 
+/**
+ * @internal
+ *
+ * To be removed in 1.7.1.
+ */
 class ServiceLocator
 {
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow us to build our objects a more flexible and powerful way
| Type?         | improvement
| Category?     | CO
| Test            | In legacy controllers, use $this->get('sf_finder') for instance

- [x] Todos:
  - [x] Bootstrap a container for both legacy admin and front office environments
