### PR TITLE
Error importing theme when cache directory is cleared

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -1490,7 +1490,7 @@ class AdminThemesControllerCore extends AdminController
             if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_FILES['themearchive']) && isset($_POST['filename']) && Tools::isSubmit('theme_archive_server')) {
                 $uniqid = uniqid();
                 $sandbox = _PS_CACHE_DIR_.'sandbox'.DIRECTORY_SEPARATOR.$uniqid.DIRECTORY_SEPARATOR;
-                mkdir($sandbox);
+                mkdir($sandbox, 0777, true);
                 $archive_uploaded = false;
 
                 if (Tools::getValue('filename') != '') {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When the cache directory is cleared importing theme was impossible due to a missing directory("sandbox"). This fix activate recursive mkdir to make sure the directory is created
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |