### PR TITLE
Fixed bug in addMissingProductFields that gives array_merge the p…

### DIFF
--- a/classes/ProductAssembler.php
+++ b/classes/ProductAssembler.php
@@ -90,7 +90,7 @@ class ProductAssemblerCore
 
         $rows = Db::getInstance()->executeS($sql);
 
-        return array_merge($rawProduct, $rows[0]);
+        return array_merge($rows[0], $rawProduct);
     }
 
     /**


### PR DESCRIPTION
…riority to $rows[0] instead of $rawProduct

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | Develop
| Description?  | Fixed bug in addMissingProductFields that gives array_merge the priority to $rows[0] instead of $rawProduct. The ProductAssembler::addMissingProductFields should add the missing values instead of overwriting them with the new selected values that are not related to the shop. For instance, the problem appears when presenting a list of products that have a shop-specific available_date that is overwritten by the new value retrieved from the ps_product.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Give the product an available_date and print that information in the product miniature

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
