### PR TITLE
Fixed actionCartSummary hook results merge with cart summary data

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3767,8 +3767,8 @@ class CartCore extends ObjectModel
         );
 
         $hook = Hook::exec('actionCartSummary', $summary, null, true);
-        if (is_array($hook)) {
-            $summary = array_merge($summary, array_shift($hook));
+        if (is_array($hook) && !empty($hook)) {
+            $summary = array_merge($summary, $hook);
         }
 
         return $summary;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed actionCartSummary hook results to be correcly merged into cart summary data. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | View any customer in Back Office who has at least one cart created and you should get error indicating that: array_merge(): Argument #2 is not an array.
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->