### PR TITLE
Display translated strings properly in SF debugger!

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -8,6 +8,7 @@ imports:
 parameters:
     AdapterSecurityAdminClass: PrestaShop\PrestaShop\Adapter\Security\Admin
     translator.class: PrestaShopBundle\Translation\Translator
+    translator.data_collector: PrestaShopBundle\Translation\DataCollectorTranslator
 
 framework:
     assets:

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * 2007-2017 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2017 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class OverrideServiceCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!in_array($container->getParameter("kernel.environment"), array('dev', 'test'))) {
+            return;
+        }
+        $definition = $container->getDefinition('translator.data_collector');
+        $definition->setClass($container->getParameter('translator.data_collector'));
+    }
+}

--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -56,5 +56,6 @@ class PrestaShopBundle extends Bundle
         $container->addCompilerPass(new PopulateTranslationProvidersPass());
         $container->addCompilerPass(new RemoveXmlCompiledContainerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RouterPass(), PassConfig::TYPE_AFTER_REMOVING);
+        $container->addCompilerPass(new DependencyInjection\Compiler\OverrideServiceCompilerPass());
     }
 }

--- a/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
+++ b/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation;
+
+use Symfony\Component\Translation\DataCollectorTranslator as BaseTranslator;
+
+class DataCollectorTranslator extends BaseTranslator
+{
+    use PrestaShopTranslatorTrait;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Debugging the missing translations used to be difficult, because we changed the domain on-the-fly. But now, we know which one are actually NOT translated.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Get the PR and look at the debugger. You will now have translated strings appearing in your lists! :)

![capture du 2017-05-08 17-08-11](https://cloud.githubusercontent.com/assets/6768917/25810674/1a383202-3411-11e7-85ae-c2da63fc926a.png)
