### PR TITLE
Add unit price to order confirmation mail (1.7.0.0)

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -497,9 +497,9 @@ abstract class PaymentModuleCore extends Module
                             'customization' => array()
                         );
 
-                        if (isset($product['unit_price']) && $product['unit_price']) {
-                            $product_var_tpl['unit_price'] = Tools::displayPrice($product['unit_price'], $this->context->currency, false);
-                            $product_var_tpl['unit_price_full'] = Tools::displayPrice($product['unit_price'], $this->context->currency, false)
+                        if (isset($product['price']) && $product['price']) {
+                            $product_var_tpl['unit_price'] = Tools::displayPrice($product['price'], $this->context->currency, false);
+                            $product_var_tpl['unit_price_full'] = Tools::displayPrice($product['price'], $this->context->currency, false)
                                 .' '.$product['unity'];
                         } else {
                             $product_var_tpl['unit_price'] = $product_var_tpl['unit_price_full'] = '';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.0
| Description?  | The order confirmation email received by the customer arrives without the unit price.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1872
| How to test?  | Order a product then you will receive an order confirmation mail containing the unit price.