### PR TITLE
BO: fix js error newTheme

### DIFF
--- a/js/rtl.js
+++ b/js/rtl.js
@@ -9,7 +9,7 @@
 $(document).ready(function () {
     $('[style]').each(function (index) {
         var styles_old = $(this).attr('style');
-        styles_old = styles_old.split(';');
+        styles_old = styles_old.split(';').filter(item => item);
         var styles = {};
         var s = '';
         var i = '';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | rtl
| Description?  | A JS error occurs when opening a symfony page (e.g: product page). This error blocks some functionality like the text editor. Error: Uncaught TypeError: Can not read property 'toUpperCase' of undefined
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Open any symfony page (e.g:product page), you can see that the editor works fine
