### PR TITLE
Fix product customization duplication

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4194,9 +4194,9 @@ class ProductCore extends ObjectModel
         }
 
         if (($customization_labels = Db::getInstance()->executeS('
-			SELECT `id_customization_field`, `id_lang`, `name`
-			FROM `'._DB_PREFIX_.'customization_field_lang` AS cfl
-			WHERE `id_customization_field` IN ('.implode(', ', $customization_field_ids).')'.($id_shop ? ' AND cfl.`id_shop` = '.(int)$id_shop : '').'
+			SELECT `id_customization_field`, `id_lang`, `id_shop`, `name`
+			FROM `'._DB_PREFIX_.'customization_field_lang`
+			WHERE `id_customization_field` IN ('.implode(', ', $customization_field_ids).')'.($id_shop ? ' AND `id_shop` = '.(int)$id_shop : '').'
 			ORDER BY `id_customization_field`')) === false) {
             return false;
         }
@@ -4248,6 +4248,7 @@ class ProductCore extends ObjectModel
                     $data = array(
                         'id_customization_field' => (int)$customization_field_id,
                         'id_lang' => (int)$customization_label['id_lang'],
+                        'id_shop' => (int)$customization_label['id_shop'],
                         'name' => pSQL($customization_label['name']),
                     );
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Fix an SQL error when duplicating a product with customization fields. This error is caused by the id_shop column added in the customization_field_lang table with PrestaShop 1.6.0.12. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Create a product, add customization fields, duplicate the product |

Fix an SQL error when duplicating a product with customization fields.
This error is caused by the id_shop column added in the customization_field_lang table with PrestaShop 1.6.0.12.

Cherry-pick of: https://github.com/PrestaShop/PrestaShop/pull/6842

already merged on 1.6.1.x https://github.com/PrestaShop/PrestaShop/pull/7099
