### PR TITLE
Update regex for tab registration

### DIFF
--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -194,7 +194,7 @@ class ModuleTabRegister
                     ->depth('== 0')
                     ->name('*.php')
                     ->exclude(['index.php'])
-                    ->contains('/extends\s+ModuleAdminController/i');
+                    ->contains('/Controller\s+extends\s+/i');
 
         return iterator_to_array($moduleFolder);
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a admin controller class does not extend directly ModuleAdminController, it was not automatically registered by the Tab event.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | 