### PR TITLE
Remove target blank from profile link

### DIFF
--- a/admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl
@@ -34,7 +34,7 @@
       <span>{$employee->firstname} {$employee->lastname}</span>
     </div>
     <hr>
-    <a class="employee-link profile-link" href="{$link->getAdminLink('AdminEmployees')|escape:'html':'UTF-8'}&amp;id_employee={$employee->id|intval}&amp;updateemployee" target="_blank">
+    <a class="employee-link profile-link" href="{$link->getAdminLink('AdminEmployees')|escape:'html':'UTF-8'}&amp;id_employee={$employee->id|intval}&amp;updateemployee">
       <i class="material-icons">settings_applications</i> {l s='Your profile'}
     </a>
     <a class="employee-link m-t-1" id="header_logout" href="{$login_link|escape:'html':'UTF-8'}&amp;logout">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Remove the target blank when opening the employee profile from header
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | --
| How to test?  | Go to one of the new pages (catalog, translation...) and click on "your profile". It should open in the same page.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->


