### PR TITLE
Module tab registration must check filenames

### DIFF
--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -192,7 +192,7 @@ class ModuleTabRegister
         $moduleFolder = $this->finder->files()
                     ->in($modulePath)
                     ->depth('== 0')
-                    ->name('*.php')
+                    ->name('*Controller.php')
                     ->exclude(['index.php'])
                     ->contains('/Controller\s+extends\s+/i');
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | This PR fixes an issue happening with modules installed while they have a admin controller without `Controller` in their filename (found by @rGaillard)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | 