### PR TITLE
Module action template can now be used everywhere

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module_card.js
+++ b/admin-dev/themes/default/js/bundle/module/module_card.js
@@ -13,15 +13,15 @@ $(document).ready(function () {
  */
 var AdminModuleCard = function () {
     /* Selectors for module action links (uninstall, reset, etc...) to add a confirm popin */
-    this.moduleActionMenuLinkSelector = 'a.module_action_menu_';
-    this.moduleActionMenuInstallLinkSelector = 'a.module_action_menu_install';
-    this.moduleActionMenuEnableLinkSelector = 'a.module_action_menu_enable';
-    this.moduleActionMenuUninstallLinkSelector = 'a.module_action_menu_uninstall';
-    this.moduleActionMenuDisableLinkSelector = 'a.module_action_menu_disable';
-    this.moduleActionMenuEnableMobileLinkSelector = 'a.module_action_menu_enable_mobile';
-    this.moduleActionMenuDisableMobileLinkSelector = 'a.module_action_menu_disable_mobile';
-    this.moduleActionMenuResetLinkSelector = 'a.module_action_menu_reset';
-    this.moduleActionMenuUpdateLinkSelector = 'a.module_action_menu_upgrade';
+    this.moduleActionMenuLinkSelector = 'button.module_action_menu_';
+    this.moduleActionMenuInstallLinkSelector = 'button.module_action_menu_install';
+    this.moduleActionMenuEnableLinkSelector = 'button.module_action_menu_enable';
+    this.moduleActionMenuUninstallLinkSelector = 'button.module_action_menu_uninstall';
+    this.moduleActionMenuDisableLinkSelector = 'button.module_action_menu_disable';
+    this.moduleActionMenuEnableMobileLinkSelector = 'button.module_action_menu_enable_mobile';
+    this.moduleActionMenuDisableMobileLinkSelector = 'button.module_action_menu_disable_mobile';
+    this.moduleActionMenuResetLinkSelector = 'button.module_action_menu_reset';
+    this.moduleActionMenuUpdateLinkSelector = 'button.module_action_menu_upgrade';
     this.moduleItemListSelector = '.module-item-list';
     this.moduleItemGridSelector = '.module-item-grid';
 
@@ -116,9 +116,10 @@ var AdminModuleCard = function () {
 
     this.requestToController = function (action, element, forceDeletion) {
         var _this = this;
-        var jqElementObj = element.closest(".btn-group");
+        var jqElementObj = element.closest("div.btn-group");
+        var form = element.closest("form");
         var spinnerObj = $("<button class=\"btn-primary-reverse onclick unbind pull-right\"></button>");
-        var url = "//" + window.location.host + element.attr("href");
+        var url = "//" + window.location.host + form.attr("action");
 
         if (forceDeletion === "true" || forceDeletion === true) {
           url +="&deletion=true";

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1970,8 +1970,8 @@ var tags = (function() {
 var recommendedModules = (function() {
   return {
     'init': function() {
-      this.moduleActionMenuLinkSelectors = 'a.module_action_menu_install, a.module_action_menu_enable, ' +
-        'a.module_action_menu_uninstall, a.module_action_menu_disable, a.module_action_menu_reset, a.module_action_menu_update';
+      this.moduleActionMenuLinkSelectors = 'button.module_action_menu_install, button.module_action_menu_enable, ' +
+        'button.module_action_menu_uninstall, button.module_action_menu_disable, button.module_action_menu_reset, button.module_action_menu_update';
       $(this.moduleActionMenuLinkSelectors).on('module_card_action_event', this.saveProduct);
     },
     'saveProduct': function(event, action) {

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -33,12 +33,20 @@
 
 <div class="pull-right btn-group">
   {% if url_active == 'buy' %}
-    <a class="btn pull-left btn-primary-reverse btn-primary-outline light-button module_action_menu_go_to_addons" href="{{ url }}" target="_blank">
+    <a class="btn pull-left btn-primary btn-primary-reverse btn-primary-outline light-button module_action_menu_go_to_addons" href="{{ url }}" target="_blank">
       {% if priceRaw != '0.00' %}{{ priceDisplay }}
       {% else %}{{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}{% endif %}
     </a>
   {% else %}
-    <a class="btn btn-primary-reverse btn-primary-outline light-button module_action_menu_{{ url_active }}" href="{{ urls[url_active] }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">{{ url_active|capitalize|replace({'_': " "}) }}</a>
+    <form class="btn-group" method="post" action="{{ urls[url_active] }}">
+        <button type="submit" class="btn btn-primary-reverse btn-primary-outline light-button module_action_menu_{{ url_active }}" 
+           data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">
+            {{ url_active|capitalize|replace({'_': " "}) }}
+        </button>
+        {% if urls|length > 1 %}
+        <input type="hidden" class="btn">
+        {% endif %}
+    </form>
     {% if urls|length > 1 %}
       <button type="button" class="btn btn-primary-outline  dropdown-toggle light-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span class="caret"></span>
@@ -48,7 +56,11 @@
         {% for module_action, module_url in urls %}
           {% if module_action != url_active %}
             <li>
-              <a class="dropdown-item module_action_menu_{{ module_action }}" href="{{ module_url }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">{{module_action|capitalize|replace({'_': " "})}}</a>
+                <form method="post" action="{{ module_url }}">
+                    <button type="button" class="dropdown-item module_action_menu_{{ module_action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">
+                        {{module_action|capitalize|replace({'_': " "})}}
+                    </button>
+                </form>
             </li>
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The template displaying a module list now works everywhere. Actions are natively sent with POST and do not require any javascript by default.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Try to install a module via the "Recommanded modules & services" modal.