### PR TITLE
BO : impossible to use two HelperList w/ Ajax

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -26,7 +26,7 @@
 {if $ajax}
 	<script type="text/javascript">
 		$(function () {
-			$(".ajax_table_link").click(function () {
+			$(".ajax_table_link").off()click(function () {
 				var link = $(this);
 				$.post($(this).attr('href'), function (data) {
 					if (data.success == 1) {

--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -26,7 +26,7 @@
 {if $ajax}
 	<script type="text/javascript">
 		$(function () {
-			$(".ajax_table_link").off()click(function () {
+			$(".ajax_table_link").off().click(function () {
 				var link = $(this);
 				$.post($(this).attr('href'), function (data) {
 					if (data.success == 1) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "develop"
| Description?  | You can't have two HelperList with ajax on a single page because lthe script is charge two time and every time you click an "active", it lunch the function two times
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | try to do a page with two helpers list and ajax

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

You cannot use two helperlist with ajax within an admin page because
of the conflict of charging two time this function