### PR TITLE
Rename id_product_redirected variable

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -566,7 +566,7 @@ function addRelatedProduct(id_product_to_add, product_name)
 	if (!id_product_to_add || id_product == id_product_to_add)
 		return;
 	$('#related_product_name').html(product_name);
-	$('input[name=id_product_redirected]').val(id_product_to_add);
+	$('input[name=id_type_redirected]').val(id_product_to_add);
 	$('#related_product_autocomplete_input').parent().hide();
 	$('#related_product_remove').show();
 }
@@ -574,7 +574,7 @@ function addRelatedProduct(id_product_to_add, product_name)
 function removeRelatedProduct()
 {
 	$('#related_product_name').html(no_related_product);
-	$('input[name=id_product_redirected]').val(0);
+	$('input[name=id_type_redirected]').val(0);
 	$('#related_product_remove').hide();
 	$('#related_product_autocomplete_input').parent().fadeIn();
 }

--- a/js/admin/products.js
+++ b/js/admin/products.js
@@ -1053,7 +1053,7 @@ product_tabs['Informations'] = new function(){
 					addRelatedProduct(i[1], i[0]);
 				$(this).val('');
 			});
-		 addRelatedProduct(id_product_redirected, product_name_redirected);
+		 addRelatedProduct(id_type_redirected, product_name_redirected);
 	};
 
 	this.bindTagImage = function (){

--- a/tests/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
+++ b/tests/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
@@ -3614,7 +3614,7 @@ class AdminProductsController extends AdminProductsControllerCore
         $data->assign('default_form_language', $this->default_form_language);
         $data->assign('currency', $currency);
         $this->object = $product;
-        $data->assign('product_name_redirected', Product::getProductName((int)$product->id_product_redirected, null, (int)$this->context->language->id));
+        $data->assign('product_name_redirected', Product::getProductName((int)$product->id_type_redirected, null, (int)$this->context->language->id));
 
         $product_download = new ProductDownload();
         if ($id_product_download = $product_download->getIdFromIdProduct($this->getFieldValue($product, 'id'))) {

--- a/tests/resources/module/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/resources/module/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -3541,7 +3541,7 @@ class AdminProductsController extends AdminProductsControllerCore
         $data->assign('currency', $currency);
         $this->object = $product;
         //$this->display = 'edit';
-        $data->assign('product_name_redirected', Product::getProductName((int)$product->id_product_redirected, null, (int)$this->context->language->id));
+        $data->assign('product_name_redirected', Product::getProductName((int)$product->id_type_redirected, null, (int)$this->context->language->id));
         /*
         * Form for adding a virtual product like software, mp3, etc...
         */


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Rename `id_product_redirected` to `id_type_redirected`. This new name was introduced in https://github.com/PrestaShop/PrestaShop/pull/7254
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 