### PR TITLE
Allow upgrade for modules coming from Must-have json

### DIFF
--- a/src/Adapter/Module/ModuleDataUpdater.php
+++ b/src/Adapter/Module/ModuleDataUpdater.php
@@ -47,7 +47,7 @@ class ModuleDataUpdater
         // Note : Data caching should be handled by the addons data provider
         // Check if the module can be downloaded from addons
         foreach ($this->adminModuleDataProvider->getCatalogModules(['name' => $name]) as $catalog_module) {
-            if ($catalog_module->name == $name && in_array($catalog_module->origin, ['native', 'native_all', 'partner', 'customer'])) {
+            if ($catalog_module->name == $name && in_array($catalog_module->origin, ['native', 'native_all', 'must-have', 'customer'])) {
                 return $this->addonsDataProvider->downloadModule($catalog_module->id);
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | We call different resources from the Addons API. Any of them are not able to be updated, and there is filter for that. However, one of its value was incorrect, preventing some modules being updated.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Please indicate how to best verify that this PR is correct.
