### PR TITLE
Remove useless isset

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -219,9 +219,7 @@
 					<li id="employee_infos" class="dropdown">
 						<a href="{$link->getAdminLink('AdminEmployees')|escape:'html':'UTF-8'}&amp;id_employee={$employee->id|intval}&amp;updateemployee" class="employee_name dropdown-toggle" data-toggle="dropdown">
 							<span class="employee_avatar_small">
-								{if isset($employee)}
-									<img class="imgm img-thumbnail" alt="" src="{$employee->getImage()}" width="32" height="32" />
-								{/if}
+                <img class="imgm img-thumbnail" alt="" src="{$employee->getImage()}" width="32" height="32" />
 							</span>
 						</a>
 						<ul id="employee_links" class="dropdown-menu">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This isset is kinda useless and may induce people in error
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

All those PRs are trying to add more issets but $employee should not be null here :

https://github.com/PrestaShop/PrestaShop/pull/6786
https://github.com/PrestaShop/PrestaShop/pull/6783
https://github.com/PrestaShop/PrestaShop/pull/6772
https://github.com/PrestaShop/PrestaShop/pull/6768

I'd rather see the BO [fail fast](https://en.wikipedia.org/wiki/Fail-fast) than try to hide the error until it's too late.