### PR TITLE
Update wording form.html.twig

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -279,7 +279,7 @@
                             <h2>
                               {{ "Reference"|trans({}, 'Admin.Catalog.Feature') }}
                               <span class="help-box" data-toggle="popover"
-                                data-content="{{ "Your internal reference code for this product. Allowed special characters: .-_#\."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                                data-content="{{ "Your reference code for this product. Allowed special characters: .-_#\."|trans({}, 'Admin.Catalog.Help') }}" ></span>
                             </h2>
                             {{ form_errors(form.step6.reference) }}
                             <div class="row">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update wording form.html.twig
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Forge ticket  | 
| How to test?  | 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

If you mean the item number (or article number), why don't you name it correctly? This is neither a *"reference code"* nor is it *"Internal"*. Just the other way around: The item number (what you call *reference*) is displayed on the shop front in product details. So nothing is internal - this field's content **is** the item number for the merchant **and** the customer!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7206)
<!-- Reviewable:end -->
