### PR TITLE
Fix get attributes in order presenter

### DIFF
--- a/src/Adapter/Order/OrderPresenter.php
+++ b/src/Adapter/Order/OrderPresenter.php
@@ -131,7 +131,7 @@ class OrderPresenter implements PresenterInterface
             }
 
             foreach ($cartProducts['products'] as $cartProduct) {
-                if ($cartProduct['id_product'] === $orderProduct['product_id']) {
+                if ($cartProduct['id_product_attribute'] === $orderProduct['id_product_attribute']) {
                     if (isset($cartProduct['attributes'])) {
                         $orderProduct['attributes'] = $cartProduct['attributes'];
                     } else {


### PR DESCRIPTION
…ibute, otherwise the attributes stored in the array are always the same.

(cherry picked from commit d959dbbcd56fad5c8034d8fc0f5ae78ab8f51c30)

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | it's an issue in the OrderPresenter core class. Product attributes stored in the products array are always the same. This is caused by a comparison on a wrong variable value (id_product, instead of id_product_attribute)
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | I noticed it developing a theme that use more informations on the order history page. You may add a {debug} in customer/history.tpl and see that product attributes are the same for each product in the order.

This is what happens without modification:
![02-wrong](https://user-images.githubusercontent.com/397671/27936287-446a9ec0-62b0-11e7-83e4-c642fb933ba0.jpg)

This is the right behavior:
![01-right](https://user-images.githubusercontent.com/397671/27936291-46609a90-62b0-11e7-817e-391b19578b0a.jpg)

