### PR TITLE
BO: Redirect prevents errors on statuschange

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -546,8 +546,7 @@ class AdminOrdersControllerCore extends AdminController
                                     }
                                 }
                             }
-                        }
-			else{
+                        } else{
                             $this->errors[] = Tools::displayError('An error occurred while changing order status, or we were unable to send an email to the customer.');
 			}
                     } else {

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -546,10 +546,10 @@ class AdminOrdersControllerCore extends AdminController
                                     }
                                 }
                             }
-
-                            Tools::redirectAdmin(self::$currentIndex.'&id_order='.(int)$order->id.'&vieworder&token='.$this->token);
                         }
-                        $this->errors[] = Tools::displayError('An error occurred while changing order status, or we were unable to send an email to the customer.');
+			else{
+                            $this->errors[] = Tools::displayError('An error occurred while changing order status, or we were unable to send an email to the customer.');
+			}
                     } else {
                         $this->errors[] = Tools::displayError('The order has already been assigned this status.');
                     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.X
| Description?  | Redirect prevents actionOrderStatusUpdate in showing warnings
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No?
| Deprecations? | No?
| Fixed ticket? | N/A
| How to test?  | Make a module, that sets $this->errors[] in hook actionOrderStatusUpdate. Without this PR it will not show the error, when you edit 1 order, due to the redirect. If you BulkUpdate you will have the errors showing up. I Do not see any reason for this redirect to happen if and it seems to work fine without.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7850)
<!-- Reviewable:end -->
