### PR TITLE
Fix grid view payment methods on small devices

### DIFF
--- a/themes/default-bootstrap/order-payment-advanced.tpl
+++ b/themes/default-bootstrap/order-payment-advanced.tpl
@@ -67,7 +67,7 @@
         {if $HOOK_ADVANCED_PAYMENT && !$adv_payment_empty}
             {foreach $HOOK_ADVANCED_PAYMENT as $advanced_payment_opt_list}
                 {foreach $advanced_payment_opt_list as $paymentOption}
-                    <div class="col-xs-6 col-md-6">
+                    <div class="col-xs-12 col-md-6">
                         <p class="payment_module pointer-box">
                             <a class="payment_module_adv">
                                 <img class="payment_option_logo" src="{$paymentOption->getLogo()}"/>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Payment methods grid breaks on small (<600px? Depends on content/language) screens. Fix: Use 12 cols instead of 6 for bootstraps display class xs.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | See screenshots

Broken:
![gridfix_before](https://cloud.githubusercontent.com/assets/24156106/20640694/913d2800-b3e5-11e6-84ed-557905e631cc.png)

Fix:
![gridfix_after](https://cloud.githubusercontent.com/assets/24156106/20640696/9532ba06-b3e5-11e6-8c91-c9cbdd4615a4.png)
