### PR TITLE
Initialize getSynopsisDetails() output as an array instead of ''

### DIFF
--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -706,7 +706,7 @@ class WebserviceOutputBuilderCore
 
     public function getSynopsisDetails($field)
     {
-        $arr_details = '';
+        $arr_details = array();
         if (array_key_exists('required', $field) && $field['required']) {
             $arr_details['required'] = 'true';
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I was getting errors trying to access /api/products?schema=blank in the resulting XML: &lt;error&gt;&lt;code&gt;&lt;![CDATA[3]]&gt;&lt;/code&gt;&lt;message&gt;&lt;![CDATA[[PHP Warning #2] Illegal string offset 'required' (/home/gaspy/www/cbi/emdm_2.1/www/classes/webservice/WebserviceOutputBuilder.php, line 711)]]&gt;&lt;/message&gt;&lt;/error&gt; While developing, I have PHP in a paranoid mode, complaining about every little error.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | In my case, create an API key for products (that's the resource i found the error), and then: curl -k -vv --basic -u "APIKEY:" https://shopurl/api/products?schema=blank

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
