### PR TITLE
Fix upgrade button with update from disk

### DIFF
--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -154,6 +154,10 @@ class Module implements ModuleInterface
             $version = $this->attributes->get('version');
         }
 
+        if (!$this->attributes->has('version_available')) {
+            $this->attributes->set('version_available', $this->disk->get('version'));
+        }
+
         $img = $this->attributes->get('img');
         if (empty($img)) {
             $this->attributes->set('img', __PS_BASE_URI__.'img/questionmark.png');
@@ -332,10 +336,17 @@ class Module implements ModuleInterface
 
     public function canBeUpgraded()
     {
-        return
-            $this->database->get('installed') == 1
-            && $this->attributes->get('version_available')
-            !== 0 && version_compare($this->database->get('version'), $this->attributes->get('version_available'), '<')
-        ;
+        if ($this->database->get('installed') == 0) {
+            return false;
+        }
+
+        // Potential update from API
+        if ($this->attributes->get('version_available') !== 0
+            && version_compare($this->database->get('version'), $this->attributes->get('version_available'), '<')) {
+            return true;
+        }
+
+        // Potential update from disk
+        return version_compare($this->database->get('version'), $this->disk->get('version'), '<');
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | When a module has been manually replaced with copy/paste, the upgrade button does not appear anymore because it was looking only on the marketplace API details. Issue brought with https://github.com/PrestaShop/PrestaShop/pull/7984
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Seen on gitter (https://gitter.im/PrestaShop/General?at=595a0474703e565c336aea38)
| How to test?  | Modify the version of one module. The upgrade must now be suggested.