### PR TITLE
Add correctly the free_shipping cart_rule to an order from BO

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1460,6 +1460,7 @@ class AdminOrdersControllerCore extends AdminController
                         $cartRuleObj->active = 0;
                         if ($res = $cartRuleObj->add()) {
                             $cart_rule['id'] = $cartRuleObj->id;
+                            $cart_rule['free_shipping'] = $cartRuleObj->free_shipping;
                         } else {
                             break;
                         }
@@ -1475,6 +1476,7 @@ class AdminOrdersControllerCore extends AdminController
                             $order_cart_rule->name = Tools::getValue('discount_name');
                             $order_cart_rule->value = $cart_rule['value_tax_incl'];
                             $order_cart_rule->value_tax_excl = $cart_rule['value_tax_excl'];
+                            $order_cart_rule->free_shipping = $cart_rule['free_shipping'];
                             $res &= $order_cart_rule->add();
 
                             $order->total_discounts += $order_cart_rule->value;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | I just add the free_shipping value in "submitNewVoucher" condition
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8909
| How to test?  | Orders -> Click on any order -> Scroll down to Products -> Click "Add a new discount" Enter a name and set the Type to "Free shipping" and click Add. Then, check the invoice PDF, you will not see a discount of the same value of the shipping like use to be but you will see free shipping.