### PR TITLE
Fixed “new client” column in orders list

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -95,7 +95,6 @@ class AdminOrdersControllerCore extends AdminController
             'new' => array(
                 'title' => $this->trans('New client', array(), 'Admin.OrdersCustomers.Feature'),
                 'align' => 'text-center',
-                'type' => 'bool',
                 'tmpTableFilter' => true,
                 'orderby' => false,
                 'callback' => 'printNewCustomer'


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR fixes the "new client" column in orders list. Currently the value is always "no".
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1917
| How to test?  | Just check the line of the first order of John Doe.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

