### PR TITLE
Fix size of button Create category

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -354,7 +354,7 @@ var formCategory = (function() {
     },
     'hideBlock': function() {
       $('#form_step1_new_category_name').val('');
-      $('#add-category-button').css('display', 'block');
+      $('#add-category-button').show();
       $('#add-categories-content').addClass('hide');
     }
   };


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | when you click on the "create a category" button, it opens the form, then click on "cancel" or "create", the button becomes much wider.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-873
| How to test?  | Edit product in the BO and click on "Create Category"