### PR TITLE
Fix empty cart on logout display

### DIFF
--- a/classes/checkout/CheckoutPersonalInformationStep.php
+++ b/classes/checkout/CheckoutPersonalInformationStep.php
@@ -108,6 +108,7 @@ class CheckoutPersonalInformationStepCore extends AbstractCheckoutStep
                 'login_form' => $this->loginForm->getProxy(),
                 'register_form' => $this->registerForm->getProxy(),
                 'guest_allowed' => $this->getCheckoutSession()->isGuestAllowed(),
+                'empty_cart_on_logout' => !Configuration::get('PS_CART_FOLLOWING'),
             )
         );
     }

--- a/themes/classic/templates/checkout/_partials/steps/personal-information.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/personal-information.tpl
@@ -26,7 +26,9 @@
         ]
       }
     </p>
-    <p><small>{l s='If you sign out now, your cart will be emptied.' d='Shop.Theme.Checkout'}</small></p>
+    {if !isset($empty_cart_on_logout) || $empty_cart_on_logout}
+      <p><small>{l s='If you sign out now, your cart will be emptied.' d='Shop.Theme.Checkout'}</small></p>
+    {/if}
 
   {else}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The warning on the checkout page which says that your cart will be emptied if you logout should only appear when the option is true
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1764
| How to test?  | Try to order something when the option is disabled and the message should appear. Try to order something when the option is enabled and the message should not appear. You can change the option in Shop Parameters > Customer Settings > Re-display cart at login