### PR TITLE
Bug when creating a tab, when one profile

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -136,12 +136,6 @@ class TabCore extends ObjectModel
             return false;
         }
 
-        /* Profile selection */
-        $profiles = Db::getInstance()->executeS('SELECT `id_profile` FROM `'._DB_PREFIX_.'profile` WHERE `id_profile` != 1');
-        if (!$profiles || empty($profiles)) {
-            return true;
-        }
-
         /* Right management */
         $slug = 'ROLE_MOD_TAB_'.strtoupper(self::getClassNameById($idTab));
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develope.
| Description?  | Bug when creating a tab, when one profile of employee. SuperAdmin for example
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | -
| Fixed ticket? | -
| How to test?  | Leave an employee profile, create a tab. Tab was created through the module in my case

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
