### PR TITLE
Add PHP CodeSniffer to travis, check only modified files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,8 @@
         "symfony/phpunit-bridge": "~3.1.3",
         "phake/phake": "@stable",
         "friendsofphp/php-cs-fixer": "^1.10",
-        "sensio/generator-bundle": "~2.3"
+        "sensio/generator-bundle": "~2.3",
+        "squizlabs/php_codesniffer": "^3"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3498c1b3e0443b92775d3af8eab8174a",
-    "content-hash": "9fd15c3a32e77852e072ddac246683aa",
+    "content-hash": "06bfa9da17f54690a7865304a6b960c6",
     "packages": [
         {
             "name": "beberlei/DoctrineExtensions",
@@ -67,7 +66,7 @@
                 "doctrine",
                 "orm"
             ],
-            "time": "2017-06-16 07:29:39"
+            "time": "2017-06-16T07:29:39+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -126,7 +125,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2017-03-06 11:59:08"
+            "time": "2017-03-06T11:59:08+00:00"
         },
         {
             "name": "composer/installers",
@@ -221,7 +220,7 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2015-02-18 17:17:01"
+            "time": "2015-02-18T17:17:01+00:00"
         },
         {
             "name": "csa/guzzle-bundle",
@@ -278,7 +277,7 @@
                 }
             ],
             "description": "A bundle integrating GuzzleHttp >= 4.0",
-            "time": "2015-11-17 00:02:55"
+            "time": "2015-11-17T00:02:55+00:00"
         },
         {
             "name": "curl/curl",
@@ -333,7 +332,7 @@
                 "curl",
                 "dot"
             ],
-            "time": "2015-04-09 16:29:25"
+            "time": "2015-04-09T16:29:25+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -392,7 +391,7 @@
                 "security",
                 "symmetric key cryptography"
             ],
-            "time": "2016-10-10 15:20:26"
+            "time": "2016-10-10T15:20:26+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -460,7 +459,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -530,7 +529,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-19 05:03:47"
+            "time": "2015-12-19T05:03:47+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -596,7 +595,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14 22:21:58"
+            "time": "2015-04-14T22:21:58+00:00"
         },
         {
             "name": "doctrine/common",
@@ -669,7 +668,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-12-25 13:10:16"
+            "time": "2015-12-25T13:10:16+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -740,7 +739,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-02-08 12:53:47"
+            "time": "2017-02-08T12:53:47+00:00"
         },
         {
             "name": "doctrine/doctrine-bundle",
@@ -818,7 +817,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2015-08-31 14:47:06"
+            "time": "2015-08-31T14:47:06+00:00"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
@@ -906,7 +905,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-01-26 17:28:51"
+            "time": "2016-01-26T17:28:51+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -973,7 +972,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06 14:35:42"
+            "time": "2015-11-06T14:35:42+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1027,7 +1026,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1081,7 +1080,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -1157,7 +1156,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2016-12-18 15:42:34"
+            "time": "2016-12-18T15:42:34+00:00"
         },
         {
             "name": "geoip2/geoip2",
@@ -1208,7 +1207,7 @@
                 "geolocation",
                 "maxmind"
             ],
-            "time": "2017-01-31 17:28:48"
+            "time": "2017-01-31T17:28:48+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1260,7 +1259,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-07-15 19:28:39"
+            "time": "2016-07-15T19:28:39+00:00"
         },
         {
             "name": "guzzlehttp/log-subscriber",
@@ -1313,7 +1312,7 @@
                 "log",
                 "plugin"
             ],
-            "time": "2014-10-13 03:31:43"
+            "time": "2014-10-13T03:31:43+00:00"
         },
         {
             "name": "guzzlehttp/ringphp",
@@ -1364,7 +1363,7 @@
                 }
             ],
             "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
-            "time": "2015-05-20 03:37:09"
+            "time": "2015-05-20T03:37:09+00:00"
         },
         {
             "name": "guzzlehttp/streams",
@@ -1414,7 +1413,7 @@
                 "Guzzle",
                 "stream"
             ],
-            "time": "2014-10-12 19:18:40"
+            "time": "2014-10-12T19:18:40+00:00"
         },
         {
             "name": "icanboogie/cldr",
@@ -1464,7 +1463,7 @@
                 "locale",
                 "territory"
             ],
