### PR TITLE
Fix rights issues on legacy module page

### DIFF
--- a/admin-dev/themes/default/template/content-legacy.tpl
+++ b/admin-dev/themes/default/template/content-legacy.tpl
@@ -1,0 +1,36 @@
+{**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+<div id="ajax_confirmation" class="alert alert-success hide"></div>
+{* ajaxBox allows*}
+<div id="ajaxBox" style="display:none"></div>
+
+
+<div class="row">
+	<div class="col-lg-12">
+		{if isset($content)}
+			{$content}
+		{/if}
+	</div>
+</div>

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -78,6 +78,8 @@ class AdminModulesControllerCore extends AdminController
         $this->bootstrap = true;
         parent::__construct();
 
+        // Rely on new module controller for right management
+        $this->id = Tab::getIdFromClassName('AdminModulesSf');
         $this->template = 'content-legacy.tpl';
 
         register_shutdown_function('displayFatalError');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When we modify the access rights of the module page, they are only given to the new module page. We change the id of the legacy controller to use the rights given to the new one. Also, it fixes a fatal error regarding a missing template.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1863, http://forge.prestashop.com/browse/BOOM-1926
| How to test?  | Create a new employee profile, and give him access to the module page and to only one module. You must be able to configure this module now.