### PR TITLE
Prevent password reset on user check by email

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -395,7 +395,8 @@ class CustomerCore extends ObjectModel
             return false;
         }
 
-        if (isset($plaintextPassword) && !$crypto->checkHash($plaintextPassword, $passwordHash)) {
+        $shouldCheckPassword = !is_null($plaintextPassword);
+        if ($shouldCheckPassword && !$crypto->checkHash($plaintextPassword, $passwordHash)) {
             return false;
         }
 
@@ -425,7 +426,8 @@ class CustomerCore extends ObjectModel
                 $this->{$key} = $value;
             }
         }
-        if (!$crypto->isFirstHash($plaintextPassword, $passwordHash)) {
+        
+        if ($shouldCheckPassword && !$crypto->isFirstHash($plaintextPassword, $passwordHash)) {
             $this->passwd = $crypto->hash($plaintextPassword);
             $this->update();
         }

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -343,7 +343,8 @@ class EmployeeCore extends ObjectModel
         $crypto = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Crypto\\Hashing');
 
         $passwordHash = $result['passwd'];
-        if (isset($plaintextPassword) && !$crypto->checkHash($plaintextPassword, $passwordHash)) {
+        $shouldCheckPassword = !is_null($plaintextPassword);
+        if ($shouldCheckPassword && !$crypto->checkHash($plaintextPassword, $passwordHash)) {
             return false;
         }
 
@@ -355,7 +356,7 @@ class EmployeeCore extends ObjectModel
             }
         }
 
-        if (!$crypto->isFirstHash($plaintextPassword, $passwordHash)) {
+        if ($shouldCheckPassword && !$crypto->isFirstHash($plaintextPassword, $passwordHash)) {
             $this->passwd = $crypto->hash($plaintextPassword);
 
             $this->update();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.1
| Description?  | When retrieving a user by email, password is reset
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1768

See https://github.com/PrestaShop/PrestaShop/pull/6925