### PR TITLE
Added new actionFrontControllerSetVariables hook

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -513,6 +513,14 @@ class FrontControllerCore extends Controller
             'token' => Tools::getToken(),
         );
 
+        $modulesVariables = Hook::exec('actionFrontControllerSetVariables', [], null, true);
+
+        if (is_array($modulesVariables)) {
+            foreach ($modulesVariables as $moduleName => $variables) {
+                $templateVars['modules'][$moduleName] = $variables;
+            }
+        }
+
         $this->context->smarty->assign($templateVars);
         Media::addJsDef(array('prestashop' => $templateVars));
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I think it would be nice to have a hook here. Modules could add their own data into prestashop JS variable, so all variables could be found in one place because it usually gets really messy when there's a lot of global variables in javascirpt. What do you think?
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | See below.

### How to test

Register hook in your module and return data you want to assign to pretashop javascirpt variable. Then you can access it in front controller by calling: prestashop.modules.module_name.variable_name.

Demo module: https://github.com/sarjon/demovars 

1. Install module
2. Access Front Office and open browser's console.
3. In console, type `prestashop.modules` and you should see data added by module:
```json
{
    "demovars": {
        "my_variable": "it works!"
    }
}
```
4. To get value, in console, type `prestashop.modules.demovars.my_variable` and you should see:
```"it works!"```
5. Uninstall or disable module and refresh Front Office page.
6. In console, type `prestashop.modules`  or  `prestashop.modules.demovars.my_variable` and you should get an error with undefined, as variable added by module is not there anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7612)
<!-- Reviewable:end -->
