### PR TITLE
BO: Fix bug PSCSX-9103, invalid token on cancel

### DIFF
--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -598,6 +598,10 @@ class AdminCustomersControllerCore extends AdminController
                 Tools::getValue('groupBox_'.$group['id_group'], in_array($group['id_group'], $customer_groups_ids));
         }
 
+        $this->tpl_form_vars = array(
+            'back_url' => urldecode(Tools::getValue('back')),
+        );
+
         return parent::renderForm();
     }
 


### PR DESCRIPTION


<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix bug #PSCSX-9103, invalid security token on cancel in Firefox browser.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9103
| How to test?  | Pressing Cancel button on Customer page does not affect Invalid security token error (see Video attached to the ticket how to reproduce this bug).

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
