### PR TITLE
Fix customized product deletion in cart

### DIFF
--- a/themes/_core/js/cart.js
+++ b/themes/_core/js/cart.js
@@ -41,8 +41,10 @@ $(document).ready(() => {
 
     var updatePrices = function (pricesInCart, $cartOverview, $newCart) {
       $.each(pricesInCart, function (index, priceInCart) {
-        var productUrl = $($(priceInCart).parents('.product-line-grid')[0]).find('a.label').attr('href');
-        var productAnchorSelector = '.label[href="' + productUrl + '"]';
+        var productLabel = $($(priceInCart).parents('.product-line-grid')[0]).find('a.label');
+        var productUrl = productLabel.attr('href');
+        var customizationId = productLabel.data('id_customization');
+        var productAnchorSelector = '.label[href="' + productUrl + '"][data-id_customization="' + customizationId + '"]';
         var newProductAnchor = $newCart.find(productAnchorSelector);
         var $cartItem = $($cartOverview.find(productAnchorSelector).parents('.cart-item')[0]);
 

--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -33,7 +33,7 @@
   <!--  product left body: description -->
   <div class="product-line-grid-body col-md-4 col-xs-8">
     <div class="product-line-info">
-      <a class="label" href="{$product.url}">{$product.name}</a>
+      <a class="label" href="{$product.url}" data-id_customization="{$product.id_customization|intval}">{$product.name}</a>
     </div>
 
     <div class="product-line-info">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When there is the same product customized twice in cart, it doesn't get removed by JS. This PR solves this issue
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create a customizable product then add it twice to cart with different customizations then delete one of the customizations

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

