### PR TITLE
Fix other XSS issues on translation module page

### DIFF
--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -43,8 +43,12 @@ trait PrestaShopTranslatorTrait
             if (isset($parameters['legacy'])) {
                 $translated = call_user_func($parameters['legacy'],$translated);
             }
-        }else {
+        } else {
             $translated = vsprintf(parent::trans($id, array(), $domain, $locale), $parameters);
+        }
+        $str = str_replace(' ', '', $translated);
+        if (substr_count($str, '<script')) {
+            $translated = htmlspecialchars($translated);
         }
 
         return $translated;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Fixed other XSS issues on translation module page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1841
| How to test?  | Use <script type="text/javascript">alert('Hello XSS');</script> in Save key. You should see the translation correctly escaped in both new and legacy pages.


