### PR TITLE
Manage the display of errors & warnings in the AdminController

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -402,6 +402,9 @@ class AdminControllerCore extends Controller
 
     /** @var string */
     protected $tabSlug;
+	
+	/** @var bool  Assign admin errors & warning to template */
+	public $show_admin_errors = true;
 
     public function __construct($forceControllerName = '', $default_theme_name = 'default')
     {
@@ -1789,20 +1792,9 @@ class AdminControllerCore extends Controller
             $page = $this->content;
         }
 
-        if ($conf = Tools::getValue('conf')) {
-            $this->context->smarty->assign('conf', $this->json ? json_encode($this->_conf[(int)$conf]) : $this->_conf[(int)$conf]);
-        }
-
-        if ($error = Tools::getValue('error')) {
-            $this->context->smarty->assign('error', $this->json ? json_encode($this->_error[(int)$error]) : $this->_error[(int)$error]);
-        }
-
-        foreach (array('errors', 'warnings', 'informations', 'confirmations') as $type) {
-            if (!is_array($this->$type)) {
-                $this->$type = (array)$this->$type;
-            }
-            $this->context->smarty->assign($type, $this->json ? json_encode(array_unique($this->$type)) : array_unique($this->$type));
-        }
+		if($this->show_admin_errors) {
+			$this->assignAdminErrors();
+		}
 
         if ($this->show_page_header_toolbar && !$this->lite_display) {
             $this->context->smarty->assign(
@@ -1824,6 +1816,27 @@ class AdminControllerCore extends Controller
 
         $this->smartyOutputContent($this->layout);
     }
+	
+	/**
+	 * Assign smarty variables for Errors & warnings in Back Office
+	 */
+	public function assignAdminErrors()
+	{
+		if ($conf = Tools::getValue('conf')) {
+			$this->context->smarty->assign('conf', $this->json ? json_encode($this->_conf[(int)$conf]) : $this->_conf[(int)$conf]);
+		}
+
+		if ($error = Tools::getValue('error')) {
+			$this->context->smarty->assign('error', $this->json ? json_encode($this->_error[(int)$error]) : $this->_error[(int)$error]);
+		}
+
+		foreach (array('errors', 'warnings', 'informations', 'confirmations') as $type) {
+			if (!is_array($this->$type)) {
+				$this->$type = (array)$this->$type;
+			}
+			$this->context->smarty->assign($type, $this->json ? json_encode(array_unique($this->$type)) : array_unique($this->$type));
+		}
+	}
 
     /**
      * Add a warning message to display at the top of the page


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.2.x & 1.6.1.x
| Description?  | With this PR, for default There is no particular change, But it allows us to display in our modules reports and errors wherever we want. for example we have complex module controller like page builder so this PR help us!
| Type?         | improvement
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | in Modules AdminController can set **$this->show_admin_errors = false** and so every where we need to display errors just we call **$this->assignAdminErrors()** so with this Assign errors to our module template and we can show errors & warning. (for advanced module like page builder )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8100)
<!-- Reviewable:end -->
