### PR TITLE
Retrieve text only from selected customization

### DIFF
--- a/classes/Customization.php
+++ b/classes/Customization.php
@@ -334,6 +334,7 @@ class CustomizationCore extends ObjectModel
 			FROM `'._DB_PREFIX_.'customization_field` cf
 			LEFT JOIN `'._DB_PREFIX_.'customized_data` cd ON (cf.id_customization_field = cd.index)
 			WHERE `id_product` = '.(int)$this->id_product.'
+			AND id_customization = '.(int)$this->id.'
 			AND cf.type = 1')) {
             return array();
         }
@@ -353,6 +354,7 @@ class CustomizationCore extends ObjectModel
 			FROM `'._DB_PREFIX_.'customization_field` cf
 			LEFT JOIN `'._DB_PREFIX_.'customized_data` cd ON (cf.id_customization_field = cd.index)
 			WHERE `id_product` = '.(int)$this->id_product.'
+			AND id_customization = '.(int)$this->id.'
 			AND cf.type = 0')) {
             return array();
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The customization API displayed all database text customizations when trying to display a cutomization by its id. This code corrects this bug. 
| Type?         | bug fix 
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7971
| How to test?  | Display the API url, example: http://www.example.com/api/customizations/6073
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->


