### PR TITLE
Required fileinfo extension (1.7.0.x)

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -85,6 +85,7 @@ class ConfigurationTestCore
                 'mails_dir' => 'mails',
                 'openssl' => 'false',
                 'zip' => false,
+                'fileinfo' => false,
             ));
         }
 
@@ -184,7 +185,7 @@ class ConfigurationTestCore
 
         return true;
     }
-    
+
     public static function test_curl()
     {
         return extension_loaded('curl');
@@ -207,6 +208,11 @@ class ConfigurationTestCore
     public static function test_zip()
     {
         return extension_loaded('zip');
+    }
+
+    public static function test_fileinfo()
+    {
+        return extension_loaded('fileinfo');
     }
 
     public static function test_dir($relative_dir, $recursive = false, &$full_report = null)

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -100,6 +100,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                         'openssl' => $this->translator->trans('PHP OpenSSL extension is not loaded', array(), 'Install'),
                         'pdo_mysql' => $this->translator->trans('PDO MySQL extension is not loaded', array(), 'Install'),
                         'zip' => $this->translator->trans('ZIP extension is not enabled', array(), 'Install'),
+                        'fileinfo' => $this->translator->trans('Fileinfo extension is not enabled', array(), 'Install'),
                     )
                 ),
                 array(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Fileinfo extension is required to guess attachment content types
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Install the product without fileinfo extension loaded. 