### PR TITLE
Remove Finder from depency injection

### DIFF
--- a/src/Adapter/Module/ModuleZipManager.php
+++ b/src/Adapter/Module/ModuleZipManager.php
@@ -49,16 +49,12 @@ class ModuleZipManager
      * @var Symfony\Component\Filesystem\Filesystem
      */
     private $filesystem;
-    /**
-     * @var Symfony\Component\Finder\Finder
-     */
-    private $finder;
+
     private $translator;
     
-    public function __construct(Filesystem $filesystem, Finder $finder, TranslatorInterface $translator)
+    public function __construct(Filesystem $filesystem, TranslatorInterface $translator)
     {
         $this->filesystem = $filesystem;
-        $this->finder = $finder;
         $this->translator = $translator;
     }
 
@@ -97,7 +93,8 @@ class ModuleZipManager
         }
 
         // Check the structure and get the module name
-        $directories = $this->finder->directories()
+        $directories = Finder::create()
+            ->directories()
             ->in($sandboxPath)
             ->depth('== 0')
             ->exclude(['__MACOSX'])
@@ -110,7 +107,8 @@ class ModuleZipManager
             $moduleName = basename(current($directories)->getFileName());
 
             // Inside of this folder, we MUST have a file called <module name>.php
-            $moduleFolder = $this->finder->files()
+            $moduleFolder = Finder::create()
+                    ->files()
                     ->in($sandboxPath.$moduleName)
                     ->depth('== 0')
                     ->exclude(['__MACOSX'])

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -62,11 +62,6 @@ class ModuleTabRegister
     private $translator;
 
     /**
-     * @var Finder
-     */
-    private $finder;
-
-    /**
      * @var Filesystem
      */
     private $filesystem;
@@ -76,13 +71,12 @@ class ModuleTabRegister
      */
     private $languages;
 
-    public function __construct(TabRepository $tabRepository, LangRepository $langRepository, LoggerInterface $logger, TranslatorInterface $translator, Finder $finder, Filesystem $filesystem, array $languages)
+    public function __construct(TabRepository $tabRepository, LangRepository $langRepository, LoggerInterface $logger, TranslatorInterface $translator, Filesystem $filesystem, array $languages)
     {
         $this->langRepository = $langRepository;
         $this->tabRepository = $tabRepository;
         $this->logger = $logger;
         $this->translator = $translator;
-        $this->finder = $finder;
         $this->filesystem = $filesystem;
         $this->languages = $languages;
     }
@@ -189,7 +183,7 @@ class ModuleTabRegister
             return array();
         }
 
-        $moduleFolder = $this->finder->files()
+        $moduleFolder = Finder::create()->files()
                     ->in($modulePath)
                     ->depth('== 0')
                     ->name('*Controller.php')

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -40,7 +40,6 @@ use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
 use PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
 use Symfony\Component\Yaml\Yaml;
@@ -170,7 +169,7 @@ class ModuleManagerBuilder
             }
         }
         
-        self::$moduleZipManager = new ModuleZipManager(new Filesystem(), new Finder(), self::$translator);
+        self::$moduleZipManager = new ModuleZipManager(new Filesystem(), self::$translator);
         self::$addonsDataProvider = new AddonsDataProvider($marketPlaceClient, self::$moduleZipManager);
 
         $kernelDir = dirname(__FILE__) . '/../../../../app';

--- a/src/Core/Addon/Theme/ThemeExporter.php
+++ b/src/Core/Addon/Theme/ThemeExporter.php
@@ -37,21 +37,18 @@ class ThemeExporter
 {
     protected $configuration;
     protected $fileSystem;
-    protected $finder;
     protected $langRepository;
     protected $translationsExporter;
 
     public function __construct(
         ConfigurationInterface $configuration,
         Filesystem $fileSystem,
-        Finder $finder,
         LangRepository $langRepository,
         TranslationsExporter $translationsExporter
     )
     {
         $this->configuration = $configuration;
         $this->fileSystem = $fileSystem;
-        $this->finder = $finder;
         $this->langRepository = $langRepository;
         $this->translationsExporter = $translationsExporter;
     }
@@ -74,9 +71,7 @@ class ThemeExporter
 
     private function copyTheme($themeDir, $cacheDir)
     {
-        $finderClassName = get_class($this->finder);
-        $this->finder = $finderClassName::create();
-        $fileList = $this->finder
+        $fileList = Finder::create()
             ->files()
             ->in($themeDir)
             ->exclude(['node_modules']);
@@ -133,9 +128,7 @@ class ThemeExporter
         $zip = new ZipArchive();
         $zip->open($destinationFileName, ZipArchive::CREATE);
 
-        $finderClassName = get_class($this->finder);
-        $this->finder = $finderClassName::create();
-        $files = $this->finder
+        $files = Finder::create()
             ->files()
             ->in($sourceDir)
             ->exclude(['node_modules']);

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -102,7 +102,6 @@ services:
             - "@prestashop.core.admin.lang.repository"
             - "@logger"
             - "@translator"
-            - "@finder"
             - "@filesystem"
             - "@=service('prestashop.adapter.legacy.context').getLanguages()"
 

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -6,10 +6,6 @@ parameters:
     prestashop.security.voter.product.class: PrestaShopBundle\Security\Voter\PageVoter
 
 services:
-    finder:
-        class: Symfony\Component\Finder\Finder
-        shared: false
-
     doctrine.cache.provider:
         class: Doctrine\Common\Cache\FilesystemCache
         arguments:
@@ -283,7 +279,6 @@ services:
         arguments:
           - "@prestashop.adapter.legacy.configuration"
           - "@filesystem"
-          - "@finder"
           - "@prestashop.core.admin.lang.repository"
           - "@prestashop.translation.theme.exporter"
 
@@ -475,7 +470,6 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager
         arguments:
             - "@filesystem"
-            - "@finder"
             - "@translator"
 
     prestashop.twig.extension.hook:

--- a/tests/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
+++ b/tests/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
@@ -137,7 +137,6 @@ class ModuleTabRegisterTest extends UnitTestCase
                 $this->sfKernel->getContainer()->get('prestashop.core.admin.lang.repository'),
                 $this->sfKernel->getContainer()->get('logger'),
                 $this->sfKernel->getContainer()->get('translator'),
-                $this->sfKernel->getContainer()->get('finder'),
                 $this->sfKernel->getContainer()->get('filesystem'),
                 $this->languages,
             )


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | Reusing the same Finder instance several times brought unexpected behavior during many searches. We now recreate it every time we need it instead of calling it from the service container.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Theme import seems to bug in some case when several modules must be enabled. If needed, see with @rGaillard for more details.