### PR TITLE
Style categories tree in footer

### DIFF
--- a/themes/default-bootstrap/modules/blockcategories/blockcategories_footer.tpl
+++ b/themes/default-bootstrap/modules/blockcategories/blockcategories_footer.tpl
@@ -28,7 +28,7 @@
 	<h4>{l s='Categories' mod='blockcategories'}</h4>
 	<div class="category_footer toggle-footer">
 		<div class="list">
-			<ul class="tree {if $isDhtml}dhtml{/if}">
+			<ul class="{if $isDhtml}dhtml{/if}">
 			{foreach from=$blockCategTree.children item=child name=blockCategTree}
 				{if $smarty.foreach.blockCategTree.last}
 					{include file="$branche_tpl_path" node=$child last='true'}


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In the footer of "Sitemap" page, there is a problem in the Categories_tree style.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-6600
| How to test?  | Click on SItemap in footer, then go to the footer and you will see that the categories_tree have the same style like in others pages.
