### PR TITLE
Fixed method Order::isVirtual

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -754,17 +754,17 @@ class OrderCore extends ObjectModel
         if (count($products) < 1) {
             return false;
         }
+
         $virtual = true;
+
         foreach ($products as $product) {
-            $pd = ProductDownload::getIdFromIdProduct((int)$product['product_id']);
-            if ($pd && Validate::isUnsignedInt($pd) && $product['download_hash'] && $product['display_filename'] != '') {
-                if ($strict === false) {
-                    return true;
-                }
-            } else {
-                $virtual &= false;
+            if ($strict === false && (bool)$product['is_virtual']) {
+                return true;
             }
+
+            $virtual &= (bool)$product['is_virtual'];
         }
+
         return $virtual;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The current method check if the product has a download, with "download_hash" and "display_filename" to be considered as virtual; but not every virtual product has a download file, etc. So, simply check if the "is_virtual" index is set to 1 instead of using ProductDownload::getIdFromIdProduct().
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create an order with a virtual product with a download and an order with a virtual product without a download, then check with (new Order($id_order))->isVirtual();
