### PR TITLE
Enabling category canonical redirection

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -38,9 +38,13 @@ class CategoryControllerCore extends ProductListingFrontController
 
     protected $category;
 
-    public function canonicalRedirection($url = '')
+    public function canonicalRedirection($canonicalURL = '')
     {
-        // FIXME
+        if (Validate::isLoadedObject($this->category)) {
+            parent::canonicalRedirection($this->context->link->getCategoryLink($this->category));
+        } elseif ($canonicalURL) {
+            parent::canonicalRedirection($canonicalURL);
+        }
     }
 
     public function getCanonicalURL()
@@ -57,8 +61,6 @@ class CategoryControllerCore extends ProductListingFrontController
      */
     public function init()
     {
-        parent::init();
-
         $id_category = (int) Tools::getValue('id_category');
         $this->category = new Category(
             $id_category,
@@ -68,6 +70,8 @@ class CategoryControllerCore extends ProductListingFrontController
         if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
             Tools::redirect('index.php?controller=404');
         }
+
+        parent::init();
 
         if (!$this->category->checkAccess($this->context->customer->id)) {
             header('HTTP/1.1 403 Forbidden');


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | FO: enabling category canonical redirection
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Configure Redirect to the canonical URL to 301 or 302 and test all your FO , especially categories

This features exists on 1.6, but is not present on current 1.7 release
(https://github.com/PrestaShop/PrestaShop/blob/1.7.0.5/controllers/front/listing/CategoryController.php#L43 )