### PR TITLE
Revert "Check if hook exists before get hook module exec list"

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -621,18 +621,19 @@ class HookCore extends ObjectModel
             throw new PrestaShopException('Invalid id_module or hook_name');
         }
 
-        // Check if hook exists
-        if (!$id_hook = Hook::getIdByName($hook_name)) {
-            return false;
-        }
+        // If no modules associated to hook_name or recompatible hook name, we stop the function
 
-        // If no modules associated to hook_name or retro-compatible hook name, we stop the function
         if (!$module_list = Hook::getHookModuleExecList($hook_name)) {
             if ($array_return) {
                 return array();
             } else {
                 return '';
             }
+        }
+
+        // Check if hook exists
+        if (!$id_hook = Hook::getIdByName($hook_name)) {
+            return false;
         }
 
         if (array_key_exists($hook_name, self::$deprecated_hooks)) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Revert of #7516. Because the same PR on `1.6.1.x` branch is breaking the tests, we prefer revert on `develop` too.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | -
