### PR TITLE
Add displayProductPageDrawer hook

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -16,6 +16,11 @@
       <title>Maintenance Page</title>
       <description>This hook displays new elements on the maintenance page</description>
     </hook>
+    <hook id="displayProductPageDrawer">
+      <name>displayProductPageDrawer</name>
+      <title>Product Page Drawer</title>
+      <description>This hook displays content in the right sidebar of the product page</description>
+    </hook>
     <hook id="actionPaymentConfirmation">
       <name>actionPaymentConfirmation</name>
       <title>Payment confirmation</title>

--- a/install-dev/upgrade/sql/1.7.1.0.sql
+++ b/install-dev/upgrade/sql/1.7.1.0.sql
@@ -67,7 +67,8 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionClearSf2Cache', 'Clear Sf2 cache', 'This hook is called when the Symfony cache is cleared', '1'),
   (NULL, 'filterProductSearch', 'Filter search products result', 'This hook is called in order to allow to modify search product result', '1'),
   (NULL, 'actionProductSearchAfter', 'Event triggered after search product completed', 'This hook is called after the product search. Parameters are already filtered', '1'),
-  (NULL, 'actionEmailSendBefore', 'Before sending an email', 'This hook is used to filter the content or the metadata of an email before sending it or even prevent its sending', '1');
+  (NULL, 'actionEmailSendBefore', 'Before sending an email', 'This hook is used to filter the content or the metadata of an email before sending it or even prevent its sending', '1'),
+  (NULL, 'displayProductPageDrawer', 'Product Page Drawer', 'This hook displays content in the right sidebar of the product page', '1');
 
 DELETE FROM `PREFIX_configuration` WHERE `name` IN ('PS_META_KEYWORDS');
 

