### PR TITLE
Fix override handling when PS_DISABLE_OVERRIDES is used

### DIFF
--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -135,6 +135,12 @@ class PrestaShopAutoload
      */
     public function generateIndex()
     {
+        if (defined('_DB_PREFIX_') && Configuration::get('PS_DISABLE_OVERRIDES')) {
+            $this->_include_override_path = false;
+        } else {
+            $this->_include_override_path = true;
+        }
+
         $classes = array_merge(
             $this->getClassesFromDir('classes/'),
             $this->getClassesFromDir('controllers/'),

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2575,9 +2575,6 @@ FileETag none
 
     public static function generateIndex()
     {
-        if (defined('_DB_PREFIX_') && Configuration::get('PS_DISABLE_OVERRIDES')) {
-            PrestaShopAutoload::getInstance()->_include_override_path = false;
-        }
         PrestaShopAutoload::getInstance()->generateIndex();
     }
 

--- a/tests/Unit/classes/PrestaShopAutoloadTest.php
+++ b/tests/Unit/classes/PrestaShopAutoloadTest.php
@@ -48,6 +48,11 @@ class    PrestaShopAutoloadTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
     }
 
+    /**
+     * Given PS_DISABLE_OVERRIDES is enabled
+     * When the class index is regenerated and we have override
+     * Then the override shouldn't be include in the class index
+     */
     public function testGenerateIndexWithoutOverride()
     {
         \Configuration::updateGlobalValue('PS_DISABLE_OVERRIDES', 1);
@@ -79,5 +84,10 @@ class    PrestaShopAutoloadTest extends PHPUnit_Framework_TestCase
     {
         PrestaShopAutoload::getInstance()->load('Core_Business_Payment_PaymentOption');
         $this->assertTrue(class_exists('Core_Business_Payment_PaymentOption', false));
+    }
+
+    public static function tearDownAfterClass()
+    {
+        @unlink(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'override/classes/Connection.php');
     }
 }

--- a/tests/Unit/classes/PrestaShopAutoloadTest.php
+++ b/tests/Unit/classes/PrestaShopAutoloadTest.php
@@ -48,6 +48,26 @@ class    PrestaShopAutoloadTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
     }
 
+    public function testGenerateIndexWithoutOverride()
+    {
+        \Configuration::updateGlobalValue('PS_DISABLE_OVERRIDES', 1);
+        @mkdir(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'override/classes/', 0777, true);
+        define('_PS_HOST_MODE_', 1);
+        file_put_contents(_PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'override/classes/Connection.php',
+            '<?php 
+            class Connection extends ConnectionCore {
+        }');
+        PrestaShopAutoload::getInstance()->generateIndex();
+        $this->assertTrue(file_exists($this->file_index));
+        $data = include($this->file_index);
+        $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
+        $this->assertEquals($data['Connection']['override'], false);
+        \Configuration::updateGlobalValue('PS_DISABLE_OVERRIDES', 0);
+        PrestaShopAutoload::getInstance()->generateIndex();
+        $data = include($this->file_index);
+        $this->assertEquals($data['Connection']['override'], true);
+    }
+
     public function testLoad()
     {
         PrestaShopAutoload::getInstance()->load('RequestSql');


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | PS_DISABLE_OVERRIDES is not properly taken into account when index_cache file is automatically regenerated
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Unittest added

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7768)
<!-- Reviewable:end -->
