### PR TITLE
Add a translator setter

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -337,6 +337,17 @@ class ContextCore
     }
 
     /**
+     * Setter: Translator
+     *
+     * @param $translator
+     * @return bool
+     */
+    public function setTranslator($translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
      *
      * @return Translator
      */

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -340,7 +340,7 @@ class ContextCore
      * Setter: Translator
      *
      * @param $translator
-     * @return bool
+     * @return void
      */
     public function setTranslator($translator)
     {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It's happen sometimes you need to serialize the Context object but you can't as translator is set with a SPFileInfo that can't be serialized. With this setter, you will be able to set translator as null if needed (and not used in some cases) and could be serialize the Context object.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to serialize the Context object before/after the merge of this PR.