### PR TITLE
Allow extra fields from modules in product form

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -424,7 +424,7 @@ class ProductController extends FrameworkBundleAdminController
         );
         $adminProductWrapper = $this->get('prestashop.adapter.admin.wrapper.product');
 
-        $form = $this->createFormBuilder($modelMapper->getFormData())
+        $form = $this->createFormBuilder($modelMapper->getFormData(), array('allow_extra_fields' => true))
             ->add('id_product', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
             ->add('step1', 'PrestaShopBundle\Form\Admin\Product\ProductInformation')
             ->add('step2', 'PrestaShopBundle\Form\Admin\Product\ProductPrice')


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | When a module add inputs to the products form with latest hooks introduced, Symfony was rejecting all save requests because of these additional inputs.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Install a module which introduces a new input with the hook (i.e `hookDisplayAdminProductsMainStepLeftColumnMiddle`), and try to save a product. You should not receive any error from Symfony.

```php
    public function hookDisplayAdminProductsMainStepLeftColumnMiddle()
    {
        return $this->displayHook(__FUNCTION__);
    }

    public function hookDisplayAdminProductsMainStepLeftColumnBottom()
    {
        return $this->displayHook(__FUNCTION__);
    }

    public function hookDisplayAdminProductsMainStepRightColumnBottom()
    {
        return $this->displayHook(__FUNCTION__);
    }

    public function hookDisplayAdminProductsQuantitiesStepBottom()
    {
        return $this->displayHook(__FUNCTION__);
    }

    public function hookDisplayAdminProductsPriceStepBottom()
    {
        return $this->displayHook(__FUNCTION__);
    }

    public function hookDisplayAdminProductsOptionsStepTop()
    {
        return $this->displayHook(__FUNCTION__);
    }

    public function hookDisplayAdminProductsOptionsStepBottom()
    {
        return $this->displayHook(__FUNCTION__);
    }

    public function hookDisplayAdminProductsSeoStepBottom()
    {
        return $this->displayHook(__FUNCTION__);
    }

    public function hookDisplayAdminProductsShippingStepBottom()
    {
        return $this->displayHook(__FUNCTION__);
    }

    public function displayHook($name)
    {
        return '<div class="form-group">
                            <h2>
                              My beautiful input
                              <span class="help-box" data-toggle="popover" data-content="That\'s an original input :o" data-original-title="" title=""></span>
                            </h2>

                            <div class="row">
                              <div class="col-xl-12 col-lg-12">
                                  <input id="" name="form[module][adminproductpage][]" class="form-control" type="text" value="'.$name.'">
                              </div>
                            </div>
                          </div>';
    }
```