### PR TITLE
Use new module name for OrderState creation

### DIFF
--- a/install-dev/data/xml/order_state.xml
+++ b/install-dev/data/xml/order_state.xml
@@ -16,7 +16,7 @@
   </fields>
   <entities>
     <order_state id="Awaiting_cheque_payment" invoice="0" send_email="1" color="#4169E1" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
-      <module_name>cheque</module_name>
+      <module_name>ps_checkpayment</module_name>
     </order_state>
     <order_state id="Payment_accepted" invoice="1" send_email="1" color="#32CD32" unremovable="1" hidden="0" logable="1" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="1">
       <module_name/>
@@ -43,7 +43,7 @@
       <module_name/>
     </order_state>
     <order_state id="Awaiting_bank_wire_payment" invoice="0" send_email="1" color="#4169E1" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
-      <module_name>bankwire</module_name>
+      <module_name>ps_wirepayment</module_name>
     </order_state>
     <order_state id="Awaiting_PayPal_payment" invoice="0" send_email="0" color="#4169E1" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
@@ -55,7 +55,7 @@
       <module_name/>
     </order_state>
     <order_state id="Awaiting_cod_validation" invoice="0" send_email="0" color="#4169E1" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0">
-      <module_name>cashondelivery</module_name>
+      <module_name>ps_cashondelivery</module_name>
     </order_state>
   </entities>
 </entity_order_state>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The extra mail vars are not get by the OrderHistory because the name of module is not the same/good as the new related module name.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Just try to make an order with one of the three payments methods.