### PR TITLE
Fix missing {url entity=product id=X}

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1239,6 +1239,19 @@ class LinkCore
             case 'language':
                 $link = $context->link->getLanguageLink($params['id']);
                 break;
+            case 'product':
+                $link = $context->link->getProductLink(
+                    $params['id'],
+                    $params['alias'],
+                    (isset($params['category']) ? $params['category'] : null),
+                    (isset($params['ean13']) ? $params['ean13'] : null),
+                    $params['id_lang'],
+                    $params['id_shop'],
+                    (isset($params['ipa']) ? (int)$params['ipa'] : 0),
+                    false,
+                    $params['relative_protocol']
+                );
+                break;
             case 'category':
                 $params = array_merge(array('selected_filters' => null), $params);
                 $link = $context->link->getCategoryLink(


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Add missing smarty url helper in order to generate product link (with rewrite)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to use {url entity=product id=1} into a TPL

URL should be something like this:
`//shopdomain.dotcom/tshirts/1-t-shirt-delave-manches-courtes.html`

But result is:
`//shopdomain.dotcom/index.php?controller=product&id_product=1`
