### PR TITLE
Fix trans errors of old translation page

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -38,8 +38,8 @@
 			{if $limit_warning['error_type'] == 'suhosin'}
 				{l s='Warning! Your hosting provider is using the Suhosin patch for PHP, which limits the maximum number of fields allowed in a form:' d='Admin.International.Notification'}
 
-      {l s='%limit% for suhosin.post.max_vars.' sprintf=['%limit%' => '<b>'|cat:$limit_warning['post.max_vars'|cat:'</b>'] d='Admin.International.Notification'}<br/>
-      {l s='%limit% for suhosin.request.max_vars.' sprintf=['%limit%' => '<b>'|cat:$limit_warning['request.max_vars'|cat:'</b>'] d='Admin.International.Notification'}<br/>
+      {l s='%limit% for suhosin.post.max_vars.' sprintf=['%limit%' => '<b>'|cat:$limit_warning['post.max_vars']|cat:'</b>'] d='Admin.International.Notification'}<br/>
+      {l s='%limit% for suhosin.request.max_vars.' sprintf=['%limit%' => '<b>'|cat:$limit_warning['request.max_vars']|cat:'</b>'] d='Admin.International.Notification'}<br/>
       {l s='Please ask your hosting provider to increase the Suhosin limit to' d='Admin.International.Notification'}
 			{else}
 				{l s='Warning! Your PHP configuration limits the maximum number of fields allowed in a form:' d='Admin.International.Notification'}<br/>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
@@ -36,8 +36,8 @@
 		{if $limit_warning['error_type'] == 'suhosin'}
 			{l s='Warning! Your hosting provider is using the Suhosin patch for PHP, which limits the maximum number of fields allowed in a form:' d='Admin.International.Notification'}
 
-      {l s='%limit% for suhosin.post.max_vars.' sprintf=['%limit%' => '<b>'|cat:$limit_warning['post.max_vars'|cat:'</b>'] d='Admin.International.Notification'}<br/>
-      {l s='%limit% for suhosin.request.max_vars.' sprintf=['%limit%' => '<b>'|cat:$limit_warning['request.max_vars'|cat:'</b>'] d='Admin.International.Notification'}<br/>
+      {l s='%limit% for suhosin.post.max_vars.' sprintf=['%limit%' => '<b>'|cat:$limit_warning['post.max_vars']|cat:'</b>'] d='Admin.International.Notification'}<br/>
+      {l s='%limit% for suhosin.request.max_vars.' sprintf=['%limit%' => '<b>'|cat:$limit_warning['request.max_vars']|cat:'</b>'] d='Admin.International.Notification'}<br/>
       {l s='Please ask your hosting provider to increase the Suhosin limit to' d='Admin.International.Notification'}
 		{else}
 			{l s='Warning! Your PHP configuration limits the maximum number of fields allowed in a form:' d='Admin.International.Notification'}<br/>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes some issues introduced by #7882
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Try to translate an old module or a non-native one. You will get the following error:

![capture du 2017-05-25 15-53-20](https://cloud.githubusercontent.com/assets/6768917/26455606/9f479dee-4162-11e7-920b-057775452861.png)
