### PR TITLE
Password controller must be in SSL when available

### DIFF
--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -30,6 +30,7 @@ class PasswordControllerCore extends FrontController
 {
     public $php_self = 'password';
     public $auth = false;
+    public $ssl = true;
 
     /**
      * Start forms process


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | When a user needs to recover its passwords, it should be on a SSL page if available on the server. This PR fixes the issue.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2673
| How to test?  | Enable SSL on your shop, but not everywhere. Send an email to recover your forgotten password. When your click on the link, you must be on a URL beginning with https://