### PR TITLE
Return empty array instead of false.

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3652,7 +3652,7 @@ class ProductCore extends ObjectModel
 				GROUP BY product_shop.id_product';
 
         if (!$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql)) {
-            return false;
+            return array();
         }
 
         foreach ($result as $k => &$row) {


### PR DESCRIPTION
Bug in some themes, return expected is array but bool returned.


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | getAccessories, array return expected but bool returned.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

