### PR TITLE
Fix search to properly look for supplier reference

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -491,7 +491,7 @@ class SearchCore
                             $sql .= ', p.reference';
                         break;
                         case 'supplier_reference':
-                            $sql .= ', p.supplier_reference';
+                            $sql .= ', ps_product_supplier';
                         break;
                         case 'ean13':
                             $sql .= ', p.ean13';


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The search function does not index the supplier reference. However, if you check the source code it (classes\search.php) it includes "supplier_reference". The problem is that it looks for the supplier_reference field in the ps_product table. But since at least version 1.5 that is no longer used. Instead the search function should now look in the ps_product_supplier table.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2954
| How to test?  | Make a search

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
