### PR TITLE
Fix buttons alignments on modal on import page

### DIFF
--- a/admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl
+++ b/admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl
@@ -85,15 +85,15 @@
   <div class="modal-footer">
     <div class="input-group pull-right">
       <button type="button" class="btn btn-primary" tabindex="-1" id="import_continue_button" style="display: none;">
-        Ignore warnings and continue?
+        {l s="Ignore warnings and continue?" d="Admin.AdvParameters.Notification"}
       </button>
       &nbsp;
       <button type="button" class="btn btn-default" tabindex="-1" id="import_stop_button">
-        Abort import
+        {l s="Abort import" d="Admin.AdvParameters.Feature"}
       </button>
       &nbsp;
       <button type="button" class="btn btn-success" data-dismiss="modal" tabindex="-1" id="import_close_button" style="display: none;">
-        Close
+        {l s="Close" d="Admin.Actions"}
       </button>
     </div>
   </div>

--- a/admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl
+++ b/admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl
@@ -82,17 +82,19 @@
 		</div>
 	</div>
 
-	<div class="input-group">
-		<button type="button" class="btn btn-primary" tabindex="-1" id="import_continue_button" style="display: none;">
-			Ignore warnings and continue?
-		</button>
-		&nbsp;
-		<button type="button" class="btn btn-default" tabindex="-1" id="import_stop_button">
-			Abort import
-		</button>
-		&nbsp;
-		<button type="button" class="btn btn-success" data-dismiss="modal" tabindex="-1" id="import_close_button" style="display: none;">
-			Close
-		</button>
-	</div>
+  <div class="modal-footer">
+    <div class="input-group pull-right">
+      <button type="button" class="btn btn-primary" tabindex="-1" id="import_continue_button" style="display: none;">
+        Ignore warnings and continue?
+      </button>
+      &nbsp;
+      <button type="button" class="btn btn-default" tabindex="-1" id="import_stop_button">
+        Abort import
+      </button>
+      &nbsp;
+      <button type="button" class="btn btn-success" data-dismiss="modal" tabindex="-1" id="import_close_button" style="display: none;">
+        Close
+      </button>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The buttons in the modal of the import page should be aligned in the bottom right
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-513
| How to test?  | Import something.