### PR TITLE
Add ISO code for spanish Colombia

### DIFF
--- a/app/Resources/legacy-to-standard-locales.json
+++ b/app/Resources/legacy-to-standard-locales.json
@@ -11,6 +11,8 @@
   "br-FR": "br-FR",
   "ca": "ca-ES",
   "es-CO": "es-CO",
+  "cb": "es-CO",
+  "co": "es-CO",
   "cs": "cs-CZ",
   "da": "da-DK",
   "de": "de-DE",


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7
| Description?  | Fix ISO code for spanish Colombia
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | if you install a new language cb is the ISO code used in PS16, but when trying to get new field "locale" must be "es-CO" but is not taken from .json file. Then if merchant create Spanish Colombia with ISO code cb and try to use translation in back-office get an exception.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->