### PR TITLE
Fix ThemeValidator for child themes

### DIFF
--- a/src/Core/Addon/Theme/ThemeManagerBuilder.php
+++ b/src/Core/Addon/Theme/ThemeManagerBuilder.php
@@ -55,7 +55,7 @@ class ThemeManagerBuilder
         return new ThemeManager(
             $this->context->shop,
             $configuration,
-            new ThemeValidator($this->context->getTranslator()),
+            new ThemeValidator($this->context->getTranslator(), new Configuration()),
             $this->context->getTranslator(),
             $this->context->employee,
             new Filesystem(),

--- a/src/Core/Addon/Theme/ThemeValidator.php
+++ b/src/Core/Addon/Theme/ThemeValidator.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class ThemeValidator
@@ -36,12 +37,14 @@ class ThemeValidator
      * @var \Symfony\Component\Translation\TranslatorInterface
      */
     private $translator;
+    private $appConfiguration;
 
     private $errors = array();
 
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator, ConfigurationInterface $configuration)
     {
         $this->translator = $translator;
+        $this->appConfiguration = $configuration;
     }
 
     public function getErrors($themeName)
@@ -96,7 +99,7 @@ class ThemeValidator
     private function hasRequiredFiles(Theme $theme)
     {
         $themeName = $theme->getName();
-        $parentDir = realpath($theme->getDirectory().'/../'.$theme->get('parent')).'/';
+        $parentDir = realpath($this->appConfiguration->get('_PS_ALL_THEMES_DIR_').$theme->get('parent')).'/';
         $parentFile = false;
 
         foreach ($this->getRequiredFiles() as $file) {

--- a/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
@@ -27,6 +27,7 @@ namespace PrestaShop\PrestaShop\Tests\Core\Addon;
 
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeValidator;
+use PrestaShop\PrestaShop\Tests\TestCase\FakeConfiguration;
 use Symfony\Component\Yaml\Parser;
 use Phake;
 
@@ -41,7 +42,11 @@ class ThemeValidatorTest extends \PHPUnit_Framework_TestCase
         $translator = Phake::mock('Symfony\Component\Translation\TranslatorInterface');
 
         /* @var \PrestaShop\PrestaShop\Core\Addon\Theme\ThemeValidator */
-        $this->validator = new ThemeValidator($translator);
+        $this->validator = new ThemeValidator($translator, new FakeConfiguration(
+            array(
+                '_PS_ALL_THEMES_DIR_' => '/themes/',
+            )
+        ));
     }
 
     protected function tearDown()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | The theme validator was searching in the wrong directory when it was validating a child theme installe by ZIP.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | I can share Parent/Child themes to test. Just ask.