### PR TITLE
FO: Fixed error when the menu option is a custom link

### DIFF
--- a/themes/classic/modules/ps_mainmenu/ps_mainmenu.tpl
+++ b/themes/classic/modules/ps_mainmenu/ps_mainmenu.tpl
@@ -3,7 +3,7 @@
     {if $nodes|count}
       <ul class="top-menu" {if $depth == 0}id="top-menu"{/if} data-depth="{$depth}">
         {foreach from=$nodes item=node}
-            <li class="{$node.type}{if $node.current} current {/if}" id="{$node.page_identifier}">
+            <li class="{$node.type}{if $node.current} current {/if}" {if $node.type != "link"}id="{$node.page_identifier}"{/if}>
             {assign var=_counter value=$_counter+1}
               <a
                 class="{if $depth >= 0}dropdown-item{/if}{if $depth === 1} dropdown-submenu{/if}"


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  "develop"
| Description?  | When a menu option in main menu is a custom link, the following error appears in browser console: **Error: Syntax error, unrecognized expression: #/contactanos .js-sub-menu**
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Using ps_mainmenu module, create a custom menu link, add this custom link to menu, check the front office.
