### PR TITLE
Home page carousel not being enabled on mobile devices

### DIFF
--- a/themes/classic/modules/ps_imageslider/views/tempaltes/hook/slider.tpl
+++ b/themes/classic/modules/ps_imageslider/views/tempaltes/hook/slider.tpl
@@ -1,0 +1,61 @@
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @version  Release: $Revision$
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{if $homeslider.slides}
+  <div id="carousel" data-ride="carousel" class="carousel slide" data-interval="{$homeslider.speed}" data-wrap="{(string)$homeslider.wrap}" data-pause="{$homeslider.pause}">
+    <ul class="carousel-inner" role="listbox">
+      {foreach from=$homeslider.slides item=slide name='homeslider'}
+        <li class="carousel-item {if $smarty.foreach.homeslider.first}active{/if}">
+          <a href="{$slide.url}">
+            <figure>
+              <img src="{$slide.image_url}" alt="{$slide.legend|escape}">
+              {if $slide.title || $slide.description}
+                <figcaption class="caption">
+                  <h2 class="display-1 text-uppercase">{$slide.title}</h2>
+                  <div class="caption-description">{$slide.description nofilter}</div>
+                </figcaption>
+              {/if}
+            </figure>
+          </a>
+        </li>
+      {/foreach}
+    </ul>
+    <div class="direction">
+      <a class="left carousel-control" href="#carousel" role="button" data-slide="prev">
+        <span class="icon-prev hidden-xs" aria-hidden="true">
+          <i class="material-icons">&#xE5CB;</i>
+        </span>
+        <span class="sr-only">{l s='Previous' d='Shop.Theme'}</span>
+      </a>
+      <a class="right carousel-control" href="#carousel" role="button" data-slide="next">
+        <span class="icon-next" aria-hidden="true">
+          <i class="material-icons">&#xE5CC;</i>
+        </span>
+        <span class="sr-only">{l s='Next' d='Shop.Theme'}</span>
+      </a>
+    </div>
+  </div>
+{/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Home page carousel not being enabled on mobile devices
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/NM-839
| How to test?  | As enabling mobile image slider (carousel) on PrestaShop 1.7.1.2 module panel, slider is not being displayed on mobile devices

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
