### PR TITLE
Fix doubled quantity when ordering a customizable product

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -909,7 +909,6 @@
 		//refresh form customization
 		searchProducts();
 
-		addProductProcess();
 	}
 
 	function addProductProcess()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Product quantity getting doubled if it has customization option while creating order via BO. This is due to a double call to a function when we order this type of products.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8438
| How to test?  |  

Add customization option for a product.
Create order in back office.
Search for the product.
The product will be listed.
Add the product the cart the quantity will be doubled.
Add any quantity and it will get doubled.