### PR TITLE
Loyalty.js - when a price is greater than 1000

### DIFF
--- a/themes/default-bootstrap/js/modules/loyalty/js/loyalty.js
+++ b/themes/default-bootstrap/js/modules/loyalty/js/loyalty.js
@@ -25,9 +25,9 @@
 
 $(document).ready(function() {
 	$(document).on('change', '#our_price_display', function(e){
-		updateLoyaltyView(parseInt($('#our_price_display').text()));
+		updateLoyaltyView(parseInt($('#our_price_display').attr('content')));
 	})
-	updateLoyaltyView(parseInt($('#our_price_display').text()));
+	updateLoyaltyView(parseInt($('#our_price_display').attr('content')));
 });
 
 function updateLoyaltyView(new_price) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | If the product has a price higher than 1000 then the module loyalty calculate a false "new_price"
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | install the Prestashop Official Loyalty module and create a product with a price over 1000. the calculation of points to display in front will be errated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7718)
<!-- Reviewable:end -->
