### PR TITLE
Fix displayed price on cart (HT/TTC)

### DIFF
--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -295,12 +295,13 @@ class CartPresenter implements PresenterInterface
         $total_excluding_tax = $cart->getOrderTotal(false);
         $total_including_tax = $cart->getOrderTotal(true);
         $total_discount = $cart->getDiscountSubtotalWithoutGifts();
+        $totalCartAmount = $cart->getOrderTotal($this->includeTaxes(), Cart::ONLY_PRODUCTS);
 
         $subtotals['products'] = array(
             'type' => 'products',
             'label' => $this->translator->trans('Subtotal', array(), 'Shop.Theme.Checkout'),
-            'amount' => $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS),
-            'value' => $this->priceFormatter->format(($cart->getOrderTotal($this->includeTaxes(), Cart::ONLY_PRODUCTS))),
+            'amount' => $totalCartAmount,
+            'value' => $this->priceFormatter->format($totalCartAmount),
         );
 
         if ($total_discount) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the order process, the subtotal is shown Tax Incl and should be Tax Excl when customer group is set to "display prices in Tax Excl".
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2140
| How to test?  | Set customer group to "display prices in Tax Excl" and go to cart in FO.