### PR TITLE
Allow installed modules translation from translation page

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -36,10 +36,17 @@
         typeOption = $('#ps_email_selector select[name="selected-emails"] option:selected');
       }
 
-      if ('legacy' === typeOption.data('controller')) {
-        formTranslation.attr('action', formTranslation.data('legacyaction'));
+      if ('modules' == $('#type option:selected').val()) {
+        formTranslation.attr(
+          'action',
+          $('#ps_module_selector select[name="selected-modules"] option:selected').data('url-to-translate') + '&lang=' + id_lang
+        );
       } else {
-        formTranslation.attr('action', formTranslation.data('sfaction'));
+        if ('legacy' === typeOption.data('controller')) {
+          formTranslation.attr('action', formTranslation.data('legacyaction'));
+        } else {
+          formTranslation.attr('action', formTranslation.data('sfaction'));
+        }
       }
 
       formTranslation.submit();
@@ -49,10 +56,12 @@
       var themeSelector = $('#ps_theme_selector');
       var themeCoreOption = themeSelector.find('select[name="selected-theme"] option#core-option');
       var emailSelector = $('#ps_email_selector');
-      var allSelectors = $('select[name="selected-emails"], select[name="selected-theme"], select[name="locale"]');
+      var moduleSelector = $('#ps_module_selector');
+      var allSelectors = $('select[name="selected-modules"], select[name="selected-emails"], select[name="selected-theme"], select[name="locale"]');
 
       themeSelector.hide();
       emailSelector.hide();
+      moduleSelector.hide();
 
       $('#type').on('change', function () {
 
@@ -65,6 +74,12 @@
           emailSelector.show();
         } else {
           emailSelector.hide();
+        }
+
+        if ('modules' === $(this).val()) {
+          moduleSelector.show();
+        } else {
+          moduleSelector.hide();
         }
 
         if ('themes' === $(this).val()) {
@@ -89,7 +104,6 @@
         }
       });
 
-
 			$('#modify-translations').click(function() {
 				var languages = $('#translations-languages option');
 				var i;
@@ -103,6 +117,12 @@
 					}
 				}
 
