### PR TITLE
Set value for Short Desc

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -110,15 +110,15 @@
   <configuration id="PS_PRODUCT_PICTURE_HEIGHT" name="PS_PRODUCT_PICTURE_HEIGHT">
     <value>64</value>
   </configuration>
-    <configuration id="PS_INVOICE_PREFIX" name="PS_INVOICE_PREFIX">
-      <value>#IN</value>
-    </configuration>
-    <configuration id="PS_INVCE_INVOICE_ADDR_RULES" name="PS_INVCE_INVOICE_ADDR_RULES">
-      <value>{"avoid":[]}</value>
-    </configuration>
-    <configuration id="PS_INVCE_DELIVERY_ADDR_RULES" name="PS_INVCE_DELIVERY_ADDR_RULES">
-      <value>{"avoid":[]}</value>
-    </configuration>
+  <configuration id="PS_INVOICE_PREFIX" name="PS_INVOICE_PREFIX">
+    <value>#IN</value>
+  </configuration>
+  <configuration id="PS_INVCE_INVOICE_ADDR_RULES" name="PS_INVCE_INVOICE_ADDR_RULES">
+    <value>{"avoid":[]}</value>
+  </configuration>
+  <configuration id="PS_INVCE_DELIVERY_ADDR_RULES" name="PS_INVCE_DELIVERY_ADDR_RULES">
+    <value>{"avoid":[]}</value>
+  </configuration>
   <configuration id="PS_DELIVERY_PREFIX" name="PS_DELIVERY_PREFIX">
     <value>#DE</value>
   </configuration>
@@ -816,6 +816,9 @@ Country</value>
     </configuration>
     <configuration id="PS_MAINTENANCE_TEXT" name="PS_MAINTENANCE_TEXT">
       <value/>
+    </configuration>
+    <configuration id="PS_PRODUCT_SHORT_DESC_LIMIT" name="PS_PRODUCT_SHORT_DESC_LIMIT">
+      <value>800</value>
     </configuration>
   </entities>
 </entity_configuration>


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Default value of PS_PRODUCT_SHORT_DESC_LIMIT is set to 800, according to the error message
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Reinstall, see if the value un AdminPPreferences is set to 800, try to put a value in the product Short Description between 400 and 800, see if it's ok

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
