### PR TITLE
Display correct quantities for shared stock

### DIFF
--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -217,7 +217,8 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
             'sav' => array(
                 'table' => 'stock_available',
                 'join' => 'LEFT JOIN',
-                'on' => 'sav.`id_product` = p.`id_product` AND sav.`id_product_attribute` = 0 AND sav.id_shop = '.$idShop,
+                'on' => 'sav.`id_product` = p.`id_product` AND sav.`id_product_attribute` = 0'.
+                \StockAvailable::addSqlShopRestriction(null, $idShop, 'sav'),
             ),
             'sa' => array(
                 'table' => 'product_shop',


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop.
| Description?  | If shared stock is enabled in multistore, displayed quantities were always 0. In order to get proper quantities, a special query is required. Note: addSqlShopRestriction is called in global namespace.  If this doesn't correspond to current standards, then another approach should be used in order to take into consideration shared stocks.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Activate shared stock, then update shared quantities and check them in product listing.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
