### PR TITLE
Add error message when ordering number of item greater than quantity

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -14,13 +14,13 @@
           />
         </div>
         <div class="add">
-          <button class="btn btn-primary add-to-cart" data-button-action="add-to-cart" type="submit" {if !$product.add_to_cart_url}disabled{/if}>
+          <button class="btn btn-primary add-to-cart" data-button-action="add-to-cart" type="submit" {if !$product.add_to_cart_url || $product.quantity_wanted>$product.quantity}disabled{/if}>
             <i class="material-icons shopping-cart">&#xE547;</i>
             {l s='Add to cart' d='Shop.Theme.Actions'}
           </button>
           {block name='product_availability'}
             <span id="product-availability">
-              {if $product.show_availability && $product.availability_message}
+              {if $product.show_availability && $product.availability_message && $product.quantity_wanted<=$product.quantity}
                 {if $product.availability == 'available'}
                   <i class="material-icons product-available">&#xE5CA;</i>
                 {elseif $product.availability == 'last_remaining_items'}
@@ -29,6 +29,9 @@
                   <i class="material-icons product-unavailable">&#xE14B;</i>
                 {/if}
                 {$product.availability_message}
+                {else}
+                  <i class="material-icons product-unavailable">&#xE14B;</i>
+                  {l s='Out of stock' d='Shop.Theme.Catalog'}
               {/if}
             </span>
           {/block}
@@ -40,7 +43,6 @@
     {block name='product_minimal_quantity'}
       <p class="product-minimal-quantity">
         {if $product.minimal_quantity > 1}
-          {l
           s='The minimum purchase order quantity for the product is %quantity%.'
           d='Shop.Theme.Checkout'
           sprintf=['%quantity%' => $product.minimal_quantity]

--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -43,6 +43,7 @@
     {block name='product_minimal_quantity'}
       <p class="product-minimal-quantity">
         {if $product.minimal_quantity > 1}
+          {l
           s='The minimum purchase order quantity for the product is %quantity%.'
           d='Shop.Theme.Checkout'
           sprintf=['%quantity%' => $product.minimal_quantity]


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When ordering a number of item greater than quantity, there is no error message
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1624
| How to test?  | Go to product detail page and add to card a number of item grater than quantity.