### PR TITLE
Display mcrypt extension warning fix

### DIFF
--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -490,7 +490,7 @@ class AdminPerformanceControllerCore extends AdminController
                             array(
                                 'id' => 'PS_CIPHER_ALGORITHM_1',
                                 'value' => 1,
-                                'label' => $this->l('Use Rijndael with mcrypt lib.').(!function_exists('mcrypt_encrypt') ? '' : $warning_mcrypt)
+                                'label' => $this->l('Use Rijndael with mcrypt lib.').(function_exists('mcrypt_encrypt') ? '' : $warning_mcrypt)
                             ),
                             array(
                                 'id' => 'PS_CIPHER_ALGORITHM_0',


### PR DESCRIPTION
Display mcrypt warning in the backoffice Advanced Parameters >  Performace settings when the mcrypt extension is not installed and not otherwise

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Display mcrypt warning when the mcrypt extension is not installed and not otherwise
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | The warning that you must install mcrypt extension in the backoffice Advanced Parameters > Performance should be displayed when the mcrypt extension is not installed and not otherwise.