### PR TITLE
Display product reference in Stock management list (ASM)

### DIFF
--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -123,9 +123,9 @@ class AdminStockManagementControllerCore extends AdminController
             $this->toolbar_btn = array();
 
             // overrides query
-            $this->_select = 'IFNULL(pa.ean13, a.ean13) as ean13,
-            IFNULL(pa.upc, a.upc) as upc,
-            IFNULL(pa.reference, a.reference) as reference,
+            $this->_select = 'a.ean13 as ean13,
+            a.upc as upc,
+            a.reference as reference,
             (SELECT SUM(physical_quantity) FROM `'._DB_PREFIX_.'stock` WHERE id_product = a.id_product) as physical_quantity,
             (SELECT SUM(usable_quantity) FROM `'._DB_PREFIX_.'stock` WHERE id_product = a.id_product) as usable_quantity,
             a.id_product as id, COUNT(pa.id_product_attribute) as variations';
@@ -221,6 +221,9 @@ class AdminStockManagementControllerCore extends AdminController
         for ($i = 0; $i < $nb_items; $i++) {
             $item = &$this->_list[$i];
 
+            $item['reference'] = (!empty($item['reference']) && isset($item['reference'])) ? $item['reference'] : '--';
+            $item['ean13'] = (!empty($item['ean13']) && isset($item['ean13'])) ? $item['ean13'] : '--';
+            $item['upc'] = (!empty($item['upc']) && isset($item['upc'])) ? $item['upc'] : '--';
             // if it's an ajax request we have to consider manipulating a product variation
             if (Tools::isSubmit('id_product')) {
                 $item['name'] = Product::getProductName($item['id_product'], empty($item['id_product_attribute']) ? null : $item['id_product_attribute']);
@@ -243,11 +246,6 @@ class AdminStockManagementControllerCore extends AdminController
                 $this->addRowActionSkipList('addstock', array($item['id']));
                 $this->addRowActionSkipList('prepareRemovestock', array($item['id']));
                 $this->addRowActionSkipList('prepareTransferstock', array($item['id']));
-
-                // does not display these informaions because this product has combinations
-                $item['reference'] = '--';
-                $item['ean13'] = '--';
-                $item['upc'] = '--';
             } else {
                 //there are no variations of current product, so we don't want to show details action
                 $this->addRowActionSkipList('details', array($item['id']));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | in BO, Stock -> Stock management, the references, ean13 and upc of products with combinations doesn't show
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7742
| How to test?  | add some products with combinations, make sure to put a reference, an ean13 and an upc for the product and to mange it with ASM, then go to Stock -> Stock management, you will see the list of products with references, ean13 and upc shown