### PR TITLE
Fix AdminSlipController filter

### DIFF
--- a/controllers/admin/AdminSlipController.php
+++ b/controllers/admin/AdminSlipController.php
@@ -48,12 +48,14 @@ class AdminSlipControllerCore extends AdminController
             'id_order' => array(
                 'title' => $this->l('Order ID'),
                 'align' => 'left',
-                'class' => 'fixed-width-md'
+                'class' => 'fixed-width-md',
+                'havingFilter' => true
             ),
             'date_add' => array(
                 'title' => $this->l('Date issued'),
                 'type' => 'date',
-                'align' => 'right'
+                'align' => 'right',
+                'filter_key' => 'a!date_add'
             ),
             'id_pdf' => array(
                 'title' => $this->l('PDF'),
@@ -185,7 +187,7 @@ class AdminSlipControllerCore extends AdminController
             'desc' => $this->l('Generate PDF file')
         );
     }
-    
+
     public function printPDFIcons($id_order_slip, $tr)
     {
         $order_slip = new OrderSlip((int)$id_order_slip);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fresh prestashop installation (from github). Im getting SQL error when trying filter by id_order in admin Slip COntroller
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9146
| How to test?  | Create some order slip, go to admin slip into order. try to filter them by id_order


<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
