### PR TITLE
Fix error when creating a zero value in the attribute size

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3421,7 +3421,7 @@ class AdminControllerCore extends Controller
             if (isset($def['lang']) && $def['lang']) {
                 if (isset($def['required']) && $def['required']) {
                     $value = Tools::getValue($field.'_'.$default_language->id);
-                    if (empty($value)) {
+                    if (!isset($value) || "" == $value) {
                         $this->errors[$field.'_'.$default_language->id] = sprintf(
                                 Tools::displayError('The field %1$s is required at least in %2$s.'),
                                 $object->displayFieldName($field, $class_name),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When adding a 0 value to an attribute in BO, this value will be considered as empty.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8874
| How to test?  | Go to catalog -> Attribute and value in the BO and add a 0 value to the attribute size.