### PR TITLE
Force query build arg_separator to &

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1722,7 +1722,7 @@ class FrontControllerCore extends Controller
             $params = array();
         }
 
-        $queryString = str_replace('%2F', '/', http_build_query($params));
+        $queryString = str_replace('%2F', '/', http_build_query($params, '', '&'));
 
         return $url.($queryString ? "?$queryString" : '');
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch    |    develop
| Description  | The http_build_query uses by default the arg_separator.output value of PHP. So we have to force it because in some cases the default arg_separator.output is : `&amp;`
| Type         | bug fix
| Category     | CO
| BC breaks    | no
| Deprecations? | no
| Fixed ticket | -
| How to test  | Try to sort a product list on category page. The answer will be a json answer and pagination urls contains `&amp;` instead of `&`. So the DOM pagination will replaced and be unusable.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->


