### PR TITLE
Let translate the edit label on order checkout

### DIFF
--- a/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
@@ -32,7 +32,7 @@
     {else}
        {l s='%products_count% items in your cart' sprintf=['%products_count%' => $products_count] d='Shop.Theme.Checkout'}
     {/if}
-  	<a href="{url entity=cart params=['action' => 'show']}"><span class="step-edit"><i class="material-icons edit">mode_edit</i> edit</span></a>
+  	<a href="{url entity=cart params=['action' => 'show']}"><span class="step-edit"><i class="material-icons edit">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span></a>
   </h3>
 </div>
 {/block}

--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -33,7 +33,7 @@
     <div class="col-md-12">
       <h4 class="h4">
       {l s='Addresses' d='Shop.Theme.Checkout'}
-        <span class="step-edit step-to-addresses js-edit-addresses"><i class="material-icons edit">mode_edit</i> edit</span>
+        <span class="step-edit step-to-addresses js-edit-addresses"><i class="material-icons edit">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
       </h4>
     </div>
   </div>
@@ -60,7 +60,7 @@
     <div class="col-md-12">
       <h4 class="h4">
       {l s='Shipping Method' d='Shop.Theme.Checkout'}
-        <span class="step-edit step-to-delivery js-edit-delivery"><i class="material-icons edit">mode_edit</i> edit</span>
+        <span class="step-edit step-to-delivery js-edit-delivery"><i class="material-icons edit">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
       </h4>
 
       <div class="col-md-12 summary-selected-carrier">

--- a/themes/classic/templates/checkout/_partials/steps/checkout-step.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/checkout-step.tpl
@@ -36,7 +36,7 @@
       <i class="material-icons done">&#xE876;</i>
       <span class="step-number">{$position}</span>
       {$title}
-      <span class="step-edit text-muted"><i class="material-icons edit">mode_edit</i> edit</span>
+      <span class="step-edit text-muted"><i class="material-icons edit">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
     </h1>
 
     <div class="content">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As now, on the checkout steps, the edit label is not translatable
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to edit the edit label and you will see that you can only after having merge this commit.