### PR TITLE
BO: show tax of shipping on invoice when ATCP_SHIPWRAP is on within aeuc module

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1322,7 +1322,7 @@ class OrderCore extends ObjectModel
 
         $address = new Address((int)$this->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
         $carrier = new Carrier((int)$this->id_carrier);
-        $tax_calculator = $carrier->getTaxCalculator($address);
+        $tax_calculator = (Configuration::get('PS_ATCP_SHIPWRAP')) ? Adapter_ServiceLocator::get('AverageTaxOfProductsTaxCalculator')->setIdOrder($this->id) : $carrier->getTaxCalculator($address);
         $order_invoice->total_discount_tax_excl = $this->total_discounts_tax_excl;
         $order_invoice->total_discount_tax_incl = $this->total_discounts_tax_incl;
         $order_invoice->total_paid_tax_excl = $this->total_paid_tax_excl;


### PR DESCRIPTION
Shipping tax should be calculated when advancedeucompliance is activated and PS_ATCP_SHIPWRAP is on

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "1.6.1.x" branch
| Description?  | From PS 1.6.1.x in combination with module advancedeucompliance and the option "partial tax on shipping/wrapping" switched to on no taxes are written to the database when an order is placed. With this fix, the config var PS_ATCP_SHIPWRAP is checked and shipping tax is calculated like it should be. After that, tax of shipping and wrapping could be seen on pdf invoice again.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8856
| How to test?  | install auec module, set options ATCP_SHIPWRAP to on and buy some items, create invoice. without fix: no tax is seen. with fix: tax is shown on invoice.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7671)
<!-- Reviewable:end -->
