### PR TITLE
Fix modules translation form

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
@@ -128,7 +128,7 @@
 														<input type="text"
 															style="width: 450px{if empty($value.trad)};background:#FBB{/if}"
 															name="{$name|md5}"
-															value="{$value.trad|regex_replace:'#"#':'&quot;'|stripslashes}"' />
+															value="{$value.trad|regex_replace:'#"#':'&quot;'|stripslashes}" />
 													{else}
 														<textarea rows="{($key|strlen / $textarea_sized)|intval}"
 															style="width: 450px{if empty($value.trad)};background:#FBB{/if}"
@@ -152,12 +152,12 @@
 									<button type="submit" id="{$table}_form_submit_btn" name="submitTranslations{$type|ucfirst}AndStay" class="btn btn-default pull-right"><i class="process-icon-save"></i> {l s='Save and stay' d='Admin.Actions'}</button>
 								</div>
 							</div>
-              </form>
 						{/if}
 					{/foreach}
 				{/foreach}
 			{/foreach}
-		{/if}
+    </form>
+	{/if}
 
     <form action="{$url_submit_installed_module|escape:'html':'UTF-8'}" method="post" enctype="multipart/form-data" class="form-horizontal">
       <div class="panel">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Modules translation form can only be submitted using the first two save buttons due to malformed output
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Open a module configuration page, click "Translate" on top and submit the form

