### PR TITLE
Use default state for tax purposes

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -446,9 +446,9 @@ class AddressCore extends ObjectModel
             } else {
                 // set the default address
                 $address             = new Address();
-                $address->id_country = (int)$context->country->id;
-                $address->id_state   = 0;
-                $address->postcode   = 0;
+                $address->id_country = Configuration::get('PS_SHOP_COUNTRY_ID') ? Configuration::get('PS_SHOP_COUNTRY_ID') : Configuration::get('PS_COUNTRY_DEFAULT');
+                $address->id_state   = Configuration::get('PS_SHOP_STATE_ID');
+                $address->postcode   = Configuration::get('PS_SHOP_CODE');
             }
             Cache::store($cache_id, $address);
 


### PR DESCRIPTION
In countries with two level of taxes, it is interesting to give an estimate of taxes based on the shop location and applying also the state tax.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In countries with two level of taxes, it is interesting to give an estimate of taxes based on the shop location and applying also the state tax.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  |  -

See: https://github.com/PrestaShop/PrestaShop/pull/4415