### PR TITLE
Fix selecting category for product

### DIFF
--- a/admin-dev/themes/new-theme/public/theme.css
+++ b/admin-dev/themes/new-theme/public/theme.css
@@ -9528,9 +9528,13 @@ ul.category-tree {
   ul.category-tree .more::before {
     content: "\E5CC"; }
   ul.category-tree .category-label {
-    display: block; }
+    display: block;
+    padding-left: 0; }
     ul.category-tree .category-label .category {
-      cursor: pointer; }
+      cursor: pointer;
+      position: absolute;
+      top: 0;
+      right: -9px; }
   ul.category-tree ul {
     padding-left: 1.563rem; }
   ul.category-tree li {
@@ -10251,6 +10255,7 @@ ul.category-tree {
     overflow-x: hidden; }
     #attributes-list .attribute-group .attributes .two-columns {
       -webkit-columns: 2;
+         -moz-columns: 2;
               columns: 2; }
     #attributes-list .attribute-group .attributes .attribute .js-attribute-checkbox {
       display: none; }

--- a/admin-dev/themes/new-theme/scss/components/_category_tree.scss
+++ b/admin-dev/themes/new-theme/scss/components/_category_tree.scss
@@ -28,8 +28,12 @@ ul.category-tree {
   }
   .category-label {
     display: block;
+    padding-left: 0;
     .category {
       cursor: pointer;
+      position: absolute;
+      top: 0;
+      right: -9px;
     }
   }
   ul {

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
@@ -54,7 +54,7 @@
                    name="form[{{ form.vars.id }}][tree]"
                    value="{{ child.id_category }}" {{ checked }}
                    class="category pull-right"
-                 />
+                 >
              </label>
          </div>
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Unable to select filter by categories, where the text of the category is long. As the text covers the tick box. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2892
| How to test?  | Go to the product page in the BO and try to select category.