### PR TITLE
Complete category tooltip in Product Page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form-categories.html.twig
@@ -50,7 +50,7 @@
   <h2>
     {{ "Create a new category"|trans({}, 'Admin.Catalog.Feature') }}
     <span class="help-box" data-toggle="popover"
-      data-content="{{ "If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.)."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+      data-content="{{ "If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).  A new category will not automatically appear in your shop's menu, please read the Help about it."|trans({}, 'Admin.Catalog.Help') }}" ></span>
   </h2>
   <div id="add-categories-content" class="hide">
     <div id="form_step1_new_category" data-action="{{ path('admin_category_simple_add_form', {'id_product': productId }) }}">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Just a new sentense in the Category tooltip, displayed in the Product Page (BO), explaining that there are more information in the Help about adding a category in the Menu
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/FF-41
| How to test?  | Go to Back office / Product Page / Tooltip of "Create a new category" and see that there is a new sentense about consulting the Help

