### PR TITLE
Return empty array on API error for customer data

### DIFF
--- a/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
@@ -148,7 +148,10 @@ class ApiClient
 
         $responseArray = json_decode($response);
 
-        return $responseArray->modules;
+        if (!empty($responseArray->modules)) {
+            return $responseArray->modules;
+        }
+        return array();
     }
 
     public function getResponse()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In case of unexpected results from the Marketplace API for customer data, it seems better for people to receive an empty array instead of an exception.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | [BOOM-1754](http://forge.prestashop.com/browse/BOOM-1754)
| How to test? | Modify the password sent in `PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider::getAddonsCredentials()` and empty your cache. You should not have any exception when loading the module catalog.