### PR TITLE
Fixed category search in product association tab

### DIFF
--- a/admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl
@@ -38,7 +38,7 @@
 	$(function() {
 
 		function startTypeahead() {
-			if (typeof $.typeahead === 'undefined') {
+			if (typeof $.fn.typeahead === 'undefined') {
 				setTimeout(startTypeahead, 100);
 				return;
 			}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | With the version 1.6.1.9 that fix problems in BO with new browsers, the category search in the "Association" not work because $.typeahead is always undefined. The correct way to test if the function exists is to test $.fn.typeahead.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | In all PS version after 1.6.1.9 (included), open in edit mode some product in BO, go to "Association" tab and try to search a category. Nothing appen. With this PR, all work properly.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->