### PR TITLE
Edit address for a Guest

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -73,7 +73,7 @@ class CustomerAddressFormCore extends AbstractForm
             return Tools::redirect('index.php?controller=404');
         }
 
-        if (!$context->customer->isLogged()) {
+        if (!$context->customer->isLogged() && !$context->customer->isGuest() ) {
             return Tools::redirect('/index.php?controller=authentication');
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you are a Guest in front, you take order without create a account. First when you take ordre, you create your adresse, Then if you want modify adresse, you can't do that, the guest is redirect on authentification's page. 
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3039
| How to test?  | Create an order, don't create an account, fill the adresse form, and after validation, come back for edit your address.