### PR TITLE
Calculate carrier price on real order price (1.6.1.x)

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2783,7 +2783,7 @@ class CartCore extends ObjectModel
         }
 
         // Order total in default currency without fees
-        $order_total = $this->getOrderTotal(true, Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING, $product_list);
+        $order_total = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $product_list);
 
         // Start with shipping cost at 0
         $shipping_cost = 0;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Calculate the carrier price with the REAL price customer is gonna pay, so have to use the BOTH_WITHOUT_SHIPPING const. By now the Discount is not use in the calculation. I think it's not the expected functionment
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | For exemple if you have a specific carrier price range for order > 50€ => free shipping. If the customer buy an 60€ item and use a -20% discount, customer gonna pay 48€ AND have the free shipping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7258)
<!-- Reviewable:end -->
