### PR TITLE
Add missing open-sans dependency prevents webpack error

### DIFF
--- a/themes/classic/_dev/package.json
+++ b/themes/classic/_dev/package.json
@@ -23,6 +23,7 @@
     "material-design-icons": "^2.1.3",
     "node-sass": "^3.4.2",
     "notosans-fontface": "~1.0.1",
+    "open-sans-fontface": "^1.4.0",
     "postcss-flexibility": "^1.0.2",
     "postcss-loader": "^0.8.0",
     "sass-loader": "^3.1.2",


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | missing open-sass node dependency, as font is loaded via ~ this caused error while compilation, note: entire package.json is missing from production PrestaShop package for some reason
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | try to compile classic theme assets without having open-sass-fontface as a global dependency

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->