### PR TITLE
Fix log page email hint

### DIFF
--- a/controllers/admin/AdminLogsController.php
+++ b/controllers/admin/AdminLogsController.php
@@ -36,7 +36,7 @@ class AdminLogsControllerCore extends AdminController
         $this->className = 'PrestaShopLogger';
         $this->lang = false;
         $this->noLink = true;
-        
+
         parent::__construct();
 
         $this->fields_list = array(
@@ -88,13 +88,13 @@ class AdminLogsControllerCore extends AdminController
                 'fields' =>    array(
                     'PS_LOGS_BY_EMAIL' => array(
                         'title' => $this->l('Minimum severity level'),
-                        'hint' => $this->l('Enter "5" if you do not want to receive any emails.').'<br />'.$this->l('Emails will be sent to the shop owner.'),
+                        'hint' => Tools::safeOutput($this->l('Enter "5" if you do not want to receive any emails.').'<br />'.$this->l('Emails will be sent to the shop owner.'), true),
                         'cast' => 'intval',
-                        'type' => 'text'
-                    )
+                        'type' => 'text',
+                    ),
                 ),
-                'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions'))
-            )
+                'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions')),
+            ),
         );
         $this->list_no_link = true;
         $this->_select .= 'CONCAT(LEFT(e.firstname, 1), \'. \', e.lastname) employee';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | The log page tooltip text should go through Tools::safeOutput
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2120
| How to test?  |