### PR TITLE
Prevent empty cart of death

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -286,6 +286,7 @@ class CartControllerCore extends FrontController
                 $this->context->cart->add();
                 if ($this->context->cart->id) {
                     $this->context->cookie->id_cart = (int)$this->context->cart->id;
+                    $this->context->cookie->write();		
                 }
             }
 
@@ -375,6 +376,9 @@ class CartControllerCore extends FrontController
      */
     public function displayAjax()
     {
+        // write cookie if can't on destruct
+        $this->context->cookie->write();
+	    
         if ($this->errors) {
             $this->ajaxDie(Tools::jsonEncode(array('hasError' => true, 'errors' => $this->errors)));
         }
@@ -382,8 +386,6 @@ class CartControllerCore extends FrontController
             $this->ajaxDie(Tools::jsonEncode(array('refresh' => true)));
         }
 
-        // write cookie if can't on destruct
-        $this->context->cookie->write();
 
         if (Tools::getIsset('summary')) {
             $result = array();


### PR DESCRIPTION
In specifics conditions , customer can't set/update his cart :
* In FO, to each product added, cart display stay empty.
* In BO, each action is logged as a new cart with an the product added.

On add action, cookie status is not updated and id_cart is not related to add action. It's explain these behaviors.

To prevent this we must save as soon as possible the id cart in cookie. Cookie write action in DisplayAjax can be act too late or never.
Then when a new cart is set, we save this id right now.
Looks better also to save cookie before any dieAjax to insure cookie consistency.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x.
| Description?  | Prevent white cart , in some case customer can't view product added. Cart stay empty
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | 
| How to test?  | Follow forum uses cases, enable at least ajax action and set some cart rule

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7727)
<!-- Reviewable:end -->
