### PR TITLE
Fix 404 bug when query string contains a LF

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -389,7 +389,7 @@ class DispatcherCore
 
         // If there are several languages, get language from uri
         if ($this->use_routes && Language::isMultiLanguageActivated()) {
-            if (preg_match('#^/([a-z]{2})(?:/.*)?$#', $this->request_uri, $m)) {
+            if (preg_match('#^/([a-z]{2})(?:/.*)?$#m', $this->request_uri, $m)) {
                 $_GET['isolang'] = $m[1];
                 $this->request_uri = substr($this->request_uri, 3);
             }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When the query string contains a Line Feed char %0A, a 404 error occurs, this may limit some modules functionalities
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Visit this URL for example /en/order?test=new%0Aline (with Friendly URLs enabled)
