### PR TITLE
Set correct value on load to display the right tab

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.tpl
@@ -15,7 +15,7 @@
 	</div>
 	<form action="{$currentIndex|escape}&amp;token={$currentToken|escape}&amp;addcart_rule" id="cart_rule_form" class="form-horizontal" method="post">
 		{if $currentObject->id}<input type="hidden" name="id_cart_rule" value="{$currentObject->id|intval}" />{/if}
-		<input type="hidden" id="currentFormTab" name="currentFormTab" value="informations" />
+		<input type="hidden" id="currentFormTab" name="currentFormTab" value="{if isset($smarty.post.currentFormTab)}{$smarty.post.currentFormTab|escape:'quotes'}{else}informations{/if}" />
 		<div id="cart_rule_informations" class="panel cart_rule_tab">
 			{include file='controllers/cart_rules/informations.tpl'}
 		</div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | This input value is set when you click on a tab. If you don't click, is possible that it doesn't have the correct one
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | N
| Deprecations? | N
| Fixed ticket? | 
| How to test?  | Try to create a cart rule. Focus on a different tab than the first one. Force an error. Save. The page load the correct tab. Save again. The page load the first tab.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
