### PR TITLE
FO: Fix price display in case of quantity specific price

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -335,7 +335,7 @@ class ProductControllerCore extends FrontController
         $quantity_discounts = SpecificPrice::getQuantityDiscounts($id_product, $id_shop, $id_currency, $id_country, $id_group, null, true, (int)$this->context->customer->id);
         foreach ($quantity_discounts as &$quantity_discount) {
             $quantity_discount['base_price'] = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, $quantity_discount['id_product_attribute']);
-        	if ($quantity_discount['id_product_attribute']) {
+            if ($quantity_discount['id_product_attribute']) {
                 $combination = new Combination((int)$quantity_discount['id_product_attribute']);
                 $attributes = $combination->getAttributesName((int)$this->context->language->id);
                 foreach ($attributes as $attribute) {

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -334,9 +334,8 @@ class ProductControllerCore extends FrontController
 
         $quantity_discounts = SpecificPrice::getQuantityDiscounts($id_product, $id_shop, $id_currency, $id_country, $id_group, null, true, (int)$this->context->customer->id);
         foreach ($quantity_discounts as &$quantity_discount) {
-            if ($quantity_discount['id_product_attribute']) {
-                $quantity_discount['base_price'] = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, $quantity_discount['id_product_attribute']);
-
+            $quantity_discount['base_price'] = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, $quantity_discount['id_product_attribute']);
+        	if ($quantity_discount['id_product_attribute']) {
                 $combination = new Combination((int)$quantity_discount['id_product_attribute']);
                 $attributes = $combination->getAttributesName((int)$this->context->language->id);
                 foreach ($attributes as $attribute) {
@@ -346,6 +345,7 @@ class ProductControllerCore extends FrontController
             }
             if ((int)$quantity_discount['id_currency'] == 0 && $quantity_discount['reduction_type'] == 'amount') {
                 $quantity_discount['reduction'] = Tools::convertPriceFull($quantity_discount['reduction'], null, Context::getContext()->currency);
+                $quantity_discount['price'] = Tools::convertPriceFull($quantity_discount['price'], null, Context::getContext()->currency);
             }
         }
 

--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -946,7 +946,7 @@ function updateDiscountTable(newPrice)
 		if (displayDiscountPrice != 0)
 			$(this).children('td').eq(1).text( formatCurrency(discountedPrice, currencyFormat, currencySign, currencyBlank) );
 		$(this).children('td').eq(2).text(upToTxt + ' ' + formatCurrency(discountUpTo, currencyFormat, currencySign, currencyBlank));
-});
+	});
 }
 
 function serialScrollFixLock(event, targeted, scrolled, items, position)

--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -944,9 +944,9 @@ function updateDiscountTable(newPrice)
 		}
 
 		if (displayDiscountPrice != 0)
-			$(this).children('td').eq(1).text( formatCurrency(discountedPrice * currencyRate, currencyFormat, currencySign, currencyBlank) );
-		$(this).children('td').eq(2).text(upToTxt + ' ' + formatCurrency(discountUpTo * currencyRate, currencyFormat, currencySign, currencyBlank));
-	});
+			$(this).children('td').eq(1).text( formatCurrency(discountedPrice, currencyFormat, currencySign, currencyBlank) );
+		$(this).children('td').eq(2).text(upToTxt + ' ' + formatCurrency(discountUpTo, currencyFormat, currencySign, currencyBlank));
+});
 }
 
 function serialScrollFixLock(event, targeted, scrolled, items, position)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fix price display when quantity discount on combination
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7797
| How to test?  | Cf. below

Additional commit to #7644:
Fixes quantity discount on all combinations case
Fixes alternate currency case

How to test:
- define a second currency
- define a fixed specific price for all combinations of a product from quantity 2
- goto product page and select the alternate currency
- volume discount table is incorrect
- set quantity to 2, product price is incorrect

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7869)
<!-- Reviewable:end -->
