### PR TITLE
Fixed processChangeProductInCart method

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -276,6 +276,15 @@ class CartControllerCore extends FrontController
             return;
         }
 
+        if (!$this->id_product_attribute && $product->hasAttributes()) {
+            $minimum_quantity = ($product->out_of_stock == 2) ? !Configuration::get('PS_ORDER_OUT_OF_STOCK') : !$product->out_of_stock;
+            $this->id_product_attribute = Product::getDefaultAttribute($product->id, $minimum_quantity);
+            // @todo do something better than a redirect admin !!
+            if (!$this->id_product_attribute) {
+                Tools::redirectAdmin($this->context->link->getProductLink($product));
+            }
+        }
+        
         $qty_to_check = $this->qty;
         $cart_products = $this->context->cart->getProducts();
 
@@ -298,15 +307,6 @@ class CartControllerCore extends FrontController
         // Check product quantity availability
         if ($this->id_product_attribute) {
             if (!Product::isAvailableWhenOutOfStock($product->out_of_stock) && !Attribute::checkAttributeQty($this->id_product_attribute, $qty_to_check)) {
-                $this->errors[] = $this->trans('There are not enough products in stock', array(), 'Shop.Notifications.Error');
-            }
-        } elseif ($product->hasAttributes()) {
-            $minimumQuantity = ($product->out_of_stock == 2) ? !Configuration::get('PS_ORDER_OUT_OF_STOCK') : !$product->out_of_stock;
-            $this->id_product_attribute = Product::getDefaultAttribute($product->id, $minimumQuantity);
-            // @todo do something better than a redirect admin !!
-            if (!$this->id_product_attribute) {
-                Tools::redirectAdmin($this->context->link->getProductLink($product));
-            } elseif (!Product::isAvailableWhenOutOfStock($product->out_of_stock) && !Attribute::checkAttributeQty($this->id_product_attribute, $qty_to_check)) {
                 $this->errors[] = $this->trans('There are not enough products in stock', array(), 'Shop.Notifications.Error');
             }
         } elseif (!$product->checkQty($qty_to_check)) {


### PR DESCRIPTION
Changed processChangeProductInCart method and moved the code that verifies product attribute ID upper in the function. This prevents redundant code to be executed and removed the duplicated code.
The error situation almost never happens, only if the product does not have the default attribute set.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Core modification
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | The error situation almost never happens, only if the product does not have the default attribute set.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
