### PR TITLE
Use the right array index while getting controller tab name

### DIFF
--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -217,7 +217,7 @@ class ModuleTabRegister
             } elseif (array_key_exists($lang['language_code'], $names)) {
                 $translatedNames[$lang['id_lang']] = $names[$lang['language_code']];
             } else {
-                $translatedNames[$lang['id_lang']] = $names[$lang[0]];
+                $translatedNames[$lang['id_lang']] = $names[0];
             }
         }
         return $translatedNames;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As now, if you try to register some controllers tabs inside a module, there is a silenced error because $lang doesn't have the index 0.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | You have to write a $this->tabs configuration inside your module and install it to see if it's working now.