### PR TITLE
Partial refund tax method always tax incl.

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -851,7 +851,7 @@ class AdminOrdersControllerCore extends AdminController
                             $cart_rule->active = 1;
 
                             $cart_rule->reduction_amount = $amount;
-                            $cart_rule->reduction_tax = true;
+                            $cart_rule->reduction_tax = $order->getTaxCalculationMethod() != PS_TAX_EXC;
                             $cart_rule->minimum_amount_currency = $order->id_currency;
                             $cart_rule->reduction_currency = $order->id_currency;
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | When creating a partial refund, the tax calculation method of the created cart rule always includes taxes. In the the order back-end form, the calculation method displayed depends on the order and can be tax exclusive.<br />See: <br />admin/themes/default/template/controllers/orders/_product_line.tpl:193<br />admin/themes/default/template/controllers/orders/helpers/view/view.tpl:903 |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |

When creating a partial refund, the tax calculation method of the created cart rule always includes taxes. In the the order back-end form, the calculation method displayed depends on the order and can be tax exclusive.
See: 
admin/themes/default/template/controllers/orders/_product_line.tpl:193
admin/themes/default/template/controllers/orders/helpers/view/view.tpl:903

cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/5847