### PR TITLE
Fix Mixed-Content issues when SSL partially enabled

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1229,7 +1229,7 @@ class LinkCore
             'id_shop' => null,
             'alias' => null,
             'ssl' => null,
-            'relative_protocol' => false,
+            'relative_protocol' => true,
         );
         $params = array_merge($default, $params);
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1464,7 +1464,7 @@ class FrontControllerCore extends Controller
         );
         foreach ($p as $page_name) {
             $index = str_replace('-', '_', $page_name);
-            $pages[$index] = $this->context->link->getPageLink($page_name, true);
+            $pages[$index] = $this->context->link->getPageLink($page_name, $this->ssl);
         }
         $pages['register'] = $this->context->link->getPageLink('authentication', true, null, array('create_account' => '1'));
         $pages['order_login'] = $this->context->link->getPageLink('order', true, null, array('login' => '1'));

--- a/src/Adapter/Assets/AssetUrlGeneratorTrait.php
+++ b/src/Adapter/Assets/AssetUrlGeneratorTrait.php
@@ -27,6 +27,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Assets;
 
+use Tools as ToolsLegacy;
+
 trait AssetUrlGeneratorTrait
 {
     protected $fqdn;
@@ -44,7 +46,7 @@ trait AssetUrlGeneratorTrait
     protected function getFQDN()
     {
         if (is_null($this->fqdn)) {
-            if ($this->configuration->get('PS_SSL_ENABLED')) {
+            if ($this->configuration->get('PS_SSL_ENABLED') && ToolsLegacy::usingSecureMode()) {
                 $this->fqdn = $this->configuration->get('_PS_BASE_URL_SSL_');
             } else {
                 $this->fqdn = $this->configuration->get('_PS_BASE_URL_');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | When SSL is enabled, but not everywhere, we get many cross-domain errors on .wott and .ttf files.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | <p>* Enable the SSL mode and check your console on the front office.<br/>* When you are on the cart, try to update the quantity or delete items</p>

Others fixes available in modules:
*  https://github.com/PrestaShop/ps_searchbar/pull/7
* https://github.com/PrestaShop/ps_shoppingcart/pull/18

# Issue to reproduce:
![capture du 2017-03-21 18-21-33](https://cloud.githubusercontent.com/assets/6768917/24163778/767cdf1e-0e63-11e7-8339-84a0efd89606.png)
