### PR TITLE
Fixed bulk actions affecting single products

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/catalog.js
+++ b/admin-dev/themes/default/js/bundle/product/catalog.js
@@ -276,17 +276,7 @@ function bulkProductAction(element, action) {
 
         $('#catalog_deletion_modal').modal('hide');
 
-        // use a progressbar if more 1 item
-        if (items.size() > 1) {
-          return bulkModalAction(items, postUrl, redirectUrl, action);
-        } else {
-          var redirectionInput = $('<input>')
-            .attr('type', 'hidden')
-            .attr('name', 'redirect_url').val(redirectUrl);
-          form.append($(redirectionInput));
-          form.attr('action', postUrl);
-          form.submit();
-        }
+        return bulkModalAction(items, postUrl, redirectUrl, action);
       });
 
       return; // No break, but RETURN, to avoid code after switch block :)
@@ -295,10 +285,7 @@ function bulkProductAction(element, action) {
       postUrl = urlHandler.attr('bulkurl');
       redirectUrl = urlHandler.attr('redirecturl');
 
-      // use a progressbar if more 1 item
-      if (items.size() > 1) {
-        return bulkModalAction(items, postUrl, redirectUrl, action);
-      }
+      return bulkModalAction(items, postUrl, redirectUrl, action);
 
       break;
 
@@ -306,10 +293,7 @@ function bulkProductAction(element, action) {
       postUrl = urlHandler.attr('bulkurl').replace(/activate_all/, action);
       redirectUrl = urlHandler.attr('redirecturl');
 
-      // use a progressbar if more 1 item
-      if (items.size() > 1) {
-        return bulkModalAction(items, postUrl, redirectUrl, action);
-      }
+      return bulkModalAction(items, postUrl, redirectUrl, action);
 
       break;
 
@@ -317,10 +301,7 @@ function bulkProductAction(element, action) {
       postUrl = urlHandler.attr('bulkurl').replace(/activate_all/, action);
       redirectUrl = urlHandler.attr('redirecturl');
 
-      // use a progressbar if more 1 item
-      if (items.size() > 1) {
-        return bulkModalAction(items, postUrl, redirectUrl, action);
-      }
+      return bulkModalAction(items, postUrl, redirectUrl, action);
 
       break;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Bulk action is not applied to single selected item.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | delete / activate / duplicate / deactivate a product using bulk action button

See also https://github.com/PrestaShop/PrestaShop/pull/7070
