### PR TITLE
Add barcode to invoices

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -310,7 +310,24 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             $legal_free_text = Configuration::get('PS_INVOICE_LEGAL_FREE_TEXT', (int)Context::getContext()->language->id, null, (int)$this->order->id_shop);
         }
 
+        $pdf = new PDFGenerator((bool)Configuration::get('PS_PDF_USE_CACHE'));
+        $barcode_params = $pdf->serializeTCPDFtagParameters(array(
+            $this->order->getUniqReference(), 'C128', '', '', 0, 0, 0.2,
+            array(
+                'position'=>'S',
+                'border'=>false,
+                'padding'=>0,
+                'fgcolor'=>array(0,0,0),
+                'bgcolor'=>array(255,255,255),
+                'text'=>true, 'font'=>'Helvetica',
+                'fontsize'=>8,
+                'stretchtext'=>0
+            ),
+            'N')
+        );
+
         $data = array(
+            'barcode_params' => $barcode_params,
             'order' => $this->order,
             'order_invoice' => $this->order_invoice,
             'order_details' => $order_details,

--- a/pdf/invoice.addresses-tab.tpl
+++ b/pdf/invoice.addresses-tab.tpl
@@ -32,4 +32,9 @@
 				{$invoice_address}
 		</td>
 	</tr>
+  <tr>
+    <td width="100%">
+      <tcpdf method="write1DBarcode" params="{$barcode_params}" />
+    </td>
+  </tr>
 </table>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | Develop
| Description?  | Used TCPDF for generating BARCODE. <br/> First we created TCPDF parameters in HTMLTemplateInvoice.php and then used it in invoice.addresses-tab.tpl to print barcode.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Generate a invoice.


Cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/6899

ping @vincentbz @thenote 