### PR TITLE
Fix not handled new tab ID during migration

### DIFF
--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -122,6 +122,14 @@ CREATE TABLE `PREFIX_authorization_role` (
 RENAME TABLE `PREFIX_access` TO `PREFIX_access_old`;
 RENAME TABLE `PREFIX_module_access` TO `PREFIX_module_access_old`;
 
+CREATE TABLE `PREFIX_tab_transit` (
+  `id_old_tab` int(11),
+  `id_new_tab` int(11),
+  `key` VARCHAR(128) /* class_name and module concatenation */
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
+/* Save the old IDs */
+INSERT INTO `PREFIX_tab_transit` (`id_old_tab`, `key`) SELECT `id_tab`, CONCAT(`class_name`, COALESCE(`module`, '')) FROM `PREFIX_tab`;
+
 CREATE TABLE `PREFIX_access` (
   `id_profile` int(10) unsigned NOT NULL,
   `id_authorization_role` int(10) unsigned NOT NULL,
@@ -197,8 +205,22 @@ DELETE FROM `PREFIX_configuration` WHERE `name` IN (
 ALTER TABLE `PREFIX_tab` ADD `icon` varchar(32) DEFAULT '';
 
 /* PHP:migrate_tabs_17(); */;
+
+/* Save the new IDs */
+UPDATE `PREFIX_tab_transit` tt SET `id_new_tab` = (
+  SELECT `id_tab` FROM `PREFIX_tab` WHERE CONCAT(`class_name`, COALESCE(`module`, '')) = tt.`key`
+);
+/* Update default tab IDs for employees */
+UPDATE `PREFIX_employee` e SET `default_tab` = (
+  SELECT IFNULL(`id_new_tab`,
+    /* If the tab does not exist anymore, fallback to the dashboard. */
+    (SELECT `id_tab` FROM `PREFIX_tab` WHERE `class_name` = 'AdminDashboard' AND `module` IS NULL)
+  ) FROM `PREFIX_tab_transit` WHERE `id_old_tab` = e.`default_tab`
+);
+
 /* Properly migrate the rights associated with each tabs */
 /* PHP:ps_1700_right_management(); */;
 
 DROP TABLE IF EXISTS `PREFIX_access_old`;
 DROP TABLE IF EXISTS `PREFIX_module_access_old`;
+DROP TABLE IF EXISTS `PREFIX_tab_transit`;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Tab IDs are changed since 1.7.0.0 and are not handled during migration
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3269 <br> http://forge.prestashop.com/browse/BOOM-3209
| How to test?  | Use a 1.6.* database and try a migration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8020)
<!-- Reviewable:end -->
