### PR TITLE
Add sprintf check constraint on translations

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Controller\Admin;
 
 use Doctrine\Common\Util\Inflector;
 use PrestashopBundle\Entity\Translation;
+use PrestaShopBundle\Translation\Constraints\PassVsprintf;
 use PrestaShopBundle\Translation\Provider\ModuleProvider;
 use PrestaShopBundle\Translation\View\TreeBuilder;
 use PrestaShopBundle\Security\Voter\PageVoter;
@@ -36,6 +37,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Validator\Validation;
 
 /**
  * Admin controller for the International pages.
@@ -276,6 +278,15 @@ class TranslationsController extends FrameworkBundleAdminController
         } else {
             $translation->setTheme($theme);
             $translation->setTranslation($requestParams['translation_value']);
+        }
+
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($translation, new PassVsprintf);
+        if (0 !== count($violations)) {
+            foreach ($violations as $violation) {
+                $this->container->get('logger')->error($violation->getMessage());
+            }
+            return false;
         }
 
         $updatedTranslationSuccessfully = false;

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -249,6 +249,7 @@ class TranslationsController extends FrameworkBundleAdminController
     {
         $requestParams = $request->request->all();
         $entityManager = $this->getDoctrine()->getManager();
+        $logger = $this->container->get('logger');
 
         $lang = $this->findLanguageByLocale($requestParams['locale']);
 
@@ -284,7 +285,7 @@ class TranslationsController extends FrameworkBundleAdminController
         $violations = $validator->validate($translation, new PassVsprintf);
         if (0 !== count($violations)) {
             foreach ($violations as $violation) {
-                $this->container->get('logger')->error($violation->getMessage());
+                $logger->error($violation->getMessage());
             }
             return false;
         }
@@ -297,7 +298,7 @@ class TranslationsController extends FrameworkBundleAdminController
 
             $updatedTranslationSuccessfully = true;
         } catch (\Exception $exception) {
-            $this->container->get('logger')->error($exception->getMessage());
+            $logger->error($exception->getMessage());
         }
 
         return $updatedTranslationSuccessfully;

--- a/src/PrestaShopBundle/Entity/Translation.php
+++ b/src/PrestaShopBundle/Entity/Translation.php
@@ -28,6 +28,7 @@
 namespace PrestaShopBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use PrestaShopBundle\Translation\Constraints\PassVsprintf;
 
 /**
  * Translation.
@@ -36,6 +37,7 @@ use Doctrine\ORM\Mapping as ORM;
  *     indexes={@ORM\Index(name="key", columns={"domain"})},
  * )
  * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\TranslationRepository")
+ * @PassVsprintf
  */
 class Translation
 {

--- a/src/PrestaShopBundle/Translation/Constraints/PassVsprintf.php
+++ b/src/PrestaShopBundle/Translation/Constraints/PassVsprintf.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * 2007-2017 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2017 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"CLASS", "ANNOTATION"})
+ */
+class PassVsprintf extends Constraint
+{
+    public $message = 'You must specify as many arguments (%d, %s ...) as the original string.';
+
+    public function getTargets()
+    {
+        return static::CLASS_CONSTRAINT;
+    }
+}

--- a/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
+++ b/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Translation\Constraints;
 
 use Exception;
 use PrestaShopBundle\Entity\Translation;
