### PR TITLE
FO: Restore link variable on AJAX rendering

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1765,6 +1765,7 @@ class FrontControllerCore extends Controller
         );
 
         $scope->assign($params);
+        $scope->assign('link', $this->context->link);
 
         try {
             $tpl = $this->context->smarty->createTemplate(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The link tool may be used on some custom theme and then fail on ajax loading.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3254
| How to test?  | Override `catalog/_partials/miniatures/product.tpl` file and use `$link`.

This is working great, but I don't know if it's the best way to do.

Please tell me if I have to update this PR.