### PR TITLE
Js responsive value is not changed on resize

### DIFF
--- a/themes/classic/_dev/js/responsive.js
+++ b/themes/classic/_dev/js/responsive.js
@@ -65,7 +65,6 @@ $(window).on('resize', function() {
 	var _mw = prestashop.responsive.min_width;
 	var _w = $(window).width();
 	var _toggle = (_cw >= _mw && _w < _mw) || (_cw < _mw && _w >= _mw);
-	prestashop.responsive.mobile = _cw >= _mw;
 	prestashop.responsive.current_width = _w;
   prestashop.responsive.mobile = prestashop.responsive.current_width < prestashop.responsive.min_width;
 	if (_toggle) {

--- a/themes/classic/_dev/js/responsive.js
+++ b/themes/classic/_dev/js/responsive.js
@@ -67,6 +67,7 @@ $(window).on('resize', function() {
 	var _toggle = (_cw >= _mw && _w < _mw) || (_cw < _mw && _w >= _mw);
 	prestashop.responsive.mobile = _cw >= _mw;
 	prestashop.responsive.current_width = _w;
+  prestashop.responsive.mobile = prestashop.responsive.current_width < prestashop.responsive.min_width;
 	if (_toggle) {
 		toggleMobileStyles();
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | To corectly calculate prestashop.responsive.mobile value it is needed to base on actual window width. Previosly it was base on _cw value which stored window with value calculated before window resize.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | /no
| Fixed ticket? | 
| How to test?  | Resize window and print prestashop.responsive.mobile 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
