### PR TITLE
Clean order detail cache after setting invoice id

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1259,7 +1259,7 @@ class OrderCore extends ObjectModel
 				UPDATE `'._DB_PREFIX_.'order_detail`
 				SET `id_order_invoice` = '.(int)$order_invoice->id.'
 				WHERE `id_order` = '.(int)$order_invoice->id_order);
-            Cache::clean('objectmodel_'.'OrderDetail'.'_*');
+            Cache::clean('objectmodel_OrderDetail_*');
 
             // Update order payment
             if ($use_existing_payment) {

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1259,6 +1259,7 @@ class OrderCore extends ObjectModel
 				UPDATE `'._DB_PREFIX_.'order_detail`
 				SET `id_order_invoice` = '.(int)$order_invoice->id.'
 				WHERE `id_order` = '.(int)$order_invoice->id_order);
+            Cache::clean('objectmodel_'.'OrderDetail'.'_*');
 
             // Update order payment
             if ($use_existing_payment) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Order detail cache was not cleaned after invoice id is set. If an order detail is updated afterwards from a module, the invoice id is lost and the related line is absent from the invoice document 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Load order details within a hook before invoice creation and load them again and save in another hook after invoice creation => invoice id is lost
