### PR TITLE
Use PhpParser to check parse errors in modules

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1267,27 +1267,11 @@ abstract class ModuleCore
                     $file_path = _PS_MODULE_DIR_.$module.'/'.$module.'.php';
                     $file = trim(file_get_contents(_PS_MODULE_DIR_.$module.'/'.$module.'.php'));
 
-                    if (substr($file, 0, 5) == '<?php') {
-                        $file = substr($file, 5);
-                    }
-
-                    if (substr($file, -2) == '?>') {
-                        $file = substr($file, 0, -2);
-                    }
-
-                    // We check any parse error before including the file.
-                    // If (false) is a trick to not load the class with "eval".
-                    // This way require_once will works correctly
-                    // But namespace and use statements need to be removed
-                    $content = preg_replace('/\n[\s\t]*?use\s.*?;/', '', $file);
-                    $content = preg_replace('/\n[\s\t]*?namespace\s.*?;/', '', $content);
                     try {
-                        if (substr(`php -l $file_path`, 0, 16) == 'No syntax errors' || eval('if (false){	'.$content.' }') !== false) {
-                            require_once(_PS_MODULE_DIR_.$module.'/'.$module.'.php');
-                        } else {
-                            throw new ParseError("Parse error");
-                        }
-                    } catch (ParseError $e) {
+                        $parser = (new PhpParser\ParserFactory)->create(PhpParser\ParserFactory::PREFER_PHP7);
+                        $parser->parse($file);
+                        require_once($file_path);
+                    } catch (PhpParser\Error $e) {
                         $errors[] = sprintf(Tools::displayError('%1$s (parse error in %2$s)'), $module, substr($file_path, strlen(_PS_ROOT_DIR_)));
                     }
 

--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,8 @@
     "prestashop/welcome": "dev-master",
     "prestashop/dashtrends": "dev-master",
     "beberlei/DoctrineExtensions": "^1.0",
-    "composer/ca-bundle": "^1.0"
+    "composer/ca-bundle": "^1.0",
+    "nikic/php-parser": "^2.1"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.5",


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | This PR is a partial cherry-pick of #6627. We wanted to remove an eval in the legacy class `Module`, but the exec used hung multiple environments. We now use the PhpParser to detect potential parse errors in the module main class.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | <p>http://forge.prestashop.com/browse/BOOM-1871<br/>http://forge.prestashop.com/browse/BOOM-1880<br/>http://forge.prestashop.com/browse/BOOM-1889<br/>http://forge.prestashop.com/browse/BOOM-1908</p>
| How to test?  | Put a module with a parse error on your shop, and go to the carriers page. You should have a message saying you have a parse error in your module.

