### PR TITLE
Get value in sf request if exists

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -412,9 +412,10 @@ class ToolsCore
             return false;
         }
 
-        if (getenv('kernel.environment') === 'test' && self::$request instanceof Request) {
-            $value = self::$request->request->get($key, self::$request->query->get($key, $default_value));
-        } else {
+        if (self::$request instanceof Request) {
+            $value = self::$request->request->get($key);
+        }
+        if (null === $value) {
             $value = (isset($_POST[$key]) ? $_POST[$key] : (isset($_GET[$key]) ? $_GET[$key] : $default_value));
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Some parameters can only be found in the symfony requests, because they have been added during the kernel execution.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1956
| How to test?  | Calling `Tools::getValue('id')` on the product page in the BO must return a value