### PR TITLE
Add impact on price to the product price

### DIFF
--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -681,13 +681,7 @@ function updatePrice()
 	// 0 by default, +x if price is inscreased, -x if price is decreased
 	basePriceWithoutTax = basePriceWithoutTax + +combination.price;
 	basePriceWithTax = basePriceWithTax + +combination.price * (taxRate/100 + 1);
-
-	// If a specific price redefine the combination base price
-	if (combination.specific_price && combination.specific_price.price > 0)
-	{
-		basePriceWithoutTax = +combination.specific_price.price;
-		basePriceWithTax = +combination.specific_price.price * (taxRate/100 + 1);
-	}
+	
 
 	var priceWithDiscountsWithoutTax = basePriceWithoutTax;
 	var priceWithDiscountsWithTax = basePriceWithTax;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |1.6.1.x
| Description?  | When you have a specific price fo a product and its combinations have an impact on price. The displayed price in the FO is not correct (only for default combination)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8631
| How to test?  | Add a specific price to a product and add an impact of price to its combinations. Now, in the FO, when you change combinations the price will change correctly.
