### PR TITLE
Image not displayed in BO when creating new store

### DIFF
--- a/admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl
@@ -34,7 +34,7 @@
 					</label>
 				</div>
 				<div class="theme-container">
-					<img class="thumbnail" src="{$theme->get('preview')|escape:'html':'UTF-8'}" />
+					<img class="thumbnail" src="../{$theme->get('preview')|escape:'html':'UTF-8'}" />
 				</div>
 			</div>
 		{/foreach}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The image of the Classic theme is not displayed in BO when creating new store
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2042
| How to test?  | Enable multistore option, and try to create a new store.