### PR TITLE
Update only checked fields when multishop option activated

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -675,10 +675,20 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
                 // A little explanation of what we do here : we want to create multishop entry when update is called, but
                 // only if we are in a shop context (if we are in all context, we just want to update entries that alread exists)
                 $shop_exists = Db::getInstance()->getValue('SELECT '.$this->def['primary'].' FROM '._DB_PREFIX_.$this->def['table'].'_shop WHERE '.$where);
+
+                $display_multishop_checkboxes = Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP;
+
                 if ($shop_exists) {
-                    $result &= Db::getInstance()->update($this->def['table'].'_shop', $fields, $where, 0, $null_values);
+                    if ($display_multishop_checkboxes) {
+                        foreach ($fields as $key => $val) {
+                            if (!array_key_exists($key, $this->update_fields)) {
+                                unset($fields[$key]);
+                            }
+                        }
+                    }
+                    $result &= Db::getInstance()->update($this->def['table'] . '_shop', $fields, $where, 0, $null_values);
                 } elseif (Shop::getContext() == Shop::CONTEXT_SHOP) {
-                    $result &= Db::getInstance()->insert($this->def['table'].'_shop', $all_fields, $null_values);
+                    $result &= Db::getInstance()->insert($this->def['table'] . '_shop', $all_fields, $null_values);
                 }
             }
         }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -676,10 +676,8 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
                 // only if we are in a shop context (if we are in all context, we just want to update entries that alread exists)
                 $shop_exists = Db::getInstance()->getValue('SELECT '.$this->def['primary'].' FROM '._DB_PREFIX_.$this->def['table'].'_shop WHERE '.$where);
 
-                $display_multishop_checkboxes = Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP;
-
                 if ($shop_exists) {
-                    if ($display_multishop_checkboxes) {
+                    if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
                         foreach ($fields as $key => $val) {
                             if (!array_key_exists($key, $this->update_fields)) {
                                 unset($fields[$key]);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When updating only one checked field in multi shop product edit view, all prices are updated in all products. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8758
| How to test?  | Check allShops, then update only one field in product edit page, you will get only this field updated in all shops.