### PR TITLE
Format error message

### DIFF
--- a/themes/classic/templates/_partials/form-errors.tpl
+++ b/themes/classic/templates/_partials/form-errors.tpl
@@ -27,7 +27,7 @@
     {block name='form_errors'}
       <ul>
         {foreach $errors as $error}
-          <li>{$error}</li>
+          <li class="alert alert-danger">{$error}</li>
         {/foreach}
       </ul>
     {/block}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When I enter wrong login/password in the FO, there is an error displayed. But this error is not visible.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2902
| How to test?  | Try to connect in the FO with wrong login or password

Before :
![auth0](https://user-images.githubusercontent.com/20836092/27079162-84ca51b6-502e-11e7-8b61-081890bc2779.png)
After:
![auth](https://user-images.githubusercontent.com/20836092/27079172-8fadb06e-502e-11e7-8bfd-979862e919f4.png)
![auth2](https://user-images.githubusercontent.com/20836092/27079175-917bcf84-502e-11e7-88fd-d8aa4bbad9c7.png)
