### PR TITLE
Empty customization ID after adding to cart

### DIFF
--- a/themes/_core/js/cart.js
+++ b/themes/_core/js/cart.js
@@ -45,6 +45,8 @@ $(document).ready(() => {
       $('.cart-voucher').replaceWith(resp.cart_voucher);
       $('.cart-overview').replaceWith(resp.cart_detailed);
 
+      $('#product_customization_id').val(0);
+
       $('.js-cart-line-product-quantity').each((index, input) => {
         var $input = $(input);
         $input.attr('value', $input.val());


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | After adding a product to cart, the customization ID should be reset
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Add a customized product to cart. Add another product without customization. They both come up with the same customization because the customization ID was submitted with the second product too. This fix makes sure the customization ID field is emptied after adding to cart.
