### PR TITLE
Fix Cookie standalone mode

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -76,9 +76,6 @@ class CookieCore
         $this->_allow_writing = true;
         $this->_salt = $this->_standalone ? str_pad('', 8, md5('ps'.__FILE__)) : _COOKIE_IV_;
 
-        if ($this->_standalone) {
-            $this->cipherTool = new PhpEncryption(str_pad('', 32, __FILE__));
-        }
         $this->cipherTool = new PhpEncryption(_NEW_COOKIE_KEY_);
 
         $this->_secure = (bool) $secure;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | standalone mode on a cookie is not working anymore. Exception is fired. `$this->cipherTool` is overwrited at line 82 anyway, so this part is useless.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Try to create a new instance of Cookie, using standalone parameter as true. <br/><br/> Fatal error: Uncaught Defuse\Crypto\\Exception\BadFormatException: Encoding::hexToBin() input is not a hex string. in vendor/defuse/php-encryption/src/Encoding.php on line 65

