### PR TITLE
Fix Administering email setting whith/without log

### DIFF
--- a/controllers/admin/AdminEmailsController.php
+++ b/controllers/admin/AdminEmailsController.php
@@ -32,18 +32,18 @@ class AdminEmailsControllerCore extends AdminController
     public function __construct()
     {
         $this->bootstrap = true;
+        
+        $this->table = 'mail';
+        $this->className = 'Mail';
+        
+        parent::__construct();
 
         if (Configuration::get('PS_LOG_EMAILS')) {
-            $this->table = 'mail';
-            $this->className = 'Mail';
-
             $this->lang = false;
             $this->noLink = true;
             $this->list_no_link = true;
             $this->explicitSelect = true;
             $this->addRowAction('delete');
-
-            parent::__construct();
 
             $this->bulk_actions = array(
                 'delete' => array(


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop branch;
| Description?  | Fix a bug in administering email settings. When you disabled log email, an error is occurred.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2311?jql=project%20%3D%20BOOM%20AND%20fixVersion%20%3D%201.7.1.1
| How to test?  | In administrator email. In applet e-mail, put false for log email. After select use my own parameters (for expert). When you save modification in this applet, before fix an error is occured.