### PR TITLE
Fix array_merge call on null

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3767,7 +3767,7 @@ class CartCore extends ObjectModel
 
         $hook = Hook::exec('actionCartSummary', $summary, null, true);
         if (is_array($hook)) {
-            $summary = array_merge($summary, array_shift($hook));
+            $summary = array_merge($summary, (array)array_shift($hook));
         }
 
         return $summary;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | if `$hook` is an empty `array()` then `array_shift($hook)` returns `null`... And you can't use `array_merge()` on `null` :rabbit: 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

![shopping_cart](https://cloud.githubusercontent.com/assets/3316447/22298730/d9af63d0-e321-11e6-80b5-d5b9319fe32e.png)
