### PR TITLE
BO : Fix when saving product with same name categories

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -78,7 +78,7 @@ class ProductInformation extends CommonAbstractType
         $this->locales = $this->context->getLanguages();
         $this->currency = $this->context->getContext()->currency;
 
-        $this->categories = $this->formatDataChoicesList(
+        $this->categories = $this->formatDataDuplicateChoicesList(
             $this->categoryDataProvider->getAllCategoriesName(
                 $root_category = null,
                 $id_lang = false,


### PR DESCRIPTION


<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | develop
| Description  | This commit uses the new formatDataDuplicateChoicesList() function added in CommonAbstractType.php to allow duplicates categories names and prevent an error when you save a product and Prestashop contains 2 categories with the same name.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create categories with exactly the same name, and try to add them to a product

