### PR TITLE
Fixed Huge Bug for passed validation

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1184,8 +1184,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             // Checking for fields validity
             // Hack for postcode required for country which does not have postcodes
             if (!empty($value) || $value === '0' || ($field == 'postcode' && $value == '0')) {
-                if (isset($data['validate'])) {
-                    if (!call_user_func('Validate::'.$data['validate'],$value) && (!empty($value) || $data['required'])) {
+                if (isset($data['validate']) && (!call_user_func('Validate::'.$data['validate'], $value) && (!empty($value) || $data['required']))) {
                         $errors[$field] = $this->trans(
                             '%s is invalid.',
                             array(
@@ -1193,7 +1192,6 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                             ),
                             'Admin.Notifications.Error'
                         );
-                    }
                 } else {
                     if (isset($data['copy_post']) && !$data['copy_post']) {
                         continue;


### PR DESCRIPTION
This bug is causing no update when there is a validation rule set and the validation is passing.
Because when a validation rule was set, the value was never updated, even if the validation passed.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This bug is causing no update when there is a validation rule set and the validation is passing. Because when a validation rule was set, the value was never updated, even if the validation passed.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Just use a ObjectModel and validateController

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
