### PR TITLE
Fix customer message order

### DIFF
--- a/classes/CustomerThread.php
+++ b/classes/CustomerThread.php
@@ -135,6 +135,8 @@ class CustomerThreadCore extends ObjectModel
             $sql .= ' AND ct.`id_order` = '.(int)$id_order;
         }
 
+        $sql .= ' ORDER BY cm.date_add DESC';
+
         return Db::getInstance()->executeS($sql);
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Customer messages were ordered so that the oldest ones are on the top. However orders (which is a table just beside messages) have the newest on top. This should be consistent.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 
