### PR TITLE
Fix for CMS tree on sitemap

### DIFF
--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -63,17 +63,9 @@ class SitemapControllerCore extends FrontController
      */
     protected function getPagesLinks()
     {
-        $links = array();
-
         $cms = CMSCategory::getRecurseCategory($this->context->language->id, 1, 1, 1);
-        foreach ($cms['cms'] as $p) {
-            $links[] = array(
-                'id' => 'cms-page-' . $p['id_cms'],
-                'label' => $p['meta_title'],
-                'url' => $this->context->link->getCMSLink(new CMS($p['id_cms'])),
-            );
-        }
-
+        $links = $this->getCmsTree($cms);
+        
         $links[] = array(
             'id' => 'stores-page',
             'label' => $this->trans('Our stores', array(), 'Shop.Theme'),
@@ -91,6 +83,35 @@ class SitemapControllerCore extends FrontController
             'label' => $this->trans('Sitemap', array(), 'Shop.Theme'),
             'url' => $this->context->link->getPageLink('sitemap'),
         );
+
+        return $links;
+    }
+    
+    /**
+     * @return array
+     */
+    protected function getCmsTree($cms)
+    {
+        $links = array();
+
+        foreach ($cms['cms'] as $p) {
+            $links[] = array(
+                'id' => 'cms-page-' . $p['id_cms'],
+                'label' => $p['meta_title'],
+                'url' => $p['link'],
+            );
+        }
+
+        if (isset($cms['children'])) {
+            foreach ($cms['children'] as $c) {
+                $links[] = array(
+                'id' => 'cms-category-' . $c['id_cms_category'],
+                'label' => $c['name'],
+                'url' => $c['link'],
+                'children' => $this->getCmsTree($c),
+            );
+            }
+        }
 
         return $links;
     }

--- a/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
@@ -22,11 +22,10 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-<div id="order-items" class="col-md-8">
-
-  {block name='order_items_table_head'}
-    <h3 class="card-title h3">{l s='Order items' d='Shop.Theme.Checkout'}</h3>
-  {/block}
+{block name='order_items_table_head'}
+  <div id="order-items" class="col-md-8">
+  <h3 class="card-title h3">{l s='Order items' d='Shop.Theme.Checkout'}</h3>
+{/block}
 
   <div class="order-confirmation-table">
 

--- a/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
@@ -24,7 +24,7 @@
  *}
 {extends file='checkout/_partials/order-confirmation-table.tpl'}
 
-{block name='order-items-table-head'}
+{block name='order_items_table_head'}
 <div id="order-items" class="col-md-12">
   <h3 class="card-title h3">
     {if $products_count == 1}
@@ -34,5 +34,4 @@
     {/if}
   	<a href="{url entity=cart params=['action' => 'show']}"><span class="step-edit"><i class="material-icons edit">mode_edit</i> edit</span></a>
   </h3>
-</div>
 {/block}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | On sitemap there was only first level of cms pages. Also removed unnecesary New cms page class creation for getting a link since links is already provided by CMSCategory::getRecurseCategor.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | /no
| Fixed ticket? | 
| How to test?  | In backoffice create some cms categories and put some cms pages inside them, Then go to sitemap page in frontoffice,

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
