### PR TITLE
Impossible to uninstall module when overridden file is missing

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2915,7 +2915,11 @@ abstract class ModuleCore
             $override_path = _PS_OVERRIDE_DIR_.$path;
         }
 
-        if (!is_file($override_path) || !is_writable($override_path)) {
+        if (!is_file($override_path)) {
+            return true;
+        }
+
+        if (!is_writable($override_path)) {
             return false;
         }
 


### PR DESCRIPTION
When overridden file is missing (already removed) module uninstall fails.
In terms of task "remove overridden code from the file" if file is missing the task is successful and the function should return "true".

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Impossible to uninstall module when overridden file is missing. PS1.7
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Install module with overrides. Delete overridden file. Uninstall.
