### PR TITLE
Fix id_order ambiguous search

### DIFF
--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -45,7 +45,7 @@ class AdminReturnControllerCore extends AdminController
 
         $this->fields_list = array(
             'id_order_return' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'align' => 'center', 'width' => 25),
-            'id_order' => array('title' => $this->trans('Order ID', array(), 'Admin.Orderscustomers.Feature'), 'width' => 100, 'align' => 'center', 'filter_key'=>'a!id_order'),
+            'id_order' => array('title' => $this->trans('Order ID', array(), 'Admin.Orderscustomers.Feature'), 'width' => 100, 'align' => 'center', 'filter_key'=>'a!id_order', 'havingFilter' => true),
             'name' => array('title' => $this->trans('Status', array(), 'Admin.Global'),'color' => 'color', 'width' => 'auto', 'align' => 'left'),
             'date_add' => array('title' => $this->trans('Date issued', array(), 'Admin.Orderscustomers.Feature'), 'width' => 150, 'type' => 'date', 'align' => 'right', 'filter_key'=>'a!date_add'),
         );


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix id_order ambiguous search
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | -

Permet d'éviter, dans un environnement strict, une erreur SQL de type "Column 'id_order' in where clause is ambiguous" au moment de rechercher un Retour produits à partir de l'ID d'une commande (le 'filter_key'=>'a!id_order' ne suffisant pas à régler ce problème).

Fix the id_order ambiguous search in strict environmen

Cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/5072/commits