### PR TITLE
Display the login form after an failed authentication

### DIFF
--- a/classes/checkout/CheckoutPersonalInformationStep.php
+++ b/classes/checkout/CheckoutPersonalInformationStep.php
@@ -75,6 +75,7 @@ class CheckoutPersonalInformationStepCore extends AbstractCheckoutStep
                 $this->step_is_complete = true;
             } else {
                 $this->getCheckoutProcess()->setHasErrors(true);
+                $this->show_login_form = true;
             }
         } elseif (array_key_exists('login', $requestParameters)) {
             $this->show_login_form = true;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Problem isset when you trying to log in at the cart. When login data's are incorrect after reload site you can see 'Order as a guest', but you should see tab 'Log in' where is placed message 'Authentication failed'.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| How to test?  | Try log in at the cart and put wrong log in data



