### PR TITLE
Fix updating positions when sorting products

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/catalog.js
+++ b/admin-dev/themes/default/js/bundle/product/catalog.js
@@ -68,7 +68,11 @@ $(document).ready(function() {
 	/*
 	 * Sortable case when ordered by position ASC
 	 */
-	$('tbody.sortable td.placeholder', form).disableSelection();
+
+	$("body").on("mousedown", "tbody.sortable [data-uniturl]", function () {
+		$(this).find('input:checkbox[name="bulk_action_selected_products[]"]').attr("checked", true);
+	});
+
 	$('tbody.sortable', form).sortable({
 		placeholder: 'placeholder',
 		update: function(event, ui) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you change the positions of the products in the catalog page, the positions are not saved in the database. And that was due to disabling checking products.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1749
| How to test?  | Go to product catalog page, filter with categories, sort products with Drag&Drop then click on "save and refresh" button.