### PR TITLE
Install Deutsch instead of Deutsch CH for Switzerland

### DIFF
--- a/localization/ch.xml
+++ b/localization/ch.xml
@@ -4,7 +4,7 @@
 		<currency name="Franc" iso_code="CHF" iso_code_num="756" sign="CHF" blank="1" conversion_rate="1.34183" format="5" decimals="1" />
 	</currencies>
 	<languages>
-		<language iso_code="dh" />
+		<language iso_code="de" />
 		<language iso_code="fr" />
 		<language iso_code="it" />
 	</languages>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Seen with @AlexEven, we will install Deutsch instead of Deutsch CH for Switzerland. I've also made the modifications on the translations files.
| Type?         | improvement
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | In order to test, you need to make some changes. As the list of available languages is fetch from a remote server according to PrestaShop Version, you need to edit `config/autoload.php` and `install-dev/install_version.php` and set it `1.7.2.0`. Then, check that when you install the Switzerland localization pack you have the french, german and italian languages. Make sure to set `Download pack data` to `no` as this PR is not merged yet. Also, when you go to `International > Translations` you shouldn't see `Deutsch (German)` anymore.