### PR TITLE
Fix category names translations on product page category tree

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -25,6 +25,7 @@
  */
 namespace PrestaShopBundle\Form\Admin\Product;
 
+use Context;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvents;
@@ -71,8 +72,8 @@ class ProductInformation extends CommonAbstractType
         $this->manufacturerDataProvider = $manufacturerDataProvider;
         $this->configuration = new Configuration();
 
-        $this->categories = $this->formatDataChoicesList($this->categoryDataProvider->getAllCategoriesName(), 'id_category');
-        $this->nested_categories = $this->categoryDataProvider->getNestedCategories();
+        $this->categories = $this->formatDataChoicesList($this->categoryDataProvider->getAllCategoriesName(null, Context::getContext()->language->id), 'id_category');
+        $this->nested_categories = $this->categoryDataProvider->getNestedCategories(null, Context::getContext()->language->id);
         $this->productAdapter = $this->productDataProvider;
         $this->locales = $this->context->getLanguages();
         $this->currency = $this->context->getContext()->currency;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | The category names in the category tree on the product page should be translated
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2104
| How to test?  |