### PR TITLE
Notification after theme reset, warning about images regeneration

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -279,7 +279,13 @@ class AdminThemesControllerCore extends AdminController
             $this->theme_manager->uninstall(Tools::getValue('theme_name'));
             $this->redirect_after = $this->context->link->getAdminLink('AdminThemes');
         } elseif (Tools::getValue('action') == 'resetToDefaults') {
-            $this->theme_manager->reset(Tools::getValue('theme_name'));
+            if ($this->theme_manager->reset(Tools::getValue('theme_name'))) {
+                $this->confirmations[] = $this->trans(
+                    'Your theme has been correctly reseted to default settings, you may want to regenerate your images again.',
+                    array(),
+                    'Admin.Notifications.Success'
+                );
+            }
         }
 
         if (Tools::isSubmit('submitOptionsconfiguration')) {

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -279,7 +279,13 @@ class AdminThemesControllerCore extends AdminController
             $this->theme_manager->uninstall(Tools::getValue('theme_name'));
             $this->redirect_after = $this->context->link->getAdminLink('AdminThemes');
         } elseif (Tools::getValue('action') == 'resetToDefaults') {
-            $this->theme_manager->reset(Tools::getValue('theme_name'));
+            if ($this->theme_manager->reset(Tools::getValue('theme_name'))) {
+                $this->confirmations[] = $this->trans(
+                    'Your theme has been correctly reset to default settings, you may want to regenerate your images again.',
+                    array(),
+                    'Admin.Notifications.Success'
+                );
+            }
         }
 
         if (Tools::isSubmit('submitOptionsconfiguration')) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | i think that we needed that information as after adding some image types i forgot to regenerate them :D
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | reset theme to defaults

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->