### PR TITLE
Translate file upload button label

### DIFF
--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -64,7 +64,7 @@
         <div class="form-group row">
           <label class="col-md-3 form-control-label">{l s='Attachment' d='Shop.Forms.Labels'}</label>
           <div class="col-md-6">
-            <input type="file" name="fileUpload" class="filestyle">
+            <input type="file" name="fileUpload" class="filestyle" data-buttonText="{l s='Choose file' d='Shop.Theme.Actions'}">
           </div>
           <span class="col-md-3 form-control-comment">
             {l s='optional' d='Shop.Forms.Help'}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Translate file upload button label. The string is already in the default catalog, so it can be merged in a patch version.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2684
| How to test?  |