### PR TITLE
Permissions on Module import

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -249,10 +249,10 @@ class AdminControllerCore extends Controller
     const LEVEL_DELETE = 4;
 
     /** @var array Cache for translations */
-    const LEVEL_EDIT = 3;
+    const LEVEL_EDIT = 2;
 
     /** @var array Cache for translations */
-    const LEVEL_ADD = 2;
+    const LEVEL_ADD = 3;
 
     /** @var array Cache for translations */
     const LEVEL_VIEW = 1;

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -82,7 +82,7 @@ class AdminThemesControllerCore extends AdminController
             !$this->logged_on_addons
             || !in_array(
                     $this->authorizationLevel(),
-                    array(AdminController::LEVEL_ADD, AdminController::LEVEL_EDIT, AdminController::LEVEL_DELETE)
+                    array(AdminController::LEVEL_ADD, AdminController::LEVEL_DELETE)
                 )
             || _PS_MODE_DEMO_
         ) {
@@ -255,7 +255,7 @@ class AdminThemesControllerCore extends AdminController
                 if(
                     !in_array(
                         $this->authorizationLevel(),
-                        array(AdminController::LEVEL_ADD, AdminController::LEVEL_EDIT, AdminController::LEVEL_DELETE))
+                        array(AdminController::LEVEL_ADD, AdminController::LEVEL_DELETE))
                     || _PS_MODE_DEMO_
                 ) {
                     Throw new Exception ($this->trans('You do not have permission to add this.', array(), 'Admin.Notifications.Error'));
@@ -286,7 +286,7 @@ class AdminThemesControllerCore extends AdminController
             if(
                 !in_array(
                     $this->authorizationLevel(),
-                    array(AdminController::LEVEL_EDIT, AdminController::LEVEL_DELETE))
+                    array(AdminController::LEVEL_EDIT, AdminController::LEVEL_ADD, AdminController::LEVEL_DELETE))
                 || _PS_MODE_DEMO_
             ) {
                 $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
@@ -298,7 +298,7 @@ class AdminThemesControllerCore extends AdminController
             if(
                 !in_array(
                     $this->authorizationLevel(),
-                    array(AdminController::LEVEL_ADD, AdminController::LEVEL_EDIT, AdminController::LEVEL_DELETE))
+                    array(AdminController::LEVEL_EDIT, AdminController::LEVEL_ADD, AdminController::LEVEL_DELETE))
                 || _PS_MODE_DEMO_
             ) {
                 $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
@@ -329,7 +329,7 @@ class AdminThemesControllerCore extends AdminController
             if(
                 !in_array(
                     $this->authorizationLevel(),
-                    array(AdminController::LEVEL_EDIT, AdminController::LEVEL_DELETE))
+                    array(AdminController::LEVEL_EDIT, AdminController::LEVEL_ADD, AdminController::LEVEL_DELETE))
                 || _PS_MODE_DEMO_
             ) {
                 $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
@@ -342,7 +342,7 @@ class AdminThemesControllerCore extends AdminController
             if(
                 !in_array(
                     $this->authorizationLevel(),
-                    array(AdminController::LEVEL_ADD, AdminController::LEVEL_EDIT, AdminController::LEVEL_DELETE))
+                    array(AdminController::LEVEL_EDIT, AdminController::LEVEL_ADD, AdminController::LEVEL_DELETE))
                 || _PS_MODE_DEMO_
             ) {
                 $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error'); 
@@ -380,7 +380,7 @@ class AdminThemesControllerCore extends AdminController
         if(
             !in_array(
                 $this->authorizationLevel(),
-                array(AdminController::LEVEL_ADD, AdminController::LEVEL_EDIT, AdminController::LEVEL_DELETE))
+                array(AdminController::LEVEL_ADD, AdminController::LEVEL_DELETE))
             || _PS_MODE_DEMO_
         ) {
             $this->errors[] = $this->trans('You do not have permission to upload this.', array(), 'Admin.Notifications.Error');
@@ -714,7 +714,7 @@ class AdminThemesControllerCore extends AdminController
         if(
             !in_array(
                 $this->authorizationLevel(),
-                array(AdminController::LEVEL_ADD, AdminController::LEVEL_EDIT, AdminController::LEVEL_DELETE))
+                array(AdminController::LEVEL_EDIT, AdminController::LEVEL_ADD, AdminController::LEVEL_DELETE))
             || _PS_MODE_DEMO_
         ) {
             Tools::clearCache();
@@ -736,10 +736,10 @@ class AdminThemesControllerCore extends AdminController
         switch (true) {
             case (Access::isGranted('ROLE_MOD_TAB_' . strtoupper('ADMINTHEMES') . '_DELETE', $this->context->employee->id_profile)) :
                 return AdminController::LEVEL_DELETE;
-            case (Access::isGranted('ROLE_MOD_TAB_' . strtoupper('ADMINTHEMES') . '_UPDATE', $this->context->employee->id_profile)) :
-                return AdminController::LEVEL_EDIT;
             case (Access::isGranted('ROLE_MOD_TAB_' . strtoupper('ADMINTHEMES') . '_CREATE', $this->context->employee->id_profile)) :
                 return AdminController::LEVEL_ADD;
+            case (Access::isGranted('ROLE_MOD_TAB_' . strtoupper('ADMINTHEMES') . '_UPDATE', $this->context->employee->id_profile)) :
+                return AdminController::LEVEL_EDIT;
             case (Access::isGranted('ROLE_MOD_TAB_' . strtoupper('ADMINTHEMES') . '_READ', $this->context->employee->id_profile)) :
                 return AdminController::LEVEL_VIEW;
             default :

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -551,7 +551,7 @@ class ModuleController extends FrameworkBundleAdminController
         }
 
         try {
-            if(!in_array($this->authorizationLevel(), array(PageVoter::LEVEL_CREATE, PageVoter::LEVEL_UPDATE, PageVoter::LEVEL_DELETE))){
+            if( !in_array($this->authorizationLevel(), array( PageVoter::LEVEL_CREATE, PageVoter::LEVEL_DELETE))){
                 return new JsonResponse(
                     array(
                         'status' => false,
@@ -781,10 +781,10 @@ class ModuleController extends FrameworkBundleAdminController
         switch (true) {
             case ($this->isGranted(PageVoter::DELETE, 'ADMINMODULESSF_')) :
                 return PageVoter::LEVEL_DELETE;
-            case ($this->isGranted(PageVoter::UPDATE, 'ADMINMODULESSF_')) :
-                return PageVoter::LEVEL_UPDATE;
             case ($this->isGranted(PageVoter::CREATE, 'ADMINMODULESSF_')) :
                 return PageVoter::LEVEL_CREATE;
+            case ($this->isGranted(PageVoter::UPDATE, 'ADMINMODULESSF_')) :
+                return PageVoter::LEVEL_UPDATE;
             case ($this->isGranted(PageVoter::READ, 'ADMINMODULESSF_')) :
                 return PageVoter::LEVEL_READ;
             default :

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -41,7 +41,7 @@
     {% else %}
       <form class="btn-group" method="post" action="{{ urls[url_active] }}">
         <button type="submit" class="btn btn-primary-reverse btn-primary-outline light-button module_action_menu_{{ url_active }}"
-           data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}" {% if (level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_CREATE')) or (level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_DELETE') and (url_active not in ['configure', 'install', 'upgrade'])) %} disabled="disabled" {% endif %}>
+           data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}" {% if (level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) or (level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_DELETE') and (url_active not in ['configure', 'install', 'upgrade'])) %} disabled="disabled" {% endif %}>
             {{ url_active|capitalize|replace({'_': " "}) }}
         </button>
         {% if urls|length > 1 %}
@@ -49,7 +49,7 @@
         {% endif %}
       </form>
       {% if (urls|length > 1) %}
-        {% if (level > constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) or ((('configure' in urls|keys) and ('upgrade' in urls|keys)) and  url_active in ['configure', 'install', 'upgrade']) %}
+        {% if (level > constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_CREATE')) or ((('configure' in urls|keys) and ('upgrade' in urls|keys)) and  url_active in ['configure', 'install', 'upgrade']) %}
             <button type="button" class="btn btn-primary-outline  dropdown-toggle light-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <span class="caret"></span>
               <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
@@ -31,7 +31,7 @@
         <h4 class="modal-title module-modal-title">{{ 'Connect to Addons marketplace'|trans({}, 'Admin.Modules.Feature') }}</h4>
       </div>
       <div class="modal-body">
-        {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_READ') %}
+        {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') %}
           <div class="row">
             <div class="col-md-12">
               <div class="alert alert-danger">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
@@ -31,7 +31,7 @@
                 <h4 class="modal-title module-modal-title">{{ 'Upload a module'|trans({}, 'Admin.Modules.Feature') }}</h4>
             </div>
             <div class="modal-body">
-                {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_READ') %}
+                {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') %}
                     <div class="row">
                         <div class="col-md-12">
                             <div class="alert alert-danger">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -64,7 +64,7 @@
                       data-title="{{ "Modules to update"|trans({}, 'Admin.Modules.Feature') }}"
                       data-content="{{ "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help') }}">
                 </span>
-                {% if (modules.to_update|length > 1) and (level >= 3) %}
+                {% if (modules.to_update|length > 1) and (level >= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) %}
                 <a class="btn btn-primary-reverse pull-right btn-primary-outline light-button module_action_menu_upgrade_all" href="#" data-confirm_modal="module-modal-confirm-upgrade-all">Upgrade All</a>
                 {% endif %}
             </div>

--- a/src/PrestaShopBundle/Security/Voter/PageVoter.php
+++ b/src/PrestaShopBundle/Security/Voter/PageVoter.php
@@ -42,9 +42,9 @@ class PageVoter extends Voter
 
     const LEVEL_DELETE   = 4;
 
-    const LEVEL_UPDATE   = 3;
+    const LEVEL_UPDATE   = 2;
 
-    const LEVEL_CREATE   = 2;
+    const LEVEL_CREATE   = 3;
 
     const LEVEL_READ   = 1;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Problems when import Module. An edit permission give add permission. But when you install the module, an error occurred after get module. We secures the popup and verify only the add permission when add. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/barowse/BOOM-2222
| How to test?  | Permission Module, Theme and Product in administration/Team/Permissions and test access page and option on pages. Action on Theme for upload, inpload, modify, etc ...  