### PR TITLE
Fix fatal on getModulesToEnable()

### DIFF
--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -78,9 +78,11 @@ class Theme implements AddonInterface
         $modulesToHook = $this->get('global_settings.hooks.modules_to_hook', array());
 
         foreach ($modulesToHook as $hookName => $modules) {
-            foreach (array_values($modules) as $module) {
-                if (!in_array($module, $modulesToEnable)) {
-                    $modulesToEnable[] = $module;
+            if (is_array($modules)) {
+                foreach (array_values($modules) as $module) {
+                    if (!in_array($module, $modulesToEnable)) {
+                        $modulesToEnable[] = $module;
+                    }
                 }
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Fix fatal on getModulesToEnable() when you try to display the installed modules with a malformed theme.yml file
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2258
| How to test?  | Try the theme.yml in the forge ticket. Don't forget to clear the theme cache in /config/themes/ folder