### PR TITLE
Fix html interpreted as text in carrier's wizard summary

### DIFF
--- a/admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl
+++ b/admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl
@@ -26,13 +26,13 @@
 <script type="text/javascript">
 	var summary_translation_undefined = '{l s='[undefined]' js=1}';
 	var summary_translation_meta_informations = '{l s='This carrier is @s1 and the delivery announced is: @s2.' js=1}';
-	var summary_translation_free = '<strong>{l s='free' js=1}</strong>';
-	var summary_translation_paid = '<strong>{l s='not free' js=1}</strong>';
+	var summary_translation_free = '{l s='free' js=1}';
+	var summary_translation_paid = '{l s='not free' js=1}';
 	var summary_translation_range = '<span class="is_free">{l s='This carrier can deliver orders from @s1 to @s2.' js=1}</span>';
 	var summary_translation_range_limit =  '{l s='If the order is out of range, the behavior is to @s3.' js=1}';
 	var summary_translation_shipping_cost = '{l s='The shipping cost is calculated @s1 and the tax rule @s2 will be applied.' js=1}';
-	var summary_translation_price = '<strong>{l s='according to the price' js=1}</strong>';
-	var summary_translation_weight = '<strong>{l s='according to the weight' js=1}</strong>';
+	var summary_translation_price = '{l s='according to the price' js=1}';
+	var summary_translation_weight = '{l s='according to the weight' js=1}';
 </script>
 
 <div class="defaultForm">

--- a/js/admin/carrier_wizard.js
+++ b/js/admin/carrier_wizard.js
@@ -204,10 +204,10 @@ function displaySummary()
 
 
 
-	$('#summary_shipping_cost').text(tmp);
+	$('#summary_shipping_cost').html(tmp);
 
 	// Weight or price ranges
-	$('#summary_range').text(summary_translation_range+' '+summary_translation_range_limit);
+	$('#summary_range').html(summary_translation_range+' '+summary_translation_range_limit);
 
 
 	if ($('input[name="shipping_method"]:checked').val() == 1)

--- a/js/admin/carrier_wizard.js
+++ b/js/admin/carrier_wizard.js
@@ -185,30 +185,33 @@ function displaySummary()
 	$('#summary_name').text($('#name').val());
 
 	// Delay and pricing
-	tmp = summary_translation_meta_informations.replace('@s2', '<strong>' + delay_text + '</strong>');
+	$('#summary_meta_informations').html(summary_translation_meta_informations
+		.replace('@s1', '<strong></strong>')
+		.replace('@s2', '<strong></strong>')
+	);
 	if ($('#is_free_on').attr('checked'))
-		tmp = tmp.replace('@s1', summary_translation_free);
+		$('#summary_meta_informations').find('strong:eq(0)').text(summary_translation_free);
 	else
-		tmp = tmp.replace('@s1', summary_translation_paid);
-	$('#summary_meta_informations').html(tmp);
+		$('#summary_meta_informations').find('strong:eq(0)').text(summary_translation_paid);
+	$('#summary_meta_informations').find('strong:eq(1)').text(delay_text);
 
 	// Tax and calculation mode for the shipping cost
-	tmp = summary_translation_shipping_cost.replace('@s2', '<strong>' + $('#id_tax_rules_group option:selected').text() + '</strong>');
+	$('#summary_shipping_cost').html(summary_translation_shipping_cost
+		.replace('@s1', '<strong></strong>')
+		.replace('@s2', '<strong></strong>')
+	);
 
-		if ($('#billing_price').attr('checked'))
-			tmp = tmp.replace('@s1', summary_translation_price);
-		else if ($('#billing_weight').attr('checked'))
-			tmp = tmp.replace('@s1', summary_translation_weight);
-		else
-			tmp = tmp.replace('@s1', '<strong>' + summary_translation_undefined + '</strong>');
+	if ($('#billing_price').attr('checked'))
+		$('#summary_shipping_cost').find('strong:eq(0)').text(summary_translation_price);
+	else if ($('#billing_weight').attr('checked'))
+		$('#summary_shipping_cost').find('strong:eq(0)').text(summary_translation_weight);
+	else
+		$('#summary_shipping_cost').find('strong:eq(0)').text(summary_translation_undefined);
 
-
-
-	$('#summary_shipping_cost').html(tmp);
+	$('#summary_shipping_cost').find('strong:eq(1)').text($('#id_tax_rules_group option:selected').text());
+	
 
 	// Weight or price ranges
-	$('#summary_range').html(summary_translation_range+' '+summary_translation_range_limit);
-
 
 	if ($('input[name="shipping_method"]:checked').val() == 1)
 		unit = PS_WEIGHT_UNIT;
@@ -229,15 +232,21 @@ function displaySummary()
 		if (!isNaN(parseFloat($(this).val())) && (range_sup == summary_translation_undefined || parseFloat(range_sup) < parseFloat($(this).val())))
 			range_sup = $(this).val();
 	});
-
-	$('#summary_range').html(
-		$('#summary_range').html()
-		.replace('@s1', '<strong>' + range_inf +' '+ unit + '</strong>')
-		.replace('@s2', '<strong>' + range_sup +' '+ unit + '</strong>')
-		.replace('@s3', '<strong>' + $('#range_behavior option:selected').text().toLowerCase() + '</strong>')
+	
+	tmp = summary_translation_range+' '+summary_translation_range_limit;
+	$('#summary_range').html(tmp
+		.replace('@s1', '<strong></strong>')
+		.replace('@s2', '<strong></strong>')
+		.replace('@s3', '<strong></strong>')
 	);
+
+	$('#summary_range').find('strong:eq(0)').text(range_inf +' '+ unit);
+	$('#summary_range').find('strong:eq(1)').text(range_sup +' '+ unit);
+	$('#summary_range').find('strong:eq(2)').text($('#range_behavior option:selected').text().toLowerCase());
+
 	if ($('#is_free_on').attr('checked'))
 		$('span.is_free').hide();
+
 	// Delivery zones
 	$('#summary_zones').html('');
 	$('.input_zone').each(function(){


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In carrier's wizard summary, html is interpreted as text and html tags are visible.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Edit a carrier and go on the summary. You will see `<strong>not free</strong>` instead of "**not free**" for instance.