### PR TITLE
Fix moving module from a hook to another one

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
@@ -84,6 +84,7 @@
 			{if $edit_graft}
 				<input type="hidden" name="id_module" value="{$id_module}" />
 				<input type="hidden" name="id_hook" value="{$id_hook}" />
+				<input type="hidden" name="new_hook" id="new_hook" value="{$id_hook}" />
 			{/if}
 			<button type="submit" name="{if $edit_graft}submitEditGraft{else}submitAddToHook{/if}" id="{$table}_form_submit_btn" class="btn btn-default pull-right"><i class="process-icon-save"></i> {l s='Save' d='Admin.Actions'}</button>
 		</div>
@@ -118,6 +119,9 @@
 		});
 		$('form[id="hook_module_form"] select[id^="em_list_"]').each(function(){
 			$(this).change(position_exception_listchange);
+		});
+		$('select[name=id_hook]').on('change', function() {
+			$('#new_hook').attr('value', $(this).val());
 		});
 	});
 	//]]>

--- a/controllers/admin/AdminModulesPositionsController.php
+++ b/controllers/admin/AdminModulesPositionsController.php
@@ -123,13 +123,26 @@ class AdminModulesPositionsControllerCore extends AdminController
                 $id_module = (int)Tools::getValue('id_module');
                 $module = Module::getInstanceById($id_module);
                 $id_hook = (int)Tools::getValue('id_hook');
-                $hook = new Hook($id_hook);
+                $new_hook = (int)Tools::getValue('new_hook');
+                $hook = new Hook($new_hook);
 
                 if (!$id_module || !Validate::isLoadedObject($module)) {
                     $this->errors[] = $this->trans('This module cannot be loaded.', array(), 'Admin.Modules.Notification');
                 } elseif (!$id_hook || !Validate::isLoadedObject($hook)) {
                     $this->errors[] = $this->trans('Hook cannot be loaded.', array(), 'Admin.Modules.Notification');
                 } else {
+                    if ($new_hook !== $id_hook) {
+                        /** Connect module to a newer hook */
+                        if (!$module->registerHook($hook->name, Shop::getContextListShopID())) {
+                            $this->errors[] = $this->trans('An error occurred while transplanting the module to its hook.', array(), 'Admin.Modules.Notification');
+                        }
+                        /** Unregister module from hook & exceptions linked to module */
+                        if (!$module->unregisterHook($id_hook, Shop::getContextListShopID())
+                            || !$module->unregisterExceptions($id_hook, Shop::getContextListShopID())) {
+                            $this->errors[] = $this->trans('An error occurred while deleting the module from its hook.', array(), 'Admin.Modules.Notification');
+                        }
+                        $id_hook = $new_hook;
+                    }
                     $exceptions = Tools::getValue('exceptions');
                     if (is_array($exceptions)) {
                         foreach ($exceptions as $id => $exception) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you try to move a module from a hook to another one, although you get no error, the module stay attached to the old hook
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2509
| How to test?  | Go to BO Appearance ->  Position and try to edit a module and attach it to another hook.