### PR TITLE
CO: Update Cart.php in order to use MySQL Index

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -269,12 +269,12 @@ class CartCore extends ObjectModel
         }
 
         Db::getInstance()->execute('
-			DELETE FROM `'._DB_PREFIX_.'customized_data`
-			WHERE `id_customization` IN (
-				SELECT `id_customization`
-				FROM `'._DB_PREFIX_.'customization`
-				WHERE `id_cart`='.(int)$this->id.'
-			)'
+         		DELETE FROM `'._DB_PREFIX_.'customized_data` USING `'._DB_PREFIX_.'customized_data`
+         		INNER JOIN (
+         				SELECT `id_customization`
+         				FROM `'._DB_PREFIX_.'customization`
+         				WHERE `id_cart`='.(int)$this->id.'
+         		) AS cu ON `'._DB_PREFIX_.'customized_data`.`id_customization` = `cu`.`id_customization`'
         );
 
         Db::getInstance()->execute('


### PR DESCRIPTION

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "1.6.1.x" 
| Description?  |  In MYSQL 5.5 and 5.6 the DELETE with a nested query do not use indexes, and performance became slow when there are multiple customization. As reported in the MySQL docs https://dev.mysql.com/doc/refman/5.5/en/delete.html it is needed to use the JOIN in order to use the indexes
| Type?         | improvement 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Check that the modified query perform the delete to the same rows. Perform the explain plan in the original query and in the proposed. You will see that the original query perform a full table scan, and the proposed one use indexes. During your test please add in the ps_customized_data 100K rows and use the show with multiple users. You will see the performance degradation in the system

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
