### PR TITLE
Fix show currency name in tab "Catalog Price Rules" for option "All currencies"

### DIFF
--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -153,8 +153,10 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
         parent::getList($id_lang, $order_by, $order_way, $start, $limit, $id_lang_shop);
 
         foreach ($this->_list as $k => $list) {
-            $currency = $this->cldr->getCurrency($this->_list[$k]['currency_iso_code']);
-            $this->_list[$k]['currency_name'] = ucfirst($currency['name']);
+            if (!is_null($this->_list[$k]['currency_iso_code'])) {
+                $currency = $this->cldr->getCurrency($this->_list[$k]['currency_iso_code']);
+                $this->_list[$k]['currency_name'] = ucfirst($currency['name']);
+            }
 
             if ($list['reduction_type'] == 'amount') {
                 $this->_list[$k]['reduction_type'] = $this->list_reduction_type['amount'];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | Show currency name in tab "Catalog Price Rules" for option  "All currencies". Need show '--'
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create catalog price rule and set 'All currency' for 'Currency'. View tab "Catalog Price Rules"

![1](https://cloud.githubusercontent.com/assets/8409258/23831514/b994e47a-072b-11e7-8962-e1d8643ac466.jpg)
![2](https://cloud.githubusercontent.com/assets/8409258/23831515/b9993a16-072b-11e7-9dd4-2241dd77813c.jpg)

