### PR TITLE
Resolve incompatibility between canonical redirections, attributes and product route not only containing rewrite

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -55,7 +55,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         if (Validate::isLoadedObject($this->product)) {
             if (!$this->product->hasCombinations()) {
                 unset($_GET['id_product_attribute']);
-            } else if (!Tools::getValue('id_product_attribute') || Tools::getValue('rewrite') !== $this->product->link_rewrite) {
+            } else if (Tools::getValue('id_product_attribute')) {
+                $combination = new Combination(Tools::getValue('id_product_attribute'));
+                if (!Validate::isLoadedObject($combination) || !$combination->id_product == $this->product->id) {
+                    $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
+                }
+            } else {
                 $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
             }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -55,16 +55,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         if (Validate::isLoadedObject($this->product)) {
             if (!$this->product->hasCombinations()) {
                 unset($_GET['id_product_attribute']);
-            } else if (Tools::getValue('id_product_attribute')) {
-                $combination = new Combination(Tools::getValue('id_product_attribute'));
-                if (!Validate::isLoadedObject($combination) || !$combination->id_product == $this->product->id) {
-                    $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
-                }
-            } else {
+            } else if (!$this->isValidCombination(Tools::getValue('id_product_attribute'), $this->product->id)) {
                 $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
             }
 
-            $id_product_attribute = $this->getIdProductAttribute();
+            $idProductAttribute = $this->getIdProductAttribute();
             parent::canonicalRedirection($this->context->link->getProductLink(
                 $this->product,
                 null,
@@ -72,7 +67,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 null,
                 null,
                 null,
-                $id_product_attribute
+                $idProductAttribute
             ));
         }
     }
@@ -1196,5 +1191,27 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $page['admin_notifications'] = array_merge($page['admin_notifications'], $this->adminNotifications);
 
         return $page;
+    }
+
+    /**
+     * Indicates if the provided combination exists and belongs to the product
+     *
+     * @param int $productAttributeId
+     * @param int $productId
+     *
+     * @return bool
+     */
+    protected function isValidCombination($productAttributeId, $productId)
+    {
+        if ($productAttributeId > 0 && $productId > 0) {
+            $combination = new Combination($productAttributeId);
+
+            return (
+                Validate::isLoadedObject($combination)
+                && $combination->id_product == $productId
+            );
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | resolve incompatibility between canonical redirections, attributes and product route not only containing rewrite (2 bugs related)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3000
| How to test?  | see bellow please

How to test :
- enable canonical redirection if not enebled,
- use a custom road to product on seo configuration, or default one (`{category:/}{id}{-:id_product_attribute}-{rewrite}{-:ean13}.html`)
- fill the field ean13 on one product having combinations,
- go to this product on front office

Bugs :
- first one, you can not select another combination than default one and buy it, "product refresh" after choosing another combination return always the default combination.
- canonical redirection of non-default attribute redirect you to default attribute ( no way to reach the non default atttribute on FO product page)

Correction
- try to apply this commit ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7775)
<!-- Reviewable:end -->
