### PR TITLE
FO: Fix the forbidden access to favicon.ico

### DIFF
--- a/img/.htaccess
+++ b/img/.htaccess
@@ -2,7 +2,7 @@
 	php_flag engine off
 </IfModule>
 deny from all
-<Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm)$">
+<Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico)$">
 	order deny,allow
 	allow from all
 </Files>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | when we upload a favicon (.ico forced), we can't access to the favicon cause of the .htaccess (403 Forbidden)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Just upload a favicon in BO, and try to see it in FO/BO. In the network log console, we see a 403 response for the favicon.