### PR TITLE
Fix imageFolder path for colorPicker inputs

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -896,6 +896,11 @@
 	});
 </script>
 {/if}
+{if isset($color) && $color}
+<script type="text/javascript">
+	$.fn.mColorPicker.defaults.imageFolder = baseDir + 'img/admin/';
+</script>
+{/if}
 {if $firstCall}
 	<script type="text/javascript">
 		var module_dir = '{$smarty.const._MODULE_DIR_}';

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -191,6 +191,7 @@ class HelperFormCore extends Helper
                             if ($color) {
                                 // Added JS file
                                 $this->context->controller->addJqueryPlugin('colorpicker');
+                                $this->tpl_vars['color'] = true;
                                 $color = false;
                             }
                             break;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | As now, while you use an input type color in a HelperForm, there is a problem with the associated images.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Edit an order status and see that the color picker have no images. With this Pull Request, you will see the good images while setting the colorPicker inside a HelperForm.