### PR TITLE
Fix branch checkout for starter theme

### DIFF
--- a/travis-scripts/test-startertheme
+++ b/travis-scripts/test-startertheme
@@ -2,8 +2,13 @@
 
 rm -Rf themes/classic
 git clone https://github.com/PrestaShop/StarterTheme themes/StarterTheme
-git fetch origin
-git checkout $TRAVIS_BRANCH
+cd themes/StarterTheme
+# We switch to the same branch on the StarterTheme repo, but only if it exists.
+git branch -r | grep -P "(^|\s)\Korigin/$TRAVIS_BRANCH(?=\s|$)"
+if [ $? -eq 0 ]; then
+    git checkout $TRAVIS_BRANCH
+fi
+cd $TRAVIS_BUILD_DIR
 cp themes/StarterTheme/config/theme.dist.yml themes/StarterTheme/config/theme.yml
 bash ./travis-scripts/install-prestashop
 bash ./travis-scripts/run-selenium-tests


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | Woups, it appeared that we didn't execute `git checkout` on the proper folder. During the tests, we are supposed to clone the StarterTheme repository and checkout the same branch as PrestaShop. Unfortunately, a `cd` was missing to go in the theme folder ...
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Travis logs should not show modified files when checking another branch of the StarterTheme repository