### PR TITLE
Fixed product permissions

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -1,5 +1,6 @@
 parameters:
-  AdapterSecurityAdminClass: PrestaShopBundle\Tests\Mock\AdapterSecurityAdminMock
+    AdapterSecurityAdminClass:                PrestaShopBundle\Tests\Mock\AdapterSecurityAdminMock
+    prestashop.security.voter.product.class:  PrestaShopBundle\Tests\Mock\ProductVoter
 
 imports:
     - { resource: config_dev.yml }

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -2,6 +2,9 @@ imports:
     - { resource: admin/services.yml }
     - { resource: admin/services-form.yml }
 
+parameters:
+    prestashop.security.voter.product.class: PrestaShopBundle\Security\Voter\ProductVoter
+
 services:
     finder:
         class: Symfony\Component\Finder\Finder
@@ -45,8 +48,13 @@ services:
         arguments: ["@router"]
 
     prestashop.security.role.dynamic_role_hierarchy:
-        class:      PrestaShopBundle\Security\Role\DynamicRoleHierarchy
+        class: PrestaShopBundle\Security\Role\DynamicRoleHierarchy
 
+    prestashop.security.voter.product:
+        class: "%prestashop.security.voter.product.class%"
+        tags:
+            - { name: security.voter }
+        public: false
 
     prestashop.service.product:
         class: PrestaShopBundle\Service\ProductService

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
@@ -76,6 +76,21 @@
     {{ renderhook('legacy_block_kpi', {'kpi_controller': 'AdminProductsController'}) }}
 
     <div class="content container-fluid">
+
+      {% if permission_error|length %}
+      <div class="row">
+        <div class="col-md-12">
+          <div class="alert alert-danger">
+            <button type="button" class="close" data-dismiss="alert">&times;</button>
+            <i class="material-icons">error_outline</i>
+            <p>
+              {{ permission_error }}
+            </p>
+          </div>
+        </div>
+      </div>
+      {% endif %}
+
       <div class="row">
         <div class="col-md-12">
           <div class="pull-right">

--- a/src/PrestaShopBundle/Security/Voter/ProductVoter.php
+++ b/src/PrestaShopBundle/Security/Voter/ProductVoter.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Security\Voter;
+
+use Access;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class ProductVoter extends Voter
+{
+    const CREATE = 'create';
+
+    const UPDATE = 'update';
+
+    const DELETE = 'delete';
+
+    /**
+     * @param string $attribute
+     * @param mixed $subject
+     * @return bool
+     */
+    protected function supports($attribute, $subject)
+    {
+        if (!in_array($attribute, array(self::CREATE, self::UPDATE, self::DELETE))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $attribute
+     * @param mixed $subject
+     * @param TokenInterface $token
+     * @return bool
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        $employeeProfileId = $user->getData()->id_profile;
+
+        return $this->can($attribute, $employeeProfileId);
+    }
+
+    /**
+     * @param $action
+     * @param $employeeProfileId
+     * @return bool
+     */
+    protected function can($action, $employeeProfileId)
+    {
+        return Access::isGranted('ROLE_MOD_TAB_ADMINPRODUCTS_' . strtoupper($action), $employeeProfileId) &&
+            Access::isGranted('ROLE_MOD_TAB_ADMINCATALOG_' . strtoupper($action), $employeeProfileId);
+    }
+}

--- a/src/PrestaShopBundle/Tests/Mock/ProductVoter.php
+++ b/src/PrestaShopBundle/Tests/Mock/ProductVoter.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Tests\Mock;
+
+use PrestaShopBundle\Security\Voter\ProductVoter as BaseVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class ProductVoter extends BaseVoter
+{
+    /**
+     * @param string $attribute
+     * @param mixed $subject
+     * @param TokenInterface $token
+     * @return bool
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Fix product permissions 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1840
| How to test?  | Try to create, edit, delete, duplicate, deactivate, activate, sort product (or applying some of these actions in bulk mode) without having been granted the "add", "modify", "delete" permissions. Those actions should fail for employees without required permissions.