### PR TITLE
Fix multistore search indexation

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -601,6 +601,7 @@ class SearchCore
             $db->execute('DELETE si FROM `'._DB_PREFIX_.'search_index` si
 				INNER JOIN `'._DB_PREFIX_.'product` p ON (p.id_product = si.id_product)
 				'.Shop::addSqlAssociation('product', 'p').'
+				INNER JOIN `'._DB_PREFIX_.'search_word` sw ON (sw.id_word = si.id_word AND product_shop.id_shop = sw.id_shop)
 				WHERE product_shop.`visibility` IN ("both", "search")
 				AND product_shop.`active` = 1
 				AND '.($id_product ? 'p.`id_product` = '.(int)$id_product : 'product_shop.`indexed` = 0'));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When multistore is activated, for some stores, the search results are empty, while others show results.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9154
| How to test?  | enable multistore, create 2 stores (S1 & S2), create a product you could sell in multistore, then go to Preference -> General parameters  and click on the link "rebuild index". In one store S1, edit this product. Then go to FO, make a search on the product in the 2 stores, (usually, S1 show result despite S2 doesn't show)  you will get same result.