### PR TITLE
FO: Support multistore in assignCountries

### DIFF
--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -201,7 +201,7 @@ class AuthControllerCore extends FrontController
         if (Configuration::get('PS_RESTRICT_DELIVERED_COUNTRIES')) {
             $countries = Carrier::getDeliveredCountries($this->context->language->id, true, true);
         } else {
-            $countries = Country::getCountries($this->context->language->id, true);
+            $countries = Country::getCountriesByIdShop((int)Tools::getValue('id_shop'), $this->context->language->id);
         }
         $this->context->smarty->assign(array(
                 'countries' => $countries,


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Support multistore in assignCountries. Use getCountriesByIdShop instead of getCountries.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | maybe not
| Deprecations? | no

Support multistore in assignCountries. Use getCountriesByIdShop instead of getCountries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7135)
<!-- Reviewable:end -->
