### PR TITLE
Hotfix for module notifications page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -418,7 +418,6 @@ class ModuleController extends FrameworkBundleAdminController
             $modules->{$moduleLabel} = $this->getPresentedProducts($modulesPart);
         }
 
-        $translator = $this->container->get('translator');
         $errorMessage = $translator->trans(
             'You do not have permission to add this.',
             array(),
@@ -428,9 +427,9 @@ class ModuleController extends FrameworkBundleAdminController
         return $this->render('PrestaShopBundle:Admin/Module:notifications.html.twig', array(
             'enableSidebar' => true,
             'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
-            'layoutTitle' => $layoutTitle,
+            'layoutTitle' => $translator->trans('Module notifications', array(), 'Admin.Modules.Feature'),
             'help_link' => $this->generateSidebarLink('AdminModules'),
-            'modules' => $moduleManager->getModulesWithNotifications($modulesPresenter),
+            'modules' => $modules,
             'requireAddonsSearch' => false,
             'requireBulkActions' => false,
             'requireFilterStatus' => false,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.0.x
| Description?  | With commit https://github.com/PrestaShop/PrestaShop/commit/2fd9e64bf1a168f14e3de9e6cdf42f1dbcbac931, we use undefined variables. This PR fixes the issue.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | 
| How to test?  | Go to the "Modules & services > Notifications". No error should appear.
