### PR TITLE
Pass variables of hook `actionProductSearchComplete` by link

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -385,7 +385,8 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
             )),
         );
 
-        Hook::exec('actionProductSearchComplete', $searchVariables);
+        Hook::exec('filterProductSearch', array('searchVariables' => &$searchVariables));
+        Hook::exec('actionProductSearchAfter', $searchVariables);
 
         return $searchVariables;
     }

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -651,5 +651,15 @@
       <title>After dispatch</title>
       <description>This hook is called at the end of the dispatch method of the Dispatcher</description>
     </hook>
+    <hook id="filterProductSearch">
+      <name>filterProductSearch</name>
+      <title>Filter search products result</title>
+      <description>This hook is called in order to allow to modify search product result</description>
+    </hook>
+    <hook id="actionProductSearchAfter">
+      <name>actionProductSearchAfter</name>
+      <title>Event triggered after search product completed</title>
+      <description>This hook is called after the product search. Parameters are already filtered</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.1.0.sql
+++ b/install-dev/upgrade/sql/1.7.1.0.sql
@@ -63,6 +63,8 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   (NULL, 'actionDispatcherAfter', 'After dispatch', 'This hook is called at the end of the dispatch method of the Dispatcher', '1');
   (NULL, 'actionClearCache', 'Clear smarty cache', 'This hook is called when the cache of the theme is cleared', '1'),
   (NULL, 'actionClearCompileCache', 'Clear smarty compile cache', 'This hook is called when smarty''s compile cache is cleared', '1'),
-  (NULL, 'actionClearSf2Cache', 'Clear Sf2 cache', 'This hook is called when the Symfony cache is cleared', '1');
+  (NULL, 'actionClearSf2Cache', 'Clear Sf2 cache', 'This hook is called when the Symfony cache is cleared', '1'),
+  (NULL, 'filterProductSearch', 'Filter search products result', 'This hook is called in order to allow to modify search product result', '1'),
+  (NULL, 'actionProductSearchAfter', 'Event triggered after search product completed', 'This hook is called after the product search. Parameters are already filtered', '1');
 
 DELETE FROM `PREFIX_configuration` WHERE `name` IN ('PS_META_KEYWORDS');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Pass variables of the hook "actionProductSearchComplete" by link. This trick will allow to modify search results, for example useful together with "displayOverrideTemplate" hook for show search results among CMS pages, etc.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Just open page with results of search

See: https://github.com/PrestaShop/PrestaShop/pull/6956

ping @Simonchik