### PR TITLE
Make sure that invoice siblings are related to the same order id

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -709,7 +709,9 @@ class OrderInvoiceCore extends ObjectModel
         $query->innerJoin(
             'order_invoice_payment',
             'oip2',
-            'oip2.id_order_payment = oip1.id_order_payment AND oip2.id_order_invoice <> oip1.id_order_invoice'
+            'oip2.id_order_payment = oip1.id_order_payment 
+                AND oip2.id_order_invoice <> oip1.id_order_invoice
+                AND oip2.id_order = oip1.id_order'
         );
         $query->where('oip1.id_order_invoice = '.(int) $this->id);
 
@@ -745,7 +747,9 @@ class OrderInvoiceCore extends ObjectModel
         $query->innerJoin(
             'order_invoice_payment',
             'oip2',
-            'oip2.id_order_payment = oip1.id_order_payment AND oip2.id_order_invoice <> oip1.id_order_invoice'
+            'oip2.id_order_payment = oip1.id_order_payment 
+                AND oip2.id_order_invoice <> oip1.id_order_invoice
+                AND oip2.id_order = oip1.id_order'
         );
         $query->leftJoin(
             'order_invoice',


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Make sure that invoice siblings are related to the same order id
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | do several orders and change state

cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/7112