### PR TITLE
BO: Unable to generate invoice with button

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/_documents.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_documents.tpl
@@ -61,6 +61,7 @@
 									{l s='Delivery slip'}
 								{else}
 									{l s='Invoice'}
+                                    {$invoice_generated = 1}
 								{/if}
 							{elseif get_class($document) eq 'OrderSlip'}
 								{l s='Credit Slip'}
@@ -164,6 +165,12 @@
 							<i class="icon-warning-sign list-empty-icon"></i>
 							{l s='There is no available document'}
 						</div>
+					</td>
+				</tr>
+			{/foreach}
+			{if !isset($invoice_generated)}
+				<tr>
+					<td colspan="5" class="list-empty">
 						{if isset($invoice_management_active) && $invoice_management_active}
 							<a class="btn btn-default" href="{$current_index}&amp;viewOrder&amp;submitGenerateInvoice&amp;id_order={$order->id}{if isset($smarty.get.token)}&amp;token={$smarty.get.token|escape:'html':'UTF-8'}{/if}">
 								<i class="icon-repeat"></i>
@@ -172,7 +179,7 @@
 						{/if}
 					</td>
 				</tr>
-			{/foreach}
+			{/if}
 		</tbody>
 	</table>
 </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x.
| Description?  | Unable to generate the invoice with button in 'Documents' tab if before is generated the delivery document
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | No
| How to test?  | Generate a delivery document without generate the invoice first. So the unique method to generate the invoice is with a status change.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

BO: Unable to generate the invoice with button in 'Documents' tab if before is generated the delivery document

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7649)
<!-- Reviewable:end -->
