### PR TITLE
Make the sub-categories disabled when you edit the category

### DIFF
--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -29,6 +29,34 @@ var Tree = function (element, options)
 	this.init();
 };
 
+function getCategoryById(param) {
+	var elem = null;
+	$('input[name=id_parent]').each(function (index) {
+		if ($(this).val() === param + '') {
+			elem = $(this);
+		}
+	});
+	return elem;
+}
+
+function disableTreeItem(item) {
+	item.find('input[name=id_parent]').attr('disabled', 'disabled');
+	if (item.hasClass('tree-folder')) {
+		item.find('span.tree-folder-name').addClass('tree-folder-name-disable');
+		item.find('ul li').each(function (index) {
+			disableTreeItem($(this));
+		});
+	} else if (item.hasClass('tree-item')) {
+		item.addClass('tree-item-disable');
+	}
+}
+
+function organizeTree() {
+	var id = $('#id_category').val();
+	var item = getCategoryById(id).parent().parent();
+	disableTreeItem(item);
+}
+
 Tree.prototype =
 {
 	constructor: Tree,
@@ -187,6 +215,7 @@ Tree.prototype =
 				function(content)
 				{
 					$('#'+idTree).html(content);
+					organizeTree();
 					$('#'+idTree).tree('init');
 					that.$element.find("label.tree-toggler").each(
 						function()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | the problem is that category will be deleted when you try to add main cat to sub-category
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3114
| How to test?  | try to edit a category, you will find all its sub-categories are disabled, so you can't add to one of its sub-cat.