### PR TITLE
getBaseLink() should be public

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -656,7 +656,7 @@ class LinkCore
         return Language::getIsoById($id_lang).'/';
     }
 
-    protected function getBaseLink($id_shop = null, $ssl = null, $relative_protocol = false)
+    public function getBaseLink($id_shop = null, $ssl = null, $relative_protocol = false)
     {
         static $force_ssl = null;
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | this method should be public because its usefull for ex in modules (already fixed in 1.7)
| Type?         |  improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | use $link->getBaseLink() from outside of Link class
