### PR TITLE
FO: Use $base_dir_ssl if SSL is enabled on CMS categories pages

### DIFF
--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -76,12 +76,6 @@ class CategoryControllerCore extends FrontController
         if (Tools::getValue('live_edit')) {
             return;
         }
-
-        if (!Validate::isLoadedObject($this->category) || !$this->category->inShop() || !$this->category->isAssociatedToShop() || in_array($this->category->id, array(Configuration::get('PS_HOME_CATEGORY'), Configuration::get('PS_ROOT_CATEGORY')))) {
-            $this->redirect_after = '404';
-            $this->redirect();
-        }
-
         if (!Tools::getValue('noredirect') && Validate::isLoadedObject($this->category)) {
             parent::canonicalRedirection($this->context->link->getCategoryLink($this->category));
         }
@@ -107,11 +101,11 @@ class CategoryControllerCore extends FrontController
         parent::init();
 
         // Check if the category is active and return 404 error if is disable.
-        if (!$this->category->active) {
+        if (!$this->category->active || !Validate::isLoadedObject($this->category) || !$this->category->inShop() || !$this->category->isAssociatedToShop() || in_array($this->category->id, array(Configuration::get('PS_HOME_CATEGORY'), Configuration::get('PS_ROOT_CATEGORY')))) {
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
-        }
-
+            $this->errors[] = Tools::displayError('Category not found');
+        } else 
         // Check if category can be accessible by current customer and return 403 if not
         if (!$this->category->checkAccess($this->context->customer->id)) {
             header('HTTP/1.1 403 Forbidden');
@@ -129,6 +123,10 @@ class CategoryControllerCore extends FrontController
         parent::initContent();
 
         $this->setTemplate(_PS_THEME_DIR_.'category.tpl');
+		
+        if ($this->errors) {
+            return;
+        }
 
         if (!$this->customer_access) {
             return;

--- a/themes/default-bootstrap/cms.tpl
+++ b/themes/default-bootstrap/cms.tpl
@@ -41,7 +41,7 @@
 	</div>
 {elseif isset($cms_category)}
 	<div class="block-cms">
-		<h1><a href="{if $cms_category->id eq 1}{$base_dir}{else}{$link->getCMSCategoryLink($cms_category->id, $cms_category->link_rewrite)}{/if}">{$cms_category->name|escape:'html':'UTF-8'}</a></h1>
+		<h1><a href="{if $cms_category->id eq 1}{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}{else}{$link->getCMSCategoryLink($cms_category->id, $cms_category->link_rewrite)}{/if}">{$cms_category->name|escape:'html':'UTF-8'}</a></h1>
 		{if $cms_category->description}
 			<p>{$cms_category->description|escape:'html':'UTF-8'}</p>
 		{/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | On Prestashop 1.6.1.X, I have a link with no https protocol. And yet SSL is enabled.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) 
| How to test?  | Test on local environment

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
