### PR TITLE
Add API_KEY field to display the map

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -336,7 +336,11 @@ class AdminOrdersControllerCore extends AdminController
 
         $this->addJqueryUI('ui.datepicker');
         $this->addJS(_PS_JS_DIR_.'vendor/d3.v3.min.js');
-        $this->addJS('https://maps.googleapis.com/maps/api/js?v=3.exp');
+        $api_key = '';
+        if(Configuration::get('PS_API_KEY')){
+            $api_key = 'key='.Configuration::get('PS_API_KEY').'&';
+        }
+        $this->addJS('http://maps.google.com/maps/api/js?'.$api_key.'v=3.26');
 
         if ($this->tabAccess['edit'] == 1 && $this->display == 'view') {
             $this->addJS(_PS_JS_DIR_.'admin/orders.js');

--- a/controllers/admin/AdminPreferencesController.php
+++ b/controllers/admin/AdminPreferencesController.php
@@ -140,6 +140,13 @@ class AdminPreferencesControllerCore extends AdminController
                     'type' => 'bool',
                     'default' => '0'
                 ),
+                'PS_API_KEY' => array(
+                    'title' => $this->l('API key'),
+                    'desc' => $this->l('Add your API key to display Google Map'),
+                    'cast' => 'strval',
+                    'type' => 'text',
+                    'class' => 'fixed-width-xxl'
+                ),
                 'PS_PRICE_ROUND_MODE' => array(
                     'title' => $this->l('Round mode'),
                     'desc' => $this->l('You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.'),

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -285,8 +285,12 @@ class StoresControllerCore extends FrontController
         $this->addCSS(_THEME_CSS_DIR_.'stores.css');
 
         if (!Configuration::get('PS_STORES_SIMPLIFIED')) {
+            $api_key = '';
+            if(Configuration::get('PS_API_KEY')){
+                $api_key = 'key='.Configuration::get('PS_API_KEY').'&';
+            }
             $default_country = new Country((int)Tools::getCountry());
-            $this->addJS('http'.((Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE')) ? 's' : '').'://maps.google.com/maps/api/js?region='.substr($default_country->iso_code, 0, 2));
+            $this->addJS('http'.((Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE')) ? 's' : '').'://maps.google.com/maps/api/js?'.$api_key.'region='.substr($default_country->iso_code, 0, 2));
             $this->addJS(_THEME_JS_DIR_.'stores.js');
         }
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | the map produces a javascript error because of missing API key
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8178 http://forge.prestashop.com/browse/PSCSX-8749
| How to test?  | BO, Preference -> General settings, under "Use HTMLPurifier Library" you will find new field "API key", so type it there and click on the save button. FO, in the footer click on "our stores", the map will be displayed without any error. BO, in the order details, the map will be displayed without any error.