### PR TITLE
Set new product cover when current is deleted

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1539,6 +1539,11 @@ var imagesProduct = (function() {
     },
     'checkDropzoneMode': function() {
       checkDropzoneMode();
+    },
+    'getOlderImageId': function() {
+      return Math.min.apply(Math,$('.dz-preview').map(function(){
+        return $(this).data('id');
+      }));
     }
   };
 })();
@@ -1620,9 +1625,14 @@ var formImagesProduct = (function() {
             url: dropZoneElem.find('.dz-preview[data-id="' + id + '"]').attr('url-delete'),
             complete: function() {
               formZoneElem.find('.close').click();
+              var wasCover = !!dropZoneElem.find('.dz-preview[data-id="' + id + '"] .iscover').length;
               dropZoneElem.find('.dz-preview[data-id="' + id + '"]').remove();
               $('.images .product-combination-image [value=' + id + ']').parent().remove();
               imagesProduct.checkDropzoneMode();
+              if (true === wasCover) {
+                // The controller will choose the oldest image as the new cover.
+                imagesProduct.updateDisplayCover(imagesProduct.getOlderImageId());
+              }
             }
           });
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When we remove the current cover of a product, we need to choose a new one. The controller will automatically set the oldest image as the new cover, so we need to apply this in the frontend. 
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | [BOOM-849](http://forge.prestashop.com/browse/BOOM-849)
| How to test?  | <p>**First case:** Delete the cover of a product, the oldest image must take the "cover" label. <br><br>**Second case:** Add a image to a product, set it as cover. Delete another image and nothing should change.</p>
