### PR TITLE
Fix order return format in OrderReturnPresenter

### DIFF
--- a/src/Adapter/Order/OrderReturnPresenter.php
+++ b/src/Adapter/Order/OrderReturnPresenter.php
@@ -51,7 +51,7 @@ class OrderReturnPresenter implements PresenterInterface
         $presentedOrderReturn = $orderReturn;
         $presentedOrderReturn['id'] = $orderReturn['id_order_return'];
 
-        $presentedOrderReturn['return_number'] = $this->prefix.sprintf('#%06d', $orderReturn['id_order_return']);
+        $presentedOrderReturn['return_number'] = $this->prefix.sprintf('%06d', $orderReturn['id_order_return']);
         $presentedOrderReturn['return_date'] = Tools::displayDate($orderReturn['date_add'], null, false);
         $presentedOrderReturn['print_url'] = ($orderReturn['state'] == 2)
             ? $this->link->getPageLink('pdf-order-return', true, null, 'id_order_return='.(int) $orderReturn['id_order_return'])


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There shouldn't be a '#' character before the return number
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1983
| How to test?  |

Before :

![before](https://cloud.githubusercontent.com/assets/3316447/21101895/b322aef2-c07b-11e6-880b-386f7ad4da14.png)

After :

![after](https://cloud.githubusercontent.com/assets/3316447/21101899/b918bb76-c07b-11e6-8776-eaa1c3c49c5a.png)
