### PR TITLE
Uploader helper multiple files undefined _max_files

### DIFF
--- a/admin-dev/themes/default/template/helpers/uploader/ajax.tpl
+++ b/admin-dev/themes/default/template/helpers/uploader/ajax.tpl
@@ -154,8 +154,10 @@
 				}
 			},
 		}).on('fileuploadalways', function (e, data) {
+				if (typeof {$id|escape:'html':'UTF-8'}_max_files !== 'undefined') {
+					{$id|escape:'html':'UTF-8'}_max_files--;
+				}
 				{$id|escape:'html':'UTF-8'}_total_files--;
-				{$id|escape:'html':'UTF-8'}_max_files--;
 
 				if ({$id|escape:'html':'UTF-8'}_total_files == 0)
 				{


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Trying to use uploader helper to upload multiple files at once stops after first image because of js error undefined _max_files
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Please indicate how to best verify that this PR is correct.

Using the upload helper to upload multiple files results in undefined variable _max_files.
The same check made in event 'fileuploadadd' must be made in 'fileuploadalways'.