### PR TITLE
Fix assets path when theme has the same name than PS

### DIFF
--- a/src/Adapter/Assets/AssetUrlGeneratorTrait.php
+++ b/src/Adapter/Assets/AssetUrlGeneratorTrait.php
@@ -40,7 +40,11 @@ trait AssetUrlGeneratorTrait
 
     protected function getPathFromUri($fullUri)
     {
-        return $this->configuration->get('_PS_ROOT_DIR_').str_replace(rtrim($this->configuration->get('__PS_BASE_URI__'), '/'), '', $fullUri);
+        if ('' !== ($trimmedUri = rtrim($this->configuration->get('__PS_BASE_URI__'), '/'))) {
+            return $this->configuration->get('_PS_ROOT_DIR_').preg_replace('/\\'.$trimmedUri.'/', '', $fullUri, 1);
+        }
+
+        return $this->configuration->get('_PS_ROOT_DIR_').$fullUri;
     }
 
     protected function getFQDN()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | When the theme folder was the same than the PrestaShop one, the path was wrong because the name was replaced too much. Now, we only replace the first one and only if PrestaShop is in a subfolder.<br />**Before:**<br />`/Users/mbiloe/Sites/PrestaShop_develop/classic/themes/assets/css/theme.css`<br />**After:**<br />`/Users/mbiloe/Sites/PrestaShop_develop/classic/themes/classic/assets/css/theme.css`
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2872
| How to test?  |