### PR TITLE
Fixed specific price not computed if more that 1000 specific prices

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -238,7 +238,7 @@ class SpecificPriceCore extends ObjectModel
             $specific_list = SpecificPrice::$_filterOutCache[$key_cache];
         }
 
-        if (in_array($field_value, $specific_list)) {
+        if (empty($specific_list) || in_array($field_value, $specific_list)) {
             $query_extra = 'AND `'.$name.'` '.self::formatIntInQuery(0, $field_value).' ';
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This fix an issue where if you have more than 1000 Specific prices in the database, none of them are applied. This bug was already solved for 1.6.1 but is still there in 1.7. See : https://github.com/PrestaShop/PrestaShop/pull/4480
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create more than 1000 products, and create a specific price for all of them, then go see one product in front office.

