### PR TITLE
Add "use instead" doc on method display as deprecated when possible

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3204,7 +3204,7 @@ class CartCore extends ObjectModel
      */
     public function getOrderShippingCost($id_carrier = null, $use_tax = true, Country $default_country = null, $product_list = null)
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use Cart->getPackageShippingCost()');
         return $this->getPackageShippingCost((int)$id_carrier, $use_tax, $default_country, $product_list);
     }
 
@@ -3941,7 +3941,7 @@ class CartCore extends ObjectModel
      */
     public function deletePictureToProduct($id_product, $index)
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use deleteCustomizationToProduct() instead');
         return $this->deleteCustomizationToProduct($id_product, 0);
     }
 

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -210,7 +210,7 @@ class CookieCore
      */
     public function isLogged($withGuest = false)
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use Customer::isLogged() instead');
         if (!$withGuest && $this->is_guest == 1) {
             return false;
         }
@@ -232,7 +232,7 @@ class CookieCore
      */
     public function isLoggedBack()
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use Employee::isLoggedBack() instead');
         /* Employee is valid only if it can be load and if cookie password is the same as database one */
         return $this->id_employee
             && Validate::isUnsignedId($this->id_employee)

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -885,7 +885,7 @@ abstract class PaymentModuleCore extends Module
      */
     public function formatProductAndVoucherForEmail($content)
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use $content instead');
         return $content;
     }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1543,7 +1543,7 @@ class ProductCore extends ObjectModel
     public function updateProductAttribute($id_product_attribute, $wholesale_price, $price, $weight, $unit, $ecotax,
         $id_images, $reference, $id_supplier = null, $ean13, $default, $location = null, $upc = null, $minimal_quantity, $available_date, $isbn = '')
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use updateAttribute() instead');
 
         $return = $this->updateAttribute(
             $id_product_attribute, $wholesale_price, $price, $weight, $unit, $ecotax,

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2091,7 +2091,7 @@ class ToolsCore
 
     public static function replaceByAbsoluteURL($matches)
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use Media::replaceByAbsoluteURL($matches) instead');
         return Media::replaceByAbsoluteURL($matches);
     }
 

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -158,7 +158,7 @@ class PrestaShopExceptionCore extends Exception
      */
     protected function getExentedMessage($html = true)
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use getExtendedMessage instead');
         return $this->getExtendedMessage($html);
     }
 

--- a/classes/helper/Helper.php
+++ b/classes/helper/Helper.php
@@ -369,7 +369,7 @@ class HelperCore
      */
     public static function renderShopList()
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use HelperShop->getRenderedShopList instead');
 
         if (!Shop::isFeatureActive() || Shop::getTotalShops(false, null) < 2) {
             return null;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2665,7 +2665,7 @@ abstract class ModuleCore
 
     /**
      * Getter for $tabs attribute
-     * 
+     *
      * @return array
      */
     public function getTabs()

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -769,11 +769,11 @@ class OrderCore extends ObjectModel
     }
 
     /**
-     * @deprecated 1.5.0.1
+     * @deprecated 1.5.0.1 use Order::getCartRules() instead
      */
     public function getDiscounts($details = false)
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use Order::getCartRules() instead');
         return Order::getCartRules();
     }
 
@@ -1133,7 +1133,7 @@ class OrderCore extends ObjectModel
      */
     public function addDiscount($id_cart_rule, $name, $value)
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use Order::addCartRule($id_cart_rule, $name, array(\'tax_incl\' => $value, \'tax_excl\' => \'0.00\')) instead');
         return Order::addCartRule($id_cart_rule, $name, array('tax_incl' => $value, 'tax_excl' => '0.00'));
     }
 

--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -247,7 +247,7 @@ class OrderSlipCore extends ObjectModel
      */
     public static function createOrderSlip($order, $productList, $qtyList, $shipping_cost = false)
     {
-        Tools::displayAsDeprecated();
+        Tools::displayAsDeprecated('Use OrderSlip::create() instead');
 
         $product_list = array();
         foreach ($productList as $id_order_detail) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add document method to use instead of deprecated one.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

Cherry-pick from https://github.com/PrestaShop/PrestaShop/pull/5171