### PR TITLE
Fix clear media cache

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -670,11 +670,14 @@ class MediaCore
      */
     public static function clearCache()
     {
-        foreach (array(_PS_THEME_DIR_.'cache') as $dir) {
-            if (file_exists($dir)) {
-                foreach (array_diff(scandir($dir), array('..', '.', 'index.php')) as $file) {
-                    Tools::deleteFile($dir.DIRECTORY_SEPARATOR.$file);
-                }
+        $files = array_merge(
+            glob(_PS_THEME_DIR_.'assets/cache/*'),
+            glob(_PS_THEME_DIR_.'cache/*')
+        );
+
+        foreach ($files as $file) {
+            if ('index.php' !== basename($file)) {
+                Tools::deleteFile($file);
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Fix clear media cache
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2236
| How to test?  | enable front cache, see if you theme generates cache. Try to clear cache on BO & see if cache files are always here. Before yes, now no.

