### PR TITLE
Fix JS event thrown on module uninstall

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -142,7 +142,7 @@ var AdminModuleController = function() {
 
   this.initBOEventRegistering = function() {
     BOEvent.on('Module Disabled', this.onModuleDisabled, this);
-    BOEvent.on('Module Uninstalled', this.updateTotalResults, "Back office");
+    BOEvent.on('Module Uninstalled', this.updateTotalResults, this);
   };
 
   this.onModuleDisabled = function() {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | This PR fixes the black overlay staying on the module page when a uninstall was successful.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3384
| How to test?  | Uninstall a module. When the action is successful, you must be able to use the page again instead of having an overlay covering the whole page.