### PR TITLE
Make the store email clickable in the footer

### DIFF
--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -58,8 +58,8 @@
         {l
           s='Email us: [1]%email%[/1]'
           sprintf=[
-            '[1]' => '<span>',
-            '[/1]' => '</span>',
+            '[1]' => '<a href="mailto:'|cat:$contact_infos.email|cat:'" class="dropdown">',
+            '[/1]' => '</a>',
             '%email%' => $contact_infos.email
           ]
           d='Shop.Theme'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The store email is not clickable in the footer
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3181
| How to test?  | Check if the store email can be clickable in the FO footer.
