### PR TITLE
Required fileinfo extension

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -87,6 +87,7 @@ class ConfigurationTestCore
                 'openssl' => 'false',
                 'simplexml' => false,
                 'zip' => false,
+                'fileinfo' => false,
             ));
         }
 
@@ -186,7 +187,7 @@ class ConfigurationTestCore
 
         return true;
     }
-    
+
     public static function test_curl()
     {
         return extension_loaded('curl');
@@ -219,6 +220,11 @@ class ConfigurationTestCore
     public static function test_zip()
     {
         return extension_loaded('zip');
+    }
+
+    public static function test_fileinfo()
+    {
+        return extension_loaded('fileinfo');
     }
 
     public static function test_dir($relative_dir, $recursive = false, &$full_report = null)

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -102,6 +102,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                         'pdo_mysql' => $this->translator->trans('PDO MySQL extension is not loaded', array(), 'Install'),
                         'simplexml' => $this->translator->trans('SimpleXML extension is not loaded', array(), 'Install'),
                         'zip' => $this->translator->trans('ZIP extension is not enabled', array(), 'Install'),
+                        'fileinfo' => $this->translator->trans('Fileinfo extension is not enabled', array(), 'Install'),
                     )
                 ),
                 array(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fileinfo extension is required to guess attachment content types
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Install the product without fileinfo extension loaded. 