### PR TITLE
Fix missing displayNavFullWidth into checkout

### DIFF
--- a/themes/classic/templates/checkout/_partials/header.tpl
+++ b/themes/classic/templates/checkout/_partials/header.tpl
@@ -70,4 +70,5 @@
       </div>
     </div>
   </div>
+  {hook h='displayNavFullWidth'}
 {/block}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | displayNavFullWidth is missing into checkout process
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | go to the checkout page, module hooked on displayNavFullWidth aren't displayed...

