### PR TITLE
Add new hooks to admin product page

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -671,5 +671,50 @@
       <title>Before sending an email</title>
       <description>This hook is used to filter the content or the metadata of an email before sending it or even prevent its sending</description>
     </hook>
+    <hook id="displayAdminProductsMainStepLeftColumnMiddle">
+      <name>displayAdminProductsMainStepLeftColumnMiddle</name>
+      <title>Display new elements in back office product page, left column of the Basic settings tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
+    <hook id="displayAdminProductsMainStepLeftColumnBottom">
+      <name>displayAdminProductsMainStepLeftColumnBottom</name>
+      <title>Display new elements in back office product page, left column of the Basic settings tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
+    <hook id="displayAdminProductsMainStepRightColumnBottom">
+      <name>displayAdminProductsMainStepRightColumnBottom</name>
+      <title>Display new elements in back office product page, right column of the Basic settings tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
+    <hook id="displayAdminProductsQuantitiesStepBottom">
+      <name>displayAdminProductsQuantitiesStepBottom</name>
+      <title>Display new elements in back office product page, Quantities/Combinations tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
+    <hook id="displayAdminProductsPriceStepBottom">
+      <name>displayAdminProductsPriceStepBottom</name>
+      <title>Display new elements in back office product page, Price tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
+    <hook id="displayAdminProductsOptionsStepTop">
+      <name>displayAdminProductsOptionsStepTop</name>
+      <title>Display new elements in back office product page, Options tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
+    <hook id="displayAdminProductsOptionsStepBottom">
+      <name>displayAdminProductsOptionsStepBottom</name>
+      <title>Display new elements in back office product page, Options tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
+    <hook id="displayAdminProductsSeoStepBottom">
+      <name>displayAdminProductsSeoStepBottom</name>
+      <title>Display new elements in back office product page, SEO tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
+    <hook id="displayAdminProductsShippingStepBottom">
+      <name>displayAdminProductsShippingStepBottom</name>
+      <title>Display new elements in back office product page, Shipping tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.2.0.sql
+++ b/install-dev/upgrade/sql/1.7.2.0.sql
@@ -1,0 +1,12 @@
+SET NAMES 'utf8';
+
+INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'displayAdminProductsMainStepLeftColumnMiddle', 'Display new elements in back office product page, left column of the Basic settings tab', 'This hook launches modules when the back office product page is displayed', '1'),
+  (NULL, 'displayAdminProductsMainStepLeftColumnBottom', 'Display new elements in back office product page, left column of the Basic settings tab', 'This hook launches modules when the back office product page is displayed', '1'),
+  (NULL, 'displayAdminProductsMainStepRightColumnBottom', 'Display new elements in back office product page, right column of the Basic settings tab', 'This hook launches modules when the back office product page is displayed', '1'),
+  (NULL, 'displayAdminProductsQuantitiesStepBottom', 'Display new elements in back office product page, Quantities/Combinations tab', 'This hook launches modules when the back office product page is displayed', '1'),
+  (NULL, 'displayAdminProductsPriceStepBottom', 'Display new elements in back office product page, Price tab', 'This hook launches modules when the back office product page is displayed', '1'),
+  (NULL, 'displayAdminProductsOptionsStepTop', 'Display new elements in back office product page, Options tab', 'This hook launches modules when the back office product page is displayed', '1'),
+  (NULL, 'displayAdminProductsOptionsStepBottom', 'Display new elements in back office product page, Options tab', 'This hook launches modules when the back office product page is displayed', '1'),
+  (NULL, 'displayAdminProductsSeoStepBottom', 'Display new elements in back office product page, SEO tab', 'This hook launches modules when the back office product page is displayed', '1'),
+  (NULL, 'displayAdminProductsShippingStepBottom', 'Display new elements in back office product page, Shipping tab', 'This hook launches modules when the back office product page is displayed', '1');

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_seo.html.twig
@@ -124,4 +124,7 @@
       </div>
     </div>
   </div>
+
+  {{ renderhook('displayAdminProductsSeoStepBottom', { 'id_product': id_product }) }}
+
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_shipping.html.twig
@@ -107,3 +107,5 @@
     {% endif %}
   </div>
 </div>
+
+{{ renderhook('displayAdminProductsShippingStepBottom', { 'id_product': id_product }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -212,6 +212,8 @@
                       </div>
                     </div>
 
+                    {{ renderhook('displayAdminProductsMainStepLeftColumnMiddle', { 'id_product': id_product }) }}
+
                     <div id="features" class="m-b-1 m-t-1">
                       <div id="features-content" class="content {{ form.step1.features|length == 0 ? 'hide':'' }}">
                         <h2>{{ 'Features'|trans({}, 'Admin.Catalog.Feature') }}</h2>
@@ -241,6 +243,8 @@
                     <div id="related-product" class="m-b-1">
                       {{ include('PrestaShopBundle:Admin/Product/Include:form_related_products.html.twig', { 'form':form.step1.related_products }) }}
                     </div>
+
+                    {{ renderhook('displayAdminProductsMainStepLeftColumnBottom', { 'id_product': id_product }) }}
 
                   </div>
 
@@ -354,6 +358,9 @@
                           <div class="form-group">
                             {{ include('PrestaShopBundle:Admin/Product/Include:form-categories.html.twig', { 'form': form.step1, 'productId': id_product }) }}
                           </div>
+
+                          {{ renderhook('displayAdminProductsMainStepRightColumnBottom', { 'id_product': id_product }) }}
+
                         </div>
                       </div>
                   </div>
@@ -496,6 +503,8 @@
                       </div>
                     {% endif %}
                     {{ include('PrestaShopBundle:Admin/Product/Include:form_combinations.html.twig', {'form': form.step3, 'form_combination_bulk': formCombinations}) }}
+
+                    {{ renderhook('displayAdminProductsQuantitiesStepBottom', { 'id_product': id_product }) }}
 
                   </div>
                 </div>
@@ -708,6 +717,8 @@
                     </div>
                   </div>
 
+                  {{ renderhook('displayAdminProductsPriceStepBottom', { 'id_product': id_product }) }}
+
                 </div>
               </div>
             </div>
@@ -737,6 +748,8 @@
                 <div class="row">
 
                   <div class="col-md-12">
+
+                    {{ renderhook('displayAdminProductsOptionsStepTop', { 'id_product': id_product }) }}
 
                     <div class="row">
                       <div class="col-md-12">
@@ -915,6 +928,8 @@
                         {{ include('PrestaShopBundle:Admin:Product/Include/form-supplier-combination.html.twig', { 'suppliers': form.step6.suppliers.vars.value, 'form': form.step6 }) }}
                       </div>
                     </div>
+
+                    {{ renderhook('displayAdminProductsOptionsStepBottom', { 'id_product': id_product }) }}
 
                   </div>
                 </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Many times I wanted to add simple input/checkbox to the product admin page, if I use `displayAdminProductsExtra` for that, some users can't find this new option. So I think it would be good to add new hooks which can be used for adding custom fields. I think `displayAdminProductsExtra` should be used for more complex setting. What do you thing about this PR? 
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

