### PR TITLE
Fix tax calculation when vat number is used

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2910,8 +2910,8 @@ class ProductCore extends ObjectModel
         }
 
         if ($usetax != false
-            && !empty($address_infos['vat_number'])
-            && $address_infos['id_country'] != Configuration::get('VATNUMBER_COUNTRY')
+            && !empty($address->vat_number)
+            && $address->id_country != Configuration::get('VATNUMBER_COUNTRY')
             && Configuration::get('VATNUMBER_MANAGEMENT')) {
             $usetax = false;
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix issue introduced by PR #7532 regarding price calculation when VAT number is used as `$address_infos` is undefined here
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3368
| How to test?  | Install VAT addon and use a customer address with VAT number and a different country than the shop one.