### PR TITLE
PHP 7.1 Fatal error: operator not supported in DbQuery.php

### DIFF
--- a/classes/db/DbQuery.php
+++ b/classes/db/DbQuery.php
@@ -93,6 +93,7 @@ class DbQueryCore
     public function from($table, $alias = null)
     {
         if (!empty($table)) {
+            $this->query['from'] = array();
             $this->query['from'][] = '`'._DB_PREFIX_.$table.'`'.($alias ? ' '.$alias : '');
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | Use the "develop" branch if you target PrestaShop 1.7; use the "1.6.1.x" branch if you target PrestaShop 1.6 (bugfixes only).
| Description?  | Please be specific when describing the PR. <br/> Every detail helps: versions, browser/server configuration, specific module/theme, etc.
| Type?         | bug fix / improvement / new feature
| Category?     | See [the Category list](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message#Howtowriteacommitmessage-Category), i.e.: BO
| BC breaks?    | Does it break backward compatibility? yes/no
| Deprecations? | Does it deprecate an existing feature? yes/no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

If use PHP 7.1 for PrestaShop 1.6.x or PrestaShop 1.7.x we have get this fatal error:

[16-Dec-2016 01:15:47 Europe/Kiev] PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /var/www/classes/db/DbQuery.php:96