### PR TITLE
Fixed product customization duplication

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4110,7 +4110,7 @@ class ProductCore extends ObjectModel
         }
 
         if (($customization_labels = Db::getInstance()->executeS('
-			SELECT `id_customization_field`, `id_lang`, `name`
+			SELECT `id_customization_field`, `id_lang`, `id_shop`, `name`
 			FROM `'._DB_PREFIX_.'customization_field_lang`
 			WHERE `id_customization_field` IN ('.implode(', ', $customization_field_ids).')'.($id_shop ? ' AND cfl.`id_shop` = '.$id_shop : '').'
 			ORDER BY `id_customization_field`')) === false) {
@@ -4164,6 +4164,7 @@ class ProductCore extends ObjectModel
                     $data = array(
                         'id_customization_field' => (int)$customization_field_id,
                         'id_lang' => (int)$customization_label['id_lang'],
+                        'id_shop' => (int)$customization_label['id_shop'],
                         'name' => pSQL($customization_label['name']),
                     );
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4112,7 +4112,7 @@ class ProductCore extends ObjectModel
         if (($customization_labels = Db::getInstance()->executeS('
 			SELECT `id_customization_field`, `id_lang`, `id_shop`, `name`
 			FROM `'._DB_PREFIX_.'customization_field_lang`
-			WHERE `id_customization_field` IN ('.implode(', ', $customization_field_ids).')'.($id_shop ? ' AND cfl.`id_shop` = '.$id_shop : '').'
+			WHERE `id_customization_field` IN ('.implode(', ', $customization_field_ids).')'.($id_shop ? ' AND `id_shop` = '.$id_shop : '').'
 			ORDER BY `id_customization_field`')) === false) {
             return false;
         }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop
| Description? | Fix an SQL error when duplicating a product with customization fields. This error is caused by the id_shop column added in the customization_field_lang table with PrestaShop 1.6.0.12. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Create a product, add customization fields, duplicate de product |

Fix an SQL error when duplicating a product with customization fields.
This error is caused by the id_shop column added in the customization_field_lang table with PrestaShop 1.6.0.12.

Cherry-pick of : https://github.com/PrestaShop/PrestaShop/pull/6842