### PR TITLE
Fix "There is 0 product." label

### DIFF
--- a/themes/classic/templates/catalog/_partials/products-top.tpl
+++ b/themes/classic/templates/catalog/_partials/products-top.tpl
@@ -26,8 +26,8 @@
   <div class="col-md-6 hidden-sm-down total-products">
     {if $listing.pagination.total_items > 1}
       <p>{l s='There are %product_count% products.' d='Shop.Theme.Catalog' sprintf=['%product_count%' => $listing.pagination.total_items]}</p>
-    {else}
-      <p>{l s='There is %product_count% product.' d='Shop.Theme.Catalog' sprintf=['%product_count%' => $listing.pagination.total_items]}</p>
+    {else if $listing.pagination.total_items > 0}
+      <p>{l s='There is 1 product.' d='Shop.Theme.Catalog'}</p>
     {/if}
   </div>
   <div class="col-md-6">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "develop"
| Description?  | If there are no products at all, there is no need to display total products label. Without this fix, label is "There is 0 product." Moreover, with this fix there is no need for sprintf in label "There is 1 product"
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Try setting $listing.pagination.total_items = 0

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
