### PR TITLE
Fix upgrade from very old versions

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -808,11 +808,30 @@ class LanguageCore extends ObjectModel
 				LEFT JOIN `'._DB_PREFIX_.'lang_shop` ls ON (l.id_lang = ls.id_lang)';
 
         $result = Db::getInstance()->executeS($sql);
+
         foreach ($result as $row) {
-            if (!isset(self::$_LANGUAGES[(int) $row['id_lang']])) {
-                self::$_LANGUAGES[(int) $row['id_lang']] = $row;
+            $idLang = (int) $row['id_lang'];
+
+            if (!isset(self::$_LANGUAGES[$idLang])) {
+                self::$_LANGUAGES[$idLang] = $row;
             }
-            self::$_LANGUAGES[(int) $row['id_lang']]['shops'][(int) $row['id_shop']] = true;
+            self::$_LANGUAGES[$idLang]['shops'][(int) $row['id_shop']] = true;
+        }
+    }
+
+    public static function loadLanguagesLegacy()
+    {
+        self::$_LANGUAGES = array();
+
+        $result = Db::getInstance()->executeS('SELECT * FROM `'._DB_PREFIX_.'lang`');
+
+        foreach ($result as $row) {
+            $idLang = (int) $row['id_lang'];
+
+            if (!isset(self::$_LANGUAGES[$idLang])) {
+                self::$_LANGUAGES[$idLang] = $row;
+            }
+            self::$_LANGUAGES[$idLang]['shops'][1] = true;
         }
     }
 

--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -69,7 +69,7 @@ require_once(dirname(__FILE__).'/../init.php');
 Upgrade::migrateSettingsFile();
 require_once(_PS_CONFIG_DIR_.'bootstrap.php');
 
-$logDir = _PS_ROOT_DIR_.'/'.(_PS_MODE_DEV_ ? 'dev' : 'prod').'/log/';
+$logDir = _PS_ROOT_DIR_.'/app/logs/'.(_PS_MODE_DEV_ ? 'dev' : 'prod').'/';
 @mkdir($logDir, 0777, true);
 
 $upgrade = new Upgrade($logDir, dirname(dirname(__FILE__)).'/');

--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -319,7 +319,11 @@ namespace PrestaShopBundle\Install {
             require_once _PS_ROOT_DIR_.'/config/smarty.config.inc.php';
 
             Context::getContext()->smarty = $smarty;
-            Language::loadLanguages();
+            if(version_compare(_PS_VERSION_, '1.5.0.0', '<=')) {
+                Language::loadLanguagesLegacy();
+            } else {
+                Language::loadLanguages();
+            }
 
             $this->translator = Context::getContext()->getTranslator();
         }
@@ -383,7 +387,7 @@ namespace PrestaShopBundle\Install {
 
                 if ($handle = opendir(_PS_INSTALLER_SQL_UPGRADE_DIR_)) {
                     while (false !== ($file = readdir($handle))) {
-                        if ($file != '.' and $file != '..') {
+                        if (!in_array($file, array('.', '..', 'index.php'))) {
                             $upgradeFiles[] = str_replace(".sql", "", $file);
                         }
                     }
@@ -757,7 +761,11 @@ namespace PrestaShopBundle\Install {
                         Language::installEmailsLanguagePack($lang_pack, $errorsLanguage);
 
                         if (empty($errorsLanguage)) {
-                            Language::loadLanguages();
+                            if(version_compare(_PS_VERSION_, '1.5.0.0', '<=')) {
+                                Language::loadLanguagesLegacy();
+                            } else {
+                                Language::loadLanguages();
+                            }
 
                             $cldrUpdate = new Update(_PS_TRANSLATIONS_DIR_);
                             $cldrUpdate->fetchLocale(Language::getLocaleByIso($isoCode));
@@ -1180,13 +1188,13 @@ namespace PrestaShopBundle\Install {
                             'database_password' => _LEGACY_DB_PASSWD_,
                             'database_name' => _LEGACY_DB_NAME_,
                             'database_prefix' => _LEGACY_DB_PREFIX_,
-                            'database_engine' => _LEGACY_MYSQL_ENGINE_,
+                            'database_engine' => defined(_LEGACY_MYSQL_ENGINE_) ? _LEGACY_MYSQL_ENGINE_ : 'InnoDB',
                             'cookie_key' => _LEGACY_COOKIE_KEY_,
                             'cookie_iv' => _LEGACY_COOKIE_IV_,
                             'new_cookie_key' => _LEGACY_NEW_COOKIE_KEY_,
-                            'ps_caching' => _LEGACY_PS_CACHING_SYSTEM_,
-                            'ps_cache_enable' => _LEGACY_PS_CACHE_ENABLED_,
-                            'ps_creation_date' => _LEGACY_PS_CREATION_DATE_,
+                            'ps_caching' => defined(_LEGACY_PS_CACHING_SYSTEM_) ? _LEGACY_PS_CACHING_SYSTEM_ : 'CacheMemcache',
+                            'ps_cache_enable' => defined(_LEGACY_PS_CACHE_ENABLED_) ? _LEGACY_PS_CACHE_ENABLED_ : false,
+                            'ps_creation_date' => defined(_LEGACY_PS_CREATION_DATE_) ? _LEGACY_PS_CREATION_DATE_ : date('Y-m-d H:i:s'),
                             'secret' => $secret,
                             'mailer_transport' => 'smtp',
                             'mailer_host' => '127.0.0.1',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This patch will fix upgrade from very old versions. There was a fatal error because ps_lang_shop don't exist in older versions. And versions like 1.1 don't have this constants _PS_CACHING_SYSTEM_, _PS_CREATION_DATE_, _MYSQL_ENGINE_ and _PS_CACHING_SYSTEM_
| Type?         | bug fix 
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 




