### PR TITLE
Fix preg_replace /e modifier for PHP 7.1

### DIFF
--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -161,7 +161,9 @@ class WebserviceOutputJSON implements WebserviceOutputInterface
     {
         $content = '';
         $content .= json_encode($this->content);
-        $content = preg_replace("/\\\\u([a-f0-9]{4})/e", "iconv('UCS-4LE','UTF-8',pack('V', hexdec('U$1')))", $content);
+        $content = preg_replace_callback("/\\\\u([a-f0-9]{4})/", function ($matches) {
+            return iconv('UCS-4LE','UTF-8', pack('V', hexdec('U' . $matches[1])));
+        }, $content);
         return $content;
     }
 


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | PHP 7.1 deprecated the use of "/e" modifier in preg_replace. We need to use preg_replace_callback instead |
| Type? | bug fix
| Category? | WS
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Same as 1.7 branch: http://forge.prestashop.com/browse/BOOM-2207 |
| How to test? | Send any WS request with the "output_format=JSON" parameter |
