### PR TITLE
Fix send to multiple addresses with different names

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -187,12 +187,14 @@ class MailCore extends ObjectModel
                     return false;
                 }
 
-                if (is_array($to_name) && $to_name && is_array($to_name) && Validate::isGenericName($to_name[$key])) {
-                    $to_name = $to_name[$key];
+                if (is_array($to_name) && isset($to_name[$key])) {
+                    $addrName = $to_name[$key];
+                } else {
+                    $addrName = $to_name;
                 }
-
-                $to_name = (($to_name == null || $to_name == $addr) ? '' : self::mimeEncode($to_name));
-                $message->addTo($addr, $to_name);
+                
+                $addrName = (($addrName == null || $addrName == $addr || !Validate::isGenericName($addrName)) ? '' : self::mimeEncode($addrName));
+                $message->addTo($addr, $addrName);
             }
             $to_plugin = $to[0];
         } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In the foreach loop the array $toName is reaffected with its first value on the first pass. On the second pass it is reaffected with the second character of this value. Solved by changing the name of the value inside the loop.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8731
| How to test?  | use the Mail::Send function with an array for the $to parameter and another array for $toName parameter