### PR TITLE
Add error message when ordering number of item greater than quantity

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -404,8 +404,12 @@ class ProductPresenter
                 if ($product['quantity'] < $settings->lastRemainingItems) {
                     $presentedProduct = $this->applyLastItemsInStockDisplayRule($product, $settings, $presentedProduct);
                 } else {
-                    if(isset($product['quantity_wanted']) && $product['quantity_wanted'] > $product['quantity']) {
-                        $presentedProduct['availability_message'] = $this->translator->trans('We don\'t have enough products in stock', array(), 'Shop.Theme.Catalog');
+                    if (isset($product['quantity_wanted']) && $product['quantity_wanted'] > $product['quantity']) {
+                        $presentedProduct['availability_message'] = $this->translator->trans(
+                            'There are not enough products in stock',
+                            array(),
+                            'Shop.Notifications.Error'
+                        );
                         $presentedProduct['availability'] = 'unavailable';
                     } else {
                         $presentedProduct['availability_message'] = $product['available_now'];

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -404,7 +404,7 @@ class ProductPresenter
                 if ($product['quantity'] < $settings->lastRemainingItems) {
                     $presentedProduct = $this->applyLastItemsInStockDisplayRule($product, $settings, $presentedProduct);
                 } else {
-                    if($product['quantity_wanted'] > $product['quantity']) {
+                    if(isset($product['quantity_wanted']) && $product['quantity_wanted'] > $product['quantity']) {
                         $presentedProduct['availability_message'] = $this->translator->trans('We don\'t have enough products in stock', array(), 'Shop.Theme.Catalog');
                         $presentedProduct['availability'] = 'unavailable';
                     } else {

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -405,7 +405,7 @@ class ProductPresenter
                     $presentedProduct = $this->applyLastItemsInStockDisplayRule($product, $settings, $presentedProduct);
                 } else {
                     if($product['quantity_wanted'] > $product['quantity']) {
-                        $presentedProduct['availability_message'] = 'Out of stock';
+                        $presentedProduct['availability_message'] = $this->translator->trans('We don\'t have enough products in stock', array(), 'Shop.Theme.Catalog');
                         $presentedProduct['availability'] = 'unavailable';
                     } else {
                         $presentedProduct['availability_message'] = $product['available_now'];

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -404,8 +404,13 @@ class ProductPresenter
                 if ($product['quantity'] < $settings->lastRemainingItems) {
                     $presentedProduct = $this->applyLastItemsInStockDisplayRule($product, $settings, $presentedProduct);
                 } else {
-                    $presentedProduct['availability_message'] = $product['available_now'];
-                    $presentedProduct['availability'] = 'available';
+                    if($product['quantity_wanted'] > $product['quantity']) {
+                        $presentedProduct['availability_message'] = 'Out of stock';
+                        $presentedProduct['availability'] = 'unavailable';
+                    } else {
+                        $presentedProduct['availability_message'] = $product['available_now'];
+                        $presentedProduct['availability'] = 'available';
+                    }
                 }
             } elseif ($product['allow_oosp']) {
                 if ($product['available_later']) {

--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -38,13 +38,13 @@
           />
         </div>
         <div class="add">
-          <button class="btn btn-primary add-to-cart" data-button-action="add-to-cart" type="submit" {if !$product.add_to_cart_url}disabled{/if}>
+          <button class="btn btn-primary add-to-cart" data-button-action="add-to-cart" type="submit" {if !$product.add_to_cart_url || $product.quantity_wanted>$product.quantity}disabled{/if}>
             <i class="material-icons shopping-cart">&#xE547;</i>
             {l s='Add to cart' d='Shop.Theme.Actions'}
           </button>
           {block name='product_availability'}
             <span id="product-availability">
-              {if $product.show_availability && $product.availability_message}
+              {if $product.show_availability && $product.availability_message && $product.quantity_wanted<=$product.quantity}
                 {if $product.availability == 'available'}
                   <i class="material-icons product-available">&#xE5CA;</i>
                 {elseif $product.availability == 'last_remaining_items'}
@@ -53,6 +53,9 @@
                   <i class="material-icons product-unavailable">&#xE14B;</i>
                 {/if}
                 {$product.availability_message}
+              {else}
+                <i class="material-icons product-unavailable">&#xE14B;</i>
+                {l s='Out of stock' d='Shop.Theme.Catalog'}
               {/if}
             </span>
           {/block}

--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -44,7 +44,7 @@
           </button>
           {block name='product_availability'}
             <span id="product-availability">
-              {if $product.show_availability && $product.availability_message && $product.quantity_wanted<=$product.quantity}
+              {if $product.show_availability && $product.availability_message}
                 {if $product.availability == 'available'}
                   <i class="material-icons product-available">&#xE5CA;</i>
                 {elseif $product.availability == 'last_remaining_items'}
@@ -53,9 +53,6 @@
                   <i class="material-icons product-unavailable">&#xE14B;</i>
                 {/if}
                 {$product.availability_message}
-              {else}
-                <i class="material-icons product-unavailable">&#xE14B;</i>
-                {l s='Out of stock' d='Shop.Theme.Catalog'}
               {/if}
             </span>
           {/block}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | When ordering a number of item greater than quantity, there is no error message
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1965
| How to test?  | Go to product detail page and add to card a number of item grater than quantity.