### PR TITLE
Fix Stock cover report stock out calculation

### DIFF
--- a/classes/stock/StockManagerInterface.php
+++ b/classes/stock/StockManagerInterface.php
@@ -135,4 +135,16 @@ interface StockManagerInterface
      * @return int time
      */
     public function getProductCoverage($id_product, $id_product_attribute, $coverage, $id_warehouse = null);
+
+    /**
+     * For a given product, returns the number of products sold for the the given coverage period.
+     * By default, for the given product, it will use sum(quantities removed in all warehouses)
+     *
+     * @param int $id_product
+     * @param int $id_product_attribute
+     * @param int $coverage
+     * @param int $id_warehouse Optional
+     * @return int time
+     */
+    public function getProductOutForCoverage($id_product, $id_product_attribute, $coverage, $id_warehouse = null);
 }

--- a/classes/stock/StockManagerInterface.php
+++ b/classes/stock/StockManagerInterface.php
@@ -143,8 +143,8 @@ interface StockManagerInterface
      * @param int $id_product
      * @param int $id_product_attribute
      * @param int $coverage
-     * @param int $id_warehouse Optional
-     * @return int time
+     * @param int|null $id_warehouse Optional
+     * @return int Number of products sold over the coverage period
      */
     public function getProductOutForCoverage($id_product, $id_product_attribute, $coverage, $id_warehouse = null);
 }

--- a/controllers/admin/AdminStockCoverController.php
+++ b/controllers/admin/AdminStockCoverController.php
@@ -365,20 +365,12 @@ class AdminStockCoverControllerCore extends AdminController
      */
     protected function getQuantitySold($id_product, $id_product_attribute, $coverage)
     {
-        $query = new DbQuery();
-        $query->select('SUM(od.product_quantity)');
-        $query->from('order_detail', 'od');
-        $query->leftJoin('orders', 'o', 'od.id_order = o.id_order');
-        $query->leftJoin('order_history', 'oh', 'o.date_upd = oh.date_add');
-        $query->leftJoin('order_state', 'os', 'os.id_order_state = oh.id_order_state');
-        $query->where('od.product_id = '.(int)$id_product);
-        $query->where('od.product_attribute_id = '.(int)$id_product_attribute);
-        $query->where('TO_DAYS("'.date('Y-m-d').' 00:00:00") - TO_DAYS(oh.date_add) <= '.(int)$coverage);
-        $query->where('o.valid = 1');
-        $query->where('os.logable = 1 AND os.delivery = 1 AND os.shipped = 1');
-
-        $quantity = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
-        return $quantity;
+        return StockManagerFactory::getManager()->getProductOutForCoverage(
+                $id_product,
+                $id_product_attribute,
+                $coverage,
+                (($this->getCurrentCoverageWarehouse() == -1) ? null : Tools::getValue('id_warehouse', -1))
+        );
     }
     
     public function initContent()


### PR DESCRIPTION
When running the Stock Cover Report from the Back Office > Stock > Stock Cover, the data in the field "Quantity Sold" is displaying either no value ("--") or an incorrect value.

In AdminStockCoverController.php in the getList method the quantity sold is calculated TWICE, in TWO different ways, resulting in two different results.

The first time quantity sold is calculated is getList in the following call:
$coverage = StockManagerFactory::getManager()->getProductCoverage.

StockManagerFactory::getManager()->getProductCoverage is used to determine the amount of stock sold over the coverage period specified then uses this value to calculate the amount of coverage required based on the amount of physical stock available.

The second time quantity sold is calculated in getList in the following call:
$qty_sold = $this->getQuantitySold($item['id_product'], $item['id'], $this->getCurrentCoveragePeriod());

Unfortunately this method performs a different query compared to that in StockManagerFactory::getManager()->getProductCoverage and yields different results to the value used in the first coverage calculation.

Based on my analysis the results reported by getQuantitySold can be significantly different (reporting no results), close or accurate depending on a variety of situations.

This fix creates a new method in StockManager with the query extracted from getProductCoverage to calculate the Product Out over the coverage period so it can be reused by AdminStockCoverController and hence return a consistent result.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Done
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-6674
| How to test?  | Run the Stock Coverage Report

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7844)
<!-- Reviewable:end -->
