### PR TITLE
 Fix fatal when no product to set in CategorySearchProvider

### DIFF
--- a/src/Adapter/BestSales/BestSalesProductSearchProvider.php
+++ b/src/Adapter/BestSales/BestSalesProductSearchProvider.php
@@ -65,27 +65,29 @@ class BestSalesProductSearchProvider implements ProductSearchProviderInterface
         $count = (int) ProductSale::getNbSales();
 
         $result = new ProductSearchResult();
-        $result
-            ->setProducts($products)
-            ->setTotalProductsCount($count)
-        ;
 
-        $result->setAvailableSortOrders(
-            array(
-                (new SortOrder('product', 'name', 'asc'))->setLabel(
-                    $this->translator->trans('Name, A to Z', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'name', 'desc'))->setLabel(
-                    $this->translator->trans('Name, Z to A', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'price', 'asc'))->setLabel(
-                    $this->translator->trans('Price, low to high', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'price', 'desc'))->setLabel(
-                    $this->translator->trans('Price, high to low', array(), 'Shop.Theme.Catalog')
-                ),
-            )
-        );
+        if (!empty($products)) {
+            $result
+                ->setProducts($products)
+                ->setTotalProductsCount($count);
+
+            $result->setAvailableSortOrders(
+                array(
+                    (new SortOrder('product', 'name', 'asc'))->setLabel(
+                        $this->translator->trans('Name, A to Z', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'name', 'desc'))->setLabel(
+                        $this->translator->trans('Name, Z to A', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'price', 'asc'))->setLabel(
+                        $this->translator->trans('Price, low to high', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'price', 'desc'))->setLabel(
+                        $this->translator->trans('Price, high to low', array(), 'Shop.Theme.Catalog')
+                    ),
+                )
+            );
+        }
 
         return $result;
     }

--- a/src/Adapter/Category/CategoryProductSearchProvider.php
+++ b/src/Adapter/Category/CategoryProductSearchProvider.php
@@ -87,14 +87,16 @@ class CategoryProductSearchProvider implements ProductSearchProviderInterface
         $count = $this->getProductsOrCount($context, $query, 'count');
 
         $result = new ProductSearchResult();
-        $result
-            ->setProducts($products)
-            ->setTotalProductsCount($count)
-        ;
 
-        $result->setAvailableSortOrders(
-            $this->sortOrderFactory->getDefaultSortOrders()
-        );
+        if (!empty($products)) {
+            $result
+                ->setProducts($products)
+                ->setTotalProductsCount($count);
+
+            $result->setAvailableSortOrders(
+                $this->sortOrderFactory->getDefaultSortOrders()
+            );
+        }
 
         return $result;
     }

--- a/src/Adapter/NewProducts/NewProductsProductSearchProvider.php
+++ b/src/Adapter/NewProducts/NewProductsProductSearchProvider.php
@@ -73,33 +73,35 @@ class NewProductsProductSearchProvider implements ProductSearchProviderInterface
         $count = $this->getProductsOrCount($context, $query, 'count');
 
         $result = new ProductSearchResult();
-        $result
-            ->setProducts($products)
-            ->setTotalProductsCount($count)
-        ;
 
-        $result->setAvailableSortOrders(
-            array(
-                (new SortOrder('product', 'date_add', 'desc'))->setLabel(
-                    $this->translator->trans('Date added, newest to oldest', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'date_add', 'asc'))->setLabel(
-                    $this->translator->trans('Date added, oldest to newest', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'name', 'asc'))->setLabel(
-                    $this->translator->trans('Name, A to Z', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'name', 'desc'))->setLabel(
-                    $this->translator->trans('Name, Z to A', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'price', 'asc'))->setLabel(
-                    $this->translator->trans('Price, low to high', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'price', 'desc'))->setLabel(
-                    $this->translator->trans('Price, high to low', array(), 'Shop.Theme.Catalog')
-                ),
-            )
-        );
+        if (!empty($products)) {
+            $result
+                ->setProducts($products)
+                ->setTotalProductsCount($count);
+
+            $result->setAvailableSortOrders(
+                array(
+                    (new SortOrder('product', 'date_add', 'desc'))->setLabel(
+                        $this->translator->trans('Date added, newest to oldest', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'date_add', 'asc'))->setLabel(
+                        $this->translator->trans('Date added, oldest to newest', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'name', 'asc'))->setLabel(
+                        $this->translator->trans('Name, A to Z', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'name', 'desc'))->setLabel(
+                        $this->translator->trans('Name, Z to A', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'price', 'asc'))->setLabel(
+                        $this->translator->trans('Price, low to high', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'price', 'desc'))->setLabel(
+                        $this->translator->trans('Price, high to low', array(), 'Shop.Theme.Catalog')
+                    ),
+                )
+            );
+        }
 
         return $result;
     }

