### PR TITLE
Fix bug on uploading too large images

### DIFF
--- a/admin-dev/filemanager/upload.php
+++ b/admin-dev/filemanager/upload.php
@@ -36,7 +36,7 @@ while ($cycle && $i < $max_cycles) {
     $path = fix_dirname($path).'/';
 }
 
-if (!empty($_FILES)) {
+if (!empty($_FILES) && isset($_FILES['file']) && $_FILES['file']['size']) {
     $info = pathinfo($_FILES['file']['name']);
     if (isset($info['extension']) && in_array(fix_strtolower($info['extension']), $ext)) {
         $tempFile = $_FILES['file']['tmp_name'];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On uploading too large image with tinymce, no errors are reported. This test check if the image is really uploaded. The reason of the error is not displayed, but the image is circled with red instead of green
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ?
| How to test?  | Uploading a very large image on any tinymce textarea the image must be marked with red border instead of green