### PR TITLE
Redirect to 404 when CMS page doesn't exist

### DIFF
--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -68,16 +68,16 @@ class CmsControllerCore extends FrontController
         if (Validate::isLoadedObject($this->cms)) {
             $adtoken = Tools::getAdminToken('AdminCmsContent'.(int) Tab::getIdFromClassName('AdminCmsContent').(int) Tools::getValue('id_employee'));
             if (!$this->cms->isAssociatedToShop() || !$this->cms->active && Tools::getValue('adtoken') != $adtoken) {
-                header('HTTP/1.1 404 Not Found');
-                header('Status: 404 Not Found');
+              $this->redirect_after = '404';
+              $this->redirect();
             } else {
                 $this->assignCase = 1;
             }
         } elseif (Validate::isLoadedObject($this->cms_category) && $this->cms_category->active) {
             $this->assignCase = 2;
         } else {
-            header('HTTP/1.1 404 Not Found');
-            header('Status: 404 Not Found');
+          $this->redirect_after = '404';
+          $this->redirect();
         }
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Redirect to 404 page when CMS page/category doesn't exist or is deactivated. Default 404 page is better then a blank page.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Open non existing CMS page, e.g.: http://localhost/content/1000-test

