### PR TITLE
searchTag now uses product_shop.visibility

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -814,7 +814,7 @@ class SearchCore
 			LEFT JOIN `'._DB_PREFIX_.'category_shop` cs ON (cp.`id_category` = cs.`id_category` AND cs.`id_shop` = '.(int)$id_shop.')
 			'.(Group::isFeatureActive() ? 'LEFT JOIN `'._DB_PREFIX_.'category_group` cg ON (cg.`id_category` = cp.`id_category`)' : '').'
 			WHERE product_shop.`active` = 1
-			AND p.visibility IN (\'both\', \'search\')
+			AND product_shop.`visibility` IN (\'both\', \'search\')
 			AND cs.`id_shop` = '.(int)Context::getContext()->shop->id.'
 			'.$sql_groups.'
 			AND t.`name` LIKE \'%'.pSQL($tag).'%\'');
@@ -849,6 +849,7 @@ class SearchCore
 				LEFT JOIN `'._DB_PREFIX_.'category_shop` cs ON (cp.`id_category` = cs.`id_category` AND cs.`id_shop` = '.(int)$id_shop.')
 				'.Product::sqlStock('p', 0).'
 				WHERE product_shop.`active` = 1
+                    AND product_shop.`visibility` IN (\'both\', \'search\')
 					AND cs.`id_shop` = '.(int)Context::getContext()->shop->id.'
 					'.$sql_groups.'
 					AND t.`name` LIKE \'%'.pSQL($tag).'%\'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | searchTags() used the wrong column (product instead of product_shop).Also it didn't check the product visibility status so products that were hidden for search would still be in the FO search result when searched on a tag.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | No
| How to test?  | Hide a product from search and catalog, now use search in the frontoffice to search for a tag used by the product. You will see that the product shows up in the search results

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7799)
<!-- Reviewable:end -->
