### PR TITLE
Eliminate currencies doubling in ASM currency list

### DIFF
--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -344,7 +344,7 @@ class AdminStockManagementControllerCore extends AdminController
         }
 
         //get currencies list
-        $currencies = Currency::getCurrencies();
+        $currencies = Currency::getCurrencies(false, true, true);
         if (1 < count($currencies)) {
             array_unshift($currencies, '-');
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | if I have more than one store (multistore option activated), and I try to add stock (ASM) for a product, I get the currencies doubling in the currency list
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9105
| How to test?  | Activate ASM and multistore options, add a new store, manage one of products with ASM, then go to ASM-> Stock management, try to add stock qty of the chosen product, in the add page, select the currency list, you will see all currency without doubling