### PR TITLE
IN: Migration from earlier version, zero before product EAN13 where deleted

### DIFF
--- a/install-dev/upgrade/sql/1.6.0.11.sql
+++ b/install-dev/upgrade/sql/1.6.0.11.sql
@@ -43,12 +43,6 @@ CHANGE COLUMN `total_shipping_tax_excl` `total_shipping_tax_excl` DECIMAL(20,6) 
 CHANGE COLUMN `total_wrapping` `total_wrapping` DECIMAL(20,6) NOT NULL DEFAULT '0.00' ,
 CHANGE COLUMN `total_wrapping_tax_incl` `total_wrapping_tax_incl` DECIMAL(20,6) NOT NULL DEFAULT '0.00' ,
 CHANGE COLUMN `total_wrapping_tax_excl` `total_wrapping_tax_excl` DECIMAL(20,6) NOT NULL DEFAULT '0.00';
-ALTER IGNORE TABLE `PREFIX_product` CHANGE `ean13` `ean13` BIGINT( 15 ) NULL DEFAULT NULL;
 
-ALTER TABLE `PREFIX_product` CHANGE `ean13` `ean13` VARCHAR( 13 ) NULL DEFAULT NULL;
-
-ALTER IGNORE TABLE `PREFIX_product_attribute` CHANGE `ean13` `ean13` BIGINT( 15 ) NULL DEFAULT NULL;
-
-ALTER TABLE `PREFIX_product_attribute` CHANGE `ean13` `ean13` VARCHAR( 13 ) NULL DEFAULT NULL;
 
 ALTER TABLE `PREFIX_order_slip` ADD `order_slip_type` TINYINT(1) NOT NULL DEFAULT 0 AFTER `partial`;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Migration from earlier version, zero before product EAN13 where deleted
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  Fixes #16284
| How to test?  | ugrade from a version before 1.6.0.11 having ean13 looking like 000001234

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7017)
<!-- Reviewable:end -->
