### PR TITLE
BO: Change link 1.6 to 1.7 in import page

### DIFF
--- a/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
@@ -39,7 +39,7 @@
 			<div class="alert alert-info">
 				<ul class="list-unstyled">
 					<li>{l s='You can read information on import at:'}
-						<a href="http://doc.prestashop.com/display/PS16/CSV+Import+Parameters" class="_blank">http://doc.prestashop.com/display/PS16/CSV+Import+Parameters</a>
+						<a href="http://doc.prestashop.com/display/PS17/Import" class="_blank">http://doc.prestashop.com/display/PS17/Import</a>
 					</li>
 					<li>{l s='Read more about the CSV format at:'}
 						<a href="http://en.wikipedia.org/wiki/Comma-separated_values" class="_blank">http://en.wikipedia.org/wiki/Comma-separated_values</a>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | A link redirected to the 1.6 doc instead of the 1.7, in the import page. It corrects it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2674
| How to test?  | see the link in the import page

