### PR TITLE
Fixed use of hook return value in customer address validation

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -111,7 +111,7 @@ class CustomerAddressFormCore extends AbstractForm
             }
         }
 
-        if ($hookReturn = Hook::exec('actionValidateCustomerAddressForm', array('form' => $this)) != '') {
+        if (($hookReturn = Hook::exec('actionValidateCustomerAddressForm', array('form' => $this))) != '') {
             $is_valid &= (bool) $hookReturn;
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | A return value of '0' from hook actionValidateCustomerAddressForm wasn't preventing the form being submitted
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Hook a module to the actionValidateCustomerAddressForm and return '0'. Submit an address form. Current code allows the address to be submitted, this PR prevents it.
