### PR TITLE
Fix doctrine association between translation and lang

### DIFF
--- a/src/PrestaShopBundle/Entity/Translation.php
+++ b/src/PrestaShopBundle/Entity/Translation.php
@@ -51,7 +51,6 @@ class Translation
     /**
      * @var Lang
      *
-     * @ORM\Column(name="id_lang", type="integer")
      * @ORM\ManyToOne(targetEntity="Lang", inversedBy="translations")
      * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false)
      */


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR fixes the database insertion on the translation page. As seen on [Stack Overflow](http://stackoverflow.com/questions/20941905/doctrine-object-of-class-user-could-not-be-converted-to-string), it seems we should not write the column details when we deal with an association.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2566 - Part 1
| How to test?  | Go to the back-office translations, and try to save any text to translate. It must work!

![capture du 2017-03-03 13-27-31](https://cloud.githubusercontent.com/assets/6768917/23551189/626aeb1c-0015-11e7-8f71-2e50fe547f47.png)
