### PR TITLE
Fix type of errors variable in module configuration feature

### DIFF
--- a/src/Adapter/Module/Configuration/ModuleSelfConfigurator.php
+++ b/src/Adapter/Module/Configuration/ModuleSelfConfigurator.php
@@ -202,7 +202,7 @@ class ModuleSelfConfigurator
             }
 
             if (empty($config)) {
-                $errors = 'Parsed config file is empty';
+                $errors[] = 'Parsed config file is empty';
             }
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | Validation of configuration parameters replace an array for a string in a specific case. This PR fixes it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Create an empty `self_config.yml` in a module folder, and call the command `app/console prestashop:module configure <module name>` to trigger the configuration. You must have this error:

```
                                               
  Validation of configuration details failed:  
  - Parsed config file is empty                
                                               
```