### PR TITLE
Fix module loading for upgrade process and version displayed

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1198,7 +1198,7 @@ abstract class ModuleCore
         $result = Db::getInstance()->executeS('
         SELECT m.name, m.version, mp.interest, module_shop.enable_device
         FROM `'._DB_PREFIX_.'module` m
-        '.Shop::addSqlAssociation('module', 'm').'
+        '.Shop::addSqlAssociation('module', 'm', false).'
         LEFT JOIN `'._DB_PREFIX_.'module_preference` mp ON (mp.`module` = m.`name` AND mp.`id_employee` = '.(int)$id_employee.')');
         foreach ($result as $row) {
             $modules_installed[$row['name']] = $row;

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -289,6 +289,9 @@ class AdminModuleDataProvider implements ModuleInterface
                         $addon->categoryParent = $this->categoriesProvider
                             ->getParentCategory($addon->categoryName)
                         ;
+                        if (isset($addon->version)) {
+                            $addon->version_available = $addon->version;
+                        }
                         if (! isset($addon->product_type)) {
                             $addon->productType = isset($addonsType)?rtrim($addonsType, 's'):'module';
                         } else {

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -145,9 +145,13 @@ class Module implements ModuleInterface
         $this->disk->add($disk);
         $this->database->add($database);
 
-        $version = is_null($this->attributes->get('version')) && $this->disk->get('is_valid') ?
-            $this->disk->get('version') :
-            $this->attributes->get('version');
+        if ($this->database->get('installed')) {
+            $version = $this->database->get('version');
+        } elseif (is_null($this->attributes->get('version')) && $this->disk->get('is_valid')) {
+            $version = $this->disk->get('version');
+        } else {
+            $version = $this->attributes->get('version');
+        }
 
         $img = $this->attributes->get('img');
         if (empty($img)) {
@@ -329,8 +333,8 @@ class Module implements ModuleInterface
     {
         return
             $this->database->get('installed') == 1
-            && $this->database->get('version')
-            !== 0 && version_compare($this->database->get('version'), $this->attributes->get('version'), '<')
+            && $this->attributes->get('version_available')
+            !== 0 && version_compare($this->database->get('version'), $this->attributes->get('version_available'), '<')
         ;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
@@ -28,7 +28,7 @@
 
 {# Display "Old version -> New version" #}
 {% block addon_version %}
-  v{{ module.database.version }} <i class="material-icons" style="font-size: 10px; ">arrow_forward</i> v{{ module.attributes.version }}
+  v{{ module.database.version }} <i class="material-icons" style="font-size: 10px; ">arrow_forward</i> v{{ module.attributes.version_available }}
 {% endblock %}
 
 {# Display changelog instead of the description #}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Upgrading a disabled module was not possible, because it was considered as uninstalled by the legacy. This PR fixes it. It fixes another issue with the version displayed on the installed tab, when a module can be upgraded. It was displaying the version available on the API instead of the disk.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2951
| How to test?  | Disable a module and upgrade it. This must work. Check also a module ready to be upgraded has still its local version displayed.