### PR TITLE
Fallback on stable environment of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,7 @@ services:
 
 addons:
     apt:
-        sources:
-        - deb http://archive.ubuntu.com/ubuntu/ trusty multiverse
-        - deb http://archive.ubuntu.com/ubuntu/ trusty-updates multiverse
-        - deb http://archive.ubuntu.com/ubuntu/ trusty universe
-        - deb http://archive.ubuntu.com/ubuntu/ trusty-updates universe
         packages:
-        - mysql-server-5.6
-        - mysql-client-5.6
-        - mysql-client-core-5.6
         - apache2
         - postfix
         - libapache2-mod-fastcgi
@@ -27,7 +19,6 @@ cache:
     - $HOME/.npm
 
 sudo: required
-dist: trusty
 group: edge
 
 php:
@@ -55,11 +46,6 @@ before_install:
   - sudo a2ensite prestashop.conf
   - sudo service apache2 restart
   - cp -Rf .composer/* ~/.composer/ & composer global install;
-  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-  - sudo dpkg -i google-chrome*.deb
-
-before_script:
-  - export CHROME_BIN=/usr/bin/google-chrome
 
 notifications:
   slack: prestashop:Eovjydk55zPrwPkoQIOF0cZn
@@ -81,7 +67,6 @@ script:
 
 after_script:
   - sudo cat /var/log/apache2/error.log
-  - google-chrome --version
 
 after_failure:
   - openssl version

--- a/tests/travis-ci-apache-vhost
+++ b/tests/travis-ci-apache-vhost
@@ -10,11 +10,11 @@
   DocumentRoot /var/www/
   <Directory /var/www/>
     AllowOverride All
-    Require all granted
+    Allow from all
   </Directory>
 
   <Directory /usr/lib/cgi-bin>
-      Require all granted
+    Allow from all
   </Directory>
 
 </VirtualHost>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The new trusty environment does not work properly (MySQL server cannot start). Because we need to run tests on the next release ASAP, we fallback on the previous Travis environment.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Tests must pass

### Notes
* Chrome is not used in this version (--> firefox)
* MySQL 5.6 is not used (--> MySQL 5.5)
* Old version of Apache is used (Not compatible with the current vhost on develop)