### PR TITLE
Fix already defines smarty function

### DIFF
--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -62,20 +62,26 @@ class PDFCore
         $this->smarty = clone $smarty;
         $this->smarty->escape_html = false;
 
+        /* We need to get the old instance of the LazyRegister
+         * because some of the functions are already defined
+         * and we need to check in the old one first
+         */
+        $original_lazy_register = SmartyLazyRegister::getInstance($smarty);
+
         /* For PDF we restore some functions from Smarty
          * they've been removed in PrestaShop 1.7 so
          * new themes don't use them. Although PDF haven't been
          * reworked so every PDF controller must extend this class.
          */
-        smartyRegisterFunction($this->smarty, 'function', 'convertPrice', array('Product', 'convertPrice'));
-        smartyRegisterFunction($this->smarty, 'function', 'convertPriceWithCurrency', array('Product', 'convertPriceWithCurrency'));
-        smartyRegisterFunction($this->smarty, 'function', 'displayWtPrice', array('Product', 'displayWtPrice'));
-        smartyRegisterFunction($this->smarty, 'function', 'displayWtPriceWithCurrency', array('Product', 'displayWtPriceWithCurrency'));
-        smartyRegisterFunction($this->smarty, 'function', 'displayPrice', array('Tools', 'displayPriceSmarty'));
-        smartyRegisterFunction($this->smarty, 'modifier', 'convertAndFormatPrice', array('Product', 'convertAndFormatPrice')); // used twice
-        smartyRegisterFunction($this->smarty, 'function', 'displayAddressDetail', array('AddressFormat', 'generateAddressSmarty'));
-        smartyRegisterFunction($this->smarty, 'function', 'getWidthSize', array('Image', 'getWidth'));
-        smartyRegisterFunction($this->smarty, 'function', 'getHeightSize', array('Image', 'getHeight'));
+        smartyRegisterFunction($this->smarty, 'function', 'convertPrice', array('Product', 'convertPrice'), true, $original_lazy_register);
+        smartyRegisterFunction($this->smarty, 'function', 'convertPriceWithCurrency', array('Product', 'convertPriceWithCurrency'), true, $original_lazy_register);
+        smartyRegisterFunction($this->smarty, 'function', 'displayWtPrice', array('Product', 'displayWtPrice'), true, $original_lazy_register);
+        smartyRegisterFunction($this->smarty, 'function', 'displayWtPriceWithCurrency', array('Product', 'displayWtPriceWithCurrency'), true, $original_lazy_register);
+        smartyRegisterFunction($this->smarty, 'function', 'displayPrice', array('Tools', 'displayPriceSmarty'), true, $original_lazy_register);
+        smartyRegisterFunction($this->smarty, 'modifier', 'convertAndFormatPrice', array('Product', 'convertAndFormatPrice'), true, $original_lazy_register); // used twice
+        smartyRegisterFunction($this->smarty, 'function', 'displayAddressDetail', array('AddressFormat', 'generateAddressSmarty'), true, $original_lazy_register);
+        smartyRegisterFunction($this->smarty, 'function', 'getWidthSize', array('Image', 'getWidth'), true, $original_lazy_register);
+        smartyRegisterFunction($this->smarty, 'function', 'getHeightSize', array('Image', 'getHeight'), true, $original_lazy_register);
 
         $this->objects = $objects;
         if (!($objects instanceof Iterator) && !is_array($objects)) {

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -108,7 +108,7 @@ function smarty_modifier_htmlentitiesUTF8($string)
     return Tools::htmlentitiesUTF8($string);
 }
 
-function smartyRegisterFunction($smarty, $type, $function, $params, $lazy = true)
+function smartyRegisterFunction($smarty, $type, $function, $params, $lazy = true, $initial_lazy_register = null)
 {
     if (!in_array($type, array('function', 'modifier', 'block'))) {
         return false;
@@ -116,6 +116,10 @@ function smartyRegisterFunction($smarty, $type, $function, $params, $lazy = true
 
     // lazy is better if the function is not called on every page
     if ($lazy) {
+        if (null !== $initial_lazy_register && $initial_lazy_register->isRegistered($params)) {
+            return;
+        }
+
         $lazy_register = SmartyLazyRegister::getInstance($smarty);
         if ($lazy_register->isRegistered($params)) {
             return;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix already defines smarty function. It was due to the cloning of the smarty ressource. In BO, some of the functions were already registered and we were checking in the lazyloader of the new instance. Now we check in the original lazyloader, then in the new one.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1993
| How to test?  |