### PR TITLE
Fix non-implementation JavaScript in RTL

### DIFF
--- a/js/rtl.js
+++ b/js/rtl.js
@@ -17,7 +17,7 @@ $(document).ready(function () {
         for (var x = 0, l = styles_old.length; x < l; x++) {
             s = styles_old[x].split(':');
             i = $.trim(s[0]);
-            styles[makeGeneralRTL(i)] = makeValueRTL(i, $.trim(s[1]));
+            if(s[0] !== '') styles[makeGeneralRTL(i)] = makeValueRTL(i, $.trim(s[1]));
         }
         $(this).removeAttr("style");
         $(this).css(styles);


### PR DESCRIPTION

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Fix the problem of non-implementation of the JavaScript when new admin theme run in RTL
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  |  In the pages of the new theme admin is used RTL in error "error text" will cause the execution of JavaScript code. Such as: lack of modules in Modules
