### PR TITLE
Make the sub-categories disabled when you edit the category

### DIFF
--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -5,6 +5,35 @@ var Tree = function (element, options)
 	this.init();
 };
 
+function getCategoryById(param) {
+	var elem = null;
+	$('input[name=id_parent]').each(function (index) {
+		if ($(this).val() === param + '') {
+			elem = $(this);
+		}
+	});
+	return elem;
+}
+
+function disableTreeItem(item) {
+	item.find('input[name=id_parent]').attr('disabled', 'disabled');
+	if (item.hasClass('tree-folder')) {
+		item.find('span.tree-folder-name').addClass('tree-folder-name-disable');
+		item.find('ul li').each(function (index) {
+			disableTreeItem($(this));
+		});
+	} else if (item.hasClass('tree-item')) {
+		item.addClass('tree-item-disable');
+	}
+
+}
+
+function organizeTree() {
+	var id = $('#id_category').val();
+	var item = getCategoryById(id).parent().parent();
+	disableTreeItem(item);
+}
+
 Tree.prototype =
 {
 	constructor: Tree,
@@ -163,6 +192,7 @@ Tree.prototype =
 				function(content)
 				{
 					$('#'+idTree).html(content);
+					organizeTree();
 					$('#'+idTree).tree('init');
 					that.$element.find("label.tree-toggler").each(
 						function()

--- a/classes/helper/HelperTreeCategories.php
+++ b/classes/helper/HelperTreeCategories.php
@@ -59,15 +59,42 @@ class HelperTreeCategoriesCore extends TreeCore
         $this->setUseShopRestriction($use_shop_restriction);
     }
 
-    private function fillTree(&$categories, $id_category)
+    private function fillTree(&$categories, $rootCategoryId)
     {
         $tree = array();
-        foreach ($categories[$id_category] as $category) {
-            $tree[$category['id_category']] = $category;
-            if (!empty($categories[$category['id_category']])) {
-                $tree[$category['id_category']]['children'] = $this->fillTree($categories, $category['id_category']);
-            } elseif ($result = Category::hasChildren($category['id_category'], $this->getLang(), false, $this->getShop()->id)) {
-                $tree[$category['id_category']]['children'] = array($result[0]['id_category'] => $result[0]);
+        $rootCategoryId = (int)$rootCategoryId;
+
+        foreach ($categories[$rootCategoryId] as $category) {
+            $categoryId = (int)$category['id_category'];
+            $tree[$categoryId] = $category;
+
+            if (Category::hasChildren($categoryId, $this->getLang(), false, $this->getShop()->id)) {
+                $categoryChildren = Category::getChildren(
+                    $categoryId,
+                    $this->getLang(),
+                    false,
+                    $this->getShop()->id
+                );
+
+                foreach ($categoryChildren as $index => $child) {
+                    $childId = (int)$child['id_category'];
+
+                    if (!array_key_exists('children', $tree[$categoryId])) {
+                        $tree[$categoryId]['children'] = array($childId => $child);
+                    } else {
+                        $tree[$categoryId]['children'][$childId] = $child;
+                    }
+
+                    $categories[$childId] = array($child);
+                }
+
+                foreach ($tree[$categoryId]['children'] as $childId => $child) {
+                    $subtree = $this->fillTree($categories, $childId);
+
+                    foreach ($subtree as $subcategoryId => $subcategory) {
+                        $tree[$categoryId]['children'][$subcategoryId] = $subcategory;
+                    }
+                }
             }
         }
         return $tree;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | the problem is that category will be deleted when you try to add main cat to sub-category
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8220 and http://forge.prestashop.com/browse/BOOM-3114
| How to test?  | try to edit a category, you will find all its sub-categories are disabled, so you can't add to one of its sub-cat.