### PR TITLE
Calcul Tax included and excluded with Eastern Arabe translation

### DIFF
--- a/js/cldr.js
+++ b/js/cldr.js
@@ -144,7 +144,7 @@ function cldrForNumber(callback) {
  */
 function cldrForCurrencies(callback) {
 	var catalogs = ['main/en/numbers', 'main/en/currencies', 'supplemental/likelySubtags',
-	                'supplemental/currencyData', 'supplemental/plurals'];
+	                'supplemental/currencyData', 'supplemental/plurals', 'supplemental/numberingSystems'];
 	return cldrLazyLoadCatalogs(catalogs, callback);
 }
 

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -27,11 +27,24 @@ namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\DataTransformerInterface;
 
-class CustomMoneyType extends AbstractTypeExtension
+class CustomMoneyType extends AbstractTypeExtension implements DataTransformerInterface
 {
     const PRESTASHOP_DECIMALS = 6;
 
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getExtendedType()
     {
         return 'Symfony\Component\Form\Extension\Core\Type\MoneyType';
@@ -52,5 +65,43 @@ class CustomMoneyType extends AbstractTypeExtension
         ));
 
         $resolver->setAllowedTypes('scale', 'int');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($data)
+    {
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($data)
+    {
+        return empty($data) ? '' : $data;
+    }
+
+    /**
+     * Partial correction for "Price Tax Calculation" on Product view (only on arab).
+     * When your local is in ar-SA, we use the Eastearn Arabic number (٠١٢٣٤٥٧٨٩).
+     * This number is translate in a string data and not retransform after in Weastern Arabic number.
+     * In this tempory fix, we forced to use the Westearn Arab number like in 1.6.
+     * When we use this, the tax calculation is correct.
+     */
+    public function __construct() {
+        if ('ar' === substr(\Locale::getDefault(), 0, 2)) {
+            \Locale::setDefault('ar-TN');
+        }
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function __destruct() {
+        if ('ar' ===  substr(\Locale::getDefault(), 0, 2)) {
+            \Locale::setDefault('ar-SA');
+        }
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | In arabic language, you have more than one numeric translation, but we use only one in this application. When you use Eastern Arabic, all money are text and you don't can use this for calculation, like price with or without taxes. The translation is forced for Western Arabic for all case of Arab like v1.6
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/FF-44
| How to test?  | Select Arabic language for employee in team. The go in back office, select one product. On this page you can see the calculation for Taxe includind or excluding. Same in the tabs Price in this same page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7754)
<!-- Reviewable:end -->
