### PR TITLE
Fix error when saving traslations (1.7.0.0)

### DIFF
--- a/src/PrestaShopBundle/Entity/Translation.php
+++ b/src/PrestaShopBundle/Entity/Translation.php
@@ -34,7 +34,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Table(
  *     indexes={@ORM\Index(name="key", columns={"domain"})},
- *     uniqueConstraints={@ORM\UniqueConstraint(name="theme", columns={"theme", "id_lang", "domain"})}
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="theme", columns={"key", "theme", "id_lang", "domain"})}
  * )
  * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\TranslationRepository")
  */
@@ -52,7 +52,7 @@ class Translation
     /**
      * @var string
      *
-     * @ORM\Column(name="`key`", type="text")
+     * @ORM\Column(name="`key`", type="string")
      */
     private $key;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Error when saving translations for themes.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1867
| How to test?  | Reinstall Prestashop or run "php app/console doctrine:schema:update --force" then Go to BO International -> Translations -> Edit translations and translate theme with any language.