### PR TITLE
Fixed bug deleteCustomizationToProduct in Cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3978,7 +3978,15 @@ class CartCore extends ObjectModel
             WHERE `id_customization` = '.(int)$cust_data['id_customization'].'
             AND `index` = '.(int)$index
         );
-        return $result;
+        
+        if (!$result) {
+            return false;
+        }
+
+        return Db::getInstance()->execute(
+            'DELETE FROM `'._DB_PREFIX_.'customization`
+             WHERE `id_customization` = '.(int)$cust_data['id_customization']
+            );
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | Develop
| Description?  | When allready saved a customization and you empty the textfield because you don't want to get a customized product anymore the data in customized_data is deleted but not in table customization. If you then add the product to the cart you will get an empty costumization line in the cart 
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No ticket found
| How to test?  | 1)Create a customizable product with a textfield. <br/>2)Open product on the shop (front)<br/>3)Add some text to the Textfield to customize the product. Save it.<br/>4) Add it to cart.<br/>5) Open the product on the shop again (front)<br/>6)Add some text to the Textfield to customize the product. Save it.<br/>7)Again, typ some text in the textfield, but don't save.<br/>8)Remove text and save it<br/>9) Add it to cart.<br/>10) Open cart<br/>Now you see 1 line that has a customization and 1 empty line<br/><br/>View description why it's causing that.<br/>Maybe there is an easier way to test but in my case this always goes wrong when you follow these steps<br/>


CO: Fixed bug deleteCustomizationToProduct in Cart