### PR TITLE
Use the right wording when guest is disabled

### DIFF
--- a/themes/classic/templates/checkout/_partials/steps/personal-information.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/personal-information.tpl
@@ -33,7 +33,11 @@
     <ul class="nav nav-inline m-y-2">
       <li class="nav-item">
         <a class="nav-link {if !$show_login_form}active{/if}" data-toggle="tab" href="#checkout-guest-form" role="tab">
-          {l s='Order as a guest' d='Shop.Theme.Checkout'}
+          {if $guest_allowed}
+            {l s='Order as a guest' d='Shop.Theme.Checkout'}
+          {else}
+            {l s='Create an account' d='Shop.Theme.CustomerAccount'}
+          {/if}
         </a>
       </li>
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Use the right wording when guest is disabled on the checkout. No need to report on `StarterTheme`.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2119
| How to test?  |