### PR TITLE
Do not clutter webcaches with duplicated assets' objects

### DIFF
--- a/classes/tree/Tree.php
+++ b/classes/tree/Tree.php
@@ -387,12 +387,10 @@ class TreeCore
             $bo_theme = 'default';
         }
 
-        $js_path = __PS_BASE_URI__.$admin_webpath.'/themes/'.$bo_theme.'/js/tree.js';
+        $js_path = __PS_BASE_URI__.$admin_webpath.'/themes/'.$bo_theme.'/js/tree.js?v=' ._PS_VERSION_;
         if ($this->getContext()->controller->ajax) {
             if (!$this->_no_js) {
-                $html = '<script type="text/javascript">
-                    $(function(){ $.getScript(\''.$js_path.'\'); });
-                </script>';
+                $html = '<script type="text/javascript">$(function(){ $.ajax({url: "' .$js_path . '",cache:true,dataType: "script"})});</script>';
             }
         } else {
             $this->getContext()->controller->addJs($js_path);

--- a/classes/tree/TreeToolbarSearch.php
+++ b/classes/tree/TreeToolbarSearch.php
@@ -58,10 +58,8 @@ class TreeToolbarSearchCore extends TreeToolbarButtonCore implements
         }
 
         if ($this->getContext()->controller->ajax) {
-            $path = __PS_BASE_URI__.$admin_webpath.'/themes/'.$bo_theme.'/js/vendor/typeahead.min.js';
-            $html = '<script type="text/javascript">
-                $(function(){ $.getScript(\''.$path.'\'); });
-            </script>';
+            $path = __PS_BASE_URI__.$admin_webpath.'/themes/'.$bo_theme.'/js/vendor/typeahead.min.js?v=' ._PS_VERSION_;
+            $html = '<script type="text/javascript">$(function(){ $.ajax({url: "' .$path . '",cache:true,dataType: "script"})});</script>';
         } else {
             $this->getContext()->controller->addJs(__PS_BASE_URI__.$admin_webpath.'/themes/'.$bo_theme.'/js/vendor/typeahead.min.js');
         }

--- a/classes/tree/TreeToolbarSearchCategories.php
+++ b/classes/tree/TreeToolbarSearchCategories.php
@@ -55,10 +55,8 @@ class TreeToolbarSearchCategoriesCore extends TreeToolbarButtonCore implements
         }
 
         if ($this->getContext()->controller->ajax) {
-            $path = __PS_BASE_URI__.$admin_webpath.'/themes/'.$bo_theme.'/js/vendor/typeahead.min.js';
-            $html = '<script type="text/javascript">
-                $(function(){ $.getScript(\''.$path.'\'); });
-            </script>';
+            $path = __PS_BASE_URI__.$admin_webpath.'/themes/'.$bo_theme.'/js/vendor/typeahead.min.js?v=' ._PS_VERSION_;
+            $html = '<script type="text/javascript">$(function(){ $.ajax({url: "' .$path . '",cache:true,dataType: "script"})});</script>';
         } else {
             $this->getContext()->controller->addJs(__PS_BASE_URI__.$admin_webpath.'/themes/'.$bo_theme.'/js/vendor/typeahead.min.js');
         }

--- a/js/tiny_mce/tiny_mce.js
+++ b/js/tiny_mce/tiny_mce.js
@@ -10,4 +10,4 @@ window.tinyMCEPreInit = {};
 window.tinyMCEPreInit.base = final_path+'/js/tiny_mce';
 window.tinyMCEPreInit.suffix = '.min';
 
-$.getScript(final_path+'/js/tiny_mce/tinymce.min.js');
+$.ajax({url: final_path+'/js/tiny_mce/tinymce.min.js',dataType: "script",cache: true});


### PR DESCRIPTION
* typeahead.min.js
* tinymce.min.js
* tree.js
are still fetched using jQuery's getScript() which is an alias to $.ajax
that in it's default configuration, use a cache-buster (append ?<timestamp> to the URI)

This is suboptimal as it disables caching for otherwise cacheable resources (assets)

Suffixing them with PS_VERSION helps keeping the cache slim.
(In a prodcution instance the number of cached objects globally drops from ~5.5k to ~700)


Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Helps reverse/forward caching proxies to serve static resources
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | load a back-office page with a JS-enabled browser and looks at the assets HTTP requests