-            "time": "2015-02-01 12:02:54"
+            "time": "2015-02-01T12:02:54+00:00"
         },
         {
             "name": "icanboogie/common",
@@ -1510,7 +1509,7 @@
             "keywords": [
                 "toolkit"
             ],
-            "time": "2014-10-21 12:06:36"
+            "time": "2014-10-21T12:06:36+00:00"
         },
         {
             "name": "icanboogie/datetime",
@@ -1560,7 +1559,7 @@
                 "time",
                 "timezone"
             ],
-            "time": "2015-01-27 21:04:04"
+            "time": "2015-01-27T21:04:04+00:00"
         },
         {
             "name": "incenteev/composer-parameter-handler",
@@ -1611,7 +1610,7 @@
             "keywords": [
                 "parameters management"
             ],
-            "time": "2015-11-10 17:04:01"
+            "time": "2015-11-10T17:04:01+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -1653,7 +1652,7 @@
                 "hashing",
                 "password"
             ],
-            "time": "2014-11-20 16:49:30"
+            "time": "2014-11-20T16:49:30+00:00"
         },
         {
             "name": "ircmaxell/random-lib",
@@ -1708,7 +1707,7 @@
                 "random-numbers",
                 "random-strings"
             ],
-            "time": "2016-09-07 15:52:06"
+            "time": "2016-09-07T15:52:06+00:00"
         },
         {
             "name": "ircmaxell/security-lib",
@@ -1754,7 +1753,7 @@
             ],
             "description": "A Base Security Library",
             "homepage": "https://github.com/ircmaxell/SecurityLib",
-            "time": "2015-03-20 14:31:23"
+            "time": "2015-03-20T14:31:23+00:00"
         },
         {
             "name": "jakeasmith/http_build_url",
@@ -1787,7 +1786,7 @@
                 }
             ],
             "description": "Provides functionality for http_build_url() to environments without pecl_http.",
-            "time": "2017-05-01 15:36:40"
+            "time": "2017-05-01T15:36:40+00:00"
         },
         {
             "name": "jdorn/sql-formatter",
@@ -1837,7 +1836,7 @@
                 "highlight",
                 "sql"
             ],
-            "time": "2014-01-12 16:20:24"
+            "time": "2014-01-12T16:20:24+00:00"
         },
         {
             "name": "matthiasmullie/minify",
@@ -1897,7 +1896,7 @@
                 "minifier",
                 "minify"
             ],
-            "time": "2017-07-06 12:26:44"
+            "time": "2017-07-06T12:26:44+00:00"
         },
         {
             "name": "matthiasmullie/path-converter",
@@ -1946,7 +1945,7 @@
                 "paths",
                 "relative"
             ],
-            "time": "2017-01-26 08:54:49"
+            "time": "2017-01-26T08:54:49+00:00"
         },
         {
             "name": "maxmind-db/reader",
@@ -2001,7 +2000,7 @@
                 "geolocation",
                 "maxmind"
             ],
-            "time": "2017-01-19 23:49:38"
+            "time": "2017-01-19T23:49:38+00:00"
         },
         {
             "name": "maxmind/web-service-common",
@@ -2047,7 +2046,7 @@
             ],
             "description": "Internal MaxMind Web Service API",
             "homepage": "https://github.com/maxmind/web-service-common-php",
-            "time": "2017-07-06 17:48:21"
+            "time": "2017-07-06T17:48:21+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -2099,7 +2098,7 @@
                 "mobile detector",
                 "php mobile detect"
             ],
-            "time": "2017-03-29 13:59:30"
+            "time": "2017-03-29T13:59:30+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2177,7 +2176,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-06-19 01:22:40"
+            "time": "2017-06-19T01:22:40+00:00"
         },
         {
             "name": "mrclay/minify",
@@ -2222,7 +2221,7 @@
             ],
             "description": "Minify is a PHP5 app that helps you follow several rules for client-side performance. It combines multiple CSS or Javascript files, removes unnecessary whitespace and comments, and serves them with gzip encoding and optimal client-side cache headers",
             "homepage": "http://code.google.com/p/minify/",
