### PR TITLE
Fix default products sorting order

### DIFF
--- a/src/PrestaShopBundle/Resources/config/admin/routing_product.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/routing_product.yml
@@ -7,7 +7,7 @@ admin_product_catalog:
         limit: last
         offset: 0
         orderBy: last
-        sortOrder: last
+        sortOrder: desc
     requirements:
         limit: _limit|last|\d+
         orderBy: last|id_product|name|reference|name_category|price|sav_quantity|position|active|position_ordering


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Products should be sorted in descending order against id.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/STAB-79
| How to test?  | Check the catalogue