### PR TITLE
Update Israel VAT to 17%

### DIFF
--- a/localization/il.xml
+++ b/localization/il.xml
@@ -8,9 +8,9 @@
 		<language iso_code="he" />
 	</languages>
 	<taxes>
-		<tax id="1" name="Ma'am IL 18%" rate="18" />
-		
-		<taxRulesGroup name="IL Standard Rate (18%)">
+		<tax id="1" name="Ma'am IL 17%" rate="17" />
+
+		<taxRulesGroup name="IL Standard Rate (17%)">
 			<taxRule iso_code_country="il" id_tax="1" />
 		</taxRulesGroup>
 	</taxes>

--- a/localization/il.xml
+++ b/localization/il.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <localizationPack name="Israel" version="1.0">
 	<currencies>
-		<currency name="Shekel" iso_code="ILS" iso_code_num="376" sign="₪‎" blank="0" conversion_rate="4.97713" format="2" decimals="1" />
+		<currency name="Shekel" iso_code="ILS" iso_code_num="376" sign="₪‎" blank="0" conversion_rate="4.97713" format="2" decimals="2" />
 	</currencies>
 	<languages>
 		<language iso_code="ar" />


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x.
| Description?  | Correct the Isreal VAT rate to 17% as it should be + updated currency format to have 2 decimals.
| Type?         | improvement
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no.
| How to test?  | Install Israel localization pack and VAT rate should be 17%.