### PR TITLE
Set size limits on Doctrine Translation entity

### DIFF
--- a/src/PrestaShopBundle/Entity/Translation.php
+++ b/src/PrestaShopBundle/Entity/Translation.php
@@ -34,7 +34,6 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Table(
  *     indexes={@ORM\Index(name="key", columns={"domain"})},
- *     uniqueConstraints={@ORM\UniqueConstraint(name="theme", columns={"key", "theme", "id_lang", "domain"})}
  * )
  * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\TranslationRepository")
  */
@@ -43,7 +42,7 @@ class Translation
     /**
      * @var int
      *
-     * @ORM\Column(name="id_translation", type="integer")
+     * @ORM\Column(name="id_translation", type="integer", options={"unsigned": true})
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      */
@@ -52,14 +51,14 @@ class Translation
     /**
      * @var string
      *
-     * @ORM\Column(name="`key`", type="string")
+     * @ORM\Column(name="`key`", type="text", length=65500)
      */
     private $key;
 
     /**
      * @var string
      *
-     * @ORM\Column(name="translation", type="text")
+     * @ORM\Column(name="translation", type="text", length=65500)
      */
     private $translation;
 
@@ -74,14 +73,14 @@ class Translation
     /**
      * @var string
      *
-     * @ORM\Column(name="domain", type="string")
+     * @ORM\Column(name="domain", type="string", length=80)
      */
     private $domain;
 
     /**
      * @var string
      *
-     * @ORM\Column(name="theme", type="string", nullable=true)
+     * @ORM\Column(name="theme", type="string", length=32, nullable=true)
      */
     private $theme = null;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | `develop`
| Description?  | The current column sizes are way too large. Especially since they are used in an index. Updating the scheme manuall results in the error below. We need to limit the strings to `VARCHAR(XX)` and `TEXT` and remove the index, because the index key size exceeds the limit on MySQL < 5.6.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1986 
| How to test?  | A manual schema update should work again: `php app/console doctrine:database:update --force`

Error at the moment (MySQL 5.5):
```
[Doctrine\DBAL\Exception\DriverException]                                    
  An exception occurred while executing 'CREATE UNIQUE INDEX theme ON ps_tran  
  slation (`key`, theme, id_lang, domain)':                                    
  SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT column 'k  
  ey' used in key specification without a key length
```
