### PR TITLE
Fix slide down of carrier extra content in order funnel

### DIFF
--- a/themes/classic/_dev/js/checkout.js
+++ b/themes/classic/_dev/js/checkout.js
@@ -60,6 +60,6 @@ $(document).ready(() => {
     // Hide all carrier extra content ...
     $(".carrier-extra-content").hide();
     // and show the one related to the selected carrier
-    params.deliveryOption.find(".carrier-extra-content").slideDown();
+    params.deliveryOption.next(".carrier-extra-content").slideDown();
   });
 });

--- a/themes/classic/_dev/js/checkout.js
+++ b/themes/classic/_dev/js/checkout.js
@@ -57,6 +57,9 @@ $(document).ready(() => {
   }
 
   prestashop.on('updatedDeliveryForm', (params) => {
+    if (typeof params.deliveryOption === 'undefined' || 0 === params.deliveryOption.length) {
+        return;
+    }
     // Hide all carrier extra content ...
     $(".carrier-extra-content").hide();
     // and show the one related to the selected carrier


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | The page structure of the carrier step has been updated, but not the JS displaying the extra carrier content. In consequence, we could not see the carrier details without reloading the page. This PR fixes the JS.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2843
| How to test?  | This PR requires a `npm run build` in /themes/classic/_dev. Get a module with the hook `displayCarrierExtraContent`, and go to the order funnel. Selecting the carrier related to the module will display additional information after its line.