### PR TITLE
Require php zip extension before install

### DIFF
--- a/install-dev/index.php
+++ b/install-dev/index.php
@@ -25,7 +25,7 @@
  */
 
 
-if (!extension_loaded('SimpleXML') || PHP_VERSION_ID < 50400) {
+if (!extension_loaded('SimpleXML') || !extension_loaded('zip') || PHP_VERSION_ID < 50400) {
     require_once dirname(__FILE__).'/missing_extension.php';
     exit();
 }

--- a/install-dev/missing_extension.php
+++ b/install-dev/missing_extension.php
@@ -100,6 +100,11 @@
         PrestaShop installation requires at least the <b>SimpleXML extension</b> to be enabled.
     </li>
     <?php endif; ?>
+    <?php if (!extension_loaded('zip')): ?>
+      <li>
+          PrestaShop installation requires at least the <b>zip extension</b> to be enabled.
+      </li>
+    <?php endif; ?>
     <?php if (PHP_VERSION_ID < 50400): ?>
       <li>
           PrestaShop requires at least PHP 5.4 or newer versions.


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | Since we are using the `ZipArchive` class php `zip` extension must be enabled
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2306
| How to test?  | Disable the zip extension then install PrestaShop