### PR TITLE
Prevent adding pack in itself

### DIFF
--- a/admin-dev/ajax_products_list.php
+++ b/admin-dev/ajax_products_list.php
@@ -51,6 +51,7 @@ if ($excludeIds && $excludeIds != 'NaN') {
     $excludeIds = implode(',', array_map('intval', explode(',', $excludeIds)));
 } else {
     $excludeIds = '';
+    $excludePackItself= Tools::getValue('packItself', false);
 }
 
 // Excluding downloadable products from packs because download from pack is not supported
@@ -68,6 +69,7 @@ $sql = 'SELECT p.`id_product`, pl.`link_rewrite`, p.`reference`, pl.`name`, imag
 		LEFT JOIN `'._DB_PREFIX_.'image_lang` il ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = '.(int)$context->language->id.')
 		WHERE (pl.name LIKE \'%'.pSQL($query).'%\' OR p.reference LIKE \'%'.pSQL($query).'%\')'.
         (!empty($excludeIds) ? ' AND p.id_product NOT IN ('.$excludeIds.') ' : ' ').
+        (!empty($excludePackItself) ? ' AND p.id_product <> '.$excludePackItself.' ' : ' ').
         ($excludeVirtuals ? 'AND NOT EXISTS (SELECT 1 FROM `'._DB_PREFIX_.'product_download` pd WHERE (pd.id_product = p.id_product))' : '').
         ($exclude_packs ? 'AND (p.cache_is_pack IS NULL OR p.cache_is_pack = 0)' : '').
         ' GROUP BY p.id_product';

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -5022,7 +5022,7 @@ class AdminProductsControllerCore extends AdminController
                         $item_id_attribute = 0;
                         count($array = explode('x', $line)) == 3 ? list($qty, $item_id, $item_id_attribute) = $array : list($qty, $item_id) = $array;
                         if ($qty > 0 && isset($item_id)) {
-                            if (Pack::isPack((int)$item_id)) {
+                            if (Pack::isPack((int)$item_id || $product->id == (int)$item_id)) {
                                 $this->errors[] = Tools::displayError('You can\'t add product packs into a pack');
                             } elseif (!Pack::addItem((int)$product->id, (int)$item_id, (int)$qty, (int)$item_id_attribute)) {
                                 $this->errors[] = Tools::displayError('An error occurred while attempting to add products to the pack.');

--- a/js/admin/products.js
+++ b/js/admin/products.js
@@ -1244,7 +1244,8 @@ product_tabs['Pack'] = new function() {
 				dataType: 'json',
 				data: function (term) {
 					return {
-						q: term
+						q: term,
+						packItself: $('input[name=\'id_product\']').val()
 					};
 				},
 				results: function (data) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When creating a product pack (by editing an exisiting standard product and setting it as a pack) Prestashop is allowing to insert the same ID product in the product pack list.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8516
| How to test?  | Create a standard product -> Edit the product and mark it as a pack of products -> Add a product to the pack and choose the same product -> Save -> Try to open that product from front office with a profiler.
