### PR TITLE
Use shop email as sender for template order_customer_comment

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -128,8 +128,15 @@ class OrderDetailControllerCore extends FrontController
                             ),
                             $to,
                             $toName,
-                            $customer->email,
-                            $customer->firstname.' '.$customer->lastname
+                            strval(Configuration::get('PS_SHOP_EMAIL')),
+                            $customer->firstname.' '.$customer->lastname,
+                            null,
+                            null,
+                            _PS_MAIL_DIR_,
+                            false,
+                            null,
+                            null,
+                            $customer->email
                         );
                     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a customer sends a comment from the order detail page, an email is sent to the shop's main email address, using the customer's email address as sender. This is a bad practice because the mail server of the shop is not authorized to send email using a customer's address. In many cases it wouldn't work anyway.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | place an order from FO, and from the order detail page, send a comment to the shop. The email that is received from the backoffice is sent with the shop email as sender, and customer's email address as "reply-to".
