### PR TITLE
Fix Validate::isUnsignedInt

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -731,7 +731,7 @@ class ValidateCore
      */
     public static function isUnsignedInt($value)
     {
-        return ((string)(int)$value === (string)$value && $value < 4294967296 && $value >= 0);
+        return (is_numeric($value) && $value < 4294967296 && $value >= 0);
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The `int` cast would turn `$value` into a negative integer if it was > PHP_INT_MAX
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

See https://github.com/PrestaShop/PrestaShop/pull/6533