### PR TITLE
Add PHP 7.1 as optional on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ php:
   - 5.4
   - 5.6
   - 7.0
+  - 7.1
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - php: 7.1
   
 env:
     global:

--- a/tests/Unit/classes/PhpEncryptionLegacyEngineTest.php
+++ b/tests/Unit/classes/PhpEncryptionLegacyEngineTest.php
@@ -35,6 +35,10 @@ class PhpEncryptionLegacyEngineTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+            $this->markTestSkipped('Legacy encryption with mcrypt is deprecated from PHP 7.1.');
+        }
+
         $key = \Defuse\Crypto\Key::createNewRandomKey();
         $this->engine = new PhpEncryptionLegacyEngine($key->saveToAsciiSafeString());
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PHP 7.1 is now available from a few months. It's time to include it in the tests matrix. Eventually, it can replace PHP 7.0.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | 