### PR TITLE
Fixed bug where address required fields were required for any address type (customer, brand...)

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -524,12 +524,6 @@ class AddressCore extends ObjectModel
      */
     public function getFieldsRequiredDB()
     {
-        $this->cacheFieldsRequiredDatabase(false);
-        $objectName = $this->getObjectName();
-        if (isset(self::$fieldsRequiredDatabase[$objectName])) {
-            return self::$fieldsRequiredDatabase[$objectName];
-        }
-
-        return array();
+        return parent::getCachedFieldsRequiredDatabase();
     }
 }

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -525,8 +525,9 @@ class AddressCore extends ObjectModel
     public function getFieldsRequiredDB()
     {
         $this->cacheFieldsRequiredDatabase(false);
-        if (isset(self::$fieldsRequiredDatabase['Address'])) {
-            return self::$fieldsRequiredDatabase['Address'];
+        $objectName = $this->getObjectName();
+        if (isset(self::$fieldsRequiredDatabase[$objectName])) {
+            return self::$fieldsRequiredDatabase[$objectName];
         }
 
         return array();

--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -628,7 +628,7 @@ class AddressFormatCore extends ObjectModel
      */
     public static function getFieldsRequired()
     {
-        $address = new Address();
+        $address = new CustomerAddress();
 
         return array_unique(array_merge($address->getFieldsRequiredDB(), AddressFormat::$requireFormFieldsList));
     }

--- a/classes/CustomerAddress.php
+++ b/classes/CustomerAddress.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Class CustomerAddressCore
+ */
+class CustomerAddressCore extends AddressCore
+{
+}

--- a/classes/CustomerAddress.php
+++ b/classes/CustomerAddress.php
@@ -26,6 +26,9 @@
 
 /**
  * Class CustomerAddressCore
+ *
+ * Holds address info of a Customer.
+ * This class extends AddressCore to be differentiated from other AddressCore objects in DB.
  */
 class CustomerAddressCore extends AddressCore
 {

--- a/classes/ManufacturerAddress.php
+++ b/classes/ManufacturerAddress.php
@@ -26,6 +26,9 @@
 
 /**
  * Class ManufacturerAddressCore
+ *
+ * Holds address info of a Manufacturer.
+ * This class extends AddressCore to be differentiated from other AddressCore objects in DB.
  */
 class ManufacturerAddressCore extends AddressCore
 {

--- a/classes/ManufacturerAddress.php
+++ b/classes/ManufacturerAddress.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Class ManufacturerAddressCore
+ */
+class ManufacturerAddressCore extends AddressCore
+{
+}

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1467,7 +1467,13 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     {
         $this->cacheFieldsRequiredDatabase($all);
 
-        return $all ? self::$fieldsRequiredDatabase : self::$fieldsRequiredDatabase[$this->getObjectName()];
+        if ((bool)$all) {
+            return self::$fieldsRequiredDatabase;
+        }
+
+        return !empty(self::$fieldsRequiredDatabase[$this->getObjectName()])
+            ? self::$fieldsRequiredDatabase[$this->getObjectName()]
+            : array();
     }
 
     /**

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1467,12 +1467,14 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     {
         $this->cacheFieldsRequiredDatabase($all);
 
-        if ((bool)$all) {
+        if ($all) {
             return self::$fieldsRequiredDatabase;
         }
 
-        return !empty(self::$fieldsRequiredDatabase[$this->getObjectName()])
-            ? self::$fieldsRequiredDatabase[$this->getObjectName()]
+        $objectName = $this->getObjectName();
+
+        return !empty(self::$fieldsRequiredDatabase[$objectName])
+            ? self::$fieldsRequiredDatabase[$objectName]
             : array();
     }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1495,7 +1495,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         $objectName = $this->getObjectName();
         if (!Db::getInstance()->execute(
             'DELETE FROM ' . _DB_PREFIX_ . 'required_field'
-            . "WHERE object_name = '" . Db::getInstance()->escape($objectName) . "'")
+            . " WHERE object_name = '" . Db::getInstance()->escape($objectName) . "'")
         ) {
             return false;
         }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1040,10 +1040,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
 
         // Check if field is required
-        $objectName = $this->getObjectName();
-        $required_fields = (isset(self::$fieldsRequiredDatabase[$objectName]))
-            ? self::$fieldsRequiredDatabase[$objectName]
-            : array();
+        $required_fields = $this->getCachedFieldsRequiredDatabase();
         if (!$id_lang || $id_lang == $ps_lang_default) {
             if (!in_array('required', $skip) && (!empty($data['required']) || in_array($field, $required_fields))) {
                 if (Tools::isEmpty($value)) {
@@ -1170,10 +1167,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     {
         $this->cacheFieldsRequiredDatabase();
         $errors = array();
-        $objectName = $this->getObjectName();
-        $required_fields_database = (isset(self::$fieldsRequiredDatabase[$objectName]))
-            ? self::$fieldsRequiredDatabase[$objectName]
-            : array();
+        $required_fields_database = $this->getCachedFieldsRequiredDatabase();
         foreach ($this->def['fields'] as $field => $data) {
             $value = Tools::getValue($field, $this->{$field});
             // Check if field is required by user
@@ -1279,10 +1273,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         $resource_parameters = array_merge_recursive($default_resource_parameters, $this->{$ws_params_attribute_name});
 
-        $objectName = $this->getObjectName();
-        $required_fields = (isset(self::$fieldsRequiredDatabase[$objectName])
-            ? self::$fieldsRequiredDatabase[$objectName]
-            : array());
+        $required_fields = $this->getCachedFieldsRequiredDatabase();
         foreach ($this->def['fields'] as $field_name => $details) {
             if (!isset($resource_parameters['fields'][$field_name])) {
                 $resource_parameters['fields'][$field_name] = array();
@@ -1388,10 +1379,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     {
         $this->cacheFieldsRequiredDatabase();
         $errors = array();
-        $objectName = $this->getObjectName();
-        $required_fields = (isset(self::$fieldsRequiredDatabase[$objectName]))
-            ? self::$fieldsRequiredDatabase[$objectName]
-            : array();
+        $required_fields = $this->getCachedFieldsRequiredDatabase();
 
         foreach ($this->def['fields'] as $field => $data) {
             if (!in_array($field, $required_fields)) {
@@ -1466,6 +1454,20 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                 self::$fieldsRequiredDatabase = array();
             }
         }
+    }
+
+    /**
+     * Get required fields list for this model or for all the models
+     *
+     * @param bool $all : whether it should return required fields for this model or all the models
+     *
+     * @return array
+     */
+    public function getCachedFieldsRequiredDatabase($all = false)
+    {
+        $this->cacheFieldsRequiredDatabase($all);
+
+        return $all ? self::$fieldsRequiredDatabase : self::$fieldsRequiredDatabase[$this->getObjectName()];
     }
 
     /**

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1486,7 +1486,8 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         $objectName = $this->getObjectName();
         if (!Db::getInstance()->execute(
-            'DELETE FROM ' . _DB_PREFIX_ . "required_field WHERE object_name = '$objectName'")
+            'DELETE FROM ' . _DB_PREFIX_ . 'required_field'
+            . "WHERE object_name = '" . Db::getInstance()->escape($objectName) . "'")
         ) {
             return false;
         }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -463,6 +463,17 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     }
 
     /**
+     * Get object name
+     * Used for read/write in required fields table
+     *
+     * @return string
+     */
+    public function getObjectName()
+    {
+        return get_class($this);
+    }
+
+    /**
      * Saves current object to database (add or update)
      *
      * @param bool $null_values
@@ -1029,7 +1040,10 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
 
         // Check if field is required
-        $required_fields = (isset(self::$fieldsRequiredDatabase[get_class($this)])) ? self::$fieldsRequiredDatabase[get_class($this)] : array();
+        $objectName = $this->getObjectName();
+        $required_fields = (isset(self::$fieldsRequiredDatabase[$objectName]))
+            ? self::$fieldsRequiredDatabase[$objectName]
+            : array();
         if (!$id_lang || $id_lang == $ps_lang_default) {
             if (!in_array('required', $skip) && (!empty($data['required']) || in_array($field, $required_fields))) {
                 if (Tools::isEmpty($value)) {
@@ -1156,7 +1170,10 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     {
         $this->cacheFieldsRequiredDatabase();
         $errors = array();
-        $required_fields_database = (isset(self::$fieldsRequiredDatabase[get_class($this)])) ? self::$fieldsRequiredDatabase[get_class($this)] : array();
+        $objectName = $this->getObjectName();
+        $required_fields_database = (isset(self::$fieldsRequiredDatabase[$objectName]))
+            ? self::$fieldsRequiredDatabase[$objectName]
+            : array();
         foreach ($this->def['fields'] as $field => $data) {
             $value = Tools::getValue($field, $this->{$field});
             // Check if field is required by user
@@ -1262,7 +1279,10 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         $resource_parameters = array_merge_recursive($default_resource_parameters, $this->{$ws_params_attribute_name});
 
-        $required_fields = (isset(self::$fieldsRequiredDatabase[get_class($this)]) ? self::$fieldsRequiredDatabase[get_class($this)] : array());
+        $objectName = $this->getObjectName();
+        $required_fields = (isset(self::$fieldsRequiredDatabase[$objectName])
+            ? self::$fieldsRequiredDatabase[$objectName]
+            : array());
         foreach ($this->def['fields'] as $field_name => $details) {
             if (!isset($resource_parameters['fields'][$field_name])) {
                 $resource_parameters['fields'][$field_name] = array();
@@ -1368,7 +1388,10 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     {
         $this->cacheFieldsRequiredDatabase();
         $errors = array();
-        $required_fields = (isset(self::$fieldsRequiredDatabase[get_class($this)])) ? self::$fieldsRequiredDatabase[get_class($this)] : array();
+        $objectName = $this->getObjectName();
+        $required_fields = (isset(self::$fieldsRequiredDatabase[$objectName]))
+            ? self::$fieldsRequiredDatabase[$objectName]
+            : array();
 
         foreach ($this->def['fields'] as $field => $data) {
             if (!in_array($field, $required_fields)) {
@@ -1402,7 +1425,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         return Db::getInstance()->executeS('
 		SELECT id_required_field, object_name, field_name
 		FROM '._DB_PREFIX_.'required_field
-		'.(!$all ? 'WHERE object_name = \''.pSQL(get_class($this)).'\'' : ''));
+		'.(!$all ? 'WHERE object_name = \''.pSQL($this->getObjectName()).'\'' : ''));
     }
 
     /**
@@ -1422,7 +1445,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             SELECT id_required_field
             FROM '._DB_PREFIX_.'required_field
             WHERE field_name = "'. Db::getInstance()->escape($field_name) .'"
-            '.(!$all ? ' AND object_name = \''.pSQL(get_class($this)).'\'' : ''));
+            '.(!$all ? ' AND object_name = \''.pSQL($this->getObjectName()).'\'' : ''));
         }
     }
 
@@ -1459,12 +1482,18 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             return false;
         }
 
-        if (!Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'required_field WHERE object_name = \''.get_class($this).'\'')) {
+        $objectName = $this->getObjectName();
+        if (!Db::getInstance()->execute(
+            'DELETE FROM ' . _DB_PREFIX_ . "required_field WHERE object_name = '$objectName'")
+        ) {
             return false;
         }
 
         foreach ($fields as $field) {
-            if (!Db::getInstance()->insert('required_field', array('object_name' => get_class($this), 'field_name' => pSQL($field)))) {
+            if (!Db::getInstance()->insert(
+                'required_field',
+                array('object_name' => $objectName, 'field_name' => pSQL($field))
+            )) {
                 return false;
             }
         }

--- a/classes/SupplierAddress.php
+++ b/classes/SupplierAddress.php
@@ -26,6 +26,9 @@
 
 /**
  * Class SupplierAddressCore
+ *
+ * Holds address info of a Supplier.
+ * This class extends AddressCore to be differentiated from other AddressCore objects in DB.
  */
 class SupplierAddressCore extends AddressCore
 {

--- a/classes/SupplierAddress.php
+++ b/classes/SupplierAddress.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Class SupplierAddressCore
+ */
+class SupplierAddressCore extends AddressCore
+{
+}

--- a/classes/WarehouseAddress.php
+++ b/classes/WarehouseAddress.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Class WarehouseAddressCore
+ */
+class WarehouseAddressCore extends AddressCore
+{
+}

--- a/classes/WarehouseAddress.php
+++ b/classes/WarehouseAddress.php
@@ -26,6 +26,9 @@
 
 /**
  * Class WarehouseAddressCore
+ *
+ * Holds address info of a Warehouse.
+ * This class extends AddressCore to be differentiated from other AddressCore objects in DB.
  */
 class WarehouseAddressCore extends AddressCore
 {

--- a/classes/checkout/AddressValidator.php
+++ b/classes/checkout/AddressValidator.php
@@ -50,7 +50,7 @@ class AddressValidatorCore
         );
 
         foreach ($addressesIds as $idAddress) {
-            $address = new Address((int)$idAddress);
+            $address = new CustomerAddress((int)$idAddress);
             try {
                 $address->validateFields();
             } catch (PrestaShopException $e) {
@@ -82,7 +82,7 @@ class AddressValidatorCore
         if (is_array($addresses)) {
             foreach ($addresses as $address) {
                 try {
-                    $adressObject = new Address((int)$address['id_address']);
+                    $adressObject = new CustomerAddress((int)$address['id_address']);
                     $adressObject->validateFields();
                 } catch (PrestaShopException $e) {
                     $invalidAddresses[] = (int)$address['id_address'];

--- a/classes/stock/SupplyOrderDetail.php
+++ b/classes/stock/SupplyOrderDetail.php
@@ -277,10 +277,11 @@ class SupplyOrderDetailCore extends ObjectModel
         /* required fields */
         $fields_required = $this->fieldsRequired;
 
-        if (isset(self::$fieldsRequiredDatabase[get_class($this)])) {
+        $objectName = $this->getObjectName();
+        if (isset(self::$fieldsRequiredDatabase[$objectName])) {
             $fields_required = array_merge(
                 $this->fieldsRequired,
-                self::$fieldsRequiredDatabase[get_class($this)]
+                self::$fieldsRequiredDatabase[$objectName]
             );
         }
 

--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -440,7 +440,7 @@ class AdminAddressesControllerCore extends AdminController
      */
     protected function processAddressFormat()
     {
-        $tmp_addr = new Address((int)Tools::getValue('id_address'));
+        $tmp_addr = new CustomerAddress((int)Tools::getValue('id_address'));
 
         $selected_country = ($tmp_addr && $tmp_addr->id_country) ? $tmp_addr->id_country : (int)Configuration::get('PS_COUNTRY_DEFAULT');
         $adr_fields = AddressFormat::getOrderedAddressFields($selected_country, false, true);

--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -38,7 +38,7 @@ class AdminAddressesControllerCore extends AdminController
         $this->required_database = true;
         $this->required_fields = array('company','address2', 'postcode', 'other', 'phone', 'phone_mobile', 'vat_number', 'dni');
         $this->table = 'address';
-        $this->className = 'Address';
+        $this->className = 'CustomerAddress';
         $this->lang = false;
         $this->addressType = 'customer';
         $this->explicitSelect = true;

--- a/controllers/admin/AdminManufacturersController.php
+++ b/controllers/admin/AdminManufacturersController.php
@@ -438,11 +438,11 @@ class AdminManufacturersControllerCore extends AdminController
     {
         // Change table and className for addresses
         $this->table = 'address';
-        $this->className = 'Address';
+        $this->className = 'ManufacturerAddress';
         $id_address = Tools::getValue('id_address');
 
         // Create Object Address
-        $address = new Address($id_address);
+        $address = new ManufacturerAddress($id_address);
 
         $res = $address->getFieldsRequiredDatabase();
         $required_fields = array();
@@ -791,7 +791,7 @@ class AdminManufacturersControllerCore extends AdminController
     {
         if (Tools::isSubmit('submitAddaddress') || Tools::isSubmit('deleteaddress') || Tools::isSubmit('submitBulkdeleteaddress') || Tools::isSubmit('exportaddress')) {
             $this->table = 'address';
-            $this->className = 'Address';
+            $this->className = 'ManufacturerAddress';
             $this->identifier = 'id_address';
             $this->deleted = true;
             $this->fields_list = $this->getAddressFieldsList();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed bug where address required fields were required for any address type (customer, brand...). Now, multiple address types are used to read/write required fields.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2027
| How to test?  | Go to "customers" -> "addresses" and add VAT number field as required. Then go to "catalog" -> "manufacturers and suppliers" and try to edit and save a manufacturer. You SHOULD NOT have a "required field VAT number" message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/7986)
<!-- Reviewable:end -->
