### PR TITLE
Fix Category Block in the Left Sidebar on Sitemap Page

### DIFF
--- a/themes/default-bootstrap/js/tools/treeManagement.js
+++ b/themes/default-bootstrap/js/tools/treeManagement.js
@@ -53,6 +53,7 @@ $(document).ready(function(){
 		$('ul.tree.dhtml').addClass('dynamized');
 
 		$('ul.tree.dhtml').removeClass('dhtml');
+		$('ul.tree.dynamized').removeClass('tree');
 	}
 });
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | in the sitemap page, the block categories css is broken
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8999
| How to test?  | access to the sitemap page then see the category block, it will be the same as other pages.
