### PR TITLE
Bug fix for specific product combination cases

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5726,19 +5726,44 @@ class ProductCore extends ObjectModel
         return $result;
     }
 
-    public static function getIdProductAttributesByIdAttributes($id_product, $id_attributes)
+    public static function getIdProductAttributesByIdAttributes($id_product, $id_attributes, $find_best = false)
     {
         if (!is_array($id_attributes)) {
             return 0;
         }
 
-        return Db::getInstance()->getValue('
+        $id_product_attribute =  Db::getInstance()->getValue('
         SELECT pac.`id_product_attribute`
         FROM `'._DB_PREFIX_.'product_attribute_combination` pac
         INNER JOIN `'._DB_PREFIX_.'product_attribute` pa ON pa.id_product_attribute = pac.id_product_attribute
         WHERE id_product = '.(int)$id_product.' AND id_attribute IN ('.implode(',', array_map('intval', $id_attributes)).')
         GROUP BY id_product_attribute
         HAVING COUNT(id_product) = '.count($id_attributes));
+
+        if ($id_product_attribute === false && $find_best) {
+            //find the best possible combination
+            //first we order $id_attributes by the group position
+            $orderred = array();
+            $result = Db::getInstance()->executeS('SELECT `id_attribute` FROM `'._DB_PREFIX_.'attribute` a
+            INNER JOIN `'._DB_PREFIX_.'attribute_group` g ON a.`id_attribute_group` = g.`id_attribute_group`
+            WHERE `id_attribute` IN ('.implode(',', array_map('intval', $id_attributes)).') ORDER BY g.`position` ASC');
+
+            foreach ($result as $row) {
+                $orderred[] = $row['id_attribute'];
+            }
+
+            while ($id_product_attribute === false && count($orderred) > 0) {
+                array_pop($orderred);
+                $id_product_attribute =  Db::getInstance()->getValue('
+                SELECT pac.`id_product_attribute`
+                FROM `'._DB_PREFIX_.'product_attribute_combination` pac
+                INNER JOIN `'._DB_PREFIX_.'product_attribute` pa ON pa.id_product_attribute = pac.id_product_attribute
+                WHERE id_product = '.(int)$id_product.' AND id_attribute IN ('.implode(',', array_map('intval', $orderred)).')
+                GROUP BY id_product_attribute
+                HAVING COUNT(id_product) = '.count($orderred));
+            }
+        }
+        return $id_product_attribute;
     }
 
     /**

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -150,7 +150,7 @@ class CartControllerCore extends FrontController
                 null,
                 $this->context->language->id,
                 null,
-                (int)Product::getIdProductAttributesByIdAttributes($this->id_product, Tools::getValue('group')),
+                (int)Product::getIdProductAttributesByIdAttributes($this->id_product, Tools::getValue('group'), true),
                 false,
                 false,
                 true,


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the case where you have 2 or more attribute groups on a product, say group A and group B, having respectively the following attributes 10, 11, 12 and 20, 21, 22.<br>The product having the following combinations : <br> - 10 & 20 <br> - 10 & 21 <br> - 11 & 22<br><br>It is impossible to select the 11 attribute, it will always come back to the 10. This PR fixes this bug.
| Type?         | bug fix / improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a product as below, and you will see

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7372)
<!-- Reviewable:end -->
