### PR TITLE
BO: Fix backoffice order with deleted address

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -1049,6 +1049,14 @@
 				delivery_address_edit_link = "{$link->getAdminLink('AdminAddresses')}&id_address="+this.id_address+"&updateaddress&realedit=1&liteDisplaying=1&submitFormAjax=1#";
 			}
 
+			if(address_invoice_detail == '') {
+				address_invoice_detail = this.formated_address;
+			}
+
+			if(address_delivery_detail == '') {
+				address_delivery_detail = this.formated_address;
+			}
+
 			addresses_delivery_options += '<option value="'+this.id_address+'" '+(this.id_address == id_address_delivery ? 'selected="selected"' : '')+'>'+this.alias+'</option>';
 			addresses_invoice_options += '<option value="'+this.id_address+'" '+(this.id_address == id_address_invoice ? 'selected="selected"' : '')+'>'+this.alias+'</option>';
 		});


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix backoffice order with deleted address
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | If you want to add an order via backoffice and you have chosen an existing customer, his carts and orders are loaded. But if the address of the cart is not existing anymore (marked as deleted), there is no chance to edit it. This code change makes sure, that an existing backup address is loaded properly.


Cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/5360

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
