### PR TITLE
Add paid order to stats dashboard even when there's no related invoice generated

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -99,6 +99,8 @@ class OrderHistoryCore extends ObjectModel
         // executes hook
         if (in_array($new_os->id, array(Configuration::get('PS_OS_PAYMENT'), Configuration::get('PS_OS_WS_PAYMENT')))) {
             Hook::exec('actionPaymentConfirmation', array('id_order' => (int)$order->id), null, false, true, false, $order->id_shop);
+            //initialize invoice date
+            $order->invoice_date =date('Y-m-d H:i:s');
         }
 
         // executes hook


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | when the invoice option is disabled for the order status "Payment accepted", and you change the order status to "Payment accepted", the dashboard stats will not consider the order cause the invoice_date is null, so when the payment accepted, I initialized the invoice_date.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9094
| How to test?  | Orders -> states -> disable invoice for "Payment accepted" status, Orders -> edit Order -> change status to "Payment accepted" (there will be not invoice generated), Dashboard -> check the number of orders and the value of sales (everything looks well calculated), so the order is considered even when the invoice is not generated.

