### PR TITLE
Do not load index.php file in catalogue

### DIFF
--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
@@ -54,6 +54,10 @@ trait TranslationFinderTrait
         }
 
         foreach ($translationFiles as $file) {
+            if ('index.php' === $file->getFileName()) {
+                continue;
+            }
+
             if (strpos($file->getBasename('.xlf'), $locale) !== false) {
                 $domain = $file->getBasename('.xlf');
             } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Do not load index.php file in catalogue
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2283 (partially) Need a fix on TranlationToolsBundle too (https://github.com/PrestaShop/TranslationToolsBundle/pull/28)
| How to test?  |