### PR TITLE
Fix getPathFromUri() when uri contains slashes

### DIFF
--- a/src/Adapter/Assets/AssetUrlGeneratorTrait.php
+++ b/src/Adapter/Assets/AssetUrlGeneratorTrait.php
@@ -40,8 +40,11 @@ trait AssetUrlGeneratorTrait
 
     protected function getPathFromUri($fullUri)
     {
-        if ('' !== ($trimmedUri = rtrim($this->configuration->get('__PS_BASE_URI__'), '/'))) {
-            return $this->configuration->get('_PS_ROOT_DIR_').preg_replace('/\\'.$trimmedUri.'/', '', $fullUri, 1);
+        $trimmedUri = rtrim($this->configuration->get('__PS_BASE_URI__'), '/');
+
+        if ('' !== $trimmedUri) {
+            $uri = str_replace('/', '\\/', $trimmedUri);
+            return $this->configuration->get('_PS_ROOT_DIR_').preg_replace('/'.$uri.'/', '', $fullUri, 1);
         }
 
         return $this->configuration->get('_PS_ROOT_DIR_').$fullUri;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When slashes are not escaped you get: Warning: preg_replace(): Unknown modifier.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | I have installed PS in localhost/demo/develop directory and got this exception.

