### PR TITLE
Fix the specific price of the default combination

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -460,7 +460,7 @@ class ProductControllerCore extends FrontController
 
                 // Call getPriceStatic in order to set $combination_specific_price
                 if (!isset($combination_prices_set[(int)$row['id_product_attribute']])) {
-                    Product::getPriceStatic((int)$this->product->id, false, $row['id_product_attribute'], 6, null, false, true, 1, false, null, null, null, $combination_specific_price);
+                    Product::getPriceStatic((int)$this->product->id, false, $row['id_product_attribute'], 6, null, false, false, 1, false, null, null, null, $combination_specific_price);
                     $combination_prices_set[(int)$row['id_product_attribute']] = true;
                     $combinations[$row['id_product_attribute']]['specific_price'] = $combination_specific_price;
                 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | the price of the default combination get the discount twice, meanwhile the others seems to be good.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9077
| How to test?  | create a specific price for each combinations with fixed price and percentage discount, check the default combination in FO, the discount will be applied on the price just once.