### PR TITLE
Fix installer in Canadian and catalog cache

### DIFF
--- a/install-dev/controllers/http/welcome.php
+++ b/install-dev/controllers/http/welcome.php
@@ -78,16 +78,7 @@ class InstallControllerHttpWelcome extends InstallControllerHttp implements Http
 
     private function clearCache()
     {
-        try {
-            $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-            $sf2Refresh->addCacheClear();
-            $sf2Refresh->execute();
-        } catch (\Exception $exception) {
-            $finder = new \Symfony\Component\Finder\Finder;
-            $fs = new \Symfony\Component\Filesystem\Filesystem();
-            foreach ($finder->in(_PS_ROOT_DIR_.'/app/cache') as $file) {
-                $fs->remove($file->getFilename());
-            }
-        }
+        $fs = new \Symfony\Component\Filesystem\Filesystem();
+        $fs->remove(_PS_ROOT_DIR_ . '/app/cache/' . (_PS_MODE_DEV_ ? 'dev' : 'prod'));
     }
 }

--- a/install-dev/controllers/http/welcome.php
+++ b/install-dev/controllers/http/welcome.php
@@ -50,8 +50,10 @@ class InstallControllerHttpWelcome extends InstallControllerHttp implements Http
             $this->redirect('welcome');
         }
 
-        $locale = $this->language->getLanguage($this->session->lang)->locale;
-        if (!empty($this->session->lang) && !is_file(_PS_ROOT_DIR_.'/app/Resources/translations/'.$locale.'/Install.'.$locale.'.xlf')) {
+        $cldrRepository = \Tools::getCldr(null, $this->language->getLanguage($this->session->lang)->locale);
+        $cldrLocale = $cldrRepository->getCulture();
+
+        if (!empty($this->session->lang) && !is_file(_PS_ROOT_DIR_.'/app/Resources/translations/'.$cldrLocale.'/Install.'.$cldrLocale.'.xlf')) {
             Language::downloadAndInstallLanguagePack($this->session->lang, _PS_VERSION_, null, false);
             $this->clearCache();
             $this->redirect('welcome');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | On the first step of installer, when we change for French Canadian it was causing a white screen. Also, the language detected by the browser was not applied.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2094
| How to test?  | Try on a fresh install