+        if ('modules' === $('#type option:selected').val() && '' === $('[name="selected-modules"]').val()) {
+          alert('{l s='Please select a module!'}');
+
+          return;
+        }
+
 				if (0 === selectedLanguage.length) {
 					alert('{l s='Please select your language!'}');
 
@@ -115,7 +135,7 @@
 	</script>
   <form method="post" action="{url entity=sf route=admin_international_translations_list }"
         data-sfaction="{url entity=sf route=admin_international_translations_list }"
-        data-legacyaction="#"
+        data-legacyaction="{$link->getAdminLink('AdminTranslations', true)}"
         id="typeTranslationForm" class="form-horizontal">
     <div class="panel">
       <h3>
@@ -144,6 +164,17 @@
           <select name="selected-emails">
             <option value="subject" data-controller="sf">{l s='Subject'}</option>
             <option value="body" data-controller="legacy">{l s='Body'}</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-group" id="ps_module_selector">
+        <label class="control-label col-lg-3" for="selected-modules">{l s='Select your module'}</label>
+        <div class="col-lg-4">
+          <select name="selected-modules">
+            <option id="no-module" value="">---</option>
+            {foreach $modules as $module}
+              <option value="{$module.name}" data-url-to-translate="{$module.urlToTranslate}">{$module.name}</option>
+            {/foreach}
           </select>
         </div>
       </div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -37,10 +37,13 @@
       }
 
       if ('modules' == $('#type option:selected').val()) {
-        formTranslation.attr(
-          'action',
-          $('#ps_module_selector select[name="selected-modules"] option:selected').data('url-to-translate') + '&lang=' + id_lang
-        );
+        urlToTranslate = $('#ps_module_selector select[name="selected-modules"] option:selected').data('url-to-translate');
+        if ('' !== urlToTranslate) {
+          formTranslation.attr(
+            'action',
+            urlToTranslate + '&lang=' + id_lang
+          );
+        }
       } else {
         if ('legacy' === typeOption.data('controller')) {
           formTranslation.attr('action', formTranslation.data('legacyaction'));

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -89,7 +89,8 @@ class LinkCore
      * @return Product
      * @throws PrestaShopException
      */
-    public function getProductObject($product, $idLang, $idShop) {
+    public function getProductObject($product, $idLang, $idShop)
+    {
         if (!is_object($product)) {
             if (is_array($product) && isset($product['id_product'])) {
                 $product = new Product($product['id_product'], false, $idLang, $idShop);
@@ -178,7 +179,7 @@ class LinkCore
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['supplier'] = Tools::str2url($product->isFullyLoaded ? $product->supplier_name : Supplier::getNameById($product->id_supplier));
         }
-        
+
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'price', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['price'] = $product->isFullyLoaded ? $product->price : Product::getPriceStatic($product->id, false, null, 6, null, false, true, 1, false, null, null, null, $product->specificPrice);
@@ -361,7 +362,8 @@ class LinkCore
      * @return Category
      * @throws PrestaShopException
      */
-    public function getCategoryObject($category, $idLang) {
+    public function getCategoryObject($category, $idLang)
+    {
         if (!is_object($category)) {
             if (is_array($category) && isset($category['id_category'])) {
                 $category = new Category($category, $idLang);
@@ -670,14 +672,16 @@ class LinkCore
      *
      * @return string url
      */
-    public function getAdminLink($controller, $withToken = true, $sfRouteParams = array())
+    public function getAdminLink($controller, $withToken = true, $sfRouteParams = array(), $params = array())
     {
         // Cannot generate admin link from front
         if (!defined('_PS_ADMIN_DIR_')) {
             return '';
         }
 
-        $params = $withToken ? array('token' => Tools::getAdminTokenLite($controller)) : array();
+        if ($withToken) {
+            $params['token'] = Tools::getAdminTokenLite($controller);
+        }
 
         // Even if URL rewriting is not enabled, the page handled by Symfony must work !
         // For that, we add an 'index.php' in the URL before the route
@@ -801,9 +805,9 @@ class LinkCore
 
         if (file_exists(_PS_SUPP_IMG_DIR_.$idSupplier.(empty($type) ? '.jpg' : '-'.$type.'.jpg'))) {
             $uriPath = _THEME_SUP_DIR_.$idSupplier.(empty($type) ? '.jpg' : '-'.$type.'.jpg');
-        } else if (!empty($type) && file_exists(_PS_SUPP_IMG_DIR_.$idSupplier.'.jpg')) { // !empty($type) because if is empty, is already tested
+        } elseif (!empty($type) && file_exists(_PS_SUPP_IMG_DIR_.$idSupplier.'.jpg')) { // !empty($type) because if is empty, is already tested
             $uriPath = _THEME_SUP_DIR_.$idSupplier.'.jpg';
-        } else if (file_exists(_PS_SUPP_IMG_DIR_.'fr'.(empty($type) ? '.jpg' : '-default-'.$type.'.jpg'))) {
+        } elseif (file_exists(_PS_SUPP_IMG_DIR_.'fr'.(empty($type) ? '.jpg' : '-default-'.$type.'.jpg'))) {
             $uriPath = _THEME_SUP_DIR_.Context::getContext()->language->iso_code.(empty($type) ? '.jpg' : '-default-'.$type.'.jpg');
         } else {
             $uriPath = _THEME_SUP_DIR_.Context::getContext()->language->iso_code.'.jpg';
@@ -826,9 +830,9 @@ class LinkCore
 
         if (file_exists(_PS_MANU_IMG_DIR_.$idManufacturer.(empty($type) ? '.jpg' : '-'.$type.'.jpg'))) {
             $uriPath = _THEME_MANU_DIR_.$idManufacturer.(empty($type) ? '.jpg' : '-'.$type.'.jpg');
-        } else if (!empty($type) && file_exists(_PS_MANU_IMG_DIR_.$idManufacturer.'.jpg')) { // !empty($type) because if is empty, is already tested
+        } elseif (!empty($type) && file_exists(_PS_MANU_IMG_DIR_.$idManufacturer.'.jpg')) { // !empty($type) because if is empty, is already tested
             $uriPath = _THEME_MANU_DIR_.$idManufacturer.'.jpg';
-        } else if (file_exists(_PS_MANU_IMG_DIR_.'fr'.(empty($type) ? '.jpg' : '-default-'.$type.'.jpg'))) {
+        } elseif (file_exists(_PS_MANU_IMG_DIR_.'fr'.(empty($type) ? '.jpg' : '-default-'.$type.'.jpg'))) {
             $uriPath = _THEME_MANU_DIR_.Context::getContext()->language->iso_code.(empty($type) ? '.jpg' : '-default-'.$type.'.jpg');
         } else {
             $uriPath = _THEME_MANU_DIR_.Context::getContext()->language->iso_code.'.jpg';
@@ -1260,7 +1264,7 @@ class LinkCore
                         return $sfRouter->generate($params['route'], $params['sf-params'], UrlGeneratorInterface::ABSOLUTE_URL);
                     }
                     $link = $sfRouter->generate($params['route'], array(), UrlGeneratorInterface::ABSOLUTE_URL);
-                }else{
+                } else {
                     throw new \InvalidArgumentException('You can\'t use Symfony router in legacy context.');
                 }
                 break;

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -207,7 +207,7 @@ class AdminTranslationsControllerCore extends AdminController
         foreach ($this->getListModules() as $module) {
             $modules[$module] = array(
                 'name' => $module,
-                'urlToTranslate' => $this->context->link->getAdminLink(
+                'urlToTranslate' => !$this->isUsingNewTranslationsSystem($module) ? $this->context->link->getAdminLink(
                     'AdminTranslations',
                     true,
                     array(),
@@ -215,7 +215,7 @@ class AdminTranslationsControllerCore extends AdminController
                         'type' => 'modules',
                         'module' => $module,
                     )
-                ),
+                ) : '',
             );
         }
 
@@ -241,6 +241,18 @@ class AdminTranslationsControllerCore extends AdminController
         $this->content .= parent::renderView();
 
         return $this->content;
+    }
+
+    private function isUsingNewTranslationsSystem($moduleName)
+    {
+        $domains = array_keys($this->context->getTranslator()->getCatalogue()->all());
+        $moduleName = preg_replace('/^ps_(\w+)/', '$1', $moduleName);
+
+        if (count(preg_grep('/'.$moduleName.'/i', $domains))) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -203,6 +203,22 @@ class AdminTranslationsControllerCore extends AdminController
             }
         }
 
+        $modules = array();
+        foreach ($this->getListModules() as $module) {
+            $modules[$module] = array(
+                'name' => $module,
+                'urlToTranslate' => $this->context->link->getAdminLink(
+                    'AdminTranslations',
+                    true,
+                    array(),
+                    array(
+                        'type' => 'modules',
+                        'module' => $module,
+                    )
+                ),
+            );
+        }
+
         $this->tpl_view_vars = array(
             'theme_default' => self::DEFAULT_THEME_NAME,
             'theme_lang_dir' =>_THEME_LANG_DIR_,
@@ -213,6 +229,7 @@ class AdminTranslationsControllerCore extends AdminController
             'packs_to_update' => $packsToUpdate,
             'url_submit' => self::$currentIndex.'&token='.$this->token,
             'themes' => $this->themes,
+            'modules' => $modules,
             'current_theme_name' => $this->context->shop->theme_name,
             'url_create_language' => 'index.php?controller=AdminLanguages&addlang&token='.$token,
         );
@@ -1301,6 +1318,14 @@ class AdminTranslationsControllerCore extends AdminController
                 'sf_controller' => true,
                 'choice_theme' => true,
             ),
+            'modules' => array(
+                'name' => $this->trans('Installed modules translations', array(), 'Admin.International.Feature'),
+                'var' => '_MODULES',
+                'dir' => _PS_ROOT_DIR_.'/modules/',
+                'file' => '',
+                'sf_controller' => false,
+                'choice_theme' => false,
+            ),
             'mails' => array(
                 'name' => $this->trans('Email translations', array(), 'Admin.International.Feature'),
                 'var' => '_LANGMAIL',
@@ -1317,10 +1342,6 @@ class AdminTranslationsControllerCore extends AdminController
                 'sf_controller' => true,
                 'choice_theme' => false,
             ),
-            'modules' => array(
-                'dir' => _PS_MODULE_DIR_,
-                'file' => '',
-            )
         );
 
         if (defined('_PS_THEME_SELECTED_DIR_')) {

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1323,7 +1323,7 @@ class AdminTranslationsControllerCore extends AdminController
                 'var' => '_MODULES',
                 'dir' => _PS_ROOT_DIR_.'/modules/',
                 'file' => '',
-                'sf_controller' => false,
+                'sf_controller' => true,
                 'choice_theme' => false,
             ),
             'mails' => array(

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -168,6 +168,14 @@ services:
             themeRepository:          "@prestashop.core.addon.theme.repository"
             themeExtractor:           "@prestashop.translation.theme_extractor"
 
+    prestashop.translation.modules_provider:
+        class: PrestaShopBundle\Translation\Provider\ModulesProvider
+        arguments:
+            - "@prestashop.translation.database_loader"
+            - "%translations_dir%"
+        tags:
+            - { name: "ps.translation_provider" }
+
     # TRANSLATIONS
     prestashop.translation.database_loader:
         class: PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader

--- a/src/PrestaShopBundle/Tests/Translation/Provider/ModulesProviderTest.php
+++ b/src/PrestaShopBundle/Tests/Translation/Provider/ModulesProviderTest.php
@@ -26,11 +26,11 @@
 
 namespace PrestaShopBundle\Tests\Translation\Provider;
 
-use PrestaShopBundle\Translation\Provider\FrontOfficeProvider;
+use PrestaShopBundle\Translation\Provider\ModulesProvider;
 
-class FrontOfficeProviderTest extends \PHPUnit_Framework_TestCase
+class ModulesProviderTest extends \PHPUnit_Framework_TestCase
 {
-    // @see /resources/translations/en-US/ShopNotificationsWarning.en-US.xlf
+    // @see /resources/translations/en-US/AdminActions.en-US.xlf
     private $provider;
     private static $resourcesDir;
 
@@ -41,32 +41,26 @@ class FrontOfficeProviderTest extends \PHPUnit_Framework_TestCase
         ;
 
         self::$resourcesDir = __DIR__.'/../../resources/translations';
-        $this->provider = new FrontOfficeProvider($loader, self::$resourcesDir);
+        $this->provider = new ModulesProvider($loader, self::$resourcesDir);
     }
 
     public function testGetMessageCatalogue()
     {
-        // The xliff file contains 6 keys
         $expectedReturn = $this->provider->getMessageCatalogue();
         $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
 
         // Check integrity of translations
-        $this->assertArrayHasKey('ShopNotificationsWarning.en-US', $expectedReturn->all());
-        $this->assertArrayHasKey('ModulesShoppingCartShop.en-US', $expectedReturn->all());
+        $this->assertArrayHasKey('ModulesWirePaymentAdmin.en-US', $expectedReturn->all());
+        $this->assertArrayHasKey('ModulesWirePaymentShop.en-US', $expectedReturn->all());
 
-        $this->assertCount(4, $expectedReturn->all());
+        $moduleAdminTranslations = $expectedReturn->all('ModulesCheckPaymentAdmin.en-US');
+        $this->assertCount(9, $moduleAdminTranslations);
+        $this->assertArrayHasKey('Payments by check', $moduleAdminTranslations);
+        $this->assertSame('Payments by check', $moduleAdminTranslations['Payments by check']);
 
-        $frontTranslations = $expectedReturn->all('ShopNotificationsWarning.en-US');
-        $this->assertCount(6, $frontTranslations);
-        $this->assertArrayHasKey('You do not have any vouchers.', $frontTranslations);
-        $this->assertSame('You do not have any vouchers.', $frontTranslations['You do not have any vouchers.']);
-
-        $moduleTranslations = $expectedReturn->all('ModulesShoppingCartShop.en-US');
-        $this->assertCount(1, $moduleTranslations);
-        $this->assertArrayHasKey('Customers who bought this product also bought:', $moduleTranslations);
-        $this->assertSame(
-            'Customers who bought this product also bought:',
-            $moduleTranslations['Customers who bought this product also bought:']
-        );
+        $moduleFrontTranslations = $expectedReturn->all('ModulesCheckPaymentShop.en-US');
+        $this->assertCount(15, $moduleFrontTranslations);
+        $this->assertArrayHasKey('Pay by check', $moduleFrontTranslations);
+        $this->assertSame('Pay by check', $moduleFrontTranslations['Pay by check']);
     }
 }

--- a/src/PrestaShopBundle/Tests/resources/translations/en-US/ModulesCheckPaymentAdmin.en-US.xlf
+++ b/src/PrestaShopBundle/Tests/resources/translations/en-US/ModulesCheckPaymentAdmin.en-US.xlf
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="modules/ps_checkpayment/ps_checkpayment.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7b4cc4f79be9aae43efd53b4ae5cba4d" approved="yes">
+        <source>Payments by check</source>
+        <target xml:lang="en">Payments by check</target>
+        <note>Context:
+File: modules/ps_checkpayment/ps_checkpayment.php:64</note>
+      </trans-unit>
+      <trans-unit id="e09484ba6c16bc20236b63cc0d87ee95" approved="yes">
+        <source>Are you sure you want to delete these details?</source>
+        <target xml:lang="en">Are you sure you want to delete these details?</target>
+        <note>Context:
+File: modules/ps_checkpayment/ps_checkpayment.php:66</note>
+      </trans-unit>
+      <trans-unit id="a02758d758e8bec77a33d7f392eb3f8a" approved="yes">
+        <source>No currency has been set for this module.</source>
+        <target xml:lang="en">No currency has been set for this module.</target>
+        <note>Context:
+File: modules/ps_checkpayment/ps_checkpayment.php:73</note>
+      </trans-unit>
+      <trans-unit id="a60468657881aa431a0a5fccc76258e2" approved="yes">
+        <source>Pay by Check</source>
+        <target xml:lang="en">Pay by Check</target>
+        <note>Context:
+File: modules/ps_checkpayment/ps_checkpayment.php:159</note>
+      </trans-unit>
+      <trans-unit id="5dd532f0a63d89c5af0243b74732f63c" approved="yes">
+        <source>Contact details</source>
+        <target xml:lang="en">Contact details</target>
+        <note>Context:
+File: modules/ps_checkpayment/ps_checkpayment.php:215</note>
+      </trans-unit>
+      <trans-unit id="dd7bf230fde8d4836917806aff6a6b27" approved="yes">
+        <source>Address</source>
+        <target xml:lang="en">Address</target>
+        <note>Context:
+File: modules/ps_checkpayment/ps_checkpayment.php:227</note>
+      </trans-unit>
+      <trans-unit id="0fe62049ad5246bc188ec1bae347269e" approved="yes">
+        <source>Address where the check should be sent to.</source>
+        <target xml:lang="en">Address where the check should be sent to.</target>
+        <note>Context:
+File: modules/ps_checkpayment/ps_checkpayment.php:228</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_checkpayment/views/templates/hook/infos.tpl" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="14e41f4cfd99b10766cc15676d8cda66" approved="yes">
+        <source>This module allows you to accept payments by check.</source>
+        <target xml:lang="en">This module allows you to accept payments by check.</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/infos.tpl:28</note>
+      </trans-unit>
+      <trans-unit id="8c88bbf5712292b26e2a6bbeb0a7b5c4" approved="yes">
+        <source>You will need to manually confirm the order as soon as you receive a check.</source>
+        <target xml:lang="en">You will need to manually confirm the order as soon as you receive a check.</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/infos.tpl:30</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/PrestaShopBundle/Tests/resources/translations/en-US/ModulesCheckPaymentShop.en-US.xlf
+++ b/src/PrestaShopBundle/Tests/resources/translations/en-US/ModulesCheckPaymentShop.en-US.xlf
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="modules/ps_checkpayment/views/templates/front/payment_infos.tpl" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b2f40690858b404ed10e62bdf422c704" approved="yes">
+        <source>Amount</source>
+        <target xml:lang="en">Amount</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/front/payment_infos.tpl:29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_checkpayment/views/templates/hook/payment.tpl" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4b80fae2153218ed763bdadc418e8589" approved="yes">
+        <source>Pay by check</source>
+        <target xml:lang="en">Pay by check</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment.tpl:29</note>
+      </trans-unit>
+      <trans-unit id="4e1fb9f4b46556d64db55d50629ee301" approved="yes">
+        <source>(order processing will be longer)</source>
+        <target xml:lang="en">(order processing will be longer)</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment.tpl:29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_checkpayment/views/templates/hook/payment_return.tpl" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="88526efe38fd18179a127024aba8c1d7" approved="yes">
+        <source>Your order on %s is complete.</source>
+        <target xml:lang="en">Your order on %s is complete.</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:27</note>
+      </trans-unit>
+      <trans-unit id="61da27a5dd1f8ced46c77b0feaa9e159" approved="yes">
+        <source>Your check must include:</source>
+        <target xml:lang="en">Your check must include:</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:29</note>
+      </trans-unit>
+      <trans-unit id="621455d95c5de701e05900a98aaa9c66" approved="yes">
+        <source>Payment amount.</source>
+        <target xml:lang="en">Payment amount.</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:30</note>
+      </trans-unit>
+      <trans-unit id="9b8f932b1412d130ece5045ecafd1b42" approved="yes">
+        <source>Payable to the order of</source>
+        <target xml:lang="en">Payable to the order of</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:31</note>
+      </trans-unit>
+      <trans-unit id="9a94f1d749a3de5d299674d6c685e416" approved="yes">
+        <source>Mail to</source>
+        <target xml:lang="en">Mail to</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:32</note>
+      </trans-unit>
+      <trans-unit id="e1c54fdba2544646684f41ace03b5fda" approved="yes">
+        <source>Do not forget to insert your order number #%d.</source>
+        <target xml:lang="en">Do not forget to insert your order number #%d.</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:34</note>
+      </trans-unit>
+      <trans-unit id="4761b03b53bc2b3bd948bb7443a26f31" approved="yes">
+        <source>Do not forget to insert your order reference %s.</source>
+        <target xml:lang="en">Do not forget to insert your order reference %s.</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:36</note>
+      </trans-unit>
+      <trans-unit id="610abe74e72f00210e3dcb91a0a3f717" approved="yes">
+        <source>An email has been sent to you with this information.</source>
+        <target xml:lang="en">An email has been sent to you with this information.</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:38</note>
+      </trans-unit>
+      <trans-unit id="ffd2478830ca2f519f7fe7ee259d4b96" approved="yes">
+        <source>Your order will be sent as soon as we receive your payment.</source>
+        <target xml:lang="en">Your order will be sent as soon as we receive your payment.</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:39</note>
+      </trans-unit>
+      <trans-unit id="0db71da7150c27142eef9d22b843b4a9" approved="yes">
+        <source>For any questions or for further information, please contact our</source>
+        <target xml:lang="en">For any questions or for further information, please contact our</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:40</note>
+      </trans-unit>
+      <trans-unit id="decce112a9e64363c997b04aa71b7cb8" approved="yes">
+        <source>customer service department.</source>
+        <target xml:lang="en">customer service department.</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:45</note>
+      </trans-unit>
+      <trans-unit id="9bdf695c5a30784327137011da6ef568" approved="yes">
+        <source>We have noticed that there is a problem with your order. If you think this is an error, you can contact our</source>
+        <target xml:lang="en">We have noticed that there is a problem with your order. If you think this is an error, you can contact our</target>
+        <note>Context:
+File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:44</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/PrestaShopBundle/Tests/resources/translations/en-US/ModulesWirePaymentShop.en-US.xlf
+++ b/src/PrestaShopBundle/Tests/resources/translations/en-US/ModulesWirePaymentShop.en-US.xlf
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="modules/ps_wirepayment/ps_wirepayment.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="763538d192c0e4a3a341c1c7d0db9240" approved="yes">
+        <source>%1$s (tax incl.)</source>
+        <target xml:lang="en">%1$s (tax incl.)</target>
+        <note>Context:
+File: modules/ps_wirepayment/ps_wirepayment.php:403</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_wirepayment/validation.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e2b7dec8fa4b498156dfee6e4c84b156" approved="yes">
+        <source>This payment method is not available.</source>
+        <target xml:lang="en">This payment method is not available.</target>
+        <note>Context:
+File: modules/ps_wirepayment/validation.php:51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_wirepayment/views/templates/hook/payment.tpl" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5e1695822fc5af98f6b749ea3cbc9b4c" approved="yes">
+        <source>Pay by bank wire</source>
+        <target xml:lang="en">Pay by bank wire</target>
+        <note>Context:
+File: modules/ps_wirepayment/views/templates/hook/payment.tpl:29</note>
+      </trans-unit>
+      <trans-unit id="4e1fb9f4b46556d64db55d50629ee301" approved="yes">
+        <source>(order processing will be longer)</source>
+        <target xml:lang="en">(order processing will be longer)</target>
+        <note>Context:
+File: modules/ps_wirepayment/views/templates/hook/payment.tpl:29</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/PrestaShopBundle/Translation/Provider/ModulesProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ModulesProvider.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation\Provider;
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+class ModulesProvider extends AbstractProvider implements UseDefaultCatalogueInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains()
+    {
+        return array(
+            '^Modules*',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            '#^Modules*#',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        return 'modules';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultCatalogue($empty = true)
+    {
+        $defaultCatalogue = new MessageCatalogue($this->getLocale());
+
+        foreach ($this->getFilters() as $filter) {
+            $filteredCatalogue = $this->getCatalogueFromPaths(
+                array($this->getDefaultResourceDirectory()),
+                $this->getLocale(),
+                $filter
+            );
+            $defaultCatalogue->addCatalogue($filteredCatalogue);
+        }
+
+        if ($empty) {
+            $defaultCatalogue = $this->emptyCatalogue($defaultCatalogue);
+        }
+
+        return $defaultCatalogue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultResourceDirectory()
+    {
+        return $this->resourceDirectory.'/default';
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Allow installed modules translation from translation page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1838
| How to test?  | Select modules in the list, choose the module you want to translate and check if you are redirected to the right page. When you're translating a module which use the new translation system you must be redirected to the new translation page, otherwise, it will be the old one with the right module selected.