### PR TITLE
Add the disabled categories in product page

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -44,7 +44,10 @@ class ProductInformation extends CommonAbstractType
     private $context;
     private $translator;
     private $locales;
+    private $productDataProvider;
     private $nested_categories;
+    private $categoryDataProvider;
+    private $manufacturerDataProvider;
     private $manufacturers;
     private $productAdapter;
     private $configuration;
@@ -65,20 +68,40 @@ class ProductInformation extends CommonAbstractType
         $this->context = $legacyContext;
         $this->translator = $translator;
         $this->router = $router;
-        $this->categoryDataProvider = $categoryDataProvider;
         $this->productDataProvider = $productDataProvider;
-        $this->featureDataProvider = $featureDataProvider;
-        $this->manufacturerDataProvider = $manufacturerDataProvider;
-        $this->configuration = new Configuration();
-
-        $this->categories = $this->formatDataChoicesList($this->categoryDataProvider->getAllCategoriesName(), 'id_category');
-        $this->nested_categories = $this->categoryDataProvider->getNestedCategories();
         $this->productAdapter = $this->productDataProvider;
+        $this->categoryDataProvider = $categoryDataProvider;
+        $this->manufacturerDataProvider = $manufacturerDataProvider;
+        $this->featureDataProvider = $featureDataProvider;
+
+        $this->configuration = new Configuration();
         $this->locales = $this->context->getLanguages();
         $this->currency = $this->context->getContext()->currency;
+
+        $this->categories = $this->formatDataChoicesList(
+            $this->categoryDataProvider->getAllCategoriesName(
+                $root_category = null,
+                $id_lang = false,
+                $active = false
+            ), 'id_category'
+        );
+
+        $this->nested_categories = $this->categoryDataProvider->getNestedCategories(
+            $root_category = null,
+            $id_lang = false,
+            $active = false
+        );
+
         $this->manufacturers = $this->formatDataChoicesList(
-            $this->manufacturerDataProvider->getManufacturers(false, 0, true, false, false, false, true),
-            'id_manufacturer'
+            $this->manufacturerDataProvider->getManufacturers(
+                $get_nb_products = false,
+                $id_lang = 0,
+                $active = true,
+                $p = false,
+                $n = false,
+                $all_group = false,
+                $group_by = true
+            ), 'id_manufacturer'
         );
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
@@ -24,7 +24,7 @@
  *#}
 <h2>{{ "Categories"|trans({}, 'Admin.Catalog.Feature') }}
   <span class="help-box" data-toggle="popover"
-    data-content="{{ "Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+    data-content="{{ "Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL. Disabled categories are written in italics"|trans({}, 'Admin.Catalog.Help') }}" ></span>
 </h2>
 <div class="categories-tree js-categories-tree">
   <fieldset class="form-group">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_3_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_3_layout.html.twig
@@ -176,7 +176,14 @@
         {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
         {% if multiple -%}
             <div class="checkbox">
-                <label><input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>{{ child.name }}</label>
+                <label>
+                    <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
+                    {% if child.active is defined and child.active == 0 %}
+                        <i>{{ child.name }}</i>
+                    {%- else -%}
+                        {{ child.name }}
+                    {% endif %}
+                </label>
                 {% if defaultCategory is defined %}
                 <div class="radio pull-right">
                     <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | display the disabled categories in category tree while adding or editing a product
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1932
| How to test?  | add/edit a product, expand the categories tree to choose one, you see the disabled ones in Italic. Choose a disabled one and save it, it works :)


- Screenshot:
![category-tree](https://cloud.githubusercontent.com/assets/23308427/22285866/a11eae74-e2ed-11e6-8c96-1262a0d1953d.png)
