### PR TITLE
Fixed bug where only 5 store contacts were imported (csv import)

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3682,6 +3682,8 @@ class AdminImportControllerCore extends AdminController
             );
         }
         $this->closeCsvFile($handle);
+
+        return $line_count;
     }
 
     public function storeContactImportOne($info, $shop_is_feature_active, $regenerate, $force_ids, $validateOnly = false)


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers                                                                          |
|---------------|----------------------------------------------------------------------------------|
| Branch?       | 1.7.2.x                                                                          |
| Description?  | Fixed bug where store contact data csv importer imported only the 5 first lines. |
| Type?         |bug fix|
| Category?     |BO|
| BC breaks?    | no                                                                               |
| Deprecations? | no                                                                               |
| Fixed ticket? | [BOOM-294](http://forge.prestashop.com/browse/BOOM-294)                          |
| How to test?  | Try to import more than 5 lines with the store contacts importer.                |
