### PR TITLE
Avoid ERR_TOO_MANY_REDIRECTS at install

### DIFF
--- a/install-dev/controllers/http/welcome.php
+++ b/install-dev/controllers/http/welcome.php
@@ -45,16 +45,15 @@ class InstallControllerHttpWelcome extends InstallControllerHttp implements Http
     {
         if (Tools::getValue('language')) {
             $this->session->lang = Tools::getValue('language');
-            Language::downloadAndInstallLanguagePack($this->session->lang, _PS_VERSION_, null, false);
-            $this->clearCache();
-            $this->redirect('welcome');
         }
 
         $locale = $this->language->getLanguage($this->session->lang)->locale;
-        if (!empty($this->session->lang) && !is_file(_PS_ROOT_DIR_.'/app/Resources/translations/'.$locale.'/Install.'.$locale.'.xlf')) {
+        if (!empty($this->session->lang) && !is_file(_PS_ROOT_DIR_ . '/app/Resources/translations/' . $locale . '/Install.' . $locale . '.xlf')) {
             Language::downloadAndInstallLanguagePack($this->session->lang, _PS_VERSION_, null, false);
             $this->clearCache();
-            $this->redirect('welcome');
+            if (is_dir(_PS_ROOT_DIR_ . '/app/Resources/translations/' . $locale)) {
+                $this->redirect('welcome');
+            }
         }
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When first extracting PrestaShop files on server it might not have all the permissions necessary to function, this leads for many users to see ERR_TOO_MANY_REDIRECTS and not be able to continue the installation process. This happens because Language::downloadAndInstallLanguagePack() can't write the files and there isn't any warning to tell that permissions are wrong.<br>This fix allows the user to use the already existing language pack "default" and it can get to step "System compatibility" where it can see the permission errors and other incompatibilities that it needs to fix.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1802
| How to test?  | 

