### PR TITLE
Unable to unselect the last  image associated to a combination

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -113,6 +113,9 @@ class AdminProductWrapper
         }
         if (!empty($combinationValues['id_image_attr'])) {
             $images = $combinationValues['id_image_attr'];
+        } else {
+            $combination = new Combination($id_product_attribute);
+            $combination->setImages(array());
         }
 
         $product->updateAttribute(


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Unable to unselect the last  image associated to a combination
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | try to unselect all images associated to a combination, then save, it seem to be ok ( then refresh the BO product page), but you can't before the patch unselect all.


![capture du 2017-03-24 11 26 08](https://cloud.githubusercontent.com/assets/3170104/24290304/cac63890-1084-11e7-97d5-0bb3dc8e1307.png)
