### PR TITLE
Allow admin folder name inside quick access link

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1181,7 +1181,7 @@ class LinkCore
 
         $patterns = array(
             '#'.Context::getContext()->link->getBaseLink().'#',
-            '#'.basename(_PS_ADMIN_DIR_).'#',
+            '#'.basename(_PS_ADMIN_DIR_).'/#',
             '/index.php/',
             '/_?token=[a-zA-Z0-9\_]+/'
         );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As now, if your admin folder is name like "ps" and that you want to add the module ps_bankwire in the quick access, the link will remove the ps part of the module and the link will be not good.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | As described previously.