### PR TITLE
Fix SmartyLazyLoader for multiple smarty instances

### DIFF
--- a/classes/Smarty/SmartyLazyRegister.php
+++ b/classes/Smarty/SmartyLazyRegister.php
@@ -29,7 +29,7 @@
 class SmartyLazyRegister
 {
     protected $registry = array();
-    protected static $instance;
+    protected static $instances = array();
 
     /**
      * Register a function or method to be dynamically called later.
@@ -84,12 +84,14 @@ class SmartyLazyRegister
         }
     }
 
-    public static function getInstance()
+    public static function getInstance($smarty)
     {
-        if (!self::$instance) {
-            self::$instance = new self();
+        $hash = spl_object_hash($smarty);
+
+        if (!isset(self::$instances[$hash])) {
+            self::$instances[$hash] = new self();
         }
 
-        return self::$instance;
+        return self::$instances[$hash];
     }
 }

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -117,7 +117,7 @@ function smartyRegisterFunction($smarty, $type, $function, $params, $lazy = true
 
     // lazy is better if the function is not called on every page
     if ($lazy) {
-        $lazy_register = SmartyLazyRegister::getInstance();
+        $lazy_register = SmartyLazyRegister::getInstance($smarty);
         if ($lazy_register->isRegistered($params)) {
             return;
         }

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -97,7 +97,6 @@ smartyRegisterFunction($smarty, 'modifier', 'cleanHtml', 'smartyCleanHtml');
 smartyRegisterFunction($smarty, 'modifier', 'classname', 'smartyClassname');
 smartyRegisterFunction($smarty, 'modifier', 'classnames', 'smartyClassnames');
 smartyRegisterFunction($smarty, 'function', 'url', array('Link', 'getUrlSmarty'));
-smartyRegisterFunction($smarty, 'function', 'displayPrice', array('Tools', 'displayPriceSmarty'));
 
 function smartyDump($params, &$smarty)
 {

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -37,6 +37,7 @@ smartyRegisterFunction($smarty, 'function', 'convertPrice', array('Product', 'co
 smartyRegisterFunction($smarty, 'function', 'convertPriceWithCurrency', array('Product', 'convertPriceWithCurrency'));
 smartyRegisterFunction($smarty, 'function', 'displayWtPrice', array('Product', 'displayWtPrice'));
 smartyRegisterFunction($smarty, 'function', 'displayWtPriceWithCurrency', array('Product', 'displayWtPriceWithCurrency'));
+smartyRegisterFunction($smarty, 'function', 'displayPrice', array('Tools', 'displayPriceSmarty'));
 smartyRegisterFunction($smarty, 'modifier', 'convertAndFormatPrice', array('Product', 'convertAndFormatPrice')); // used twice
 smartyRegisterFunction($smarty, 'function', 'getAdminToken', array('Tools', 'getAdminTokenLiteSmarty'));
 smartyRegisterFunction($smarty, 'function', 'displayAddressDetail', array('AddressFormat', 'generateAddressSmarty'));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | SmartyLazyLoader shouldn't be a singleton since we could use multiple smarty instances while answering to one request.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1870
| How to test?  |

Ping @julienbourdeau what do you think about it?