### PR TITLE
Fix select delivery_option when changing the address in OPC

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2599,11 +2599,19 @@ class CartCore extends ObjectModel
         // The delivery option was selected
         if (isset($this->delivery_option) && $this->delivery_option != '') {
             $delivery_option = Tools::unSerialize($this->delivery_option);
-            $validated = true;
-            foreach ($delivery_option as $id_address => $key) {
-                if (!isset($delivery_option_list[$id_address][$key])) {
-                    $validated = false;
-                    break;
+            $validated = false;
+            foreach ($delivery_option as $key) {
+                foreach ($delivery_option_list as $id_address => $option) {
+                    if (isset($delivery_option_list[$id_address][$key])) {
+                        $validated = true;
+
+                        if (!isset($delivery_option[$id_address])) {
+                            $delivery_option = array();
+                            $delivery_option[$id_address] = $key;
+                        }
+
+                        break 2;
+                    }
                 }
             }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Keep the selected carrier by user when changing the address in OPC page
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8901
| How to test?  | you need a customer account with two different adresses, and two different carriers that both delivers to those two adresses, then enable the OnePageCheckout. access to FO -> OPC, select the second carrier then change the delivery address to another one. The carrier will be still selected and won't change.