### PR TITLE
CO: Using hyphen instead of underscores in suppliers and manufacturers urls

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -57,7 +57,7 @@ class DispatcherCore
         ),
         'supplier_rule' => array(
             'controller' =>    'supplier',
-            'rule' =>        '{id}__{rewrite}',
+            'rule' =>        'supplier/{id}-{rewrite}',
             'keywords' => array(
                 'id' =>            array('regexp' => '[0-9]+', 'param' => 'id_supplier'),
                 'rewrite' =>        array('regexp' => '[_a-zA-Z0-9\pL\pS-]*'),
@@ -67,7 +67,7 @@ class DispatcherCore
         ),
         'manufacturer_rule' => array(
             'controller' =>    'manufacturer',
-            'rule' =>        '{id}_{rewrite}',
+            'rule' =>        'manufacturer/{id}-{rewrite}',
             'keywords' => array(
                 'id' =>            array('regexp' => '[0-9]+', 'param' => 'id_manufacturer'),
                 'rewrite' =>        array('regexp' => '[_a-zA-Z0-9\pL\pS-]*'),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Using by default hyphen instead of underscores in suppliers and manufacturers urls
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8869
| How to test?  | Check Backend SEO config and Frontend suppliers and manufacturers pages are working correctly.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
