### PR TITLE
Fix issue of Module notification page after 1.7.0.x backport

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -385,6 +385,7 @@ class ModuleController extends FrameworkBundleAdminController
         };
 
         $moduleManager = $this->get('prestashop.module.manager');
+        $modules = $moduleManager->getModulesWithNotifications($modulesPresenter);
         $translator = $this->get('translator');
         $layoutTitle = $translator->trans(
             'Module notifications',
@@ -401,7 +402,7 @@ class ModuleController extends FrameworkBundleAdminController
         return $this->render('PrestaShopBundle:Admin/Module:notifications.html.twig', array(
             'enableSidebar' => true,
             'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
-            'layoutTitle' => $translator->trans('Module notifications', array(), 'Admin.Modules.Feature'),
+            'layoutTitle' => $layoutTitle,
             'help_link' => $this->generateSidebarLink('AdminModules'),
             'modules' => $modules,
             'requireAddonsSearch' => false,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Changes made on the branch 1.7.0.x don't work properly when pulled on the branch 1.7.1.x. This PR fixes an issue about properties in callback.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Go to the page `Modules & Services` > `Notifications` tab