### PR TITLE
Handle multishop in console commands

### DIFF
--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -94,5 +94,33 @@ class Context
         return \ShopCore::getContext() === \ShopCore::CONTEXT_ALL;
     }
 
+    /**
+     * Update Multishop context for only one shop
+     *
+     * @param int $id Shop id to set in the current context
+     */
+    public function setShopContext($id)
+    {
+        \ShopCore::setContext(\ShopCore::CONTEXT_SHOP, $id);
+    }
 
+    /**
+     * Update Multishop context for only one shop group
+     *
+     * @param int $id Shop id to set in the current context
+     */
+    public function setShopGroupContext($id)
+    {
+        \ShopCore::setContext(\ShopCore::CONTEXT_GROUP, $id);
+    }
+
+    /**
+     * Update Multishop context for only one shop group
+     *
+     * @param int $id Shop id to set in the current context
+     */
+    public function setAllContext($id)
+    {
+        \ShopCore::setContext(\ShopCore::CONTEXT_ALL, $id);
+    }
 }

--- a/src/PrestaShopBundle/EventListener/MultishopCommandListener.php
+++ b/src/PrestaShopBundle/EventListener/MultishopCommandListener.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * 2007-2017 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2017 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\EventListener;
+
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputOption;
+
+class MultishopCommandListener
+{
+    public $context;
+
+    /**
+     * Path to root dir, needed to require config file
+     * @var string
+     */
+    public $rootDir;
+
+    public function __construct(Context $context, $rootDir)
+    {
+        $this->context = $context;
+        $this->rootDir = $rootDir;
+    }
+
+    public function onConsoleCommand(ConsoleCommandEvent $event)
+    {
+        $definition = $event->getCommand()->getDefinition();
+        $input = $event->getInput();
+
+        $definition->addOption(new InputOption('id_shop', null, InputOption::VALUE_OPTIONAL, 'Specify shop context.'));
+        $definition->addOption(new InputOption('id_shop_group', null, InputOption::VALUE_OPTIONAL, 'Specify shop group context.'));
+        $input->bind($definition);
+
+        $id_shop = $input->getOption('id_shop');
+        $id_shop_group = $input->getOption('id_shop_group');
+
+        if ($id_shop && $id_shop_group) {
+            throw new LogicException('Do not specify an ID shop and an ID group shop at the same time.');
+        }
+
+        if ($id_shop) {
+            // Unfortunately, there is SQL requests executed in the legacy. I have to include the config file.
+            require($this->rootDir.'/../config/config.inc.php');
+            $this->context->setShopContext($id_shop);
+        }
+        if ($id_shop_group) {
+            $this->context->setShopGroupContext($id_shop_group);
+        }
+    }
+}

--- a/src/PrestaShopBundle/EventListener/MultishopCommandListener.php
+++ b/src/PrestaShopBundle/EventListener/MultishopCommandListener.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\EventListener;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Exception\LogicException;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputOption;
 
 class MultishopCommandListener
@@ -66,11 +65,22 @@ class MultishopCommandListener
 
         if ($id_shop) {
             // Unfortunately, there is SQL requests executed in the legacy. I have to include the config file.
-            require($this->rootDir.'/../config/config.inc.php');
+            $this->fixUnloadedConfig();
             $this->context->setShopContext($id_shop);
         }
         if ($id_shop_group) {
             $this->context->setShopGroupContext($id_shop_group);
+        }
+    }
+
+    /**
+     * This function is an hack.
+     * Calling setShopContext will trigger a sql request, we need to be sure the config is properly loaded.
+     */
+    private function fixUnloadedConfig()
+    {
+        if (!defined('_DB_PREFIX_')) {
+            require_once($this->rootDir.'/../config/config.inc.php');
         }
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -114,6 +114,14 @@ services:
             - "@prestashop.adapter.legacy.context"
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+            
+    prestashop.multishop_command_listener:
+        class: PrestaShopBundle\EventListener\MultishopCommandListener
+        arguments:
+            - "@prestashop.adapter.shop.context"
+            - "@=service('kernel').getRootDir()"
+        tags:
+            - { name: kernel.event_listener, event: console.command, method: onConsoleCommand }
 
     prestashop.router:
         class: PrestaShopBundle\Service\Routing\Router

--- a/tests/TestCase/UnitTestCase.php
+++ b/tests/TestCase/UnitTestCase.php
@@ -177,7 +177,6 @@ class UnitTestCase extends PHPUnit_Framework_TestCase
         require_once __DIR__.'/../../app/autoload.php';
         require_once __DIR__.'/../../app/AppKernel.php';
         $this->sfKernel = new \AppKernel('test', true);
-        $this->sfKernel->loadClassCache();
         $this->sfKernel->boot();
 
         return $this->sfKernel;

--- a/tests/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
@@ -92,4 +92,17 @@ class MultishopCommandListenerTest extends UnitTestCase
         // Check!
         $this->assertTrue($this->multishopContext->isShopGroupContext());
     }
