### PR TITLE
FO: Fix empty template var on non utf8 values

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1584,6 +1584,10 @@ class FrontControllerCore extends Controller
             'fax' => Configuration::get('PS_SHOP_FAX'),
         );
 
+        array_walk($shop, function (&$entry) {
+                $entry = utf8_encode($entry);
+        });
+
         return $shop;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This patch fix empty templates variables when they are encoded in non utf-8
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Test with non utf-8 characters strings