### PR TITLE
Clear cache on url rewriting settings modification

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -24,6 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+use PrestaShopBundle\Service\Cache\Refresh;
 use Symfony\Component\HttpFoundation\Request;
 
 use Composer\CaBundle\CaBundle;
@@ -2810,15 +2811,26 @@ exit;
     }
 
     /**
+     * Clear Symfony cache
+     */
+    public static function clearSf2Cache($env = null)
+    {
+        if (!$env) {
+            $env = _PS_MODE_DEV_ ? 'dev' : 'prod';
+        }
+
+        $sf2Refresh = new Refresh($env);
+        $sf2Refresh->addCacheClear();
+        return $sf2Refresh->execute();
+    }
+
+    /**
      * Clear both Smarty and Symfony cache
      */
     public static function clearAllCache()
     {
         Tools::clearSmartyCache();
-
-        $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-        $sf2Refresh->addCacheClear(_PS_MODE_DEV_ ? 'dev' : 'prod');
-        $sf2Refresh->execute();
+        Tools::clearSf2Cache();
     }
 
     public static function clearColorListCache($id_product = false)

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -576,6 +576,7 @@ class AdminMetaControllerCore extends AdminController
             Tools::enableCache();
             Tools::clearCache($this->context->smarty);
             Tools::restoreCacheSettings();
+            Tools::clearSf2Cache();
         } else {
             Configuration::updateValue('PS_REWRITING_SETTINGS', 0);
             // Message copied/pasted from the information tip

--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -840,9 +840,7 @@ class AdminPerformanceControllerCore extends AdminController
         if ((bool)Tools::getValue('empty_sf2_cache')) {
             $redirectAdmin = true;
 
-            $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-            $sf2Refresh->addCacheClear(_PS_MODE_DEV_ ? 'dev' : 'prod');
-            $sf2Refresh->execute();
+            Tools::clearSf2Cache();
         }
 
         if (Tools::isSubmit('submitAddconfiguration')) {

--- a/install-dev/controllers/http/welcome.php
+++ b/install-dev/controllers/http/welcome.php
@@ -77,9 +77,7 @@ class InstallControllerHttpWelcome extends InstallControllerHttp implements Http
     private function clearCache()
     {
         try {
-            $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-            $sf2Refresh->addCacheClear();
-            $sf2Refresh->execute();
+            Tools::clearSf2Cache();
         } catch (\Exception $exception) {
             $finder = new \Symfony\Component\Finder\Finder;
             $fs = new \Symfony\Component\Filesystem\Filesystem();

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -207,18 +207,14 @@ class Install extends AbstractInstall
 
     protected function clearCache()
     {
-        $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh('prod');
-        $sf2Refresh->addCacheClear();
-        $output = $sf2Refresh->execute();
+        $output = Tools::clearSf2Cache('prod');
 
         if (0 !== $output['cache:clear']['exitCode']) {
             $this->setError(explode("\n", $output['cache:clear']['output']));
             return false;
         }
 
-        $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-        $sf2Refresh->addCacheClear();
-        $output = $sf2Refresh->execute();
+        $output = Tools::clearSf2Cache();
 
         if (0 !== $output['cache:clear']['exitCode']) {
             $this->setError(explode("\n", $output['cache:clear']['output']));

--- a/src/PrestaShopBundle/Service/Cache/Refresh.php
+++ b/src/PrestaShopBundle/Service/Cache/Refresh.php
@@ -66,8 +66,6 @@ class Refresh
 
     /**
      * Add cache:clear to the execution.
-     *
-     * @param string $env Environment to clear.
      */
     public function addCacheClear()
     {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The cache should be cleared when enabling/disabling friendly URL rewriting
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1825

How to test? 
<ul><li>FO: Go on the front page (in order to cache the menu)</li><li>BO: Disable friendly URLs (Shop parameters => Traffic)</li><li>FO: Reload the front page</li><li>FO: Items of the menu should not 404</li></ul>