### PR TITLE
Fix missing reference symbol into Product::getProductProperties

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4315,7 +4315,7 @@ class ProductCore extends ObjectModel
     {
         Hook::exec('actionGetProductPropertiesBefore', [
             'id_lang'   => $id_lang,
-            'product'   => $row,
+            'product'   => &$row,
             'context'   => $context
         ]);
 
@@ -4505,7 +4505,7 @@ class ProductCore extends ObjectModel
 
         Hook::exec('actionGetProductPropertiesAfter', [
             'id_lang'   => $id_lang,
-            'product'   => $row,
+            'product'   => &$row,
             'context'   => $context
         ]);
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow Product::getProductProperties to be used correctly
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Just try to edit something from "product" hook parameter, it will only work if you use this fix