+
+    public function testExceptionWhenIdShopAndIdShopGroupSet()
+    {
+        // Prepare ...
+        $command = new Command('Fake');
+        $input = new StringInput('--id_shop=2 --id_shop_group=1');
+        $output = new NullOutput();
+        $event = new ConsoleCommandEvent($command, $input, $output);
+
+        // Call ...
+        $this->setExpectedException('LogicException', 'Do not specify an ID shop and an ID group shop at the same time.');
+        $this->commandListener->onConsoleCommand($event);
+    }
 }

--- a/tests/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * 2007-2017 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2017 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Tests\Unit\PrestaShopBundle;
+
+use PrestaShop\PrestaShop\tests\TestCase\UnitTestCase;
+use PrestaShopBundle\EventListener\MultishopCommandListener;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class MultishopCommandListenerTest extends UnitTestCase
+{
+    /**
+     * @var MultishopCommandListener
+     */
+    public $commandListener;
+
+    /**
+     *
+     * @var Context
+     */
+    public $multishopContext;
+
+    public function setup()
+    {
+        parent::setup();
+        $this->setupSfKernel();
+
+        $this->commandListener = $this->sfKernel->getContainer()->get('prestashop.multishop_command_listener');
+        $this->multishopContext = $this->sfKernel->getContainer()->get('prestashop.adapter.shop.context');
+    }
+    
+    public function testDefaultMultishopContext()
+    {
+        $this->assertFalse($this->multishopContext->isShopContext());
+        $this->assertFalse($this->multishopContext->isShopGroupContext());
+        $this->assertFalse($this->multishopContext->isAllContext());
+    }
+
+    public function testSetShopID()
+    {
+        // Prepare ...
+        $command = new Command('Fake');
+        $input = new StringInput('--id_shop=1');
+        $output = new NullOutput();
+        $event = new ConsoleCommandEvent($command, $input, $output);
+
+        // Call ...
+        $this->commandListener->onConsoleCommand($event);
+
+        // Check!
+        $this->assertTrue($this->multishopContext->isShopContext());
+    }
+
+    public function testSetShopGroupID()
+    {
+        // Prepare ...
+        $command = new Command('Fake');
+        $input = new StringInput('--id_shop_group=1');
+        $output = new NullOutput();
+        $event = new ConsoleCommandEvent($command, $input, $output);
+
+        // Call ...
+        $this->commandListener->onConsoleCommand($event);
+
+        // Check!
+        $this->assertTrue($this->multishopContext->isShopGroupContext());
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR is a preliminary work for #7778, which allows to handle multishop in any console command with `--id_shop=` and `--id_shop_group=`.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | No command can currently handle the multishop options. However, executing any command with this option and the debug mode will show you the method is properly called.

### Command debug

```
$ app/console cache:clear --id_shop=1 -vvv
[2017-04-26 16:56:23] event.DEBUG: Notified event "console.command" to listener "Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure".  
[2017-04-26 16:56:23] event.DEBUG: Notified event "console.command" to listener "Symfony\Component\HttpKernel\EventListener\DumpListener::configure".  
[2017-04-26 16:56:23] event.DEBUG: Notified event "console.command" to listener "Symfony\Bridge\Monolog\Handler\ConsoleHandler::onCommand".  
[2017-04-26 16:56:23] event.DEBUG: Notified event "console.command" to listener "Symfony\Bridge\Monolog\Handler\ConsoleHandler::onCommand".  
[2017-04-26 16:56:23] event.DEBUG: Notified event "console.command" to listener "PrestaShopBundle\EventListener\MultishopCommandListener::onConsoleCommand".  

 // Clearing the cache for the dev environment with debug true                                                          

 // Warming up cache...    
```

### Console help

![capture du 2017-04-26 15-52-51](https://cloud.githubusercontent.com/assets/6768917/25441109/3de32e4a-2a99-11e7-801e-0628432d42da.png)
