### PR TITLE
Fix unit price of the product with combinations

### DIFF
--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -863,7 +863,7 @@ function updatePrice()
 	// It doesn't modify the price, it's only for display
 	if (productUnitPriceRatio > 0)
 	{
-		$('#unit_price_display').text(formatCurrency(unit_price * currencyRate, currencyFormat, currencySign, currencyBlank));
+		$('#unit_price_display').text(formatCurrency(unit_price, currencyFormat, currencySign, currencyBlank));
 		$('.unit-price').show();
 	}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | the unit price is already calculated so it's wrong to re-multiply it with the currency rate
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9134
| How to test?  | create a product with combinations and set its unit price. Then see the product details in FO, there's no problem with the default currency but if you change the currency, the unit price will be wrongly calculated