### PR TITLE
Subrequest error in SQL Manager

### DIFF
--- a/classes/RequestSql.php
+++ b/classes/RequestSql.php
@@ -416,7 +416,7 @@ class RequestSqlCore extends ObjectModel
         $nb = count($select);
         for ($i = 0; $i < $nb; $i++) {
             $attribut = $select[$i];
-            if ($attribut['base_expr'] != '*' && !preg_match('/\.*$/', $attribut['base_expr'])) {
+            if ($attribut['base_expr'] != '*' && !preg_match('/\.$/', $attribut['base_expr'])) {
                 if ($attribut['expr_type'] == 'colref') {
                     if ($attr = $this->cutAttribute(trim($attribut['base_expr']), $from)) {
                         if (!$this->attributExistInTable($attr['attribut'], $attr['table'])) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "1.6.1.x"
| Description?  | When creating an SQL query containing a "WHERE [...] IN ([...])" statement, Prestashop responds with the error "The "*" operator cannot be used in a nested query.". The regex condition that checks whether the column name ends with a "." is in fault : "/\.\*$/" should be "/\.$/" in method checkedSelect.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a simple request as with a subquery in the SQL Manager:<br />SELECT id_product<br />FROM lbo16_product<br />WHERE id_product IN (SELECT id_product FROM lbo16_image WHERE cover = 1)
