### PR TITLE
Show Duplicate option when multishop selected

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
@@ -144,19 +144,17 @@
           }
           ] %}
 
-          {# Only duplicate if shop or group is selected #}
-          {% if is_shop_context %}
-            {% set buttons_action = buttons_action|merge([
-            {
-            "divider": true
-            },
-            {
-            "onclick": "bulkProductAction(this, 'duplicate_all');",
-            "icon": "content_copy",
-            "label": "Duplicate selection"|trans({}, 'Admin.Actions')
-            }
-            ]) %}
-          {% endif %}
+          {% set buttons_action = buttons_action|merge([
+          {
+          "divider": true
+          },
+          {
+          "onclick": "bulkProductAction(this, 'duplicate_all');",
+          "icon": "content_copy",
+          "label": "Duplicate selection"|trans({}, 'Admin.Actions')
+          }
+          ]) %}
+
 
           {% set buttons_action = buttons_action|merge([
           {

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/list.html.twig
@@ -98,16 +98,13 @@
                       }
                     ] %}
 
-                    {# Only duplicate if shop or group is selected #}
-                    {% if is_shop_context %}
-                      {% set buttons_action = buttons_action|merge([
-                        {
-                        "onclick": "unitProductAction(this, 'duplicate');",
-                        "icon": "content_copy",
-                        "label": "Duplicate"|trans({}, 'Admin.Actions')
-                        }
-                      ]) %}
-                    {% endif %}
+                    {% set buttons_action = buttons_action|merge([
+                      {
+                      "onclick": "unitProductAction(this, 'duplicate');",
+                      "icon": "content_copy",
+                      "label": "Duplicate"|trans({}, 'Admin.Actions')
+                      }
+                    ]) %}
 
                     {% set buttons_action = buttons_action|merge([
                       {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Duplicate button in catalog is not displayed when multishop selected
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3189
| How to test?  | Select multishop option and duplicate products