### PR TITLE
Update Store.php

### DIFF
--- a/classes/Store.php
+++ b/classes/Store.php
@@ -99,7 +99,7 @@ class StoreCore extends ObjectModel
             'city' => array('type' => self::TYPE_STRING, 'validate' => 'isCityName', 'required' => true, 'size' => 64),
             'latitude' => array('type' => self::TYPE_FLOAT, 'validate' => 'isCoordinate', 'size' => 13),
             'longitude' => array('type' => self::TYPE_FLOAT, 'validate' => 'isCoordinate', 'size' => 13),
-            'hours' => array('type' => self::TYPE_STRING, 'validate' => 'isJson', 'size' => 65000),
+            'hours' => array('type' => self::TYPE_STRING, 'validate' => 'isJson', 'size' => 254),
             'phone' => array('type' => self::TYPE_STRING, 'validate' => 'isPhoneNumber', 'size' => 16),
             'fax' => array('type' => self::TYPE_STRING, 'validate' => 'isPhoneNumber', 'size' => 16),
             'note' => array('type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 65000),


### PR DESCRIPTION
It disn't validate the field hours correctly, If input in every field is like "09.00 - 12.30; 15.30 - 19.30; 20:30 - 23:30" it will truncate when saving to db and make data inconsistent on decode.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | 1.7
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Try to use "09.00 - 12.30; 15.30 - 19.30; 20:30 - 23:30" for each hour in store opening hours for each day.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
