### PR TITLE
Remove download limit (SQL manager CSV export)

### DIFF
--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -351,23 +351,18 @@ class AdminRequestSqlControllerCore extends AdminController
                 }
                 if (file_exists($export_dir.$file)) {
                     $filesize = filesize($export_dir.$file);
-                    $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
-                    if ($filesize < $upload_max_filesize) {
-                        if (Configuration::get('PS_ENCODING_FILE_MANAGER_SQL')) {
-                            $charset = Configuration::get('PS_ENCODING_FILE_MANAGER_SQL');
-                        } else {
-                            $charset = self::$encoding_file[0]['name'];
-                        }
-
-                        header('Content-Type: text/csv; charset='.$charset);
-                        header('Cache-Control: no-store, no-cache');
-                        header('Content-Disposition: attachment; filename="'.$file.'"');
-                        header('Content-Length: '.$filesize);
-                        readfile($export_dir.$file);
-                        die();
+                    if (Configuration::get('PS_ENCODING_FILE_MANAGER_SQL')) {
+                        $charset = Configuration::get('PS_ENCODING_FILE_MANAGER_SQL');
                     } else {
-                        $this->errors[] = Tools::DisplayError('The file is too large and can not be downloaded. Please use the LIMIT clause in this query.');
+                        $charset = self::$encoding_file[0]['name'];
                     }
+
+                    header('Content-Type: text/csv; charset='.$charset);
+                    header('Cache-Control: no-store, no-cache');
+                    header('Content-Disposition: attachment; filename="'.$file.'"');
+                    header('Content-Length: '.$filesize);
+                    readfile($export_dir.$file);
+                    die();
                 }
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | If you create an SQL query that generates a large amount of data (larger than upload_max_filesize), you don't get an error, but you you get an export of the requests list :-|
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | You need a HUGE amount of data inyour DB. Then, in SQL Manager, create a requets that should generate a large amount of data. Click ont the Export button. You won't get your data in the exported file nor an error. Instead, you receive the requests list. This old commit https://github.com/PrestaShop/PrestaShop/commit/c85f23ba5a08832707ec143a996af45f1e39e71b added a filesize check against the upload_max_filesize server directive, but this seems irrelevant for a download (we didn't manage to understand why this condition was introduced). removing this condition solves the problem.