### PR TITLE
Fix ecotax rounded twice

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -321,10 +321,12 @@ class ProductControllerCore extends FrontController
         $product_price_without_eco_tax = (float)$product_price_with_tax - $this->product->ecotax;
 
         $ecotax_rate = (float)Tax::getProductEcotaxRate($this->context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
-        $ecotax_tax_amount = Tools::ps_round($this->product->ecotax, 2);
         if (Product::$_taxCalculationMethod == PS_TAX_INC && (int)Configuration::get('PS_TAX')) {
-            $ecotax_tax_amount = Tools::ps_round($ecotax_tax_amount * (1 + $ecotax_rate / 100), 2);
+            $ecotax_tax_amount = Tools::ps_round($this->product->ecotax * (1 + $ecotax_rate / 100), 2);
         }
+	else {
+	    $ecotax_tax_amount = Tools::ps_round($this->product->ecotax, 2);
+	}
 
         $id_currency = (int)$this->context->cookie->id_currency;
         $id_product = (int)$this->product->id;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | If taxes are turned on on ecotax, ecotax used to be rounded twice. Once after fetching the DB value and the second time after multiplying it with the tax rate. Now it's only rounded after taxes. Example: If you want an ecotax of 10 (with 21% VAT), the ecotax in database is 8.264463 (because 8.264463 * 1.21 = 10). But without this fix, PrestaShop would round the ecotax DB value to 8.26, then multiply it 8.26 * 1.21 = 9.99 (wrong, one cent too little)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Test a product with an ecotax of 10 and tax rate of 21% on ecotax, before and after this patch

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->


Cherry-pick of https://github.com/PrestaShop/PrestaShop/pull/7448