### PR TITLE
Avoid silencious fail of simple category creation from product form

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -272,7 +272,7 @@ var formCategory = (function() {
   var elem = $('#form_step1_new_category');
 
   /** Send category form and it to nested categories */
-  function send() {
+  function send(form) {
     $.ajax({
       type: 'POST',
       url: elem.attr('data-action'),
@@ -319,6 +319,9 @@ var formCategory = (function() {
           'breadcrumb': ''
         };
         productCategoriesTags.createTag(tag);
+
+        //hide the form
+        form.hideBlock();
       },
       error: function(response) {
         $.each(jQuery.parseJSON(response.responseText), function(key, errors) {
@@ -343,10 +346,7 @@ var formCategory = (function() {
       var that = this;
       /** remove all categories from selector, except pre defined */
       $('#add-categories button.save').click(function(){
-        send();
-        if($('#form_step1_new_category_name').val().length > 2){
-          that.hideBlock();
-        }
+        send(that);
       });
       $('#add-categories button[type="reset"]').click(function(){
         that.hideBlock();

--- a/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
+++ b/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
@@ -81,7 +81,7 @@ class SimpleCategory extends CommonAbstractType
             'attr' => ['placeholder' => $this->translator->trans('Category name', [], 'Admin.Catalog.Feature'), 'class' => 'ajax'],
             'constraints' => $options['ajax'] ? [] : array(
                 new Assert\NotBlank(),
-                new Assert\Length(array('min' => 1))
+                new Assert\Length(array('min' => 1, 'max' => 128))
             )
         ))
         ->add('id_parent', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Avoid silencious fail of simple category creation from product form, if category name is not valid
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create quicly a category from product admin Form, first test : whith a name less than 128 chars long, second with greater categoryes name. ( before this commit, it failed whitout any message, now one is present)

This is due to the fact that new form from symfony located in src/PrestaShopBundle/Form/Admin/[..] dont rely error form ObjectModel related, maybe there is a better way to have the same constraint between ObjectModels definitions and forms.
I do not found the cleanest way, here we duplicate constraint, it's not really a good practice.
![capture du 2017-02-28 18 05 21](https://cloud.githubusercontent.com/assets/3170104/23415769/8bd12494-fde0-11e6-8c60-e244ac9c7dd6.png)
