### PR TITLE
Remove empty place of a deleted product in a pack of products

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
@@ -108,7 +108,7 @@
 
                     modalConfirmation.create(translate_javascripts['Are you sure to delete this?'], null, {
                         onContinue: function(){
-                            _this.parent().remove();
+                            _this.closest('li').remove();
                             if(_this.parent().parent().length == 0){
                                 $('#js_{{ form.vars.id }} h4.title-products').addClass('hide');
                             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | When a product is added then deleted in a pack of products (in BO), its place became empty and when we add another product it does not take the empty place.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1879
| How to test?  |  Create a pack of products and add three products to the pack then delete the second one