### PR TITLE
Do not throw exception on API request error for module categories

### DIFF
--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -181,9 +181,9 @@ class ModuleManagerBuilder
 
         self::$cacheProvider = new FilesystemCache(self::$addonsDataProvider->cacheDir.'/doctrine');
 
-        self::$categoriesProvider = new CategoriesProvider($marketPlaceClient);
-        self::$lecacyContext = new LegacyContext();
         self::$legacyLogger = new LegacyLogger();
+        self::$categoriesProvider = new CategoriesProvider($marketPlaceClient, self::$legacyLogger);
+        self::$lecacyContext = new LegacyContext();
 
         if (is_null(self::$adminModuleDataProvider)) {
             self::$adminModuleDataProvider = new AdminModuleDataProvider(

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -203,7 +203,7 @@ services:
 
     prestashop.categories_provider:
         class: PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider
-        arguments: ['@prestashop.addons.client_api']
+        arguments: ['@prestashop.addons.client_api', '@logger']
 
     # Presenters
     prestashop.adapter.presenter.module:

--- a/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
@@ -25,7 +25,9 @@
  */
 namespace PrestaShopBundle\Service\DataProvider\Admin;
 
+use GuzzleHttp\Exception\RequestException;
 use PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient;
+use Psr\Log\LoggerInterface;
 
 /**
  * Provide the categories used to order modules and themes on https://addons.prestashop.com.
@@ -33,19 +35,26 @@ use PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient;
 class CategoriesProvider
 {
     private $apiClient;
+    private $logger;
 
     static $categories;
     static $categoriesFromApi;
 
-    public function __construct(ApiClient $apiClient)
+    public function __construct(ApiClient $apiClient, LoggerInterface $logger)
     {
         $this->apiClient = $apiClient;
+        $this->logger = $logger;
     }
 
     public function getCategories()
     {
         if (null === self::$categoriesFromApi) {
-            self::$categoriesFromApi = $this->apiClient->getCategories();
+            try {
+                self::$categoriesFromApi = $this->apiClient->getCategories();
+            } catch (RequestException $e) {
+                $this->logger->error('Module & services categories could not be loaded from marketplace API');
+                self::$categoriesFromApi = array();
+            }
         }
 
         return self::$categoriesFromApi;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In case of error during the module & services categories loading, we now try to go on the page loading. Any error will be registered in the log instead. This will allow our merchants to manage their module even if errors coming from the marketplace API.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | You can change the endpoint of the marketplace API in `app/config/config.yml` in order to throw errors. You will now see an empty category list.