### PR TITLE
Fix empty title tag in CMS category

### DIFF
--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -520,14 +520,14 @@ class MetaCore extends ObjectModel
      */
     public static function getCmsCategoryMetas($idCmsCategory, $idLang, $pageName)
     {
-        $sql = 'SELECT `meta_title`, `meta_description`, `meta_keywords`
+        $sql = 'SELECT `name`, `meta_title`, `meta_description`, `meta_keywords`
 				FROM `'._DB_PREFIX_.'cms_category_lang`
 				WHERE id_lang = '.(int) $idLang.'
 					AND id_cms_category = '.(int) $idCmsCategory.
-                    ((int) Context::getContext()->shop->id ?
-                        ' AND id_shop = '.(int)Context::getContext()->shop->id : '');
+            ((int) Context::getContext()->shop->id ?
+            ' AND id_shop = '.(int)Context::getContext()->shop->id : '');
         if ($row = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($sql)) {
-            $row['meta_title'] = $row['meta_title'];
+            $row['meta_title'] = empty($row['meta_title']) ? $row['name'] : $row['meta_title'];
             return Meta::completeMetaTags($row, $row['meta_title']);
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix empty `title` tag in CMS category when category has empty `Meta title` field
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | create new CMS category with empty `Meta title` field and check if title tag in front-end is empty
