### PR TITLE
Disable FK checks during DB export

### DIFF
--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -230,7 +230,9 @@ class PrestaShopBackupCore
         $this->id = realpath($backupfile);
 
         fwrite($fp, '/* Backup for '.Tools::getHttpHost(false, false).__PS_BASE_URI__."\n *  at ".date($date)."\n */\n");
-        fwrite($fp, "\n".'SET NAMES \'utf8\';'."\n\n");
+        fwrite($fp, "\n".'SET NAMES \'utf8\';');
+        fwrite($fp, "\n".'SET FOREIGN_KEY_CHECKS = 0;');
+        fwrite($fp, "\n".'SET SESSION sql_mode = \'\';'."\n\n");
 
         // Find all tables
         $tables = Db::getInstance()->executeS('SHOW TABLES');


### PR DESCRIPTION
Cherry pick of #7010

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | On PrestaShop 1.7.0.0, we finally use the foreign keys in our database. However, we need to disable the checks during the SQL import because of the tables sorted by name, not by dependency.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | [BOOM-1751](http://forge.prestashop.com/browse/BOOM-1751) && [BOOM-1772](http://forge.prestashop.com/browse/BOOM-1772)
| How to test?  | Generate a SQL dump from "Advanced parameters" > Database > "DB export", open the sql file inside the generated package, and check you have the two following lines in it.

## Lines to find in the SQL file:
```sql
SET FOREIGN_KEY_CHECKS = 0;
SET SESSION sql_mode = '';
```
