### PR TITLE
Fixed CORS setting the header

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2297,7 +2297,7 @@ class ToolsCore
         fwrite($write_fd, "AddType application/font-woff2 .woff2\n");
         fwrite($write_fd, "<IfModule mod_headers.c>
     <FilesMatch \"\.(ttf|ttc|otf|eot|woff|woff2|svg)$\">
-        Header add Access-Control-Allow-Origin \"*\"
+        Header set Access-Control-Allow-Origin \"*\"
     </FilesMatch>
 </IfModule>\n\n");
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop (should be cherry-picked)
| Description?  | Assure only one CORS header is sent for fonts in .htaccess
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Already applied at https://ZiZuu.com
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

Replaced "add" with "set" to assure only one header is sent.
Having multiple instances of this header leds to missing resources when strict CORS policies are enforced.