### PR TITLE
Fix wrong displayed discount when it's higher than price

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -170,6 +170,12 @@ class ProductPresenter
         $presentedProduct['regular_price_amount'] = $regular_price;
         $presentedProduct['regular_price'] = $this->priceFormatter->format($regular_price);
 
+        if ($product['reduction'] < $product['price_without_reduction'] ){
+            $presentedProduct['discount_to_display'] = $presentedProduct['discount_amount'];
+        } else {
+            $presentedProduct['discount_to_display'] = $presentedProduct['regular_price'];
+        }
+
         if (isset($product['unit_price']) && $product['unit_price']) {
             $presentedProduct['unit_price'] = $this->priceFormatter->format($product['unit_price']);
             $presentedProduct['unit_price_full'] = $this->priceFormatter->format($product['unit_price'])

--- a/tests/Unit/Core/Business/Product/ProductPresenterTest.php
+++ b/tests/Unit/Core/Business/Product/ProductPresenterTest.php
@@ -71,6 +71,7 @@ class ProductPresenterTest extends UnitTestCase
         $this->product['id_product_attribute'] = 0;
         $this->product['link_rewrite'] = 'hérisson';
         $this->product['price'] = null;
+        $this->product['price_without_reduction'] = null;
         $this->product['price_tax_exc'] = null;
         $this->product['specific_prices'] = null;
         $this->product['customizable'] = false;

--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -51,12 +51,8 @@
               <span class="discount discount-percentage">{l s='Save %percentage%' d='Shop.Theme.Catalog' sprintf=['%percentage%' => $product.discount_percentage_absolute]}</span>
             {else}
               <span class="discount discount-amount">
-                {if $product.reduction < $product.price_without_reduction}
-                  {l s='Save %amount%' d='Shop.Theme.Catalog' sprintf=['%amount%' => $product.discount_amount]}
-                {else}
-                  {l s='Save %amount%' d='Shop.Theme.Catalog' sprintf=['%amount%' => $product.regular_price]}
-                {/if}
-               </span>
+                  {l s='Save %amount%' d='Shop.Theme.Catalog' sprintf=['%amount%' => $product.discount_to_display]}
+              </span>
             {/if}
           {/if}
         </div>

--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -50,7 +50,13 @@
             {if $product.discount_type === 'percentage'}
               <span class="discount discount-percentage">{l s='Save %percentage%' d='Shop.Theme.Catalog' sprintf=['%percentage%' => $product.discount_percentage_absolute]}</span>
             {else}
-              <span class="discount discount-amount">{l s='Save %amount%' d='Shop.Theme.Catalog' sprintf=['%amount%' => $product.discount_amount]}</span>
+              <span class="discount discount-amount">
+                {if $product.reduction < $product.price_without_reduction}
+                  {l s='Save %amount%' d='Shop.Theme.Catalog' sprintf=['%amount%' => $product.discount_amount]}
+                {else}
+                  {l s='Save %amount%' d='Shop.Theme.Catalog' sprintf=['%amount%' => $product.regular_price]}
+                {/if}
+               </span>
             {/if}
           {/if}
         </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | When having a discount higher than the price of a product, the user will save the price of the product (not all the discount)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1998
| How to test?  | Add specific price in BO to a product higher than his price, then visualize it in FO, you will have the right discount displayed. 