### PR TITLE
Add parent menu permission if sub-menu is selected

### DIFF
--- a/admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl
@@ -82,10 +82,10 @@
          if (parent != 0){
             var $parentelem = $(table + ' .ajaxPower.' + perm + '.' + parent);
             if(!$parentelem.is(':checked')){
-               $parentelem.click();
+               $parentelem.prop("checked", true).change();
             }else{
                if(!$(this).is(':checked') && !getChildren(table, perm, parent, rel))
-                  $parentelem.click();
+                  $parentelem.prop("checked", false).change();
             }
          }
          switch (true) {

--- a/admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl
@@ -54,8 +54,19 @@
          $('.tab-profile').hide()
          $('.'+id).show();
       });
+      function getChildren(table, perm, parent, rel) {
+         var kids = document.querySelectorAll(table+" [data-parent='"+parent+"'][data-type='"+perm+"']:not([data-rel='"+rel+"'])");
+         for(var i=0; i<kids.length;i++)
+         {
+            if(kids[i].checked) {
+               return true;
+            }
+         }
+         return false;
+      }
       $('.ajaxPower').change(function(){
          var tout = $(this).data('rel').split('||');
+         var rel = $(this).data('rel');
          var id_tab = tout[0];
          var id_profile = tout[1];
          var perm = tout[2];
@@ -67,6 +78,16 @@
          var classes = $parentRow.attr('class');
          var $permissionCheckbox = $(this);
          var targetPermissionType;
+         var parent = $(this).attr('data-parent');
+         if (parent != 0){
+            var $parentelem = $(table + ' .ajaxPower.' + perm + '.' + parent);
+            if(!$parentelem.is(':checked')){
+               $parentelem.click();
+            }else{
+               if(!$(this).is(':checked') && !getChildren(table, perm, parent, rel))
+                  $parentelem.click();
+            }
+         }
          switch (true) {
             case $permissionCheckbox.hasClass('view'): targetPermissionType = '.view'; break;
             case $permissionCheckbox.hasClass('add'): targetPermissionType = '.add'; break;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | When adding permissions for sub-menus, the parent menu is checked automatically but not saved and vice versa 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2121
| How to test?  | Go To Employee -> Permissions in the BO and add a sub-menu view permission for example, the parent menu will be checked and saved.