### PR TITLE
Add "quick_view" block to classic theme

### DIFF
--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -70,13 +70,15 @@
       </ul>
     {/block}
     <div class="highlighted-informations{if !$product.main_variants} no-variants{/if} hidden-sm-down">
-      <a
-        href="#"
-        class="quick-view"
-        data-link-action="quickview"
-      >
-        <i class="material-icons search">&#xE8B6;</i> {l s='Quick view' d='Shop.Theme.Actions'}
-      </a>
+      {block name='quick_view'}
+        <a
+          href="#"
+          class="quick-view"
+          data-link-action="quickview"
+        >
+          <i class="material-icons search">&#xE8B6;</i> {l s='Quick view' d='Shop.Theme.Actions'}
+        </a>
+       {/block}
 
       {block name='product_variants'}
         {if $product.main_variants}

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -78,7 +78,7 @@
         >
           <i class="material-icons search">&#xE8B6;</i> {l s='Quick view' d='Shop.Theme.Actions'}
         </a>
-       {/block}
+      {/block}
 
       {block name='product_variants'}
         {if $product.main_variants}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add the quick_view block to classic theme to let us modify the content easily with a extends of the source template.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to change the source content of this block.