### PR TITLE
Fixed bug in javascriptManager causing by unregisterById

### DIFF
--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -50,7 +50,7 @@ class JavascriptManagerCore extends AbstractAssetManager
             foreach ($this->list[$position] as $type => $null) {
                 foreach ($this->list[$position][$type] as $id => $item) {
                     if ($idToRemove === $id) {
-                        unset($this->list[$position][$type]);
+                        unset($this->list[$position][$type][$id]);
                     }
                 }
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | unregisterById in classes/assets/JavascriptManager.php was emptying the whole list of files instead of just the file with the id to remove. This was due to the unset not specifying the id. 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | (optional)
| How to test?  | Use $this->context->controller->unregisterJavascript('modules-searchbar'); in a frontcontroller context. Before the fix, all javascript contained in list[bottom][external] will disappear. After fix only modules-searchbar disappears. 