### PR TITLE
Product with 0 quantity should be buyable when stock management is disabled

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -213,27 +213,28 @@ class ProductPresenter
     protected function shouldEnableAddToCartButton(array $product, ProductPresentationSettings $settings)
     {
         if (($product['customizable'] == 2 || !empty($product['customization_required']))) {
-            $shouldShowButton = false;
+            $shouldEnable = false;
 
             if (isset($product['customizations'])) {
-                $shouldShowButton = true;
+                $shouldEnable = true;
                 foreach ($product['customizations']['fields'] as $field) {
                     if ($field['required'] && !$field['is_customized']) {
-                        $shouldShowButton = false;
+                        $shouldEnable = false;
                     }
                 }
             }
         } else {
-            $shouldShowButton = true;
+            $shouldEnable = true;
         }
 
-        $shouldShowButton = $shouldShowButton && $this->shouldShowAddToCartButton($product);
+        $shouldEnable = $shouldEnable && $this->shouldShowAddToCartButton($product);
 
-        if ($product['quantity'] <= 0 && !$product['allow_oosp']) {
-            $shouldShowButton = false;
+        if ($settings->stock_management_enabled && !$product['allow_oosp'] && isset($product['quantity_wanted']) &&
+            ($product['quantity'] <= 0 || $product['quantity'] < $product['quantity_wanted'])) {
+            $shouldEnable = false;
         }
 
-        return $shouldShowButton;
+        return $shouldEnable;
     }
 
     private function getAddToCartURL(array $product)

--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -38,7 +38,14 @@
           />
         </div>
         <div class="add">
-          <button class="btn btn-primary add-to-cart" data-button-action="add-to-cart" type="submit" {if !$product.add_to_cart_url || $product.quantity_wanted>$product.quantity}disabled{/if}>
+          <button
+            class="btn btn-primary add-to-cart"
+            data-button-action="add-to-cart"
+            type="submit"
+            {if !$product.add_to_cart_url}
+              disabled
+            {/if}
+          >
             <i class="material-icons shopping-cart">&#xE547;</i>
             {l s='Add to cart' d='Shop.Theme.Actions'}
           </button>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | A product with no quantity should be buyable when the stock management is disabled.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2203
| How to test?  | <ul><li>Create a product with some stock and a product without</li><li>Disable the stock management</li><li>On the front end both product should be buyable</li></ul>

Don't even need to report on starter theme : https://github.com/PrestaShop/StarterTheme/blob/develop/templates/catalog/_partials/product-add-to-cart.tpl#L30