### PR TITLE
CO: dump file fails with access denied message

### DIFF
--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -251,6 +251,10 @@ class PrestaShopAutoload
         }
         // Ignore for filesystems that do not support umask
         @chmod($tmpFile, 0666);
+        // If the file exists 'rename' can fail with access denied message, remove it first.
+        if (is_file($filename)) {
+            @unlink($filename);
+        }
         rename($tmpFile, $filename);
 
         return true;

--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -254,6 +254,17 @@ class PrestaShopAutoload
         // If the file exists 'rename' can fail with access denied message, remove it first.
         if (is_file($filename)) {
             @unlink($filename);
+            if (is_file($filename)) {
+                // File handler is not immediately released, especially in Windows.
+                // Wait for a while, but not very long.
+                for ($i = 0; $i < 5; $i++) {             
+                    time_nanosleep(0, 100000000); // 0.1 sec
+                    clearstatcache(true, $filename); // essential line, because results of 'is_file' are cached
+                    if (!is_file($filename)) {
+                        break;
+                    }
+                }
+            }
         }
         rename($tmpFile, $filename);
 


### PR DESCRIPTION
If the file exists 'rename' fails with access denied message, remove the file first.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | access denied happened on creating class_index.php
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Happened to me many times in W10, PHP5.4.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7262)
<!-- Reviewable:end -->
