### PR TITLE
Fix the refresh button of the stats bloc in the products list

### DIFF
--- a/admin-dev/themes/default/template/helpers/kpi/kpi.tpl
+++ b/admin-dev/themes/default/template/helpers/kpi/kpi.tpl
@@ -22,7 +22,9 @@
 *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 *}
-
+<script>
+    var callFunction = false;
+</script>
 <{if isset($href) && $href}a style="display:block" href="{$href|escape:'html':'UTF-8'}"{else}div{/if} id="{$id|escape:'html':'UTF-8'}" data-toggle="tooltip" class="box-stats label-tooltip {$color|escape}" data-original-title="{$tooltip|escape}">
 	<div class="kpi-content">
 	{if isset($icon) && $icon}
@@ -43,30 +45,36 @@
 
 {if isset($source) && $source != '' && isset($refresh) && $refresh != ''}
 <script>
-	function refresh_{$id|replace:'-':'_'|addslashes}()
-	{
-		$.ajax({
-			url: '{$source|addslashes}' + '&rand=' + new Date().getTime(),
-			dataType: 'json',
-			type: 'GET',
-			cache: false,
-			headers: { 'cache-control': 'no-cache' },
-			success: function(jsonData){
-				if (!jsonData.has_errors)
-				{
-					if (jsonData.value != undefined)
-						$('#{$id|addslashes} .value').html(jsonData.value);
-					if (jsonData.data != undefined)
-					{
-						$("#{$id|addslashes} .boxchart svg").remove();
-						set_d3_{$id|replace:'-':'_'|addslashes}(jsonData.data);
-					}
-				}
-			}
-		});
-	}
+    callFunction = true;
 </script>
 {/if}
+<script>
+    function refresh_{$id|replace:'-':'_'|addslashes}(callFunction)
+    {
+        if(callFunction){
+            $.ajax({
+                url: '{$source|addslashes}' + '&rand=' + new Date().getTime(),
+                dataType: 'json',
+                type: 'GET',
+                cache: false,
+                headers: { 'cache-control': 'no-cache' },
+                success: function(jsonData){
+                    if (!jsonData.has_errors)
+                    {
+                        if (jsonData.value != undefined)
+                            $('#{$id|addslashes} .value').html(jsonData.value);
+                        if (jsonData.data != undefined)
+                        {
+                            $("#{$id|addslashes} .boxchart svg").remove();
+                            set_d3_{$id|replace:'-':'_'|addslashes}(jsonData.data);
+                        }
+                    }
+                }
+            });
+        }
+    }
+</script>
+
 
 {if $chart}
 <script>

--- a/admin-dev/themes/default/template/helpers/kpi/row.tpl
+++ b/admin-dev/themes/default/template/helpers/kpi/row.tpl
@@ -23,7 +23,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div class="panel kpi-container">
-	<div class="kpi-refresh"><button class="close refresh" type="button" onclick="refresh_kpis();"><i class="process-icon-refresh" style="font-size:1em"></i></button></div>
+	<div class="kpi-refresh"><button class="close refresh" type="button" onclick="refresh_kpis(true);"><i class="process-icon-refresh" style="font-size:1em"></i></button></div>
 	<div class="row">
 		{assign var='col' value=(int)(12 / $kpis|count)}
 		{foreach from=$kpis item=i name=kpi}

--- a/js/admin.js
+++ b/js/admin.js
@@ -1528,14 +1528,13 @@ function parseDate(date){
 	return $.datepicker.parseDate("yy-mm-dd", date);
 }
 
-function refresh_kpis()
+function refresh_kpis(callFunction)
 {
 	$('.box-stats').each(function() {
 		if ($(this).attr('id')) {
 			var functionName = 'refresh_' + $(this).attr('id').replace(/-/g, '_');
-
 			if (typeof window[functionName] === 'function') {
-				window[functionName]();
+				window[functionName](callFunction);
 			}
 		}
 	});


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | in the Products list, the stats bloc doesn't refresh even when you delete some products or disable some, and the refresh button doesn't work either. So to get a realistic stats, I fixed the refresh button.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8775
| How to test?  | in Products list, try to disable some products, the value of disabled products stats doesn't change, then click to the refresh button and you will see the new value of the stats.