### PR TITLE
Add missing option to bcc multiple addresses in Mail::send()

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -71,8 +71,8 @@ class MailCore extends ObjectModel
      * @param string $template Template: the name of template not be a var but a string !
      * @param string $subject Subject of the email
      * @param string $template_vars Template variables for the email
-     * @param string $to To email
-     * @param string $to_name To name
+     * @param string|array $to To email
+     * @param string|array $to_name To name
      * @param string $from From email
      * @param string $from_name To email
      * @param array $file_attachment Array with three parameters (content, mime and name). You can use an array of array to attach multiple files
@@ -80,7 +80,7 @@ class MailCore extends ObjectModel
      * @param string $template_path Template path
      * @param bool $die Die after error
      * @param int $id_shop Shop ID
-     * @param string $bcc Bcc recipient (email address)
+     * @param string|array $bcc Bcc recipient(s) (email address)
      * @param string $reply_to Email address for setting the Reply-To header
      * @return bool|int Whether sending was successful. If not at all, false, otherwise amount of recipients succeeded.
      */
@@ -201,7 +201,17 @@ class MailCore extends ObjectModel
             $to_name = (($to_name == null || $to_name == $to) ? '' : self::mimeEncode($to_name));
             $message->addTo($to, $to_name);
         }
-        if (isset($bcc)) {
+
+        if (isset($bcc) && is_array($bcc)) {
+            foreach ($bcc as $addr) {
+                $addr = trim($addr);
+                if (!Validate::isEmail($addr)) {
+                    Tools::dieOrLog(Tools::displayError('Error: invalid e-mail address'), $die);
+                    return false;
+                }
+                $message->addBcc($addr);
+            }
+        } elseif (isset($bcc)) {
             $message->addBcc($bcc);
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x.
| Description?  | In commit https://github.com/PrestaShop/PrestaShop/pull/7157/commits/1cd93a88778d45bc0ff9dc23f258abc51b3e76e4 on develop the bcc array handling was added. I believe it's not just a new feature, but it's an actual bugfix, since on line 156 of this file a check is made on the bcc variable being an array, meaning that it is contemplated that it could very well be. Passing an array as `$bcc` (like with `$to` and `$to_name`) does not cause an the function to `dieOrLog`, it causes a `PHP Warning:  Illegal offset type in httpdocs/tools/swift/classes/Swift/Mime/SimpleMessage.php on line 404`. This is an inconsistency that needs to be addressed.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Call Mail::send() passing an array of email addresses as the `$bcc` parameter.
