### PR TITLE
Fix redirection when filtering in attribute's value

### DIFF
--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -482,6 +482,10 @@ class AdminAttributesGroupsControllerCore extends AdminController
             } elseif ($this->display != 'view' && !$this->ajax) {
                 $this->content .= $this->renderList();
                 $this->content .= $this->renderOptions();
+                /** reset all attributes filter */
+                if (!Tools::getValue('submitFilterattribute_group', 0) && !Tools::getIsset('id_attribute_group')) {
+                    $this->processResetFilters('attribute_values');
+                }
             } elseif ($this->display == 'view' && !$this->ajax) {
                 $this->content = $this->renderView();
             }
@@ -715,6 +719,11 @@ class AdminAttributesGroupsControllerCore extends AdminController
             $this->table = 'attribute';
             $this->className = 'Attribute';
             $this->identifier = 'id_attribute';
+        }
+
+        /** set location with current index */
+        if (Tools::getIsset('id_attribute_group') && Tools::getIsset('viewattribute_group')) {
+            self::$currentIndex = self::$currentIndex . '&id_attribute_group=' . Tools::getValue('id_attribute_group', 0) . '&viewattribute_group';
         }
 
         // If it's an attribute, load object Attribute()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When filtering a value under the attributes and values tab or turning to a next page, prestashop always returns to the main attributes and values page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2776
| How to test?  | 1- Just try to filter for a value under an attribute group that has values. 2- Create values for "attributes" or "features" on more than one page and try to go on the other pages 