### PR TITLE
Wrong close of 'product_tabs' {block} in product.tpl

### DIFF
--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -224,9 +224,9 @@
                    {$extra.content nofilter}
                  </div>
                  {/foreach}
-              </div>
-            {/block}
-          </div>
+              </div>  
+            </div>
+          {/block}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There is an error in the close tag "{/block}" of the product_tab, that is before than the </div> close.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3295
| How to test?  | File: /themes/classic/templates/catalog/product.tpl

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
