### PR TITLE
Fix the upload quota for the product image

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -148,7 +148,7 @@
                       <div id="product-images-dropzone" class="panel dropzone ui-sortable col-md-12"
                            url-upload="{{ path('admin_product_image_upload', {'idProduct': id_product}) }}"
                            url-position="{{ path('admin_product_image_positions') }}"
-                           data-max-size="{{ 'PS_ATTACHMENT_MAXIMUM_SIZE'|configuration }}"
+                           data-max-size="{{ 'PS_LIMIT_UPLOAD_IMAGE_VALUE'|configuration }}"
                       >
                         <div id="product-images-dropzone-error" class="text-danger"></div>
                         <div class="dz-default dz-message openfilemanager">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When setting the maximum quota for uploading the product image, you are able to upload an image which size is upper than the specified quota.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3347
| How to test?  | Go to BO > Advanced Parameters > Administration > Upload quota, set the maximum size for a product's image with a specified quota, go to BO > Catalog > Products, try to upload an image with size upper than the specified quota (check if an error message is displayed).