### PR TITLE
Rounding errors for roundMode 1 specific cases

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -91,7 +91,7 @@ function formatCurrency(price, currencyFormat, currencySign, currencyBlank)
 {
   // if you modified this function, don't forget to modify the PHP function displayPrice (in the Tools.php class)
   var blank = '';
-  price = parseFloat(price.toFixed(10));
+  price = parseFloat(price.toFixed(14));
   price = ps_round(price, priceDisplayPrecision);
   if (currencyBlank > 0)
   	blank = ' ';


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x, 1.7.0.x, 1.7.1.x
| Description?  | If roundMode is 1 then for formatCurrency(77.35000000001, 2, 'lei', 1) the result is 77.34 and it should be 77.35;
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | 
| How to test?  | Test in javascript console in a product page for roundMode 1  formatCurrency(77.35000000001, 2, 'lei', 1) should return 77.35

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7859)
<!-- Reviewable:end -->
