### PR TITLE
Fix product redirection from back office search results 

### DIFF
--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -42,6 +42,15 @@ class AdminSearchControllerCore extends AdminController
         $this->context = Context::getContext();
         $this->query = trim(Tools::getValue('bo_query'));
         $searchType = (int)Tools::getValue('bo_search_type');
+        
+        /* 1.6 code compatibility, as we use HelperList, we need to handle click to go to product */
+        $action = Tools::getValue('action');
+        if ($action == 'redirectToProduct') {
+            $id_product = (int)Tools::getValue('id_product');
+            $link = $this->context->link->getAdminLink('AdminProducts', false, array('id_product' => $id_product));
+            Tools::redirectAdmin($link);
+        }
+        
         /* Handle empty search field */
         if (!empty($this->query)) {
             if (!$searchType && strlen($this->query) > 1) {
@@ -358,7 +367,9 @@ class AdminSearchControllerCore extends AdminController
                 $helper->actions = array('edit');
                 $helper->show_toolbar = false;
                 $helper->table = 'product';
-                $helper->currentIndex = $this->context->link->getAdminLink('AdminProducts', false);
+                /* 1.6 code compatibility, as we use HelperList, we need to handle click to go to product, a better way need to be find */
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminSearch', false);
+                $helper->currentIndex .= '&action=redirectToProduct';
 
                 $query = trim(Tools::getValue('bo_query'));
                 $searchType = (int)Tools::getValue('bo_search_type');
@@ -367,7 +378,7 @@ class AdminSearchControllerCore extends AdminController
                     $helper->currentIndex .= '&bo_query='.$query.'&bo_search_type='.$searchType;
                 }
 
-                $helper->token = Tools::getAdminTokenLite('AdminProducts');
+                $helper->token = Tools::getAdminTokenLite('AdminSearch');
 
                 if ($this->_list['products']) {
                     $view = $helper->generateList($this->_list['products'], $this->fields_list['products']);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Patched bug : you can't go to a product after searching it ,more description above
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  
| How to test?  | Use BO serch functionality and search a product, then clic on the product result

![image](https://cloud.githubusercontent.com/assets/3170104/20831154/0208457c-b884-11e6-96ce-54f14eefc16e.png)

The product list use 1.6 helper list who can not handle correctly new BO product routes (@see : https://github.com/PrestaShop/PrestaShop/blob/develop/admin-dev/themes/default/template/helpers/list/list_content.tpl#L52),
i correct this by doing a redirection, it's not the best way.
I suggest for the future to use here the same list than the new Product list, does anyone know how to do this ?
(or is a new HelperList planned ?)
