### PR TITLE
CO: Fix Bug that give infinite gift 

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -555,7 +555,10 @@ abstract class PaymentModuleCore extends Module
                         );
 
                         // If the reduction is not applicable to this order, then continue with the next one
+                        // We set $values to 0, because if in a cart there is only a gift without reduction the $order->addCartRule() do not save data inside order_cart_rule
                         if (!$values['tax_excl']) {
+                            $values['tax_excl'] = 0;
+                            $values['tax_incl'] = 0;
                             continue;
                         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
|Branch	| develop
|Description | When we have a rule in a cart that only have a gift, prestashop 1.6.x.x and 1.7.x.x don't save data inside the table order_cart_rule, so the customer can have infinite gift, if we set $values to 0 when we call $order->addCartRule we can save data and the customer have a limited gift for rule.` is malformed or incomplete. classes/PaymentModule.php
|Type | bug fix
|Category |  CO
|BC breaks | no
|How to test? |  Create a rule, limit 1 time for a user, if the customer pay X amount give only a gift in this case the voucher is not saved so if the customer make another order with the same rule the customer have the same gift.