### PR TITLE
Fix email translations

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -118,6 +118,7 @@
 							var rte_mail_config = {};
 							rte_mail_config['editor_selector'] = 'rte-mail-' + rte_mail_selector;
 							rte_mail_config['height'] = '500px';
+							rte_mail_config['plugins'] = 'colorpicker link image paste pagebreak table contextmenu filemanager table code media autoresize textcolor anchor fullpage';
 							// move controls to active panel
 							$('#translation_mails-control-actions').appendTo($(this).find('.panel-collapse.in'));
 							// when user first open email

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1549,6 +1549,7 @@ class AdminTranslationsControllerCore extends AdminController
 
     protected function getMailPattern()
     {
+        Tools::displayAsDeprecated('Email pattern is no longer used, emails are always saved like they are.');
         // Let the indentation like it.
         return '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/1999/REC-html401-19991224/strict.dtd">
 <html>
@@ -1621,9 +1622,6 @@ class AdminTranslationsControllerCore extends AdminController
                         // replace correct end of line
                         $content = str_replace("\r\n", PHP_EOL, $content);
 
-                        $string_mail = $this->getMailPattern();
-                        $content = str_replace(array('#content'), array($content), $string_mail);
-
                         // Magic Quotes shall... not.. PASS!
                         if (_PS_MAGIC_QUOTES_GPC_) {
                             $content = stripslashes($content);
@@ -1638,8 +1636,6 @@ class AdminTranslationsControllerCore extends AdminController
                         if (!file_exists($path) && !mkdir($path, 0777, true)) {
                             throw new PrestaShopException(sprintf($this->trans('Directory "%s" cannot be created', array(), 'Admin.International.Notification'), dirname($path)));
                         }
-
-                        $content = Tools::purifyHTML($content, array('{', '}'), true);
 
                         if ($type_content == 'tpl') {
                             preg_match('/{\s*[^$]+/s', $content, $matches);
@@ -2567,18 +2563,12 @@ class AdminTranslationsControllerCore extends AdminController
 
     protected function cleanMailContent(&$content, $lang, &$title)
     {
-        // Because TinyMCE don't work correctly with <DOCTYPE>, <html> and <body> tags
         if (stripos($content[$lang], '<body')) {
             $array_lang = $lang != 'en' ? array('en', $lang) : array($lang);
             foreach ($array_lang as $language) {
                 $title[$language] = substr($content[$language], 0, stripos($content[$language], '<body'));
                 preg_match('#<title>([^<]+)</title>#Ui', $title[$language], $matches);
                 $title[$language] = empty($matches[1])?'':$matches[1];
-                // The 2 lines below allow to exlude <body> tag from the content.
-                // This allow to exclude body tag even if attributs are setted.
-                $content[$language] = substr($content[$language], stripos($content[$language], '<body') + 5);
-                $content[$language] = substr($content[$language], stripos($content[$language], '>') + 1);
-                $content[$language] = substr($content[$language], 0, stripos($content[$language], '</body>'));
             }
         }
         $content[$lang] = (isset($content[$lang]) ? Tools::htmlentitiesUTF8(stripslashes($content[$lang])) : '');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.0
| Description?  | Emails should be saved with HTML tags in order to preserve the style
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1763
How to test?
<ul><li>BO: Go on the translation page</li><li>BO: Modify the HTML version of one of the email template (example: order_conf) and save</li><li>BO: Go back on the template and look at the HTML version => The style shouldn't have changed</li></ul>

https://github.com/PrestaShop/PrestaShop/pull/5333
https://github.com/PrestaShop/PrestaShop/pull/6961