### PR TITLE
Fix pack price calc when using non-default attributes

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -92,7 +92,7 @@ class PackCore extends Product
         $items = Pack::getItems($id_product, Configuration::get('PS_LANG_DEFAULT'));
         foreach ($items as $item) {
             /** @var Product $item */
-            $sum += $item->getPrice($price_display_method) * $item->pack_quantity;
+            $sum += $item->getPrice($price_display_method, ($item->id_pack_product_attribute ? $item->id_pack_product_attribute : null)) * $item->pack_quantity;
         }
 
         return $sum;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PrestaShop always applies the prices of the default product attributes when calculating the price of a whole pack. This PR passes the `id_product_attribute` again, so that the price can be calculated from the correct attributes. 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8659
| How to test?  | Create a product pack with 3 products, at least one has to have several attributes. For one product in the pack, make sure it is not the default attribute. 

cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/7036