### PR TITLE
Fix translation cache preventing load of new language

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -350,6 +350,21 @@ class ContextCore
         $cacheDir = _PS_CACHE_DIR_.'translations';
         $this->translator = new Translator($this->language->locale, null, $cacheDir, false);
 
+        // In case we have at least 1 translated message, we return the current translator.
+        // If some translations are missing, clear cache
+        if (count($this->translator->getCatalogue($this->language->locale)->all())) {
+            return $this->translator;
+        }
+
+        // However, in some case, even empty catalog were stored in the cache and then used as-is.
+        // For this one, we drop the cache and try to regenerate it.
+        $cache_file = Finder::create()
+            ->files()
+            ->in($cacheDir)
+            ->depth('==0')
+            ->name('*.'.$this->language->locale.'.*');
+        (new Filesystem())->remove($cache_file);
+
         $adminContext = defined('_PS_ADMIN_DIR_');
         $this->translator->addLoader('xlf', new XliffFileLoader());
 

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1013,6 +1013,7 @@ class LanguageCore extends ObjectModel
             $zipArchive = new ZipArchive();
             $zipArchive->open(_PS_TRANSLATIONS_DIR_.'sf-'.$locale.'.zip');
             $zipArchive->extractTo(_PS_ROOT_DIR_.'/app/Resources/translations');
+            $zipArchive->close();
         }
     }
 
@@ -1029,6 +1030,7 @@ class LanguageCore extends ObjectModel
             $zipArchive = new ZipArchive();
             $zipArchive->open($folder.'.zip');
             $zipArchive->extractTo($folder);
+            $zipArchive->close();
 
             $coreDestPath = _PS_ROOT_DIR_.'/mails/'.$lang_pack['iso_code'];
             $fileSystem->mkdir($coreDestPath, 0755);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | This PR fixes an issue when a new language is imported. A test made to check if the cache already exists is too strong, preventing the translator to load the new files. We replace it to regenerate the language cache if no message is found.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2572
| How to test?  | Import a new language in "International > Translations". It must work immediately on the front office.