### PR TITLE
Change Stores controller option from 'Status' to 'Active'

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -239,7 +239,7 @@ class AdminStoresControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'switch',
-                    'label' => $this->trans('Status', array(), 'Admin.Global'),
+                    'label' => $this->trans('Active', array(), 'Admin.Global'),
                     'name' => 'active',
                     'required' => false,
                     'is_bool' => true,


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Shop Parameters > Contact > Stores > Add new. "Status: Yes/No" is not a proper name for an option, so I changed it to "Active: Y/N" which seems more appropriate.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | na
| How to test?  | Check label in said page.


