### PR TITLE
Failure during module catalog fetch do not throw an exception anymore

### DIFF
--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -183,19 +183,20 @@ class ModuleManagerBuilder
 
         self::$categoriesProvider = new CategoriesProvider($marketPlaceClient);
         self::$lecacyContext = new LegacyContext();
+        self::$legacyLogger = new LegacyLogger();
 
         if (is_null(self::$adminModuleDataProvider)) {
             self::$adminModuleDataProvider = new AdminModuleDataProvider(
                 self::$translator,
-                $this->getSymfonyRouter(),
+                self::$legacyLogger,
                 self::$addonsDataProvider,
                 self::$categoriesProvider,
                 self::$cacheProvider
             );
+            self::$adminModuleDataProvider->setRouter($this->getSymfonyRouter());
 
             self::$translator = Context::getContext()->getTranslator();
             self::$moduleDataUpdater = new ModuleDataUpdater(self::$addonsDataProvider, self::$adminModuleDataProvider);
-            self::$legacyLogger = new LegacyLogger();
             self::$moduleDataUpdater = new ModuleDataUpdater(
                 self::$addonsDataProvider,
                 self::$adminModuleDataProvider,

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -75,10 +75,12 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider
         arguments:
              - "@translator"
-             - "@router"
+             - "@logger"
              - "@prestashop.core.admin.data_provider.addons_interface"
              - "@prestashop.categories_provider"
              - "@doctrine.cache.provider"
+        calls:
+            - [ setRouter, ['@router']]
         decorates: prestashop.core.admin.data_provider.module_interface
         public: false
 

--- a/tests/Unit/Adapter/Module/AdminModuleDataProviderTest.php
+++ b/tests/Unit/Adapter/Module/AdminModuleDataProviderTest.php
@@ -52,9 +52,9 @@ class AdminModuleDataProviderTest extends UnitTestCase
         }
 
         $this->setupSfKernel();
-        $this->sfRouter = $this->sfKernel->getContainer()->get('router');
         $this->translator = $this->sfKernel->getContainer()->get('translator');
         list($this->languageISOCode) = explode('-', $this->translator->getLocale());
+        $this->logger = $this->sfKernel->getContainer()->get('logger');
 
         $this->addonsDataProviderS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider')
             ->disableOriginalConstructor()
@@ -104,7 +104,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
 
         $this->adminModuleDataProvider = new AdminModuleDataProvider(
             $this->translator,
-            $this->sfRouter,
+            $this->logger,
             $this->addonsDataProviderS,
             $this->categoriesProviderS,
             $this->cacheProviderS
@@ -158,7 +158,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
             array('convertJsonForNewCatalog'),
             array(
                 'languageISO' => $this->translator,
-                'router' => $this->sfRouter,
+                'logger' => $this->logger,
                 'addonsDataProvider' => $this->addonsDataProviderS,
                 'categoriesProvider' => $this->categoriesProviderS,
                 'cacheProvider' => $this->cacheProviderS,

--- a/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
@@ -85,7 +85,7 @@ class ModuleRepositoryTest extends UnitTestCase
             ->willReturn(true);
 
         $this->setupSfKernel();
-        $this->sfRouter = $this->sfKernel->getContainer()->get('router');
+        $this->logger = $this->sfKernel->getContainer()->get('logger');
 
         $this->apiClientS = $this->getMockBuilder('PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient')
             ->disableOriginalConstructor()
@@ -111,7 +111,7 @@ class ModuleRepositoryTest extends UnitTestCase
 
         $this->adminModuleDataProviderStub = $this->getMock('PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider',
             array('getCatalogModulesNames'),
-            array($this->translatorStub, $this->sfRouter, $this->addonsDataProviderS, $this->categoriesProviderS)
+            array($this->translatorStub, $this->logger, $this->addonsDataProviderS, $this->categoriesProviderS)
         );
 
         $this->adminModuleDataProviderStub
@@ -128,7 +128,7 @@ class ModuleRepositoryTest extends UnitTestCase
                     $this->addonsDataProviderS,
                     new AdminModuleDataProvider(
                         $this->translatorStub,
-                        $this->sfRouter,
+                        $this->logger,
                         $this->addonsDataProviderS,
                         $this->categoriesProviderS
                     )


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When something goes wrong when loading the catalog from the marketplace, and we could not fallback on the cache, we were displaying an error or we did not catch (by choice) the exception. With this PR, we now make this error silent and ALWAYS display content on the module page, even if limited.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | In the function AdminModuleDataProvider::loadCatalogData(), throw an exception right after the `try {`. From now, you will always have results on all tabs. The error will be found in the logs of PrestaShop of in the symfony debug tools.