### PR TITLE
Update ps_featuredproducts.tpl

### DIFF
--- a/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
+++ b/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
@@ -26,7 +26,7 @@
   <h1 class="h1 products-section-title text-uppercase">
     {l s='Popular Products' d='Shop.Theme.Catalog'}
   </h1>
-  <div class="products">
+  <div class="products row">
     {foreach from=$products item="product"}
       {include file="catalog/_partials/miniatures/product.tpl" product=$product}
     {/foreach}


### PR DESCRIPTION
If one use the 2 column layout (left col small), the number of product per line showed in this module is less than the number of products showed in the products list, so adding the class row we can have the same behaviour of the products list.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If one use the 2 column layout (left col small), the number of product per line showed in this module is less than the number of products showed in the products list, so adding the class row we can have the same behaviour of the products list.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 
#