### PR TITLE
Add missing nofilter after display hook

### DIFF
--- a/themes/classic/templates/customer/order-detail.tpl
+++ b/themes/classic/templates/customer/order-detail.tpl
@@ -145,7 +145,7 @@
     </div>
   {/block}
 
-  {$HOOK_DISPLAYORDERDETAIL}
+  {$HOOK_DISPLAYORDERDETAIL nofilter}
 
   {block name='order_detail'}
     {if $order.details.is_returnable}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | the nofilter filter was missing after a hook call
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1815
| How to test?  | hook a module on displayOrderDetail and try to display some HTML => the markup should not be displayed