### PR TITLE
Fix getPriceWithoutReduct default id_product_attribute

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3255,7 +3255,7 @@ class ProductCore extends ObjectModel
         );
     }
 
-    public function getPriceWithoutReduct($notax = false, $id_product_attribute = false, $decimals = 6)
+    public function getPriceWithoutReduct($notax = false, $id_product_attribute = null, $decimals = 6)
     {
         return Product::getPriceStatic((int)$this->id, !$notax, $id_product_attribute, $decimals, null, false, false);
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix getPriceWithoutReduct default id_product_attribute
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

Rework of https://github.com/PrestaShop/PrestaShop/pull/4405

If $id_product_attribute is set to false by default :
In Product::getPriceStatic, you call Product::priceCalculation with $id_product_attribute set to false.
This method tests if ($id_product_attribute === null) on line 2955.
That leads to bugs on some themes regarding price display.