### PR TITLE
Versions completions for the max value

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -261,7 +261,7 @@ abstract class ModuleCore
         }
 
         if (strlen($this->ps_versions_compliancy['max']) == 5) {
-            $this->ps_versions_compliancy['max'] .= '.0';
+            $this->ps_versions_compliancy['max'] .= '.999';
         }
 
         if (strlen($this->ps_versions_compliancy['max']) == 3) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | In some case when you install a module, the version max is incorrect. The module is not installed 
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2835
| How to test?  | Install module 