### PR TITLE
Improve tag tips in product page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -783,7 +783,7 @@
                         <div class="alert alert-info alert-down" role="alert">
                           <p class="alert-down-text">
                             {{ 'Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.'|trans({}, 'Admin.Catalog.Help')|raw }}<br>
-                            {{ 'You can manage tag aliases in the [1]Search section[/1].'|trans({}, 'Admin.Catalog.Help')|
+                            {{ 'You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.'|trans({}, 'Admin.Catalog.Help')|
                               replace({
                                 '[1]' : '<a href="'~ getAdminLink("AdminSearchConf") ~'" target="_blank">',
                                 '[/1]' : '</a>'


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I complete the tips message for tags in the BO product page, saying it needs to rebuild the index.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1127
| How to test?  | Just see the text, it should talk about the index



