### PR TITLE
Fix taxes in credit slip

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2282,13 +2282,8 @@ class OrderCore extends ObjectModel
                 $order_discount_tax_excl -= $order_cart_rule['value_tax_excl'];
             }
         }
-
-        $products_tax    = $this->total_products_wt - $this->total_products;
-        $discounts_tax    = $this->total_discounts_tax_incl - $this->total_discounts_tax_excl;
-
-        // We add $free_shipping_tax because when there is free shipping, the tax that would
-        // be paid if there wasn't is included in $discounts_tax.
-        $expected_total_tax = $products_tax - $discounts_tax + $free_shipping_tax;
+        
+        $expected_total_tax = $this->total_products_wt - $this->total_products;
         $actual_total_tax = 0;
         $actual_total_base = 0;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | There was some kind of calculation issue in invoice-tax-tab of a credit slip, when it is generated from an order which have a discount code.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8211
| How to test?  | Add a cart rule (apply a discount of 50% for example) and enable returns in "Orders/Merchandise Returns". Create an order of two products (tax incl) then, modify the order status to "Shipped", return one of the two products and generate a credit slip.