### PR TITLE
Alter currency name to varchar(64)

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -61,7 +61,7 @@ class CurrencyCore extends ObjectModel
         'primary' => 'id_currency',
         'multilang_shop' => true,
         'fields' => array(
-            'name' => array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 32),
+            'name' => array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 64),
             'iso_code' => array('type' => self::TYPE_STRING, 'validate' => 'isLanguageIsoCode', 'required' => true, 'size' => 3),
             'conversion_rate' => array('type' => self::TYPE_FLOAT, 'validate' => 'isUnsignedFloat', 'required' => true, 'shop' => true),
             'deleted' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -509,7 +509,7 @@ CREATE TABLE `PREFIX_country_lang` (
 
 CREATE TABLE `PREFIX_currency` (
   `id_currency` int(10) unsigned NOT NULL auto_increment,
-  `name` varchar(32) NOT NULL,
+  `name` varchar(64) NOT NULL,
   `iso_code` varchar(3) NOT NULL DEFAULT '0',
   `conversion_rate` decimal(13,6) NOT NULL,
   `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',

--- a/install-dev/upgrade/sql/1.7.0.5.sql
+++ b/install-dev/upgrade/sql/1.7.0.5.sql
@@ -1,1 +1,2 @@
 /* PHP:ps_update_tabs(); */;
+ALTER TABLE `PREFIX_currency` ALTER COLUMN `name` varchar(64) NOT NULL;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Some currencies have a name that are too long to fit in the DB.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2170
| How to test?  | Try to add the 'Bosnia-Herzegovina Convertible Mark (BAM)' currency.

Ping @aleeks @maximebiloe 
Since it alters a table in the database maybe we should wait for 1.7.1.0?
