### PR TITLE
Fix attribute color list  doesn't show on product list if turning on smarty cache 

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1664,9 +1664,8 @@ class FrontControllerCore extends Controller
                         'img_col_dir' => _THEME_COL_DIR_,
                         'col_img_dir' => _PS_COL_IMG_DIR_
                     ));
-                }
-                if (isset($colors[$product['id_product']])) {
-                    $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
+                    
+                  $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
                 } else {
                     $product['color_list'] = '';
                 }
@@ -1675,7 +1674,7 @@ class FrontControllerCore extends Controller
                 $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
             }
         }
-        Tools::restoreCacheSettings();     
+        Tools::restoreCacheSettings(); 
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1654,24 +1654,28 @@ class FrontControllerCore extends Controller
 
         Tools::enableCache();
         foreach ($products as &$product) {
-            $tpl = $this->context->smarty->createTemplate(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
-            if (isset($colors[$product['id_product']])) {
-                $tpl->assign(array(
-                    'id_product'  => $product['id_product'],
-                    'colors_list' => $colors[$product['id_product']],
-                    'link'        => Context::getContext()->link,
-                    'img_col_dir' => _THEME_COL_DIR_,
-                    'col_img_dir' => _PS_COL_IMG_DIR_
-                ));
-            }
-
-            if (!in_array($product['id_product'], $products_need_cache) || isset($colors[$product['id_product']])) {
-                $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
+            if (in_array($product['id_product'], $products_need_cache)) { 
+                $tpl = $this->context->smarty->createTemplate(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
+                if (isset($colors[$product['id_product']])) {
+                    $tpl->assign(array(
+                        'id_product'  => $product['id_product'],
+                        'colors_list' => $colors[$product['id_product']],
+                        'link'        => Context::getContext()->link,
+                        'img_col_dir' => _THEME_COL_DIR_,
+                        'col_img_dir' => _PS_COL_IMG_DIR_
+                    ));
+                }
+                if (isset($colors[$product['id_product']])) {
+                    $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
+                } else {
+                    $product['color_list'] = '';
+                }
             } else {
-                $product['color_list'] = '';
+                $tpl = $this->context->smarty->createTemplate(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
+                $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
             }
         }
-        Tools::restoreCacheSettings();
+        Tools::restoreCacheSettings();     
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1651,10 +1651,10 @@ class FrontControllerCore extends Controller
         if (count($products_need_cache)) {
             $colors = Product::getAttributesColorList($products_need_cache);
         }
-
-        Tools::enableCache();
+        
         foreach ($products as &$product) {
             if (in_array($product['id_product'], $products_need_cache)) { 
+                Tools::enableCache();
                 $tpl = $this->context->smarty->createTemplate(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
                 if (isset($colors[$product['id_product']])) {
                     $tpl->assign(array(
@@ -1669,12 +1669,13 @@ class FrontControllerCore extends Controller
                 } else {
                     $product['color_list'] = '';
                 }
+                Tools::restoreCacheSettings();
             } else {
                 $tpl = $this->context->smarty->createTemplate(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
                 $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
             }
         }
-        Tools::restoreCacheSettings();
+        
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1674,7 +1674,7 @@ class FrontControllerCore extends Controller
                 $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_.'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
             }
         }
-        Tools::restoreCacheSettings(); 
+        Tools::restoreCacheSettings();
     }
 
     /**


### PR DESCRIPTION
 

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.x
| Description?  | attribute color list  doen't show on product list if turning on smarty cache 
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-6778
| How to test?  | turn on smarty cache

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
