### PR TITLE
Fix error in HelperOptions

### DIFF
--- a/classes/helper/HelperOptions.php
+++ b/classes/helper/HelperOptions.php
@@ -158,6 +158,8 @@ class HelperOptionsCore extends Helper
 
                 // Fill values for all languages for all lang fields
                 if (substr($field['type'], -4) == 'Lang') {
+                    $field['value'] = array();
+                    $field['languages'] = array();
                     foreach ($languages as $language) {
                         if ($field['type'] == 'textLang') {
                             $value = Tools::getValue($key.'_'.$language['id_lang'], Configuration::get($key, $language['id_lang']));
@@ -165,6 +167,8 @@ class HelperOptionsCore extends Helper
                             $value = Configuration::get($key, $language['id_lang']);
                         } elseif ($field['type'] == 'selectLang') {
                             $value = Configuration::get($key, $language['id_lang']);
+                        } else {
+                            $value = '';
                         }
                         $field['languages'][$language['id_lang']] = $value;
                         $field['value'][$language['id_lang']] = $this->getOptionValue($key.'_'.strtoupper($language['iso_code']), $field);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | On PHP 7, HelperOptions shows an error (Cannot assign an empty string to a string offset) when a textarea is used.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | On PHP 7, go on a page where a HelperOptions is used with a textarea (AdminSearchConf for instance).