### PR TITLE
Fix products alignment in delivery slip pdf

### DIFF
--- a/pdf/delivery-slip.product-tab.tpl
+++ b/pdf/delivery-slip.product-tab.tpl
@@ -38,7 +38,7 @@
 			{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 			<tr class="product {$bgcolor_class}">
 
-				<td class="product center">
+				<td class="product left">
 					{if empty($order_detail.product_reference)}
 						---
 					{else}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Products names should be aligned on the left in the delivery slip pdf
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-601
| How to test?  | Order & ship something. The names should be aligned on the left.