### PR TITLE
Undefined index base_price

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -334,6 +334,9 @@ class ProductControllerCore extends FrontController
 
         $quantity_discounts = SpecificPrice::getQuantityDiscounts($id_product, $id_shop, $id_currency, $id_country, $id_group, null, true, (int)$this->context->customer->id);
         foreach ($quantity_discounts as &$quantity_discount) {
+            if (!isset($quantity_discount['base_price'])) {
+                $quantity_discount['base_price'] = 0;
+            }
             if ($quantity_discount['id_product_attribute']) {
                 $quantity_discount['base_price'] = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, $quantity_discount['id_product_attribute']);
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | initialize base_price for quantity_discount before passing it to formatQuantityDiscounts
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a product without attribute and with quantity discount. On the product page a notice will show with an undefined index base_price
