### PR TITLE
Optimized products counting in BO product list

### DIFF
--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -353,24 +353,15 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
     public function countAllProducts()
     {
         $idShop = \ContextCore::getContext()->shop->id;
-        $sqlSelect = array(
-            'id_product' => array('table' => 'p', 'field' => 'id_product'),
-        );
-        $sqlTable = array(
-            'p' => 'product',
-            'sa' => array(
-                'table' => 'product_shop',
-                'join' => 'JOIN',
-                'on' => 'p.`id_product` = sa.`id_product` AND sa.id_shop = '.$idShop,
-            ),
-        );
 
-        $sql = $this->compileSqlQuery($sqlSelect, $sqlTable);
-        \Db::getInstance()->executeS($sql, true, false);
-        $total = \Db::getInstance()->executeS('SELECT FOUND_ROWS();', true, false);
-        $total = $total[0]['FOUND_ROWS()'];
+        $query = new \DbQuery();
+        $query->select('COUNT(ps.id_product)');
+        $query->from('product_shop', 'ps');
+        $query->where('ps.id_shop = '.(int)$idShop);
 
-        return $total;
+        $total = \Db::getInstance()->getValue($query);
+
+        return (int) $total;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When there's ~150000 or more products in PrestaShop you can't access product list in Back Office since it crashes due to insufficient SQL optimization. This PR fixes the issue.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | You must have ~100k or more (I had ~150k) products and try to access product list in Back Office. 
