### PR TITLE
Bug fix - Determine the best warehouse for packages

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2299,9 +2299,8 @@ class CartCore extends ObjectModel
                 $warehouse_count_by_address[$product['id_address_delivery']][$warehouse['id_warehouse']]++;
             }
         }
+        arsort($warehouse_count_by_address[$product['id_address_delivery']]);
         unset($product);
-
-        arsort($warehouse_count_by_address);
 
         // Step 2 : Group product by warehouse
         $grouped_by_warehouse = array();


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description? | I think that arsort($warehouse_count_by_address); is doing nothing because the deep of the array so the preference for the warehouse that can deliver more products its not working.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test? | 