### PR TITLE
Allow HTML in customization when it's displayed by a module

### DIFF
--- a/themes/classic/modules/ps_shoppingcart/ps_shoppingcart-product-line.tpl
+++ b/themes/classic/modules/ps_shoppingcart/ps_shoppingcart-product-line.tpl
@@ -21,7 +21,7 @@
                             <li>
                                 <span>{$field.label}</span>
                                 {if $field.type == 'text'}
-                                    <span>{$field.text}</span>
+                                    <span>{$field.text nofilter}</span>
                                 {else if $field.type == 'image'}
                                     <img src="{$field.image.small.url}">
                                 {/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow modules to display html in customizations (in the cart module)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Having a module which is hooked to "displayCustomization", the returned html output will be displayed as text in the cart module
