### PR TITLE
Add the option to enable APCu cache.

### DIFF
--- a/classes/cache/CacheApcu.php
+++ b/classes/cache/CacheApcu.php
@@ -1,0 +1,165 @@
+<?php
+/*
+* 2007-2016 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2016 PrestaShop SA
+*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+/**
+ * This class require PECL APCu extension
+ *
+ * @since 1.6.1
+ */
+class CacheApcuCore extends Cache
+{
+	public function __construct()
+	{
+		if (!function_exists('apcu_exists'))
+		{
+			$this->keys = array();
+			$cache_info = apcu_cache_info();
+			foreach ($cache_info['cache_list'] as $entry)
+			{
+				if (isset($entry['key']))
+					$this->keys[$entry['key']] = $entry['ttl'];
+				else
+					$this->keys[$entry['info']] = $entry['ttl'];
+			}
+		}
+	}
+
+	/**
+	 * Delete one or several data from cache (* joker can be used, but avoid it !)
+	 * 	E.g.: delete('*'); delete('my_prefix_*'); delete('my_key_name');
+	 *
+	 * @param string $key
+	 * @return bool
+	 */
+	public function delete($key)
+	{
+		if ($key == '*')
+			$this->flush();
+		elseif (strpos($key, '*') === false)
+			$this->_delete($key);
+		else
+		{
+			$pattern = str_replace('\\*', '.*', preg_quote($key));
+
+			$cache_info = apcu_cache_info();
+			foreach ($cache_info['cache_list'] as $entry)
+			{
+				if (isset($entry['key']))
+					$key = $entry['key'];
+				else
+					$key = $entry['info'];
+				if (preg_match('#^'.$pattern.'$#', $key))
+					$this->_delete($key);
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * @see Cache::_set()
+	 */
+	protected function _set($key, $value, $ttl = 0)
+	{
+		return apcu_store($key, $value, $ttl);
+	}
+
+	/**
+	 * @see Cache::_get()
+	 */
+	protected function _get($key)
+	{
+		return apcu_fetch($key);
+	}
+
+	/**
+	 * @see Cache::_exists()
+	 */
+	protected function _exists($key)
+	{
+		if (!function_exists('apcu_exists'))
+			return isset($this->keys[$key]);
+		else
+			return apcu_exists($key);
+	}
+
+	/**
+	 * @see Cache::_delete()
+	 */
+	protected function _delete($key)
+	{
+		return apcu_delete($key);
+	}
+
+	/**
+	 * @see Cache::_writeKeys()
+	 */
+	protected function _writeKeys()
+	{
+	}
+
+	/**
+	 * @see Cache::flush()
+	 */
+	public function flush()
+	{
+		return apcu_clear_cache();
+	}
+
+	/**
+	 * Store a data in cache
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 * @param int $ttl
+	 * @return bool
+	 */
+	public function set($key, $value, $ttl = 0)
+	{
+		return $this->_set($key, $value, $ttl);
+	}
+
+	/**
+	 * Retrieve a data from cache
+	 *
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function get($key)
+	{
+		return $this->_get($key);
+	}
+
+	/**
+	 * Check if a data is cached
+	 *
+	 * @param string $key
+	 * @return bool
+	 */
+	public function exists($key)
+	{
+		return $this->_exists($key);
+	}
+}

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -526,6 +526,10 @@ class AdminPerformanceControllerCore extends AdminController
         $warning_apc = str_replace('[a]', '<a href="http://php.net/manual/'.substr($php_lang, 0, 2).'/apc.installation.php" target="_blank">', $warning_apc);
         $warning_apc = str_replace('[/a]', '</a>', $warning_apc);
 
+        $warning_apcu = ' '.$this->l('(you must install the [a]APCu PECL extension[/a])');
+        $warning_apcu = str_replace('[a]', '<a href="http://php.net/manual/'.substr($php_lang, 0, 2).'/apcu.installation.php" target="_blank">', $warning_apcu);
+        $warning_apcu = str_replace('[/a]', '</a>', $warning_apcu);
+
         $warning_xcache = ' '.$this->l('(you must install the [a]Xcache extension[/a])');
         $warning_xcache = str_replace('[a]', '<a href="http://xcache.lighttpd.net" target="_blank">', $warning_xcache);
         $warning_xcache = str_replace('[/a]', '</a>', $warning_xcache);
@@ -585,6 +589,11 @@ class AdminPerformanceControllerCore extends AdminController
                             'id' => 'CacheApc',
                             'value' => 'CacheApc',
                             'label' => $this->l('APC').(extension_loaded('apc') ? '' : $warning_apc)
+                        ),
+                        array(
+                            'id' => 'CacheApcu',
+                            'value' => 'CacheApcu',
+                            'label' => $this->l('APCu').(extension_loaded('apcu') ? '' : $warning_apcu)
                         ),
                         array(
                             'id' => 'CacheXcache',
@@ -917,6 +926,9 @@ class AdminPerformanceControllerCore extends AdminController
                     } elseif ($caching_system == 'CacheApc' && !extension_loaded('apc')) {
                         $this->errors[] = Tools::displayError('To use APC cache, you must install the APC PECL extension on your server.').'
 							<a href="http://fr.php.net/manual/fr/apc.installation.php">http://fr.php.net/manual/fr/apc.installation.php</a>';
+                    } elseif ($caching_system == 'CacheApcu' && !extension_loaded('apcu')) {
+                        $this->errors[] = Tools::displayError('To use APCu cache, you must install the APCu PECL extension on your server.').'
+							<a href="http://fr.php.net/manual/fr/apcu.installation.php">http://fr.php.net/manual/fr/apcu.installation.php</a>';
                     } elseif ($caching_system == 'CacheXcache' && !extension_loaded('xcache')) {
                         $this->errors[] = Tools::displayError('To use Xcache, you must install the Xcache extension on your server.').'
 							<a href="http://xcache.lighttpd.net">http://xcache.lighttpd.net</a>';


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Add a new option to support APCu, without impacting the existing APC support.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Enable the newly added APCu cache option from Admin, make sure the pages are loaded without error.