### PR TITLE
Fix Combination filter in stock management section

### DIFF
--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -176,7 +176,20 @@ class AdminStockManagementControllerCore extends AdminController
             $this->_where = 'AND a.id_product = '.$product_id;
             $this->_group = 'GROUP BY a.id_product_attribute';
 
-            self::$currentIndex = self::$currentIndex.'&id_product='.(int)$product_id;
+            $this->fields_list ['name'] =
+                array(
+                    'title' => $this->l('Name'),
+                    'orderby' => false,
+                    'filter' => false,
+                    'search' => false
+                );
+
+            if (Tools::getIsset('id_product_attribute')) {
+                self::$currentIndex = self::$currentIndex.'&id_product='.(int)$product_id;
+            } else {
+                self::$currentIndex = self::$currentIndex.'&id_product='.(int)$product_id.'&detailsproduct';
+            }
+            
             $this->processFilter();
             return parent::renderList();
         }
@@ -870,6 +883,13 @@ class AdminStockManagementControllerCore extends AdminController
             $redirect = self::$currentIndex.'&token='.$token;
         }
 
+        if(Tools::isSubmit('submitFilter') && Tools::getIsset('detailsproduct')){
+            $id_product = (int)Tools::getValue('id_product', 0);
+            $token = Tools::getValue('token') ? Tools::getValue('token') : $this->token;
+            $redirect = self::$currentIndex.'&id_product='.$id_product.'&detailsproduct&token='.$token;
+            Tools::redirectAdmin($redirect);
+        }
+
         // Global checks when add / remove product
         if ((Tools::isSubmit('addstock') || Tools::isSubmit('removestock')) && Tools::isSubmit('is_post')) {
             $stockAttributes = $this->getStockAttributes();
@@ -1347,6 +1367,10 @@ class AdminStockManagementControllerCore extends AdminController
     {
         if (!array_key_exists('RemoveStock', self::$cache_lang)) {
             self::$cache_lang['RemoveStock'] = $this->l('Remove stock');
+        }
+
+        if(Tools::getIsset('detailsproduct')) {
+            self::$currentIndex = str_replace('&detailsproduct', '', self::$currentIndex);
         }
 
         $this->context->smarty->assign(array(

--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -176,7 +176,7 @@ class AdminStockManagementControllerCore extends AdminController
             $this->_where = 'AND a.id_product = '.$product_id;
             $this->_group = 'GROUP BY a.id_product_attribute';
 
-            $this->fields_list ['name'] =
+            $this->fields_list['name'] =
                 array(
                     'title' => $this->l('Name'),
                     'orderby' => false,
@@ -883,7 +883,7 @@ class AdminStockManagementControllerCore extends AdminController
             $redirect = self::$currentIndex.'&token='.$token;
         }
 
-        if(Tools::isSubmit('submitFilter') && Tools::getIsset('detailsproduct')){
+        if (Tools::isSubmit('submitFilter') && Tools::getIsset('detailsproduct')) {
             $id_product = (int)Tools::getValue('id_product', 0);
             $token = Tools::getValue('token') ? Tools::getValue('token') : $this->token;
             $redirect = self::$currentIndex.'&id_product='.$id_product.'&detailsproduct&token='.$token;
@@ -1369,7 +1369,7 @@ class AdminStockManagementControllerCore extends AdminController
             self::$cache_lang['RemoveStock'] = $this->l('Remove stock');
         }
 
-        if(Tools::getIsset('detailsproduct')) {
+        if (Tools::getIsset('detailsproduct')) {
             self::$currentIndex = str_replace('&detailsproduct', '', self::$currentIndex);
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you do a search by name or by reference, or sort combinations it shows "No records found".
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8859
| How to test?  | In the Stock > Stock Management, view details of product that have combinations and use search and sort options.