### PR TITLE
Fix product attachments lookup

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
@@ -213,8 +213,9 @@ class ProductOptions extends CommonAbstractType
             'multiple'  => true,
             'choices'  => $this->attachmentList,
             'choices_as_values' => true,
-            'choice_label' => function ($value, $key, $index) {
-                return $this->fullAttachmentList[$index - 1]['name'];
+            'choice_label' => function ($choice, $key, $value) {
+                $attachmentKey = array_search($key, array_column($this->fullAttachmentList, 'file'));
+                return $this->fullAttachmentList[$attachmentKey]['name'];
             },
             'required' => false,
             'attr' => ['data' => $this->fullAttachmentList],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | This PRs fixes the array initialization for product attachments. The error could only be detected if one of them was removed after being created.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2610
| How to test?  | On one of your product, add several attachments. Then, go to "Catalog > Files" and remove one of the first files. When you go back to your updated product, you must not get anymore PHP errors.