### PR TITLE
Fix catalog mode display prices

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -695,7 +695,8 @@ class ConfigurationCore extends ObjectModel
      */
     public static function showPrices()
     {
-        return Group::isFeatureActive() ? (bool) Group::getCurrent()->show_prices : true;
+        return !Configuration::get('PS_CATALOG_MODE')
+            && (Group::isFeatureActive() ? (bool) Group::getCurrent()->show_prices : true);
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The prices should not appear on the front office when the shop is in catalog mode
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1803
| How to test?  | Enable the catalog mode & clear the cache. On the front you should not see any price.