### PR TITLE
Do not check module download on upgrade

### DIFF
--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -199,8 +199,6 @@ class ModuleManager implements AddonManagerInterface
                 'Admin.Modules.Notification'));
         }
 
-        $result = true;
-
         // Get new module
         // 1- From source
         if ($source != null) {
@@ -208,15 +206,13 @@ class ModuleManager implements AddonManagerInterface
         }
         // 2- From Addons
         else {
-            $result &= $this->moduleUpdater->setModuleOnDiskFromAddons($name);
+            // This step is not mandatory (in case of local module),
+            // we do not check the result
+            $this->moduleUpdater->setModuleOnDiskFromAddons($name);
         }
 
-        if ($result) {
-            // Load and execute upgrade files
-            $result &= $this->moduleUpdater->upgrade($name);
-        }
-
-        return (bool) $result;
+        // Load and execute upgrade files
+        return $this->moduleUpdater->upgrade($name);
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When the module files have been updated via FTP, an upgrade is anyway required. A download from the Addons Marketplace is not mandatory, so I removed the check.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2010
| How to test?  | Modify manually the version number of one module (not available on the marketplace !). The upgrade button will appear but will fail until you apply the PR.