### PR TITLE
Fix error in error message when no address available

### DIFF
--- a/themes/classic/templates/_partials/notifications.tpl
+++ b/themes/classic/templates/_partials/notifications.tpl
@@ -55,7 +55,7 @@
         <article class="alert alert-success" role="alert" data-alert="success">
           <ul>
             {foreach $notifications.success as $notif}
-              <li>{$notif}</li>
+              <li>{$notif nofilter}</li>
             {/foreach}
           </ul>
         </article>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | There is a badly displayed message in the address page
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3033
| How to test?  | 1. Go to Classic<br/>2. Your Account<br/>3. If you have an address, delete it (if you don't have one, create and delete it)<br/>4. refresh the page