### PR TITLE
Choose Theme on Mail Translation

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -53,7 +53,7 @@
 			<div class="panel">
 				<input type="hidden" name="lang" value="{$lang}" />
 				<input type="hidden" name="type" value="{$type}" />
-				<input type="hidden" name="theme" value="{$theme}" />
+				<input type="hidden" name="selected-theme" value="{$theme}" />
 				<script type="text/javascript">
 					$(document).ready(function(){
 						$('a.useSpecialSyntax').click(function(){

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1391,7 +1391,7 @@ class AdminTranslationsControllerCore extends AdminController
         }
 
         // Get folder name of theme
-        if (($theme = Tools::getValue('theme')) && !is_array($theme)) {
+        if (($theme = Tools::getValue('selected-theme')) && !is_array($theme)) {
             $theme_exists = $this->theme_exists($theme);
             if (!$theme_exists) {
                 throw new PrestaShopException(sprintf($this->trans('Invalid theme "%s"', array(), 'Admin.International.Notification'), Tools::safeOutput($theme)));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | On translation page, when you modify body or subject from template mail, your choose or theme is not validate. You have always the core theme. And any other choose on visualization. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2714  http://forge.prestashop.com/browse/BOOM-2745
| How to test?  | Add a theme (eg : jadeite), add a new language (e.g French - Germany) In Back office, choose International/Translation. On forms select type of translation mail, body or subject, a theme, and a language. Change an email (e.g account) go to another theme or language and see if the modificaiton is no apply. You can also see files for see if modification is done (e.g : mail/fr/account.html and themes/wt_jadeite/mail/fr/account.html)   