### PR TITLE
Fix call to actionCartSummary hook

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3766,9 +3766,18 @@ class CartCore extends ObjectModel
             'carrier' => new Carrier($this->id_carrier, $id_lang),
         );
 
-        $hook = Hook::exec('actionCartSummary', $summary, null, true);
-        if (is_array($hook)) {
-            $summary = array_merge($summary, (array)array_shift($hook));
+        $hook = Hook::exec(
+            'actionCartSummary',
+            $summary,
+            null,
+            true,
+            true,
+            false,
+            null,
+            true
+        );
+        if (is_array($hook) && !empty($hook)) {
+            $summary = array_merge($summary, $hook);
         }
 
         return $summary;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed actionCartSummary hook results to be correcly merged into cart summary data.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

See https://github.com/PrestaShop/PrestaShop/pull/6917