### PR TITLE
Avoid INSTALL_PATH re-define error

### DIFF
--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -201,7 +201,9 @@ namespace PrestaShopBundle\Install {
         private function defineConst()
         {
             // retrocompatibility (is present in some upgrade scripts)
-            define('INSTALL_PATH', $this->installDir);
+            if (!defined('INSTALL_PATH')) {
+                define('INSTALL_PATH', $this->installDir);
+            }
             require_once(INSTALL_PATH . 'install_version.php');
             // needed for upgrade before 1.5
             if (!defined('__PS_BASE_URI__')) {


### PR DESCRIPTION
If multiple Upgrade::do* methods are called on one script, the constant
is re-defined.

Prevent this issue by check the definition first.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Prevents multiple defined of `INSTALL_PATH` constant
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | See below.

If you call multiple `Upgrade` action on one script:

```php
$upgrade = new Upgrade($logDir, $installDir);
$upgrade->setAdminDir(_PS_ADMIN_DIR_);

$upgradeActions = [
    'doUpgradeDb',
    'doUpdateImage',
    'doUpdateLangHtaccess',
    'doUpdateTheme'
];

foreach ($upgradeActions as $upgradeAction) {
    \call_user_func([$upgrade, $upgradeAction]);
}
```

You will have a `Constant INSTALL_PATH already defined` warning.

This PR fix the issue.