### PR TITLE
Make email templates parent/child compatible

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -292,14 +292,12 @@ class MailCore extends ObjectModel
             }
             foreach ($isoArray as $isoCode) {
                 $isoTemplate = $isoCode.'/'.$template;
-                $overrideMail = false;
 
                 if ($moduleName !== false && (file_exists($themePath.'modules/'.$moduleName.'/mails/'.$isoTemplate.'.txt') ||
                         file_exists($themePath.'modules/'.$moduleName.'/mails/'.$isoTemplate.'.html'))) {
                     $templatePath = $themePath.'modules/'.$moduleName.'/mails/';
                 } elseif (file_exists($themePath.'mails/'.$isoTemplate.'.txt') || file_exists($themePath.'mails/'.$isoTemplate.'.html')) {
                     $templatePath = $themePath.'mails/';
-                    $overrideMail  = true;
                 }
 
                 if (!file_exists($templatePath.$isoTemplate.'.txt') && ($configuration['PS_MAIL_TYPE'] == Mail::TYPE_BOTH || $configuration['PS_MAIL_TYPE'] == Mail::TYPE_TEXT)) {

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -109,6 +109,10 @@ class MailCore extends ObjectModel
             $idShop = Context::getContext()->shop->id;
         }
 
+        if (is_numeric($idShop) && $idShop) {
+            $shop = new Shop((int) $idShop);
+        }
+
         $configuration = Configuration::getMultiple(
             array(
                 'PS_SHOP_EMAIL',
@@ -139,18 +143,6 @@ class MailCore extends ObjectModel
                 'template_vars' => &$templateVars,
             )
         );
-
-        $themePath = _PS_THEME_DIR_;
-
-        // Get the path of theme by id_shop if exist
-        if (is_numeric($idShop) && $idShop) {
-            $shop = new Shop((int) $idShop);
-            $themeName = $shop->theme->getName();
-
-            if (_THEME_NAME_ != $themeName) {
-                $themePath = _PS_ROOT_DIR_.'/themes/'.$themeName.'/';
-            }
-        }
 
         if (!isset($configuration['PS_MAIL_SMTP_ENCRYPTION']) || Tools::strtolower($configuration['PS_MAIL_SMTP_ENCRYPTION']) === 'off') {
             $configuration['PS_MAIL_SMTP_ENCRYPTION'] = false;
@@ -292,13 +284,7 @@ class MailCore extends ObjectModel
             }
             foreach ($isoArray as $isoCode) {
                 $isoTemplate = $isoCode.'/'.$template;
-
-                if ($moduleName !== false && (file_exists($themePath.'modules/'.$moduleName.'/mails/'.$isoTemplate.'.txt') ||
-                        file_exists($themePath.'modules/'.$moduleName.'/mails/'.$isoTemplate.'.html'))) {
-                    $templatePath = $themePath.'modules/'.$moduleName.'/mails/';
-                } elseif (file_exists($themePath.'mails/'.$isoTemplate.'.txt') || file_exists($themePath.'mails/'.$isoTemplate.'.html')) {
-                    $templatePath = $themePath.'mails/';
-                }
+                $templatePath = self::getTemplateBasePath($isoTemplate, $moduleName, $shop->theme);
 
                 if (!file_exists($templatePath.$isoTemplate.'.txt') && ($configuration['PS_MAIL_TYPE'] == Mail::TYPE_BOTH || $configuration['PS_MAIL_TYPE'] == Mail::TYPE_TEXT)) {
                     PrestaShopLogger::addLog(Context::getContext()->getTranslator()->trans('Error - The following e-mail template is missing: %s', array($templatePath.$isoTemplate.'.txt'), 'Admin.Advparameters.Notification'));
@@ -458,6 +444,30 @@ class MailCore extends ObjectModel
 
             return false;
         }
+    }
+
+    protected static function getTemplateBasePath($isoTemplate, $moduleName, $theme)
+    {
+        $basePathList = [
+            _PS_ROOT_DIR_.'/themes/'.$theme->getName().'/',
+            _PS_ROOT_DIR_.'/themes/'.$theme->get('parent').'/',
+            _PS_ROOT_DIR_,
+        ];
+
+        if ($moduleName !== false) {
+            $templateRelativePath = '/modules/'.$moduleName.'/mails/';
+        } else {
+            $templateRelativePath = '/mails/';
+        }
+
+        foreach ($basePathList as $base) {
+            $templatePath = $base.$templateRelativePath;
+            if (file_exists($templatePath.$isoTemplate.'.txt') || file_exists($templatePath.$isoTemplate.'.html')) {
+                return $templatePath;
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -153,7 +153,7 @@ class ThemeManager implements AddonManagerInterface
         }
 
         /* if file exits, remove it and use YAML configuration file instead */
-        @unlink($this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json');
+        @unlink($this->appConfiguration->get('_PS_CACHE_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json');
 
         $theme = $this->themeRepository->getInstanceByName($name);
         if (!$this->themeValidator->isValid($theme)) {
@@ -188,6 +188,8 @@ class ThemeManager implements AddonManagerInterface
      */
     public function disable($name)
     {
+        @unlink($this->appConfiguration->get('_PS_CACHE_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json');
+
         return true;
     }
 
@@ -357,14 +359,11 @@ class ThemeManager implements AddonManagerInterface
 
     public function saveTheme($theme)
     {
-        $jsonConfigFolder = $this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$theme->getName();
+        $jsonConfigFolder = $this->appConfiguration->get('_PS_CACHE_DIR_').'themes/'.$theme->getName();
         if (!$this->filesystem->exists($jsonConfigFolder) && !is_dir($jsonConfigFolder)) {
             mkdir($jsonConfigFolder, 0777, true);
         }
 
-        file_put_contents(
-            $jsonConfigFolder.'/shop'.$this->shop->id.'.json',
-            json_encode($theme->get(null))
-        );
+        file_put_contents($jsonConfigFolder.'/shop'.$this->shop->id.'.json', json_encode($theme->get(null)));
     }
 }

--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -52,22 +52,17 @@ class ThemeRepository implements AddonRepositoryInterface
     {
         $dir = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_').$name;
 
+        $jsonConf = '';
         if ($this->shop) {
-            $jsonConf = $this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json';
-        } else {
-            $jsonConf = '';
+            $jsonConf = $this->appConfiguration->get(
+                    '_PS_CACHE_DIR_'
+                ) . 'themes/' . $name . '/shop' . $this->shop->id . '.json';
         }
 
         if ($this->filesystem->exists($jsonConf)) {
-            $data = $this->getConfigFromFile(
-                $jsonConf,
-                $name
-            );
+            $data = $this->getConfigFromFile($jsonConf);
         } else {
-            $data = $this->getConfigFromFile(
-                $dir.'/config/theme.yml',
-                $name
-            );
+            $data = $this->getConfigFromFile($dir.'/config/theme.yml');
         }
 
         $data['directory'] = $dir;
@@ -128,10 +123,10 @@ class ThemeRepository implements AddonRepositoryInterface
         return $themes;
     }
 
-    private function getConfigFromFile($file, $name)
+    private function getConfigFromFile($file)
     {
         if (!$this->filesystem->exists($file)) {
-            throw new \PrestaShopException(sprintf('[ThemeRepository] Theme configuration file not found for theme `%s`.', $name));
+            throw new \PrestaShopException(sprintf('[ThemeRepository] Theme configuration file not found for theme at `%s`.', $file));
         }
 
         $content = file_get_contents($file);

--- a/src/PrestaShopBundle/Cache/CacheWarmer.php
+++ b/src/PrestaShopBundle/Cache/CacheWarmer.php
@@ -46,6 +46,7 @@ class CacheWarmer implements CacheWarmerInterface
             $cacheDir.DIRECTORY_SEPARATOR.'push',
             $cacheDir.DIRECTORY_SEPARATOR.'sandbox',
             $cacheDir.DIRECTORY_SEPARATOR.'tcpdf',
+            $cacheDir.DIRECTORY_SEPARATOR.'themes',
         );
 
         $this->fileSystem->mkdir($legacyDirs);

--- a/tests/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
@@ -68,7 +68,7 @@ class ThemeRepositoryTest extends \PHPUnit_Framework_TestCase
 
     public function testGetInstanceByNameNotFound()
     {
-        $this->setExpectedException('PrestaShopException', '[ThemeRepository] Theme configuration file not found for theme `not_found`.');
+        $this->setExpectedException('PrestaShopException');
         $this->repository->getInstanceByName('not_found');
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When sending emails, PrestaShop will look for override in your theme directory. This feature wasn't compatible with the new parent/child feature yet. In the mean time I moved the theme config json file (the cache version of the yaml) to the `app/cache/env` directory.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | Use the [childtheme-example](https://github.com/PrestaShop/childtheme-example) theme to test emails

![capture d ecran 2017-01-25 18 07 31](https://cloud.githubusercontent.com/assets/1525636/22301504/a1f4645e-e32b-11e6-8d8e-aa975e1b8737.png)
