### PR TITLE
BO: Define currency_id inside HelperList content, price field

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_content.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_content.tpl
@@ -98,7 +98,7 @@
 							{/if}
 						{/if}
 					{elseif isset($params.type) && $params.type == 'price'}
-						{displayPrice price=$tr.$key}
+						{displayPrice currency=$tr['id_currency'] price=$tr.$key}
 					{elseif isset($params.float)}
 						{$tr.$key}
 					{elseif isset($params.type) && $params.type == 'date'}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7 and 1.6.1.x
| Description?  | Define id_currency inside the HelperList price field
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create supply order with differents currency, then click on details button to view the supply order details. The products list keep always the default currency .
