### PR TITLE
Let the back page be an URL while adding an address

### DIFF
--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -93,8 +93,12 @@ class AddressControllerCore extends FrontController
     {
         if (!$this->ajax && $this->should_redirect) {
             if (($back = Tools::getValue('back')) && Tools::secureReferrer($back)) {
-                $mod = Tools::getValue('mod');
-                $this->redirectWithNotifications('index.php?controller='.$back.($mod ? '&back='.$mod : ''));
+                if (strpos($back, 'http://') !== false || strpos($back, 'https://') !== false) {
+                    $this->redirectWithNotifications($back);
+                } else {
+                    $mod = Tools::getValue('mod');
+                    $this->redirectWithNotifications('index.php?controller='.$back.($mod ? '&back='.$mod : ''));
+                }
             } else {
                 $this->redirectWithNotifications('index.php?controller=addresses');
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Set the back page as an URL inside the address creation form and see that you will be redirected to the home.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Set a URL as back page while adding an adress and see if you are redirect on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7970)
<!-- Reviewable:end -->
