### PR TITLE
Prevents problem with missing params in getWidgetVariables()

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -124,7 +124,7 @@ function smartyWidgetBlock($params, $content, &$smarty)
         withWidget($params, function ($widget, $params) use (&$smarty, &$backedUpVariablesStack) {
             // Assign widget variables and backup all the variables they override
             $currentVariables = $smarty->getTemplateVars();
-            $scopedVariables = $widget->getWidgetVariables();
+            $scopedVariables = $widget->getWidgetVariables(null, $params);
             $backedUpVariables = array();
             foreach ($scopedVariables as $key => $value) {
                 if (array_key_exists($key, $currentVariables)) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | refs https://github.com/PrestaShop/StarterTheme/issues/171
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | try to use shoppingcart as a `{widget_block}` before and after this change
| Sponsor company | impSolutions

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->