### PR TITLE
Fix tax problems in shopping cart

### DIFF
--- a/controllers/front/OrderOpcController.php
+++ b/controllers/front/OrderOpcController.php
@@ -256,13 +256,15 @@ class OrderOpcControllerCore extends ParentOrderController
                                         // Wrapping fees
                                         $wrapping_fees = $this->context->cart->getGiftWrappingPrice(false);
                                         $wrapping_fees_tax_inc = $this->context->cart->getGiftWrappingPrice();
+                                        $summary = $this->getFormatedSummaryDetail();
                                         $result = array_merge($result, array(
+                                            'HOOK_DISPLAY_PRODUCT_PRICE_BLOCK' => Hook::exec('displayCartTotalPriceLabel',$summary),
                                             'HOOK_TOP_PAYMENT' => Hook::exec('displayPaymentTop'),
                                             'HOOK_PAYMENT' => $this->_getPaymentMethods(),
                                             'gift_price' => Tools::displayPrice(Tools::convertPrice(Product::getTaxCalculationMethod() == 1 ? $wrapping_fees : $wrapping_fees_tax_inc, new Currency((int)$this->context->cookie->id_currency))),
                                             'carrier_data' => $this->_getCarrierList(),
                                             'refresh' => (bool)$this->ajax_refresh),
-                                            $this->getFormatedSummaryDetail()
+                                            $summary
                                         );
                                         $this->ajaxDie(Tools::jsonEncode($result));
                                     }

--- a/themes/default-bootstrap/js/order-opc.js
+++ b/themes/default-bootstrap/js/order-opc.js
@@ -318,6 +318,10 @@ function updatePaymentMethods(json)
 	$('#opc_payment_methods-content #HOOK_PAYMENT').html(json.HOOK_PAYMENT);
 }
 
+function updateDisplayPrice(json) {
+	$('#HOOK_DISPLAY_PRODUCT_PRICE_BLOCK').html(json.HOOK_DISPLAY_PRODUCT_PRICE_BLOCK);
+}
+
 function updatePaymentMethodsDisplay()
 {
 	var checked = '';
@@ -448,6 +452,7 @@ function updateAddressSelection(is_adv_api)
 				}
 				updateCarrierList(jsonData.carrier_data);
 				updatePaymentMethods(jsonData);
+				updateDisplayPrice(jsonData);
 				updateCartSummary(jsonData.summary);
 				updateHookShoppingCart(jsonData.HOOK_SHOPPING_CART);
 				updateHookShoppingCartExtra(jsonData.HOOK_SHOPPING_CART_EXTRA);

--- a/themes/default-bootstrap/shopping-cart.tpl
+++ b/themes/default-bootstrap/shopping-cart.tpl
@@ -169,7 +169,10 @@
 									{/if}
 								{/if}
 							</td>
-							<td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax incl.)'}{else}{l s='Total products'}{/if}</td>
+							<td colspan="{$col_span_subtotal}" class="text-right">
+								{l s='Total products'}
+								(<span class="hookDisplayProductPriceBlock-price" id="HOOK_DISPLAY_PRODUCT_PRICE_BLOCK">{hook h="displayCartTotalPriceLabel"}</span>)
+							</td>
 							<td colspan="2" class="price" id="total_product">{displayPrice price=$total_products_wt}</td>
 						</tr>
 					{/if}
@@ -282,7 +285,7 @@
 				<tr class="cart_total_price">
 					<td colspan="{$col_span_subtotal}" class="total_price_container text-right">
 						<span>{l s='Total'}</span>
-                        <div class="hookDisplayProductPriceBlock-price">
+                        <div class="hookDisplayProductPriceBlock-price" id="HOOK_DISPLAY_PRODUCT_PRICE_BLOCK">
                             {hook h="displayCartTotalPriceLabel"}
                         </div>
 					</td>

--- a/themes/default-bootstrap/shopping-cart.tpl
+++ b/themes/default-bootstrap/shopping-cart.tpl
@@ -287,12 +287,18 @@
                         </div>
 					</td>
 					{if $use_taxes}
-						<td colspan="2" class="price" id="total_price_container">
-							<span id="total_price">{displayPrice price=$total_price}</span>
-						</td>
+						{if $priceDisplay}
+							<td colspan="2" class="price" id="total_price_container">
+								<span id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</span>
+							</td>
+						{else}
+							<td colspan="2" class="price" id="total_price_container">
+								<span id="total_price">{displayPrice price=$total_price}</span>
+							</td>
+						{/if}
 					{else}
 						<td colspan="2" class="price" id="total_price_container">
-							<span id="total_price">{displayPrice price=$total_price_without_tax}</span>
+							<span id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</span>
 						</td>
 					{/if}
 				</tr>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When we select to display prices tax excluded in the group, the total in cart is tax included.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9119
| How to test?  | BO->Customers->Groups-> edit Client -> choose "Tax excluded" as "Price display method", then access to FO-> add a product to your cart then click on "Proceed to checkout", you find the TOTAL well displayed without tax, even when you try to change your carrier, the TOTAL will be displayed without tax.