### PR TITLE
Increase size of the hours column in PREFIX_store db table

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1841,7 +1841,7 @@ CREATE TABLE `PREFIX_store` (
   `postcode` varchar(12) NOT NULL,
   `latitude` decimal(13,8) DEFAULT NULL,
   `longitude` decimal(13,8) DEFAULT NULL,
-  `hours` varchar(254) DEFAULT NULL,
+  `hours` text,
   `phone` varchar(16) DEFAULT NULL,
   `fax` varchar(16) DEFAULT NULL,
   `email` varchar(128) DEFAULT NULL,

--- a/install-dev/upgrade/sql/1.7.2.0.sql
+++ b/install-dev/upgrade/sql/1.7.2.0.sql
@@ -1,5 +1,7 @@
 SET NAMES 'utf8';
 
+ALTER TABLE `PREFIX_store` MODIFY `hours` text;
+
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'displayAdminProductsMainStepLeftColumnMiddle', 'Display new elements in back office product page, left column of the Basic settings tab', 'This hook launches modules when the back office product page is displayed', '1'),
   (NULL, 'displayAdminProductsMainStepLeftColumnBottom', 'Display new elements in back office product page, left column of the Basic settings tab', 'This hook launches modules when the back office product page is displayed', '1'),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | see https://github.com/PrestaShop/PrestaShop/pull/7555
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | see https://github.com/PrestaShop/PrestaShop/pull/7555
| Sponsor company | impSolutions

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

PS: I don't know what's next, 1.7.0.6 or 1.7..1? :| i hope that 1.7.0.6 as we have very important bugfix related to `{widget_block}` feature