### PR TITLE
Add default message on ajax error in installer

### DIFF
--- a/install-dev/theme/js/process.js
+++ b/install-dev/theme/js/process.js
@@ -98,9 +98,10 @@ function process_install(step)
 			}
 		},
 		// An error HTTP (page not found, json not valid, etc.) occured during this step
-		error: function() {
-			install_error(step);
-		}
+		error: function( jqXHR, textStatus ) {
+                    var errorMsg = 'HTTP '+ jqXHR.status + ' - '+ textStatus +' - '+ jqXHR.responseText;
+                    install_error(step, errorMsg);
+                }
 	});
 }
 
@@ -151,9 +152,10 @@ function process_install_subtask(step, current_subtask)
 				install_error(step, (json) ? json.message : '');
 		},
 		// An error HTTP (page not found, json not valid, etc.) occured during this step
-		error: function() {
-			install_error(step);
-		}
+                error: function( jqXHR, textStatus ) {
+                    var errorMsg = 'HTTP '+ jqXHR.status + ' - '+ textStatus +' - '+ jqXHR.responseText;
+                    install_error(step, errorMsg);
+                }
 	});
 }
 
@@ -189,9 +191,7 @@ function install_error(step, errors)
 
 		display += '</ol>';
 		$('#error_process').append(display);
-	}
-
-	if (typeof psuser_assistance != 'undefined') {
+	} else if (typeof psuser_assistance != 'undefined') {
 		psuser_assistance.setStep('install_process_error', {'error': 'No message || {"version": "' + ps_version + '"}'});
 	}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Having "no message" in the log when an error happen do not allow us to debug afterwards. This PR adds some info when an ajax request fails.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | [BOOM-1793](http://forge.prestashop.com/browse/BOOM-1793)
| How to test?  | Make your ajax requests fail and check your network tab to verify if something is sent