--- a/src/Core/Product/ProductAdminDrawer.php
+++ b/src/Core/Product/ProductAdminDrawer.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ * 2007-2017 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2017 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Product;
+
+use PrestaShopBundle\Service\Hook\HookContentClassInterface;
+
+class ProductAdminDrawer implements HookContentClassInterface
+{
+    /**
+     * Material icon reference to display above the title
+     * @var string
+     */
+    protected $icon;
+
+    /**
+     * ID suffix to add in the generated DOM element
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * Destination of the link
+     * @var string
+     */
+    protected $link;
+
+    /**
+     * Title of the button. Should be short.
+     * @var string
+     */
+    protected $title;
+
+    public function __construct(array $data = array())
+    {
+        if (!empty($data['icon'])) {
+            $this->setIcon($data['icon']);
+        }
+        if (!empty($data['id'])) {
+            $this->setId($data['id']);
+        }
+        if (!empty($data['link'])) {
+            $this->setLink($data['link']);
+        }
+        if (!empty($data['title'])) {
+            $this->setTitle($data['title']);
+        }
+    }
+
+    public function getIcon()
+    {
+        return $this->icon;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getLink()
+    {
+        return $this->link;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setIcon($icon)
+    {
+        $this->icon = $icon;
+        return $this;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function setLink($link)
+    {
+        $this->link = $link;
+        return $this;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function toArray()
+    {
+        return array(
+            'icon' => $this->icon,
+            'id' => $this->id,
+            'link' => $this->link,
+            'title' => $this->title,
+        );
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -563,6 +563,19 @@ class ProductController extends FrameworkBundleAdminController
             ->getRepository('PrestaShopBundle:Attribute')
             ->findByLangAndShop(1, 1);
 
+        $drawerModules = array();
+        foreach ((array)\Hook::exec('displayProductPageDrawer', array('product' => $product), null, true) as $module) {
+            if (!empty($module)) {
+                if (isset($module[0])) {
+                    foreach ($module as $item) {
+                        $drawerModules[] = $item;
+                    }
+                } else {
+                    $drawerModules[] = $module;
+                }
+            }
+        }
+
         return array(
             'form' => $form->createView(),
             'formCombinations' => $formBulkCombinations->createView(),
@@ -586,6 +599,7 @@ class ProductController extends FrameworkBundleAdminController
             'max_upload_size' => \Tools::formatBytes(UploadedFile::getMaxFilesize()),
             'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
             'editable' => $this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_'),
+            'drawerModules' => $drawerModules,
         );
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -33,6 +33,7 @@ use PrestaShopBundle\Service\Hook\HookEvent;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use PrestaShopBundle\Service\Hook\HookFinder;
 use PrestaShopBundle\Service\TransitionalBehavior\AdminPagePreferenceInterface;
 use PrestaShopBundle\Service\DataProvider\Admin\ProductInterface as ProductInterfaceProvider;
 use PrestaShopBundle\Service\DataUpdater\Admin\ProductInterface as ProductInterfaceUpdater;
@@ -563,18 +564,10 @@ class ProductController extends FrameworkBundleAdminController
             ->getRepository('PrestaShopBundle:Attribute')
             ->findByLangAndShop(1, 1);
 
-        $drawerModules = array();
-        foreach ((array)\Hook::exec('displayProductPageDrawer', array('product' => $product), null, true) as $module) {
-            if (!empty($module)) {
-                if (isset($module[0])) {
-                    foreach ($module as $item) {
-                        $drawerModules[] = $item;
-                    }
-                } else {
-                    $drawerModules[] = $module;
-                }
-            }
-        }
+        $drawerModules = (new HookFinder())->setHookName('displayProductPageDrawer')
+            ->setParams(array('product' => $product))
+            ->addExpectedInstanceClasses('PrestaShop\PrestaShop\Core\Product\ProductAdminDrawer')
+            ->present();
 
         return array(
             'form' => $form->createView(),

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -88,6 +88,20 @@
               <i class="material-icons">help</i>
               <span class="title">{{ 'Help'|trans({}, 'Admin.Global') }}</span>
             </a>
+
+            {% for module in drawerModules %}
+              <a class="toolbar-button btn-module btn-sidebar" href="#"
+                 title="{{ module['title']|e }}"
+                 data-toggle="sidebar"
+                 data-target="#right-sidebar"
+                 data-url="{{ module['link']|e }}"
+                 id="product_form_open_{{ module['id']|e }}"
+              >
+                <i class="material-icons">{{ module['icon']|e }}</i>
+                <span class="title">{{ module['title']|e }}</span>
+              </a>
+            {% endfor %}
+
           </div>
         </div>
         <div class="row">

--- a/src/PrestaShopBundle/Service/Hook/HookDispatcher.php
+++ b/src/PrestaShopBundle/Service/Hook/HookDispatcher.php
@@ -91,7 +91,7 @@ class HookDispatcher extends EventDispatcher
                 $listenerName = $event->popListener() ?: $listener[1];
 
                 $eventContent = $event->popContent();
-                $this->renderingContent[$listenerName] = strlen($eventContent) > strlen($obContent)
+                $this->renderingContent[$listenerName] = (!is_string($eventContent) || strlen($eventContent) > strlen($obContent))
                     ? $eventContent
                     : $obContent;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Add displayProductPageDrawer hook
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

The module has to return something like 

```php
    public function hookDisplayProductPageDrawer($params)
    {
        return array(
            new \PrestaShop\PrestaShop\Core\Product\ProductAdminDrawer(array(
            'title' => 'stats',
            'link' => 'http://localhost/index.html',
            'id' => 'ps_banner',
            'icon' => 'label',
       )));
    }
```
or
```php
    public function hookDisplayProductPageDrawer($params)
    {
        return array(
            // The value can be send via an array for the constructor
            new \PrestaShop\PrestaShop\Core\Product\ProductAdminDrawer(array(
            'title' => 'Stats',
            'link' => 'http://localhost/index.html',
            'id' => 'ps_banner',
            'icon' => 'help',
        )), // Or with setters for each properties
            (new \PrestaShop\PrestaShop\Core\Product\ProductAdminDrawer())
            ->setTitle('Plan')
            ->setLink('http://localhost/index.html')
        );
    }
```
Result:
![capture du 2017-03-13 17-25-40](https://cloud.githubusercontent.com/assets/6768917/23866883/1ddaa5be-0812-11e7-9382-ef7861a03476.png)
