### PR TITLE
Fixed XSS issue on translation module page

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3119,6 +3119,7 @@ abstract class ModuleCore
 
     protected function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
+        $parameters['legacy'] = 'htmlspecialchars';
         return $this->getTranslator()->trans($id, $parameters, $domain, $locale);
     }
 }

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -62,7 +62,7 @@ function smartyTranslate($params, &$smarty)
     $isInModule = isset($params['mod']) && !empty($params['mod']);
     $sprintf = isset($params['sprintf']) ? $params['sprintf'] : array();
 
-    if (($htmlEntities || $addSlashes) && is_array($sprintf)) {
+    if (($htmlEntities || $addSlashes) && is_array($sprintf) && !empty($sprintf)) {
         $sprintf['legacy'] = $htmlEntities ? 'htmlspecialchars': 'addslashes';
     }
 

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -62,7 +62,7 @@ function smartyTranslate($params, &$smarty)
     $isInModule = isset($params['mod']) && !empty($params['mod']);
     $sprintf = isset($params['sprintf']) ? $params['sprintf'] : array();
 
-    if ($htmlEntities ||  $addSlashes) {
+    if (($htmlEntities || $addSlashes) && is_array($sprintf)) {
         $sprintf['legacy'] = $htmlEntities ? 'htmlspecialchars': 'addslashes';
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As you can put everything you want in translations, you need to clean the display.
| Type?         | bug fix
| Category?     | CO
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1841
| How to test?  | Use ``<script type="text/javascript">alert('Hello XSS');</script>`` in Save key. You should see the translation correctly escaped in both new and legacy pages.