### PR TITLE
Improve database connection character set declaration

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -39,6 +39,22 @@ class DbPDOCore extends Db
 
     /**
      * Returns a new PDO object (database link)
+     * @deprecated use getPDO
+     *
+     * @param string $host
+     * @param string $user
+     * @param string $password
+     * @param string $dbname
+     * @param int $timeout
+     * @return PDO
+     */
+    protected static function _getPDO($host, $user, $password, $dbname, $timeout = 5)
+    {
+        return static::getPDO($host, $user, $host, $dbname, $timeout);
+    }
+
+    /**
+     * Returns a new PDO object (database link)
      *
      * @param string $host
      * @param string $user

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -47,7 +47,7 @@ class DbPDOCore extends Db
      * @param int $timeout
      * @return PDO
      */
-    protected static function _getPDO($host, $user, $password, $dbname, $timeout = 5)
+    protected static function getPDO($host, $user, $password, $dbname, $timeout = 5)
     {
         $dsn = 'mysql:';
         if ($dbname) {
@@ -78,7 +78,7 @@ class DbPDOCore extends Db
     public static function createDatabase($host, $user, $password, $dbname, $dropit = false)
     {
         try {
-            $link = DbPDO::_getPDO($host, $user, $password, false);
+            $link = DbPDO::getPDO($host, $user, $password, false);
             $success = $link->exec('CREATE DATABASE `'.str_replace('`', '\\`', $dbname).'`');
             if ($dropit && ($link->exec('DROP DATABASE `'.str_replace('`', '\\`', $dbname).'`') !== false)) {
                 return true;
@@ -98,7 +98,7 @@ class DbPDOCore extends Db
     public function connect()
     {
         try {
-            $this->link = $this->_getPDO($this->server, $this->user, $this->password, $this->database, 5);
+            $this->link = $this->getPDO($this->server, $this->user, $this->password, $this->database, 5);
         } catch (PDOException $e) {
             throw new PrestaShopException('Link to database cannot be established: '.$e->getMessage());
         }
@@ -280,7 +280,7 @@ class DbPDOCore extends Db
     public static function hasTableWithSamePrefix($server, $user, $pwd, $db, $prefix)
     {
         try {
-            $link = DbPDO::_getPDO($server, $user, $pwd, $db, 5);
+            $link = DbPDO::getPDO($server, $user, $pwd, $db, 5);
         } catch (PDOException $e) {
             return false;
         }
@@ -304,7 +304,7 @@ class DbPDOCore extends Db
     public static function checkCreatePrivilege($server, $user, $pwd, $db, $prefix, $engine = null)
     {
         try {
-            $link = DbPDO::_getPDO($server, $user, $pwd, $db, 5);
+            $link = DbPDO::getPDO($server, $user, $pwd, $db, 5);
         } catch (PDOException $e) {
             return false;
         }
@@ -341,7 +341,7 @@ class DbPDOCore extends Db
     public static function tryToConnect($server, $user, $pwd, $db, $new_db_link = true, $engine = null, $timeout = 5)
     {
         try {
-            $link = DbPDO::_getPDO($server, $user, $pwd, $db, $timeout);
+            $link = DbPDO::getPDO($server, $user, $pwd, $db, $timeout);
         } catch (PDOException $e) {
             // hhvm wrongly reports error status 42000 when the database does not exist - might change in the future
             return ($e->getCode() == 1049 || (defined('HHVM_VERSION') && $e->getCode() == 42000)) ? 2 : 1;
@@ -399,7 +399,7 @@ class DbPDOCore extends Db
     public static function tryUTF8($server, $user, $pwd)
     {
         try {
-            $link = DbPDO::_getPDO($server, $user, $pwd, false, 5);
+            $link = DbPDO::getPDO($server, $user, $pwd, false, 5);
         } catch (PDOException $e) {
             return false;
         }
@@ -420,7 +420,7 @@ class DbPDOCore extends Db
     public static function checkAutoIncrement($server, $user, $pwd)
     {
         try {
-            $link = DbPDO::_getPDO($server, $user, $pwd, false, 5);
+            $link = DbPDO::getPDO($server, $user, $pwd, false, 5);
         } catch (PDOException $e) {
             return false;
         }

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -94,6 +94,7 @@ class DbPDOCore extends Db
      *
      * @see DbCore::connect()
      * @return PDO
+     * @throws PrestaShopException
      */
     public function connect()
     {
@@ -364,7 +365,7 @@ class DbPDOCore extends Db
 
         if (!$result) {
             $value = 'MyISAM';
-        }else {
+        } else {
             $row = $result->fetch();
             if (!$row || strtolower($row['Value']) != 'yes') {
                 $value = 'MyISAM';

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -60,6 +60,7 @@ class DbPDOCore extends Db
         } else {
             $dsn .= 'host='.$host;
         }
+        $dsn .= ';charset=utf8';
 
         return new PDO($dsn, $user, $password, array(PDO::ATTR_TIMEOUT => $timeout, PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true));
     }
@@ -99,12 +100,7 @@ class DbPDOCore extends Db
         try {
             $this->link = $this->_getPDO($this->server, $this->user, $this->password, $this->database, 5);
         } catch (PDOException $e) {
-            throw new PrestaShopException('Link to database cannot be established:'.$e->getMessage());
-        }
-
-        // UTF-8 support
-        if ($this->link->exec('SET NAMES \'utf8\'') === false) {
-            throw new PrestaShopException('PrestaShop Fatal error: no utf-8 support. Please check your server configuration.');
+            throw new PrestaShopException('Link to database cannot be established: '.$e->getMessage());
         }
 
         $this->link->exec('SET SESSION sql_mode = \'\'');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Currently the PDO database abstraction issues a "SET NAMES" query every time in order to set the character set for the connection. This is no longer the preferred way of doing it (it should be set [in the DSN](https://stackoverflow.com/a/14132028/13275)).
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | --
| How to test?  | Enter unicode characters anywhere that's saved to the database (for example a new product), then verify that the text is correctly displayed when reading it from the database.