### PR TITLE
Fix the weird syntax in customer information page

### DIFF
--- a/admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl
@@ -262,7 +262,7 @@
 					{/if}
 				{else}
 				<p class="text-muted text-center">
-					{l s='%firstname% %lastname% has not placed any orders yet' sprintf=['%firstname' => '$customer->firstname', '%lastname%' => '$customer->lastname'] d='Admin.Orderscustomers.Feature'}
+					{l s='%firstname% %lastname% has not placed any orders yet' sprintf=['%firstname%' => $customer->firstname, '%lastname%' => $customer->lastname] d='Admin.Orderscustomers.Feature'}
 				</p>
 				{/if}
 			</div>
@@ -404,7 +404,7 @@
 					</table>
 				{else}
 				<p class="text-muted text-center">
-					{l s='%firstname% %lastname% has never contacted you' sprintf=['%firstname%' => '$customer->firstname', '%lastname%' => '$customer->lastname'] d='Admin.Orderscustomers.Feature'}
+					{l s='%firstname% %lastname% has never contacted you' sprintf=['%firstname%' => $customer->firstname, '%lastname%' => $customer->lastname] d='Admin.Orderscustomers.Feature'}
 				</p>
 				{/if}
 			</div>
@@ -452,7 +452,7 @@
 					</table>
 				{else}
 				<p class="text-muted text-center">
-					{l s='%firstname% %lastname% has no discount vouchers' sprintf=['%firstname%' => '$customer->firstname', '%lastname%' => '$customer->lastname'] d='Admin.Orderscustomers.Feature'}
+					{l s='%firstname% %lastname% has no discount vouchers' sprintf=['%firstname%' => $customer->firstname, '%lastname%' => $customer->lastname] d='Admin.Orderscustomers.Feature'}
 				</p>
 				{/if}
 			</div>
@@ -650,7 +650,7 @@
 					</table>
 				{else}
 					<p class="text-muted text-center">
-						{l s='%firstname% %lastname% has not registered any addresses yet' sprintf=['%firstname%' => '$customer->firstname', '%lastname%' => '$customer->lastname']}
+						{l s='%firstname% %lastname% has not registered any addresses yet' sprintf=['%firstname%' => $customer->firstname, '%lastname%' => $customer->lastname]}
 					</p>
 				{/if}
 			</div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When viewing the customer information, there is some weird syntax code instead of the customer name in the orders, messages, vouchers and addresses tabs.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3421
| How to test?  | Go to BO > Customers, chose a customer without messages or orders or vouchers or addresses, and check if the weird syntax code does not appear.