### PR TITLE
Fix unregisteration of Stylesheet by ID

### DIFF
--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -62,9 +62,15 @@ class StylesheetManagerCore extends AbstractAssetManager
         }
     }
 
-    public function unregisterById($id)
+    public function unregisterById($idToRemove)
     {
-        unset($this->list[$id]);
+        foreach ($this->list as $type => $null) {
+            foreach ($this->list[$type] as $id => $item) {
+                if ($idToRemove === $id) {
+                    unset($this->list[$type][$id]);
+                }
+            }
+        }
     }
 
     public function getList()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The unregisteration need to be the same as the JavaScript unregister method
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Use $this->context->controller->unregisterStylesheet('yourid');