### PR TITLE
Only display the module you want to translate

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -43,6 +43,8 @@
             'action',
             urlToTranslate + '&lang=' + id_lang
           );
+        } else {
+          formTranslation.attr('action', formTranslation.data('moduleaction'));
         }
       } else {
         if ('legacy' === typeOption.data('controller')) {
@@ -138,6 +140,7 @@
 	</script>
   <form method="post" action="{url entity=sf route=admin_international_translations_list }"
         data-sfaction="{url entity=sf route=admin_international_translations_list }"
+        data-moduleaction="{url entity=sf route=admin_international_translations_module }"
         data-legacyaction="{$link->getAdminLink('AdminTranslations', true)}"
         id="typeTranslationForm" class="form-horizontal">
     <div class="panel">

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -79,6 +79,22 @@ class TranslationsController extends FrameworkBundleAdminController
     }
 
     /**
+     * List translations keys and corresponding editable values for one module.
+     *
+     * @Template("@PrestaShop/Admin/Translations/list.html.twig")
+     *
+     * @param Request $request
+     *
+     * @return array Template vars
+     */
+    public function moduleAction(Request $request)
+    {
+        if (!$request->isMethod('POST')) {
+            return $this->redirect('/admin-dev/index.php?controller=AdminTranslations');
+        }
+    }
+
+    /**
      * @param Request $request
      * @return JsonResponse
      */

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -56,8 +56,12 @@ class TranslationsController extends FrameworkBundleAdminController
             return $this->redirect('/admin-dev/index.php?controller=AdminTranslations');
         }
 
+        $lang = $request->get('lang');
+        $theme = $request->get('selected-theme');
+
         $catalogue = $this->getTranslationsCatalogue($request);
