### PR TITLE
Display texture image in combination form

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/AttributeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeRepository.php
@@ -84,11 +84,17 @@ class AttributeRepository extends \Doctrine\ORM\EntityRepository
 
     private function getAttributeRow($attribute)
     {
-        return array(
+        $attributes = array(
             'id' => $attribute['id'],
             'color' => $attribute['color'],
             'position' => $attribute['attributePosition'],
             'name' => $attribute['attributeName'],
+            'texture' => '',
         );
+        if (@file_exists(_PS_COL_IMG_DIR_ . $attribute['id'] . '.jpg')) {
+            $attributes['texture'] = _THEME_COL_DIR_ . $attribute['id'] . '.jpg';
+        }
+
+        return $attributes;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -148,8 +148,9 @@
                 >
                 <label class="attribute-label" for="attribute-{{ attribute.id }}">
                   <span
-                    class="pretty-checkbox {% if attribute.color is empty %} not-color {% endif %}"
+                    class="pretty-checkbox {% if attribute.color is empty and attribute.texture is empty %} not-color {% endif %}"
                     {% if attribute.color is not empty %} style="background-color: {{ attribute.color }}" {% endif %}
+                    {% if attribute.texture is not empty %} style="content: url({{ attribute.texture }})" {% endif %}
                   >
                   </span>
                   {{ attribute.name }}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | The texture image is not displayed in the product page when creating combinations.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3270
| How to test?  | Create a new attribute with type "color and texture", go to product combination form, check if the texture image is displayed