### PR TITLE
Fix module install and blank screen after PS install

### DIFF
--- a/src/PrestaShopBundle/Cache/LocalizationWarmer.php
+++ b/src/PrestaShopBundle/Cache/LocalizationWarmer.php
@@ -54,7 +54,7 @@ class LocalizationWarmer implements CacheWarmerInterface
             }
         }
 
-        $path_cache_file = _PS_CACHE_DIR_.'sandbox'.DIRECTORY_SEPARATOR.$this->version.$this->country.'.xml';
+        $path_cache_file = $cacheDir.$this->version.$this->country.'.xml';
 
         if (is_file($path_cache_file)) {
             $localization_file_content = file_get_contents($path_cache_file);
@@ -74,7 +74,7 @@ class LocalizationWarmer implements CacheWarmerInterface
             }
 
             try {
-                $fs->dumpFile($cacheDir, $localization_file_content);
+                $fs->dumpFile($path_cache_file, $localization_file_content);
             } catch (IOExceptionInterface $e) {
                 //@todo: log
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | During the installation, the `LocalizationWarmer` was dumping a file content into something meant to be a directory. Later when you were trying to create this directory, you had a `File exists` error. So, this PR fixes the module installation from a ZIP and also the blank screen when you were trying to access to your BO for the first time.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2009
| How to test?  | To reproduce the issues I had to be on a Windows environment and with the dev mode turned to false