### PR TITLE
Save zero to id_state if country has no states

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -133,6 +133,10 @@ class CustomerAddressFormCore extends AbstractForm
             $address->{$formField->getName()} = $formField->getValue();
         }
 
+        if (!isset($this->formFields['id_state'])) {
+            $address->id_state = 0;
+        }
+
         if (empty($address->alias)) {
             $address->alias = $this->translator->trans('My Address', [], 'Shop.Theme.Checkout');
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | This will fix problems which can happen when switching between countries with/without states.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

1. Create "Zone A" and add to this zone country with states
2. Create "Zone B" and add to this zone country without states
3. Create Carrier and for each zone
4. Go to checkout
5. In address form select country from Zone A, and save address
6. Go back to the last step and edit your address, but now select country from Zone B
7. Check if you see carrier which should be visible only for Zone B