### PR TITLE
Add link to products for Pack

### DIFF
--- a/themes/classic/templates/catalog/_partials/miniatures/pack-product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/pack-product.tpl
@@ -28,15 +28,19 @@
       <div class="pack-product-container">
         <div class="thumb-mask">
           <div class="mask">
-            <img
-              src="{$product.cover.medium.url}"
-              alt="{$product.cover.legend}"
-              data-full-size-image-url="{$product.cover.large.url}"
-            >
+            <a href="{$product.url}" title="{$product.name}">
+              <img
+                src="{$product.cover.medium.url}"
+                alt="{$product.cover.legend}"
+                data-full-size-image-url="{$product.cover.large.url}"
+              >
+            </a>
           </div>
         </div>
         <div class="pack-product-name">
-          {$product.name}
+          <a href="{$product.url}" title="{$product.name}">
+            {$product.name}
+          </a>
         </div>
         <div class="pack-product-price">
           <strong>{$product.price}</strong>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In a pack, composed by some products, in Classic, I cannot access to the products composing the pack. There is no link to the products details or name.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1194
| How to test?  | Create a pack, and go to his details page in the FO. Name and details are links to the products.