### PR TITLE
Fix issue on translations without params

### DIFF
--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -35,18 +35,23 @@ trait PrestaShopTranslatorTrait
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
         if (null !== $domain) {
-            $domain = preg_replace('/\./', '', $domain);
+            $domain = str_replace('.', '', $domain);
         }
-
-        $translated = parent::trans($id, $parameters, $domain, $locale);
+        
         if (isset($parameters['legacy'])) {
-            $translated = call_user_func($parameters['legacy'], $translated);
+            $legacy = $parameters['legacy'];
+            unset($parameters['legacy']);
+        }
+        
+        if (!empty($parameters) && $this->isSprintfString($id)) {
+            $translated = vsprintf(parent::trans($id, array(), $domain, $locale), $parameters);
+        } else {
+            $translated = parent::trans($id, $parameters, $domain, $locale);
         }
 
-        if ($this->isSprintfString($id) && !empty($parameters)) {
-            $translated = vsprintf($translated, $parameters);
+        if (isset($legacy)) {
+            $translated = call_user_func($legacy, $translated);
         }
-
         return $translated;
     }
 
@@ -56,7 +61,7 @@ trait PrestaShopTranslatorTrait
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
         if (null !== $domain) {
-            $domain = preg_replace('/\./', '', $domain);
+            $domain = str_replace('.', '', $domain);
         }
 
         if (!$this->isSprintfString($id)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When we send to the translator a legacy string with a `%s` inside but without parameters, we got an `htmlspecialchars` in the translated value.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1896
| How to test?  | You should not have htmlspecialchars displayed on the theme/customer page