### PR TITLE
Option MultiViews not allowed here

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -24,6 +24,482 @@ International Registered Trademark & Property of PrestaShop SA
 Release Notes for PrestaShop 1.7
 --------------------------------
 ####################################
+#   v1.7.1.0 - (2017-04-03)
+####################################
+- Back Office:
+   - New feature:
+     - #7619: Add responsive nav-bar
+     - #7529: Product module page
+     - #7508: Mail in-transit improvement (webservice, markup)
+     - #7491: Allow to exclude tax and shipping in affiliation sales total
+     - #7287: Add counter to the inputs
+     - #6906: Implement "Update all" modules feature
+   - Improvement:
+     - #7596: Add displayProductPageDrawer hook
+     - #7570: Notification after theme reset, warning about images regeneration
+     - #7576: Remove useless meta_title
+     - #7573: Two wordings on the module tab of the product page
+     - #7551: Restore compiled assets
+     - #7516: Check if hook exists before get hook module exec list
+     - #7439: Header BO responsive (legacy part)
+     - #7497: Display shipping max. refundable amount in order partial refund form
+     - #7206: Update wording form.html.twig
+     - #7435: Remove initForm* from old product controller
+     - #7467: Update comment for jQuery migrate
+     - #7256: Add notifications counter
+     - #7421: Remove useless isset
+     - #7405: Domains tree on translations page now on more than 2 levels
+     - #7373: Add a new hook on dashboard
+     - #7364: Sort products in descending order
+     - #7315: Fix integration issues with translation page
+     - #7352: Reduce width of brand select input
+     - #7320: Only display the module you want to translate
+     - #7254: Add redirect to category for product not available
+     - #6712: Rename the productDisplayButtons hook to productDisplayAdditionalInfo
+     - #7308: Add version to help api feedback
+     - #7280: Change locales json
+     - #7175: Test admin controllers
+     - #7025: Add translation domains to Adv. param controllers 2
+     - #7238: Harmonize wording cms.xml tab.xml
+     - #6990: Change Stores controller option from 'Status' to 'Active'
+     - #7100: Add some more translation domains to controllers
+     - #7230: Change PS color for tinymce
+     - #7188: Add text format selector to TinyMCE
+     - #6743: Implement optionnal but specific action to display on module page
+     - #7015: Set new product cover when current is deleted
+     - #7098: Removed sensor parameter from Google Maps JS API
+     - #6776: Do not display empty module categories
+     - #3915: Removed _includeContainer ; never more used
+   - Bug fix:
+     - #7701: Fix access denied on Customers Service
+     - #7668: Implode Translation Permission
+     - #7670: Allow upgrade for modules coming from Must-have json
+     - #7646: Fix imageFolder path for colorPicker inputs
+     - #7665: Fix inactive request in HookEvent
+     - #7663: Fix issue of Module notification page after 1.7.0.x backport
+     - #7648: Fix product attachments lookup
+     - #7585: Fix placeholder width in product options
+     - #7627: Fix wrong domain for product module page
+     - #7616: Fix getAvailableFields malformed json
+     - #7599: Fix required custom field alignment
+     - #7584: Employee permissions not saved
+     - #7586: Fix chosen width
+     - #7542: Update default catalog & compile assets
+     - #7572: Fix bug with TinyMCE button
+     - #7574: Fix tab registration (non-instantiated module)
+     - #7568: Fix default products sorting order
+     - #7559: Fix filter image icon
+     - #7552: Callback on HelperList should have highest priority
+     - #7546: Prevent widgets to break back-office
+     - #7544: Fix module configure button when in dropdown
+     - #7535: Fix desktop menu regressions
+     - #7534: Remove call to an undefined attribute
+     - #7520: Fix minors integration issues on sidebar
+     - #7513: Refresh forms for specific price
+     - #7514: Fix product customization duplication
+     - #7511: Fix back-office order
+     - #7503: Add missing attributes on function removeProduct
+     - #7507: Fix unclosed tag
+     - #7496: You can now search for a customer with several words
+     - #7492: Add missing metadata to translations catalogues on export
+     - #7486: Fix incorrect product-list-colors caching
+     - #7489: Update deleteFeatures() for Multi-shop
+     - #7481: Bug Fix on Save product
+     - #7479: Fix problem with default combination
+     - #6950:  BO: allow disabled by item in Helper Form
+     - #7474: Fix Administering email setting whith/without log
+     - #7455: Fix Module configure permission
+     - #7473: Update ObjectModelCore::getFieldsLang
+     - #7470: Fix image doesn't exists
+     - #7449: Update keyboard shortcuts in product page
+     - #7462: Update invoice pdf
+     - #7459: Fix id_order ambiguous search
+     - #7454: Fixed use of hook return value in customer address validation
+     - #7444: Update the dashboardTop hook
+     - #7436: Remove tinymce synchronous loading
+     - #7415: Display correct quantities for shared stock
+     - #7428: Update wording AdminPerformanceController.php
+     - #7150: Fix "Uncaught ReferenceError: prestashop is not defined"
+     - #7395: Add the disabled categories in product page
+     - #7406: Custom error-layout for maintenance/restricted country page
+     - #7404: Replace "Default-bootstrap" in Translations tab
+     - #7390: Changed ID column name in CSV products export
+     - #7389: Fix translation page integration issues
+     - #7380: Remove wrong URL encoding from AdminStockMvtController
+     - #7371: Fix nested categories cache id
+     - #7366: Fix wrong domain
+     - #7332: Redirect with message when root category is not available for a shop
+     - #6997: Fix buttons alignments on modal on import page
+     - #7139: Fix product redirection from back office search results
+     - #7341: Update version on profile configuration page
+     - #6775: Add potential email error in order bulk action message failure.
+     - #6833: Deleted space and : in sql manager page
+     - #7330: Fix email translation edit when file doesn't exist
+     - #7115: Fix "Other translations" save action
+     - #7281: Module action template can now be used everywhere
+     - #7282: Fix selection of boolean option
+     - #7260: Set product image container to static position
+     - #7270: Add number of selected images in edit combination page
+     - #7255: Remove hardcoded version from help links
+     - #7196: Update keyboard shortcut in product page for preview
+     - #7251: Fix quick links with apostrophes
+     - #7236: Partial refund tax method always tax incl.
+     - #7039: Fix friendly url text on product page
+     - #7071: Add hints on some category fields
+     - #7229: Do not check module download on upgrade
+     - #7052: Fixed help wording for Tax Rules Group
+     - #7210: Fix date filter on dashboard when entering BO
+     - #7215: TinyMCE media plugin shouldn't be activated twice
+     - #7204: Fix import information display
+     - #7171: Fix rights issues on legacy module page
+     - #6942: Fix modules translation form
+     - #7180: Fixed "new client" column in orders list
+     - #6935: Fix localization pack import
+     - #7174: Fix warning on BO
+     - #6988: Clear cache on url rewriting settings modification
+     - #6996: Fix products alignment in delivery slip pdf
+     - #7019: Fix fancybox on cart rules conditions
+     - #6970: Fix virtual product file removal
+     - #6976: Fix error on layout when warnings exist
+     - #7023: Fix permission issues when creating modules sandbox folders recursively
+     - #6742: Fixed file attachment on product form
+     - #7050: Fix fallback dataformate duplicate value
+     - #7060: Fix save product when empty name in default lang
+     - #7136: Fixed search and redirection to module
+     - #6992: Fixed warning on AdminStore Controller
+     - #7010: Disable FK checks during DB export
+     - #7007: Display preview button in 13 inches
+     - #6930: Fixed bulk actions affecting single products
+     - #7048: Fix access to payment preferences
+     - #6926: Fixed payment methods of carriers
+     - #6978: Fixed security issue on SpecificPrice class
+     - #6957: Fix email preview in translation page
+     - #6955: Fix updating positions when sorting products
+     - #6953: Fix recommended modules modal window
+     - #6941: Fix email translations
+     - #6936: Return empty array on API error for customer data
+     - #6920: Fixed translation choice in BO
+     - #6891: Remove z-index of ps tagger reset button
+     - #6921: Removed warning notice on translation
+     - #6898: Fixed imagesController icons
+     - #6764: Add hotkeys on product page
+     - #6797: Display missing hook (displayCustomerAccountForm)
+     - #6825: Fixed wrong order detail updated
+     - #6858: Fixed css animation on onboarding
+     - #6868: Fix theme export
+     - #6812: Encrypt modules cookies
+     - #6857: Fixed error compile
+     - #6799: Add missing hook call for actionSubmitAccountBefore
+     - #6748: Fixed customers registration in Back Office
+     - #6811: Fixed border style of translation textarea
+     - #6805: Remove synchronous call to the CLDR
+     - #6778: Fix create combination
+     - #6793: Fixed employee password validation
+     - #6792: Use the correct email template for employee password recovery
+     - #6758: Fixed load of Jquery-ui JS/CSS cache
+     - #6750: Fixed delete combination on product
+
+ - Front Office:
+   - New feature:
+     - #7675: Allow delivery module to confirm the checkout step
+     - #6903: Ported emailalert on classic
+     - #6886: Ported ps_crosseling module on classic
+     - #6881: Ported module ps_viewedproduct on classic
+     - #6878: Ported ps_specials module on classic
+     - #6877: Ported ps_newsproduct on classic
+     - #6871: Ported ps_supplierlist on classic & some fix on ps_brandlist
+     - #6866: Ported module ps_brandlist on classic
+     - #6828: Ported module ps_rssfeed for classic
+     - #6800: Ported module ps_productinfo for classic
+     - #6820: Ported bestsellers module on classic
+   - Improvement:
+     - #7575: Restore hook displayProductListReviews on catalog
+     - #6908: Add customization message
+     - #7478: Expose checkout process to inheriting classes
+     - #7362: Add smarty blocks everywhere
+     - #7384: Fix alerts icons and margin
+     - #7309: Integrate sitemap
+     - #7344: Hide virtual product download link until it's paid
+     - #7314: Integrate forgotten password alerts
+     - #7243: Add "quick_view" block to classic theme
+     - #7199: Fix "There is 0 product." label
+     - #7076: Add external libraries
+     - #7104: Add missing translation keys in home slider
+     - #6875: Replace Open Sans with Noto Sans
+     - #6766: Export translations when exporting theme
+   - Bug fix:
+     - #7694: Fixed a typo in template Product
+     - #7684: Incorrect event dataset call
+     - #7686: Fix Mixed-Content issues when SSL partially enabled
+     - #7657: Fix translation cache preventing load of new language
+     - #7603: Validate lengths of fields submitted from registration form
+     - #7636: Fix wrong translation/variable syntax
+     - #7617: Fix out of stock combination hiding
+     - #7561: Remove fakepath
+     - #7598: Fix registration form validation
+     - #7594: Restore hook displayBanner
+     - #7533: Fix url rewrite starting with numbers
+     - #7518: Fix front initcontent and My account display
+     - #7512: Fix a problem when a voucher is added on checkout
+     - #7500: Add cart in prestashop javascript object
+     - #7368: Allow HTML in customization when it's displayed by a module
+     - #7475: Fix hook name due to conflict resolution
+     - #7372: Bug fix for specific product combination cases
+     - #7461: Add manufacturer name in cart products
+     - #7453: Fix %email% are not replaced by user's email when asking a new password
+     - #7446: Remove wrong opening table tag
+     - #7445: Fix div tag in ordersummary header
+     - #7433: Fix button on the same line in order confirmation modal
+     - #7116: Fix some facets design
+     - #5053: Orders amount currency fixed
+     - #7410: Redirect to 404 when CMS page doesn't exist
+     - #7409: Fix empty title tag in CMS category
+     - #7345: Product with 0 quantity should be buyable when stock management is disabled
+     - #7361: Mobile Cart - Carriers Improperly integrated
+     - #7378: Fix FrontController#setTemplate default locale parameter
+     - #7365: Mobile Cart - Improperly integrated Fields
+     - #7272: Fixed bug when logged in customer can access login/registration p…
+     - #7358: Fix duplicate payment submissions and address initialization
+     - #7343: Check whether order is paid before serving a virtual product download
+     - #6597: Add carriage return to store information
+     - #7329: Fix arrow click & position
+     - #7323: Fix fatal when requesting product refresh without product id in cart
+     - #7297: Fix clean filter event handler
+     - #7264: Display Add to cart button in product listing
+     - #7259: Fix missing displayNavFullWidth into checkout
+     - #7247: Fix search bar icon display
+     - #7182: Remove useless vars display_column_*
+     - #7202: Fix order return format in OrderReturnPresenter
+     - #7009: Remove box-shadow around contact form in classic
+     - #7170: Fix classic's override of ps_imageslider
+     - #6995: Fix empty cart on logout display
+     - #6972: Add missing nofilter after display hook
+     - #7166: Fix total products label
+     - #7037: Fix breadcrumb margin on classic
+     - #7042: Add download link for virtual products
+     - #6987: Fix changing combination when catalog mode is enabled
+     - #6980: Fix undefined event in core.js
+     - #6905: Fix category images generation
+     - #6892: Revert to Bootstrap 4 alpha 4
+     - #6847: Fix geolocation
+     - #6829: Fix PDF generation by removing non existing files requirement
+     - #6790: Replaced placeholder with email in notification
+     - #6808: Fix fatal on Best Sales
+     - #6741: Properly translate isbn, ean and upc
+     - #6774: Ported ps_categoryproducts for classic theme
+     - #6780: Add missing link on footer
+     - #6752: Remove extra tag block closed
+
+ - Core:
+   - New feature:
+     - #5922: Install module tabs automatically
+     - #7291: Happy new Year PrestaShop!
+   - Improvement:
+     - #7621: Allows multiple retro names for a hook
+     - #7685: Don't update url_rewrite with upside lang
+     - #7679: Upside down language for crowdin
+     - #7669: Updated wording
+     - #7625: All we need to autoupgrade!
+     - #7577: Improved model namescape handling
+     - #7592: Default catalog update
+     - #7562: Add missing domains
+     - #7536: Add windows 8.1 & 10 to guest useragent
+     - #7532: Use Address:initialize to manage default state in one area
+     - #7522: Make sure that invoice siblings are related to the same order id
+     - #7524: Revert "Check if hook exists before get hook module exec list"
+     - #7495: Remove some globals
+     - #7490: Pass the object we're displaying to the action{$controller}FormMo…
+     - #6959: Convert namespaced object model class names to hook compatible names
+     - #7480: Sql fix & documentation
+     - #7468: Allow rel="nofollow" in anchors
+     - #7443: Add actionEmailSendBefore hook
+     - #6327: Deprecate getOrderByCartId method, add alternative
+     - #7456: Pass variables of hook `actionProductSearchComplete` by link
+     - #7442: Add new hook 'actionClearCache'
+     - #7440: Add new hook actionOutputHTMLBefore
+     - #7403: Make email templates parent/child compatible
+     - #7413: Optimized products counting in BO product list
+     - #7269: Webservices now show PS validation errors
+     - #7289: Code standard fixes & improvements
+     - #7335: Re-introduce server media
+     - #6911: Added dependency injection container in legacy
+     - #7142: Replace specific cache management with doctrine cache for module catalog
+     - #7298: Add file line number where the error occured
+     - #7265: Product.php optimization if not $id_cart
+     - #7183: Add app/config/config.php to gitignore
+     - #7093: Move entity repositories in existing subfolder
+     - #7178: Use ModuleZipManager for addons downloads
+     - #7177: Doctrine optimizations
+     - #6734: Generate robots.txt on install
+     - #7095: Add Reply-To recipient name to Mail::send()
+     - #7157: Be able to send an e-mail with multiple BCC
+     - #6694: Send email in English if current language don't have email template
+     - #6918: Allowed to add remote assets
+     - #6753: Improve global performances
+   - Bug fix:
+     - #7719: Delete unique key name for ps_profile_lang
+     - #7711: Use trans() instead of undefined l()
+     - #7700: Fixes needed for upgrade
+     - #7708: Use the browser country prior to the shop one
+     - #7705: Hide upside down language
+     - #7652: Rename id_product_redirected variable
+     - #7683: Remove clear cache for autoupgrade
+     - #7674: Fix ThemeValidator for child themes
+     - #7653: Fix invoice generation
+     - #7589: Fix missing reference symbol into Product::getProductProperties
+     - #7635: Update robot.txt using english
+     - #7629: Merge 1.7.0.x on 1.7.1.x
+     - #7633: Fix doctrine association between translation and lang
+     - #7597: Change CLDR url
+     - #7593: Fix the product page
+     - #7587: Increase curl timeout to 60s
+     - #7509: Format price for noPackPrice in product and Gift wrapping
+     - #7569: Fix entity integrity for upgrade
+     - #7538: Add composer.lock in order to fix composer install
+     - #7539: Update licences
+     - #7531: Payment method title extended to 255 characters
+     - #6681: Fix work authorization for (back|front)-office. After transition from RC1 to RC2.
+     - #7519:  Fix fatal when no product to set in CategorySearchProvider
+     - #7312: Fixed Huge Bug for passed validation
+     - #7505: Fix nonexistent field on customer
+     - #7501: Do not display related product id customer can't see it
+     - #7485: Don't convert already converted currency
+     - #7502: Prevents problem with missing params in getWidgetVariables()
+     - #7499: Use UTF-8 for PaymentOptions
+     - #7482: Use default state for tax purposes
+     - #7488: Allow quotes in translation strings
+     - #7483: Update Mail lang settings
+     - #7148: Fix send to multiple addresses with different names
+     - #7477: Only link orders with same cart
+     - #7476: IdLang shouldn't be <= 0
+     - #7471: Fix installation & tab entity
+     - #7472: Add "use instead" doc on method display as deprecated when possible
+     - #7463: Use boolean variables for tracking configuration value type
+     - #7466: Improvement in SpecificPrice::getSpecificPrice
+     - #7464: Calculate carrier price on the real order price
+     - #7460: Superfluous table alias
+     - #7457: Harmonize hook
+     - #7438: Add 2 new hooks actionDispatcherBefore and actionDispatcherAfter
+     - #7452: Revert "CO: fix Validate::isUnsignedInt"
+     - #7441: Add displayAfterProductThumb hook
+     - #7437: Use 1.7.1 modules
+     - #7430: Fixed rendering condition of default groups form
+     - #7429: Fix Validate::isUnsignedInt
+     - #7293: Fix dependencies definitions
+     - #7382: Use shop email as sender for template order_customer_comment
+     - #7334: Remove smartyDump() in Smarty config
+     - #7425: Update composer with modules
+     - #7420: Use the right modules branch
+     - #6928: Fix Cart cache key on CartRules
+     - #7401: Change some translated strings
+     - #7412: Fix logger namespace for ServiceLocator
+     - #7402: Update doc import files
+     - #7400: Fix array_merge call on null
+     - #7399: Fix pdf header
+     - #7393: Deprecate Tools::displayError()
+     - #6527: Fixed Geolocation behavior for NON existing countries
+     - #7386: Fix empty query
+     - #7316: Fixed bug that erases current customization fields
+     - #7277: Improve MARIA DB compatibility
+     - #7348: Fix wrong domain
+     - #7346: Fix getPriceWithoutReduct default id_product_attribute
+     - #7321: Improved translator performances
+     - #6722: Fix uncaught IOException on module deletion
+     - #7311: Introduce new hooks filtered & use it for product/category/brand/supplier/cms & html content
+     - #7313: Add actionSearch hook on ProductSearchProvider
+     - #7328: Fix store image & implement generation
+     - #7163: Enable the cart rule feature when updating one if it's enabled
+     - #7222: Fixed method Order::isVirtual
+     - #7257: Impossible to uninstall module when overridden file is missing
+     - #7241: Add native email missing
+     - #7194: Fix issue on translations without params
+     - #7235: Fix getImageLink for watermark module
+     - #7237: Fix pack price calc when using non-default attributes
+     - #7225: Fix missing subfolder in Repository namespace
+     - #6904: Fixes for module upgrade with zip upload
+     - #7211: Add missing SQL alias
+     - #7176: Set size limits on Doctrine Translation entity
+     - #7164: Update Mail::send documentation
+     - #7096: Use english email template as fallback in getEmailTemplateContent
+     - #7056: Restore deprecated method
+     - #7061: Fix command description
+     - #7111: Fix notice on $currency_to which may be null
+     - #7109: Fix unregisteration of Stylesheet by ID
+     - #7108: Fix unregisteration of JavaScript by ID
+     - #7014: Removed realpath for assets
+     - #6966: Fixed tools var
+     - #7126: Merge 1.7.0.x on develop
+     - #7081: Fixed CORS setting the header
+     - #7069: Protect translations display against XSS injections
+     - #7034: Use the locale to fallback on the good one in CLDR Repository
+     - #6927: Fix sprintf condition
+     - #6974: Created temporary file in cache directory
+     - #6929: Fix Cookie standalone mode
+     - #7013: Load autoload first
+     - #6994: Fixed on included files for autoupgrade
+     - #6848: Refresh CA bundle
+     - #6925: Prevent password reset on user check by email
+     - #6902: Fix PHP version for composer
+     - #6895: Fixed path windows assets
+     - #6890: Fixed translation render
+     - #6883: Fix multilang configuration insert
+     - #6803: Fix AJAX sync calls - Partial revert of 840fb00
+     - #6856: Cart cache key should take id_zone into account
+     - #6849: Fixed missing escape
+     - #6872: Fixed path for windows
+     - #6831: Use module_name to get error on upload
+     - #6798: Hook:exec should always return an array when array_return = true
+     - #6837: Fix fatal if payment module return a non array result
+     - #6761: Clean installation files from deleted hooks
+     - #6816: Fixed hook & moved hook before body
+     - #6802: Configured Twig autoescape option
+     - #6779: Fixed module cache with 2 systems
+     - #6745: Fixed path for asset directory
+     - #6755: Fixed customer account add/update hook call
+     - #6739: Fix changed namespace
+
+ - Installer:
+   - New feature:
+     - #7021: Adding country Tanzania
+   - Improvement:
+     - #7691: Remove awaiting Paypal order status
+     - #7517: Refactoring of the upgrade, to be easily usable in the auto upgrade module
+     - #7363: Update install with trans from crowdin
+     - #7302: Refacto 1.7.1.0.sql & remove 1.7.1.x.sql
+     - #7306: Add installed modules to quick access
+     - #7083: Updated tabs in FR
+     - #6939: Increase memory limit
+     - #6859: Declare default timezone when none is available
+   - Bug fix:
+     - #7638: Fix language refresh on dropdown change
+     - #7579: Avoid ERR_TOO_MANY_REDIRECTS at install
+     - #7571: Fix installation for languages without fixtures
+     - #7375: Fix error message display in installer
+     - #7374: Import sql upgrade from 1.6.x
+     - #6965: Add missing hooks actionObjectProductInCartDelete(Before|After)
+     - #7082: Small fixes for installer
+     - #7283: Do not launch install wizard if no write access to the cache folder
+     - #7057: Change india address form
+     - #7138: Fix wrong extension in the install.txt
+     - #7085: Update configuration.xml in SV
+     - #6817: Do not create parameters.php during install
+     - #7064: Install.txt file & documentation link update
+     - #7032: Required fileinfo extension
+     - #7053: Fix settings migration script
+     - #6967: Caught broken environment exception
+     - #6944: Add default message on ajax error in installer
+     - #6887: Add JSON, SimpleXML and DOM extensions as install requirements
+     - #6818: Clear the cache before trying to update the DB schema
+     - #6864: Fixed redirect on installer
+     - #6854: Add cURL check at installation
+     - #6845: Fix BDD required during install
+     - #6769: Added PS_MAINTENANCE_TEXT key in database
+
+ - Web Services:
+   - Bug fix:
+     - #6910: Add watermark to new product images
+
+####################################
 #   v1.7.0.5 - (2017-02-06)
 ####################################
 - Back Office:

