### PR TITLE
Fix out of stock combination hiding

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2117,10 +2117,13 @@ class ProductCore extends ObjectModel
     * @param bool $groupByIdAttributeGroup
     * @return array Product attributes combinations
     */
-    public function getAttributeCombinations($id_lang, $groupByIdAttributeGroup = true)
+    public function getAttributeCombinations($id_lang = null, $groupByIdAttributeGroup = true)
     {
         if (!Combination::isFeatureActive()) {
             return array();
+        }
+        if (is_null($id_lang)) {
+            $id_lang = Context::getContext()->language->id;
         }
 
         $sql = 'SELECT pa.*, product_attribute_shop.*, ag.`id_attribute_group`, ag.`is_color_group`, agl.`name` AS group_name, al.`name` AS attribute_name,

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -58,7 +58,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             } else if (!Tools::getValue('id_product_attribute') || Tools::getValue('rewrite') !== $this->product->link_rewrite) {
                 $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
             }
-            $id_product_attribute = Tools::getValue('id_product_attribute');
+
+            $id_product_attribute = $this->getIdProductAttribute();
             parent::canonicalRedirection($this->context->link->getProductLink(
                 $this->product,
                 null,
@@ -894,6 +895,28 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         return $this->category;
     }
 
+    private function getIdProductAttribute()
+    {
+        $requestedIdProductAttribute = (int)Tools::getValue('id_product_attribute');
+
+        if (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
+            $productAttributes = array_filter(
+                $this->product->getAttributeCombinations(),
+                function ($elem) {
+                    return $elem['quantity'] > 0;
+                });
+            $productAttribute = array_filter(
+                $productAttributes,
+                function ($elem) use ($requestedIdProductAttribute) {
+                    return $elem['id_product_attribute'] == $requestedIdProductAttribute;
+                });
+            if (empty($productAttribute) && !empty($productAttributes)) {
+                return (int)array_shift($productAttributes)['id_product_attribute'];
+            }
+        }
+        return $requestedIdProductAttribute;
+    }
+
     public function getTemplateVarProduct()
     {
         $productSettings = $this->getProductPresentationSettings();
@@ -904,7 +927,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['id_product'] = (int) $this->product->id;
         $product['out_of_stock'] = (int) $this->product->out_of_stock;
         $product['new'] = (int) $this->product->new;
-        $product['id_product_attribute'] = (int) Tools::getValue('id_product_attribute');
+        $product['id_product_attribute'] = $this->getIdProductAttribute();
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);
         $product['extraContent'] = $extraContentFinder->addParams(array('product' => $this->product))->present();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Redirect automagically to the first available combination when the "Display unavailable product attributes on the product page" os set to false.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2408
| How to test?  | Take a product with combinations and remove the stock for its default combination. Disable the option Configure > Shop parameters > Product Settings > Product Page > Display unavailable product attributes on the product page and go to the product's page. You should have been redirected to the first combination with stock.