### PR TITLE
Allow 255 char to company field in Adress

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -115,7 +115,7 @@ class AddressCore extends ObjectModel
             'id_country' =>        array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
             'id_state' =>            array('type' => self::TYPE_INT, 'validate' => 'isNullOrUnsignedId'),
             'alias' =>                array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 32),
-            'company' =>            array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'size' => 64),
+            'company' =>            array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'size' => 255),
             'lastname' =>            array('type' => self::TYPE_STRING, 'validate' => 'isName', 'required' => true, 'size' => 32),
             'firstname' =>            array('type' => self::TYPE_STRING, 'validate' => 'isName', 'required' => true, 'size' => 32),
             'vat_number' =>            array('type' => self::TYPE_STRING, 'validate' => 'isGenericName'),

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -26,7 +26,7 @@ CREATE TABLE `PREFIX_address` (
   `id_supplier` int(10) unsigned NOT NULL DEFAULT '0',
   `id_warehouse` int(10) unsigned NOT NULL DEFAULT '0',
   `alias` varchar(32) NOT NULL,
-  `company` varchar(64) DEFAULT NULL,
+  `company` varchar(255) DEFAULT NULL,
   `lastname` varchar(32) NOT NULL,
   `firstname` varchar(32) NOT NULL,
   `address1` varchar(128) NOT NULL,

--- a/install-dev/upgrade/sql/1.6.1.13.sql
+++ b/install-dev/upgrade/sql/1.6.1.13.sql
@@ -1,0 +1,3 @@
+SET NAMES 'utf8';
+
+ALTER TABLE `PREFIX_address` CHANGE `company` `company` VARCHAR(255) DEFAULT NULL;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Company field in Address doesn't allow more than 64 char.
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8949
| How to test?  | Reinstall your shop and try to add new Address with a long name of company