### PR TITLE
Fix changing combination when catalog mode is enabled

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -70,7 +70,7 @@ class CartControllerCore extends FrontController
      */
     public function initContent()
     {
-        if (Configuration::isCatalogMode()) {
+        if (Configuration::isCatalogMode() && Tools::getValue('action') === 'show' ) {
             Tools::redirect('index.php');
         }
 
@@ -142,9 +142,6 @@ class CartControllerCore extends FrontController
 
     public function displayAjaxProductRefresh()
     {
-        if (Configuration::isCatalogMode()) {
-            return;
-        }
         $url = $this->context->link->getProductLink(
             $this->id_product,
             null,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When the catalog mode is enabled and you are on the FO's product page and you try to pick another combination than the default one nothing happens.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1817
| How to test?  | Go to Configure -> Shop Settings -> Products in the BO and enable the catalog mode, Then go to the product detail page in the FO and change combinations and colors