### PR TITLE
Fix recommended modules popup on legacy BO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ php:
   - 5.4
   - 5.6
   - 7.0
+  
+env:
+    global:
+        - SYMFONY_DEPRECATIONS_HELPER=disabled
 
 before_install:
   # Apache & php-fpm configuration
@@ -38,7 +42,7 @@ script:
   - bash tests/check_file_syntax.sh
   - bash travis-scripts/install-prestashop
   - php bin/phpunit -c tests/
-  - SYMFONY_DEPRECATIONS_HELPER=disabled php bin/phpunit -c tests/phpunit-admin.xml
+  - php bin/phpunit -c tests/phpunit-admin.xml
   - composer phpunit-sf
   - composer phpunit-controllers
   - bash ./travis-scripts/run-selenium-tests

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -54,11 +54,22 @@ class ModuleDataProvider
      */
     private $entityManager;
 
+    /**
+     * @var integer
+     */
+    private $employeeID;
+
     public function __construct(LoggerInterface $logger, TranslatorInterface $translator, EntityManager $entityManager = null)
     {
         $this->logger = $logger;
         $this->translator = $translator;
         $this->entityManager = $entityManager;
+        $this->employeeID = 0;
+    }
+
+    public function setEmployeeId($employeeID)
+    {
+        $this->employeeID = (int)$employeeID;
     }
 
     /**
@@ -75,17 +86,14 @@ class ModuleDataProvider
             $result['active_on_mobile'] = (bool)($this->getDeviceStatus($name) & AddonListFilterDeviceStatus::DEVICE_MOBILE);
             $lastAccessDate = '0000-00-00 00:00:00';
 
-            if (!Tools::isPHPCLI() && !is_null($this->entityManager)) {
+            if (!Tools::isPHPCLI() && !is_null($this->entityManager) && $this->employeeID) {
                 $moduleID = (int)$result['id'];
-                $legacyContext = new LegacyContext();
-                $legacyContext = $legacyContext->getContext();
-                $employeeID = (int)$legacyContext->employee->id;
 
                 $qb = $this->entityManager->createQueryBuilder();
                 $qb->select('mh')
                     ->from('PrestaShopBundle:ModuleHistory', 'mh', 'mh.idModule')
                     ->where('mh.idEmployee = ?1')
-                    ->setParameter(1, $employeeID);
+                    ->setParameter(1, $this->employeeID);
                 $query = $qb->getQuery();
                 $query->useResultCache(true);
                 $modulesHistory = $query->getResult();

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -473,6 +473,7 @@ class ModuleController extends FrameworkBundleAdminController
         $twigParams = array(
             'currentIndex' => '',
             'modulesList' => $moduleListSorted,
+            'level' => $this->authorizationLevel($this::controller_name),
         );
 
         if ($request->request->has('admin_list_from_source')) {

--- a/src/PrestaShopBundle/Controller/Admin/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ModuleController.php
@@ -502,7 +502,7 @@ class ModuleController extends FrameworkBundleAdminController
             if (!isset($modulesSelectList) || in_array($module->get('name'), $modulesSelectList)) {
                 $perm = true;
                 if ($module->get('id')) {
-                    $perm &= \Module::getPermissionStatic($module->get('id'), 'configure');
+                    $perm &= \Module::getPermissionStatic($module->get('id'), 'configure', $this->getContext()->employee);
                 } else {
                     $id_admin_module = $tabRepository->findOneIdByClassName('AdminModules');
                     $access = \Profile::getProfileAccess($this->getContext()->employee->id_profile, $id_admin_module);

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -195,6 +195,8 @@ services:
     prestashop.adapter.data_provider.module:
         class: PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider
         arguments: ["@prestashop.adapter.legacy.logger", "@translator", "@doctrine.orm.entity_manager"]
+        calls:
+                - [ "setEmployeeId", ["@=service('prestashop.adapter.legacy.context').getContext().employee?service('prestashop.adapter.legacy.context').getContext().employee.id:0"]]
 
     prestashop.categories_provider:
         class: PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/ModuleControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/ModuleControllerTest.php
@@ -78,6 +78,18 @@ class ModuleControllerTest extends WebTestCase
         $this->assertEquals($this->getExpectedErrorMessage(), $decodedContent['msg']);
     }
 
+    public function testRecommendedModules()
+    {
+        $recommendedModuleRoute = $this->router->generate('admin_module_catalog_post', array(
+            'tab_modules_list' => 'fianetsceau,trustedshops,trustedshopsintegration,ebadgeletitbuy,protectedshops,ebadgeletitbuy,emailverify,allinone_rewards,allexport,apiway,zendesk',
+        ));
+        $this->client->request('GET', $recommendedModuleRoute);
+
+        $response = $this->client->getResponse();
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
     /**
      * @return string
      */

--- a/tests/Integration/PrestaShopBundle/Test/WebTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Test/WebTestCase.php
@@ -52,7 +52,8 @@ class WebTestCase extends TestCase
         $this->translator = self::$kernel->getContainer()->get('translator');
 
         $employeeMock = $this->getMockBuilder('\Employee')
-        ->getMock();
+            ->getMock();
+        $employeeMock->id_profile = 1;
 
         $contextMock = $this->getMockBuilder('\Context')
             ->disableAutoload()
@@ -66,6 +67,12 @@ class WebTestCase extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $contextMock->language = $languageMock;
+
+        $currencyMock = $this->getMockBuilder('\Currency')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $contextMock->currency = $currencyMock;
 
         $legacyContextMock = $this->getMockBuilder('\PrestaShop\PrestaShop\Adapter\LegacyContext')
             ->setMethods([


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Make recommended modules on any legacy controller in BO work again.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Open the recommended modules and services popup. It must work instead of throwing an Error 500