### PR TITLE
FO: Use default_template to get override

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1439,7 +1439,7 @@ class FrontControllerCore extends Controller
         if ($this->useMobileTheme()) {
             $this->setMobileTemplate($default_template);
         } else {
-            $template = $this->getOverrideTemplate();
+            $template = $this->getOverrideTemplate($default_template);
             if ($template) {
                 parent::setTemplate($template);
             } else {
@@ -1454,11 +1454,15 @@ class FrontControllerCore extends Controller
      * specific controller.
      *
     * @since 1.5.0.13
+    * @param string $defaul_template
     * @return string|bool
     */
-    public function getOverrideTemplate()
+    public function getOverrideTemplate($default_template)
     {
-        return Hook::exec('DisplayOverrideTemplate', array('controller' => $this));
+        return Hook::exec('DisplayOverrideTemplate', array(
+            'controller' => $this,
+            'default_template' => $default_template,
+        ));
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x.
| Description?  | This allows to get the default (frond end) template filename used when having an opportunity to override it. Currently we "only" get the full controller instance. In practice, it will allow modules to hook on DisplayOverrideTemplate and search for "_template_-override", or whatever suffix registered or not in conf table, or whatever complex/simple strategy from the developer / end user to choose an override. I see this PR as a bugfix, because default_template filename is obviously a missing information.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | N/A

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
