### PR TITLE
Fix unregisteration of JavaScript by ID

### DIFF
--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -67,7 +67,7 @@ class JavascriptManagerCore extends AbstractAssetManager
             foreach ($this->list[$position] as $type => $null) {
                 foreach ($this->list[$position][$type] as $id => $item) {
                     if ($idToRemove === $id) {
-                        unset($this->list[$position][$type]);
+                        unset($this->list[$position][$type][$id]);
                     }
                 }
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As now, the unregisteration of a JavaScript file by ID will remove all the type array (like external/bottom array)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Use $this->context->controller->unregisterJavascript('yourid');