### PR TITLE
Fix product without combination hashchange

### DIFF
--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -250,7 +250,9 @@ $(window).resize(function(){
 
 $(window).bind('hashchange', function(){
 	checkUrl();
-	findCombination();
+	if (typeof productHasAttributes !== 'undefined' && productHasAttributes) {
+		findCombination();
+	}
 });
 
 //hover 'other views' images management


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | 1.6.1.x.
| Description  | Fixes a bug occuring on products without combination. The fix is based on the same logic used during page initialization to handle products without combination, to avoid a useless call to the `findCombination()` method in `product.js`
| Type         | bug fix
| Category     | FO
| BC breaks    | no
| Deprecations | no
| How to test  | 1. Go to a product page (one without combinations). 2. Change the URL hash (add `#something`, or click on a link adding a hash to the url). 3. You will see the "add to cart" button disappear and the "unavailable" product text.

Fixes a bug occuring on products without combination. To reproduce the bug:

- Go to a product page (one without combinations)
- Change the URL hash (add `#something`, or click on a link adding a hash to the url)
- You will see the "add to cart" button disappear and the "unavailable" product text

The fix is based on the same logic used during page initialization to handle products without combination, to avoid a useless call to the `findCombination()` method in `product.js`
