### PR TITLE
Allow to define module front controllers layout

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1308,6 +1308,9 @@ class FrontControllerCore extends Controller
     public function getLayout()
     {
         $entity = $this->php_self;
+        if (empty($entity) && $this->controller_type === 'modulefront' && !empty($this->page_name)) {
+            $entity = $this->page_name;
+        }
 
         $layout = $this->context->shop->theme->getLayoutRelativePathForPage($entity);
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1308,8 +1308,8 @@ class FrontControllerCore extends Controller
     public function getLayout()
     {
         $entity = $this->php_self;
-        if (empty($entity) && $this->controller_type === 'modulefront' && !empty($this->page_name)) {
-            $entity = $this->page_name;
+        if (empty($entity)) {
+            $entity = $this->getPageName();
         }
 
         $layout = $this->context->shop->theme->getLayoutRelativePathForPage($entity);


### PR DESCRIPTION
Re-open : https://github.com/PrestaShop/PrestaShop/pull/7771 with good convention name.
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | 1.7.x
| Description?  | Currently it is not possible to define the layout of a module front controller.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Try to define the layout of a module from AdminThemes back office controller.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->


