### PR TITLE
Fix the conversion_rate in the order_payment table

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -385,7 +385,7 @@ class OrderHistoryCore extends ObjectModel
                     }
                     $order->save();
 
-                    $payment->conversion_rate = 1;
+                    $payment->conversion_rate = ($order ? $order->conversion_rate : 1);
                     $payment->save();
                     Db::getInstance()->execute('
                     INSERT INTO `'._DB_PREFIX_.'order_invoice_payment` (`id_order_invoice`, `id_order_payment`, `id_order`)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The table that contains payments related to orders (ps_order_payment) contains a field named conversion_rate. This field is always set to 1.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8983
| How to test?  | made an order with another currency (not the default one), then update its status to "payment accepted", check the "order_payment" table, you will see the "conversion_rate" is correctly saved.

(cherry picked from commit 2c7fa67e57eb6a0aff84d2902988c4087a948d91)
