### PR TITLE
Bugfix JS with advancedEuCompliance

### DIFF
--- a/themes/default-bootstrap/shopping-cart-advanced.tpl
+++ b/themes/default-bootstrap/shopping-cart-advanced.tpl
@@ -371,3 +371,7 @@
     </a>
     <button data-show-if-js="" style="" id="confirmOrder" type="button" class="button btn btn-default standard-checkout button-medium"><span>{l s='Order With Obligation To Pay'}</span></button>
 </p>
+
+{strip}
+{addJsDef deliveryAddress=$cart->id_address_delivery|intval}
+{/strip}


### PR DESCRIPTION
Fix of JS error "Uncaught Reference: deliveryAddress in order-opc.js" when changing address in one page checkout with activated advancedEuCompliance module.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fix of JS error "Uncaught Reference: deliveryAddress in order-opc.js" when changing address in one page checkout with activated advancedEuCompliance module.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Use one-page-checkout and advancedEuCompliance module, put something in the cart. Then try to checkout as guest, save your address details and see in the JS console the error coming up. With this fix, the error should not be there anymore.
