### PR TITLE
Fix spelling from conversation to conversion rate.

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -560,6 +560,19 @@ class CurrencyCore extends ObjectModel
         return self::$currencies[(int) ($id)];
     }
 
+
+    /**
+     * Get conversion rate
+     *
+     * @return int|string
+     * @deprecated 1.7.2.0, use Currency::getConversionRate() instead
+     */
+    public function getConversationRate()
+    {
+        Tools::displayAsDeprecated('Use Currency::getConversionRate() instead');
+        return $this->getConversionRate();
+    }
+
     /**
      * Get conversion rate
      *

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -565,7 +565,7 @@ class CurrencyCore extends ObjectModel
      *
      * @return int|string
      */
-    public function getConversationRate()
+    public function getConversionRate()
     {
         return ($this->id != (int) Configuration::get('PS_CURRENCY_DEFAULT')) ? $this->conversion_rate : 1;
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes a typo. The function was called a conversation rate, which I think was meant to be conversion rate.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | none
| How to test?  | Test with any system that gets the currency conversion rate, from a currency object. Using the new function getConversionRate will test the improvement. Using the old function getConversationRate will test for backwards compatibility.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
