### PR TITLE
Fix product with combinations auto-indexation

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -149,10 +149,13 @@ class AdminProductWrapper
                 $product->cache_default_attribute = (int)$id_product_attribute;
             }
 
+            // We need to reload the product because some other calls have modified the database
+            // It's done just for the setAvailableDate to avoid side effects
+            $consistentProduct = new Product($product->id);
             if ($available_date = $combinationValues['available_date_attribute']) {
-                $product->setAvailableDate($available_date);
+                $consistentProduct->setAvailableDate($available_date);
             } else {
-                $product->setAvailableDate();
+                $consistentProduct->setAvailableDate();
             }
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix product with combinations auto-indexation. When a product has combination, we cal setAvailableDate, but it was updating the product with some old values. We reload the product into a new variable, to update the date.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2563
| How to test?  |