### PR TITLE
Fix manufacturer pagination

### DIFF
--- a/controllers/front/ManufacturerController.php
+++ b/controllers/front/ManufacturerController.php
@@ -115,8 +115,8 @@ class ManufacturerControllerCore extends FrontController
         if (Configuration::get('PS_DISPLAY_SUPPLIERS')) {
             $data = Manufacturer::getManufacturers(false, $this->context->language->id, true, false, false, false);
             $nbProducts = count($data);
-            $data = Manufacturer::getManufacturers(true, $this->context->language->id, true, $this->p, $this->n, false);
             $this->pagination($nbProducts);
+            $data = Manufacturer::getManufacturers(true, $this->context->language->id, true, $this->p, $this->n, false);
 
             foreach ($data as &$item) {
                 $item['image'] = (!file_exists(_PS_MANU_IMG_DIR_.$item['id_manufacturer'].'-'.ImageType::getFormatedName('medium').'.jpg')) ? $this->context->language->iso_code.'-default' : $item['id_manufacturer'];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | the page is defaulted to show 12 manufacturers per page, but the problem is that the entire list is displayed immediately, regardless of the number selected.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8987
| How to test?  | in FO, display the manufacturer list and use the pagination, it works!
