### PR TITLE
Fix url rewrite starting with numbers

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -112,7 +112,7 @@ class DispatcherCore
             'keywords' => array(
                 'id' =>            array('regexp' => '[0-9]+', 'param' => 'id_product'),
                 'id_product_attribute' => array('regexp' => '[0-9]+', 'param' => 'id_product_attribute'),
-                'rewrite' =>        array('regexp' => '[_a-zA-Z0-9\pL\pS-]*'),
+                'rewrite' =>        array('regexp' => '[_a-zA-Z0-9\pL\pS-]*', 'param' => 'rewrite'),
                 'ean13' =>        array('regexp' => '[0-9\pL]*'),
                 'category' =>        array('regexp' => '[_a-zA-Z0-9-\pL]*'),
                 'categories' =>        array('regexp' => '[/_a-zA-Z0-9-\pL]*'),

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5753,6 +5753,18 @@ class ProductCore extends ObjectModel
         return $result;
     }
 
+    /**
+     * @return bool
+     */
+    public function hasCombinations()
+    {
+        if (is_null($this->id) || 0 >= $this->id) {
+            return false;
+        }
+        $attributes = self::getAttributesInformationsByProduct($this->id);
+        return !empty($attributes);
+    }
+
     public static function getIdProductAttributesByIdAttributes($id_product, $id_attributes, $find_best = false)
     {
         if (!is_array($id_attributes)) {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -119,6 +119,9 @@ class FrontControllerCore extends Controller
     /** @var bool If true, forces display to maintenance page. */
     protected $maintenance = false;
 
+    /** @var string[] Adds excluded $_GET keys for redirection */
+    protected $redirectionExtraExcludedKeys = array();
+
     /**
      * True if controller has already been initialized.
      * Prevents initializing controller more than once.
@@ -771,6 +774,7 @@ class FrontControllerCore extends Controller
                 }
             }
             $excluded_key = array('isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms');
+            $excluded_key = array_merge($excluded_key, $this->redirectionExtraExcludedKeys);
             foreach ($_GET as $key => $value) {
                 if (!in_array($key, $excluded_key) && Validate::isUrl($key) && Validate::isUrl($value)) {
                     $params[Tools::safeOutput($key)] = Tools::safeOutput($value);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -40,6 +40,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /** @var Category */
     protected $category;
 
+    protected $redirectionExtraExcludedKeys = ['id_product_attribute', 'rewrite'];
+
     /**
      * @var array
      */
@@ -53,6 +55,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         if (Validate::isLoadedObject($this->product)) {
             if (!$this->product->hasCombinations()) {
                 unset($_GET['id_product_attribute']);
+            } else if (!Tools::getValue('id_product_attribute') || Tools::getValue('rewrite') !== $this->product->link_rewrite) {
+                $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
             }
             $id_product_attribute = Tools::getValue('id_product_attribute');
             parent::canonicalRedirection($this->context->link->getProductLink(

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -50,8 +50,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     public function canonicalRedirection($canonical_url = '')
     {
-        $id_product_attribute = Tools::getValue('id_product_attribute');
         if (Validate::isLoadedObject($this->product)) {
+            if (!$this->product->hasCombinations()) {
+                unset($_GET['id_product_attribute']);
+            }
+            $id_product_attribute = Tools::getValue('id_product_attribute');
             parent::canonicalRedirection($this->context->link->getProductLink(
                 $this->product,
                 null,
@@ -594,7 +597,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                     }
                 }
             }
-            
+
             // wash attributes list depending on available attributes depending on selected preceding attributes
             $current_selected_attributes = array();
             $count = 0;

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -723,6 +723,7 @@ class AdminProductWrapper
             return false;
         }
 
+        $id_product_attribute = \Product::getDefaultAttribute($product->id);
         $is_rewrite_active = (bool)\ConfigurationCore::get('PS_REWRITING_SETTINGS');
         $preview_url = $context->link->getProductLink(
             $product,
@@ -731,7 +732,7 @@ class AdminProductWrapper
             null,
             $id_lang,
             (int)$context->shop->id,
-            0,
+            $id_product_attribute,
             $is_rewrite_active
         );
 

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -723,7 +723,6 @@ class AdminProductWrapper
             return false;
         }
 
-        $id_product_attribute = \Product::getDefaultAttribute($product->id);
         $is_rewrite_active = (bool)\ConfigurationCore::get('PS_REWRITING_SETTINGS');
         $preview_url = $context->link->getProductLink(
             $product,
@@ -732,7 +731,7 @@ class AdminProductWrapper
             null,
             $id_lang,
             (int)$context->shop->id,
-            $id_product_attribute,
+            0,
             $is_rewrite_active
         );
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | URL Rewrites starting with numbers and dash were breaking the front for product without combinations.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2393
| How to test?  | Create a product without combinations. Give it a price and a quantity. Set the url rewrite to `5-{product_name}` and go to its front page. You should be able to buy the product.