### PR TITLE
Incorrect translation on Symfony page (problems with TinyMCE)

### DIFF
--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -33,8 +33,19 @@ class AdminLegacyLayoutControllerCore extends AdminController
     private $headerTabContent = '';
     private $enableSidebar = false;
     private $helpLink;
+    private $isoLocale = '';
 
-    public function __construct($controllerName = '', $title = '', $headerToolbarBtn = array(), $displayType = '', $showContentHeader = true, $headerTabContent = '', $enableSidebar = false, $helpLink = '')
+    public function __construct(
+        $controllerName = '',
+        $title = '',
+        $headerToolbarBtn = array(),
+        $displayType = '',
+        $showContentHeader = true,
+        $headerTabContent = '',
+        $enableSidebar = false,
+        $helpLink = '',
+        $isoLocale = ''
+    )
     {
         parent::__construct($controllerName, 'new-theme');
 
@@ -48,6 +59,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $this->headerTabContent = $headerTabContent;
         $this->enableSidebar = $enableSidebar;
         $this->helpLink = $helpLink;
+        $this->isoLocale = $isoLocale;
     }
 
     public function setMedia()
@@ -89,11 +101,16 @@ class AdminLegacyLayoutControllerCore extends AdminController
             'page_header_toolbar_title' => $this->page_header_toolbar_title,
             'title' => $this->title ? $this->title : $this->page_header_toolbar_title,
             'toolbar_btn' => $this->page_header_toolbar_btn,
-            'page_header_toolbar_btn' => $this->page_header_toolbar_btn
+            'page_header_toolbar_btn' => $this->page_header_toolbar_btn,
         );
 
         if (!empty($this->helpLink)) {
             $vars['help_link'] = $this->helpLink;
+        }
+        if (!empty($this->isoLocale)) {
+            $vars['iso'] = $this->isoLocale;
+            $vars['iso_user'] = $this->isoLocale;
+            $vars['lang_iso'] = $this->isoLocale;
         }
 
         $this->context->smarty->assign($vars);

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -137,7 +137,17 @@ class LegacyContext
      *
      * @return string The html layout
      */
-    public function getLegacyLayout($controllerName = "", $title = "", $headerToolbarBtn = [], $displayType = "", $showContentHeader = true, $headerTabContent = '', $enableSidebar, $helpLink = '')
+    public function getLegacyLayout(
+        $controllerName = '',
+        $title = '',
+        $headerToolbarBtn = array(),
+        $displayType = '',
+        $showContentHeader = true,
+        $headerTabContent = '',
+        $enableSidebar,
+        $helpLink = '',
+        $isoLocale = ''
+    )
     {
         $originCtrl = new \AdminLegacyLayoutControllerCore(
             $controllerName,
@@ -147,8 +157,10 @@ class LegacyContext
             $showContentHeader,
             $headerTabContent,
             $enableSidebar,
-            $helpLink
+            $helpLink,
+            $isoLocale
         );
+
         $originCtrl->run();
 
         return $originCtrl->outPutHtml;

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -593,6 +593,7 @@ class ProductController extends FrameworkBundleAdminController
             'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
             'editable' => $this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_'),
             'drawerModules' => $drawerModules,
+            'iso_locale' => $languages[0]['locale'],
         );
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -23,6 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% set isoLocale = iso_locale %}
 
 {% block content %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
@@ -31,7 +31,8 @@
         showContentHeader is defined ? showContentHeader : true,
         headerTabContent is defined ? headerTabContent : '',
         enableSidebar is defined ? enableSidebar : false,
-        help_link is defined ? help_link : ''
+        help_link is defined ? help_link : '',
+        isoLocale is defined ? isoLocale : ''
     )
 )) %}
 

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -143,7 +143,8 @@ class LayoutExtension extends \Twig_Extension implements \Twig_Extension_Globals
         $showContentHeader = true,
         $headerTabContent = '',
         $enableSidebar = false,
-        $helpLink = ''
+        $helpLink = '',
+        $isoLocale = ''
     )
     {
         if ($this->environment == 'test') {
@@ -173,7 +174,8 @@ EOF;
             $showContentHeader,
             $headerTabContent,
             $enableSidebar,
-            $helpLink
+            $helpLink,
+            $isoLocale
         );
 
         //test if legacy template from "content.tpl" has '{$content}'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | When you selected language like chinesse or Vitename, the tinyMCE is incorrect on page modification. You have no possibility to modify textarea with option in bar. 
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2511
| How to test?  | Select language Chinese (or other in ticket) and in product page, verify all is ok. 