### PR TITLE
Modification permissions on Product Catalog and Module

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -1,6 +1,6 @@
 parameters:
     AdapterSecurityAdminClass:                PrestaShopBundle\Tests\Mock\AdapterSecurityAdminMock
-    prestashop.security.voter.product.class:  PrestaShopBundle\Tests\Mock\ProductVoter
+    prestashop.security.voter.product.class:  PrestaShopBundle\Tests\Mock\PageVoter
 
 imports:
     - { resource: config_dev.yml }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -245,6 +245,18 @@ class AdminControllerCore extends Controller
     /** @var HelperList */
     protected $helper;
 
+    /** @var array Cache for translations */
+    const LEVEL_DELETE = 4;
+
+    /** @var array Cache for translations */
+    const LEVEL_EDIT = 3;
+
+    /** @var array Cache for translations */
+    const LEVEL_ADD = 2;
+
+    /** @var array Cache for translations */
+    const LEVEL_VIEW = 1;
+
     /**
      * Actions to execute on multiple selections.
      *

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -32,6 +32,10 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
+use PrestaShop\PrestaShop\Adapter\ServiceLocator;
+use PrestaShopBundle\Security\Voter\PageVoter;
+use PrestaShopBundle\Event\ModuleManagementEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Tools;
 
@@ -103,7 +107,7 @@ class ModuleManager implements AddonManagerInterface
     {
         // in CLI mode, there is no employee set up
         if (!Tools::isPHPCLI()) {
-            if (!$this->employee->can('add', 'AdminModules')) {
+            if (!$this->employee->can('edit', 'AdminModulessf')) {
                 throw new Exception(
                     $this->translator->trans(
                         'You are not allowed to install modules.',
@@ -147,7 +151,7 @@ class ModuleManager implements AddonManagerInterface
         // Check permissions:
         // * Employee can delete
         // * Employee can delete this specific module
-        if (!$this->employee->can('delete', 'AdminModules')
+        if (!$this->employee->can('delete', 'AdminModulessf')
             || !$this->moduleProvider->can('uninstall', $name)) {
             throw new Exception(
                 $this->translator->trans(
@@ -183,7 +187,7 @@ class ModuleManager implements AddonManagerInterface
     */
     public function upgrade($name, $version = 'latest', $source = null)
     {
-        if (!$this->employee->can('edit', 'AdminModules')
+        if (!$this->employee->can('edit', 'AdminModulessf')
             || !$this->moduleProvider->can('configure', $name)) {
             throw new Exception(
                 $this->translator->trans(
@@ -229,7 +233,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function disable($name)
     {
-        if (!$this->employee->can('edit', 'AdminModules')
+        if (!$this->employee->can('edit', 'AdminModulessf')
             || !$this->moduleProvider->can('configure', $name)) {
             throw new Exception(
                 $this->translator->trans(
@@ -263,7 +267,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function enable($name)
     {
-        if (!$this->employee->can('edit', 'AdminModules')
+        if (!$this->employee->can('edit', 'AdminModulessf')
             || !$this->moduleProvider->can('configure', $name)) {
             throw new Exception(
                 $this->translator->trans(
@@ -297,7 +301,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function disable_mobile($name)
     {
-        if (!$this->employee->can('edit', 'AdminModules')
+        if (!$this->employee->can('edit', 'AdminModulessf')
             || !$this->moduleProvider->can('configure', $name)) {
             throw new Exception(
                 $this->translator->trans(
@@ -331,7 +335,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function enable_mobile($name)
     {
-        if (!$this->employee->can('edit', 'AdminModules')
+        if (!$this->employee->can('edit', 'AdminModulessf')
             || !$this->moduleProvider->can('configure', $name)) {
             throw new Exception(
                 $this->translator->trans(
@@ -362,8 +366,8 @@ class ModuleManager implements AddonManagerInterface
      */
     public function reset($name, $keep_data = false)
     {
-        if (!$this->employee->can('add', 'AdminModules')
-            || !$this->employee->can('delete', 'AdminModules')
+        if (!$this->employee->can('add', 'AdminModulessf')
+            || !$this->employee->can('delete', 'AdminModulessf')
             || !$this->moduleProvider->can('uninstall', $name)) {
             throw new Exception(
                 $this->translator->trans(

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Addon\AddonListFilter;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterStatus;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterType;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
+use PrestaShopBundle\Security\Voter\PageVoter;
 use PrestaShopBundle\Entity\ModuleHistory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,7 +50,20 @@ class ModuleController extends FrameworkBundleAdminController
      */
     public function catalogAction()
     {
+        if (
+            !$this->isGranted(PageVoter::READ, 'ADMINMODULESSF_')
+            && !$this->isGranted(PageVoter::UPDATE, 'ADMINMODULESSF_')
+            && !$this->isGranted(PageVoter::CREATE, 'ADMINMODULESSF_')
+        ) {
+            return $this->redirect('admin_dashboard');
+        }
+
         $translator = $this->container->get('translator');
+        $errorMessage = $translator->trans(
+                'You do not have permission to add this.',
+                array(),
+                'Admin.Notifications.Error'
+            );
 
         return $this->render('PrestaShopBundle:Admin/Module:catalog.html.twig', array(
                 'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
@@ -60,6 +74,8 @@ class ModuleController extends FrameworkBundleAdminController
                 'enableSidebar' => true,
                 'help_link' => $this->generateSidebarLink('AdminModules'),
                 'requireFilterStatus' => false,
+                'level' => $this->authorizationLevel(),
+                'errorMessage' => $errorMessage,
             ));
     }
 
@@ -122,12 +138,21 @@ class ModuleController extends FrameworkBundleAdminController
             )
         )->getContent();
 
+        $translator = $this->container->get('translator');
+        $errorMessage = $translator->trans(
+            'You do not have permission to add this.',
+            array(),
+            'Admin.Notifications.Error'
+        );
+
         $formattedContent['content'] .= $this->render(
             'PrestaShopBundle:Admin/Module/Includes:grid.html.twig',
             array(
                 'modules' => $this->getPresentedProducts($modules),
                 'requireAddonsSearch' => true,
                 'id' => 'all',
+                'level' => $this->authorizationLevel(),
+                'errorMessage' => $errorMessage,
             )
         )->getContent();
 
@@ -206,6 +231,12 @@ class ModuleController extends FrameworkBundleAdminController
 
         $categoriesMenu = $this->get('prestashop.categories_provider')->getCategoriesMenu($installedProducts);
 
+        $errorMessage = $translator->trans(
+            'You do not have permission to add this.',
+            array(),
+            'Admin.Notifications.Error'
+        );
+
         return $this->render('PrestaShopBundle:Admin/Module:manage.html.twig', array(
                 'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
                 'layoutTitle' => $translator->trans('Manage installed modules', array(), 'Admin.Modules.Feature'),
@@ -216,11 +247,17 @@ class ModuleController extends FrameworkBundleAdminController
                 'enableSidebar' => true,
                 'help_link' => $this->generateSidebarLink('AdminModules'),
                 'requireFilterStatus' => true,
+                'level' => $this->authorizationLevel(),
+                'errorMessage' => $errorMessage,
             ));
     }
 
     public function moduleAction(Request $request)
     {
+        if (!in_array($this->authorizationLevel(), array(PageVoter::LEVEL_CREATE, PageVoter::LEVEL_UPDATE, PageVoter::LEVEL_DELETE))) {
+            return $this->redirect('admin_dashboard');
+        }
+
         $action = $request->get('action');
         $module = $request->get('module_name');
         $forceDeletion = $request->query->has('deletion');
@@ -301,6 +338,7 @@ class ModuleController extends FrameworkBundleAdminController
                 $moduleInstanceWithUrl = $modulesProvider->generateAddonsUrls(array($moduleInstance));
                 $response[$module]['action_menu_html'] = $this->render('PrestaShopBundle:Admin/Module/Includes:action_menu.html.twig', array(
                         'module' => $this->getPresentedProducts($moduleInstanceWithUrl)[0],
+                        'level' => $this->authorizationLevel(),
                     ))->getContent();
             }
 
@@ -380,15 +418,24 @@ class ModuleController extends FrameworkBundleAdminController
             $modules->{$moduleLabel} = $this->getPresentedProducts($modulesPart);
         }
 
+        $translator = $this->container->get('translator');
+        $errorMessage = $translator->trans(
+            'You do not have permission to add this.',
+            array(),
+            'Admin.Notifications.Error'
+        );
+
         return $this->render('PrestaShopBundle:Admin/Module:notifications.html.twig', array(
-                'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
-                'layoutTitle' => $translator->trans('Module notifications', array(), 'Admin.Modules.Feature'),
-                'modules' => $modules,
-                'requireAddonsSearch' => false,
-                'requireBulkActions' => false,
-                'enableSidebar' => true,
-                'help_link' => $this->generateSidebarLink('AdminModules'),
-                'requireFilterStatus' => false,
+            'enableSidebar' => true,
+            'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
+            'layoutTitle' => $layoutTitle,
+            'help_link' => $this->generateSidebarLink('AdminModules'),
+            'modules' => $moduleManager->getModulesWithNotifications($modulesPresenter),
+            'requireAddonsSearch' => false,
+            'requireBulkActions' => false,
+            'requireFilterStatus' => false,
+            'level' => $this->authorizationLevel(),
+            'errorMessage' => $errorMessage,
         ));
     }
 
@@ -504,6 +551,19 @@ class ModuleController extends FrameworkBundleAdminController
         }
 
         try {
+            if(!in_array($this->authorizationLevel(), array(PageVoter::LEVEL_CREATE, PageVoter::LEVEL_UPDATE, PageVoter::LEVEL_DELETE))){
+                return new JsonResponse(
+                    array(
+                        'status' => false,
+                        'msg' => $translator->trans(
+                            'You do not have permission to add this.',
+                            array(),
+                            'Admin.Notifications.Error'),
+                    ),
+                    200,
+                    array('Content-Type' => 'application/json')
+                );
+            }
             $file_uploaded = $request->files->get('file_uploaded');
             $constraints = array(
                 new Assert\NotNull(),
@@ -706,7 +766,29 @@ class ModuleController extends FrameworkBundleAdminController
             '@PrestaShop/Admin/Module/Includes/modal_read_more_content.html.twig',
             array(
                 'module' => $moduleToPresent,
+                'level' => $this->authorizationLevel(),
             )
         );
+    }
+
+    /**
+     * Return the type of authorization on module page.
+     *
+     * @return int(integer)
+     */
+    public function authorizationLevel()
+    {
+        switch (true) {
+            case ($this->isGranted(PageVoter::DELETE, 'ADMINMODULESSF_')) :
+                return PageVoter::LEVEL_DELETE;
+            case ($this->isGranted(PageVoter::UPDATE, 'ADMINMODULESSF_')) :
+                return PageVoter::LEVEL_UPDATE;
+            case ($this->isGranted(PageVoter::CREATE, 'ADMINMODULESSF_')) :
+                return PageVoter::LEVEL_CREATE;
+            case ($this->isGranted(PageVoter::READ, 'ADMINMODULESSF_')) :
+                return PageVoter::LEVEL_READ;
+            default :
+                return 0;
+        }
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -27,7 +27,7 @@ namespace PrestaShopBundle\Controller\Admin;
 
 use PrestaShop\PrestaShop\Adapter\Warehouse\WarehouseDataProvider;
 use PrestaShopBundle\Entity\AdminFilter;
-use PrestaShopBundle\Security\Voter\ProductVoter;
+use PrestaShopBundle\Security\Voter\PageVoter;
 use PrestaShopBundle\Service\DataProvider\StockInterface;
 use PrestaShopBundle\Service\Hook\HookEvent;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -81,6 +81,14 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function catalogAction(Request $request, $limit = 10, $offset = 0, $orderBy = 'id_product', $sortOrder = 'asc')
     {
+        if (
+            !$this->isGranted(PageVoter::READ, 'ADMINPRODUCTS_')
+            && !$this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_')
+            && !$this->isGranted(PageVoter::CREATE, 'ADMINPRODUCTS_')
+        ) {
+            return $this->redirect('admin_dashboard');
+        }
+
         $context = $this->get('prestashop.adapter.legacy.context')->getContext();
         $request->getSession()->set('_locale', $context->language->locale);
 
@@ -321,7 +329,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function newAction()
     {
-        if (!$this->isGranted(ProductVoter::CREATE)) {
+        if (!$this->isGranted(PageVoter::CREATE, 'ADMINPRODUCTS_')) {
             $translator = $this->get('translator');
             $errorMessage = $translator->trans(
                 'You do not have permission to add this.',
@@ -368,16 +376,12 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function formAction($id, Request $request)
     {
-        if (!$this->isGranted(ProductVoter::UPDATE)) {
-            $translator = $this->get('translator');
-            $errorMessage = $translator->trans(
-                'You do not have permission to edit this.',
-                array(),
-                'Admin.Notifications.Error'
-            );
-            $this->get('session')->getFlashBag()->add('permission_error', $errorMessage);
-
-            return $this->redirectToRoute('admin_product_catalog');
+        if (
+            !$this->isGranted(PageVoter::READ, 'ADMINPRODUCTS_')
+            && !$this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_')
+            && !$this->isGranted(PageVoter::CREATE, 'ADMINPRODUCTS_')
+        ) {
+            return $this->redirect('admin_dashboard');
         }
 
         $productAdapter = $this->get('prestashop.adapter.data_provider.product');
@@ -576,6 +580,7 @@ class ProductController extends FrameworkBundleAdminController
             'attribute_groups' => $attributeGroups,
             'max_upload_size' => \Tools::formatBytes(UploadedFile::getMaxFilesize()),
             'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
+            'editable' => $this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_'),
         );
     }
 
@@ -684,7 +689,7 @@ class ProductController extends FrameworkBundleAdminController
     {
         $translator = $this->get('translator');
 
-        if (!$this->isGranted(ProductVoter::UPDATE)) {
+        if (!$this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_')) {
             $errorMessage = $translator->trans(
                 'You do not have permission to edit this.',
                 array(),
@@ -994,13 +999,13 @@ class ProductController extends FrameworkBundleAdminController
     protected function shouldDenyAction($action, $suffix = '')
     {
         return (
-                $action === 'delete' . $suffix && !$this->isGranted(ProductVoter::DELETE)
+                $action === 'delete' . $suffix && !$this->isGranted(PageVoter::DELETE, 'ADMINPRODUCTS_')
             ) || (
                 ($action === 'activate' . $suffix || $action === 'deactivate' . $suffix) &&
-                !$this->isGranted(ProductVoter::UPDATE)
+                !$this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_')
             ) || (
                 ($action === 'duplicate' . $suffix) &&
-                (!$this->isGranted(ProductVoter::UPDATE) || !$this->isGranted(ProductVoter::CREATE))
+                (!$this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_') || !$this->isGranted(PageVoter::CREATE, 'ADMINPRODUCTS_'))
             )
         ;
     }

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -3,7 +3,7 @@ imports:
     - { resource: admin/services-form.yml }
 
 parameters:
-    prestashop.security.voter.product.class: PrestaShopBundle\Security\Voter\ProductVoter
+    prestashop.security.voter.product.class: PrestaShopBundle\Security\Voter\PageVoter
 
 services:
     finder:

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -32,27 +32,45 @@
 %}
 
 <div class="pull-right btn-group">
-  {% if url_active == 'buy' %}
-    <a class="btn pull-left btn-primary-reverse btn-primary-outline light-button module_action_menu_go_to_addons" href="{{ url }}" target="_blank">
-      {% if priceRaw != '0.00' %}{{ priceDisplay }}
-      {% else %}{{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}{% endif %}
-    </a>
-  {% else %}
-    <a class="btn btn-primary-reverse btn-primary-outline light-button module_action_menu_{{ url_active }}" href="{{ urls[url_active] }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">{{ url_active|capitalize|replace({'_': " "}) }}</a>
-    {% if urls|length > 1 %}
-      <button type="button" class="btn btn-primary-outline  dropdown-toggle light-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <span class="caret"></span>
-        <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
-      </button>
-      <div class="dropdown-menu">
-        {% for module_action, module_url in urls %}
-          {% if module_action != url_active %}
-            <li>
-              <a class="dropdown-item module_action_menu_{{ module_action }}" href="{{ module_url }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">{{module_action|capitalize|replace({'_': " "})}}</a>
-            </li>
-          {% endif %}
-        {% endfor %}
-      </div>
+  {% if level > constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_READ') %}
+    {% if url_active == 'buy' %}
+      <a class="btn pull-left btn-primary btn-primary-reverse btn-primary-outline light-button module_action_menu_go_to_addons" href="{{ url }}" target="_blank">
+        {% if priceRaw != '0.00' %}{{ priceDisplay }}
+        {% else %}{{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}{% endif %}
+      </a>
+    {% else %}
+      <form class="btn-group" method="post" action="{{ urls[url_active] }}">
+        <button type="submit" class="btn btn-primary-reverse btn-primary-outline light-button module_action_menu_{{ url_active }}"
+           data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}" {% if (level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_CREATE')) or (level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_DELETE') and (url_active not in ['configure', 'install', 'upgrade'])) %} disabled="disabled" {% endif %}>
+            {{ url_active|capitalize|replace({'_': " "}) }}
+        </button>
+        {% if urls|length > 1 %}
+        <input type="hidden" class="btn">
+        {% endif %}
+      </form>
+      {% if (urls|length > 1) %}
+        {% if (level > constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) or ((('configure' in urls|keys) and ('upgrade' in urls|keys)) and  url_active in ['configure', 'install', 'upgrade']) %}
+            <button type="button" class="btn btn-primary-outline  dropdown-toggle light-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <span class="caret"></span>
+              <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
+            </button>
+            <div class="dropdown-menu">
+              {% for module_action, module_url in urls %}
+                {% if module_action != url_active %}
+                  {% if ((level >= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_DELETE')) or ((level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_DELETE')) and (module_action in ['configure', 'install', 'upgrade']))) %}
+                    <li>
+                      <form method="post" action="{{ module_url }}">
+                        <button type="submit" class="dropdown-item module_action_menu_{{ module_action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">
+                          {{module_action|capitalize|replace({'_': " "})}}
+                        </button>
+                      </form>
+                    </li>
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+            </div>
+        {% endif %}
+      {% endif %}
     {% endif %}
   {% endif %}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_grid.html.twig
@@ -94,9 +94,9 @@
           <input type="checkbox" data-name="{{ module.attributes.displayName }}" data-tech-name="{{module.attributes.name}}" />
         </div>
       {% endif %}
-      {% include 'PrestaShopBundle:Admin/Module/Includes:action_menu.html.twig' with { 'module': module } %}
+      {% include 'PrestaShopBundle:Admin/Module/Includes:action_menu.html.twig' with { 'module': module, 'level' : level } %}
     </div>
-    {% include 'PrestaShopBundle:Admin/Module/Includes:modal_read_more.html.twig' with { 'module': module, 'additionalModalSuffix': additionalModalSuffix|default('') } %}
+    {% include 'PrestaShopBundle:Admin/Module/Includes:modal_read_more.html.twig' with { 'module': module, 'additionalModalSuffix': additionalModalSuffix|default(''), 'level' : level } %}
     {% include 'PrestaShopBundle:Admin/Module/Includes:modal_confirm.html.twig' with { 'module': module } %}
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid.html.twig
@@ -25,7 +25,7 @@
 <div id="modules-list-container-{{ id }}" class="row modules-list">
   {% if app.request.attributes.get('_route') == 'admin_module_catalog_refresh' %}
     {% for module in modules %}
-      {% include 'PrestaShopBundle:Admin/Module/Includes:card_grid.html.twig' with { 'module': module, 'origin': origin|default('none') } %}
+      {% include 'PrestaShopBundle:Admin/Module/Includes:card_grid.html.twig' with { 'module': module, 'origin': origin|default('none'), 'level' : level } %}
     {% endfor %}
   {% endif %}
   {% for module in modules %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
@@ -31,6 +31,17 @@
         <h4 class="modal-title module-modal-title">{{ 'Connect to Addons marketplace'|trans({}, 'Admin.Modules.Feature') }}</h4>
       </div>
       <div class="modal-body">
+        {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_READ') %}
+          <div class="row">
+            <div class="col-md-12">
+              <div class="alert alert-danger">
+                <p>
+                  {{ errorMessage }}
+                </p>
+              </div>
+            </div>
+          </div>
+        {% else %}
           <div class="row">
               <div class="col-md-12">
                   <p>
@@ -59,6 +70,7 @@
                 </p>
               </div>
           </div>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
@@ -27,47 +27,59 @@
         <!-- Modal content-->
         <div class="modal-content">
             <div class="modal-header">
-              <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
-              <h4 class="modal-title module-modal-title">{{ 'Upload a module'|trans({}, 'Admin.Modules.Feature') }}</h4>
+                <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
+                <h4 class="modal-title module-modal-title">{{ 'Upload a module'|trans({}, 'Admin.Modules.Feature') }}</h4>
             </div>
             <div class="modal-body">
-                <div class="row">
-                    <div class="col-md-12">
-                        <form action="#" class="dropzone" id="importDropzone">
-                            <div class="module-import-start">
-                                <i class="module-import-start-icon material-icons">cloud_upload</i><br/>
-                                <p class=module-import-start-main-text>
-                                    {{ 'Drop your module archive here or [1]select file[/1]'|trans({}, 'Admin.Modules.Feature')|replace({'[1]' : '<a href="#" class="module-import-start-select-manual">', '[/1]' : '</a>'})|raw }}
-                                </p>
-                                <p class=module-import-start-footer-text>
-                                    {{ 'Please upload one file at a time, .zip or tarball format (.tar, .tar.gz or .tgz).'|trans({}, 'Admin.Modules.Help') }}
-                                    {{ 'Your module will be installed right after that.'|trans({}, 'Admin.Modules.Help') }}
+                {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_READ') %}
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="alert alert-danger">
+                                <p>
+                                    {{ errorMessage }}
                                 </p>
                             </div>
-                            <div class='module-import-processing'>
-                                <!-- Loader -->
-                                <button class="btn btn-primary-reverse btn-lg onclick" ></button>
-                                <p class=module-import-processing-main-text>{{ 'Installing module...'|trans({}, 'Admin.Modules.Notification') }}</p>
-                                <p class=module-import-processing-footer-text>
-                                    {{ "It will close as soon as the module is installed. It won't be long!"|trans({}, 'Admin.Modules.Notification') }}
-                                </p>
-                            </div>
-                            <div class='module-import-success'>
-                                <i class="module-import-success-icon material-icons">done</i><br/>
-                                <p class='module-import-success-msg'>{{ 'Module installed!'|trans({}, 'Admin.Modules.Notification') }}</p>
-                                <p class="module-import-success-details"></p>
-                                <a class="module-import-success-configure btn btn-primary btn-sm light-button" href='#'>{{ 'Configure'|trans({}, 'Admin.Actions') }}</a>
-                            </div>
-                            <div class='module-import-failure'>
-                                <i class="module-import-failure-icon material-icons">error</i><br/>
-                                <p class='module-import-failure-msg'>{{ 'Oops... Upload failed.'|trans({}, 'Admin.Modules.Notification') }}</p>
-                                <a href="#" class="module-import-failure-details-action">{{ 'What happened?'|trans({}, 'Admin.Modules.Help') }}</a>
-                                <div class='module-import-failure-details'></div>
-                                <a class="module-import-failure-retry btn btn-tertiary" href='#'>{{ 'Try again'|trans({}, 'Admin.Actions') }}</a>
-                            </div>
-                        </form>
+                        </div>
                     </div>
-                </div>
+                {% else %}
+                    <div class="row">
+                        <div class="col-md-12">
+                            <form action="#" class="dropzone" id="importDropzone">
+                                <div class="module-import-start">
+                                    <i class="module-import-start-icon material-icons">cloud_upload</i><br/>
+                                    <p class=module-import-start-main-text>
+                                        {{ 'Drop your module archive here or [1]select file[/1]'|trans({}, 'Admin.Modules.Feature')|replace({'[1]' : '<a href="#" class="module-import-start-select-manual">', '[/1]' : '</a>'})|raw }}
+                                    </p>
+                                    <p class=module-import-start-footer-text>
+                                        {{ 'Please upload one file at a time, .zip or tarball format (.tar, .tar.gz or .tgz).'|trans({}, 'Admin.Modules.Help') }}
+                                        {{ 'Your module will be installed right after that.'|trans({}, 'Admin.Modules.Help') }}
+                                    </p>
+                                </div>
+                                <div class='module-import-processing'>
+                                    <!-- Loader -->
+                                    <button class="btn btn-primary-reverse btn-lg onclick" ></button>
+                                    <p class=module-import-processing-main-text>{{ 'Installing module...'|trans({}, 'Admin.Modules.Notification') }}</p>
+                                    <p class=module-import-processing-footer-text>
+                                        {{ "It will close as soon as the module is installed. It won't be long!"|trans({}, 'Admin.Modules.Notification') }}
+                                    </p>
+                                </div>
+                                <div class='module-import-success'>
+                                    <i class="module-import-success-icon material-icons">done</i><br/>
+                                    <p class='module-import-success-msg'>{{ 'Module installed!'|trans({}, 'Admin.Modules.Notification') }}</p>
+                                    <p class="module-import-success-details"></p>
+                                    <a class="module-import-success-configure btn btn-primary btn-sm light-button" href='#'>{{ 'Configure'|trans({}, 'Admin.Actions') }}</a>
+                                </div>
+                                <div class='module-import-failure'>
+                                    <i class="module-import-failure-icon material-icons">error</i><br/>
+                                    <p class='module-import-failure-msg'>{{ 'Oops... Upload failed.'|trans({}, 'Admin.Modules.Notification') }}</p>
+                                    <a href="#" class="module-import-failure-details-action">{{ 'What happened?'|trans({}, 'Admin.Modules.Help') }}</a>
+                                    <div class='module-import-failure-details'></div>
+                                    <a class="module-import-failure-retry btn btn-tertiary" href='#'>{{ 'Try again'|trans({}, 'Admin.Actions') }}</a>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
             <div class="modal-footer">
             </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -192,7 +192,7 @@
           {% endfor %}
         </div>
       {% endif %}
-      {% include 'PrestaShopBundle:Admin/Module/Includes:action_menu.html.twig' with { 'module': module } %}
+      {% include 'PrestaShopBundle:Admin/Module/Includes:action_menu.html.twig' with { 'module': module, 'level' : level } %}
     </div>
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/catalog.html.twig
@@ -42,9 +42,9 @@
     <div class="row">
         <div class="col-lg-10 col-lg-offset-1 module-catalog-page">
             {# Addons connect modal #}
-            {% include 'PrestaShopBundle:Admin/Module/Includes:modal_addons_connect.html.twig' %}
+            {% include 'PrestaShopBundle:Admin/Module/Includes:modal_addons_connect.html.twig' with { 'level' : level, 'errorMessage' : errorMessage } %}
             {# Contains toolbar-nav for module page #}
-            {% include 'PrestaShopBundle:Admin/Module/Includes:modal_import.html.twig' %}
+            {% include 'PrestaShopBundle:Admin/Module/Includes:modal_import.html.twig' with { 'level' : level, 'errorMessage' : errorMessage } %}
             {# Contains menu with Selection/Categories/Popular and Tag Search #}
             {% include 'PrestaShopBundle:Admin/Module/Includes:menu_top.html.twig' %}
             {# Temporary loader until ajax has finished and display the full catalog #}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -43,26 +43,28 @@
         <div class="col-lg-10 col-lg-offset-1">
             {# Bulk Action confirm modal #}
             {% include 'PrestaShopBundle:Admin/Module/Includes:modal_confirm_bulk_action.html.twig' %}
-            {# Addons connect modal #}
-            {% include 'PrestaShopBundle:Admin/Module/Includes:modal_addons_connect.html.twig' %}
-            {# Contains toolbar-nav for module page #}
-            {% include 'PrestaShopBundle:Admin/Module/Includes:modal_import.html.twig' %}
+            {# Addons connect modal with level authorization#}
+            {% include 'PrestaShopBundle:Admin/Module/Includes:modal_addons_connect.html.twig' with { 'level' : level, 'errorMessage' : errorMessage } %}
+            {# Contains toolbar-nav for module page with level authorization #}
+            {% include 'PrestaShopBundle:Admin/Module/Includes:modal_import.html.twig' with { 'level' : level, 'errorMessage' : errorMessage } %}
             {# Contains menu with Selection/Categories/Popular and Tag Search #}
             {% include 'PrestaShopBundle:Admin/Module/Includes:menu_top.html.twig' with { 'topMenuData': topMenuData } %}
             <div class="module-sorting-menu">
                 <div class="row">
                     <div class="col-lg-12">
-                        <div class="module-sorting module-bulk-actions pull-right">
-                            <select class="c-select c-select-sm">
-                              <option value="" disabled selected>{{ 'Bulk Actions'|trans({}, 'Admin.Global') }}</option>
-                              <option value="bulk-uninstall">{{ 'Uninstall'|trans({}, 'Admin.Actions') }}</option>
-                              <option value="bulk-disable">{{ 'Disable'|trans({}, 'Admin.Actions') }}</option>
-                              <option value="bulk-enable">{{ 'Enable'|trans({}, 'Admin.Actions') }}</option>
-                              <option value="bulk-reset">{{ 'Reset'|trans({}, 'Admin.Actions') }}</option>
-                              <option value="bulk-enable-mobile">{{ 'Enable Mobile'|trans({}, 'Admin.Modules.Feature') }}</option>
-                              <option value="bulk-disable-mobile">{{ 'Disable Mobile'|trans({}, 'Admin.Modules.Feature') }}</option>
-                            </select>
-                        </div>
+                        {% if level > constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') %}
+                            <div class="module-sorting module-bulk-actions pull-right">
+                                <select class="c-select c-select-sm">
+                                  <option value="" disabled selected>{{ 'Bulk Actions'|trans({}, 'Admin.Global') }}</option>
+                                  <option value="bulk-uninstall">{{ 'Uninstall'|trans({}, 'Admin.Actions') }}</option>
+                                  <option value="bulk-disable">{{ 'Disable'|trans({}, 'Admin.Actions') }}</option>
+                                  <option value="bulk-enable">{{ 'Enable'|trans({}, 'Admin.Actions') }}</option>
+                                  <option value="bulk-reset">{{ 'Reset'|trans({}, 'Admin.Actions') }}</option>
+                                  <option value="bulk-enable-mobile">{{ 'Enable Mobile'|trans({}, 'Admin.Modules.Feature') }}</option>
+                                  <option value="bulk-disable-mobile">{{ 'Disable Mobile'|trans({}, 'Admin.Modules.Feature') }}</option>
+                                </select>
+                            </div>
+                        {% endif %}
                         <div class="module-sorting module-sorting-author pull-right">
                             <select class="c-select c-select-sm">
                               <option value="" disabled>- {{ 'Sort by'|trans({}, 'Admin.Actions') }} -</option>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -40,15 +40,14 @@
 
 {% block content %}
     {# Addons connect modal #}
-    {% include 'PrestaShopBundle:Admin/Module/Includes:modal_addons_connect.html.twig' %}
+    {% include 'PrestaShopBundle:Admin/Module/Includes:modal_addons_connect.html.twig' with { 'level' : level, 'errorMessage' : errorMessage } %}
     {# Contains toolbar-nav for module page #}
-    {% include 'PrestaShopBundle:Admin/Module/Includes:modal_import.html.twig' %}
+    {% include 'PrestaShopBundle:Admin/Module/Includes:modal_import.html.twig' with { 'level' : level, 'errorMessage' : errorMessage } %}
     {# Module notification KPI's #}
     {% include 'PrestaShopBundle:Admin/Module/Includes:notification_kpis.html.twig' %}
     {# Actual Page Content #}
     <div class="row">
         <div class="col-lg-10 col-lg-offset-1">
-
             <div class="module-short-list">
                 <span class="module-search-result-wording">{{ '%nbModules% modules to configure'|trans({'%nbModules%' : modules.to_configure|length}, 'Admin.Modules.Feature') }}</span>
                 <span class="help-box" data-toggle="popover"
@@ -65,8 +64,11 @@
                       data-title="{{ "Modules to update"|trans({}, 'Admin.Modules.Feature') }}"
                       data-content="{{ "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help') }}">
                 </span>
+                {% if (modules.to_update|length > 1) and (level >= 3) %}
+                <a class="btn btn-primary-reverse pull-right btn-primary-outline light-button module_action_menu_upgrade_all" href="#" data-confirm_modal="module-modal-confirm-upgrade-all">Upgrade All</a>
+                {% endif %}
             </div>
-            {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_update.html.twig' with { 'modules': modules.to_update, 'display_type': 'list', id: 'update' } %}
+            {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_update.html.twig' with { 'modules': modules.to_update, 'display_type': 'list', id: 'update', 'level' : level } %}
         </div>
     </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -28,6 +28,7 @@
 
   <form name="form" id="form" method="post" class="form-horizontal product-page row" novalidate="novalidate">
 
+    {% if not editable %} <fieldset disabled id="field-disabled"> {% endif %}
     {# PRODUCT HEADER #}
     <div class="product-header">
       {% if is_multishop_context %}
@@ -160,9 +161,11 @@
                             </small>
                         </div>
                         {% if form.step1.vars.value.images is defined %}
-                            <div class="dz-preview disabled openfilemanager">
-                              <div><span>+</span></div>
-                            </div>
+                            {% if editable %}
+                                <div class="dz-preview disabled openfilemanager">
+                                    <div><span>+</span></div>
+                                </div>
+                            {% endif %}
                           {% for image in form.step1.vars.value.images %}
                             <div class="dz-preview dz-processing dz-image-preview dz-complete ui-sortable-handle"
                                  data-id="{{ image.id }}"
@@ -969,7 +972,6 @@
       {{ form_widget(form._token) }}
 
     </div>
-
     {# FOOTER #}
     <div class="product-footer">
       <div class="col-lg-5">
@@ -993,7 +995,7 @@
          >
           {{ 'Preview'|trans({}, 'Admin.Actions')}}
         </a>
-
+        {% if editable %}
         <h2 class="for-switch online-title" {% if not form.step1.vars.value.active %}style="display:none;"{% endif %} data-toggle="tooltip"
             title="{{ 'Enable or disable the product on your shop: CTRL+O'|trans({}, 'Admin.Catalog.Help') }}">{{ 'Online'|trans({}, 'Admin.Global') }}</h2>
         <h2 class="for-switch offline-title" {% if form.step1.vars.value.active %}style="display:none;"{% endif %} data-toggle="tooltip"
@@ -1006,7 +1008,7 @@
           value="1"
           {{ form.step1.vars.value.active ? 'checked="checked"' : '' }}
         />
-
+        {% endif %}
       </div>
       <div class="col-lg-6 text-lg-right">
         {% if is_shop_context %}
@@ -1092,6 +1094,7 @@
         </div>
       </div>
     </div>
+    {% if not editable %} </fieldset> {% endif %}
   </form>
 
 
@@ -1138,6 +1141,26 @@
   <script src="{{ asset('../js/tiny_mce/tiny_mce.js') }}"></script>
   <script src="{{ asset('../js/admin/tinymce.inc.js') }}"></script>
   <script src="{{ asset('../js/admin/tinymce_loader.js') }}"></script>
+
+  <script>
+      $(function() {
+        var editable = '{{ editable }}';
+
+        if (editable !== '1'){
+          $('#field-disabled').find("select").each(function() {
+            $(this).removeClass('select2-hidden-accessible');
+          });
+          $('#field-disabled').find("span.select2").each(function() {
+            $(this).hide();
+          });
+          $('#field-disabled').find("a.pstaggerClosingCross").each(function() {
+            $(this).attr("disabled", "disabled").on("click", function() {
+              return false;
+            });
+          });
+        }
+      });
+  </script>
 {% endblock %}
 
 {% set js_translatable = {

--- a/src/PrestaShopBundle/Security/Voter/PageVoter.php
+++ b/src/PrestaShopBundle/Security/Voter/PageVoter.php
@@ -30,13 +30,23 @@ use Access;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
-class ProductVoter extends Voter
+class PageVoter extends Voter
 {
     const CREATE = 'create';
 
     const UPDATE = 'update';
 
     const DELETE = 'delete';
+
+    const READ   = 'read';
+
+    const LEVEL_DELETE   = 4;
+
+    const LEVEL_UPDATE   = 3;
+
+    const LEVEL_CREATE   = 2;
+
+    const LEVEL_READ   = 1;
 
     /**
      * @param string $attribute
@@ -45,7 +55,7 @@ class ProductVoter extends Voter
      */
     protected function supports($attribute, $subject)
     {
-        if (!in_array($attribute, array(self::CREATE, self::UPDATE, self::DELETE))) {
+        if (!in_array($attribute, array(self::CREATE, self::UPDATE, self::DELETE, self::READ))) {
             return false;
         }
 
@@ -62,8 +72,9 @@ class ProductVoter extends Voter
     {
         $user = $token->getUser();
         $employeeProfileId = $user->getData()->id_profile;
+        $global =  $subject . $attribute;
 
-        return $this->can($attribute, $employeeProfileId);
+        return $this->can($global, $employeeProfileId);
     }
 
     /**
@@ -73,7 +84,6 @@ class ProductVoter extends Voter
      */
     protected function can($action, $employeeProfileId)
     {
-        return Access::isGranted('ROLE_MOD_TAB_ADMINPRODUCTS_' . strtoupper($action), $employeeProfileId) &&
-            Access::isGranted('ROLE_MOD_TAB_ADMINCATALOG_' . strtoupper($action), $employeeProfileId);
+        return Access::isGranted('ROLE_MOD_TAB_' . strtoupper($action), $employeeProfileId);
     }
 }

--- a/src/PrestaShopBundle/Tests/Mock/PageVoter.php
+++ b/src/PrestaShopBundle/Tests/Mock/PageVoter.php
@@ -26,10 +26,10 @@
 
 namespace PrestaShopBundle\Tests\Mock;
 
-use PrestaShopBundle\Security\Voter\ProductVoter as BaseVoter;
+use PrestaShopBundle\Security\Voter\PageVoter as BaseVoter;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
-class ProductVoter extends BaseVoter
+class PageVoter extends BaseVoter
 {
     /**
      * @param string $attribute


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update permission about product, theme and module. In product we have no error message when you access a page without permission. On Module and product optimization about permission on this page (new Symfony) cf ticket for have more precision. On Theme we have access without permission and can operate on theme as we want.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/barowse/BOOM-2222
| How to test?  | Permission Module, Theme and Product in administration/Team/Permissions and test access page and option on pages. Action on Theme for upload, inpload, modify, etc ...  