### PR TITLE
Fixed 500 server error when invalid sort direction is set

### DIFF
--- a/src/Core/Product/Search/SortOrder.php
+++ b/src/Core/Product/Search/SortOrder.php
@@ -114,10 +114,7 @@ class SortOrder
     {
         $direction = strtolower($dir);
         if (!in_array($direction, ['asc', 'desc', 'random'])) {
-            throw new Exception(sprintf(
-                'Invalid SortOrder direction `%s`. Expecting one of: `ASC`, `DESC`, or `RANDOM`.',
-                $dir
-            ));
+            $direction = 'asc';
         }
 
         $this->direction = $direction;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Visi http://localhost/en/3-women?order=product.name.test Since "test" direction does not exist you will get 500 HTTP server error when DEBUG mode is off (in production) just because sorting order value is invalid. Really? Shouldn't there be like default value?
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | See changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7676)
<!-- Reviewable:end -->
