### PR TITLE
Message Customer on order details page

### DIFF
--- a/classes/CustomerThread.php
+++ b/classes/CustomerThread.php
@@ -227,4 +227,25 @@ class CustomerThreadCore extends ObjectModel
             ' ORDER BY ct.date_upd ASC
 		');
     }
+
+    public static function getCustomerMessagesOrder($id_customer, $id_order)
+    {
+        $sql = 
+            'SELECT cm.*, c.`firstname` AS cfirstname, c.`lastname` AS clastname,
+                e.`firstname` AS efirstname, e.`lastname` AS elastname
+			FROM '._DB_PREFIX_.'customer_thread ct
+			LEFT JOIN '._DB_PREFIX_.'customer_message cm
+				ON ct.id_customer_thread = cm.id_customer_thread
+            LEFT JOIN `'._DB_PREFIX_.'customer` c 
+                ON ct.`id_customer` = c.`id_customer`
+            LEFT OUTER JOIN `'._DB_PREFIX_.'employee` e 
+                ON e.`id_employee` = cm.`id_employee`
+			WHERE ct.id_customer = '.(int)$id_customer.
+                ' AND ct.`id_order` = '.(int)$id_order.'
+            GROUP BY cm.id_customer_message
+		 	ORDER BY cm.date_add DESC
+            LIMIT 2';
+         
+        return Db::getInstance()->executeS($sql);
+    }
 }

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1871,7 +1871,7 @@ class AdminOrdersControllerCore extends AdminController
             'shipping_refundable_tax_incl' => $shipping_refundable_tax_incl,
             'customer_thread_message' => CustomerThread::getCustomerMessages($order->id_customer, null, $order->id),
             'orderMessages' => OrderMessage::getOrderMessages($order->id_lang),
-            'messages' => Message::getMessagesByOrderId($order->id, true),
+            'messages' => CustomerThread::getCustomerMessagesOrder($order->id_customer, $order->id),
             'carrier' => new Carrier($order->id_carrier),
             'history' => $history,
             'states' => OrderState::getOrderStates($this->context->language->id),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | If after placing an order, a customer sends a message via the history > order details page, this message could be seen in the BO in the order details page. 
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2280
| How to test?  | Send a message from customer history order, response. See in Order details if you can see message (History only on 2 message) 