### PR TITLE
Display module confirm uninstall message

### DIFF
--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -101,6 +101,7 @@ class Module implements ModuleInterface
         'avgRate' => 0,
         'nbRates' => 0,
         'fullDescription' => '',
+        'confirmUninstall' => '',
     );
 
     /**

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -416,7 +416,7 @@ class ModuleRepository implements ModuleRepositoryInterface
                 // We load the main class of the module, and get its properties
                 $tmp_module = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get($name);
                 foreach (array('warning', 'name', 'tab', 'displayName', 'description', 'author', 'author_uri',
-                    'limited_countries', 'need_instance', ) as $data_to_get) {
+                    'limited_countries', 'need_instance', 'confirmUninstall', ) as $data_to_get) {
                     if (isset($tmp_module->{$data_to_get})) {
                         $main_class_attributes[$data_to_get] = $tmp_module->{$data_to_get};
                     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
@@ -55,6 +55,8 @@
                   {% if module_action == 'uninstall' %}
                     {{ "You are about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
                     <br>
+                    {{ module.attributes.confirmUninstall }}
+                    <br>
                     <br>
                     {{ "This will disable the module and delete all its files. For good."|trans({}, 'Admin.Modules.Notification') }}
                     <br>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | User defined in $this->confirmUninstall message not displayed. Instead the general message is displayed.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | /no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2097
| How to test?  | Uninstall module