### PR TITLE
Fix module enabling when ~ in theme.yml

### DIFF
--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -81,7 +81,7 @@ class Theme implements AddonInterface
         foreach ($modulesToHook as $hookName => $modules) {
             if (is_array($modules)) {
                 foreach (array_values($modules) as $module) {
-                    if (!in_array($module, $modulesToEnable)) {
+                    if (null !== $module && !in_array($module, $modulesToEnable)) {
                         $modulesToEnable[] = $module;
                     }
                 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | Fix module enabling when ~ in theme.yml. It was causing a fatal error because we were trying to enable a "null" module.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3417
| How to test?  |