### PR TITLE
Replace specific cache management with doctrine cache for module catalog

### DIFF
--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -26,6 +26,7 @@
 namespace PrestaShop\PrestaShop\Core\Addon\Module;
 
 use Context;
+use Doctrine\Common\Cache\FilesystemCache;
 use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
@@ -61,6 +62,7 @@ class ModuleManagerBuilder
     public static $addonsDataProvider = null;
     public static $categoriesProvider = null;
     public static $instance = null;
+    public static $cacheProvider = null;
 
     /**
      * @return null|ModuleManagerBuilder
@@ -117,7 +119,9 @@ class ModuleManagerBuilder
                     self::$moduleDataProvider,
                     self::$moduleDataUpdater,
                     self::$legacyLogger,
-                    self::$translator
+                    self::$translator,
+                    Context::getContext()->language->iso_code,
+                    self::$cacheProvider
                 );
             }
         }
@@ -170,6 +174,8 @@ class ModuleManagerBuilder
         if (_PS_MODE_DEV_) {
             self::$addonsDataProvider->cacheDir = $kernelDir . '/cache/dev';
         }
+        
+        self::$cacheProvider = new FilesystemCache(self::$addonsDataProvider->cacheDir.'/doctrine');
 
         self::$categoriesProvider = new CategoriesProvider($marketPlaceClient);
 
@@ -178,7 +184,8 @@ class ModuleManagerBuilder
                 $this->getLanguageIso(),
                 $this->getSymfonyRouter(),
                 self::$addonsDataProvider,
-                self::$categoriesProvider
+                self::$categoriesProvider,
+                self::$cacheProvider
             );
 
             self::$moduleDataUpdater = new ModuleDataUpdater(self::$addonsDataProvider, self::$adminModuleDataProvider);

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -78,6 +78,7 @@ services:
              - "@router"
              - "@prestashop.core.admin.data_provider.addons_interface"
              - "@prestashop.categories_provider"
+             - "@doctrine.cache.provider"
         decorates: prestashop.core.admin.data_provider.module_interface
         public: false
 

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -10,15 +10,15 @@ services:
         class: Symfony\Component\Finder\Finder
         shared: false
 
-    guzzle.cache.provider:
+    doctrine.cache.provider:
         class: Doctrine\Common\Cache\FilesystemCache
         arguments:
-            - "%kernel.cache_dir%/guzzle"
+            - "%kernel.cache_dir%/doctrine"
 
     guzzle.cache:
         class: Csa\Bundle\GuzzleBundle\GuzzleHttp\Cache\DoctrineAdapter
         arguments:
-            - "@guzzle.cache.provider"
+            - "@doctrine.cache.provider"
             - "%prestashop.addons.api_client.ttl%"
         shared: false
 

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -261,6 +261,8 @@ services:
             - "@prestashop.core.module.updater"
             - "@prestashop.adapter.legacy.logger"
             - "@translator"
+            - "@=service('prestashop.adapter.legacy.context').getContext().language.iso_code"
+            - "@doctrine.cache.provider"
 
     prestashop.core.addon.theme.repository:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository

--- a/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
@@ -131,6 +131,7 @@ class ModuleRepositoryTest extends UnitTestCase
                 )),
                 new FakeLogger(),
                 $this->translatorStub,
+                'en'
             )
         );
 

--- a/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
@@ -345,7 +345,5 @@ class ModuleRepositoryTest extends UnitTestCase
         if ($this->http_host_not_found) {
             unset($_SERVER['HTTP_HOST']);
         }
-
-        $this->moduleRepositoryStub->clearCache();
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The generated catalog cache was stored in a file created by ourselves. But we can also use the existing doctrine cache to handle that for us. The class AdminModuleDataProvider has been cleaned of the cache management. :)
| Type?         | improvement
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1950
| How to test?  | This PR has no visible impact.
