### PR TITLE
Fix product qty when we get two orders on the same time of the same product

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -171,6 +171,19 @@ abstract class PaymentModuleCore extends Module
             $this->context = Context::getContext();
         }
         $this->context->cart = new Cart((int)$id_cart);
+        //Check that products have available quantity
+        $products = $this->context->cart->getProducts();
+        foreach ($products as $row) {
+            $quantityToSell = $row['cart_quantity'];
+            $quantityProduct = Product::getQuantity($row['id_product'], $row['id_product_attribute'], $row['id_shop']);
+            $product = new Product($row['id_product'], true, null, $row['id_shop']);
+            if (!Validate::isLoadedObject($product)) {
+                die($this->module->l('The Product object could not be loaded.'));
+            }
+            if (($quantityToSell > $quantityProduct) && (!$product->isAvailableWhenOutOfStock((int)$product->out_of_stock))) {
+                Tools::redirect('index.php?controller=order&step=1');
+            }
+        }
         $this->context->customer = new Customer((int)$this->context->cart->id_customer);
         // The tax cart is loaded before the customer so re-cache the tax calculation method
         $this->context->cart->setTaxCalculationMethod();


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | when you have a lot of sales at same time, customers can add products to cart and complete the process, until the payment is not validated, prestashop dont rest the stock, so if you have 3 items, and 4 customers purchase at same time, until the payment getaway back to the store, the stock is not deducted, so when back to the store, you have sell 4 items instead or 3 items.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9166
| How to test?  | create a product P with 4 as quantity. Try to connect to FO with two different customers at the same time, then, make two orders of the product P with quantity 4 for each one at the same time. When the customers confirm their orders, one of them his order will proceed normally and the other will be noticed that the product P is out of stock.