### PR TITLE
Reuse symfony translator in legacy context if instantiated

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -27,6 +27,7 @@
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShopBundle\Translation\TranslatorComponent as Translator;
 use PrestaShopBundle\Translation\Loader\SqlTranslationLoader;
 
@@ -345,6 +346,12 @@ class ContextCore
     {
         if (null !== $this->translator) {
             return $this->translator;
+        }
+
+        $sfContainer = SymfonyContainer::getInstance();
+        if (!is_null($sfContainer)) {
+            $sfTranslator = $sfContainer->get('translator');
+            $sfTranslator->setLocale($this->language->locale);
         }
 
         $cacheDir = _PS_CACHE_DIR_.'translations';


### PR DESCRIPTION
- [ ] https://github.com/PrestaShop/ps_linklist/pull/36 must be merged first!

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Prevent multiple loads of the translator if Symfony did the job.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | Check of `Context::getTranslator()` type must be compared to `Symfony\Component\Translation\TranslatorInterface`
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | You can add a dump() in the constructor of Translator, and check it is not called two times.