### PR TITLE
Fix the tab permissions when only one profile

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -132,15 +132,6 @@ class TabCore extends ObjectModel
         if (!$context) {
             $context = Context::getContext();
         }
-        if (!$context->employee || !$context->employee->id_profile) {
-            return false;
-        }
-
-        /* Profile selection */
-        $profiles = Db::getInstance()->executeS('SELECT `id_profile` FROM `'._DB_PREFIX_.'profile` WHERE `id_profile` != 1');
-        if (!$profiles || empty($profiles)) {
-            return true;
-        }
 
         /* Right management */
         $slug = 'ROLE_MOD_TAB_'.strtoupper(self::getClassNameById($idTab));
@@ -153,7 +144,10 @@ class TabCore extends ObjectModel
 
         foreach (array('view', 'add', 'edit', 'delete') as $action) {
             $access->updateLgcAccess('1', $idTab, $action, true);
-            $access->updateLgcAccess($context->employee->id_profile, $idTab, $action, true);
+
+            if ($context->employee && $context->employee->id_profile) {
+                $access->updateLgcAccess($context->employee->id_profile, $idTab, $action, true);
+            }
         }
 
         return true;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | When you have only one profile (eg in installing prestashop without fixtures), the accesses to the tab is not created on tab addition
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Add a tab on a PrestaShop with only one profile

