### PR TITLE
Restore deprecated method

### DIFF
--- a/classes/ImageType.php
+++ b/classes/ImageType.php
@@ -168,6 +168,21 @@ class ImageTypeCore extends ObjectModel
     /**
      * Get formatted name
      *
+     * @deprecated 1.7.0.0 Use ImageType::getFormattedName($name) instead
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public static function getFormatedName($name)
+    {
+        Tools::displayAsDeprecated('Please use ImageType::getFormattedName($name) instead');
+        return self::getFormattedName($name);
+    }
+
+    /**
+     * Get formatted name
+     *
      * @param string $name
      *
      * @return string


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The method "getFormatedName" was renamed to "getFormattedName" and the first version of the method was mention as deprecated. In the commit 6a6df79471322f37d8719e29727db2f4799def85 the method deprecated was removed.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Use the ImageType::getFormatedName($name) call.
