### PR TITLE
Load id_shop routes when needed

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -569,6 +569,9 @@ class DispatcherCore
         if (isset(Context::getContext()->shop) && $id_shop === null) {
             $id_shop = (int)Context::getContext()->shop->id;
         }
+        if (!isset($this->routes[$id_shop])) {
+            $this->loadRoutes($id_shop);
+        }
 
         return isset($this->routes[$id_shop]) && isset($this->routes[$id_shop][$id_lang]) && isset($this->routes[$id_shop][$id_lang][$route_id]);
     }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -374,7 +374,7 @@ class LinkCore
 
         // If the module has its own route ... just use it !
         if (Dispatcher::getInstance()->hasRoute('module-'.$module.'-'.$controller, $id_lang, $id_shop)) {
-            return $this->getPageLink('module-'.$module.'-'.$controller, $ssl, $id_lang, $params);
+            return $this->getPageLink('module-'.$module.'-'.$controller, $ssl, $id_lang, $params, false, $id_shop);
         } else {
             if ($id_shop) {
                 $allow = (int)Configuration::get('PS_REWRITING_SETTINGS', null, null, $id_shop);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In a multistore context and with a module registering its own routes, this allow Link::getModuleLink to create a link pointing to a different store than the current shop. Eg: "View this module page in our other store : https://www.otherstore.com/customroute". Dispatcher::hasRoute curently doesn't load the other store routes, so Link::getModuleLink#L376 think it has no routes.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Enable multistore. Create a second store. Register a route with hookModuleRoutes. Display a link from one store to the other with $link->getModuleLink(..., $id_other_store, ...). Instead of having https://www.otherstore.com/customroute, it creates https://www.otherstore.com/module/modulename/route

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
