### PR TITLE
throwing Prestashop exception instead of friendly error message in dev mode [module development]

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -960,7 +960,7 @@ class ToolsCore
     */
     public static function displayError($string = 'Fatal error', $htmlentities = true, Context $context = null)
     {
-        if (defined('_PS_MODE_DEV_') && _PS_MODE_DEV_) {
+        if (defined('_PS_MODE_DEV_') && _PS_MODE_DEV_ && $string == 'Fatal error') {
             throw new PrestaShopException($string);
         } else if ('Fatal error' !== $string) {
             return $string;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  |Throwing PrestaShop exception instead of friendly error message in DEV mode
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | use Tools::displayError() to display a friendly error message in any module.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
