### PR TITLE
Protect translations display against XSS injections

### DIFF
--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -229,6 +229,7 @@ abstract class ControllerCore
 
     protected function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
+        $parameters['legacy'] = 'htmlspecialchars';
         return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -62,6 +62,10 @@ function smartyTranslate($params, &$smarty)
     $isInModule = isset($params['mod']) && !empty($params['mod']);
     $sprintf = isset($params['sprintf']) ? $params['sprintf'] : array();
 
+    if ($htmlEntities ||  $addSlashes) {
+        $sprintf['legacy'] = $htmlEntities ? 'htmlspecialchars': 'addslashes';
+    }
+
     if (isset($params['d']) && !empty($params['d'])) {
         if (isset($params['tags'])) {
             $backTrace = debug_backtrace();

--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -39,10 +39,12 @@ trait PrestaShopTranslatorTrait
         }
 
         if (!$this->isSprintfString($id) || empty($parameters)) {
-            return parent::trans($id, $parameters, $domain, $locale);
+            $translated = htmlspecialchars(parent::trans($id, $parameters, $domain, $locale));
+        }else {
+            $translated = vsprintf(parent::trans($id, array(), $domain, $locale), $parameters);
         }
 
-        return vsprintf(parent::trans($id, array(), $domain, $locale), $parameters);
+        return $translated;
     }
 
     /**

--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -39,7 +39,10 @@ trait PrestaShopTranslatorTrait
         }
 
         if (!$this->isSprintfString($id) || empty($parameters)) {
-            $translated = htmlspecialchars(parent::trans($id, $parameters, $domain, $locale));
+            $translated = parent::trans($id, $parameters, $domain, $locale);
+            if (isset($parameters['legacy'])) {
+                $translated = call_user_func($parameters['legacy'],$translated);
+            }
         }else {
             $translated = vsprintf(parent::trans($id, array(), $domain, $locale), $parameters);
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | As you can put everything you want in translations, you need to clean the display.
| Type?         | bug fix
| Category?     | CO
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1841
| How to test?  | Use ``<script type="text/javascript">alert('Hello XSS');</script>`` in Save key. You should see the translation correctly escaped in both new and legacy pages.

**In collaboration with Michel /c @AntoineMille**

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

See: https://github.com/PrestaShop/PrestaShop/pull/7026