### PR TITLE
CO: Type mismatch fix in DB class (DbQuery)

### DIFF
--- a/classes/db/DbQuery.php
+++ b/classes/db/DbQuery.php
@@ -39,7 +39,7 @@ class DbQueryCore
     protected $query = array(
         'type'   => 'SELECT',
         'select' => array(),
-        'from'   => '',
+        'from'   => array(),
         'join'   => array(),
         'where'  => array(),
         'group'  => array(),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | types mismatch fix to avoid php fatal error. bug: php engine puts a website into permanent down w/ 500 code by throwing the fatal error «[] operator not supported for strings in htdocs/classes/db/DbQuery.php:96». fix: declare type of «from» on line 42 as «array». list of tech details included in comment on update                        
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | php & prestashop engine become running ok after update

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

type of «from» on line 42 should probably be declared as «array», otherwise php engine puts a website into permanent down w/ 500 code by throwing the fatal error «[] operator not supported for strings in htdocs/classes/db/DbQuery.php:96»

line 96: $this->query['from'][] = '`'._DB_PREFIX_.$table.'`'.($alias ? ' '.$alias : '')

stack trace
[] operator not supported for strings in htdocs/classes/db/DbQuery.php:96

stack trace:
#0 htdocs/Adapter/Adapter_EntityMapper.php(45): DbQueryCore->from('shop', 'a')
#1 htdocs/classes/ObjectModel.php(233): Adapter_EntityMapper->load('1', NULL, Object(Shop), Array, NULL, true)
#2 htdocs/classes/shop/Shop.php(131): ObjectModelCore->__construct('1', NULL, NULL)
#3 htdocs/classes/shop/Shop.php(397): ShopCore->__construct('1')
#4 htdocs/config/config.inc.php(114): ShopCore::initialize()
#5 htdocs/backoffice/ajax.php(30)

presta — 1.6.1.10, 1.6.1.7
db — mysql 5.7.16-10-log percona server, release 10
php — php-fpm 7.1.0, 7.0.10
php db driver — mysqlnd 5.0.12-dev (api extensions mysqli, pdo_mysql)
os — x86_64 rhel6 (centos 6.8), kernel 2.6.32-642.11.1

you are welcome to request any additional info if needed