### PR TITLE
Module code cleanup and fix module action in details modal

### DIFF
--- a/src/Adapter/Addons/AddonsDataProvider.php
+++ b/src/Adapter/Addons/AddonsDataProvider.php
@@ -259,25 +259,6 @@ class AddonsDataProvider implements AddonsInterface
         throw new Exception('Cannot execute request '.$action.' to Addons');
     }
 
-    /**
-     * @param $moduleId
-     * @return Module
-     */
-    public function getModuleById($moduleId)
-    {
-        $moduleAttributes = $this->request('module', array('id_module' => $moduleId));
-
-        $attributes = $this->moduleRepository->getModuleAttributes($moduleAttributes['name']);
-
-        foreach ($attributes->all() as $name => $value) {
-            if (!array_key_exists($name, $moduleAttributes)) {
-                $moduleAttributes[$name] = $value;
-            }
-        }
-
-        return new Module($moduleAttributes);
-    }
-
     protected function getAddonsCredentials()
     {
         $request = Request::createFromGlobals();

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -460,21 +460,22 @@ class ModuleRepository implements ModuleRepositoryInterface
     }
 
     /**
+     * Send request to get module details on the marketplace, then merge the data received in Module instance
      * @param $moduleId
      * @return Module
      */
     public function getModuleById($moduleId)
     {
         $moduleAttributes = $this->adminModuleProvider->getModuleAttributesById($moduleId);
-        $attributes = $this->getModuleAttributes($moduleAttributes['name']);
+        $module = $this->getModule($moduleAttributes['name']);
 
-        foreach ($attributes->all() as $name => $value) {
-            if (!array_key_exists($name, $moduleAttributes)) {
-                $moduleAttributes[$name] = $value;
+        foreach ($moduleAttributes as $name => $value) {
+            if (!$module->attributes->has($name)) {
+                $module->attributes->set($name, $value);
             }
         }
 
-        return new Module($moduleAttributes);
+        return $module;
     }
 
     /**
@@ -524,45 +525,9 @@ class ModuleRepository implements ModuleRepositoryInterface
 
         return $modules;
     }
-    /*
-     * PROTECTED FUNCTIONS
-     */
 
     /**
-     * In order to avoid class parsing, we generate a cache file which will keep mandatory data of modules.
-     *
-     * @param string $name The technical module name to find
-     *
-     * @return array Module data stored in file
-     */
-    private function generateCacheFile($data)
-    {
-        if (!$data) {
-            return;
-        }
-        $encoded_data = json_encode($data);
-        file_put_contents($this->cacheFilePath, $encoded_data);
-
-        return $data;
-    }
-
-    /**
-     * We load the file which contains cached data.
-     *
-     * @return array Module data loaded in file
-     */
-    private function readCacheFile()
-    {
-        // JSON file not found ? Generate it
-        if (!file_exists($this->cacheFilePath)) {
-            return array();
-        }
-        $data = json_decode(file_get_contents($this->cacheFilePath), true);
-
-        return ($data == null) ? array() : $data;
-    }
-
-    /**
+     * Function loading all installed modules on the shop. Can be used as example for AddonListFilter use.
      * @return array
      */
     public function getInstalledModules()

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -758,8 +758,8 @@ class ModuleController extends FrameworkBundleAdminController
 
     public function getModuleCartAction($moduleId)
     {
-        $adminModuleRepository = $this->get('prestashop.core.admin.module.repository');
-        $module = $adminModuleRepository->getModuleById($moduleId);
+        $moduleRepository = $this->get('prestashop.core.admin.module.repository');
+        $module = $moduleRepository->getModuleById($moduleId);
 
         $addOnsAdminDataProvider = $this->get('prestashop.core.admin.data_provider.module_interface');
         $addOnsAdminDataProvider->generateAddonsUrls(array($module));

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -222,7 +222,7 @@ EOF;
      */
     public function getYoutubeLink($watchUrl)
     {
-        $embedUrl = str_replace('watch?v=', 'embed/', $watchUrl);
+        $embedUrl = str_replace(array('watch?v=', 'youtu.be/'), array('embed/', 'youtube.com/embed/'), $watchUrl);
 
         return '<iframe width="560" height="315" src="'.$embedUrl.
             '" frameborder="0" allowfullscreen class="youtube-iframe m-x-auto"></iframe>';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | This PR fixes the action buttons displayed in the module modal. It also fixes an issue with Youtube links like `youtu.be/<id>` 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2430
| How to test?  | Open the details modal of a installed module. You should not have the button "Install" anymore

![capture du 2017-03-29 15-39-02](https://cloud.githubusercontent.com/assets/6768917/24460346/f466c98e-1495-11e7-93eb-a186a53277df.png)
