### PR TITLE
Changed SearchController extend to allow override

### DIFF
--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -27,7 +27,7 @@
  use PrestaShop\PrestaShop\Core\Product\Search\SortOrder;
  use PrestaShop\PrestaShop\Adapter\Search\SearchProductSearchProvider;
 
- class SearchControllerCore extends ProductListingFrontControllerCore
+ class SearchControllerCore extends ProductListingFrontController
  {
      public $php_self = 'search';
      public $instant_search;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Class "SearchControllerCore" (/controllers/front/listing/SearchController.php) extends ProductListingFrontControllerCore when every other class from this directory extends ProductListingFrontController (no "Core" suffix), preventing override.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2994
| How to test?  | Override a function in ProductListingFrontController and test if it is called

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
