### PR TITLE
Throw module events right after each action and remove reset

### DIFF
--- a/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
+++ b/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
@@ -55,20 +55,12 @@ class ModuleTabManagementSubscriber implements EventSubscriberInterface
         return [
             ModuleManagementEvent::INSTALL => 'onModuleInstall',
             ModuleManagementEvent::UNINSTALL => 'onModuleUninstall',
-            
-            ModuleManagementEvent::RESET => 'onModuleReset',
         ];
     }
 
     public function onModuleInstall(ModuleManagementEvent $event)
     {
         $this->moduleTabRegister->registerTabs($event->getModule());
-    }
-    
-    public function onModuleReset(ModuleManagementEvent $event)
-    {
-        $this->onModuleUninstall($event);
-        $this->onModuleInstall($event);
     }
     
     public function onModuleUninstall(ModuleManagementEvent $event)

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -165,6 +165,10 @@ class ModuleTabRegister
         if (!in_array($className.'Controller.php', $this->getModuleAdminControllersFilename($moduleName))) {
             throw new Exception(sprintf('Class "%sController" not found in controllers/admin', $className));
         }
+        // Deprecation check
+        if ($data->has('ParentClassName') && !$data->has('parent_class_name')) {
+            $this->logger->warning('Tab attribute "ParentClassName" is deprecated. You must use "parent_class_name" instead.');
+        }
         return true;
     }
 
@@ -250,7 +254,7 @@ class ModuleTabRegister
         $tab->icon = $data->get('icon');
 
         // Handle parent menu
-        $parentClassName = $data->get('ParentClassName');
+        $parentClassName = $data->get('parent_class_name', $data->get('ParentClassName'));
         if (!empty($parentClassName)) {
             $tab->id_parent = (int)$this->tabRepository->findOneIdByClassName($parentClassName);
         } elseif (true === $tab->active) {

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -135,6 +135,10 @@ class ModuleTabRegister
                 continue;
             }
 
+            if ($this->tabRepository->findOneIdByClassName($adminControllerName)) {
+                continue;
+            }
+
             $tabs[] = array(
                 'class_name' => $adminControllerName,
                 'visible' => false,

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -493,9 +493,11 @@ class ModuleManager implements AddonManagerInterface
         $module = $this->moduleRepository->getModule($name);
         try {
             if ((bool)$keep_data && method_exists($this, 'reset')) {
+                $this->dispatch(ModuleManagementEvent::UNINSTALL, $module);
                 $status = $module->onReset();
+                $this->dispatch(ModuleManagementEvent::INSTALL, $module);
             } else {
-                $status = ($module->onUninstall() && $module->onInstall());
+                $status = ($this->uninstall($name) && $this->install($name));
             }
         } catch (Exception $e) {
             throw new Exception(
@@ -508,7 +510,6 @@ class ModuleManager implements AddonManagerInterface
                 0, $e);
         }
 
-        $this->dispatch(ModuleManagementEvent::RESET, $module);
         return $status;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The 'module:reset' event made wrong data about module tabs inserted into the database. The PR fixes a bug where invoking the events after a module reset (= install then uninstall) was removing all the tabs previously removed.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | https://twitter.com/prestarocket/status/859852324780507137
| How to test?  | Reset the module module `ps_linklist`. When checking your database, the tabs details must not change except the ID.

![capture du 2017-05-04 15-19-34](https://cloud.githubusercontent.com/assets/6768917/25705305/21ba064a-30dd-11e7-9af1-2a40153a3b85.png)
