### PR TITLE
Fix the deletion of manufacturing addresses

### DIFF
--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -124,10 +124,14 @@ class ManufacturerCore extends ObjectModel
      */
     public function delete()
     {
-        $address = new Address($this->id_address);
-
-        if (Validate::isLoadedObject($address) && !$address->delete()) {
-            return false;
+        $addresses = $this->getAddresses();
+        if (is_array($addresses)) {
+            foreach ($addresses as $data) {
+                $address = new Address($data['id_address']);
+                if (Validate::isLoadedObject($address) && !$address->delete()) {
+                    return false;
+                }
+            }
         }
 
         if (parent::delete()) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you delete a manufacturer, its associated addresses are not deleted.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1410
| How to test?  | Go to BO > Catalog > Brands & Suppliers > Brands, create a new brand, create a new address and associate it with the brand, delete the brand and check if its associated addresses are deleted.
