### PR TITLE
CO: Attribute's EAN in the friendly URLS

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -161,11 +161,10 @@ class LinkCore
             $product = $this->getProductObject($product, $idLang, $idShop);
         }
         $product_attribute_ean = null;
-        if ($ipa) {
+        if ($ipa && is_numeric($ipa)) {
             // get ean from product attribute
-            $id_product_attribute = (int) $ipa;
-            $product_attribute_eans = Db::getInstance()->executeS('SELECT `ean13` FROM `'._DB_PREFIX_.'product_attribute` pa WHERE pa.id_product_attribute='.$id_product_attribute);
-            $product_attribute_ean = (empty($product_attribute_eans) ? null : (int) $product_attribute_eans[0]['ean13']);
+            $product_attribute_eans = Db::getInstance()->executeS('SELECT `ean13` FROM `'._DB_PREFIX_.'product_attribute` pa WHERE pa.id_product_attribute='.$ipa);
+            $product_attribute_ean = ((empty($product_attribute_eans) || !is_numeric($product_attribute_eans[0]['ean13'])) ? null : $product_attribute_eans[0]['ean13']);
         }
         $params['ean13'] = (!$ean13) ? (!$product_attribute_ean) ? $product->ean13 : $product_attribute_ean: $ean13;
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'meta_keywords', $idShop)) {

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -160,7 +160,14 @@ class LinkCore
         if (!$ean13) {
             $product = $this->getProductObject($product, $idLang, $idShop);
         }
-        $params['ean13'] = (!$ean13) ? $product->ean13 : $ean13;
+        $product_attribute_ean = null;
+        if ($ipa) {
+            // get ean from product attribute
+            $id_product_attribute = (int) $ipa;
+            $product_attribute_eans = Db::getInstance()->executeS('SELECT `ean13` FROM `'._DB_PREFIX_.'product_attribute` pa WHERE pa.id_product_attribute='.$id_product_attribute);
+            $product_attribute_ean = (empty($product_attribute_eans) ? null : (int) $product_attribute_eans[0]['ean13']);
+        }
+        $params['ean13'] = (!$ean13) ? (!$product_attribute_ean) ? $product->ean13 : $product_attribute_ean: $ean13;
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'meta_keywords', $idShop)) {
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['meta_keywords'] = Tools::str2url($product->getFieldByLang('meta_keywords'));


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "develop"
| Description?  | CO: Show product attribute's ean in the product's friendly url if there is one set
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3032
| How to test?  | Create a product with multiple attributes, each attribute with EAN. Go to product page and check if the EAN part of the URL changes when you select another product variant