### PR TITLE
Fix formatFields in all shops context

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -364,12 +364,12 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             // E.g. if only lang fields are filtered, ignore fields without lang => true
             if (($type == self::FORMAT_LANG && empty($data['lang']))
                 || ($type == self::FORMAT_SHOP && empty($data['shop']))
-                || ($type == self::FORMAT_COMMON && ((!empty($data['shop']) && $data['shop'] != 'both') || !empty($data['lang'])))) {
+                || ($type == self::FORMAT_COMMON && ((!empty($data['shop']) && $data['shop'] !== 'both') || !empty($data['lang'])))) {
                 continue;
             }
 
             if (is_array($this->update_fields)) {
-                if ((!empty($data['lang']) || (!empty($data['shop']) && $data['shop'] != 'both')) && (empty($this->update_fields[$field]) || ($type == self::FORMAT_LANG && empty($this->update_fields[$field][$id_lang])))) {
+                if ((!empty($data['lang']) || (!empty($data['shop']) && $data['shop'] !== 'both')) && (empty($this->update_fields[$field]) || ($type == self::FORMAT_LANG && empty($this->update_fields[$field][$id_lang])))) {
                     continue;
                 }
             }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix a bug when comparing the shop property with the value 'both', when the field has the shop property with the value true.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | In a shop with the multishop feature active. Set a product with different price in two shops. Change the context to all shops and save the product. When you save the product with the all shops context, the price is changed in every shop although the multishop_check for the price is unchecked.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7624)
<!-- Reviewable:end -->
