### PR TITLE
CO: pass variables of hook `actionProductSearchComplete` by link

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -349,7 +349,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
             )),
         );
 
-        Hook::exec('actionProductSearchComplete', $searchVariables);
+        Hook::exec('actionProductSearchComplete', array('searchVariables' => &$searchVariables));
 
         return $searchVariables;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Pass variables of the hook "actionProductSearchComplete" by link. This trick will allow to modify search results, for example useful together with "displayOverrideTemplate" hook for show search results among CMS pages, etc.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Just open page with results of search
