### PR TITLE
Fix notice on $currency_to which may be null

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -743,6 +743,10 @@ class ToolsCore
             $currency_from = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
         }
 
+        if ($currency_to === null) {
+            $currency_to = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
+        }
+
         if ($currency_from->id == Configuration::get('PS_CURRENCY_DEFAULT')) {
             $amount *= $currency_to->conversion_rate;
         } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Whoops, looks like something went wrong. ContextErrorException in Tools.php line 751: Notice: Trying to get property of non-object
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to run Tools::convertPriceFull($amount, Currency $currency_from = null, Currency $currency_to = null) without passing the `$currency_to` param

