### PR TITLE
Change all OrderController private methods and var to protected

### DIFF
--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -70,7 +70,7 @@ class OrderControllerCore extends FrontController
         $this->bootstrap();
     }
 
-    private function getCheckoutSession()
+    protected function getCheckoutSession()
     {
         $deliveryOptionsFinder = new DeliveryOptionsFinder(
             $this->context,
@@ -87,7 +87,7 @@ class OrderControllerCore extends FrontController
         return $session;
     }
 
-    private function bootstrap()
+    protected function bootstrap()
     {
         $translator = $this->getTranslator();
 
@@ -147,7 +147,7 @@ class OrderControllerCore extends FrontController
         ;
     }
 
-    private function saveDataToPersist(CheckoutProcess $process)
+    protected function saveDataToPersist(CheckoutProcess $process)
     {
         $data = $process->getDataToPersist();
         $data['checksum'] = $this->cartChecksum->generateChecksum($this->context->cart);
@@ -158,7 +158,7 @@ class OrderControllerCore extends FrontController
         );
     }
 
-    private function restorePersistedData(CheckoutProcess $process)
+    protected function restorePersistedData(CheckoutProcess $process)
     {
         $rawData = Db::getInstance()->getValue(
             'SELECT checkout_session_data FROM '._DB_PREFIX_.'cart WHERE id_cart = '.(int) $this->context->cart->id


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |develop
| Description?  | Methods and variables in the OrderController.php file changed to protected to enable overriding.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Try overriding method getCheckoutSession in  OrderController.php

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
