### PR TITLE
Support of bqSQL in Twig

### DIFF
--- a/src/PrestaShopBundle/Twig/DataFormatterExtension.php
+++ b/src/PrestaShopBundle/Twig/DataFormatterExtension.php
@@ -42,6 +42,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFilter('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFilter('intCast', array($this, 'intCast')),
             new \Twig_SimpleFilter('unsetElement', array($this, 'unsetElement')),
+            new \Twig_SimpleFilter('bqSQL', array($this, 'bqSQL')),
         );
     }
 
@@ -56,6 +57,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFunction('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFunction('intCast', array($this, 'intCast')),
             new \Twig_SimpleFunction('unsetElement', array($this, 'unsetElement')),
+            new \Twig_SimpleFilter('bqSQL', array($this, 'bqSQL')),
         );
     }
 
@@ -94,6 +96,18 @@ class DataFormatterExtension extends \Twig_Extension
     {
         unset($array[$key]);
         return $array;
+    }
+
+    /**
+     * Avoid every possible SQL injection, but should be used with intCast() to maximise the security.
+     *
+     * @param string string A string containing zero, one or more characters.
+     * @return string
+     *
+     */
+    public function bqSQL($array, $key)
+    {
+        return bqSQL($string);
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | bqSQL is a great way to protect developpers against SQL injections. Since arrayCast and intCast are supported, bqSQL should be supported too.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | You can use bqSQL in your twig template to protect sql injections.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

I don't see why bqSQL is not supported in twig since arrayCast and intCast are supported. bqSQL() is always a great way to prevent SQL injections and people should be allowed to use it in their templates.