### PR TITLE
Fix "Uncaught ReferenceError: prestashop is not defined"

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1555,7 +1555,7 @@ class FrontControllerCore extends Controller
                 'address2' => $address->address2,
                 'postcode' => $address->postcode,
                 'city' => $address->city,
-                'state' => (new State($address->id_state))->name[$this->context->language->id],
+                'state' => (new State($address->id_state))->name,
                 'country' => (new Country($address->id_country))->name[$this->context->language->id],
             ),
             'phone' => Configuration::get('PS_SHOP_PHONE'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | State has not a lang table. After add state in contact shop, browser generate error "Uncaught ReferenceError: prestashop is not defined" and javascript does not work. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Reproduce| Select a state whose name is not English