### PR TITLE
Fix invalid value in quantity input

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -57,6 +57,12 @@ $(document).ready(function () {
     }
   );
 
+  $('body').on('change', '#quantity_wanted[type="text"]', function (event) {
+    if( isNaN($(event.target).val()) || parseInt($(event.target).val()) < parseInt($(event.target).attr('min')) ) {
+      $this.val( $(event.target).attr('min') );
+    }
+  });
+
   prestashop.on('updateProduct', function (event) {
     if (typeof event.refreshUrl == "undefined") {
         event.refreshUrl = true;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix invalid value in quantity input. It should not be possible to insert anything else than a number.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Put invalid value into quantity input in product page (for example: insert alphabetical characters) or delete value in input field (with Backspace key)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7580)
<!-- Reviewable:end -->
