### PR TITLE
Allow filtering of modules by display name inside the translations controller

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -176,10 +176,10 @@
       <div class="form-group" id="ps_module_selector">
         <label class="control-label col-lg-3" for="selected-modules">{l s='Select your module'}</label>
         <div class="col-lg-4">
-          <select name="selected-modules">
+          <select name="selected-modules" class="chosen">
             <option id="no-module" value="">---</option>
             {foreach $modules as $module}
-              <option value="{$module.name}" data-url-to-translate="{$module.urlToTranslate}">{$module.name}</option>
+              <option value="{$module.name}" data-url-to-translate="{$module.urlToTranslate}">{$module.displayName}</option>
             {/foreach}
           </select>
         </div>

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -217,16 +217,17 @@ class AdminTranslationsControllerCore extends AdminController
         }
 
         $modules = array();
-        foreach ($this->getListModules() as $module) {
-            $modules[$module] = array(
-                'name' => $module,
-                'urlToTranslate' => !$this->isUsingNewTranslationsSystem($module) ? $this->context->link->getAdminLink(
+        foreach ($this->getListModules(true) as $module) {
+            $modules[$module->name] = array(
+                'name' => $module->name,
+                'displayName' => $module->displayName,
+                'urlToTranslate' => !$this->isUsingNewTranslationsSystem($module->name) ? $this->context->link->getAdminLink(
                     'AdminTranslations',
                     true,
                     array(),
                     array(
                         'type' => 'modules',
-                        'module' => $module,
+                        'module' => $module->name,
                     )
                 ) : '',
             );
@@ -2161,7 +2162,7 @@ class AdminTranslationsControllerCore extends AdminController
      * @return array List of modules
      * @throws PrestaShopException
      */
-    public function getListModules()
+    public function getListModules($withInstance = false)
     {
         if (!Tools::file_exists_cache($this->translations_informations['modules']['dir'])) {
             throw new PrestaShopException($this->trans('Fatal error: The module directory does not exist.', array(), 'Admin.Notifications.Error').'('.$this->translations_informations['modules']['dir'].')');
@@ -2173,6 +2174,18 @@ class AdminTranslationsControllerCore extends AdminController
         $modules = array();
         // Get all module which are installed for to have a minimum of POST
         $modules = Module::getModulesInstalled();
+        if ($withInstance) {
+            foreach ($modules as $module) {
+                if ($tmp_instance = Module::getInstanceById((int)$module['id_module'])) {
+                    // We want to be able to sort modules by display name
+                    $module_instances[$tmp_instance->displayName] = $tmp_instance;
+                }
+            }
+            ksort($module_instances);
+
+            return $module_instances;
+        }
+
         foreach ($modules as &$module) {
             $module = $module['name'];
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow filtering module by display name inside the "Translations" controller as we did in the "Modules positions" one.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Fetch this PR and see the difference (as shown in screens) in Translations controller.

**Before**:
![before](https://cloud.githubusercontent.com/assets/1162527/26035721/fb726652-38d0-11e7-9090-8ae392c51de8.png)

**After**:
![after](https://cloud.githubusercontent.com/assets/1162527/26035722/feb12434-38d0-11e7-8a06-99015f1d5312.png)
