### PR TITLE
Check if hook exists before get hook module exec list

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -435,15 +435,18 @@ class HookCore extends ObjectModel
             throw new PrestaShopException('Invalid id_module or hook_name');
         }
 
-        // If no modules associated to hook_name or recompatible hook name, we stop the function
-
-        if (!$module_list = Hook::getHookModuleExecList($hook_name)) {
-            return '';
-        }
-
         // Check if hook exists
         if (!$id_hook = Hook::getIdByName($hook_name)) {
             return false;
+        }
+
+        // If no modules associated to hook_name or retro-compatible hook name, we stop the function
+        if (!$module_list = Hook::getHookModuleExecList($hook_name)) {
+            if ($array_return) {
+                return array();
+            } else {
+                return '';
+            }
         }
 
         // Store list of executed hooks on this page


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Class: Hook / Check if hook exists before get hook module exec list
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | -

cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/4600