### PR TITLE
Fix logger namespace for ServiceLocator

### DIFF
--- a/src/Adapter/HookManager.php
+++ b/src/Adapter/HookManager.php
@@ -65,7 +65,7 @@ class HookManager
             try {
                 return \HookCore::exec($hook_name, $hook_args, $id_module, $array_return, $check_exceptions, $use_push, $id_shop);
             } catch (\Exception $e) {
-                $logger = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('logger');
+                $logger = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\LegacyLogger');
                 $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()));
             }
         }


### PR DESCRIPTION
Update from #7228 

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Unable to load logger class
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | n/a
| How to test?  | Passing an undefined value to the setAction method in the PaymentOption class.

'logger' does not appear to be a class name fix.