### PR TITLE
Drop unused fields from ps_product_lang

### DIFF
--- a/install-dev/upgrade/php/drop_column_from_product_lang_if_exists.php
+++ b/install-dev/upgrade/php/drop_column_from_product_lang_if_exists.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+function drop_column_from_product_lang_if_exists()
+{
+    $columns = Db::getInstance()->executeS('SHOW COLUMNS FROM `' . _DB_PREFIX_ . 'product_lang` 
+        WHERE Field IN (\'social_sharing_title\', \'social_sharing_description\')');
+
+    if (!empty($columns)) {
+        foreach ($columns as $column) {
+            Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'product_lang` DROP COLUMN `' . $column['Field'] . '`');
+        }
+    }
+}

--- a/install-dev/upgrade/sql/1.7.2.0.sql
+++ b/install-dev/upgrade/sql/1.7.2.0.sql
@@ -16,3 +16,5 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'displayWrapperBottom', 'Main wrapper section (bottom)', 'This hook displays new elements in the bottom of the main wrapper', '1'),
   (NULL, 'displayContentWrapperTop', 'Content wrapper section (top)', 'This hook displays new elements in the top of the content wrapper', '1'),
   (NULL, 'displayContentWrapperBottom', 'Content wrapper section (bottom)', 'This hook displays new elements in the bottom of the content wrapper', '1');
+
+/* PHP:drop_column_from_product_lang_if_exists(); */;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fields social_sharing_title and social_sharing_description are never been used. 
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3092
| How to test?  | Upgrade Prestashop and check if they still exist 