### PR TITLE
Fix url rewrite setting not used on multishop

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -376,7 +376,12 @@ class LinkCore
         if (Dispatcher::getInstance()->hasRoute('module-'.$module.'-'.$controller, $id_lang, $id_shop)) {
             return $this->getPageLink('module-'.$module.'-'.$controller, $ssl, $id_lang, $params);
         } else {
-            return $url.Dispatcher::getInstance()->createUrl('module', $id_lang, $params, $this->allow, '', $id_shop);
+            if ($id_shop) {
+                $allow = (int)Configuration::get('PS_REWRITING_SETTINGS', null, null, $id_shop);
+            } else {
+                $allow = $this->allow;
+            }
+            return $url.Dispatcher::getInstance()->createUrl('module', $id_lang, $params, $allow, '', $id_shop);
         }
     }
 


### PR DESCRIPTION

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | If one shop uses url rewrite and not an other Link::getModuleLink doesn't use this parameter if you want to generate an url for the other shop.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create two shops, one with url rewritting and not the other. Try to use Link::getModuleLink to generate a module url from a shop for the other.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
