### PR TITLE
Prevent disabled modules from executing on displayBackOfficeHeader

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -585,8 +585,8 @@ class HookCore extends ObjectModel
             $sql->from('module', 'm');
             if ($hook_name != 'displayBackOfficeHeader') {
                 $sql->join(Shop::addSqlAssociation('module', 'm', true, 'module_shop.enable_device & '.(int)Context::getContext()->getDevice()));
-                $sql->innerJoin('module_shop', 'ms', 'ms.`id_module` = m.`id_module`');
             }
+            $sql->innerJoin('module_shop', 'ms', 'ms.`id_module` = m.`id_module`');
             $sql->innerJoin('hook_module', 'hm', 'hm.`id_module` = m.`id_module`');
             $sql->innerJoin('hook', 'h', 'hm.`id_hook` = h.`id_hook`');
             if ($hook_name != 'paymentOptions') {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Type?         | bug fix
| Category?     | CO
| Description? | A disabled module will still have its displayBackOfficeHeader hook executed, this fix will prevent this issue. Honestly, I don't know why it worked :D as I didn't debug further but it was my first try after step debugging. This also occurs on 1.6.
| BC breaks?    | no
| Deprecations? | no