### PR TITLE
Employee permissions not saved

### DIFF
--- a/controllers/admin/AdminAccessController.php
+++ b/controllers/admin/AdminAccessController.php
@@ -152,8 +152,9 @@ class AdminAccessControllerCore extends AdminController
             $enabled = (int)Tools::getValue('enabled');
             $id_tab = (int)Tools::getValue('id_tab');
             $id_profile = (int)Tools::getValue('id_profile');
+            $addFromParent = (int)Tools::getValue('addFromParent');
 
-            die($access->updateLgcAccess((int)$id_profile, $id_tab, $perm, $enabled));
+            die($access->updateLgcAccess((int)$id_profile, $id_tab, $perm, $enabled, $addFromParent));
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Problems when select checkbox in administration permission. Child of Menu is not saved. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2451
| How to test?  | In BO, select on permission the hight menu "Sell" all submenu is checked. When you reload the page, before the submenu (like Catalog or Product) is not saved. Now when you reload all information is the same. 
