### PR TITLE
Fix getImageLink for watermark module

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -762,7 +762,10 @@ class LinkCore
         }
 
         // Check if module is installed, enabled, customer is logged in and watermark logged option is on
-        if ($watermarkLogged && ($moduleManager->isInstalled('watermark') && $moduleManager->isEnabled('watermark')) && isset(Context::getContext()->customer->id)) {
+        if (!empty($type) && $watermarkLogged &&
+            ($moduleManager->isInstalled('watermark') && $moduleManager->isEnabled('watermark')) &&
+            isset(Context::getContext()->customer->id)
+        ) {
             $type .= '-'.$watermarkHash;
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | If watermark module is enable Link::getImageLink doesn't return a valid link for original picture. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Enable watermark,  Link::getImageLink('my-picture', 12) return http://example.com/12--EZEJSDSD/my-picture.jpg instead of http://example.com/12/my-picture.jpg |

cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/6207
