### PR TITLE
Add missing hooks actionObjectProductInCartDelete(Before|After)

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -234,16 +234,23 @@ class CartControllerCore extends FrontController
             }
         }
 
-        if ($this->context->cart->deleteProduct($this->id_product, $this->id_product_attribute, $this->customization_id, $this->id_address_delivery)) {
-            $data = array(
-                'id_cart' => (int)$this->context->cart->id,
-                'id_product' => (int)$this->id_product,
-                'id_product_attribute' => (int)$this->id_product_attribute,
-                'customization_id' => (int)$this->customization_id,
-                'id_address_delivery' => (int)$this->id_address_delivery
-            );
+        $data = array(
+            'id_cart' => (int)$this->context->cart->id,
+            'id_product' => (int)$this->id_product,
+            'id_product_attribute' => (int)$this->id_product_attribute,
+            'customization_id' => (int)$this->customization_id,
+            'id_address_delivery' => (int)$this->id_address_delivery
+        );
 
-            Hook::exec('actionDeleteProductInCartAfter', $data);
+        Hook::exec('actionObjectProductInCartDeleteBefore', $data, null, true);
+
+        if ($this->context->cart->deleteProduct(
+                $this->id_product,
+                $this->id_product_attribute,
+                $this->customization_id,
+                $this->id_address_delivery
+            )) {
+            Hook::exec('actionObjectProductInCartDeleteAfter', $data);
 
             if (!Cart::getNbProducts((int)$this->context->cart->id)) {
                 $this->context->cart->setDeliveryOption(null);
@@ -253,7 +260,7 @@ class CartControllerCore extends FrontController
             }
         }
 
-        $removed = CartRule::autoRemoveFromCart();
+        CartRule::autoRemoveFromCart();
         CartRule::autoAddToCart();
     }
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -101,6 +101,16 @@
       <title>Product deletion</title>
       <description>This hook is called when a product is deleted</description>
     </hook>
+    <hook id="actionObjectProductInCartDeleteBefore">
+      <name>actionObjectProductInCartDeleteBefore</name>
+      <title>Cart product removal</title>
+      <description>This hook is called before a product is removed from a cart</description>
+    </hook>
+    <hook id="actionObjectProductInCartDeleteAfter">
+      <name>actionObjectProductInCartDeleteAfter</name>
+      <title>Cart product removal</title>
+      <description>This hook is called after a product is removed from a cart</description>
+    </hook>
     <hook id="displayFooterProduct">
       <name>displayFooterProduct</name>
       <title>Product footer</title>

--- a/install-dev/upgrade/sql/1.7.1.0.sql
+++ b/install-dev/upgrade/sql/1.7.1.0.sql
@@ -1,3 +1,5 @@
+SET NAMES 'utf8';
+
 UPDATE `PREFIX_address_format` SET `format` = 'firstname lastname
 company
 vat_number
@@ -51,3 +53,7 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   (NULL, 'filteredManufacturerContent', 'Filter the content page manufacturer', 'This hook is called just before fetching content page manufacturer.', '1'),
   (NULL, 'filteredSupplierContent', 'Filter the content page supplier', 'This hook is called just before fetching content page supplier.', '1'),
   (NULL, 'filteredHtmlContent', 'Filter HTML field before rending a page', 'This hook is called just before fetching a page on HTML field.', '1');
+
+INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES
+  ('actionObjectProductInCartDeleteBefore', 'Cart product removal', 'This hook is called before a product is removed from a cart', '1'),
+  ('actionObjectProductInCartDeleteAfter', 'Cart product removal', 'This hook is called after a product is removed from a cart', '1');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The hooks 'actionObjectProductInCartDelete(Before\|After)' didn't exist in the database
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1801
| How to test?  | Hook a module on ''actionObjectProductInCartDelete(Before\|After)' and remove a product from your cart.

Since 'actionObjectProductInCartDelete(Before|After) is called [here](https://github.com/PrestaShop/PrestaShop/pull/6965/files#diff-0dac05a6abe4d202319dd093b8ab2b37R241) but is never created via hook.xml and is not a generated one (like actionDeleteProductAfter) then it can't be called.