### PR TITLE
Protect translated strings from XSS

### DIFF
--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -39,14 +39,19 @@ trait PrestaShopTranslatorTrait
         }
 
         if (isset($parameters['legacy'])) {
-            $id = call_user_func($parameters['legacy'], $id);
+            $legacy = $parameters['legacy'];
             unset($parameters['legacy']);
         }
 
+        $translated = parent::trans($id, array(), $domain, $locale);
+        if (isset($legacy)) {
+            $translated = call_user_func($legacy, $translated);
+        }
+
         if (!empty($parameters) && $this->isSprintfString($id)) {
-            $translated = vsprintf(parent::trans($id, array(), $domain, $locale), $parameters);
-        } else {
-            $translated = parent::trans($id, $parameters, $domain, $locale);
+            $translated = vsprintf($translated, $parameters);
+        } elseif (!empty($parameters)) {
+            $translated = strtr($translated, $parameters);
         }
 
         return $translated;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | We need to protect translated strings **BEFORE** using `sprintf()` when they are using the legacy system. Also, we don't let Symfony handle the parameters replacement, because we want to protect the strings from XSS. So, we send an empty parameters array and we replace them after.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |