### PR TITLE
Missing product-flag class on product miniature

### DIFF
--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -73,7 +73,7 @@
     {block name='product_flags'}
       <ul class="product-flags">
         {foreach from=$product.flags item=flag}
-          <li class="{$flag.type}">{$flag.label}</li>
+          <li class="product-flag {$flag.type}">{$flag.label}</li>
         {/foreach}
       </ul>
     {/block}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The needed CSS class is missing
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2531
| How to test?  | See description.

The `product-flag` class is missing from miniature, rendering this:

![image](https://user-images.githubusercontent.com/1698357/27233208-053d1b4e-52b9-11e7-9392-869f0a08130d.png)

Should be this:

![image](https://user-images.githubusercontent.com/1698357/27233211-08f169f2-52b9-11e7-959b-dbe94485f705.png)
