### PR TITLE
Fix cldr url in tests

### DIFF
--- a/tests/Unit/Core/Cldr/RepositoryTest.php
+++ b/tests/Unit/Core/Cldr/RepositoryTest.php
@@ -44,7 +44,7 @@ class RepositoryTest extends UnitTestCase
         $this->locale = 'fr';
         $this->region = 'FR';
 
-        $provider = new RunTimeProvider(new FileProvider(new WebProvider, _PS_CACHE_DIR_.'cldr-test'));
+        $provider = new RunTimeProvider(new FileProvider(new WebProvider('http://i18n.prestashop.com/cldr/json-full/'), _PS_CACHE_DIR_.'cldr-test'));
 
         $this->repository = new Repository($provider);
         $this->localeRepository = $this->repository->locales[$this->locale];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Requesting too many times the unicode server makes your IP banned. We updated the server to use in production, but forgot it in tests.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Got the error (slow tests) after many hours of work. It depends on the unicode server