### PR TITLE
Prevent widgets to break back-office

### DIFF
--- a/classes/Smarty/SmartyResourceModule.php
+++ b/classes/Smarty/SmartyResourceModule.php
@@ -31,9 +31,10 @@
  */
 class SmartyResourceModuleCore extends Smarty_Resource_Custom
 {
-    public function __construct(array $paths)
+    public function __construct(array $paths, $isAdmin = false)
     {
         $this->paths = $paths;
+        $this->isAdmin = $isAdmin;
     }
 
     /**
@@ -45,6 +46,12 @@ class SmartyResourceModuleCore extends Smarty_Resource_Custom
      */
     protected function fetch($name, &$source, &$mtime)
     {
+        if ($this->isAdmin) {
+            $source = '';
+            $mtime = time();
+            return;
+        }
+
         foreach ($this->paths as $path) {
             if (Tools::file_exists_cache($file = $path.$name)) {
                 if (_PS_MODE_DEV_) {

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -47,6 +47,9 @@ smartyRegisterFunction($smarty, 'function', 'addJsDef', array('Media', 'addJsDef
 smartyRegisterFunction($smarty, 'block', 'addJsDefL', array('Media', 'addJsDefL'));
 smartyRegisterFunction($smarty, 'modifier', 'secureReferrer', array('Tools', 'secureReferrer'));
 
+$module_resources['modules'] = _PS_MODULE_DIR_;
+$smarty->registerResource('module', new SmartyResourceModule($module_resources, $isAdmin = true));
+
 function toolsConvertPrice($params, &$smarty)
 {
     return Tools::convertPrice($params['price'], Context::getContext()->currency);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Prevent widgets to break back-office. When you hooked a widgetized front module on a back-office display hook it was breaking.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2412
| How to test?  | Try to hook the ps_imageslider on displayAdminAfterHeader