### PR TITLE
FO: Add missing variable to order_customer_comment email

### DIFF
--- a/mails/en/order_customer_comment.html
+++ b/mails/en/order_customer_comment.html
@@ -89,6 +89,7 @@
 						<span style="color:#777">
 							You have received a new message regarding order with the reference <span style="color:#333"><strong>{order_name}</strong></span>.<br /><br />
 							<span style="color:#333"><strong>Customer:</strong></span> {firstname} {lastname} ({email})<br /><br />
+							<span style="color:#333"><strong>Product:</strong></span> {product_name}<br /><br />
 							{message}
 						</span>
 					</font>

--- a/mails/en/order_customer_comment.txt
+++ b/mails/en/order_customer_comment.txt
@@ -8,6 +8,8 @@ You have received a new message regarding order with the reference
 
 CUSTOMER: {firstname} {lastname} ({email})
 
+PRODUCT: {product_name}
+
 {message} 		 
 
 {shop_name} [{shop_url}] powered by


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When sending a comment the user can select a product as well. The product name is sent to the template [here](https://github.com/PrestaShop/PrestaShop/blob/1ea276bca8287641876e998528ae5b1ccd478d58/controllers/front/OrderDetailController.php#L111-L120) but is never used. We're often unable to understand what the customer is talking about as a result.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | In FO go to order history and add a message as customer - select a product in the form. The administrator of the shop will not see the product name without this fix.
