### PR TITLE
Use correct module name column for authorization role

### DIFF
--- a/install-dev/upgrade/php/ps_1700_right_management.php
+++ b/install-dev/upgrade/php/ps_1700_right_management.php
@@ -31,12 +31,12 @@ function ps_1700_right_management()
     /**
      * Add roles
      */
-    foreach (array('TAB', 'MODULE') as $element) {
+    foreach (array('TAB' => 'class_name', 'MODULE' => 'name') as $element => $nameColumn) {
         foreach ($actions as $action) {
             Db::getInstance()->execute('
                 INSERT IGNORE INTO `'._DB_PREFIX_.'authorization_role`
                 (`slug`)
-                SELECT CONCAT("ROLE_MOD_'.$element.'_", UCASE(`class_name`), "_'.$action.'")
+                SELECT CONCAT("ROLE_MOD_'.$element.'_", UCASE(`'.$nameColumn.'`), "_'.$action.'")
                 FROM `'._DB_PREFIX_.strtolower($element).'`
             ');
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Wrong name column was used for module role migration.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3209 (with #8020)
| How to test?  | Do a migration from 1.6 to 1.7.