### PR TITLE
Allow image for categories when no description

### DIFF
--- a/themes/classic/templates/catalog/listing/category.tpl
+++ b/themes/classic/templates/catalog/listing/category.tpl
@@ -29,6 +29,8 @@
       <h1 class="h1">{$category.name}</h1>
       {if $category.description}
         <div id="category-description" class="text-muted">{$category.description nofilter}</div>
+      {/if}
+      {if $category.image.large.url}
         <div class="category-cover">
           <img src="{$category.image.large.url}" alt="{$category.image.legend}">
         </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Allow image for categories when no description
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1744
| How to test?  | Add a new category, add a picture, and see if you have the image on your front office
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
