### PR TITLE
Modification permission on Theme Page and option

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4418,18 +4418,13 @@ class AdminControllerCore extends Controller
      */
     public function authorizationLevel()
     {
-        $access = Profile::getProfileAccess(
-                $this->context->employee->id_profile,
-                (int)Tab::getIdFromClassName($this->controller_name)
-            );
-
-        if($access['delete']) {
+        if($this->tabAccess['delete']) {
             return AdminController::LEVEL_DELETE;
-        } elseif($access['add']) {
+        } elseif($this->tabAccess['add']) {
             return AdminController::LEVEL_ADD;
-        } elseif($access['edit']){
+        } elseif($this->tabAccess['edit']){
             return AdminController::LEVEL_EDIT;
-        } elseif($access['view']){
+        } elseif($this->tabAccess['view']){
             return AdminController::LEVEL_VIEW;
         } else {
             return 0;

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -1583,14 +1583,14 @@ class AdminThemesControllerCore extends AdminController
     protected function installTheme($theme_dir, $sandbox = false, $redirect = true)
     {
         if (
-            !in_array(
+            in_array(
                 $this->authorizationLevel(),
                 array(
                     AdminController::LEVEL_ADD,
                     AdminController::LEVEL_DELETE
                     )
             )
-            || _PS_MODE_DEMO_
+            && !_PS_MODE_DEMO_
         ) {
             if (!$sandbox) {
                 $uniqid = uniqid();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Problems with permissions in theme page (access and options in page without any permission
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Use permission in parameters to give access or not on page or option. Read, only see page with themes. Edit, you can modify options of theme. Add, Edit + you can add new themes, Delete Add + you can delete page.