### PR TITLE
Fix JS error "Uncaught ReferenceError"

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -27,6 +27,7 @@ var ajaxQueries = new Array();
 var ajaxLoaderOn = 0;
 var sliderList = new Array();
 var slidersInit = false;
+var lockLocationChecking = false;
 
 $(document).ready(function()
 {


### PR DESCRIPTION
`Uncaught ReferenceError: lockLocationChecking is not defined`

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | JS variable was undefined, leading to JS error being thrown.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | With blocklayered module, when content gets loaded via JS, this error would be thrown.
