### PR TITLE
Add the condition of SSL_ENABLED to Google Maps

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -336,11 +336,9 @@ class AdminOrdersControllerCore extends AdminController
 
         $this->addJqueryUI('ui.datepicker');
         $this->addJS(_PS_JS_DIR_.'vendor/d3.v3.min.js');
-        $api_key = '';
-        if(Configuration::get('PS_API_KEY')){
-            $api_key = 'key='.Configuration::get('PS_API_KEY').'&';
-        }
-        $this->addJS('http://maps.google.com/maps/api/js?'.$api_key.'v=3.26');
+        $api_key = (Configuration::get('PS_API_KEY')) ? 'key=' . Configuration::get('PS_API_KEY') . '&' : '';
+        $protocol = (Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE')) ? 'https' : 'http';
+        $this->addJS($protocol . '://maps.google.com/maps/api/js?' . $api_key);
 
         if ($this->tabAccess['edit'] == 1 && $this->display == 'view') {
             $this->addJS(_PS_JS_DIR_.'admin/orders.js');

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -285,10 +285,7 @@ class StoresControllerCore extends FrontController
         $this->addCSS(_THEME_CSS_DIR_.'stores.css');
 
         if (!Configuration::get('PS_STORES_SIMPLIFIED')) {
-            $api_key = '';
-            if(Configuration::get('PS_API_KEY')){
-                $api_key = 'key='.Configuration::get('PS_API_KEY').'&';
-            }
+            $api_key = (Configuration::get('PS_API_KEY')) ? 'key=' . Configuration::get('PS_API_KEY') . '&' : '';
             $default_country = new Country((int)Tools::getCountry());
             $this->addJS('http'.((Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE')) ? 's' : '').'://maps.google.com/maps/api/js?'.$api_key.'region='.substr($default_country->iso_code, 0, 2));
             $this->addJS(_THEME_JS_DIR_.'stores.js');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | this PR https://github.com/PrestaShop/PrestaShop/pull/7821 is missing the condition of SSl_ENABLED in the BO OrderDetails
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9120
| How to test?  | Whatever you use HTTP or HTTPS on your site, the Google Map (BO -> OrderDetails) will be displayed without any problem