-            "time": "2017-06-08 17:49:34"
+            "time": "2017-06-08T17:49:34+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2273,7 +2272,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2016-09-16 12:04:44"
+            "time": "2016-09-16T12:04:44+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -2321,7 +2320,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13 16:27:32"
+            "time": "2017-03-13T16:27:32+00:00"
         },
         {
             "name": "pear/archive_tar",
@@ -2387,7 +2386,7 @@
                 "archive",
                 "tar"
             ],
-            "time": "2017-06-11 17:28:11"
+            "time": "2017-06-11T17:28:11+00:00"
         },
         {
             "name": "pear/console_getopt",
@@ -2434,7 +2433,7 @@
                 }
             ],
             "description": "More info available on: http://pear.php.net/package/Console_Getopt",
-            "time": "2015-07-20 20:28:12"
+            "time": "2015-07-20T20:28:12+00:00"
         },
         {
             "name": "pear/pear-core-minimal",
@@ -2478,7 +2477,7 @@
                 }
             ],
             "description": "Minimal set of PEAR core files to be used as composer dependency",
-            "time": "2017-02-28 16:46:11"
+            "time": "2017-02-28T16:46:11+00:00"
         },
         {
             "name": "pear/pear_exception",
@@ -2533,7 +2532,7 @@
             "keywords": [
                 "exception"
             ],
-            "time": "2015-02-10 20:07:52"
+            "time": "2015-02-10T20:07:52+00:00"
         },
         {
             "name": "phpoffice/phpexcel",
@@ -2590,7 +2589,7 @@
                 "xls",
                 "xlsx"
             ],
-            "time": "2014-03-02 15:22:49"
+            "time": "2014-03-02T15:22:49+00:00"
         },
         {
             "name": "prestashop/blockreassurance",
@@ -4481,7 +4480,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "react/promise",
@@ -4527,7 +4526,7 @@
                 "promise",
                 "promises"
             ],
-            "time": "2017-03-25 12:08:31"
+            "time": "2017-03-25T12:08:31+00:00"
         },
         {
             "name": "sensio/distribution-bundle",
@@ -4587,7 +4586,7 @@
                 "configuration",
                 "distribution"
             ],
-            "time": "2017-01-04 13:34:44"
+            "time": "2017-01-04T13:34:44+00:00"
         },
         {
             "name": "sensio/framework-extra-bundle",
@@ -4642,7 +4641,7 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2015-08-03 11:59:27"
+            "time": "2015-08-03T11:59:27+00:00"
         },
         {
             "name": "sensiolabs/security-checker",
@@ -4686,7 +4685,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2017-03-29 09:29:53"
+            "time": "2017-03-29T09:29:53+00:00"
         },
         {
             "name": "shudrum/array-finder",
@@ -4726,7 +4725,7 @@
             ],
             "description": "ArrayFinder component",
             "homepage": "https://github.com/Shudrum/ArrayFinder",
-            "time": "2016-02-01 12:23:32"
+            "time": "2016-02-01T12:23:32+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -4780,7 +4779,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2017-05-01 15:54:03"
+            "time": "2017-05-01T15:54:03+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -4839,7 +4838,7 @@
                 "log",
                 "logging"
             ],
-            "time": "2015-11-17 10:02:29"
+            "time": "2015-11-17T10:02:29+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",
@@ -4892,7 +4891,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09 08:25:21"
+            "time": "2017-06-09T08:25:21+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
@@ -4950,7 +4949,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09 08:25:21"
+            "time": "2017-06-09T08:25:21+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -5009,7 +5008,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09 14:24:12"
+            "time": "2017-06-09T14:24:12+00:00"
         },
         {
             "name": "symfony/polyfill-php54",
@@ -5067,7 +5066,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09 08:25:21"
+            "time": "2017-06-09T08:25:21+00:00"
         },
         {
             "name": "symfony/polyfill-php55",
@@ -5123,7 +5122,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09 08:25:21"
+            "time": "2017-06-09T08:25:21+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -5179,7 +5178,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09 08:25:21"
+            "time": "2017-06-09T08:25:21+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -5238,7 +5237,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09 14:24:12"
+            "time": "2017-06-09T14:24:12+00:00"
         },
         {
             "name": "symfony/polyfill-util",
@@ -5290,7 +5289,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2017-06-09 08:25:21"
+            "time": "2017-06-09T08:25:21+00:00"
         },
         {
             "name": "symfony/security-acl",
@@ -5351,7 +5350,7 @@
             ],
             "description": "Symfony Security Component - ACL (Access Control List)",
             "homepage": "https://symfony.com",
