### PR TITLE
Fix block name and structure on order summary

### DIFF
--- a/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
@@ -22,11 +22,10 @@
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-<div id="order-items" class="col-md-8">
-
-  {block name='order_items_table_head'}
-    <h3 class="card-title h3">{l s='Order items' d='Shop.Theme.Checkout'}</h3>
-  {/block}
+{block name='order_items_table_head'} 
+  <div id="order-items" class="col-md-8">
+  <h3 class="card-title h3">{l s='Order items' d='Shop.Theme.Checkout'}</h3>
+{/block}
 
   <div class="order-confirmation-table">
 

--- a/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary-table.tpl
@@ -24,7 +24,7 @@
  *}
 {extends file='checkout/_partials/order-confirmation-table.tpl'}
 
-{block name='order-items-table-head'}
+{block name='order_items_table_head'}
 <div id="order-items" class="col-md-12">
   <h3 class="card-title h3">
     {if $products_count == 1}
@@ -34,5 +34,4 @@
     {/if}
   	<a href="{url entity=cart params=['action' => 'show']}"><span class="step-edit"><i class="material-icons edit">mode_edit</i> edit</span></a>
   </h3>
-</div>
 {/block}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Due wrong block name and structure, ordered products was not showed correctly in final summary
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | /no
| Fixed ticket? | 
| How to test?  | In backoffice shop parametrs > order > Enable final summary then create order go to FO add products, go to checkout, go to payment step

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
