### PR TITLE
FO: make cms images htaccess compatible with pagespeed

### DIFF
--- a/img/cms/.htaccess
+++ b/img/cms/.htaccess
@@ -2,7 +2,7 @@
 	php_flag engine off
 </IfModule>
 deny from all
-<Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm)$">
+<Files ~ "(?i).*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm)$">
 	order deny,allow
 	allow from all
 </Files>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The htaccess file for cms images can't handle the rewritten image urls that pagespeed generates. Eg. IMG_6254.JPG.pagespeed.ce.xfbHIcErbb.jpg because it only expects urls in the form IMG_6254.JPG. The patch relaxes the criteria to only check for the last extension in the url.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Have pagespeed enabled on apache, any cms images that are optimized will give a 403 forbidden error. Apply the change and the images should work again.