### PR TITLE
Fix friendly url text on product page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
@@ -57,7 +57,7 @@
             {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
           {% else %}
             <strong>{{ 'Friendly URLs are currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
-            {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
+            {{ 'To disable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
           {% endif %}
         </p>
         <p class="alert-text">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The text should tell you to disable friendly URLs when they're enabled and not the other way around
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1045
| How to test?  |