### PR TITLE
Pass param content_only param to overrideLayoutTemplate call

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1313,6 +1313,8 @@ class FrontControllerCore extends Controller
         }
 
         $layout = $this->context->shop->theme->getLayoutRelativePathForPage($entity);
+        
+        $content_only = (int) Tools::getValue('content_only');
 
         if ($overridden_layout = Hook::exec(
             'overrideLayoutTemplate',
@@ -1321,12 +1323,13 @@ class FrontControllerCore extends Controller
                 'entity' => $entity,
                 'locale' => $this->context->language->locale,
                 'controller' => $this,
+                'content_only' => (int) $content_only,
             )
         )) {
             return $overridden_layout;
         }
 
-        if ((int) Tools::getValue('content_only')) {
+        if ((int) $content_only) {
             $layout = 'layouts/layout-content-only.tpl';
         }
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1323,13 +1323,13 @@ class FrontControllerCore extends Controller
                 'entity' => $entity,
                 'locale' => $this->context->language->locale,
                 'controller' => $this,
-                'content_only' => (int) $content_only,
+                'content_only' => $content_only,
             )
         )) {
             return $overridden_layout;
         }
 
-        if ((int) $content_only) {
+        if ($content_only) {
             $layout = 'layouts/layout-content-only.tpl';
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Pass the content only param to the hook call.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | It's just an easy way to get the params "content_only" inside the hook call.