### PR TITLE
Introduce new hooks filtered & use it for product/category/brand/supplier/cms & html content

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -737,7 +737,7 @@ class HookCore extends ObjectModel
                 }
 
                 if (0 !== $key && true === $chain) {
-                    $hook_args['filtered_content'] = $output;
+                    $hook_args = $output;
                 }
 
                 // Call hook method
@@ -762,7 +762,7 @@ class HookCore extends ObjectModel
                 if ($moduleInstance instanceof WidgetInterface) {
 
                     if (0 !== $key && true === $chain) {
-                        $hook_args['filtered_content'] = $output;
+                        $hook_args = $output;
                     }
 
                     $display = Hook::coreRenderWidget($moduleInstance, $hook_name, $hook_args);
@@ -783,6 +783,15 @@ class HookCore extends ObjectModel
         if ($different_shop) {
             $context->shop = $old_shop;
             $context->shop->setContext($old_context, $shop->id);
+        }
+
+        if (true === $chain) {
+            if (isset($output['cookie'])) {
+                unset($output['cookie']);
+            }
+            if (isset($output['cart'])) {
+                unset($output['cart']);
+            }
         }
 
         return $output;

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -157,6 +157,9 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     /** @var Db An instance of the db in order to avoid calling Db::getInstance() thousands of times. */
     protected static $db = false;
 
+    /** @var array|null List of HTML field (based on self::TYPE_HTML)  */
+    public static $htmlFields = null;
+
     /** @var bool Enables to define an ID before adding object. */
     public $force_id = false;
 
@@ -1989,5 +1992,30 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     public static function disableCache()
     {
         ObjectModel::$cache_objects = false;
+    }
+
+    /**
+     * Return HtmlFields for object
+     */
+    public function getHtmlFields()
+    {
+        if (!empty($this->def) && is_array($this->def) && array_key_exists('table', $this->def)) {
+
+            if (isset(self::$htmlFields[$this->def['table']])) {
+                return self::$htmlFields[$this->def['table']];
+            }
+
+            self::$htmlFields[$this->def['table']] = array();
+
+            if (array_key_exists('fields', $this->def)) {
+                foreach ($this->def['fields'] as $name => $field) {
+                    if (is_array($field) && array_key_exists('type', $field) && self::TYPE_HTML === $field['type']) {
+                        self::$htmlFields[$this->def['table']][] = $name;
+                    }
+                }
+            }
+
+            return self::$htmlFields[$this->def['table']];
+        }
     }
 }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1999,23 +1999,25 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
      */
     public function getHtmlFields()
     {
-        if (!empty($this->def) && is_array($this->def) && array_key_exists('table', $this->def)) {
+        $isDefinitionValid = !empty($this->def) && is_array($this->def) && array_key_exists('table', $this->def);
+        if (!$isDefinitionValid) {
+            return false;
+        }
 
-            if (isset(self::$htmlFields[$this->def['table']])) {
-                return self::$htmlFields[$this->def['table']];
-            }
-
-            self::$htmlFields[$this->def['table']] = array();
-
-            if (array_key_exists('fields', $this->def)) {
-                foreach ($this->def['fields'] as $name => $field) {
-                    if (is_array($field) && array_key_exists('type', $field) && self::TYPE_HTML === $field['type']) {
-                        self::$htmlFields[$this->def['table']][] = $name;
-                    }
-                }
-            }
-
+        if (isset(self::$htmlFields[$this->def['table']])) {
             return self::$htmlFields[$this->def['table']];
         }
+
+        self::$htmlFields[$this->def['table']] = array();
+
+        if (array_key_exists('fields', $this->def)) {
+            foreach ($this->def['fields'] as $name => $field) {
+                if (is_array($field) && array_key_exists('type', $field) && self::TYPE_HTML === $field['type']) {
+                    self::$htmlFields[$this->def['table']][] = $name;
+                }
+            }
+        }
+
+        return self::$htmlFields[$this->def['table']];
     }
 }

--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -94,7 +94,7 @@ class CmsControllerCore extends FrontController
 
             $cmsVar = $this->objectPresenter->present($this->cms);
 
