### PR TITLE
Set allow_url_fopen mandatory

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -88,6 +88,7 @@ class ConfigurationTestCore
                 'simplexml' => false,
                 'zip' => false,
                 'fileinfo' => false,
+                'fopen' => false,
             ));
         }
 
@@ -104,7 +105,6 @@ class ConfigurationTestCore
     {
         return array(
             'new_phpversion' => false,
-            'fopen' => false,
             'gz' => false,
             'mbstring' => false,
             'dom' => false,

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -103,6 +103,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                         'simplexml' => $this->translator->trans('SimpleXML extension is not loaded', array(), 'Install'),
                         'zip' => $this->translator->trans('ZIP extension is not enabled', array(), 'Install'),
                         'fileinfo' => $this->translator->trans('Fileinfo extension is not enabled', array(), 'Install'),
+                        'fopen' => $this->translator->trans('Cannot open external URLs (requires allow_url_fopen as On)', array(), 'Install'),
                     )
                 ),
                 array(
@@ -144,7 +145,6 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                     'title' => $this->translator->trans('Recommended PHP parameters', array(), 'Install'),
                     'success' => $this->tests['optional']['success'],
                     'checks' => array(
-                        'fopen' => $this->translator->trans('Cannot open external URLs', array(), 'Install'),
                         'gz' => $this->translator->trans('GZIP compression is not activated', array(), 'Install'),
                         'mbstring' => $this->translator->trans('Mbstring extension is not enabled', array(), 'Install'),
                         'dom' => $this->translator->trans('Dom extension is not loaded', array(), 'Install'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We have report of missing cert file on the module page. This is actually because of a PHP variable not set as `On`. This PR adds it to the mandatory list in order to avoid errors later. It is not on the branch 1.7.1.x because of a string update.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Yep, a optional condition is not mandatory in the installer 
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2998
| How to test?  | Disable `allow_url_fopen` in your php.ini and try the installer. You must have the message "incompatible system"

### Before
![capture du 2017-05-11 16-27-29](https://cloud.githubusercontent.com/assets/6768917/25959559/e7fb98c6-366b-11e7-8636-ccc7cec8ce57.png)


### After
![capture du 2017-05-11 17-00-15](https://cloud.githubusercontent.com/assets/6768917/25959567/ebacddae-366b-11e7-9271-f660b3053164.png)
