### PR TITLE
Enable the cart rule feature when updating one if it's enabled

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -163,7 +163,12 @@ class CartRuleCore extends ObjectModel
             $this->reduction_currency = (int)Configuration::get('PS_CURRENCY_DEFAULT');
         }
 
-        return parent::update($null_values);
+        if (!parent::update($null_values)) {
+            return false;
+        }
+
+        Configuration::updateGlobalValue('PS_CART_RULE_FEATURE_ACTIVE', CartRule::isCurrentlyUsed($this->def['table'], true));
+        return true;
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update configuration value when updating cart rule.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | N
| Deprecations? | N
| Fixed ticket? | 
| How to test?  | Create one cart rule. Disable it. The configuration value should be set to 0, as when you delete it.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

The configuration variable is not updated when a cart rule is modified. I could disable the only existing cart rule so the feature should be disabled too.