--- a/src/Adapter/PricesDrop/PricesDropProductSearchProvider.php
+++ b/src/Adapter/PricesDrop/PricesDropProductSearchProvider.php
@@ -74,27 +74,29 @@ class PricesDropProductSearchProvider implements ProductSearchProviderInterface
         $count = $this->getProductsOrCount($context, $query, 'count');
 
         $result = new ProductSearchResult();
-        $result
-            ->setProducts($products)
-            ->setTotalProductsCount($count)
-        ;
 
-        $result->setAvailableSortOrders(
-            [
-                (new SortOrder('product', 'name', 'asc'))->setLabel(
-                    $this->translator->trans('Name, A to Z', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'name', 'desc'))->setLabel(
-                    $this->translator->trans('Name, Z to A', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'price', 'asc'))->setLabel(
-                    $this->translator->trans('Price, low to high', array(), 'Shop.Theme.Catalog')
-                ),
-                (new SortOrder('product', 'price', 'desc'))->setLabel(
-                    $this->translator->trans('Price, high to low', array(), 'Shop.Theme.Catalog')
-                )
-            ]
-        );
+        if (!empty($products)) {
+            $result
+                ->setProducts($products)
+                ->setTotalProductsCount($count);
+
+            $result->setAvailableSortOrders(
+                [
+                    (new SortOrder('product', 'name', 'asc'))->setLabel(
+                        $this->translator->trans('Name, A to Z', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'name', 'desc'))->setLabel(
+                        $this->translator->trans('Name, Z to A', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'price', 'asc'))->setLabel(
+                        $this->translator->trans('Price, low to high', array(), 'Shop.Theme.Catalog')
+                    ),
+                    (new SortOrder('product', 'price', 'desc'))->setLabel(
+                        $this->translator->trans('Price, high to low', array(), 'Shop.Theme.Catalog')
+                    )
+                ]
+            );
+        }
 
         return $result;
     }

--- a/src/Adapter/Search/SearchProductSearchProvider.php
+++ b/src/Adapter/Search/SearchProductSearchProvider.php
@@ -81,7 +81,6 @@ class SearchProductSearchProvider implements ProductSearchProviderInterface
                 // deprecated since 1.7.x
                 'expr' => $queryString,
             ));
-
         } elseif (($tag = $query->getSearchTag())) {
             $queryString = urldecode($tag);
 
@@ -119,14 +118,18 @@ class SearchProductSearchProvider implements ProductSearchProviderInterface
         }
 
         $result = new ProductSearchResult();
-        $result
-            ->setProducts($products)
-            ->setTotalProductsCount($count)
-        ;
 
-        $result->setAvailableSortOrders(
-            $this->sortOrderFactory->getDefaultSortOrders()
-        );
+        if (!empty($products)) {
+            $result
+                ->setProducts($products)
+                ->setTotalProductsCount($count);
+
+            $result->setAvailableSortOrders(
+                $this->sortOrderFactory->getDefaultSortOrders()
+            );
+        }
+
+        return $result;
 
         return $result;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  |  Fix fatal when no product to set in CategorySearchProvider. The `CategorySearchProvider->getProductsOrCount()` function may return a boolean and we're waiting for an array in `ProductSearchResult->setProducts()`
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2382
| How to test?  |