### PR TITLE
Bug Fix BO : AdminStockMvtController.php export csv url 

### DIFF
--- a/controllers/admin/AdminStockMvtController.php
+++ b/controllers/admin/AdminStockMvtController.php
@@ -264,7 +264,7 @@ class AdminStockMvtControllerCore extends AdminController
         if (Tools::isSubmit('id_warehouse') && (int)Tools::getValue('id_warehouse') != -1) {
             $this->toolbar_btn['export-stock-mvt-csv'] = array(
                 'short' => 'Export this list as CSV',
-                'href' => $this->context->link->getAdminLink('AdminStockMvt').'&amp;csv&amp;id_warehouse='.(int)$this->getCurrentWarehouseId(),
+                'href' => $this->context->link->getAdminLink('AdminStockMvt').'&csv&id_warehouse='.(int)$this->getCurrentWarehouseId(),
                 'desc' => $this->l('Export (CSV)'),
                 'imgclass' => 'export'
             );


### PR DESCRIPTION
**Type :** Bug Fix
**Category :** BO
**Description:** 
Inside the page : Stock > Mouvements, the export link on the top right of the list is broken
Replace "&amp;" by "&" to have a correct export link . 
Tested with Firefox and Chrome