### PR TITLE
Removed finfo use for theme upload

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -316,15 +316,7 @@ class AdminThemesControllerCore extends AdminController
                 return false;
         }
 
-        $finfo = new finfo(FILEINFO_MIME_TYPE);
-        $ext = array_search(
-            $finfo->file($_FILES['themearchive']['tmp_name']),
-            array(
-                'zip' => 'application/zip',
-            ),
-            true
-        );
-        if ($ext === false) {
+        if ('application/zip' !== $_FILES['themearchive']['type']) {
             $this->errors[] = $this->trans('Invalid file format.', array(), 'Admin.Design.Notification');
             return false;
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | `finfo` class is not always available to it has been removed.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  |