### PR TITLE
Fix send to multiple addresses with different names

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -243,12 +243,14 @@ class MailCore extends ObjectModel
                     return false;
                 }
 
-                if (is_array($toName) && $toName && is_array($toName) && Validate::isGenericName($toName[$key])) {
-                    $toName = $toName[$key];
+                if (is_array($toName) && isset($toName[$key])) {
+                    $addrName = $toName[$key];
+                } else {
+                    $addrName = $toName;
                 }
 
-                $toName = (($toName == null || $toName == $addr) ? '' : self::mimeEncode($toName));
-                $message->addTo($addr, $toName);
+                $addrName = (($addrName == null || $addrName == $addr || !Validate::isGenericName($addrName)) ? '' : self::mimeEncode($addrName));
+                $message->addTo($addr, $addrName);
             }
             $toPlugin = $to[0];
         } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the foreach loop the array $toName is reaffected with its first value on the first pass. On the second pass it is reaffected with the second character of this value. Solved by changing the name of the value inside the loop.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8731
| How to test?  | use the Mail::Send function with an array for the $to parameter and another array for $toName parameter