### PR TITLE
Removed return duplication from search provider

### DIFF
--- a/src/Adapter/Search/SearchProductSearchProvider.php
+++ b/src/Adapter/Search/SearchProductSearchProvider.php
@@ -130,7 +130,5 @@ class SearchProductSearchProvider implements ProductSearchProviderInterface
         }
 
         return $result;
-
-        return $result;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | For some reason there was return statement duplication in default search provider. Not a big deal, but still. :)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | See changed file.
