### PR TITLE
Fix product weight when changing combination

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5682,7 +5682,7 @@ class ProductCore extends ObjectModel
 
         if (!Cache::isStored($cache_id)) {
             $result = Db::getInstance()->executeS('
-			SELECT a.`id_attribute`, a.`id_attribute_group`, al.`name`, agl.`name` as `group`, pa.`reference`, pa.`ean13`, pa.`isbn`,pa.`upc`
+			SELECT a.`id_attribute`, a.`id_attribute_group`, al.`name`, agl.`name` as `group`, pa.`reference`, pa.`ean13`, pa.`isbn`,pa.`upc`, pa.`weight`
 			FROM `'._DB_PREFIX_.'attribute` a
 			LEFT JOIN `'._DB_PREFIX_.'attribute_lang` al
 				ON (al.`id_attribute` = a.`id_attribute` AND al.`id_lang` = '.(int)$id_lang.')

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -488,6 +488,40 @@ class ProductPresenter
     }
 
     /**
+     * @param array $product
+     * @param array $presentedProduct
+     * @return array
+     */
+    public function AddWeightToDisplay(array $product, array $presentedProduct){
+        $product_weight = $this->getProductWeight($product);
+        foreach ($product['attributes'] as $attribute) {
+            if (isset($attribute['weight']) && 0 !== $attribute['weight']) {
+                $presentedProduct['weight_to_display'] = (float) $attribute['weight'] + $product_weight;
+            } else {
+                $presentedProduct['weight_to_display'] = $product_weight;
+            }
+        }
+
+        return $presentedProduct;
+    }
+
+    /**
+     * @param array $product
+     * @return int
+     */
+    public function getProductWeight(array $product){
+        $product_weight = 0;
+        if (isset($product['features'] )) {
+            foreach ($product['features'] as $feature) {
+                if ( '4' === $feature['id_feature']){
+                    $product_weight = (float) $feature['value'];
+                }
+            }
+        }
+        return $product_weight;
+    }
+
+    /**
      * Add all specific references to product
      * @param array $product
      * @param array $presentedProduct
@@ -502,6 +536,7 @@ class ProductPresenter
             $presentedProduct['specific_references']['id_attribute_group'],
             $presentedProduct['specific_references']['name'],
             $presentedProduct['specific_references']['group'],
+            $presentedProduct['specific_references']['weight'],
             $presentedProduct['specific_references']['reference']
         );
 
@@ -623,6 +658,11 @@ class ProductPresenter
                 $presentedProduct
             );
         }
+
+        $presentedProduct = $this->AddWeightToDisplay(
+            $product,
+            $presentedProduct
+        );
 
         $presentedProduct['embedded_attributes'] = $this->getProductEmbeddedAttributes($product);
 

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -647,22 +647,24 @@ class ProductPresenter
         );
 
         // If product has attributes and it's no added to card
-        if (isset($product['attributes']) && !isset($product['cart_quantity'])) {
-            $presentedProduct = $this->addReferenceToDisplay(
-                $product,
-                $presentedProduct
-            );
+        if (isset($product['attributes'])) {
+            if (!isset($product['cart_quantity'])) {
+                $presentedProduct = $this->addReferenceToDisplay(
+                    $product,
+                    $presentedProduct
+                );
 
-            $presentedProduct = $this->addAttributesSpecificReferences(
+                $presentedProduct = $this->addAttributesSpecificReferences(
+                    $product,
+                    $presentedProduct
+                );
+            }
+            $presentedProduct = $this->AddWeightToDisplay(
                 $product,
                 $presentedProduct
             );
         }
 
-        $presentedProduct = $this->AddWeightToDisplay(
-            $product,
-            $presentedProduct
-        );
 
         $presentedProduct['embedded_attributes'] = $this->getProductEmbeddedAttributes($product);
 

--- a/themes/classic/templates/catalog/_partials/product-details.tpl
+++ b/themes/classic/templates/catalog/_partials/product-details.tpl
@@ -53,7 +53,11 @@
           <dl class="data-sheet">
             {foreach from=$product.features item=feature}
               <dt class="name">{$feature.name}</dt>
-              <dd class="value">{$feature.value}</dd>
+              {if $feature.id_feature === '4'}
+                <dd class="value">{$product.weight_to_display}</dd>
+              {else}
+                <dd class="value">{$feature.value}</dd>
+              {/if}
             {/foreach}
           </dl>
         </section>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The weight of combination is calculated incorrectly.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1899
| How to test?  | Go to product detail page in FO and change combination, the weight will change according to the combination's impact of weight.

See: https://github.com/PrestaShop/PrestaShop/pull/7105