### PR TITLE
Fix language refresh on dropdown change

### DIFF
--- a/install-dev/controllers/http/welcome.php
+++ b/install-dev/controllers/http/welcome.php
@@ -51,9 +51,9 @@ class InstallControllerHttpWelcome extends InstallControllerHttp implements Http
         if (!empty($this->session->lang) && !is_file(_PS_ROOT_DIR_ . '/app/Resources/translations/' . $locale . '/Install.' . $locale . '.xlf')) {
             Language::downloadAndInstallLanguagePack($this->session->lang, _PS_VERSION_, null, false);
             $this->clearCache();
-            if (is_dir(_PS_ROOT_DIR_ . '/app/Resources/translations/' . $locale)) {
-                $this->redirect('welcome');
-            }
+        }
+        if (Tools::getIsset('language') && is_dir(_PS_ROOT_DIR_ . '/app/Resources/translations/' . $locale)) {
+            $this->redirect('welcome');
         }
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | When we change the installation language, the installer content does not refresh properly. This PR displays the proper language as soon as the user selects another one.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2568
| How to test?  | Go to the installer, and change the language. The content must be updated on first refresh.