### PR TITLE
Fix sprintf condition

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -49,7 +49,7 @@ class TranslateCore
         }
         $str = str_replace('"', '&quot;', $str);
 
-        if ($sprintf !== null) {
+        if ($sprintf !== null && (!is_array($sprintf) || !empty($sprintf))) {
             $str = Translate::checkAndReplaceArgs($str, $sprintf);
         }
 
@@ -189,7 +189,7 @@ class TranslateCore
 
         if (!isset($langCache[$cacheKey])) {
             if ($_MODULES == null) {
-                if ($sprintf !== null) {
+                if ($sprintf !== null && (!is_array($sprintf) || !empty($sprintf))) {
                     $string = Translate::checkAndReplaceArgs($string, $sprintf);
                 }
 
@@ -220,7 +220,7 @@ class TranslateCore
                 $ret = stripslashes($string);
             }
 
-            if ($sprintf !== null) {
+            if ($sprintf !== null && (!is_array($sprintf) || !empty($sprintf))) {
                 $ret = Translate::checkAndReplaceArgs($ret, $sprintf);
             }
 
@@ -265,7 +265,7 @@ class TranslateCore
 
         $str = (array_key_exists('PDF'.$key, $_LANGPDF) ? $_LANGPDF['PDF'.$key] : $string);
 
-        if ($sprintf !== null) {
+        if ($sprintf !== null && (!is_array($sprintf) || !empty($sprintf))) {
             $str = Translate::checkAndReplaceArgs($str, $sprintf);
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix `sprintf` condition. Sometimes we defined `sprintf` as an empty `array` but we were testing if it wasn't `null`.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1839
| How to test?  | You can use a module with a string which contains `%`. Before this PR, it was causing notice and the strings were not displayed.