### PR TITLE
Add missing simple quote in Design -> Images view

### DIFF
--- a/admin-dev/themes/default/template/controllers/images/content.tpl
+++ b/admin-dev/themes/default/template/controllers/images/content.tpl
@@ -42,7 +42,7 @@
             </div>
             <div class="row">
                 <div class="col-lg-12 pull-right">
-                    <button type="submit" name="submitMoveImages{$table}" class="btn btn-default pull-right" onclick="return confirm('{l s='Are you sure?' d=Admin.Notifications.Warning}');"><i class="process-icon-cogs"></i> {l s='Move images' d='Admin.Design.Feature'}</button>
+                    <button type="submit" name="submitMoveImages{$table}" class="btn btn-default pull-right" onclick="return confirm('{l s='Are you sure?' d='Admin.Notifications.Warning'}');"><i class="process-icon-cogs"></i> {l s='Move images' d='Admin.Design.Feature'}</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "develop"
| Description?  | Fix issue with a translation (missing simple quote, causing a SmartyCompilerException)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Go to Design -> Images : Now no exception is fired.
