### PR TITLE
Webservices now show PS validation errors

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -586,7 +586,7 @@ class WebserviceRequestCore
         if (isset($this->objOutput)) {
             $this->objOutput->setStatus($status);
         }
-        $this->errors[] = $display_errors ? array($code, $label) : 'Internal error. To see this error please display the PHP errors.';
+        $this->errors[] = array($code, $label);
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When we use Prestashop WS for writing into Prestashop, Core uses some Validate Method which use PHP exception to manage data errors. So, if php errors aren't display, it's a problem for WS. WS should display Validate errors, but of course not coding php errors. I purpose this patch in order to do this improvement.
| Type?         |improvement
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8165
| How to test?  | Call WS with a wrong API Key. You'll see a bad authentication message.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

Cherry-pick of #7269 