### PR TITLE
Close thumbs modal when area under thumbs is clicked

### DIFF
--- a/themes/classic/_dev/js/components/product-select.js
+++ b/themes/classic/_dev/js/components/product-select.js
@@ -41,7 +41,13 @@ export default class ProductSelect {
       $('.js-modal-product-cover').attr('src', $(event.target).data('image-large-src'));
       $('.js-modal-product-cover').attr('title', $(event.target).attr('title'));
       $('.js-modal-product-cover').attr('alt', $(event.target).attr('alt'));
+    })
+    .on('click', 'aside#thumbnails', (event) => {
+      if (event.target.id == 'thumbnails'){
+        $('#product-modal').modal('hide');
+      }
     });
+
     if($onsale.length && $('#product').length){
       $('.new').css('top',$onsale.height() + FLAG_MARGIN);
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Clicking under the thumbs won't make the modal close down. this minor improvement makes it a bit more intuitive
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Open a thumbs modal in a product page (by clicking on the main product image) and click under the thumbnails (on the aside#thumbnails element). the modal dialog should close down.
