### PR TITLE
Pass the object we're displaying to the action{$controller}FormMo…

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2503,6 +2503,7 @@ class AdminControllerCore extends Controller
             $fields_value = $this->getFieldsValue($this->object);
 
             Hook::exec('action'.$this->controller_name.'FormModifier', array(
+                'object' => &$this->object,
                 'fields' => &$this->fields_form,
                 'fields_value' => &$fields_value,
                 'form_vars' => &$this->tpl_form_vars,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This allows modules to register a hook instead of overriding the whole controller to add a new section to "display" templates.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

Cherry-picked from https://github.com/PrestaShop/PrestaShop/pull/4401