### PR TITLE
Fixed bug about the language link in the reply_msg mail

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -418,7 +418,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                     $params = array(
                         '{reply}' => Tools::nl2br(Tools::getValue('reply_message')),
                         '{link}' => Tools::url(
-                            $this->context->link->getPageLink('contact', true, null, null, false, $ct->id_shop),
+                            $this->context->link->getPageLink('contact', true, (int)$ct->id_lang, null, false, $ct->id_shop),
                             'id_customer_thread='.(int)$ct->id.'&token='.$ct->token
                         ),
                         '{firstname}' => $customer->firstname,


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  "1.6.1.x" 
| Description?  | Multilanguage environmente. The client open a thread in some language. the mail sent from employee includes an incorrect language link to answer the mail
| Type?         | bug fix 
| Category?     |  BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Multilanguage environmente. The client open a thread in some language. When in the backoffice the Employee answers the ticket the mail sent includes a link wich is in the incorrect language because the Customer thread language is not used in the link generation

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
