### PR TITLE
Fix flush of local cache when adding a new specific price

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -93,12 +93,22 @@ class SpecificPriceCore extends ObjectModel
     protected static $_cache_priorities = array();
     protected static $_no_specific_values = array();
 
+    /**
+     * Flush local cache
+     */
+    protected function flushCache() {
+        SpecificPrice::$_specificPriceCache = array();
+        SpecificPrice::$_filterOutCache = array();
+        SpecificPrice::$_cache_priorities = array();
+        SpecificPrice::$_no_specific_values = array();
+        Product::flushPriceCache();
+    }
+
     public function add($autodate = true, $nullValues = false)
     {
         if (parent::add($autodate, $nullValues)) {
             // Flush cache when we adding a new specific price
-            SpecificPrice::$_specificPriceCache = array();
-            Product::flushPriceCache();
+            $this->flushCache();
             // Set cache of feature detachable to true
             Configuration::updateGlobalValue('PS_SPECIFIC_PRICE_FEATURE_ACTIVE', '1');
             return true;
@@ -110,8 +120,7 @@ class SpecificPriceCore extends ObjectModel
     {
         if (parent::update($null_values)) {
             // Flush cache when we updating a new specific price
-            SpecificPrice::$_specificPriceCache = array();
-            Product::flushPriceCache();
+            $this->flushCache();
             return true;
         }
         return false;
@@ -121,8 +130,7 @@ class SpecificPriceCore extends ObjectModel
     {
         if (parent::delete()) {
             // Flush cache when we deletind a new specific price
-            SpecificPrice::$_specificPriceCache = array();
-            Product::flushPriceCache();
+            $this->flushCache();
             // Refresh cache of feature detachable
             Configuration::updateGlobalValue('PS_SPECIFIC_PRICE_FEATURE_ACTIVE', SpecificPrice::isCurrentlyUsed($this->def['table']));
             return true;
@@ -238,7 +246,8 @@ class SpecificPriceCore extends ObjectModel
             $specific_list = SpecificPrice::$_filterOutCache[$key_cache];
         }
 
-        if (in_array($field_value, $specific_list)) {
+        // $specific_list is empty if the threshold is reached
+        if (empty($specific_list) || in_array($field_value, $specific_list)) {
             $query_extra = 'AND `'.$name.'` '.self::formatIntInQuery(0, $field_value).' ';
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This fix an issue where if you have more than 1000 Specific prices in the database, none of them are applied. This bug was already solved for 1.6.1 but is still there in 1.7. See : https://github.com/PrestaShop/PrestaShop/pull/4480
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create more than 1000 products, and create a specific price for all of them, then go see one product in front office.

See: https://github.com/PrestaShop/PrestaShop/pull/7960