+use PrestaShopBundle\Translation\PrestaShopTranslatorTrait;
 use PrestaShopBundle\Translation\Constraints\PassVsprintf;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -35,14 +36,6 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class PassVsprintfValidator extends ConstraintValidator
 {
-    /**
-     * Regex found to test all vsprintf arguments
-     * Found on http://stackoverflow.com/questions/2053664/how-to-check-that-vsprintf-has-the-correct-number-of-arguments-before-running
-     *
-     * @var string
-     */
-    public $vsprintfRegex = "~%[-+]?(?:[ 0]|'.)?a?\d*(?:\.\d*)?[%bcdeEufFgGosxX]~";
-
     public function validate($translation, Constraint $constraint)
     {
         if (!$constraint instanceof PassVsprintf) {
@@ -62,7 +55,7 @@ class PassVsprintfValidator extends ConstraintValidator
     private function countArgumentsOfTranslation($property)
     {
         $matches = array();
-        if (preg_match_all($this->vsprintfRegex, $property, $matches) === false) {
+        if (preg_match_all(PrestaShopTranslatorTrait::$regexSprintfParams, $property, $matches) === false) {
             throw new Exception('Preg_match failed');
         }
 

--- a/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
+++ b/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * 2007-2017 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2017 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation\Constraints;
+
+use Exception;
+use PrestaShopBundle\Entity\Translation;
+use PrestaShopBundle\Translation\Constraints\PassVsprintf;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class PassVsprintfValidator extends ConstraintValidator
+{
+    /**
+     * Regex found to test all vsprintf arguments
+     * Found on http://stackoverflow.com/questions/2053664/how-to-check-that-vsprintf-has-the-correct-number-of-arguments-before-running
+     *
+     * @var string
+     */
+    public $vsprintfRegex = "~%[-+]?(?:[ 0]|'.)?a?\d*(?:\.\d*)?[%bcdeEufFgGosxX]~";
+
+    public function validate($translation, Constraint $constraint)
+    {
+        if (!$constraint instanceof PassVsprintf) {
+            throw new UnexpectedTypeException($constraint, 'PrestaShopBundle\Translation\Constraints\PassVsprintf');
+        }
+
+        if (!$translation instanceof Translation) {
+            throw new UnexpectedTypeException($translation, 'PrestaShopBundle\Entity\Translation');
+        }
+
+        if ($this->countArgumentsOfTranslation($translation->getKey()) != $this->countArgumentsOfTranslation($translation->getTranslation())) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+        }
+    }
+
+    private function countArgumentsOfTranslation($property)
+    {
+        $matches = array();
+        if (preg_match_all($this->vsprintfRegex, $property, $matches) === false) {
+            throw new Exception('Preg_match failed');
+        }
+
+        return count($matches[0]);
+    }
+}

--- a/tests/Unit/PrestaShopBundle/PassVsprintfContraintTest.php
+++ b/tests/Unit/PrestaShopBundle/PassVsprintfContraintTest.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * 2007-2017 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2017 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Tests\Unit\PrestaShopBundle;
+
+use PrestaShopBundle\Entity\Translation;
+use PrestaShopBundle\Translation\Constraints\PassVsprintf;
+use PrestaShopBundle\Translation\Constraints\PassVsprintfValidator;
+use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest;
+use Symfony\Component\Validator\Validation;
+
+class PassVsprintfContraintTest extends AbstractConstraintValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new PassVsprintfValidator();
+    }
+
+    public function testEmptyTranslationIsValid()
+    {
+        $this->validator->validate(new Translation(), new PassVsprintf());
+
+        $this->assertNoViolation();
+    }
+
+    public function testTranslationIsValid()
+    {
+        $translation = (new Translation())
+            ->setKey('List of products by brand %s')
+            ->setTranslation('Liste des produits de la marque %s');
+        $this->validator->validate($translation, new PassVsprintf());
+
+        $this->assertNoViolation();
+    }
+
+    public function testNotValid()
+    {
+        $translation = (new Translation())
+            ->setKey('List of products by brand %s')
+            ->setTranslation('Liste des produits de la marque nope');
+        $constraint = new PassVsprintf();
+
+        $this->validator->validate($translation, $constraint);
+        
+        $this->buildViolation($constraint->message)->assertRaised();
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR does not fix a bug, however it prevents merchants to write translations with the wrong amount of arguments for sprintf(). Because this function throws a fatal error when you do not send the correct number of arguments, we have to make sure they match in a translated value.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2561
| How to test?  | Find a translation with `%s` in it and try to translate it with the wrong number of %s. Saving must now fail.