### PR TITLE
Disable  Terms and conditions when Legal Compliance module installed

### DIFF
--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -79,6 +79,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
             'selected_payment_option' => $this->selected_payment_option,
             'selected_delivery_option' => $selectedDeliveryOption,
             'show_final_summary' => Configuration::get('PS_FINAL_SUMMARY_ENABLED'),
+            'ps_conditions' => Configuration::get('PS_CONDITIONS'),
             );
 
         return $this->renderTemplate($this->getTemplate(), $extraParams, $assignedVars);

--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -73,7 +73,7 @@
     {/foreach}
   </div>
 
-  {if $conditions_to_approve|count}
+  {if $conditions_to_approve|count && $ps_conditions}
     <p class="ps-hidden-by-js">
       {* At the moment, we're not showing the checkboxes when JS is disabled
          because it makes ensuring they were checked very tricky and overcomplicates
@@ -115,23 +115,32 @@
 
   <div id="payment-confirmation">
     <div class="ps-shown-by-js">
-      <button type="submit" {if !$selected_payment_option} disabled {/if} class="btn btn-primary center-block">
+      <button type="submit" {if !$selected_payment_option } disabled {/if} class="btn btn-primary center-block">
         {l s='Order with an obligation to pay' d='Shop.Theme.Checkout'}
       </button>
       {if $show_final_summary}
         <article class="alert alert-danger m-t-2 js-alert-payment-conditions" role="alert" data-alert="danger">
           {l
-            s='Please make sure you\'ve chosen a [1]payment method[/1] and accepted the [2]terms and conditions[/2].'
+            s='Please make sure you\'ve chosen a [1]payment method[/1]'
             sprintf=[
-              '[1]' => '<a href="#checkout-payment-step">',
-              '[/1]' => '</a>',
-              '[2]' => '<a href="#conditions-to-approve">',
-              '[/2]' => '</a>'
+            '[1]' => '<a href="#checkout-payment-step">',
+            '[/1]' => '</a>',
+            '[2]' => '<a href="#conditions-to-approve">',
+            '[/2]' => '</a>'
             ]
             d='Shop.Theme.Checkout'
           }
-        </article>
-      {/if}
+          {if $ps_conditions}
+            {l
+              s=' and accepted the [2]terms and conditions[/2].'
+              sprintf=[
+              '[2]' => '<a href="#conditions-to-approve">',
+              '[/2]' => '</a>'
+              ]
+              d='Shop.Theme.Checkout'
+            }
+          {/if}
+        {/if}
     </div>
     <div class="ps-hidden-by-js">
       {if $selected_payment_option and $all_conditions_approved}

--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -115,27 +115,29 @@
 
   <div id="payment-confirmation">
     <div class="ps-shown-by-js">
-      <button type="submit" {if !$selected_payment_option } disabled {/if} class="btn btn-primary center-block">
+      <button type="submit" {if !$selected_payment_option} disabled {/if} class="btn btn-primary center-block">
         {l s='Order with an obligation to pay' d='Shop.Theme.Checkout'}
       </button>
       {if $show_final_summary}
         <article class="alert alert-danger m-t-2 js-alert-payment-conditions" role="alert" data-alert="danger">
-          {l
-            s='Please make sure you\'ve chosen a [1]payment method[/1]'
-            sprintf=[
-            '[1]' => '<a href="#checkout-payment-step">',
-            '[/1]' => '</a>',
-            '[2]' => '<a href="#conditions-to-approve">',
-            '[/2]' => '</a>'
-            ]
-            d='Shop.Theme.Checkout'
-          }
+          {if !$ps_conditions}
+            {l
+              s='Please make sure you\'ve chosen a [1]payment method[/1].'
+              sprintf=[
+                '[1]' => '<a href="#checkout-payment-step">',
+                '[/1]' => '</a>'
+              ]
+              d='Shop.Theme.Checkout'
+            }
+          {/if}
           {if $ps_conditions}
             {l
-              s=' and accepted the [2]terms and conditions[/2].'
+              s='Please make sure you\'ve chosen a [1]payment method[/1] and accepted the [2]terms and conditions[/2].'
               sprintf=[
-              '[2]' => '<a href="#conditions-to-approve">',
-              '[/2]' => '</a>'
+                '[1]' => '<a href="#checkout-payment-step">',
+                '[/1]' => '</a>',
+                '[2]' => '<a href="#conditions-to-approve">',
+                '[/2]' => '</a>'
               ]
               d='Shop.Theme.Checkout'
             }

--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -129,8 +129,7 @@
               ]
               d='Shop.Theme.Checkout'
             }
-          {/if}
-          {if $ps_conditions}
+          {else}
             {l
               s='Please make sure you\'ve chosen a [1]payment method[/1] and accepted the [2]terms and conditions[/2].'
               sprintf=[


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | After disabling the option for agreeing with terms and conditions and installing  Legal Compliance module  you can't order if you don't agree with terms and conditions.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2447
| How to test?  | Go to Shop settings-> Orders and disable the option Terms and conditions. Try to pass an order from the FO that works fine. Now install Legal Compliance module and retry to pass an order from the FO.