### PR TITLE
Fix timeout option for guzzle config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -106,7 +106,8 @@ csa_guzzle:
         addons_api:
             config: # you can specify the options as in http://docs.guzzlephp.org/en/latest/quickstart.html#creating-a-client
                 base_url: "https://api-addons.prestashop.com"
-                timeout: "5.0"
+                defaults:
+                    timeout: "5.0"
                 headers:
                     Accept: "application/json"
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | @mickaelandrieu gave the solution and flew away. It fixes the timeout when the marketplace API is unable to answer. This PR is a cherry pick of #7128
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1887
| How to test?  | Drop your connections with the marketplace. You shop should still be able to install itself.
