### PR TITLE
Add Reply-To recipient name to Mail::send()

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -99,7 +99,8 @@ class MailCore extends ObjectModel
         $die = false,
         $idShop = null,
         $bcc = null,
-        $replyTo = null)
+        $replyTo = null,
+        $replyToName = null)
     {
         if (!$idShop) {
             $idShop = Context::getContext()->shop->id;
@@ -345,7 +346,7 @@ class MailCore extends ObjectModel
             }
 
             if (isset($replyTo) && $replyTo) {
-                $message->setReplyTo($replyTo);
+                $message->setReplyTo($replyTo, ($replyToName !== '' ? $replyToName : null));
             }
 
             $templateVars = array_map(array('Tools', 'htmlentitiesDecodeUTF8'), $templateVars);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a parameter to Mail::send() for specifying the name of the recipient in the Reply-To header. This is useful for form submissions, where the name of the customer can be indicated to Help Desk/CRM systems.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | See the following code block.

```
<?php

require 'config/config.inc.php';

Mail::Send(
    (int) Configuration::get('PS_LANG_DEFAULT'), // $idLang
    'log_alert', // $template
    'reply-to test', // $subject
    array(), // $templateVars
    Configuration::get('PS_SHOP_EMAIL'), // $to
    Configuration::get('PS_SHOP_NAME'), // $toName
    Configuration::get('PS_SHOP_EMAIL'), // $from
    Configuration::get('PS_SHOP_NAME'), // $fromName
    null, // $fileAttachment
    null, // $mode_smtp
    _PS_MAIL_DIR_, // $templatePath
    false, // $die
    null, // $idShop
    null, // $bcc
    'me@example.com', // $replyTo
    'Me' // $replyToName
);
```