### PR TITLE
Fixed bug that erases current customization fields

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -843,6 +843,12 @@ var form = (function() {
       },
       success: function(response) {
         showSuccessMessage(translate_javascripts['Form update success']);
+        //update the customization ids
+        if (typeof response.customization_fields_ids != "undefined") {
+          $.each(response.customization_fields_ids, function (k, v) {
+              $("#form_step6_custom_fields_" + k + "_id_customization_field").val(v);
+          });
+        }
         if (redirect) {
           if (target) {
             if (target == '_blank') {

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -463,21 +463,26 @@ class AdminProductWrapper
             }
         }
 
-        //remove customization field langs
+        $shopList = \ShopCore::getContextListShopID();
+
+        //remove customization field langs for current context shops
         foreach ($product->getCustomizationFieldIds() as $customizationFiled) {
-            \Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'customization_field_lang WHERE `id_customization_field` = '.(int)$customizationFiled['id_customization_field']);
+            //if the customization_field is still in use, only delete the current context shops langs,
+            //else delete all the langs
+            \Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'customization_field_lang WHERE 
+			`id_customization_field` = '.(int)$customizationFiled['id_customization_field'].
+            (in_array((int)$customizationFiled['id_customization_field'], $customization_ids) ? ' AND `id_shop` IN ('.implode(',', $shopList).')' : ''));
         }
 
         //remove unused customization for the product
         \Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'customization_field WHERE 
-            `id_product` = '.(int)$product->id.' AND `id_customization_field` NOT IN ('.implode(",", $customization_ids).')');
+        `id_product` = '.(int)$product->id.' AND `id_customization_field` NOT IN ('.implode(",", $customization_ids).')');
 
         //create new customizations
         $countFieldText = 0;
         $countFieldFile = 0;
         $productCustomizableValue = 0;
         $hasRequiredField = false;
-        $shopList = \ShopCore::getContextListShopID();
 
         $new_customization_fields_ids = array();
 

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -479,8 +479,10 @@ class AdminProductWrapper
         $hasRequiredField = false;
         $shopList = \ShopCore::getContextListShopID();
 
+        $new_customization_fields_ids = array();
+
         if ($data) {
-            foreach ($data as $customization) {
+            foreach ($data as $key => $customization) {
                 if ($customization['require']) {
                     $hasRequiredField = true;
                 }
@@ -496,6 +498,8 @@ class AdminProductWrapper
                     	VALUES ('.(int)$product->id.', '.(int)$customization['type'].', '.($customization['require'] ? 1 : 0).')');
                		$id_customization_field = (int)\Db::getInstance()->Insert_ID();
                 }
+
+                $new_customization_fields_ids[$key] = $id_customization_field;
 
                 // Create multilingual label name
                 $langValues = '';
@@ -528,6 +532,8 @@ class AdminProductWrapper
         ), 'a.id_product = '.(int)$product->id);
 
         \ConfigurationCore::updateGlobalValue('PS_CUSTOMIZATION_FEATURE_ACTIVE', '1');
+
+        return $new_customization_fields_ids;
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -507,12 +507,15 @@ class ProductController extends FrameworkBundleAdminController
                     // else quantities are managed from $adminProductWrapper->processProductAttribute() above.
 
                     $adminProductWrapper->processProductOutOfStock($product, $_POST['out_of_stock']);
-                    $adminProductWrapper->processProductCustomization($product, $_POST['custom_fields']);
+                    $customization_fields_ids = $adminProductWrapper->processProductCustomization($product, $_POST['custom_fields']);
                     $adminProductWrapper->processAttachments($product, $_POST['attachments']);
 
                     $adminProductController->processWarehouses();
 
-                    $response->setData(['product' => $product]);
+                    $response->setData([
+                        'product' => $product,
+                        'customization_fields_ids' => $customization_fields_ids
+                    ]);
                 }
 
                 if ($request->isXmlHttpRequest()) {

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
@@ -57,7 +57,10 @@ class ProductCustomField extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('label', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+        $builder->add('id_customization_field','Symfony\Component\Form\Extension\Core\Type\HiddenType', array(
+            'required' => false,
+        ))
+        ->add('label', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
             'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [ 'constraints' => array(
                 new Assert\NotBlank(),

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -589,6 +589,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
 
         foreach ($customizationFields as $customizationField) {
             $baseObject = [
+                'id_customization_field' => $customizationField[$this->locales[0]['id_lang']]['id_customization_field'],
                 'label' => [],
                 'type' => $customizationField[$this->locales[0]['id_lang']]['type'],
                 'require' => $customizationField[$this->locales[0]['id_lang']]['required'] == 1 ? true : false,

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_custom_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_custom_fields.html.twig
@@ -23,6 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 <div class="row">
+    {{ form_widget(form.id_customization_field) }}
   <div class="col-md-3">
     <fieldset class="form-group">
       <label class="form-control-label">{{ form.label.vars.label }}</label>


### PR DESCRIPTION
In the new version of PrestaShop, all the customisation fields where
recreated at each product save, thus leading to missing labels in order
details (http://forge.prestashop.com/browse/BOOM-1395)

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the new version of PrestaShop, all the customisation fields where recreated at each product save, thus leading to missing labels in order details
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1395
| How to test?  | Create a new order with customization, then update the product and go back to the order, the Customization fields label won't disapear
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
