### PR TITLE
Doctrine without foreign for autoupgrade backup

### DIFF
--- a/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\EntityManagerInterface;
+
+class UpdateSchemaCommand extends ContainerAwareCommand
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
+
+    private $metadata;
+
+    private $dbName;
+
+    private $dbPrefix;
+
+    protected function configure()
+    {
+        $this
+            ->setName('prestashop:schema:update-without-foreign')
+            ->setDescription("Update the database");
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $config = include(__DIR__.'/../../../app/config/parameters.php');
+        $this->dbName = $config['parameters']['database_name'];
+        $this->dbPrefix = $config['parameters']['database_prefix'];
+
+        $this->em = $this->getContainer()->get('doctrine')->getManager();
+        $this->metadata = $this->em->getMetadataFactory()->getAllMetadata();
+
+        $conn = $this->em->getConnection();
+        $conn->beginTransaction();
+
+        $output->writeln('Updating database schema...');
+        $sqls = 0;
+
+        // First drop any existing FK
+        $query = $conn->query(
+            'SELECT CONSTRAINT_NAME, TABLE_NAME 
+                FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+                WHERE CONSTRAINT_TYPE = "FOREIGN KEY" 
+                    AND TABLE_SCHEMA = "'.$this->dbName.'"
+                    AND TABLE_NAME LIKE "'.$this->dbPrefix.'%" '
+        );
+        
+        $results = $query->fetchAll();
+        foreach ($results as $result) {
+            $drop = 'ALTER TABLE '.$result['TABLE_NAME'].' DROP FOREIGN KEY '.$result['CONSTRAINT_NAME'];
+            $output->writeln('Executing: ' . $drop);
+            $conn->executeQuery($drop);
+            $sqls++;
+        }
+
+        $schemaTool = new SchemaTool($this->em);
+        $updateSchemaSql = $schemaTool->getUpdateSchemaSql($this->metadata, false);
+
+        $removedTables = array();
+        $dropForeignKeyQueries = array();
+
+        // Remove the DROP TABLE
+        foreach ($updateSchemaSql as $key => $sql) {
+            $matches = array();
+            if (preg_match('/DROP TABLE (.+?)$/', $sql, $matches)) {
+                unset($updateSchemaSql[$key]);
+                $removedTables[] = $matches[1];
+            }
+        }
+
+        // Then remove the ALTER TABLE on removed tables
+        foreach ($updateSchemaSql as $key => $sql) {
+            $matches = array();
+            if (preg_match('/ALTER TABLE (.+?) /', $sql, $matches)) {
+                $alteredTables = $matches[1];
+                if (in_array($alteredTables, $removedTables)) {
+                    unset($updateSchemaSql[$key]);
+                }
+            }
+        }
+
+        // Remove duplicated DROP FOREIGN KEY
+        foreach ($updateSchemaSql as $key => $sql) {
+            if (preg_match('/ DROP FOREIGN KEY /', $sql)) {
+                $hashedSql = md5($sql);
+                if (in_array($hashedSql, $dropForeignKeyQueries)) {
+                    unset($updateSchemaSql[$key]);
+                } else {
+                    $dropForeignKeyQueries[] = $hashedSql;
+                }
+            }
+        }
+
+        // Remove ADD CONSTRAINT
+        foreach ($updateSchemaSql as $key => $sql) {
+            if (preg_match('/ ADD CONSTRAINT /', $sql)) {
+                unset($updateSchemaSql[$key]);
+            }
+        }
+
+        $constraints = array();
+
+        // Move DROP FOREIGN KEY at the beginning of the sql list
+        foreach ($updateSchemaSql as $key => $sql) {
+            if (preg_match('/ DROP FOREIGN KEY /', $sql)) {
+                $constraints[] = $sql;
+                unset($updateSchemaSql[$key]);
+            }
+        }
+
+        foreach ($constraints as $constraint) {
+            array_unshift($updateSchemaSql, $constraint);
+        }
+
+        // Put back DEFAULT fields, since it cannot be described in the ORM model
+        foreach ($updateSchemaSql as $key => $sql) {
+            $matches = array();
+            if (preg_match('/ALTER TABLE (.+?) /', $sql, $matches)) {
+                $tableName = $matches[1];
+                $matches = array();
+                if (preg_match_all('/([^\s,]*?) CHANGE (.+?) (.+?)(,|$)/', $sql, $matches)) {
+                    foreach ($matches[2] as $matchKey => $fieldName) {
+                        // remove table name
+                        $matches[0][$matchKey] = preg_replace('/(.+?) CHANGE/',
+                            ' CHANGE', $matches[0][$matchKey]);
+                        // remove quote
+                        $originalFieldName = $fieldName;
+                        $fieldName = str_replace('`', '', $fieldName);
+                        // get old default value
+                        $query = $conn->query('SHOW FULL COLUMNS FROM '.$tableName.' WHERE Field="'.$fieldName.'"');
+                        $results = $query->fetchAll();
+                        $oldDefaultValue = $results[0]['Default'];
+                        $extra = $results[0]['Extra'];
+                        if ($oldDefaultValue !== null
+                            && strpos($oldDefaultValue, 'CURRENT_TIMESTAMP') === false) {
+                            $oldDefaultValue = "'".$oldDefaultValue."'";
+                        }
+                        if ($oldDefaultValue === null) {
+                            $oldDefaultValue = 'NULL';
+                        }
+                        // set the old default value
+                        if (!($results[0]['Null'] == 'NO' && $results[0]['Default'] === null)
+                            && !($oldDefaultValue === 'NULL'
+                                && strpos($matches[0][$matchKey], 'NOT NULL') !== false)
+                            && (strpos($matches[0][$matchKey], 'BLOB') === false)
+                            && (strpos($matches[0][$matchKey], 'TEXT') === false)
+                        ) {
+                            if (preg_match('/DEFAULT/', $matches[0][$matchKey])) {
+                                $matches[0][$matchKey] =
+                                    preg_replace('/DEFAULT (.+?)(,|$)/', 'DEFAULT '.
+                                        $oldDefaultValue.'$2'.' '.$extra, $matches[0][$matchKey]);
+                            } else {
+                                $matches[0][$matchKey] =
+                                    preg_replace('/(.+?)(,|$)/uis', '$1 DEFAULT '.
+                                        $oldDefaultValue.' '.$extra.'$2', $matches[0][$matchKey]);
+                            }
+                        }
+                        $updateSchemaSql[$key] = preg_replace('/ CHANGE '.$originalFieldName.' (.+?)(,|$)/uis',
+                            $matches[0][$matchKey], $updateSchemaSql[$key]);
+                    }
+                }
+            }
+        }
+
+        $sqls += count($updateSchemaSql);
+        // Now execute the queries!
+        foreach ($updateSchemaSql as $sql) {
+            try {
+                $output->writeln('Executing: ' . $sql);
+                $conn->executeQuery($sql);
+            } catch (\Exception $e) {
+                $conn->rollBack();
+                throw($e);
+            }
+        }
+        $conn->commit();
+
+        $pluralization = (1 > $sqls) ? 'query was' : 'queries were';
+        $output->writeln(sprintf('Database schema updated successfully! "<info>%s</info>" %s executed', $sqls, $pluralization));
+    }
+}

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -273,12 +273,12 @@ class Install extends AbstractInstall
      */
     public function generateSf2ProductionEnv()
     {
-        $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-        $sf2Refresh->addDoctrineSchemaUpdate();
-        $output = $sf2Refresh->execute();
+        $schemaUpgrade = new \PrestaShopBundle\Service\Database\Upgrade();
+        $schemaUpgrade->addDoctrineSchemaUpdate();
+        $output = $schemaUpgrade->execute();
 
-        if (0 !== $output['doctrine:schema:update']['exitCode']) {
-            $this->setError(explode("\n", $output['doctrine:schema:update']['output']));
+        if (0 !== $output['prestashop:schema:update-without-foreign']['exitCode']) {
+            $this->setError(explode("\n", $output['prestashop:schema:update-without-foreign']['output']));
             return false;
         }
 

--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -423,18 +423,12 @@ namespace PrestaShopBundle\Install {
 
         private function upgradeDoctrineSchema()
         {
-            $i = 0;
-            do {
-                $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-                $sf2Refresh->addDoctrineSchemaUpdate();
-                $output = $sf2Refresh->execute();
-                $i++;
-                // Doctrine could need several tries before being able to properly upgrade the schema...
-            } while((0 !== $output['doctrine:schema:update']['exitCode']) && $i < 10);
-
-            if (0 !== $output['doctrine:schema:update']['exitCode']) {
-                $msgErrors = explode("\n", $output['doctrine:schema:update']['output']);
-                $this->logError('Error upgrading Doctrine schema', 43);
+            $schemaUpgrade = new \PrestaShopBundle\Service\Database\Upgrade();
+            $schemaUpgrade->addDoctrineSchemaUpdate();
+            $output = $schemaUpgrade->execute();
+            if (0 !== $output['prestashop:schema:update-without-foreign']['exitCode']) {
+                $msgErrors = explode("\n", $output['prestashop:schema:update-without-foreign']['output']);
+                $this->logError('Error upgrading doctrine schema', 43);
                 foreach($msgErrors as $msgError) {
                     $this->logError('Doctrine SQL Error : '.$msgError, 43);
                 }

--- a/src/PrestaShopBundle/Service/Command/AbstractCommand.php
+++ b/src/PrestaShopBundle/Service/Command/AbstractCommand.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShopBundle\Service\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Input\ArrayInput;
+
+abstract class AbstractCommand
+{
+    private $env;
+    protected $application;
+    protected $commands;
+
+    /**
+     * Constructor.
+     *
+     * Construct the symfony environment.
+     *
+     * @param string $env Environment to set.
+     */
+    public function __construct($env = null)
+    {
+        umask(0000);
+        set_time_limit(0);
+
+        if (null === $env) {
+            $this->env = _PS_MODE_DEV_ ? 'dev' : 'prod';
+        } else {
+            $this->env = $env;
+        }
+
+        $this->commands = array();
+
+        require_once _PS_ROOT_DIR_.'/app/AppKernel.php';
+        $kernel = new \AppKernel($this->env, false);
+        $this->application = new Application($kernel);
+        $this->application->setAutoExit(false);
+    }
+
+    /**
+     * Execute all defined commands.
+     *
+     * @throws \Exception if no command defined
+     */
+    public function execute()
+    {
+        $bufferedOutput = new BufferedOutput();
+        $commandOutput = array();
+
+        if (empty($this->commands)) {
+            throw new \Exception('Error, you need to define at least one command');
+        }
+
+        foreach ($this->commands as $command) {
+            $exitCode = $this->application->run(new ArrayInput($command), $bufferedOutput);
+
+            $commandOutput[$command['command']] = array(
+                'exitCode' => $exitCode,
+                'output' => $bufferedOutput->fetch(),
+            );
+        }
+
+        return $commandOutput;
+    }
+}

--- a/src/PrestaShopBundle/Service/Database/Upgrade.php
+++ b/src/PrestaShopBundle/Service/Database/Upgrade.php
@@ -23,47 +23,23 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-namespace PrestaShopBundle\Service\Cache;
+namespace PrestaShopBundle\Service\Database;
 
+use PrestaShopBundle\Command\UpdateSchemaCommand;
 use PrestaShopBundle\Service\Command\AbstractCommand;
 
-class Refresh extends AbstractCommand
+class Upgrade extends AbstractCommand
 {
     /**
-     * Add cache:clear to the execution.
-     */
-    public function addCacheClear()
-    {
-        $this->commands[] = array(
-            'command' => 'doctrine:cache:clear-metadata',
-            '--flush' => true,
-        );
-
-        $this->commands[] = array(
-            'command' => 'doctrine:cache:clear-query',
-            '--flush' => true,
-        );
-
-        $this->commands[] = array(
-            'command' => 'doctrine:cache:clear-result',
-            '--flush' => true,
-        );
-
-        $this->commands[] = array(
-            'command' => 'cache:clear',
-            '--no-warmup' => true,
-        );
-    }
-
-    /**
-     * Add doctrine:schema:update to the execution.
+     * Run the custom schemaUpgrade command
      */
     public function addDoctrineSchemaUpdate()
     {
-        $this->addCacheClear();
+        $command = new UpdateSchemaCommand();
+        $this->application->add($command);
+
         $this->commands[] = array(
-            'command' => 'doctrine:schema:update',
-            '--force' => true,
+            'command' => 'prestashop:schema:update-without-foreign'
         );
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Doctrine without foreign for autoupgrade backup
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2779
| How to test?  | Do a rollback

Thanks to @jocel1 , see: https://github.com/PrestaShop/PrestaShop/pull/7620

This PR will works on release+1 backup.
**If it merged on 1.7.1.2, autoupgrade backup will works on 1.7.1.3.**