### PR TITLE
Use shop email as sender for template order_customer_comment

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -108,17 +108,31 @@ class OrderDetailControllerCore extends FrontController
                     }
 
                     if (Validate::isLoadedObject($customer)) {
-                        Mail::Send($this->context->language->id, 'order_customer_comment', Mail::l('Message from a customer'),
-                        array(
-                            '{lastname}' => $customer->lastname,
-                            '{firstname}' => $customer->firstname,
-                            '{email}' => $customer->email,
-                            '{id_order}' => (int)$order->id,
-                            '{order_name}' => $order->getUniqReference(),
-                            '{message}' => Tools::nl2br($msgText),
-                            '{product_name}' => $product_name
-                        ),
-                        $to, $toName, $customer->email, $customer->firstname.' '.$customer->lastname);
+                        Mail::Send(
+                            $this->context->language->id,
+                            'order_customer_comment',
+                            Mail::l('Message from a customer'),
+                            array(
+                                '{lastname}' => $customer->lastname,
+                                '{firstname}' => $customer->firstname,
+                                '{email}' => $customer->email,
+                                '{id_order}' => (int)$order->id,
+                                '{order_name}' => $order->getUniqReference(),
+                                '{message}' => Tools::nl2br($msgText),
+                                '{product_name}' => $product_name
+                            ),
+                            $to,
+                            $toName,
+                            strval(Configuration::get('PS_SHOP_EMAIL')),
+                            $customer->firstname.' '.$customer->lastname,
+                            null,
+                            null,
+                            _PS_MAIL_DIR_,
+                            false,
+                            null,
+                            null,
+                            $customer->email
+                        );
                     }
 
                     if (Tools::getValue('ajax') != 'true') {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When a customer sends a comment from the order detail page, an email is sent to the shop's main email address, using the customer's email address as sender. This is a bad practice because the mail server of the shop is not authorized to send email using a customer's address. In many cases it wouldn't work anyway.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | make an order, and from the order detail page, send a comment to the shop. The email that is received from the backoffice is sent with the shop email as sender, and customer's email address as "reply-to"
