### PR TITLE
Fix the export link of ASM movements

### DIFF
--- a/controllers/admin/AdminStockMvtController.php
+++ b/controllers/admin/AdminStockMvtController.php
@@ -274,7 +274,7 @@ class AdminStockMvtControllerCore extends AdminController
         if (Tools::isSubmit('id_warehouse') && (int)Tools::getValue('id_warehouse') != -1) {
             $this->toolbar_btn['export-stock-mvt-csv'] = array(
                 'short' => 'Export this list as CSV',
-                'href' => $this->context->link->getAdminLink('AdminStockMvt').'&amp;csv&amp;id_warehouse='.(int)$this->getCurrentWarehouseId(),
+                'href' => $this->context->link->getAdminLink('AdminStockMvt').'&csv&id_warehouse='.(int)$this->getCurrentWarehouseId(),
                 'desc' => $this->l('Export (CSV)'),
                 'imgclass' => 'export'
             );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | in ASM movements, the export button doesnt work because of "&amp" in URL.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9180
| How to test?  | BO -> ASM (Advanced Stock Management) -> Stock Movement, choose one warehouse in the filter select, then try to click on the export button, the CSV file will be generated.
