### PR TITLE
Replace comma with dot in special price

### DIFF
--- a/admin-dev/themes/default/template/controllers/products/prices.tpl
+++ b/admin-dev/themes/default/template/controllers/products/prices.tpl
@@ -405,7 +405,7 @@ $(document).ready(function () {
 						<div class="col-lg-4">
 							<div class="input-group">
 								<span class="input-group-addon">{$currency->prefix}{$currency->suffix}</span>
-								<input type="text" disabled="disabled" name="sp_price" id="sp_price" value="{$product->price|string_format:$priceDisplayPrecisionFormat}" />
+								<input type="text" disabled="disabled" name="sp_price" id="sp_price" value="{$product->price|string_format:$priceDisplayPrecisionFormat}" onchange="noComma('sp_price');">
 							</div>
 							<p class="checkbox">
 								<label for="leave_bprice">{l s='Leave base price:'}</label>
@@ -420,7 +420,7 @@ $(document).ready(function () {
 				<div class="col-lg-4">
 					<div class="row">
 						<div class="col-lg-3">
-							<input type="text" name="sp_reduction" id="sp_reduction" value="0.00"/>
+							<input type="text" name="sp_reduction" id="sp_reduction" value="0.00" onchange="noComma('sp_reduction');"/>
 						</div>
 						<div class="col-lg-6">
 							<select name="sp_reduction_type" id="sp_reduction_type">

--- a/admin-dev/themes/default/template/controllers/products/prices.tpl
+++ b/admin-dev/themes/default/template/controllers/products/prices.tpl
@@ -405,7 +405,7 @@ $(document).ready(function () {
 						<div class="col-lg-4">
 							<div class="input-group">
 								<span class="input-group-addon">{$currency->prefix}{$currency->suffix}</span>
-								<input type="text" disabled="disabled" name="sp_price" id="sp_price" value="{$product->price|string_format:$priceDisplayPrecisionFormat}" onchange="noComma('sp_price');">
+								<input type="text" disabled="disabled" name="sp_price" id="sp_price" value="{$product->price|string_format:$priceDisplayPrecisionFormat}" onchange="noComma('sp_price');" />
 							</div>
 							<p class="checkbox">
 								<label for="leave_bprice">{l s='Leave base price:'}</label>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | This auto replace comma with dot in special price. In some countries its normal that you use comma as a seperator for decimals and this is currently giving some wrong results.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | NO
| Fixed ticket? | 
| How to test?  | use comma instead of dot when typing price reduction. Before 2,45 would be saved as 2.00 - after this PR it should save it as 2.45

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
