### PR TITLE
Fixed search and redirection to module

### DIFF
--- a/admin-dev/themes/default/template/layout.tpl
+++ b/admin-dev/themes/default/template/layout.tpl
@@ -76,7 +76,7 @@
 		<div class="alert alert-warning">
 			<button type="button" class="close" data-dismiss="alert">&times;</button>
 			{if count($warnings) > 1}
-				<h4>{l s='There are %d warnings:' sprintf=count($warnings)}</h4>
+				<h4>{l s='There are %d warnings:' sprintf=[$warnings|count]}</h4>
 			{/if}
 			<ul class="list-unstyled">
 				{foreach $warnings as $warning}

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1479,6 +1479,9 @@ abstract class ModuleCore
         }
 
         foreach ($module_list as $key => &$module) {
+            if (!isset($module->tab)) {
+                $module->tab = 'others';
+            }
             if (defined('_PS_HOST_MODE_') && in_array($module->name, self::$hosted_modules_blacklist)) {
                 unset($module_list[$key]);
             } elseif (isset($modules_installed[$module->name])) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Back Office search were borken when a module was found. Also, I've found an error on the module url page retrieved
| Type?         | bug fix
| Category?     | BO
| How to test?  | Search "Customers" in the top search bar on Back Office

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

