### PR TITLE
Fix email override path

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -141,7 +141,7 @@ class MailCore extends ObjectModel
         // Get the path of theme by id_shop if exist
         if (is_numeric($idShop) && $idShop) {
             $shop = new Shop((int) $idShop);
-            $themeName = $shop->theme->getDirectory();
+            $themeName = $shop->theme->getName();
 
             if (_THEME_NAME_ != $themeName) {
                 $themePath = _PS_ROOT_DIR_.'/themes/'.$themeName.'/';
@@ -260,13 +260,13 @@ class MailCore extends ObjectModel
             $iso = Language::getIsoById((int) $idLang);
             $isoDefault = Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT'));
             $isoArray = array();
-            if( $iso ) {
+            if ($iso) {
                 $isoArray[] = $iso;
             }
-            if( $isoDefault && $iso !== $isoDefault ) {
+            if ($isoDefault && $iso !== $isoDefault) {
                 $isoArray[] = $isoDefault;
             }
-            if( !in_array('en', $isoArray) ) {
+            if (!in_array('en', $isoArray)) {
                 $isoArray[] = 'en';
             }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Themes can override template email by having the template in `/themes/themename/mails/pathtotemplate`. At the very beginning of 1.7 development `$theme->getDirectory()` was returning directory name. It changed to the full path, the correct function is now `$theme->getName()`.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  |