### PR TITLE
Shipping cost indication wrong

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2270,7 +2270,6 @@ class CartCore extends ObjectModel
             $total_price += $cart_rule['minimum_amount_tax'] && $cart_rule['minimum_amount_shipping'] ? $real_best_price : 0;
             $total_price += !$cart_rule['minimum_amount_tax'] && $cart_rule['minimum_amount_shipping'] ? $real_best_price_wt : 0;
             if ($cart_rule['free_shipping'] && $cart_rule['carrier_restriction']
-                && in_array($cart_rule['id_cart_rule'], $cart_rules_in_cart)
                 && $cart_rule['minimum_amount'] <= $total_price) {
                 $cr = new CartRule((int)$cart_rule['id_cart_rule']);
                 if (Validate::isLoadedObject($cr) &&

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2269,8 +2269,12 @@ class CartCore extends ObjectModel
             $total_price = $cart_rule['minimum_amount_tax'] ? $total_products_wt : $total_products;
             $total_price += $cart_rule['minimum_amount_tax'] && $cart_rule['minimum_amount_shipping'] ? $real_best_price : 0;
             $total_price += !$cart_rule['minimum_amount_tax'] && $cart_rule['minimum_amount_shipping'] ? $real_best_price_wt : 0;
-            if ($cart_rule['free_shipping'] && $cart_rule['carrier_restriction']
-                && $cart_rule['minimum_amount'] <= $total_price) {
+            $condition = ($cart_rule['free_shipping'] && $cart_rule['carrier_restriction'] && $cart_rule['minimum_amount'] <= $total_price)?1:0;
+            if(isset($cart_rule['code']) && !empty($cart_rule['code'])){
+                $condition = ($cart_rule['free_shipping'] && $cart_rule['carrier_restriction'] && in_array($cart_rule['id_cart_rule'], $cart_rules_in_cart)
+                    && $cart_rule['minimum_amount'] <= $total_price)?1:0;
+            }
+            if ($condition) {
                 $cr = new CartRule((int)$cart_rule['id_cart_rule']);
                 if (Validate::isLoadedObject($cr) &&
                     $cr->checkValidity($context, in_array((int)$cart_rule['id_cart_rule'], $cart_rules_in_cart), false, false)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | The checkout page is showing a price instead of FREE when cart rule is limitid to 1 carrier.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8922
| How to test?  | create 2 carriers, assign both of them non-zero pricing for all zones, then, create price rule, which would make free shipping above certain threshold (40$) for carrier2. Go to FO and put something to the cart with less then 40$. In carriers section, select carrier1 and increase quantity in cart, so that it exceeds 40$, check the carrier price for carrier2 - it will be Free.