### PR TITLE
BO: Product edit Combinations tab load performance fix

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -4190,7 +4190,9 @@ class AdminProductsControllerCore extends AdminController
                     $attributes = Attribute::getAttributes($this->context->language->id, true);
                     foreach ($attributes as $k => $attribute) {
                         $attribute_js[$attribute['id_attribute_group']][$attribute['id_attribute']] = $attribute['name'];
-                        natsort($attribute_js[$attribute['id_attribute_group']]);
+                    }
+                    foreach ($attribute_js as $k => $ajs) {
+                        natsort($attribute_js[$k]);
                     }
 
                     $currency = $this->context->currency;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I notice a huge performance issue with having a lot of combinations. After code performance analyses with xhproof i found that the natsort function in AdminProductsController is run on array after adding every single item to that array. Instead, the function can be run on those arrays after they're fully "build". My ps_attributes table had over 13k records and so was the natsort function called while there were only 51 arrays. So, in the end, i had reduced the natsort calls from over 13k to 51 and speed up the function from approx 1:30 min to 1.92s
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
