### PR TITLE
BO: fixed images list display

### DIFF
--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -53,17 +53,17 @@ class AdminImagesControllerCore extends AdminController
             )
         );
 
-        $this->fields_list = array(
-            'id_image_type' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'align' => 'center', 'class' => 'fixed-width-xs'),
-            'name' => array('title' => $this->trans('Name', array(), 'Admin.Global')),
-            'width' => array('title' => $this->trans('Width', array(), 'Admin.Global'),  'suffix' => ' px'),
-            'height' => array('title' => $this->trans('Height', array(), 'Admin.Global'),  'suffix' => ' px'),
-            'products' => array('title' => $this->trans('Products', array(), 'Admin.Global'), 'align' => 'center', 'callback' => 'printEntityActiveIcon', 'orderby' => false),
-            'categories' => array('title' => $this->trans('Categories', array(), 'Admin.Global'), 'align' => 'center', 'callback' => 'printEntityActiveIcon', 'orderby' => false),
-            'manufacturers' => array('title' => $this->trans('Brands', array(), 'Admin.Global'), 'align' => 'center', 'callback' => 'printEntityActiveIcon', 'orderby' => false),
-            'suppliers' => array('title' => $this->trans('Suppliers', array(), 'Admin.Global'), 'align' => 'center', 'callback' => 'printEntityActiveIcon', 'orderby' => false),
-            'stores' => array('title' => $this->trans('Stores', array(), 'Admin.Global'), 'align' => 'center', 'callback' => 'printEntityActiveIcon', 'orderby' => false)
-        );
+        $this->fields_list = [
+            'id_image_type' => ['title' => $this->trans('ID', [], 'Admin.Global'), 'align' => 'center', 'class' => 'fixed-width-xs'],
+            'name' => ['title' => $this->trans('Name', [], 'Admin.Global')],
+            'width' => ['title' => $this->trans('Width', [], 'Admin.Global'),  'suffix' => ' px'],
+            'height' => ['title' => $this->trans('Height', [], 'Admin.Global'),  'suffix' => ' px'],
+            'products' => ['title' => $this->trans('Products', [], 'Admin.Global'), 'align' => 'center', 'orderby' => false],
+            'categories' => ['title' => $this->trans('Categories', [], 'Admin.Global'), 'align' => 'center', 'orderby' => false],
+            'manufacturers' => ['title' => $this->trans('Brands', [], 'Admin.Global'), 'align' => 'center', 'orderby' => false],
+            'suppliers' => ['title' => $this->trans('Suppliers', [], 'Admin.Global'), 'align' => 'center', 'orderby' => false],
+            'stores' => ['title' => $this->trans('Stores', [], 'Admin.Global'), 'align' => 'center', 'orderby' => false]
+        ];
 
         // No need to display the old image system migration tool except if product images are in _PS_PROD_IMG_DIR_
         $this->display_move = false;
@@ -376,11 +376,6 @@ class AdminImagesControllerCore extends AdminController
         } else {
             return parent::postProcess();
         }
-    }
-
-    public static function printEntityActiveIcon($value, $object)
-    {
-        return ($value ? '<span class="list-action-enable action-enabled"><i class="icon-check"></i></span>' : '<span class="list-action-enable action-disabled"><i class="icon-remove"></i></span>');
     }
 
     protected function _childValidation()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In Back Office, Design tab Image Settings list displays wrong values (always NO). There was two problems with list fields callback function: 1. it always returns wrong value 2. HTML in PHP code (violates coding standards). So I completely removed this callback, since it only causes problems.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2247
| How to test?  | Go to Back Office then Design -> Image Settings. All values (Products, Categories & etc.) displays no. This pull request fixes the issue.
