### PR TITLE
Fix permission issues when creating modules sandbox folders recursively

### DIFF
--- a/src/Adapter/Module/ModuleZipManager.php
+++ b/src/Adapter/Module/ModuleZipManager.php
@@ -32,6 +32,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 use Exception;
 use Tools;
+use ZipArchive;
 
 class ModuleZipManager
 {
@@ -84,11 +85,14 @@ class ModuleZipManager
         }
 
         $sandboxPath = $this->getSandboxPath($source);
-        if (!Tools::ZipExtract($source, $sandboxPath)) {
+        $zip = new ZipArchive();
+        if ($zip->open($source) === false || !$zip->extractTo($sandboxPath) || !$zip->close()) {
             throw new Exception(
                 $this->translator->trans(
-                    'Cannot extract module in %path% to get its name.',
-                    array('%path%' => $sandboxPath),
+                    'Cannot extract module in %path% to get its name. %error%',
+                    array(
+                        '%path%' => $sandboxPath,
+                        '%error%' => $zip->getStatusString()),
                     'Admin.Modules.Notification'));
         }
 

--- a/src/Adapter/Module/ModuleZipManager.php
+++ b/src/Adapter/Module/ModuleZipManager.php
@@ -154,7 +154,7 @@ class ModuleZipManager
         $sandboxPath = $this->get($source, 'sandboxPath');
         if ($sandboxPath === null) {
             $sandboxPath = _PS_CACHE_DIR_.'sandbox/'.uniqid().'/';
-            $this->filesystem->mkdir($sandboxPath, 0755);
+            $this->filesystem->mkdir($sandboxPath);
             $this->set($source, 'sandboxPath', $sandboxPath);
         }
         return $sandboxPath;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On a IIS environment, creating the temporary folders for module uploads were failing because of permissions not properly applied. Removing the optional mode of the created folder fixes the issue.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | [BOOM-1679](http://forge.prestashop.com/browse/BOOM-1679)
| How to test?  | You need a web server running with IIS. With the PR, uploads should now work.