### PR TITLE
Don't get admin notifications while it's all disabled

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2851,17 +2851,15 @@ class AdminControllerCore extends Controller
      */
     public function initNotifications()
     {
-        $this->context->smarty->assign(array(
+        $notificationsSettings = array(
             'show_new_orders' => Configuration::get('PS_SHOW_NEW_ORDERS'),
             'show_new_customers' => Configuration::get('PS_SHOW_NEW_CUSTOMERS'),
             'show_new_messages' => Configuration::get('PS_SHOW_NEW_MESSAGES '),
-        ));
+        );
+        
+        $this->context->smarty->assign($notificationsSettings);
 
-        Media::addJsDef(array(
-            'show_new_orders' => Configuration::get('PS_SHOW_NEW_ORDERS'),
-            'show_new_customers' => Configuration::get('PS_SHOW_NEW_CUSTOMERS'),
-            'show_new_messages' => Configuration::get('PS_SHOW_NEW_MESSAGES '),
-        ));
+        Media::addJsDef($notificationsSettings);
     }
 
     /**

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2847,11 +2847,17 @@ class AdminControllerCore extends Controller
     }
 
     /**
-     * Sets the smarty variables used to show / hide some notifications
+     * Sets the smarty variables and js defs used to show / hide some notifications
      */
     public function initNotifications()
     {
         $this->context->smarty->assign(array(
+            'show_new_orders' => Configuration::get('PS_SHOW_NEW_ORDERS'),
+            'show_new_customers' => Configuration::get('PS_SHOW_NEW_CUSTOMERS'),
+            'show_new_messages' => Configuration::get('PS_SHOW_NEW_MESSAGES '),
+        ));
+
+        Media::addJsDef(array(
             'show_new_orders' => Configuration::get('PS_SHOW_NEW_ORDERS'),
             'show_new_customers' => Configuration::get('PS_SHOW_NEW_CUSTOMERS'),
             'show_new_messages' => Configuration::get('PS_SHOW_NEW_MESSAGES '),

--- a/js/admin/notifications.js
+++ b/js/admin/notifications.js
@@ -54,7 +54,9 @@ $(document).ready(function() {
   });
 
 	// call it once immediately, then use setTimeout
-	getPush();
+  if (parseInt(show_new_orders) || parseInt(show_new_customers) || parseInt(show_new_messages)) {
+	  getPush();
+  }
 
 });
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On the back office, we can disable type of notifications wanted (customer, orders, ...) but the AJAX query is still done.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Disable each type of notifications and see that the ajax.php is still called. Fetch the PR and see that it will be not if there is no need to.