### PR TITLE
Use trans() instead of undefined l()

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -827,7 +827,7 @@ class FrontControllerCore extends Controller
                                 $this->restrictedCountry = Country::GEOLOC_FORBIDDEN;
                             } elseif (Configuration::get('PS_GEOLOCATION_BEHAVIOR') == _PS_GEOLOCATION_NO_ORDER_) {
                                 $this->restrictedCountry = Country::GEOLOC_CATALOG_MODE;
-                                $this->warning[] = sprintf($this->l('You cannot place a new order from your country (%s).'), $record->country->name);
+                                $this->warning[] = $this->trans('You cannot place a new order from your country (%s).', array($record->country->name), 'Shop.Notifications.Warning');
                             }
                         } else {
                             $hasBeenSet = !isset($this->context->cookie->iso_code_country);
@@ -854,7 +854,15 @@ class FrontControllerCore extends Controller
                     $this->restrictedCountry = Country::GEOLOC_FORBIDDEN;
                 } elseif (Configuration::get('PS_GEOLOCATION_NA_BEHAVIOR') == _PS_GEOLOCATION_NO_ORDER_ && !FrontController::isInWhitelistForGeolocation()) {
                     $this->restrictedCountry = Country::GEOLOC_CATALOG_MODE;
-                    $this->warning[] = sprintf($this->l('You cannot place a new order from your country (%s).'), (isset($record->country->name) && $record->country->name) ? $record->country->name : $this->l('Undefined'));
+                    $countryName = $this->trans('Undefined', array(), 'Shop.Theme');
+                    if (isset($record->country->name) && $record->country->name) {
+                        $countryName = $record->country->name;
+                    }
+                    $this->warning[] = $this->trans(
+                        'You cannot place a new order from your country (%s).',
+                        array($countryName),
+                        'Shop.Notifications.Warning'
+                    );
                 }
             }
         }

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -806,7 +806,7 @@ class AdminModulesControllerCore extends AdminController
                                 $this->errors[] = $this->trans(
                                     'You need to be logged in to your PrestaShop Addons account in order to update the %s module. %s',
                                     array(
-                                        '<strong>'.$name.'</strong>',
+                                        '<strong>'.htmlspecialchars($name).'</strong>',
                                         '<a href="#" class="addons_connect" data-toggle="modal" data-target="#modal_addons_connect" title="Addons">'.
                                             $this->trans('Click here to log in.', array(), 'Admin.Modules.Help').
                                         '</a>'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Use trans() instead of undefined l() into FrontController to prevent error 500. Even if there is the string freeze, we prefer to have 3 untranslated strings instead of error 500.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2650
| How to test?  |