### PR TITLE
Add missing translation keys in home slider

### DIFF
--- a/themes/classic/modules/ps_imageslider/views/templates/hook/slider.tpl
+++ b/themes/classic/modules/ps_imageslider/views/templates/hook/slider.tpl
@@ -1,5 +1,5 @@
 {*
-* 2007-2015 PrestaShop
+* 2007-2016 PrestaShop
 *
 * NOTICE OF LICENSE
 *
@@ -46,13 +46,13 @@
         <span class="icon-prev hidden-xs" aria-hidden="true">
           <i class="material-icons">&#xE5CB;</i>
         </span>
-        <span class="sr-only">Previous</span>
+        <span class="sr-only">{l s='Previous' d='Shop.Theme'}</span>
       </a>
       <a class="right carousel-control" href="#carousel" role="button" data-slide="next">
         <span class="icon-next" aria-hidden="true">
           <i class="material-icons">&#xE5CC;</i>
         </span>
-        <span class="sr-only">Next</span>
+        <span class="sr-only">{l s='Next' d='Shop.Theme'}</span>
       </a>
     </div>
   </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add missing translation keys in home slider
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | /no
| Fixed ticket? | -
| How to test?  | Just load default theme with translations.

This allow to enable translations for the home slider in "classic" theme.