-            "time": "2015-12-28 09:39:09"
+            "time": "2015-12-28T09:39:09+00:00"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -5408,7 +5407,7 @@
             ],
             "description": "Symfony SwiftmailerBundle",
             "homepage": "http://symfony.com",
-            "time": "2016-01-15 16:41:20"
+            "time": "2016-01-15T16:41:20+00:00"
         },
         {
             "name": "symfony/symfony",
@@ -5545,7 +5544,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-07-05 08:53:15"
+            "time": "2017-07-05T08:53:15+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",
@@ -5608,7 +5607,7 @@
                 "pdf417",
                 "qrcode"
             ],
-            "time": "2015-09-12 10:08:34"
+            "time": "2015-09-12T10:08:34+00:00"
         },
         {
             "name": "twig/twig",
@@ -5673,7 +5672,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-07-04 13:19:31"
+            "time": "2017-07-04T13:19:31+00:00"
         }
     ],
     "packages-dev": [
@@ -5733,7 +5732,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-12-01 00:05:05"
+            "time": "2016-12-01T00:05:05+00:00"
         },
         {
             "name": "phake/phake",
@@ -5791,7 +5790,7 @@
                 "mock",
                 "testing"
             ],
-            "time": "2017-03-20 05:16:34"
+            "time": "2017-03-20T05:16:34+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -5840,7 +5839,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2016-01-25 08:17:30"
+            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -5903,7 +5902,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02 20:05:34"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5965,7 +5964,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -6012,7 +6011,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -6053,7 +6052,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -6102,7 +6101,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26 11:10:40"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -6151,7 +6150,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27 10:12:30"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -6223,7 +6222,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21 08:07:12"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -6279,7 +6278,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -6343,7 +6342,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -6395,7 +6394,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22 07:24:03"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -6445,7 +6444,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -6512,7 +6511,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -6563,7 +6562,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -6616,7 +6615,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03 07:41:43"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -6651,7 +6650,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "sensio/generator-bundle",
@@ -6699,7 +6698,58 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2015-03-17 06:36:52"
+            "time": "2015-03-17T06:36:52+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "f9eaf037edf22fdfccf04cb0ab57ebcb1e166219"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f9eaf037edf22fdfccf04cb0ab57ebcb1e166219",
+                "reference": "f9eaf037edf22fdfccf04cb0ab57ebcb1e166219",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-06-14T01:23:49+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
@@ -6754,7 +6804,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21 17:01:39"
+            "time": "2017-01-21T17:01:39+00:00"
         }
     ],
     "aliases": [],

--- a/tests/check_file_syntax.sh
+++ b/tests/check_file_syntax.sh
@@ -1,7 +1,35 @@
 #!/bin/bash
+color_error="\033[30;41m"
+color_success="\033[30;42m"
+color_reset="\033[0m"
 
-! (find . -name "*.php" ! -path "./vendor/*" ! -path "./tools/*" -print0 | xargs -0 -n1 -P4 php -l | grep -q "Parse error")
-php=$?
+# find out the reference commit or commit range
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ ! -z "$TRAVIS_COMMIT_RANGE" ]; then
+    COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
+else
+    COMMIT_RANGE="$(git rev-parse HEAD~1)..$(git rev-parse HEAD)"
+fi
+
+# list the php files that have been modified
+echo "Finding out which PHP files have changed between refs $COMMIT_RANGE ..."
+PHP_CHANGED_FILES=$(git diff --name-only "$COMMIT_RANGE" | grep "\.php$")
+
+# check php syntax
+if [ -z "$PHP_CHANGED_FILES" ]; then
+    echo "Nothing changed"
+    php="0"
+else
+    echo -e "$PHP_CHANGED_FILES\n"
+
+    echo "Checking PHP syntax..."
+    ! (echo "$PHP_CHANGED_FILES" | tr '\n' '\0' | xargs -0 -n 1 -P 4 -I {} sh -c "php -d display_errors=on -l {} 2> /dev/null || true " | grep "Parse error")
+    php=$?
+    if [ "$php" -ne "0" ]; then
+        echo -e "$color_error [PHP linter] Some PHP files have errors! $color_reset"
+    else
+        echo -e "$color_success [OK] File syntax looks good! $color_reset"
+    fi
+fi
 
 #twig tests
 php app/console lint:twig src
