### PR TITLE
Update bulk action combinations number after delete or add combination

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -280,3 +280,15 @@ var combinations = (function() {
 BOEvent.on("Product Combinations Management started", function initCombinationsManagement() {
   combinations.init();
 }, "Back office");
+
+/**
+ * Refresh bulk actions combination number after creating or deleting combinations
+ *
+ * @param {number} sign
+ * @param {number} number
+ */
+var refreshTotalCombinations = function (sign, number) {
+  var $bulkCombinationsTotal = $('#js-bulk-combinations-total');
+  var currentnumber = parseInt($bulkCombinationsTotal.text()) + (sign * number);
+  $bulkCombinationsTotal.text(currentnumber);
+}

--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -24,6 +24,7 @@ var combinations = (function() {
             $('#create-combinations, #apply-on-combinations, #submit, .btn-submit').attr('disabled', 'disabled');
           },
           success: function(response) {
+            refreshTotalCombinations(-1, 1);
             combinationElem.remove();
             showSuccessMessage(response.message);
             displayFieldsManager.refresh();

--- a/admin-dev/themes/new-theme/js/product-page/combination.js
+++ b/admin-dev/themes/new-theme/js/product-page/combination.js
@@ -157,7 +157,7 @@ export default function() {
         $('#create-combinations, #submit, .btn-submit').attr('disabled', 'disabled');
       },
       success: function(response) {
-        refreshTotalCombinations(1, $(response.form).andSelf().filter('.combination.loaded').length);
+        refreshTotalCombinations(1, $(response.form).filter('.combination.loaded').length);
         $('#accordion_combinations').append(response.form);
         displayFieldsManager.refresh();
         let url = $('.js-combinations-list').attr('data-action-refresh-images').replace(/product-form-images\/\d+/, 'product-form-images/' + $('.js-combinations-list').data('id-product'));

--- a/admin-dev/themes/new-theme/js/product-page/combination.js
+++ b/admin-dev/themes/new-theme/js/product-page/combination.js
@@ -157,6 +157,7 @@ export default function() {
         $('#create-combinations, #submit, .btn-submit').attr('disabled', 'disabled');
       },
       success: function(response) {
+        refreshTotalCombinations(1, $(response.form).andSelf().filter('.combination.loaded').length);
         $('#accordion_combinations').append(response.form);
         displayFieldsManager.refresh();
         let url = $('.js-combinations-list').attr('data-action-refresh-images').replace(/product-form-images\/\d+/, 'product-form-images/' + $('.js-combinations-list').data('id-product'));

--- a/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
+++ b/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
@@ -122,6 +122,8 @@ export default function() {
             },
             success: function(response) {
               showSuccessMessage(response.message);
+              refreshTotalCombinations(-1, combinationsIds.length);
+              $('span.js-bulk-combinations').text('0');
               combinationsIds.forEach((combinationId) => {
                 var combination = new Combination(combinationId);
                 combination.removeFromDOM();

--- a/admin-dev/themes/new-theme/public/main.bundle.js
+++ b/admin-dev/themes/new-theme/public/main.bundle.js
@@ -59,7 +59,7 @@
 /******/ 	
 /******/ 	
 /******/ 	var hotApplyOnUpdate = true;
-/******/ 	var hotCurrentHash = "897250660b919bc93d18"; // eslint-disable-line no-unused-vars
+/******/ 	var hotCurrentHash = "8d088984cd6a56f19090"; // eslint-disable-line no-unused-vars
 /******/ 	var hotCurrentModuleData = {};
 /******/ 	var hotCurrentChildModule; // eslint-disable-line no-unused-vars
 /******/ 	var hotCurrentParents = []; // eslint-disable-line no-unused-vars
@@ -43610,6 +43610,7 @@ let setNotificationsNumber = function (id, number) {
         __WEBPACK_IMPORTED_MODULE_0_jquery___default()('#create-combinations, #submit, .btn-submit').attr('disabled', 'disabled');
       },
       success: function(response) {
+        refreshTotalCombinations(1, __WEBPACK_IMPORTED_MODULE_0_jquery___default()(response.form).filter('.combination.loaded').length);
         __WEBPACK_IMPORTED_MODULE_0_jquery___default()('#accordion_combinations').append(response.form);
         displayFieldsManager.refresh();
         let url = __WEBPACK_IMPORTED_MODULE_0_jquery___default()('.js-combinations-list').attr('data-action-refresh-images').replace(/product-form-images\/\d+/, 'product-form-images/' + __WEBPACK_IMPORTED_MODULE_0_jquery___default()('.js-combinations-list').data('id-product'));
@@ -43912,6 +43913,8 @@ __WEBPACK_IMPORTED_MODULE_0_jquery___default()(() => {
             },
             success: function(response) {
               showSuccessMessage(response.message);
+              refreshTotalCombinations(-1, combinationsIds.length);
+              __WEBPACK_IMPORTED_MODULE_0_jquery___default()('span.js-bulk-combinations').text('0');
               combinationsIds.forEach((combinationId) => {
                 var combination = new Combination(combinationId);
                 combination.removeFromDOM();

--- a/js/tools.js
+++ b/js/tools.js
@@ -706,18 +706,6 @@ function getStorageAvailable() {
 	}
 }
 
-function refreshTotalCombinations(sign, number) {
-  let currentnumber;
-  //checking if parseInt throws exception
-  try {
-    currentnumber = parseInt($('.js-bulk-combinations-total').text()) + (sign * number);
-  }
-  catch (error) {
-    currentnumber = 0;
-  }
-  $('.js-bulk-combinations-total').text(currentnumber);
-}
-
 $(document).ready(function()
 {
 	// Hide all elements with .hideOnSubmit class when parent form is submit

--- a/js/tools.js
+++ b/js/tools.js
@@ -706,6 +706,18 @@ function getStorageAvailable() {
 	}
 }
 
+function refreshTotalCombinations(sign, number) {
+  let currentnumber;
+  //checking if parseInt throws exception
+  try {
+    currentnumber = parseInt($('.js-bulk-combinations-total').text()) + (sign * number);
+  }
+  catch (error) {
+    currentnumber = 0;
+  }
+  $('.js-bulk-combinations-total').text(currentnumber);
+}
+
 $(document).ready(function()
 {
 	// Hide all elements with .hideOnSubmit class when parent form is submit

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -65,7 +65,7 @@
             aria-controls="bulk-combinations-container"
           >
             {# First tag [1] is number of combinations selected. Second tag [2] is the total of combinations available. #}
-            <strong>{{ 'Bulk actions ([1]/[2] combination(s) selected)'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<span class="js-bulk-combinations">0</span>', '[2]': combinations_count })|raw }}</strong>
+            <strong>{{ 'Bulk actions ([1]/[2] combination(s) selected)'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<span class="js-bulk-combinations">0</span>', '[2]': '<span class="js-bulk-combinations-total">' ~ combinations_count ~ '</span>' })|raw }}</strong>
             <i class="material-icons pull-right">keyboard_arrow_down</i>
           </p>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -65,7 +65,7 @@
             aria-controls="bulk-combinations-container"
           >
             {# First tag [1] is number of combinations selected. Second tag [2] is the total of combinations available. #}
-            <strong>{{ 'Bulk actions ([1]/[2] combination(s) selected)'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<span class="js-bulk-combinations">0</span>', '[2]': '<span class="js-bulk-combinations-total">' ~ combinations_count ~ '</span>' })|raw }}</strong>
+            <strong>{{ 'Bulk actions ([1]/[2] combination(s) selected)'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<span class="js-bulk-combinations">0</span>', '[2]': '<span id="js-bulk-combinations-total">' ~ combinations_count ~ '</span>' })|raw }}</strong>
             <i class="material-icons pull-right">keyboard_arrow_down</i>
           </p>
         </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | If you create some combination then the text of the bulk actions block won't be updated
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1868
| How to test?  | Add or delete combinations, the bulk action total combination number will be updated.