### PR TITLE
Fix saving decimals in AdminProduct combination form

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1804,6 +1804,14 @@ var priceCalculation = (function() {
       $(document).on('keyup', '.combination-form .attribute_priceTI', function() {
         priceCalculation.impactTaxExclude($(this));
       });
+      /** combinations : update TTC price field on blur */
+      $(document).on('blur', '.combination-form .attribute_priceTE', function(e) {
+        $(this).val(priceCalculation.normalizePrice($(this).val()));
+      });
+      /** combinations : update wholesale price field on blur */
+      $(document).on('blur','.combination-form .attribute_wholesale_price', function(){
+        $(this).val(priceCalculation.normalizePrice($(this).val()));
+      });
 
       priceCalculation.taxInclude();
 

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1804,12 +1804,8 @@ var priceCalculation = (function() {
       $(document).on('keyup', '.combination-form .attribute_priceTI', function() {
         priceCalculation.impactTaxExclude($(this));
       });
-      /** combinations : update TTC price field on blur */
-      $(document).on('blur', '.combination-form .attribute_priceTE', function(e) {
-        $(this).val(priceCalculation.normalizePrice($(this).val()));
-      });
-      /** combinations : update wholesale price field on blur */
-      $(document).on('blur','.combination-form .attribute_wholesale_price', function(){
+      /** combinations : update wholesale price, unity and price TE field on blur */
+      $(document).on('blur','.combination-form .attribute_wholesale_price,.combination-form .attribute_unity,.combination-form .attribute_priceTE', function(){
         $(this).val(priceCalculation.normalizePrice($(this).val()));
       });
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -127,6 +127,7 @@ class ProductCombination extends CommonAbstractType
             'required' => false,
             'label' => $this->translator->trans('Impact on price per unit (tax excl.)', [], 'Admin.Catalog.Feature'),
             'currency' => $this->currency->iso_code,
+            'attr' => ['class' => 'attribute_unity'],
         ))
         ->add('attribute_minimal_quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
             'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -95,6 +95,7 @@ class ProductCombination extends CommonAbstractType
             'required' => false,
             'label' => $this->translator->trans('Cost price', [], 'Admin.Catalog.Feature'),
             'currency' => $this->currency->iso_code,
+            'attr' => ['class' => 'attribute_wholesale_price']
         ))
         ->add('attribute_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
             'required' => false,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If you save any value to every price impact form, the decimals aren't saved. The problem is that the system does'n accept comma in floats. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2126
| How to test?  | Go to edit combination in BO and edit the cost price or the impact on price and save and finally refresh.
