### PR TITLE
Update Dispatcher.php

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -132,7 +132,7 @@ class DispatcherCore
             'keywords' => array(
                 'id' =>            array('regexp' => '[0-9]+', 'param' => 'id_category'),
                 /* Selected filters is used by the module blocklayered */
-                'selected_filters' =>    array('regexp' => '.*', 'param' => 'selected_filters'),
+                'selected_filters' =>    array('regexp' => '.*', 'param' => 'q'),
                 'rewrite' =>        array('regexp' => '[_a-zA-Z0-9\pL\pS-]*'),
                 'meta_keywords' =>    array('regexp' => '[_a-zA-Z0-9-\pL]*'),
                 'meta_title' =>        array('regexp' => '[_a-zA-Z0-9-\pL]*'),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Url filter like monsite.fr/3-femmes/Couleur-Bleu doesn't show product with filter. So on the dispatch, i see that the param configureted was "selected_filter", but the param use in the url is "q". When i made the change filter work. I don't know if is the right way to debug this feature. 
| Type?         | bug fix 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| How to test?  | ndd.com/3-femmes/Couleur-Bleu

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->





