### PR TITLE
Fix module configure button when in dropdown

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -57,7 +57,7 @@
           {% if module_action != url_active %}
             <li>
                 <form method="post" action="{{ module_url }}">
-                    <button type="button" class="dropdown-item module_action_menu_{{ module_action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">
+                    <button type="submit" class="dropdown-item module_action_menu_{{ module_action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">
                         {{module_action|capitalize|replace({'_': " "})}}
                     </button>
                 </form>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR fixes an issue happening when the Configuration link is not the main action of a module.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2387
| How to test?  | Go the module page, tab "Notification". If a module needs an upgrade, try to open the dropdown of actions and click on configure. With this PR, the link must work.