### PR TITLE
No permissions filled

### DIFF
--- a/classes/Profile.php
+++ b/classes/Profile.php
@@ -153,7 +153,7 @@ class ProfileCore extends ObjectModel
                     $idProfile,
                     $type,
                     array(
-                        'id_profile' => _PS_ADMIN_PROFILE_,
+                        'id_profile' => $idProfile,
                         'view' => '0',
                         'add' => '0',
                         'edit' => '0',
@@ -172,7 +172,11 @@ class ProfileCore extends ObjectModel
 				WHERE j.`id_profile` = '.(int) $idProfile);
 
                 foreach ($result as $row) {
-                    $idTab = self::findIdTabByAuthSlug($row['slug']);
+                    if ($type == 'class_name') {
+                        $idTab = self::findClassNameByAuthSlug($row['slug']);
+                    } else {
+                        $idTab = self::findIdTabByAuthSlug($row['slug']);
+                    }
 
                     self::$_cache_accesses[$idProfile][$type][$idTab][array_search('1', $row)] = '1';
                 }
@@ -225,5 +229,27 @@ class ProfileCore extends ObjectModel
         ');
 
         return $result['id_tab'];
+    }
+    
+    /**
+     *
+     * @param string $authSlug
+     * @return string
+     */
+    private static function findClassNameByAuthSlug($authSlug)
+    {
+        preg_match(
+            '/ROLE_MOD_[A-Z]+_(?P<classname>[A-Z]+)_(?P<auth>[A-Z]+)/',
+            $authSlug,
+            $matches
+        );
+
+        $result = Db::getInstance()->getRow('
+            SELECT `class_name`
+            FROM `'._DB_PREFIX_.'tab` t
+            WHERE UCASE(`class_name`) = "'.$matches['classname'].'"
+        ');
+
+        return $result['class_name'];
     }
 }


### PR DESCRIPTION
When getProfileAccesses was requested for an idProfile different than super admin profile and for type class_name, no permissions where filled.
This was causing notification icon never to be displayed for non super admin employees for example.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When getProfileAccesses was requested for an idProfile different than super admin profile and for type class_name, no permissions where filled.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | For a non super admin employee the notification icon does not display until you apply this fix

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7982)
<!-- Reviewable:end -->