@@ -23,8 +51,53 @@ yaml_themes=$?
 php app/console lint:yaml .t9n.yml
 yaml_trad=$?
 
-if [[ "$php" == "0" && "$twig_src" == "0" && "$twig_app" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad == 0" ]]; then
-  exit 0;
+# php code sniffer
+php_codesniffer="0"
+php_codesniffer_legacy="0"
+if [ ! -z "$PHP_CHANGED_FILES" ]; then
+    # skip ignored files (see phpcs-ignore file)
+    PHP_FILES_TO_SNIFF=$(echo "$PHP_CHANGED_FILES" | grep -v -f tests/phpcs-ignore)
+
+    if [ ! -z "$PHP_FILES_TO_SNIFF" ]; then
+        echo "Starting PHP Sniffer..."
+        php vendor/squizlabs/php_codesniffer/bin/phpcs --version
+
+        # legacy files aren't namespaced, so we need to tell them apart so they can be tested differently
+        LEGACY_FILES=$(echo "$PHP_CHANGED_FILES" | grep -E -v "^(src|tests)/")
+        if [ ! -z "$LEGACY_FILES" ]; then
+            echo -e "Performing sniff with legacy constraints on the following files: \n$LEGACY_FILES\n"
+            php vendor/squizlabs/php_codesniffer/bin/phpcs --standard=PSR2 -s -n --exclude=PSR1.Classes.ClassDeclaration $LEGACY_FILES
+            php_codesniffer_legacy=$?
+
+            # remove the legacy files from the list of files to sniff
+            PHP_FILES_TO_SNIFF=$(comm -23 <(sort <(echo "$PHP_FILES_TO_SNIFF")) <(sort <(echo "$LEGACY_FILES")))
+        fi
+
+        # perform the full sniff on the rest of the files (if any)
+        if [ ! -z "$PHP_FILES_TO_SNIFF" ]; then
+            echo -e "Performing full sniff on the following files: \n$PHP_FILES_TO_SNIFF\n"
+            php vendor/squizlabs/php_codesniffer/bin/phpcs --standard=PSR2 -s -n $PHP_FILES_TO_SNIFF
+            php_codesniffer=$?
+        fi
+
+        if [[ "$php_codesniffer" -eq "0" && "$php_codesniffer_legacy" -eq "0" ]]; then
+            echo -e "$color_success [OK] Code style looks good! $color_reset"
+        else
+            echo -e "$color_error [PHP Code Sniffer] Some PHP files have errors! $color_reset"
+        fi
+    fi
+fi
+
+if [[ "$php" == "0" \
+    && "$twig_src" == "0" \
+    && "$twig_app" == "0" \
+    && "$yaml_src" == "0" \
+    && "$yaml_app" == "0" \
+    && "$yaml_themes" == "0" \
+    && "$yaml_trad" == "0" \
+    && "$php_codesniffer" == "0" \
+    &&  "$php_codesniffer_legacy" == "0" ]]; then
+    exit 0;
 else
-  exit 255;
+    exit 255;
 fi

--- a/tests/phpcs-ignore
+++ b/tests/phpcs-ignore
@@ -1,3 +1,4 @@
 app/SymfonyRequirements.php
 vendor/*
 tools/*
+modules/*

--- a/tests/phpcs-ignore
+++ b/tests/phpcs-ignore
@@ -1,0 +1,3 @@
+app/SymfonyRequirements.php
+vendor/*
+tools/*


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Travis now runs PHP CodeSniffer on the modified files in order to enforce PSR-2 rules (except the namespace on non-namespaced legacy files).<br>Also, the PHP linter is now executed on modified files only.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |  Fork this branch, introduce problems in your PHP files, commit, see the build fail 💥<br>Commit a fix, see the build pass ✅

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7979)
<!-- Reviewable:end -->
