### PR TITLE
Fix error on layout when warnings exist

### DIFF
--- a/admin-dev/themes/default/template/layout.tpl
+++ b/admin-dev/themes/default/template/layout.tpl
@@ -76,7 +76,7 @@
 		<div class="alert alert-warning">
 			<button type="button" class="close" data-dismiss="alert">&times;</button>
 			{if count($warnings) > 1}
-				<h4>{l s='There are %d warnings:' sprintf=count($warnings)}</h4>
+				<h4>{l s='There are %d warnings:' sprintf=[$warnings|count]}</h4>
 			{/if}
 			<ul class="list-unstyled">
 				{foreach $warnings as $warning}

--- a/admin-dev/themes/new-theme/template/components/layout/warning_messages.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/warning_messages.tpl
@@ -3,7 +3,7 @@
     <div class="alert alert-warning">
       <button type="button" class="close" data-dismiss="alert">&times;</button>
       {if count($warnings) > 1}
-        <h4>{l s='There are %d warnings:' sprintf=count($warnings)}</h4>
+        <h4>{l s='There are %d warnings:' sprintf=[count($warnings)]}</h4>
       {/if}
       <ul class="list-unstyled">
         {foreach $warnings as $warning}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This fixes an issue when warnings need to be displayed on a page of the backoffice.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | [BOOM-1730](http://forge.prestashop.com/browse/BOOM-1730)
| How to test?  | By using an environment with Nginx + PHP-FPM, go to the webservice page. This PR fixes the following error:

![capture d ecran 2016-11-14 a 15 30 03](https://cloud.githubusercontent.com/assets/6768917/20272170/08e62420-aa85-11e6-8b54-1aa627722295.png)
