### PR TITLE
Check whether order is paid before serving a virtual product download

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -169,7 +169,10 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
                 $order_detail['unit_price_tax_excl_before_specific_price'] = $order_detail['unit_price_tax_excl_including_ecotax'] + $order_detail['reduction_amount_tax_excl'];
             } elseif ($order_detail['reduction_percent'] > 0) {
                 $has_discount = true;
-                $order_detail['unit_price_tax_excl_before_specific_price'] = (100 * $order_detail['unit_price_tax_excl_including_ecotax']) / (100 - $order_detail['reduction_percent']);
+                if ($order_detail['reduction_percent'] == 100)
+                    $order_detail['unit_price_tax_excl_before_specific_price'] = 0;
+                else
+                    $order_detail['unit_price_tax_excl_before_specific_price'] = (100 * $order_detail['unit_price_tax_excl_including_ecotax']) / (100 - $order_detail['reduction_percent']);
             }
 
             // Set tax_code

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -82,6 +82,12 @@ class GetFileControllerCore extends FrontController
                 $this->displayCustomError('This product does not exist in our store.');
             }
 
+            /* check whether order has been paid, which is required to download the product */
+            $order = new Order((int)$info['id_order']);
+            $state = $order->getCurrentOrderState();
+            if (!$state || !$state->paid)
+                $this->displayCustomError('This order has not been paid.');
+
             /* Product no more present in catalog */
             if (!isset($info['id_product_download']) || empty($info['id_product_download'])) {
                 $this->displayCustomError('This product has been deleted.');


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | http://forge.prestashop.com/browse/BOOM-2200
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2200
| How to test?  | Try to fetch a virtual product download with/without this patch when the order is paid/not paid. Without this patch, the download works even if the order is not paid.
