### PR TITLE
Hook:exec should always return an array when array_return = true

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -462,7 +462,11 @@ class HookCore extends ObjectModel
 
         // Look on modules list
         $altern = 0;
-        $output = '';
+        if ($array_return) {
+		$output = array();
+	} else {
+		$output = '';
+	}
 
         if ($disable_non_native_modules && !isset(Hook::$native_module)) {
             Hook::$native_module = Module::getNativeModuleList();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Hook:exec should always return an array when array_return = true
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

See https://github.com/PrestaShop/PrestaShop/pull/6798