### PR TITLE
Fix virtual product file removal

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -416,7 +416,7 @@
                             </div>
                             <div id="form_step3_virtual_product_file_details" class="{{ form.step3.virtual_product.vars.value.filename is defined ? 'show' : 'hide' }}">
                               <a href="{{ form.step3.virtual_product.vars.value.file_download_link is defined ? form.step3.virtual_product.vars.value.file_download_link : '' }}" class="btn btn-default btn-sm download">{{ 'Download file'|trans({}, 'Admin.Actions') }}</a>
-                              <a href="{{ path('admin_product_virtual_remove_file_action') }}" class="btn btn-danger btn-sm delete">{{ 'Delete this file'|trans({}, 'Admin.Actions') }}</a>
+                              <a href="{{ path('admin_product_virtual_remove_file_action', { 'idProduct': 1 }) }}" class="btn btn-danger btn-sm delete">{{ 'Delete this file'|trans({}, 'Admin.Actions') }}</a>
                             </div>
                           </fieldset>
                         </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The virtual product's file removal link was missing the product's id
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1786
| How to test?  | Create a virtual product and add a file then remove it.

As suggested [here](http://forge.prestashop.com/browse/BOOM-1786?focusedCommentId=135587&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-135587).
This technique is already used [here](https://github.com/PrestaShop/PrestaShop/pull/6742#discussion_r87066864) and [here](https://github.com/PrestaShop/PrestaShop/pull/6513) and even if it's not really clean we don't have many choices since we have to match the `/\d/` regex constraint for the ids.
We should consider using something like [this](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle) in the future.