### PR TITLE
Change wrong domain on tab translations

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/_partials/_header_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/_partials/_header_tab.html.twig
@@ -22,4 +22,4 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-<a class="tab{% if tabData.isCurrent %} current{% endif %}" href="{{ path(tabData.route)}}">{{tabData.title|trans({}, 'AdminControllersListener')}}</a>
+<a class="tab{% if tabData.isCurrent %} current{% endif %}" href="{{ path(tabData.route)}}">{{tabData.title|trans({}, 'Admin.Navigation.Menu')}}</a>

--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -35,10 +35,10 @@ trait PrestaShopTranslatorTrait
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
         if (null !== $domain) {
-            $domain = preg_replace('/\./', '', $domain);
+            $domain = str_replace('/\.', '', $domain);
         }
 
-        if (!$this->isSprintfString($id) || empty($parameters)) {
+        if (empty($parameters) || !$this->isSprintfString($id)) {
             $translated = parent::trans($id, $parameters, $domain, $locale);
             if (isset($parameters['legacy'])) {
                 $translated = call_user_func($parameters['legacy'],$translated);
@@ -49,17 +49,17 @@ trait PrestaShopTranslatorTrait
 
         return $translated;
     }
-
+    
     /**
      * {@inheritdoc}
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
         if (null !== $domain) {
-            $domain = preg_replace('/\./', '', $domain);
+            $domain = str_replace('.', '', $domain);
         }
 
-        if (!$this->isSprintfString($id)) {
+        if (empty($parameters) || !$this->isSprintfString($id)) {
             return parent::transChoice($id, $number, $parameters, $domain, $locale);
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Strings written in tabs are translated with a controller name as a domain. This PR replace it with a used domain.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1888
| How to test?  | The tab should be translated

<!-- @AlexEven  -->