### PR TITLE
Add tooltips on product's combination image

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -217,6 +217,14 @@ var combinations = (function() {
           number.text(countSelectedProducts() + '/' + allProductCombination);
         });
 
+        /** Add title on product's combination image */
+        $(function() {
+            $('#combination_form_' + contentElem.attr('data')).find("img").each(function() {
+                title = $(this).attr('src').split('/').pop();
+                $(this).attr('title',title);
+            });
+        });
+        
         $('#form-nav, #form_content').hide();
       });
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -220,3 +220,14 @@
       <input class="attribute-default" type="radio" {{ checked }} data-id="{{ form.vars.value.id_product_attribute }}">
     </td>
 </tr>
+
+{% block javascripts %}
+  <script>
+      $(function() {
+        $('.js-combination-images').find("img").each(function() {
+          title = path.split('/').reverse()[0];
+          $(this).attr('title',title);
+        });
+      });
+  </script>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combination.html.twig
@@ -220,14 +220,3 @@
       <input class="attribute-default" type="radio" {{ checked }} data-id="{{ form.vars.value.id_product_attribute }}">
     </td>
 </tr>
-
-{% block javascripts %}
-  <script>
-      $(function() {
-        $('.js-combination-images').find("img").each(function() {
-          title = path.split('/').reverse()[0];
-          $(this).attr('title',title);
-        });
-      });
-  </script>
-{% endblock %}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When adding images to product with different names and trying to assign them to combinations, it's very difficult to assign to a specific combination because the name of the image doesn't show up when the mouse hovers over it
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2730
| How to test?  | Go to product declination edition, and with the mouse go over the image for see the name of this. 
