### PR TITLE
Add unicode prime symbol in PDF

### DIFF
--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -52,6 +52,7 @@ class PDFGeneratorCore extends TCPDF
         'pl' => 'dejavusans',
         'ar' => 'dejavusans',
         'fa' => 'dejavusans',
+        'fr' => 'dejavusans',
         'ur' => 'dejavusans',
         'az' => 'dejavusans',
         'ca' => 'dejavusans',
@@ -147,7 +148,7 @@ class PDFGeneratorCore extends TCPDF
         if (array_key_exists($iso_lang, $this->font_by_lang)) {
             $this->font = $this->font_by_lang[$iso_lang];
         }else {
-            $this->font = self::DEFAULT_FONT;
+            $this->font = 'dejavusans';
         }
 
         $this->setHeaderFont(array($this->font, '', PDF_FONT_SIZE_MAIN, '', false));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When using a prime symbol in product's name or its attributes descriptions/values, it will be replaced with a question mark in PDF (invoices, etc...). 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9167
| How to test?  | try to put this symbole ′  in product's description or in its attributes, then make an order with this product and generate the invoice PDF, the symbole will be displayed well without any question marks.