### PR TITLE
Optimization for Cart Rules

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -892,11 +892,6 @@ class CartRuleCore extends ObjectModel
         $all_products = $context->cart->getProducts();
         $package_products = (is_null($package) ? $all_products : $package['products']);
 
-        $all_cart_rules_ids = $context->cart->getOrderedCartRulesIds();
-
-        $cart_amount_ti = $context->cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
-        $cart_amount_te = $context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
-
         $reduction_value = 0;
 
         $cache_id = 'getContextualValue_'.(int)$this->id.'_'.(int)$use_tax.'_'.(int)$context->cart->id.'_'.(int)$filter;
@@ -907,6 +902,11 @@ class CartRuleCore extends ObjectModel
         if (Cache::isStored($cache_id)) {
             return Cache::retrieve($cache_id);
         }
+
+        $all_cart_rules_ids = $context->cart->getOrderedCartRulesIds();
+
+        $cart_amount_ti = $context->cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
+        $cart_amount_te = $context->cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
 
         // Free shipping on selected carriers
         if ($this->free_shipping && in_array($filter, array(CartRule::FILTER_ACTION_ALL, CartRule::FILTER_ACTION_ALL_NOCAP, CartRule::FILTER_ACTION_SHIPPING))) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | I have observed some performance issues with the website I am developing, and by using blackfire I realized there are some problems with getContextualValue calling getOrderTotal too many times. I saw that there are 3 variables which are initialized before the cache check but do not influence it in any way, 2 of them by calling getOrderTotal. So I optimized the way getContextualValue works by moving the initialization of those variables after the cache check.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | You can observe performance improvement on the checkout page when a client has many products that also have cart rules attached to them. Try testing for 20+ products with 5+ cart rules. I have used blackfire.io for the performance testing. For my project on my local machine I have noticed a change from 25 seconds load time to 4 seconds on a cart with 30 products and 6 cart rules.