### PR TITLE
Fix bug after removing product customization

### DIFF
--- a/classes/Customization.php
+++ b/classes/Customization.php
@@ -392,4 +392,25 @@ class CustomizationCore extends ObjectModel
 
         return true;
     }
+
+    /**
+     * Delete the current context shops langs
+     * 
+     * @param int $idCustomizationField
+     * @param int[] $shopList
+     * @return bool
+     * @throws PrestaShopDatabaseException
+     */
+    public static function deleteCustomizationFieldLangByShop($idCustomizationField, $shopList)
+    {
+        $return = Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customization_field_lang` 
+                WHERE `id_customization_field` = ' . (int)$idCustomizationField . ' 
+                AND `id_shop` IN (' . implode(',', $shopList) . ')');
+
+        if (!$return) {
+            throw new PrestaShopDatabaseException('An error occurred while deletion the customization fields lang');
+        }
+
+        return $return;
+    }
 }

--- a/classes/CustomizationField.php
+++ b/classes/CustomizationField.php
@@ -54,6 +54,7 @@ class CustomizationFieldCore extends ObjectModel
             'type' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
             'required' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => true),
             'is_module' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => false),
+            'is_deleted' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => false),
 
             /* Lang fields */
             'name' => array('type' => self::TYPE_STRING, 'lang' => true, 'required' => true, 'size' => 255),

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5188,6 +5188,7 @@ class ProductCore extends ObjectModel
 			WHERE cf.`id_product` = '.(int)$this->id.($id_lang ? ' AND cfl.`id_lang` = '.(int)$id_lang : '').
                 ($id_shop ? ' AND cfl.`id_shop` = '.(int)$id_shop : '').
                 ($front ? ' AND !cf.`is_module`' : '').'
+			AND cf.`is_deleted` = 0
 			ORDER BY cf.`id_customization_field`')) {
             return false;
         }
@@ -5202,6 +5203,25 @@ class ProductCore extends ObjectModel
         }
 
         return $customization_fields;
+    }
+
+    /**
+     * check if product has an activated and required customizationFields
+     * @return bool
+     * @throws \PrestaShopDatabaseException
+     */
+    public function hasActivatedRequiredCustomizableFields(){
+        if (!Customization::isFeatureActive()) {
+            return false;
+        }
+
+        return (bool)Db::getInstance()->executeS('
+            SELECT 1
+            FROM `' . _DB_PREFIX_ . 'customization_field`
+            WHERE `id_product` = ' . (int)$this->id . '
+            AND `required` = 1
+            AND `is_deleted` = 0'
+        );
     }
 
     public function getCustomizationFieldIds()

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -349,7 +349,7 @@ class CartControllerCore extends FrontController
             }
 
             // Check customizable fields
-            if (!$product->hasAllRequiredCustomizableFields() && !$this->customization_id) {
+            if ($product->hasActivatedRequiredCustomizableFields() && !$this->customization_id) {
                 $this->errors[] = $this->trans('Please fill in all of the required fields, and then save your customizations.', array(), 'Shop.Notifications.Error');
             }
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -684,6 +684,7 @@ CREATE TABLE `PREFIX_customization_field` (
   `type` tinyint(1) NOT NULL,
   `required` tinyint(1) NOT NULL,
   `is_module` TINYINT(1) NOT NULL DEFAULT '0',
+  `is_deleted` TINYINT(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_customization_field`),
   KEY `id_product` (`id_product`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;

--- a/install-dev/upgrade/sql/1.7.3.0.sql
+++ b/install-dev/upgrade/sql/1.7.3.0.sql
@@ -36,3 +36,5 @@ CREATE TABLE IF NOT EXISTS `PREFIX_store_lang` (
 ALTER TABLE `PREFIX_store` DROP `name`, DROP `address1`, DROP `address2`, DROP `hours`, DROP `note`;
 
 ALTER TABLE `PREFIX_feature_product` DROP PRIMARY KEY, ADD PRIMARY KEY (`id_feature`, `id_product`, `id_feature_value`);
+
+ALTER TABLE `PREFIX_customization_field` ADD `is_deleted` TINYINT(1) NOT NULL DEFAULT '0';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you remove product customization fields from product (at least one of this field had to be marked as required) then it is not possible anymore to add product to cart.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2742
| How to test?  | 1. Reinstall Prestashop<br>2. Create product<br>3. Add customization to product(mark at least one field which is required)<br>4. Go FO, fill customization field, add to cart<br>5. Back to BO and go to edit product<br>6. Remove all customization fields for previously created product and save<br>7. go to FO and add to cart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7873)
<!-- Reviewable:end -->
