### PR TITLE
Fixed adminorders concat statement not selecting customer firstname

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -59,7 +59,7 @@ class AdminOrdersControllerCore extends AdminController
         $this->_select = '
 		a.id_currency,
 		a.id_order AS id_pdf,
-		CONCAT(LEFT(c.`firstname`, 1), \'. \', c.`lastname`) AS `customer`,
+        CONCAT_WS(\' \', c.`firstname`, c.`lastname`) AS `customer`,
 		osl.`name` AS `osname`,
 		os.`color`,
 		IF((SELECT so.id_order FROM `'._DB_PREFIX_.'orders` so WHERE so.id_customer = a.id_customer AND so.id_order < a.id_order LIMIT 1) > 0, 0, 1) as new,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In 1.6.1.13 BO Orders, the customers firstname and name were missing;<br/> That is because in the AdminOrders constructor the new CONCAT option of the _select statement doesn't produce the desired output. <br/> Changed it to CONCAT_WS.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | That happened on a 1.6.1.3 upgraded to 1.6.1.13 using the default theme

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7928)
<!-- Reviewable:end -->
