### PR TITLE
Disable checkout button when no product in the cart

### DIFF
--- a/themes/classic/templates/checkout/_partials/cart-detailed-actions.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-actions.tpl
@@ -7,7 +7,7 @@
       <button type="button" class="btn btn-primary disabled" disabled>{l s='Checkout' d='Shop.Theme.Actions'}</button>
     </div>
   {elseif empty($cart.products) }
-    <div class="checkout text-xs-center card-block">
+    <div class="text-xs-center">
       <button type="button" class="btn btn-primary disabled" disabled>{l s='Checkout' d='Shop.Theme.Actions'}</button>
     </div>
   {else}

--- a/themes/classic/templates/checkout/_partials/cart-detailed-actions.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-actions.tpl
@@ -6,6 +6,10 @@
     <div class="text-xs-center">
       <button type="button" class="btn btn-primary disabled" disabled>{l s='Checkout' d='Shop.Theme.Actions'}</button>
     </div>
+  {elseif empty($cart.products) }
+    <div class="checkout text-xs-center card-block">
+      <button type="button" class="btn btn-primary disabled" disabled>{l s='Checkout' d='Shop.Theme.Actions'}</button>
+    </div>
   {else}
     <div class="text-xs-center">
       <a href="{$urls.pages.order}" class="btn btn-primary">{l s='Checkout' d='Shop.Theme.Actions'}</a>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you order an item then you delete it from the cart, you can still see "Checkout" button enabled
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1756
| How to test?  |  Go to product page, click "Add to cart", go to Shopping Cart and delete product by clicking trash icon then the checkout button will be disabled.