### PR TITLE
BO: Multiple category tree on admin forms

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -734,7 +734,8 @@
 								{elseif $input.type == 'shop'}
 									{$input.html}
 								{elseif $input.type == 'categories'}
-									{$categories_tree}
+									{*$categories_tree*}
+									{$input.categories_tree}
 								{elseif $input.type == 'file'}
 									{$input.file}
 								{elseif $input.type == 'categories_select'}

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -134,8 +134,9 @@ class HelperFormCore extends Helper
                                     $tree->setData($params['tree']['set_data']);
                                 }
 
-                                $this->context->smarty->assign('categories_tree', $tree->render());
-                                $categories = false;
+                                //$this->context->smarty->assign('categories_tree', $tree->render());
+                                //$categories = false;
+				$params['categories_tree'] = $tree->render();
                             }
                         break;
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  |Add ability to use multiple category tree on admin forms
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Developers can test it by placing two category tree in admin forms

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7782)
<!-- Reviewable:end -->
