### PR TITLE
Superfluous table alias

### DIFF
--- a/classes/Customization.php
+++ b/classes/Customization.php
@@ -231,7 +231,7 @@ class CustomizationCore extends ObjectModel
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 		SELECT `name`
 		FROM `'._DB_PREFIX_.'customization_field_lang`
-		WHERE `id_customization_field` = '.(int) $idCustomization.((int) $idShop ? ' AND cfl.`id_shop` = '.(int) $idShop : '').'
+		WHERE `id_customization_field` = '.(int) $idCustomization.((int) $idShop ? ' AND `id_shop` = '.(int) $idShop : '').'
 		AND `id_lang` = '.(int) $idLang
         );
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | An SQL alias was used when it hasn't been defined before
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

See https://github.com/PrestaShop/PrestaShop/pull/5100
Only one commit was cherry-picked because the other alias has already been patched here https://github.com/PrestaShop/PrestaShop/pull/7211