-        $translationsTree = $this->makeTranslationsTree($catalogue);
+        $treeBuilder = new TreeBuilder($this->langToLocale($lang), $theme);
+        $translationsTree = $treeBuilder->makeTranslationsTree($catalogue);
 
         return array(
             'translationsTree' => $translationsTree,
@@ -137,7 +141,8 @@ class TranslationsController extends FrameworkBundleAdminController
     {
         $theme = $this->getSelectedTheme($request);
         $catalogue = $this->getTranslationsCatalogue($request);
-        $translationsTree = $this->makeTranslationsTree($catalogue);
+        $treeBuilder = new TreeBuilder($request->get('lang'), $theme);
+        $translationsTree = $treeBuilder->makeTranslationsTree($catalogue);
 
         $translationsFormsView = $this->renderView(
             'PrestaShopBundle:Admin/Translations/include:translations-forms.html.twig',
@@ -337,66 +342,15 @@ class TranslationsController extends FrameworkBundleAdminController
      * @param $catalogue
      *
      * @return array
+     *
+     * @deprecated since 1.7.1.0
      */
     protected function makeTranslationsTree(array $catalogue)
     {
-        $translationsTree = array();
-        $flippedUnbreakableWords = array_flip($this->getUnbreakableWords());
+        trigger_error('makeTranslationsTree() is deprecated since version 1.7.1. Use PrestaShopBundle\Translation\View\TreeBuilder instead.', E_USER_DEPRECATED);
 
-        foreach ($catalogue as $domain => $messages) {
-            $unbreakableDomain = $this->makeDomainUnbreakable($domain);
-
-            $tableisedDomain = Inflector::tableize($unbreakableDomain);
-            list($basename) = explode('.', $tableisedDomain);
-            $parts = array_reverse(explode('_', $basename));
-
-            $totalParts = count($parts);
-            $subtree = &$translationsTree;
-
-            if ($totalParts - 2 < 0) {
-                $totalParts = 2;
-                $parts = array($parts[0], 'Admin');
-            }
-
-            $firstDomainPart = $parts[count($parts) - 1];
-
-            $condition = count($parts) > $totalParts - 2;
-            $depth = 0;
-
-            while ($condition) {
-                if ($depth === 1) {
-                    list($subdomain) = explode('.', str_replace(ucfirst($firstDomainPart), '', $domain));
-                    array_pop($parts);
-                } else {
-                    $subdomain = ucfirst(array_pop($parts));
-                    if (array_key_exists($subdomain, $flippedUnbreakableWords)) {
-                        $subdomain = $flippedUnbreakableWords[$subdomain];
-                    }
-                }
-
-                if (!array_key_exists($subdomain, $subtree)) {
-                    $subtree[$subdomain] = array();
-                }
-                $subtree = &$subtree[$subdomain];
-
-                $condition = count($parts) > $totalParts - 2;
-                $depth++;
-
-                if ($depth === 2) {
-                    $subtree['__fixed_length_id'] = '_' . sha1($domain);
-                    list($subtree['__domain']) = explode('.', $domain);
-
-                    $subtree['__metadata'] = $messages['__metadata'];
-                    $subtree['__metadata']['domain'] = $subtree['__domain'];
-                    unset($messages['__metadata']);
-                }
-            }
-
-            $subtree['__messages'] = array($domain => $messages);
-            unset($catalogue[$domain]);
-        }
-
-        return $translationsTree;
+        $treeBuilder = new TreeBuilder('en-US', null);
+        return $treeBuilder->makeTranslationsTree($catalogue);
     }
 
     /**
@@ -407,50 +361,28 @@ class TranslationsController extends FrameworkBundleAdminController
      * @param $domain
      *
      * @return string
+     *
+     * @deprecated since 1.7.1.0
      */
     protected function makeDomainUnbreakable($domain)
     {
-        $adjustedDomain = $domain;
-        $unbreakableWords = $this->getUnbreakableWords();
+        trigger_error('makeDomainUnbreakable() is deprecated since version 1.7.1. Use PrestaShopBundle\Translation\View\TreeBuilder instead.', E_USER_DEPRECATED);
 
-        foreach ($unbreakableWords as $search => $replacement) {
-            if (false !== strpos($domain, $search)) {
-                $adjustedDomain = str_replace($search, $replacement, $domain);
-
-                break;
-            }
-        }
-
-        return $adjustedDomain;
+        $treeBuilder = new TreeBuilder('en-US', null);
+        return $treeBuilder->makeDomainUnbreakable($domain);
     }
 
     /**
      * @return array
+     *
+     * @deprecated since 1.7.1.0
      */
     protected function getUnbreakableWords()
     {
-        return array(
-            'BankWire' => 'Bankwire',
-            'BlockBestSellers' => 'Blockbestsellers',
-            'BlockCart' => 'Blockcart',
-            'CheckPayment' => 'Checkpayment',
-            'ContactInfo' => 'Contactinfo',
-            'EmailSubscription' => 'Emailsubscription',
-            'FacetedSearch' => 'Facetedsearch',
-            'FeaturedProducts' => 'Featuredproducts',
-            'LegalCompliance' => 'Legalcompliance',
-            'ShareButtons' => 'Sharebuttons',
-            'ShoppingCart' => 'Shoppingcart',
-            'SocialFollow' => 'Socialfollow',
-            'WirePayment' => 'Wirepayment',
-            'BlockAdvertising' => 'Blockadvertising',
-            'CategoryTree' => 'Categorytree',
-            'CustomerSignIn' => 'Customersignin',
-            'CustomText' => 'Customtext',
-            'ImageSlider' => 'Imageslider',
-            'LinkList' => 'Linklist',
-            'ShopPDF' => 'ShopPdf',
-        );
+        trigger_error('getUnbreakableWords() is deprecated since version 1.7.1. Use PrestaShopBundle\Translation\View\TreeBuilder instead.', E_USER_DEPRECATED);
+
+        $treeBuilder = new TreeBuilder('en-US', null);
+        return $treeBuilder->getUnbreakableWords();
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/admin/routing_international.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/routing_international.yml
@@ -7,6 +7,14 @@ admin_international_translations_list:
     requirements:
         locale: \w+
 
+admin_international_translations_module:
+    path: /translations/module
+    methods:  [GET, POST]
+    defaults:
+        _controller: PrestaShopBundle:Admin/Translations:module
+    requirements:
+        locale: \w+
+
 admin_international_translations_messages_fragments:
     path: /translations/messages/fragments
     methods:  [POST]

--- a/src/PrestaShopBundle/Tests/Translation/Provider/ModuleProviderTest.php
+++ b/src/PrestaShopBundle/Tests/Translation/Provider/ModuleProviderTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Tests\Translation\Provider;
+
+use PrestaShopBundle\Translation\Provider\ModuleProvider;
+
+class ModuleProviderTest extends \PHPUnit_Framework_TestCase
+{
+    // @see /resources/translations/en-US/ModulesWirePaymentAdmin.en-US.xlf
+    // @see /resources/translations/en-US/ModulesWirePaymentShop.en-US.xlf
+    private $provider;
+    private $moduleName;
+    private static $resourcesDir;
+
+    public function setUp()
+    {
+        $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')
+            ->getMock()
+        ;
+
+        $this->moduleName = 'ps_wirepayment';
+        self::$resourcesDir = __DIR__.'/../../resources/translations';
+        $this->provider = new ModuleProvider($loader, self::$resourcesDir);
+        $this->provider->setModuleName($this->moduleName);
+    }
+
+    public function testGetMessageCatalogue()
+    {
+        $expectedReturn = $this->provider->getMessageCatalogue();
+        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
+
+        // Check integrity of translations
+        $this->assertArrayHasKey('ModulesWirePaymentAdmin.en-US', $expectedReturn->all());
+        $this->assertArrayHasKey('ModulesWirePaymentShop.en-US', $expectedReturn->all());
+
+        $moduleAdminTranslations = $expectedReturn->all('ModulesWirePaymentAdmin.en-US');
+        $this->assertCount(20, $moduleAdminTranslations);
+        $this->assertArrayHasKey('Wire payment', $moduleAdminTranslations);
+        $this->assertSame('Wire payment', $moduleAdminTranslations['Wire payment']);
+
+        $moduleFrontTranslations = $expectedReturn->all('ModulesWirePaymentShop.en-US');
+        $this->assertCount(4, $moduleFrontTranslations);
+        $this->assertArrayHasKey('Pay by bank wire', $moduleFrontTranslations);
+        $this->assertSame('Pay by bank wire', $moduleFrontTranslations['Pay by bank wire']);
+    }
+}

--- a/src/PrestaShopBundle/Translation/Factory/TranslationsFactory.php
+++ b/src/PrestaShopBundle/Translation/Factory/TranslationsFactory.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Translation\Factory;
 
 use PrestaShopBundle\Translation\Provider\AbstractProvider;
 use PrestaShopBundle\Translation\Provider\UseDefaultCatalogueInterface;
+use PrestaShopBundle\Translation\View\TreeBuilder;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 
@@ -77,68 +78,12 @@ class TranslationsFactory implements TranslationsFactoryInterface
     {
         foreach ($this->providers as $provider) {
             if ($domainIdentifier === $provider->getIdentifier()) {
-                $provider->setLocale($locale);
-
-                $catalogue = $provider->getXliffCatalogue();
-                $catalogue = $this->addDefaultTranslations($provider, $catalogue);
-
-                $translations = $catalogue->all();
-                $databaseCatalogue = $provider->getDatabaseCatalogue($theme)->all();
-
-                foreach ($translations as $domain => $messages) {
-                    $databaseDomain = str_replace('.'.$locale, '', $domain);
-
-                    $missingTranslations = 0;
-
-                    foreach ($messages as $translationKey => $translationValue) {
-                        $keyExists =
-                            array_key_exists($databaseDomain, $databaseCatalogue) &&
-                            array_key_exists($translationKey, $databaseCatalogue[$databaseDomain])
-                        ;
-
-                        $fallbackOnDefaultValue = $translationKey != $translationValue ||
-                            $locale === str_replace('_', '-', self::DEFAULT_LOCALE);
-                        ;
-                        $translations[$domain][$translationKey] = array(
-                            'xlf' =>  $fallbackOnDefaultValue ? $translations[$domain][$translationKey] : '',
-                            'db' => $keyExists ? $databaseCatalogue[$databaseDomain][$translationKey] : '',
-                        );
-
-                        if (
-                            empty($translations[$domain][$translationKey]['xlf']) &&
-                            empty($translations[$domain][$translationKey]['db'])
-                        ) {
-                            $missingTranslations++;
-                        }
-                    }
-
-                    $translations[$domain]['__metadata'] = array('missing_translations' => $missingTranslations);
-                }
-
-                ksort($translations);
-
-                return $translations;
+                $treeBuilder = new TreeBuilder($locale, $theme);
+                return $treeBuilder->makeTranslationArray($provider);
             }
         }
 
         throw new ProviderNotFoundException($domainIdentifier);
-    }
-
-    /**
-     * @param AbstractProvider $provider
-     * @param MessageCatalogueInterface $catalogue
-     * @return MessageCatalogueInterface
-     */
-    private function addDefaultTranslations(AbstractProvider $provider, MessageCatalogueInterface $catalogue)
-    {
-        if (!$provider instanceof UseDefaultCatalogueInterface) {
-            return $catalogue;
-        }
-
-        $catalogueWithDefault = $provider->getDefaultCatalogue();
-        $catalogueWithDefault->addCatalogue($catalogue);
-
-        return $catalogueWithDefault;
     }
 
     /**

--- a/src/PrestaShopBundle/Translation/Provider/ModuleProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ModuleProvider.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation\Provider;
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+class ModuleProvider extends AbstractProvider implements UseDefaultCatalogueInterface
+{
+    private $moduleName;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains()
+    {
+        return array(
+            '^Modules'.$this->getModuleDomain().'*',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            '#^Modules'.$this->getModuleDomain().'*#i',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        return 'module';
+    }
+
+    public function setModuleName($moduleName)
+    {
+        $this->moduleName = $moduleName;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultCatalogue($empty = true)
+    {
+        $defaultCatalogue = new MessageCatalogue($this->getLocale());
+
+        foreach ($this->getFilters() as $filter) {
+            $filteredCatalogue = $this->getCatalogueFromPaths(
+                array($this->getDefaultResourceDirectory()),
+                $this->getLocale(),
+                $filter
+            );
+            $defaultCatalogue->addCatalogue($filteredCatalogue);
+        }
+
+        if ($empty) {
+            $defaultCatalogue = $this->emptyCatalogue($defaultCatalogue);
+        }
+
+        return $defaultCatalogue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultResourceDirectory()
+    {
+        return $this->resourceDirectory.'/default';
+    }
+
+    private function getModuleDomain()
+    {
+        return preg_replace('/^ps_(\w+)/', '$1', $this->moduleName);
+    }
+}

--- a/src/PrestaShopBundle/Translation/View/TreeBuilder.php
+++ b/src/PrestaShopBundle/Translation/View/TreeBuilder.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation\View;
+
+use PrestaShopBundle\Translation\Factory\TranslationsFactory;
+use PrestaShopBundle\Translation\Provider\AbstractProvider;
+use Doctrine\Common\Util\Inflector;
+use PrestaShopBundle\Translation\Provider\UseDefaultCatalogueInterface;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+class TreeBuilder
+{
+    private $locale;
+    private $theme;
+
+    public function __construct($locale, $theme)
+    {
+        $this->locale = $locale;
+        $this->theme = $theme;
+    }
+
+    public function makeTranslationArray(AbstractProvider $provider)
+    {
+        $provider->setLocale($this->locale);
+        $catalogue = $provider->getXliffCatalogue();
+        $catalogue = $this->addDefaultTranslations($provider, $catalogue);
+
+        $translations = $catalogue->all();
+        $databaseCatalogue = $provider->getDatabaseCatalogue($this->theme)->all();
+
+        foreach ($translations as $domain => $messages) {
+            $databaseDomain = str_replace('.'.$this->locale, '', $domain);
+
+            $missingTranslations = 0;
+
+            foreach ($messages as $translationKey => $translationValue) {
+                $keyExists =
+                    array_key_exists($databaseDomain, $databaseCatalogue) &&
+                    array_key_exists($translationKey, $databaseCatalogue[$databaseDomain])
+                ;
+
+                $fallbackOnDefaultValue = $translationKey != $translationValue ||
+                    $this->locale === str_replace('_', '-', TranslationsFactory::DEFAULT_LOCALE);
+                ;
+                $translations[$domain][$translationKey] = array(
+                    'xlf' =>  $fallbackOnDefaultValue ? $translations[$domain][$translationKey] : '',
+                    'db' => $keyExists ? $databaseCatalogue[$databaseDomain][$translationKey] : '',
+                );
+
+                if (
+                    empty($translations[$domain][$translationKey]['xlf']) &&
+                    empty($translations[$domain][$translationKey]['db'])
+                ) {
+                    $missingTranslations++;
+                }
+            }
+
+            $translations[$domain]['__metadata'] = array('missing_translations' => $missingTranslations);
+        }
+
+        ksort($translations);
+
+        return $translations;
+    }
+
+    /**
+     * @return array
+     */
+    public function makeTranslationsTree($catalogue)
+    {
+        $translationsTree = array();
+        $flippedUnbreakableWords = array_flip($this->getUnbreakableWords());
+
+        foreach ($catalogue as $domain => $messages) {
+            $unbreakableDomain = $this->makeDomainUnbreakable($domain);
+
+            $tableisedDomain = Inflector::tableize($unbreakableDomain);
+            list($basename) = explode('.', $tableisedDomain);
+            $parts = array_reverse(explode('_', $basename));
+
+            $totalParts = count($parts);
+            $subtree = &$translationsTree;
+
+            if ($totalParts - 2 < 0) {
+                $totalParts = 2;
+                $parts = array($parts[0], 'Admin');
+            }
+
+            $firstDomainPart = $parts[count($parts) - 1];
+
+            $condition = count($parts) > $totalParts - 2;
+            $depth = 0;
+
+            while ($condition) {
+                if ($depth === 1) {
+                    list($subdomain) = explode('.', str_replace(ucfirst($firstDomainPart), '', $domain));
+                    array_pop($parts);
+                } else {
+                    $subdomain = ucfirst(array_pop($parts));
+                    if (array_key_exists($subdomain, $flippedUnbreakableWords)) {
+                        $subdomain = $flippedUnbreakableWords[$subdomain];
+                    }
+                }
+
+                if (!array_key_exists($subdomain, $subtree)) {
+                    $subtree[$subdomain] = array();
+                }
+                $subtree = &$subtree[$subdomain];
+
+                $condition = count($parts) > $totalParts - 2;
+                $depth++;
+
+                if ($depth === 2) {
+                    $subtree['__fixed_length_id'] = '_' . sha1($domain);
+                    list($subtree['__domain']) = explode('.', $domain);
+
+                    $subtree['__metadata'] = $messages['__metadata'];
+                    $subtree['__metadata']['domain'] = $subtree['__domain'];
+                    unset($messages['__metadata']);
+                }
+            }
+
+            $subtree['__messages'] = array($domain => $messages);
+            unset($catalogue[$domain]);
+        }
+
+        return $translationsTree;
+    }
+
+    /**
+     * There are domains containing multiple words,
+     * hence these domains should not be split from those words in camelcase.
+     * The latter are replaced from a list of unbreakable words.
+     *
+     * @param $domain
+     *
+     * @return string
+     */
+    public function makeDomainUnbreakable($domain)
+    {
+        $adjustedDomain = $domain;
+        $unbreakableWords = $this->getUnbreakableWords();
+
+        foreach ($unbreakableWords as $search => $replacement) {
+            if (false !== strpos($domain, $search)) {
+                $adjustedDomain = str_replace($search, $replacement, $domain);
+
+                break;
+            }
+        }
+
+        return $adjustedDomain;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUnbreakableWords()
+    {
+        return array(
+            'BankWire' => 'Bankwire',
+            'BlockBestSellers' => 'Blockbestsellers',
+            'BlockCart' => 'Blockcart',
+            'CheckPayment' => 'Checkpayment',
+            'ContactInfo' => 'Contactinfo',
+            'EmailSubscription' => 'Emailsubscription',
+            'FacetedSearch' => 'Facetedsearch',
+            'FeaturedProducts' => 'Featuredproducts',
+            'LegalCompliance' => 'Legalcompliance',
+            'ShareButtons' => 'Sharebuttons',
+            'ShoppingCart' => 'Shoppingcart',
+            'SocialFollow' => 'Socialfollow',
+            'WirePayment' => 'Wirepayment',
+            'BlockAdvertising' => 'Blockadvertising',
+            'CategoryTree' => 'Categorytree',
+            'CustomerSignIn' => 'Customersignin',
+            'CustomText' => 'Customtext',
+            'ImageSlider' => 'Imageslider',
+            'LinkList' => 'Linklist',
+            'ShopPDF' => 'ShopPdf',
+        );
+    }
+
+    /*
+    * @param AbstractProvider $provider
+    * @param MessageCatalogueInterface $catalogue
+    * @return MessageCatalogueInterface
+    */
+    private function addDefaultTranslations(AbstractProvider $provider, MessageCatalogueInterface $catalogue)
+    {
+        if (!$provider instanceof UseDefaultCatalogueInterface) {
+            return $catalogue;
+        }
+
+        $catalogueWithDefault = $provider->getDefaultCatalogue();
+        $catalogueWithDefault->addCatalogue($catalogue);
+
+        return $catalogueWithDefault;
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you select a module to translate you are now redirected to a page displaying only this module. It wasn't the case for the modules using the new translation system.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/STAB-66
| How to test?  |