### PR TITLE
Make module actions translatable

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -42,7 +42,7 @@
       <form class="btn-group" method="post" action="{{ urls[url_active] }}">
         <button type="submit" class="btn btn-primary-reverse btn-primary-outline light-button module_action_menu_{{ url_active }}"
            data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}" {% if (level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) or (level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_DELETE') and (url_active not in ['configure', 'install', 'upgrade'])) %} disabled="disabled" {% endif %}>
-            {{ url_active|capitalize|replace({'_': " "}) }}
+            {{ url_active|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions') }}
         </button>
         {% if urls|length > 1 %}
         <input type="hidden" class="btn">
@@ -61,7 +61,7 @@
                     <li>
                       <form method="post" action="{{ module_url }}">
                         <button type="submit" class="dropdown-item module_action_menu_{{ module_action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">
-                          {{module_action|capitalize|replace({'_': " "})}}
+                          {{module_action|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions')}}
                         </button>
                       </form>
                     </li>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -65,7 +65,7 @@
                       data-content="{{ "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help') }}">
                 </span>
                 {% if (modules.to_update|length > 1) and (level >= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) %}
-                <a class="btn btn-primary-reverse pull-right btn-primary-outline light-button module_action_menu_upgrade_all" href="#" data-confirm_modal="module-modal-confirm-upgrade-all">Upgrade All</a>
+                <a class="btn btn-primary-reverse pull-right btn-primary-outline light-button module_action_menu_upgrade_all" href="#" data-confirm_modal="module-modal-confirm-upgrade-all">{{ "Upgrade All"|trans({}, 'Admin.Modules.Feature') }}</a>
                 {% endif %}
             </div>
             {% include 'PrestaShopBundle:Admin/Module/Includes:grid_notification_update.html.twig' with { 'modules': modules.to_update, 'display_type': 'list', id: 'update', 'level' : level } %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We forgot to add the trans modifier on the module actions. This PR add them.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/FF-37
| How to test?  | Change your language and check the module actions are properly translated.

![capture du 2017-04-12 16-35-05](https://cloud.githubusercontent.com/assets/6768917/24966827/5627da38-1fa8-11e7-9f57-055ce22a11c6.png)