-            $cmsVar['content'] = Hook::exec(
+            $filteredCmsContent = Hook::exec(
                 'filteredCmsContent',
                 array('filtered_content' => $cmsVar['content']),
                 $id_module = null,
@@ -104,6 +104,9 @@ class CmsControllerCore extends FrontController
                 $id_shop = null,
                 $chain = true
             );
+            if (!empty($filteredCmsContent)) {
+                $cmsVar['content'] = $filteredCmsContent;
+            }
 
             $this->context->smarty->assign(array(
                 'cms' => $cmsVar,
@@ -121,7 +124,7 @@ class CmsControllerCore extends FrontController
 
             $cmsCategoryVar = $this->getTemplateVarCategoryCms();
 
-            $cmsCategoryVar['cms_category']['description'] = Hook::exec(
+            $filteredCmsCategoryContent = Hook::exec(
                 'filteredCmsCategoryContent',
                 array('filtered_content' => $cmsCategoryVar['cms_category']['description']),
                 $id_module = null,
@@ -131,6 +134,9 @@ class CmsControllerCore extends FrontController
                 $id_shop = null,
                 $chain = true
             );
+            if (!empty($filteredCmsCategoryContent)) {
+                $cmsCategoryVar['cms_category']['description'] = $filteredCmsCategoryContent;
+            }
 
             $this->context->smarty->assign($cmsCategoryVar);
             $this->setTemplate('cms/category');

--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -96,7 +96,7 @@ class CmsControllerCore extends FrontController
 
             $filteredCmsContent = Hook::exec(
                 'filteredCmsContent',
-                array('filtered_content' => $cmsVar['content']),
+                array('object' => $cmsVar),
                 $id_module = null,
                 $array_return = false,
                 $check_exceptions = true,
@@ -104,8 +104,8 @@ class CmsControllerCore extends FrontController
                 $id_shop = null,
                 $chain = true
             );
-            if (!empty($filteredCmsContent)) {
-                $cmsVar['content'] = $filteredCmsContent;
+            if (!empty($filteredCmsContent['object'])) {
+                $cmsVar = $filteredCmsContent['object'];
             }
 
             $this->context->smarty->assign(array(
@@ -126,7 +126,7 @@ class CmsControllerCore extends FrontController
 
             $filteredCmsCategoryContent = Hook::exec(
                 'filteredCmsCategoryContent',
-                array('filtered_content' => $cmsCategoryVar['cms_category']['description']),
+                array('object' => $cmsCategoryVar),
                 $id_module = null,
                 $array_return = false,
                 $check_exceptions = true,
@@ -134,8 +134,8 @@ class CmsControllerCore extends FrontController
                 $id_shop = null,
                 $chain = true
             );
-            if (!empty($filteredCmsCategoryContent)) {
-                $cmsCategoryVar['cms_category']['description'] = $filteredCmsCategoryContent;
+            if (!empty($filteredCmsCategoryContent['object'])) {
+                $cmsCategoryVar = $filteredCmsCategoryContent['object'];
             }
 
             $this->context->smarty->assign($cmsCategoryVar);

--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -91,8 +91,22 @@ class CmsControllerCore extends FrontController
         parent::initContent();
 
         if ($this->assignCase == 1) {
+
+            $cmsVar = $this->objectPresenter->present($this->cms);
+
+            $cmsVar['content'] = Hook::exec(
+                'filteredCmsContent',
+                array('filtered_content' => $cmsVar['content']),
+                $id_module = null,
+                $array_return = false,
+                $check_exceptions = true,
+                $use_push = false,
+                $id_shop = null,
+                $chain = true
+            );
+
             $this->context->smarty->assign(array(
-                'cms' => $this->objectPresenter->present($this->cms),
+                'cms' => $cmsVar,
             ));
 
             if ($this->cms->indexation == 0) {
@@ -104,7 +118,21 @@ class CmsControllerCore extends FrontController
                 array('entity' => 'cms', 'id' => $this->cms->id)
             );
         } elseif ($this->assignCase == 2) {
-            $this->context->smarty->assign($this->getTemplateVarCategoryCms());
+
+            $cmsCategoryVar = $this->getTemplateVarCategoryCms();
+
+            $cmsCategoryVar['cms_category']['description'] = Hook::exec(
+                'filteredCmsCategoryContent',
+                array('filtered_content' => $cmsCategoryVar['cms_category']['description']),
+                $id_module = null,
+                $array_return = false,
+                $check_exceptions = true,
+                $use_push = false,
+                $id_shop = null,
+                $chain = true
+            );
+
+            $this->context->smarty->assign($cmsCategoryVar);
             $this->setTemplate('cms/category');
         }
     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -306,9 +306,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
             $product_for_template = $this->getTemplateVarProduct();
 
-            $filteredDescription = Hook::exec(
+            $filteredProduct = Hook::exec(
                 'filteredProductContent',
-                array('filtered_content' => $product_for_template['description']),
+                array('object' => $product_for_template),
                 $id_module = null,
                 $array_return = false,
                 $check_exceptions = true,
@@ -316,22 +316,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $id_shop = null,
                 $chain = true
             );
-            if (!empty($filteredDescription)) {
-                $product_for_template['description'] = $filteredDescription;
-            }
-
-            $filteredDescriptionShort = Hook::exec(
-                'filteredProductContent',
-                array('filtered_content' => $product_for_template['description_short']),
-                $id_module = null,
-                $array_return = false,
-                $check_exceptions = true,
-                $use_push = false,
-                $id_shop = null,
-                $chain = true
-            );
-            if (!empty($filteredDescriptionShort)) {
-                $product_for_template['description_short'] = $filteredDescriptionShort;
+            if (!empty($filteredProduct['object'])) {
+                $product_for_template = $filteredProduct['object'];
             }
 
             $productManufacturer = new Manufacturer((int) $this->product->id_manufacturer, $this->context->language->id);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -305,6 +305,35 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             }
 
             $product_for_template = $this->getTemplateVarProduct();
+
+            $filteredDescription = Hook::exec(
+                'filteredProductContent',
+                array('filtered_content' => $product_for_template['description']),
+                $id_module = null,
+                $array_return = false,
+                $check_exceptions = true,
+                $use_push = false,
+                $id_shop = null,
+                $chain = true
+            );
+            if (!empty($filteredDescription)) {
+                $product_for_template['description'] = $filteredDescription;
+            }
+
+            $filteredDescriptionShort = Hook::exec(
+                'filteredProductContent',
+                array('filtered_content' => $product_for_template['description_short']),
+                $id_module = null,
+                $array_return = false,
+                $check_exceptions = true,
+                $use_push = false,
+                $id_shop = null,
+                $chain = true
+            );
+            if (!empty($filteredDescriptionShort)) {
+                $product_for_template['description_short'] = $filteredDescriptionShort;
+            }
+
             $productManufacturer = new Manufacturer((int) $this->product->id_manufacturer, $this->context->language->id);
 
             $manufacturerImageUrl = $this->context->link->getManufacturerImageLink($productManufacturer->id);

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -80,9 +80,9 @@ class CategoryControllerCore extends ProductListingFrontController
 
         $categoryVar = $this->getTemplateVarCategory();
 
-        $filteredDescription = Hook::exec(
+        $filteredCategory= Hook::exec(
             'filteredCategoryContent',
-            array('filtered_content' => $categoryVar['description']),
+            array('object' => $categoryVar),
             $id_module = null,
             $array_return = false,
             $check_exceptions = true,
@@ -90,8 +90,8 @@ class CategoryControllerCore extends ProductListingFrontController
             $id_shop = null,
             $chain = true
         );
-        if (!empty($filteredDescription)) {
-            $categoryVar['description'] = $filteredDescription;
+        if (!empty($filteredCategory['object'])) {
+            $categoryVar = $filteredCategory['object'];
         }
 
         $this->context->smarty->assign(array(

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -78,8 +78,24 @@ class CategoryControllerCore extends ProductListingFrontController
             return;
         }
 
+        $categoryVar = $this->getTemplateVarCategory();
+
+        $filteredDescription = Hook::exec(
+            'filteredCategoryContent',
+            array('filtered_content' => $categoryVar['description']),
+            $id_module = null,
+            $array_return = false,
+            $check_exceptions = true,
+            $use_push = false,
+            $id_shop = null,
+            $chain = true
+        );
+        if (!empty($filteredDescription)) {
+            $categoryVar['description'] = $filteredDescription;
+        }
+
         $this->context->smarty->assign(array(
-            'category' => $this->getTemplateVarCategory(),
+            'category' => $categoryVar,
             'subcategories' => $this->getTemplateVarSubCategories(),
         ));
 

--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -120,8 +120,24 @@ class ManufacturerControllerCore extends ProductListingFrontController
      */
     protected function assignManufacturer()
     {
+        $manufacturerVar = $this->objectPresenter->present($this->manufacturer);
+
+        $filteredManufacturer = Hook::exec(
+            'filteredManufacturerContent',
+            array('filtered_content' => $manufacturerVar['description']),
+            $id_module = null,
+            $array_return = false,
+            $check_exceptions = true,
+            $use_push = false,
+            $id_shop = null,
+            $chain = true
+        );
+        if (!empty($filteredManufacturer)) {
+            $manufacturerVar['description'] = $filteredManufacturer;
+        }
+
         $this->context->smarty->assign(array(
-            'manufacturer' => $this->objectPresenter->present($this->manufacturer),
+            'manufacturer' => $manufacturerVar,
         ));
     }
 
@@ -130,8 +146,28 @@ class ManufacturerControllerCore extends ProductListingFrontController
      */
     protected function assignAll()
     {
+        $manufacturersVar = $this->getTemplateVarManufacturers();
+
+        if (!empty($manufacturersVar)) {
+            foreach ($manufacturersVar as $k => $manufacturer) {
+                $filteredManufacturer = Hook::exec(
+                    'filteredManufacturerContent',
+                    array('filtered_content' => $manufacturer['text']),
+                    $id_module = null,
+                    $array_return = false,
+                    $check_exceptions = true,
+                    $use_push = false,
+                    $id_shop = null,
+                    $chain = true
+                );
+                if (!empty($filteredManufacturer)) {
+                    $manufacturersVar[$k]['text'] = $filteredManufacturer;
+                }
+            }
+        }
+
         $this->context->smarty->assign(array(
-            'brands' => $this->getTemplateVarManufacturers(),
+            'brands' => $manufacturersVar,
         ));
     }
 

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -125,7 +125,7 @@ class SupplierControllerCore extends ProductListingFrontController
 
         $filteredSupplier = Hook::exec(
             'filteredSupplierContent',
-            array('filtered_content' => $supplierVar['description']),
+            array('object' => $supplierVar),
             $id_module = null,
             $array_return = false,
             $check_exceptions = true,
@@ -133,8 +133,8 @@ class SupplierControllerCore extends ProductListingFrontController
             $id_shop = null,
             $chain = true
         );
-        if (!empty($filteredSupplier)) {
-            $supplierVar['description'] = $filteredSupplier;
+        if (!empty($filteredSupplier['object'])) {
+            $supplierVar = $filteredSupplier['object'];
         }
 
         $this->context->smarty->assign(array(
@@ -153,7 +153,7 @@ class SupplierControllerCore extends ProductListingFrontController
             foreach ($suppliersVar as $k => $supplier) {
                 $filteredSupplier = Hook::exec(
                     'filteredSupplierContent',
-                    array('filtered_content' => $supplier['text']),
+                    array('object' => $supplier),
                     $id_module = null,
                     $array_return = false,
                     $check_exceptions = true,
@@ -161,8 +161,8 @@ class SupplierControllerCore extends ProductListingFrontController
                     $id_shop = null,
                     $chain = true
                 );
-                if (!empty($filteredSupplier)) {
-                    $suppliersVar[$k]['text'] = $filteredSupplier;
+                if (!empty($filteredSupplier['object'])) {
+                    $suppliersVar[$k] = $filteredSupplier['object'];
                 }
             }
         }

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -121,8 +121,24 @@ class SupplierControllerCore extends ProductListingFrontController
      */
     protected function assignSupplier()
     {
+        $supplierVar = $this->objectPresenter->present($this->supplier);
+
+        $filteredSupplier = Hook::exec(
+            'filteredSupplierContent',
+            array('filtered_content' => $supplierVar['description']),
+            $id_module = null,
+            $array_return = false,
+            $check_exceptions = true,
+            $use_push = false,
+            $id_shop = null,
+            $chain = true
+        );
+        if (!empty($filteredSupplier)) {
+            $supplierVar['description'] = $filteredSupplier;
+        }
+
         $this->context->smarty->assign(array(
-            'supplier' => $this->objectPresenter->present($this->supplier),
+            'supplier' => $supplierVar,
         ));
     }
 
@@ -131,8 +147,28 @@ class SupplierControllerCore extends ProductListingFrontController
      */
     protected function assignAll()
     {
+        $suppliersVar = $this->getTemplateVarSuppliers();
+
+        if (!empty($suppliersVar)) {
+            foreach ($suppliersVar as $k => $supplier) {
+                $filteredSupplier = Hook::exec(
+                    'filteredSupplierContent',
+                    array('filtered_content' => $supplier['text']),
+                    $id_module = null,
+                    $array_return = false,
+                    $check_exceptions = true,
+                    $use_push = false,
+                    $id_shop = null,
+                    $chain = true
+                );
+                if (!empty($filteredSupplier)) {
+                    $suppliersVar[$k]['text'] = $filteredSupplier;
+                }
+            }
+        }
+
         $this->context->smarty->assign(array(
-            'brands' => $this->getTemplateVarSuppliers(),
+            'brands' => $suppliersVar,
         ));
     }
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -581,5 +581,15 @@
       <title>Filter the content page category</title>
       <description>This hook is called just before fetching content page category.</description>
     </hook>
+    <hook id="filteredManufacturerContent">
+      <name>filteredManufacturerContent</name>
+      <title>Filter the content page manufacturer</title>
+      <description>This hook is called just before fetching content page manufacturer.</description>
+    </hook>
+    <hook id="filteredSupplierContent">
+      <name>filteredSupplierContent</name>
+      <title>Filter the content page supplier</title>
+      <description>This hook is called just before fetching content page supplier.</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -7,337 +7,569 @@
   </fields>
   <entities>
     <hook id="actionValidateOrder">
-      <name>actionValidateOrder</name><title>New orders</title><description/>
+      <name>actionValidateOrder</name>
+      <title>New orders</title>
+      <description/>
     </hook>
     <hook id="displayMaintenance">
-      <name>displayMaintenance</name><title>Maintenance Page</title><description>This hook displays new elements on the maintenance page</description>
+      <name>displayMaintenance</name>
+      <title>Maintenance Page</title>
+      <description>This hook displays new elements on the maintenance page</description>
     </hook>
     <hook id="actionPaymentConfirmation">
-      <name>actionPaymentConfirmation</name><title>Payment confirmation</title><description>This hook displays new elements after the payment is validated</description>
+      <name>actionPaymentConfirmation</name>
+      <title>Payment confirmation</title>
+      <description>This hook displays new elements after the payment is validated</description>
     </hook>
     <hook id="displayPaymentReturn">
-      <name>displayPaymentReturn</name><title>Payment return</title><description/>
+      <name>displayPaymentReturn</name>
+      <title>Payment return</title>
+      <description/>
     </hook>
     <hook id="actionUpdateQuantity">
-      <name>actionUpdateQuantity</name><title>Quantity update</title><description>Quantity is updated only when a customer effectively places their order</description>
+      <name>actionUpdateQuantity</name>
+      <title>Quantity update</title>
+      <description>Quantity is updated only when a customer effectively places their order</description>
     </hook>
     <hook id="displayRightColumn">
-      <name>displayRightColumn</name><title>Right column blocks</title><description>This hook displays new elements in the right-hand column</description>
+      <name>displayRightColumn</name>
+      <title>Right column blocks</title>
+      <description>This hook displays new elements in the right-hand column</description>
     </hook>
     <hook id="displayLeftColumn">
-      <name>displayLeftColumn</name><title>Left column blocks</title><description>This hook displays new elements in the left-hand column</description>
+      <name>displayLeftColumn</name>
+      <title>Left column blocks</title>
+      <description>This hook displays new elements in the left-hand column</description>
     </hook>
     <hook id="displayHome">
-      <name>displayHome</name><title>Homepage content</title><description>This hook displays new elements on the homepage</description>
+      <name>displayHome</name>
+      <title>Homepage content</title>
+      <description>This hook displays new elements on the homepage</description>
     </hook>
     <hook id="Header">
-      <name>Header</name><title>Pages html head section</title><description>This hook adds additional elements in the head section of your pages (head section of html)</description>
+      <name>Header</name>
+      <title>Pages html head section</title>
+      <description>This hook adds additional elements in the head section of your pages (head section of html)</description>
     </hook>
     <hook id="actionCartSave">
-      <name>actionCartSave</name><title>Cart creation and update</title><description>This hook is displayed when a product is added to the cart or if the cart's content is modified</description>
+      <name>actionCartSave</name>
+      <title>Cart creation and update</title>
+      <description>This hook is displayed when a product is added to the cart or if the cart's content is modified</description>
     </hook>
     <hook id="actionAuthentication">
-      <name>actionAuthentication</name><title>Successful customer authentication</title><description>This hook is displayed after a customer successfully signs in</description>
+      <name>actionAuthentication</name>
+      <title>Successful customer authentication</title>
+      <description>This hook is displayed after a customer successfully signs in</description>
     </hook>
     <hook id="actionProductAdd">
-      <name>actionProductAdd</name><title>Product creation</title><description>This hook is displayed after a product is created</description>
+      <name>actionProductAdd</name>
+      <title>Product creation</title>
+      <description>This hook is displayed after a product is created</description>
     </hook>
     <hook id="actionProductUpdate">
-      <name>actionProductUpdate</name><title>Product update</title><description>This hook is displayed after a product has been updated</description>
+      <name>actionProductUpdate</name>
+      <title>Product update</title>
+      <description>This hook is displayed after a product has been updated</description>
     </hook>
     <hook id="displayAfterBodyOpeningTag">
-      <name>displayAfterBodyOpeningTag</name><title>Very top of pages</title><description>Use this hook for advertisement or modals you want to load first.</description>
+      <name>displayAfterBodyOpeningTag</name>
+      <title>Very top of pages</title>
+      <description>Use this hook for advertisement or modals you want to load first.</description>
     </hook>
     <hook id="displayBeforeBodyClosingTag">
-      <name>displayBeforeBodyClosingTag</name><title>Very bottom of pages</title><description>Use this hook for your modals or any content you want to load at the very end.</description>
+      <name>displayBeforeBodyClosingTag</name>
+      <title>Very bottom of pages</title>
+      <description>Use this hook for your modals or any content you want to load at the very end.</description>
     </hook>
     <hook id="displayTop">
-      <name>displayTop</name><title>Top of pages</title><description>This hook displays additional elements at the top of your pages</description>
+      <name>displayTop</name>
+      <title>Top of pages</title>
+      <description>This hook displays additional elements at the top of your pages</description>
     </hook>
     <hook id="displayNavFullWidth">
-      <name>displayNavFullWidth</name><title>Navigation</title><description>This hook displays full width navigation menu at the top of your pages</description>
+      <name>displayNavFullWidth</name>
+      <title>Navigation</title>
+      <description>This hook displays full width navigation menu at the top of your pages</description>
     </hook>
     <hook id="displayRightColumnProduct">
-      <name>displayRightColumnProduct</name><title>New elements on the product page (right column)</title><description>This hook displays new elements in the right-hand column of the product page</description>
+      <name>displayRightColumnProduct</name>
+      <title>New elements on the product page (right column)</title>
+      <description>This hook displays new elements in the right-hand column of the product page</description>
     </hook>
     <hook id="actionProductDelete">
-      <name>actionProductDelete</name><title>Product deletion</title><description>This hook is called when a product is deleted</description>
+      <name>actionProductDelete</name>
+      <title>Product deletion</title>
+      <description>This hook is called when a product is deleted</description>
     </hook>
     <hook id="displayFooterProduct">
-      <name>displayFooterProduct</name><title>Product footer</title><description>This hook adds new blocks under the product's description</description>
+      <name>displayFooterProduct</name>
+      <title>Product footer</title>
+      <description>This hook adds new blocks under the product's description</description>
     </hook>
     <hook id="displayInvoice">
-      <name>displayInvoice</name><title>Invoice</title><description>This hook displays new blocks on the invoice (order)</description>
+      <name>displayInvoice</name>
+      <title>Invoice</title>
+      <description>This hook displays new blocks on the invoice (order)</description>
     </hook>
     <hook id="actionOrderStatusUpdate">
-      <name>actionOrderStatusUpdate</name><title>Order status update - Event</title><description>This hook launches modules when the status of an order changes.</description>
+      <name>actionOrderStatusUpdate</name>
+      <title>Order status update - Event</title>
+      <description>This hook launches modules when the status of an order changes.</description>
     </hook>
     <hook id="displayAdminOrder">
-      <name>displayAdminOrder</name><title>Display new elements in the Back Office, tab AdminOrder</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office</description>
+      <name>displayAdminOrder</name>
+      <title>Display new elements in the Back Office, tab AdminOrder</title>
+      <description>This hook launches modules when the AdminOrder tab is displayed in the Back Office</description>
     </hook>
     <hook id="displayAdminOrderTabOrder">
-      <name>displayAdminOrderTabOrder</name><title>Display new elements in Back Office, AdminOrder, panel Order</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Order panel tabs</description>
+      <name>displayAdminOrderTabOrder</name>
+      <title>Display new elements in Back Office, AdminOrder, panel Order</title>
+      <description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Order panel tabs</description>
     </hook>
     <hook id="displayAdminOrderTabShip">
-      <name>displayAdminOrderTabShip</name><title>Display new elements in Back Office, AdminOrder, panel Shipping</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Shipping panel tabs</description>
+      <name>displayAdminOrderTabShip</name>
+      <title>Display new elements in Back Office, AdminOrder, panel Shipping</title>
+      <description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Shipping panel tabs</description>
     </hook>
     <hook id="displayAdminOrderContentOrder">
-      <name>displayAdminOrderContentOrder</name><title>Display new elements in Back Office, AdminOrder, panel Order</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Order panel content</description>
+      <name>displayAdminOrderContentOrder</name>
+      <title>Display new elements in Back Office, AdminOrder, panel Order</title>
+      <description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Order panel content</description>
     </hook>
     <hook id="displayAdminOrderContentShip">
-      <name>displayAdminOrderContentShip</name><title>Display new elements in Back Office, AdminOrder, panel Shipping</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Shipping panel content</description>
+      <name>displayAdminOrderContentShip</name>
+      <title>Display new elements in Back Office, AdminOrder, panel Shipping</title>
+      <description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Shipping panel content</description>
     </hook>
     <hook id="displayFooter">
-      <name>displayFooter</name><title>Footer</title><description>This hook displays new blocks in the footer</description>
+      <name>displayFooter</name>
+      <title>Footer</title>
+      <description>This hook displays new blocks in the footer</description>
     </hook>
     <hook id="displayPDFInvoice">
-      <name>displayPDFInvoice</name><title>PDF Invoice</title><description>This hook allows you to display additional information on PDF invoices</description>
+      <name>displayPDFInvoice</name>
+      <title>PDF Invoice</title>
+      <description>This hook allows you to display additional information on PDF invoices</description>
     </hook>
     <hook id="displayInvoiceLegalFreeText">
-      <name>displayInvoiceLegalFreeText</name><title>PDF Invoice - Legal Free Text</title><description>This hook allows you to modify the legal free text on PDF invoices</description>
+      <name>displayInvoiceLegalFreeText</name>
+      <title>PDF Invoice - Legal Free Text</title>
+      <description>This hook allows you to modify the legal free text on PDF invoices</description>
     </hook>
     <hook id="displayAdminCustomers">
-      <name>displayAdminCustomers</name><title>Display new elements in the Back Office, tab AdminCustomers</title><description>This hook launches modules when the AdminCustomers tab is displayed in the Back Office</description>
+      <name>displayAdminCustomers</name>
+      <title>Display new elements in the Back Office, tab AdminCustomers</title>
+      <description>This hook launches modules when the AdminCustomers tab is displayed in the Back Office</description>
     </hook>
     <hook id="displayOrderConfirmation">
-      <name>displayOrderConfirmation</name><title>Order confirmation page</title><description>This hook is called within an order's confirmation page</description>
+      <name>displayOrderConfirmation</name>
+      <title>Order confirmation page</title>
+      <description>This hook is called within an order's confirmation page</description>
     </hook>
     <hook id="actionCustomerAccountAdd">
-      <name>actionCustomerAccountAdd</name><title>Successful customer account creation</title><description>This hook is called when a new customer creates an account successfully</description>
+      <name>actionCustomerAccountAdd</name>
+      <title>Successful customer account creation</title>
+      <description>This hook is called when a new customer creates an account successfully</description>
     </hook>
     <hook id="actionCustomerAccountUpdate">
-      <name>actionCustomerAccountUpdate</name><title>Successful customer account update</title><description>This hook is called when a customer updates its account successfully</description>
+      <name>actionCustomerAccountUpdate</name>
+      <title>Successful customer account update</title>
+      <description>This hook is called when a customer updates its account successfully</description>
     </hook>
     <hook id="displayCustomerAccount">
-      <name>displayCustomerAccount</name><title>Customer account displayed in Front Office</title><description>This hook displays new elements on the customer account page</description>
+      <name>displayCustomerAccount</name>
+      <title>Customer account displayed in Front Office</title>
+      <description>This hook displays new elements on the customer account page</description>
     </hook>
     <hook id="actionOrderSlipAdd">
-      <name>actionOrderSlipAdd</name><title>Order slip creation</title><description>This hook is called when a new credit slip is added regarding client order</description>
+      <name>actionOrderSlipAdd</name>
+      <title>Order slip creation</title>
+      <description>This hook is called when a new credit slip is added regarding client order</description>
     </hook>
     <hook id="displayShoppingCartFooter">
-      <name>displayShoppingCartFooter</name><title>Shopping cart footer</title><description>This hook displays some specific information on the shopping cart's page</description>
+      <name>displayShoppingCartFooter</name>
+      <title>Shopping cart footer</title>
+      <description>This hook displays some specific information on the shopping cart's page</description>
     </hook>
     <hook id="displayCreateAccountEmailFormBottom">
-      <name>displayCreateAccountEmailFormBottom</name><title>Customer authentication form</title><description>This hook displays some information on the bottom of the email form</description>
+      <name>displayCreateAccountEmailFormBottom</name>
+      <title>Customer authentication form</title>
+      <description>This hook displays some information on the bottom of the email form</description>
     </hook>
     <hook id="displayAuthenticateFormBottom">
-      <name>displayAuthenticateFormBottom</name><title>Customer authentication form</title><description>This hook displays some information on the bottom of the authentication form</description>
+      <name>displayAuthenticateFormBottom</name>
+      <title>Customer authentication form</title>
+      <description>This hook displays some information on the bottom of the authentication form</description>
     </hook>
     <hook id="displayCustomerAccountForm">
-      <name>displayCustomerAccountForm</name><title>Customer account creation form</title><description>This hook displays some information on the form to create a customer account</description>
+      <name>displayCustomerAccountForm</name>
+      <title>Customer account creation form</title>
+      <description>This hook displays some information on the form to create a customer account</description>
     </hook>
     <hook id="displayAdminStatsModules">
-      <name>displayAdminStatsModules</name><title>Stats - Modules</title><description/>
+      <name>displayAdminStatsModules</name>
+      <title>Stats - Modules</title>
+      <description/>
     </hook>
     <hook id="displayAdminStatsGraphEngine">
-      <name>displayAdminStatsGraphEngine</name><title>Graph engines</title><description/>
+      <name>displayAdminStatsGraphEngine</name>
+      <title>Graph engines</title>
+      <description/>
     </hook>
     <hook id="actionOrderReturn">
-      <name>actionOrderReturn</name><title>Returned product</title><description>This hook is displayed when a customer returns a product </description>
+      <name>actionOrderReturn</name>
+      <title>Returned product</title>
+      <description>This hook is displayed when a customer returns a product </description>
     </hook>
     <hook id="displayProductAdditionalInfo">
-      <name>displayProductAdditionalInfo</name><title>Product page additional info</title><description>This hook adds additional information on the product page</description>
+      <name>displayProductAdditionalInfo</name>
+      <title>Product page additional info</title>
+      <description>This hook adds additional information on the product page</description>
     </hook>
     <hook id="displayBackOfficeHome">
-      <name>displayBackOfficeHome</name><title>Administration panel homepage</title><description>This hook is displayed on the admin panel's homepage</description>
+      <name>displayBackOfficeHome</name>
+      <title>Administration panel homepage</title>
+      <description>This hook is displayed on the admin panel's homepage</description>
     </hook>
     <hook id="displayAdminStatsGridEngine">
-      <name>displayAdminStatsGridEngine</name><title>Grid engines</title><description/>
+      <name>displayAdminStatsGridEngine</name>
+      <title>Grid engines</title>
+      <description/>
     </hook>
     <hook id="actionWatermark">
-      <name>actionWatermark</name><title>Watermark</title><description/>
+      <name>actionWatermark</name>
+      <title>Watermark</title>
+      <description/>
     </hook>
     <hook id="actionProductCancel">
-      <name>actionProductCancel</name><title>Product cancelled</title><description>This hook is called when you cancel a product in an order</description>
+      <name>actionProductCancel</name>
+      <title>Product cancelled</title>
+      <description>This hook is called when you cancel a product in an order</description>
     </hook>
     <hook id="displayLeftColumnProduct">
-      <name>displayLeftColumnProduct</name><title>New elements on the product page (left column)</title><description>This hook displays new elements in the left-hand column of the product page</description>
+      <name>displayLeftColumnProduct</name>
+      <title>New elements on the product page (left column)</title>
+      <description>This hook displays new elements in the left-hand column of the product page</description>
     </hook>
     <hook id="actionProductOutOfStock">
-      <name>actionProductOutOfStock</name><title>Out-of-stock product</title><description>This hook displays new action buttons if a product is out of stock</description>
+      <name>actionProductOutOfStock</name>
+      <title>Out-of-stock product</title>
+      <description>This hook displays new action buttons if a product is out of stock</description>
     </hook>
     <hook id="actionProductAttributeUpdate">
-      <name>actionProductAttributeUpdate</name><title>Product attribute update</title><description>This hook is displayed when a product's attribute is updated</description>
+      <name>actionProductAttributeUpdate</name>
+      <title>Product attribute update</title>
+      <description>This hook is displayed when a product's attribute is updated</description>
     </hook>
     <hook id="displayCarrierList">
-      <name>displayCarrierList</name><title>Extra carrier (module mode)</title><description/>
+      <name>displayCarrierList</name>
+      <title>Extra carrier (module mode)</title>
+      <description/>
     </hook>
     <hook id="displayShoppingCart">
-      <name>displayShoppingCart</name><title>Shopping cart - Additional button</title><description>This hook displays new action buttons within the shopping cart</description>
+      <name>displayShoppingCart</name>
+      <title>Shopping cart - Additional button</title>
+      <description>This hook displays new action buttons within the shopping cart</description>
     </hook>
     <hook id="actionCarrierUpdate">
-      <name>actionCarrierUpdate</name><title>Carrier Update</title><description>This hook is called when a carrier is updated</description>
+      <name>actionCarrierUpdate</name>
+      <title>Carrier Update</title>
+      <description>This hook is called when a carrier is updated</description>
     </hook>
     <hook id="actionOrderStatusPostUpdate">
-      <name>actionOrderStatusPostUpdate</name><title>Post update of order status</title><description/>
+      <name>actionOrderStatusPostUpdate</name>
+      <title>Post update of order status</title>
+      <description/>
     </hook>
     <hook id="displayCustomerAccountFormTop">
-      <name>displayCustomerAccountFormTop</name><title>Block above the form for create an account</title><description>This hook is displayed above the customer's account creation form</description>
+      <name>displayCustomerAccountFormTop</name>
+      <title>Block above the form for create an account</title>
+      <description>This hook is displayed above the customer's account creation form</description>
     </hook>
     <hook id="displayBackOfficeHeader">
-      <name>displayBackOfficeHeader</name><title>Administration panel header</title><description>This hook is displayed in the header of the admin panel</description>
+      <name>displayBackOfficeHeader</name>
+      <title>Administration panel header</title>
+      <description>This hook is displayed in the header of the admin panel</description>
     </hook>
     <hook id="displayBackOfficeTop">
-      <name>displayBackOfficeTop</name><title>Administration panel hover the tabs</title><description>This hook is displayed on the roll hover of the tabs within the admin panel</description>
+      <name>displayBackOfficeTop</name>
+      <title>Administration panel hover the tabs</title>
+      <description>This hook is displayed on the roll hover of the tabs within the admin panel</description>
     </hook>
     <hook id="displayBackOfficeFooter">
-      <name>displayBackOfficeFooter</name><title>Administration panel footer</title><description>This hook is displayed within the admin panel's footer</description>
+      <name>displayBackOfficeFooter</name>
+      <title>Administration panel footer</title>
+      <description>This hook is displayed within the admin panel's footer</description>
     </hook>
     <hook id="actionProductAttributeDelete">
-      <name>actionProductAttributeDelete</name><title>Product attribute deletion</title><description>This hook is displayed when a product's attribute is deleted</description>
+      <name>actionProductAttributeDelete</name>
+      <title>Product attribute deletion</title>
+      <description>This hook is displayed when a product's attribute is deleted</description>
     </hook>
     <hook id="actionCarrierProcess">
-      <name>actionCarrierProcess</name><title>Carrier process</title><description/>
+      <name>actionCarrierProcess</name>
+      <title>Carrier process</title>
+      <description/>
     </hook>
     <hook id="displayBeforeCarrier">
-      <name>displayBeforeCarrier</name><title>Before carriers list</title><description>This hook is displayed before the carrier list in Front Office</description>
+      <name>displayBeforeCarrier</name>
+      <title>Before carriers list</title>
+      <description>This hook is displayed before the carrier list in Front Office</description>
     </hook>
     <hook id="displayAfterCarrier">
-      <name>displayAfterCarrier</name><title>After carriers list</title><description>This hook is displayed after the carrier list in Front Office</description>
+      <name>displayAfterCarrier</name>
+      <title>After carriers list</title>
+      <description>This hook is displayed after the carrier list in Front Office</description>
     </hook>
     <hook id="displayOrderDetail">
-      <name>displayOrderDetail</name><title>Order detail</title><description>This hook is displayed within the order's details in Front Office</description>
+      <name>displayOrderDetail</name>
+      <title>Order detail</title>
+      <description>This hook is displayed within the order's details in Front Office</description>
     </hook>
     <hook id="actionPaymentCCAdd">
-      <name>actionPaymentCCAdd</name><title>Payment CC added</title><description/>
+      <name>actionPaymentCCAdd</name>
+      <title>Payment CC added</title>
+      <description/>
     </hook>
     <hook id="actionCategoryAdd">
-      <name>actionCategoryAdd</name><title>Category creation</title><description>This hook is displayed when a category is created</description>
+      <name>actionCategoryAdd</name>
+      <title>Category creation</title>
+      <description>This hook is displayed when a category is created</description>
     </hook>
     <hook id="actionCategoryUpdate">
-      <name>actionCategoryUpdate</name><title>Category modification</title><description>This hook is displayed when a category is modified</description>
+      <name>actionCategoryUpdate</name>
+      <title>Category modification</title>
+      <description>This hook is displayed when a category is modified</description>
     </hook>
     <hook id="actionCategoryDelete">
-      <name>actionCategoryDelete</name><title>Category deletion</title><description>This hook is displayed when a category is deleted</description>
+      <name>actionCategoryDelete</name>
+      <title>Category deletion</title>
+      <description>This hook is displayed when a category is deleted</description>
     </hook>
     <hook id="displayPaymentTop">
-      <name>displayPaymentTop</name><title>Top of payment page</title><description>This hook is displayed at the top of the payment page</description>
+      <name>displayPaymentTop</name>
+      <title>Top of payment page</title>
+      <description>This hook is displayed at the top of the payment page</description>
     </hook>
     <hook id="actionHtaccessCreate">
-      <name>actionHtaccessCreate</name><title>After htaccess creation</title><description>This hook is displayed after the htaccess creation</description>
+      <name>actionHtaccessCreate</name>
+      <title>After htaccess creation</title>
+      <description>This hook is displayed after the htaccess creation</description>
     </hook>
     <hook id="actionAdminMetaSave">
-      <name>actionAdminMetaSave</name><title>After saving the configuration in AdminMeta</title><description>This hook is displayed after saving the configuration in AdminMeta</description>
+      <name>actionAdminMetaSave</name>
+      <title>After saving the configuration in AdminMeta</title>
+      <description>This hook is displayed after saving the configuration in AdminMeta</description>
     </hook>
     <hook id="displayAttributeGroupForm">
-      <name>displayAttributeGroupForm</name><title>Add fields to the form 'attribute group'</title><description>This hook adds fields to the form 'attribute group'</description>
+      <name>displayAttributeGroupForm</name>
+      <title>Add fields to the form 'attribute group'</title>
+      <description>This hook adds fields to the form 'attribute group'</description>
     </hook>
     <hook id="actionAttributeGroupSave">
-      <name>actionAttributeGroupSave</name><title>Saving an attribute group</title><description>This hook is called while saving an attributes group</description>
+      <name>actionAttributeGroupSave</name>
+      <title>Saving an attribute group</title>
+      <description>This hook is called while saving an attributes group</description>
     </hook>
     <hook id="actionAttributeGroupDelete">
-      <name>actionAttributeGroupDelete</name><title>Deleting attribute group</title><description>This hook is called while deleting an attributes  group</description>
+      <name>actionAttributeGroupDelete</name>
+      <title>Deleting attribute group</title>
+      <description>This hook is called while deleting an attributes  group</description>
     </hook>
     <hook id="displayFeatureForm">
-      <name>displayFeatureForm</name><title>Add fields to the form 'feature'</title><description>This hook adds fields to the form 'feature'</description>
+      <name>displayFeatureForm</name>
+      <title>Add fields to the form 'feature'</title>
+      <description>This hook adds fields to the form 'feature'</description>
     </hook>
     <hook id="actionFeatureSave">
-      <name>actionFeatureSave</name><title>Saving attributes' features</title><description>This hook is called while saving an attributes features</description>
+      <name>actionFeatureSave</name>
+      <title>Saving attributes' features</title>
+      <description>This hook is called while saving an attributes features</description>
     </hook>
     <hook id="actionFeatureDelete">
-      <name>actionFeatureDelete</name><title>Deleting attributes' features</title><description>This hook is called while deleting an attributes features</description>
+      <name>actionFeatureDelete</name>
+      <title>Deleting attributes' features</title>
+      <description>This hook is called while deleting an attributes features</description>
     </hook>
     <hook id="actionProductSave">
-      <name>actionProductSave</name><title>Saving products</title><description>This hook is called while saving products</description>
+      <name>actionProductSave</name>
+      <title>Saving products</title>
+      <description>This hook is called while saving products</description>
     </hook>
     <hook id="displayAttributeGroupPostProcess">
-      <name>displayAttributeGroupPostProcess</name><title>On post-process in admin attribute group</title><description>This hook is called on post-process in admin attribute group</description>
+      <name>displayAttributeGroupPostProcess</name>
+      <title>On post-process in admin attribute group</title>
+      <description>This hook is called on post-process in admin attribute group</description>
     </hook>
     <hook id="displayFeaturePostProcess">
-      <name>displayFeaturePostProcess</name><title>On post-process in admin feature</title><description>This hook is called on post-process in admin feature</description>
+      <name>displayFeaturePostProcess</name>
+      <title>On post-process in admin feature</title>
+      <description>This hook is called on post-process in admin feature</description>
     </hook>
     <hook id="displayFeatureValueForm">
-      <name>displayFeatureValueForm</name><title>Add fields to the form 'feature value'</title><description>This hook adds fields to the form 'feature value'</description>
+      <name>displayFeatureValueForm</name>
+      <title>Add fields to the form 'feature value'</title>
+      <description>This hook adds fields to the form 'feature value'</description>
     </hook>
     <hook id="displayFeatureValuePostProcess">
-      <name>displayFeatureValuePostProcess</name><title>On post-process in admin feature value</title><description>This hook is called on post-process in admin feature value</description>
+      <name>displayFeatureValuePostProcess</name>
+      <title>On post-process in admin feature value</title>
+      <description>This hook is called on post-process in admin feature value</description>
     </hook>
     <hook id="actionFeatureValueDelete">
-      <name>actionFeatureValueDelete</name><title>Deleting attributes' features' values</title><description>This hook is called while deleting an attributes features value</description>
+      <name>actionFeatureValueDelete</name>
+      <title>Deleting attributes' features' values</title>
+      <description>This hook is called while deleting an attributes features value</description>
     </hook>
     <hook id="actionFeatureValueSave">
-      <name>actionFeatureValueSave</name><title>Saving an attributes features value</title><description>This hook is called while saving an attributes features value</description>
+      <name>actionFeatureValueSave</name>
+      <title>Saving an attributes features value</title>
+      <description>This hook is called while saving an attributes features value</description>
     </hook>
     <hook id="displayAttributeForm">
-      <name>displayAttributeForm</name><title>Add fields to the form 'attribute value'</title><description>This hook adds fields to the form 'attribute value'</description>
+      <name>displayAttributeForm</name>
+      <title>Add fields to the form 'attribute value'</title>
+      <description>This hook adds fields to the form 'attribute value'</description>
     </hook>
     <hook id="actionAttributePostProcess">
-      <name>actionAttributePostProcess</name><title>On post-process in admin feature value</title><description>This hook is called on post-process in admin feature value</description>
+      <name>actionAttributePostProcess</name>
+      <title>On post-process in admin feature value</title>
+      <description>This hook is called on post-process in admin feature value</description>
     </hook>
     <hook id="actionAttributeDelete">
-      <name>actionAttributeDelete</name><title>Deleting an attributes features value</title><description>This hook is called while deleting an attributes features value</description>
+      <name>actionAttributeDelete</name>
+      <title>Deleting an attributes features value</title>
+      <description>This hook is called while deleting an attributes features value</description>
     </hook>
     <hook id="actionAttributeSave">
-      <name>actionAttributeSave</name><title>Saving an attributes features value</title><description>This hook is called while saving an attributes features value</description>
+      <name>actionAttributeSave</name>
+      <title>Saving an attributes features value</title>
+      <description>This hook is called while saving an attributes features value</description>
     </hook>
     <hook id="actionTaxManager">
-      <name>actionTaxManager</name><title>Tax Manager Factory</title><description/>
+      <name>actionTaxManager</name>
+      <title>Tax Manager Factory</title>
+      <description/>
     </hook>
     <hook id="displayMyAccountBlock">
-      <name>displayMyAccountBlock</name><title>My account block</title><description>This hook displays extra information within the 'my account' block"</description>
+      <name>displayMyAccountBlock</name>
+      <title>My account block</title>
+      <description>This hook displays extra information within the 'my account' block"</description>
     </hook>
     <hook id="actionModuleInstallBefore">
-      <name>actionModuleInstallBefore</name><title>actionModuleInstallBefore</title><description></description>
+      <name>actionModuleInstallBefore</name>
+      <title>actionModuleInstallBefore</title>
+      <description/>
     </hook>
     <hook id="actionModuleInstallAfter">
-      <name>actionModuleInstallAfter</name><title>actionModuleInstallAfter</title><description></description>
+      <name>actionModuleInstallAfter</name>
+      <title>actionModuleInstallAfter</title>
+      <description/>
     </hook>
     <hook id="displayTopColumn">
-      <name>displayTopColumn</name><title>Top column blocks</title><description>This hook displays new elements in the top of columns</description>
+      <name>displayTopColumn</name>
+      <title>Top column blocks</title>
+      <description>This hook displays new elements in the top of columns</description>
     </hook>
     <hook id="displayBackOfficeCategory">
-      <name>displayBackOfficeCategory</name><title>Display new elements in the Back Office, tab AdminCategories</title><description>This hook launches modules when the AdminCategories tab is displayed in the Back Office</description>
+      <name>displayBackOfficeCategory</name>
+      <title>Display new elements in the Back Office, tab AdminCategories</title>
+      <description>This hook launches modules when the AdminCategories tab is displayed in the Back Office</description>
     </hook>
     <hook id="displayProductListFunctionalButtons">
-      <name>displayProductListFunctionalButtons</name><title>Display new elements in the Front Office, products list</title><description>This hook launches modules when the products list is displayed in the Front Office</description>
+      <name>displayProductListFunctionalButtons</name>
+      <title>Display new elements in the Front Office, products list</title>
+      <description>This hook launches modules when the products list is displayed in the Front Office</description>
     </hook>
     <hook id="displayNav">
-      <name>displayNav</name><title>Navigation</title><description></description>
+      <name>displayNav</name>
+      <title>Navigation</title>
+      <description/>
     </hook>
     <hook id="displayOverrideTemplate">
-      <name>displayOverrideTemplate</name><title>Change the default template of current controller</title><description></description>
+      <name>displayOverrideTemplate</name>
+      <title>Change the default template of current controller</title>
+      <description/>
     </hook>
     <hook id="actionAdminLoginControllerSetMedia">
-      <name>actionAdminLoginControllerSetMedia</name><title>Set media on admin login page header</title><description>This hook is called after adding media to admin login page header</description>
+      <name>actionAdminLoginControllerSetMedia</name>
+      <title>Set media on admin login page header</title>
+      <description>This hook is called after adding media to admin login page header</description>
     </hook>
     <hook id="actionOrderEdited">
-      <name>actionOrderEdited</name><title>Order edited</title><description>This hook is called when an order is edited.</description>
+      <name>actionOrderEdited</name>
+      <title>Order edited</title>
+      <description>This hook is called when an order is edited.</description>
     </hook>
     <hook id="actionEmailAddBeforeContent">
-      <name>actionEmailAddBeforeContent</name><title>Add extra content before mail content</title><description>This hook is called just before fetching mail template</description>
+      <name>actionEmailAddBeforeContent</name>
+      <title>Add extra content before mail content</title>
+      <description>This hook is called just before fetching mail template</description>
     </hook>
     <hook id="actionEmailAddAfterContent">
-      <name>actionEmailAddAfterContent</name><title>Add extra content after mail content</title><description>This hook is called just after fetching mail template</description>
+      <name>actionEmailAddAfterContent</name>
+      <title>Add extra content after mail content</title>
+      <description>This hook is called just after fetching mail template</description>
     </hook>
     <hook id="sendMailAlterTemplateVars">
-      <name>sendMailAlterTemplateVars</name><title>Alter template vars on the fly</title><description>This hook is called when Mail::send() is called</description>
+      <name>sendMailAlterTemplateVars</name>
+      <title>Alter template vars on the fly</title>
+      <description>This hook is called when Mail::send() is called</description>
     </hook>
     <hook id="displayCartExtraProductActions">
-      <name>displayCartExtraProductActions</name><title>Extra buttons in shopping cart</title><description>This hook adds extra buttons to the product lines, in the shopping cart</description>
+      <name>displayCartExtraProductActions</name>
+      <title>Extra buttons in shopping cart</title>
+      <description>This hook adds extra buttons to the product lines, in the shopping cart</description>
     </hook>
     <hook id="displayPaymentByBinaries">
-      <name>displayPaymentByBinaries</name><title>Payment form generated by binaries</title><description>This hook displays form generated by binaries during the checkout</description>
+      <name>displayPaymentByBinaries</name>
+      <title>Payment form generated by binaries</title>
+      <description>This hook displays form generated by binaries during the checkout</description>
     </hook>
     <hook id="additionalCustomerFormFields">
-      <name>additionalCustomerFormFields</name><title>Add fields to the Customer form</title><description>This hook returns an array of FormFields to add them to the customer registration form</description>
+      <name>additionalCustomerFormFields</name>
+      <title>Add fields to the Customer form</title>
+      <description>This hook returns an array of FormFields to add them to the customer registration form</description>
     </hook>
     <hook id="addWebserviceResources">
-      <name>addWebserviceResources</name><title>Add extra webservice resource</title><description>This hook is called when webservice resources list in webservice controller</description>
+      <name>addWebserviceResources</name>
+      <title>Add extra webservice resource</title>
+      <description>This hook is called when webservice resources list in webservice controller</description>
     </hook>
     <hook id="displayCustomerLoginFormAfter">
-      <name>displayCustomerLoginFormAfter</name><title>Display elements after login form</title><description>This hook displays new elements after the login form</description>
+      <name>displayCustomerLoginFormAfter</name>
+      <title>Display elements after login form</title>
+      <description>This hook displays new elements after the login form</description>
     </hook>
     <hook id="actionValidateCustomerAddressForm">
-      <name>actionValidateCustomerAddressForm</name><title>Customer address form validation</title><description>This hook is called when a customer submit its address form</description>
+      <name>actionValidateCustomerAddressForm</name>
+      <title>Customer address form validation</title>
+      <description>This hook is called when a customer submit its address form</description>
     </hook>
     <hook id="displayCarrierExtraContent">
-      <name>displayCarrierExtraContent</name><title>Display additional content for a carrier (e.g pickup points)</title><description>This hook calls only the module related to the carrier, in order to add options when needed.</description>
+      <name>displayCarrierExtraContent</name>
+      <title>Display additional content for a carrier (e.g pickup points)</title>
+      <description>This hook calls only the module related to the carrier, in order to add options when needed.</description>
     </hook>
     <hook id="validateCustomerFormFields">
-      <name>validateCustomerFormFields</name><title>Customer registration form validation</title><description>This hook is called to a module when it has sent additional fields with additionalCustomerFormFields</description>
+      <name>validateCustomerFormFields</name>
+      <title>Customer registration form validation</title>
+      <description>This hook is called to a module when it has sent additional fields with additionalCustomerFormFields</description>
     </hook>
     <hook id="displayProductExtraContent">
-      <name>displayProductExtraContent</name><title>Display extra content on the product page</title><description>This hook expects ProductExtraContent instances, which will be properly displayed by the template on the product page.</description>
+      <name>displayProductExtraContent</name>
+      <title>Display extra content on the product page</title>
+      <description>This hook expects ProductExtraContent instances, which will be properly displayed by the template on the product page.</description>
+    </hook>
+    <hook id="filteredCmsContent">
+      <name>filteredCmsContent</name>
+      <title>Filter the content page</title>
+      <description>This hook is called just before fetching content page.</description>
+    </hook>
+    <hook id="filteredCmsCategoryContent">
+      <name>filteredCmsCategoryContent</name>
+      <title>Filter the content page category</title>
+      <description>This hook is called just before fetching content page category.</description>
     </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -591,5 +591,10 @@
       <title>Filter the content page supplier</title>
       <description>This hook is called just before fetching content page supplier.</description>
     </hook>
+    <hook id="filteredHtmlContent">
+      <name>filteredHtmlContent</name>
+      <title>Filter HTML field before rending a page</title>
+      <description>This hook is called just before fetching a page on HTML field.</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -571,5 +571,15 @@
       <title>Filter the content page category</title>
       <description>This hook is called just before fetching content page category.</description>
     </hook>
+    <hook id="filteredProductContent">
+      <name>filteredProductContent</name>
+      <title>Filter the content page product</title>
+      <description>This hook is called just before fetching content page product.</description>
+    </hook>
+    <hook id="filteredCategoryContent">
+      <name>filteredCategoryContent</name>
+      <title>Filter the content page category</title>
+      <description>This hook is called just before fetching content page category.</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.1.0.sql
+++ b/install-dev/upgrade/sql/1.7.1.0.sql
@@ -42,3 +42,12 @@ ALTER TABLE `PREFIX_product_shop` CHANGE `redirect_type` `redirect_type`
 
 ALTER TABLE `PREFIX_product` CHANGE `id_product_redirected` `id_type_redirected` INT(10) NOT NULL DEFAULT '0';
 ALTER TABLE `PREFIX_product_shop` CHANGE `id_product_redirected` `id_type_redirected` INT(10) NOT NULL DEFAULT '0';
+
+INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'filteredCmsContent', 'Filter the content page', 'This hook is called just before fetching content page.', '1'),
+  (NULL, 'filteredCmsCategoryContent', 'Filter the content page category', 'This hook is called just before fetching content page category.', '1'),
+  (NULL, 'filteredProductContent', 'Filter the content page product', 'This hook is called just before fetching content page product.', '1'),
+  (NULL, 'filteredCategoryContent', 'Filter the content page category', 'This hook is called just before fetching content page category.', '1'),
+  (NULL, 'filteredManufacturerContent', 'Filter the content page manufacturer', 'This hook is called just before fetching content page manufacturer.', '1'),
+  (NULL, 'filteredSupplierContent', 'Filter the content page supplier', 'This hook is called just before fetching content page supplier.', '1'),
+  (NULL, 'filteredHtmlContent', 'Filter HTML field before rending a page', 'This hook is called just before fetching a page on HTML field.', '1');

--- a/src/Adapter/ObjectPresenter.php
+++ b/src/Adapter/ObjectPresenter.php
@@ -69,7 +69,7 @@ class ObjectPresenter implements PresenterInterface
      */
     private function filterHtmlContent($type, &$presentedObject, $htmlFields)
     {
-        if (!empty($htmlFields)) {
+        if (!empty($htmlFields) && is_array($htmlFields)) {
             $filteredHtml = Hook::exec(
                 'filteredHtmlContent',
                 array(

--- a/src/Adapter/ObjectPresenter.php
+++ b/src/Adapter/ObjectPresenter.php
@@ -55,7 +55,7 @@ class ObjectPresenter implements PresenterInterface
             }
         }
 
-        $this->filterHtmlContent($presentedObject, $object->getHtmlFields());
+        $this->filterHtmlContent($object::$definition['table'], $presentedObject, $object->getHtmlFields());
 
         return $presentedObject;
     }
@@ -63,26 +63,30 @@ class ObjectPresenter implements PresenterInterface
     /**
      * Execute filterHtml hook for html Content for objectPresenter
      *
+     * @param $type
      * @param $presentedObject
      * @param $htmlFields
      */
-    private function filterHtmlContent(&$presentedObject, $htmlFields)
+    private function filterHtmlContent($type, &$presentedObject, $htmlFields)
     {
-        foreach ($htmlFields as $field) {
-            if (array_key_exists($field, $presentedObject)) {
-                $filteredHtml = Hook::exec(
-                    'filteredHtmlContent',
-                    array('filtered_content' => $presentedObject[$field]),
-                    $id_module = null,
-                    $array_return = false,
-                    $check_exceptions = true,
-                    $use_push = false,
-                    $id_shop = null,
-                    $chain = true
-                );
-                if (!empty($filteredHtml)) {
-                    $presentedObject[$field] = $filteredHtml;
-                }
+        if (!empty($htmlFields)) {
+            $filteredHtml = Hook::exec(
+                'filteredHtmlContent',
+                array(
+                    'type' => $type,
+                    'htmlFields' => $htmlFields,
+                    'object' => $presentedObject,
+                ),
+                $id_module = null,
+                $array_return = false,
+                $check_exceptions = true,
+                $use_push = false,
+                $id_shop = null,
+                $chain = true
+            );
+
+            if (!empty($filteredHtml['object'])) {
+                $presentedObject = $filteredHtml['object'];
             }
         }
     }

--- a/src/Adapter/ObjectPresenter.php
+++ b/src/Adapter/ObjectPresenter.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter;
 
 use PrestaShop\PrestaShop\Core\Foundation\Templating\PresenterInterface;
+use Hook;
 
 class ObjectPresenter implements PresenterInterface
 {
@@ -54,6 +55,35 @@ class ObjectPresenter implements PresenterInterface
             }
         }
 
+        $this->filterHtmlContent($presentedObject, $object->getHtmlFields());
+
         return $presentedObject;
+    }
+
+    /**
+     * Execute filterHtml hook for html Content for objectPresenter
+     *
+     * @param $presentedObject
+     * @param $htmlFields
+     */
+    private function filterHtmlContent(&$presentedObject, $htmlFields)
+    {
+        foreach ($htmlFields as $field) {
+            if (array_key_exists($field, $presentedObject)) {
+                $filteredHtml = Hook::exec(
+                    'filteredHtmlContent',
+                    array('filtered_content' => $presentedObject[$field]),
+                    $id_module = null,
+                    $array_return = false,
+                    $check_exceptions = true,
+                    $use_push = false,
+                    $id_shop = null,
+                    $chain = true
+                );
+                if (!empty($filteredHtml)) {
+                    $presentedObject[$field] = $filteredHtml;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Introduce new hook filtered & use it for CMS page
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/STAB-41
| How to test?  | install a new shop (or use sql file) & register module to `filteredCmsContent` & `filteredCmsCategoryContent`, & make some action, see example. 


``` php 
// For example
public function hookFilteredProductContent($params)
{
    $params['object']['description'] = strip_tags($params['object']['description']);
    
    return $params;
}
```

You can use this module for example: https://github.com/aleeks/PrestaShopModuleShortCode

Hooks availables: 
- filterHtmlContent, used for all object fields (TYPE_HTML =6 - ObjectPresenter)
- filteredProductContent, used in ProductController before rendering the product page
- filteredCategoryContent, used in CategoryController before rendering the category page
- filteredManufacturerContent, used in ManufacturerController before rendering the manufacturer page
- filteredSupplierContent, used in SupplierController before rendering the supplier page
- filteredCmsContent, used in CmsController before rendering the cms page
- filteredCmsCategoryContent, used in CmsController before rendering the cms category page

Now, it's up to your imagination to play!

![hook](https://cloud.githubusercontent.com/assets/9074610/21683945/ea940582-d35b-11e6-9f20-42e9f1459cef.png)
