### PR TITLE
Update Dispatcher.php

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -132,7 +132,7 @@ class DispatcherCore
             'keywords' => array(
                 'id' =>            array('regexp' => '[0-9]+', 'param' => 'id_category'),
                 /* Selected filters is used by the module blocklayered */
-                'selected_filters' =>    array('regexp' => '.*', 'param' => 'selected_filters'),
+                'selected_filters' =>    array('regexp' => '.*', 'param' => 'q'),
                 'rewrite' =>        array('regexp' => '[_a-zA-Z0-9\pL\pS-]*'),
                 'meta_keywords' =>    array('regexp' => '[_a-zA-Z0-9-\pL]*'),
                 'meta_title' =>        array('regexp' => '[_a-zA-Z0-9-\pL]*'),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  Develop.
| Description?  | Url with a filter like monsite.fr/3-femmes/Couleur-Bleu doesn't show filtered products. So on the dispatch, i see that the param configureted was "selected_filter", but the param use in the url is "q". When i made the change, the filtering work properly. I don't know if is the right way to debug this feature.
| Type?         |  Bug fix
| Category?     | FO
| BC breaks?    | NO
| Deprecations? | NO
| How to test?  | Just install and test an URL like http://www.ndd.com/10-category/Filter-Value. Before the fix, products are not filtered. After it's good.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

Url with a filter like monsite.fr/3-femmes/Couleur-Bleu doesn't show filtered products. So on the dispatch, i see that the param configureted was "selected_filter", but the param use in the url is "q". When i made the change, the filtering work properly. I don't know if is the right way to debug this feature.