### PR TITLE
Calculate carrier price on the real order price

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3271,7 +3271,7 @@ class CartCore extends ObjectModel
         }
 
         // Order total in default currency without fees
-        $order_total = $this->getOrderTotal(true, Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING, $product_list);
+        $order_total = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $product_list);
 
         // Start with shipping cost at 0
         $shipping_cost = 0;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Calculate the carrier price with the REAL price customer is gonna pay, so have to use the BOTH_WITHOUT_SHIPPING const.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

Cherry-picked from https://github.com/PrestaShop/PrestaShop/pull/4402