### PR TITLE
Fix specific prices

### DIFF
--- a/themes/default-bootstrap/product.tpl
+++ b/themes/default-bootstrap/product.tpl
@@ -399,10 +399,10 @@
 			{/if}
 		</div> <!-- end pb-right-column-->
 	</div> <!-- end primary_block -->
-	{if !$content_only}
-{if (isset($quantity_discounts) && count($quantity_discounts) > 0)}
+
+	{if (isset($quantity_discounts) && count($quantity_discounts) > 0)}
 			<!-- quantity discount -->
-			<section class="page-product-box">
+			<section class="page-product-box {if $content_only}hidden{/if}">
 				<h3 class="page-product-heading">{l s='Volume discounts'}</h3>
 				<div id="quantityDiscount">
 					<table class="std table-product-discounts">
@@ -416,12 +416,18 @@
 						<tbody>
 						{foreach from=$quantity_discounts item='quantity_discount' name='quantity_discounts'}
 							{if $quantity_discount.price >= 0 || $quantity_discount.reduction_type == 'amount'}
-								{$realDiscountPrice=$quantity_discount.base_price|floatval-$quantity_discount.real_value|floatval}
+								{$realDiscountPrice=$productPriceWithoutReduction|floatval-$quantity_discount.real_value|floatval}
 							{else}
-								{$realDiscountPrice=$quantity_discount.base_price|floatval*(1 - $quantity_discount.reduction)|floatval}
+								{$realDiscountPrice=$productPriceWithoutReduction|floatval*(1 - $quantity_discount.reduction)|floatval}
 							{/if}
-							<tr class="quantityDiscount_{$quantity_discount.id_product_attribute}" data-real-discount-value="{convertPrice price = $realDiscountPrice}" data-discount-type="{$quantity_discount.reduction_type}" data-discount="{$quantity_discount.real_value|floatval}" data-discount-quantity="{$quantity_discount.quantity|intval}">
-								<td>
+						<tr class="quantityDiscount_{$quantity_discount.id_product_attribute} {if $quantity_discount.id_product_attribute == 0}used{/if}"
+							data-real-discount-value="{convertPrice price = $realDiscountPrice}"
+							data-discount-type="{$quantity_discount.reduction_type}"
+							data-discount="{$quantity_discount.real_value|floatval}"
+							data-base-Price="{convertPrice price= $productPriceWithoutReduction}"
+							data-discount-formatted="{if $quantity_discount.reduction_type == 'amount'}{convertPrice price=($quantity_discount.real_value*-1)}{else}{($quantity_discount.real_value * -1)|floatval}%{/if}"
+							data-discount-quantity="{$quantity_discount.quantity|intval}">
+							<td>
 									{$quantity_discount.quantity|intval}
 								</td>
 								<td>
@@ -464,7 +470,8 @@
 					</table>
 				</div>
 			</section>
-		{/if}
+	{/if}
+	{if !$content_only}
 		{if isset($features) && $features}
 			<!-- Data sheet -->
 			<section class="page-product-box">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | when you use specific prices for different quantities of product, as you increase the qty, the discount value will be displayed instead of discounted price, so the user will have no idea about the new discounted price
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9102 & http://forge.prestashop.com/browse/PSCSX-9095
| How to test?  | create multiple specific prices for different quantities (amount or percentage, with fixed price or without, it doesn't matter). As you increase the quantity of product on its page (in FO), the specific prices will be displayed correctly.