### PR TITLE
Fix %email% are not replaced by user's email when asking a new password

### DIFF
--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -97,7 +97,7 @@ class PasswordControllerCore extends FrontController
                         $customer->firstname.' '.$customer->lastname
                     )
                 ) {
-                    $this->success[] = $this->trans('If this email address has been registered in our shop, you will receive a link to reset your password at %email%.', array('%email%', $customer->email), 'Shop.Notifications.Success');
+                    $this->success[] = $this->trans('If this email address has been registered in our shop, you will receive a link to reset your password at %email%.', array('%email%' => $customer->email), 'Shop.Notifications.Success');
                     $this->setTemplate('customer/password-infos');
                 } else {
                     $this->errors[] = $this->trans('An error occurred while sending the email.', array(), 'Shop.Notifications.Error');


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When asking to reset password on prestashop, website display "If this email address has been registered in our shop, you will receive a link to reset your password at %email%." in case of "If this email address has been registered in our shop, you will receive a link to reset your password at email@email.com."
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Ask a mail for renew password and see message in front office

