### PR TITLE
FO: Layered navigation select does not work with friendly URLs turned OFF

### DIFF
--- a/themes/classic/templates/catalog/_partials/facets.tpl
+++ b/themes/classic/templates/catalog/_partials/facets.tpl
@@ -132,4 +132,3 @@
       {/if}
     {/foreach}
   </div>
-{debug}

--- a/themes/classic/templates/catalog/_partials/facets.tpl
+++ b/themes/classic/templates/catalog/_partials/facets.tpl
@@ -99,6 +99,8 @@
           {else}
             <form>
               <input type="hidden" name="order" value="{$sort_order}">
+              <input type="hidden" name="controller" value="category">
+              <input type="hidden" name="id_category" value="{$category['id']}">
               <select name="q">
                 <option disabled selected hidden>{l s='(no filter)' d='Shop.Theme'}</option>
                 {foreach from=$facet.filters item="filter"}
@@ -130,3 +132,4 @@
       {/if}
     {/foreach}
   </div>
+{debug}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | When selecting filter display style "select" and having friendly URLs off changing option does not filter anything. It only works with friendly URLs enabled.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/NM-856
| How to test?  | Disable the URL rewrite and set category filter display as a select box in facet search module's filter template configuration.
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
