### PR TITLE
Payment method title extended to 255 characters

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -785,7 +785,7 @@ abstract class PaymentModuleCore extends Module
                         '{order_name}' => $order->getUniqReference(),
                         '{date}' => Tools::displayDate(date('Y-m-d H:i:s'), null, 1),
                         '{carrier}' => ($virtual_product || !isset($carrier->name)) ? $this->trans('No carrier', array(), 'Admin.Payment.Notification') : $carrier->name,
-                        '{payment}' => Tools::substr($order->payment, 0, 32),
+                        '{payment}' => Tools::substr($order->payment, 0, 255),
                         '{products}' => $product_list_html,
                         '{products_txt}' => $product_list_txt,
                         '{discounts}' => $cart_rules_list_html,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | 32-char length is too short. DB schema describes this attribute as 255 char length. After fix now this is equal - DB and PHP code. It is not acceptable to trim to 32 chars, because this is used in email notifications and invoices. The buyer can't see whole title if it's more than 32 char length. E.g. if payment module name is „Credit card payment on products reception“ the buyer will see only „Credit card payment on products “.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Use payment method with title longer than 32 chars and see buyers email or PDF invoice.