### PR TITLE
Consistency & additionnal infos

### DIFF
--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -292,7 +292,7 @@ class CartPresenter implements PresenterInterface
             'type' => 'products',
             'label' => $this->translator->trans('Subtotal', array(), 'Shop.Theme.Checkout'),
             'amount' => $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS),
-            'value' => $this->priceFormatter->format(($cart->getOrderTotal(true, Cart::ONLY_PRODUCTS))),
+            'value' => $this->priceFormatter->format(($cart->getOrderTotal($this->includeTaxes(), Cart::ONLY_PRODUCTS))),
         );
 
         if ($total_discount) {
@@ -356,6 +356,18 @@ class CartPresenter implements PresenterInterface
                 'value' => $this->priceFormatter->format(
                     $this->includeTaxes() ? $total_including_tax : $total_excluding_tax
                 ),
+            ),
+            'total_including_tax' => array(
+                'type' => 'total',
+                'label' => $this->translator->trans('Total (tax incl.)', array(), 'Shop.Theme.Checkout'),
+                'amount' => $total_including_tax,
+                'value' => $this->priceFormatter->format($total_including_tax),
+            ),
+            'total_excluding_tax' => array(
+                'type' => 'total',
+                'label' => $this->translator->trans('Total (tax excl.)', array(), 'Shop.Theme.Checkout'),
+                'amount' => $total_excluding_tax,
+                'value' => $this->priceFormatter->format($total_excluding_tax),
             ),
         );
 


### PR DESCRIPTION
When displaying the prices without taxes, the product subtotal is still displayed with taxes (witch is inconsistent with the other subtotals).

And also add some grand total infos in order to have them available for use in themes (for example in B2B it can be usefull to display all to prices without taxes, but nevertheless show the grand total with taxes).

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Improvement of the display of subtotals in the cart
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->