### PR TITLE
Fixed charset problem

### DIFF
--- a/src/Core/Payment/PaymentOptionFormDecorator.php
+++ b/src/Core/Payment/PaymentOptionFormDecorator.php
@@ -35,8 +35,8 @@ class PaymentOptionFormDecorator
     public function addHiddenSubmitButton($formHTML, $optionId)
     {
         $doc = new DOMDocument();
-
-        $doc->loadHTML($formHTML);
+        
+        $doc->loadHTML('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $formHTML);
 
         $forms = $doc->getElementsByTagName('form');
         if ($forms->length !== 1) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Special characters are not displayed correctly in checkout (áéíóú..)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | N
| Deprecations? | N
| Fixed ticket? | 
| How to test?  | Add a special character in checkout text in a module payment that uses a form ($newOption->setAction(XX)->setForm(XX)).
