### PR TITLE
Fix unexpected admin controlle filename

### DIFF
--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -130,6 +130,9 @@ class ModuleTabRegister
         }, $tabs);
 
         foreach ($this->getModuleAdminControllersFilename($moduleName) as $adminControllerFileName) {
+            if (strpos($adminControllerFileName, 'Controller.php') === false) {
+                continue;
+            }
             $adminControllerName = str_replace('Controller.php', '', $adminControllerFileName);
             if (in_array($adminControllerName, $tabsNames)) {
                 continue;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develoo
| Description?  | This PR fixes an issue happening with modules installed while they have a admin controller without `Controller` in their filename (found by @rGaillard)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | 