### PR TITLE
FO : click on color's label reset the filter

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -35,6 +35,7 @@ $(document).ready(function()
 
 	// Click on color
 	$(document).on('click', '#layered_form input[type=button], #layered_form label.layered_color', function(e) {
+		e.preventDefault();
 		if (!$('input[name='+$(this).attr('name')+'][type=hidden]').length)
 			$('<input />').attr('type', 'hidden').attr('name', $(this).attr('name')).val($(this).data('rel')).appendTo('#layered_form');
 		else


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "1.6.1.x"
| Description?  | In checkbox mode : Colors' labels ('label.layered_color') contain a link ('<a href...') and the click on it should be ignored otherwise the filter will be reset.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | Don't know
| Deprecations? | no
| How to test?  | Activate blocklayered module, add a filter with colors in checkbox mode and on the front click on a color's label

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/6946)
<!-- Reviewable:end -->
