### PR TITLE
Add missing metadata to translations catalogues on export

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -208,7 +208,7 @@ class TranslationsController extends FrameworkBundleAdminController
         $locale = $langRepository->getLocaleByIsoCode($isoCode);
 
         $themeExporter = $this->get('prestashop.translation.theme.exporter');
-        $zipFile = $themeExporter->createZipArchive($themeName, $locale);
+        $zipFile = $themeExporter->createZipArchive($themeName, $locale, _PS_ROOT_DIR_.DIRECTORY_SEPARATOR);
 
         $response = new BinaryFileResponse($zipFile);
         $response->deleteFileAfterSend(true);

--- a/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
+++ b/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
@@ -76,11 +76,12 @@ class ThemeExporter
     /**
      * @param $themeName
      * @param $locale
+     * @param $rootDir
      * @return string
      */
-    public function createZipArchive($themeName, $locale)
+    public function createZipArchive($themeName, $locale, $rootDir = false)
     {
-        $archiveParentDirectory = $this->exportCatalogues($themeName, $locale);
+        $archiveParentDirectory = $this->exportCatalogues($themeName, $locale, $rootDir);
         $zipFilename = $this->makeZipFilename($themeName, $locale);
         $this->zipManager->createArchive($zipFilename, $archiveParentDirectory);
 
@@ -90,14 +91,15 @@ class ThemeExporter
     /**
      * @param $themeName
      * @param $locale
+     * @param $rootDir
      * @return string
      */
-    public function exportCatalogues($themeName, $locale)
+    public function exportCatalogues($themeName, $locale, $rootDir = false)
     {
         $this->themeProvider->setLocale($locale);
         $this->themeProvider->setThemeName($themeName);
 
-        $mergedTranslations = $this->getCatalogueExtractedFromTemplates($themeName, $locale);
+        $mergedTranslations = $this->getCatalogueExtractedFromTemplates($themeName, $locale, $rootDir);
         try {
             $themeCatalogue = $this->themeProvider->getThemeCatalogue();
         } catch (\Exception $exception) {
@@ -125,7 +127,8 @@ class ThemeExporter
 
         $this->dumper->dump($mergedTranslations, array(
             'path' => $archiveParentDirectory,
-            'default_locale' => $locale
+            'default_locale' => $locale,
+            'root_dir' => $rootDir,
         ));
 
         $this->renameCatalogues($locale, $archiveParentDirectory);
@@ -152,9 +155,10 @@ class ThemeExporter
     /**
      * @param $themeName
      * @param $locale
+     * @param $rootDir
      * @return \Symfony\Component\Translation\MessageCatalogue
      */
-    protected function getCatalogueExtractedFromTemplates($themeName, $locale)
+    protected function getCatalogueExtractedFromTemplates($themeName, $locale, $rootDir = false)
     {
         $tmpFolderPath = $this->getTemporaryExtractionFolder($themeName);
         $folderPath = $this->getFlattenizationFolder($themeName);
@@ -168,7 +172,7 @@ class ThemeExporter
         $theme = $this->themeRepository->getInstanceByName($themeName);
         $this->themeExtractor
             ->setOutputPath($tmpFolderPath)
-            ->extract($theme, $locale);
+            ->extract($theme, $locale, $rootDir);
 
         Flattenizer::flatten($tmpFolderPath . '/' . $locale, $folderPath . '/' . $locale, $locale);
 

--- a/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
+++ b/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
@@ -63,7 +63,7 @@ class ThemeExtractor
         return $this;
     }
 
-    public function extract(Theme $theme, $locale = 'en-US')
+    public function extract(Theme $theme, $locale = 'en-US', $rootDir = false)
     {
         $this->catalog = new MessageCatalogue($locale);
         // remove the last "/"
@@ -72,8 +72,9 @@ class ThemeExtractor
         $options = array(
             'path' => $themeDirectory,
             'default_locale' => $locale,
+            'root_dir' => $rootDir,
         );
-        $this->smartyExtractor->extract($themeDirectory, $this->catalog);
+        $this->smartyExtractor->extract($themeDirectory, $this->catalog, $options['root_dir']);
 
         if ($this->overrideFromDatabase) {
             $this->overrideFromDatabase($theme->getName(), $locale, $this->catalog);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Export translations catalogues with missing metadata (file and line)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2295
| How to test?  | Export translations catalogues and check metadata