--- a/docs/readme_de.txt
+++ b/docs/readme_de.txt
@@ -21,8 +21,8 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.0.5
-VERSION: 1.7.0.5
+NAME: Prestashop 1.7.1.0
+VERSION: 1.7.1.0
 
 VORBEREITUNG
 ===========

--- a/docs/readme_en.txt
+++ b/docs/readme_en.txt
@@ -21,8 +21,8 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.0.5
-VERSION: 1.7.0.5
+NAME: Prestashop 1.7.1.0
+VERSION: 1.7.1.0
 
 PREPARATION
 ===========

--- a/docs/readme_es.txt
+++ b/docs/readme_es.txt
@@ -21,8 +21,8 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.0.5
-VERSION: 1.7.0.5
+NAME: Prestashop 1.7.1.0
+VERSION: 1.7.1.0
 
 PREPARACIÓN
 ===========

--- a/docs/readme_fr.txt
+++ b/docs/readme_fr.txt
@@ -21,8 +21,8 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.0.5
-VERSION: 1.7.0.5
+NAME: Prestashop 1.7.1.0
+VERSION: 1.7.1.0
 
 PREPARATION
 ===========

--- a/docs/readme_it.txt
+++ b/docs/readme_it.txt
@@ -21,8 +21,8 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.0.5
-VERSION: 1.7.0.5
+NAME: Prestashop 1.7.1.0
+VERSION: 1.7.1.0
 
 PREPARAZIONE
 ===========


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Option MultiViews not allowed here
| Type?         | bug fix 
| Category?     | BO: 1-Click upgrade
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2633
| How to test?  | Update PrestaShop 1.7 (any version) to any hight version (include latest)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

BO:There is a problem with updating through the module 1 click upgrades
And also at the entrance to the Back Office

If you comment out this line, you can enter the Back Office

```shell
<IfModule mod_negotiation.c>
# Options -MultiViews
</ IfModule>
```

But you can not update PrestapShop 1.7 since the files are overwritten.

https://www.prestashop.com/forums/topic/596459-upgrade-1705-to-171-beta/

Regards,
Alexandr
