### PR TITLE
Fix ASM real quantity issues when changing SupplyOrder status

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -208,7 +208,9 @@ class StockAvailableCore extends ObjectModel
                             $allowed_warehouse_for_combination_clean[] = (int)$warehouse['id_warehouse'];
                         }
                         $allowed_warehouse_for_combination_clean = array_intersect($allowed_warehouse_for_combination_clean, $warehouses);
-                        if ($order_id_shop != null && !count(array_intersect($allowed_warehouse_for_combination_clean, $order_warehouses))) {
+                        if (($order_id_shop != null && !count(array_intersect($allowed_warehouse_for_combination_clean, $order_warehouses))) ||
+                            !count($allowed_warehouse_for_combination_clean)
+                        ) {
                             continue;
                         }
 
@@ -469,7 +471,7 @@ class StockAvailableCore extends ObjectModel
         }
 
         $stockManager = Adapter_ServiceLocator::get('Core_Business_Stock_StockManager');
-        $stockManager->updateQuantity($product, $id_product_attribute, $delta_quantity, $id_shop = null);
+        $stockManager->updateQuantity($product, $id_product_attribute, $delta_quantity, $id_shop);
         return true;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When I change an order status to "Pending receipt". In BO "instant stock status" page and FO product page, the real qty get changed. this is wrong! it has to be changed only when we recieve completely the Supply Order.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8935 & http://forge.prestashop.com/browse/PSCSX-9109
| How to test?  | Create a warehouse, associate this warehouse to one shop, add new supply order for this warehouse, change its status to "Pending receipt", and then check the qty in FO, nothing change GOOD! Now, change the status to "Order received completely", the available quantity is changed only for the shop selected for the warehouse chosen