### PR TITLE
Fix coverage calculations in Stock Cover Report

### DIFF
--- a/classes/stock/StockManager.php
+++ b/classes/stock/StockManager.php
@@ -861,7 +861,7 @@ class StockManagerCore implements StockManagerInterface
             return -1;
         }
 
-        $quantity_per_day = Tools::ps_round($quantity_out / $coverage);
+        $quantity_per_day = $quantity_out / $coverage;
         $physical_quantity = $this->getProductPhysicalQuantities($id_product,
                                                                  $id_product_attribute,
                                                                  ($id_warehouse ? array($id_warehouse) : null),


### PR DESCRIPTION
When caclulating the coverage qty per day this value is prematuely rounded using the shops currency rounding (ps_round) resulting in infinite qty coverage result.

If the shop is using the default rounding any coverage calculation where the result of the calculation is less than 0.5 will result a very inaccurate coverage calculation.

For example: Lets assume you have a product that sold 14 times ($quantity_out) over a coverage period of 30 days ($coverage).  The result of this calc is (14/30) = 0.4667 which is then prematurely rounded down to zero.

This ends with most coverages reporting as infinite when in actual fact there is significant impact on stock coverage.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Done
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-6671
| How to test?  | Run a Stock Cover report

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
