### PR TITLE
Fix module uninstall when overridden file is missing

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2911,7 +2911,11 @@ abstract class ModuleCore
             $override_path = _PS_OVERRIDE_DIR_.$path;
         }
 
-        if (!is_file($override_path) || !is_writable($override_path)) {
+        if (!is_file($override_path)) {
+            return true;
+        }
+
+        if (!is_writable($override_path)) {
             return false;
         }
 


### PR DESCRIPTION
When overridden file is missing (already removed) uninstall fails.
In terms of task "remove overridden code from the file" if file is missing the task is successful and the function should return "true".

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Impossible to uninstall module when overridden file is missing. PS1.7
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Install module with overrides. Delete overridden file. Uninstall.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
