### PR TITLE
Improved model namescape handling

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -459,7 +459,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
     private function getFullyQualifiedName()
     {
-        return str_replace('\\', '_', get_class($this));
+        return str_replace('\\', '', get_class($this));
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | It improves object model namespace handling. Let's assume we have Vendor\Entity\Demo model. Instead of using underscores (_) like: hookActionObjectVendor_Entity_DemoAddBefore, we could make it look a bit cleaner and avoid mixing camel case with underscores like so: hookActionObjectVendorEntityDemoAddBefore
| Type?         | improvement
| Category? | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Create namespaced model and use object model hooks on it.