### PR TITLE
Check in Symfony catalog for translations for native modules

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -172,6 +172,16 @@ class TranslateCore
 
         $language = Context::getContext()->language;
 
+        /*
+         * Native modules working on both 1.6 & 1.7 are translated in messages.xlf
+         * So we need to check in the Symfony catalog for translations
+         */
+        $newTranslation = Context::getContext()->getTranslator()->trans($string, is_array($sprintf) ? $sprintf : array($sprintf));
+
+        if ($string != $newTranslation) {
+            return $newTranslation;
+        }
+
         if (!isset($translationsMerged[$name]) && isset(Context::getContext()->language)) {
             $filesByPriority = array(
                 // Translations in theme


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Native modules working on both 1.6 & 1.7 are translated in messages.xlf. So we need to check in the Symonfy catalog for translations
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1888
| How to test?  | You can check the dashboard, everything should be translated