### PR TITLE
Fixed rendering condition of default groups form

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -101,7 +101,7 @@ class AdminGroupsControllerCore extends AdminController
 
         $groups = Group::getGroups(Context::getContext()->language->id, true);
 
-        if (Shop::isFeatureActive()) {
+        if (Group::isFeatureActive()) {
             $this->fields_options = array(
                 'general' => array(
                     'title' =>    $this->trans('Default groups options', array(), 'Admin.Shopparameters.Feature'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed the rendering condition of default groups options form in AdminGroupsController.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Go to AdminGroupsController. The default groups options form should be rendered if group feature is enabled.

See https://github.com/PrestaShop/PrestaShop/pull/6516