### PR TITLE
Fix the module "translate" button with the new link of translation page

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/modal_translation.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/modal_translation.tpl
@@ -31,7 +31,9 @@
 		</button>
 		<ul class="dropdown-menu">
 			{foreach from=$module_languages item=language}
-			<li><a href="{$trad_link|escape:'html':'UTF-8'}{$language['iso_code']|escape:'html':'UTF-8'}#{$module_name|escape:'html':'UTF-8'}">{$language.name|escape:'html':'UTF-8'}</a></li>
+				<li>
+					<a href="{$translateLinks[$language.iso_code]|escape:'html':'UTF-8'}">{$language.name|escape:'html':'UTF-8'}</a>
+				</li>
 			{/foreach}
 		</ul>
 	</div>

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -734,6 +734,11 @@ class LinkCore
                 $sfRoute = array_key_exists('route', $sfRouteParams) ? $sfRouteParams['route'] : 'admin_stock_overview';
 
                 return $sfRouter->generate($sfRoute, $sfRouteParams, UrlGeneratorInterface::ABSOLUTE_URL);
+
+            case 'AdminTranslationSf':
+                $sfRoute = array_key_exists('route', $sfRouteParams) ? $sfRouteParams['route'] : 'admin_international_translation_overview';
+
+                return $sfRouter->generate($sfRoute, $sfRouteParams, UrlGeneratorInterface::ABSOLUTE_URL);
         }
 
         $idLang = Context::getContext()->language->id;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3144,6 +3144,25 @@ abstract class ModuleCore
         $parameters['legacy'] = 'htmlspecialchars';
         return $this->getTranslator()->trans($id, $parameters, $domain, $locale);
     }
+
+    /**
+     * Check if the module uses the new translation system
+     * @return bool
+     */
+    public function isUsingNewTranslationSystem()
+    {
+        $moduleName = $this->name;
+        $domains = array_keys($this->context->getTranslator()->getCatalogue()->all());
+        $moduleName = preg_replace('/^ps_(\w+)/', '$1', $moduleName);
+
+        foreach ($domains as $domain) {
+            if (false !== stripos($domain, $moduleName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }
 
 function ps_module_version_sort($a, $b)

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1395,10 +1395,33 @@ class AdminModulesControllerCore extends AdminController
     {
         parent::initModal();
 
+        $module = Module::getInstanceByName(Tools::getValue('configure'));
+        $languages = Language::getLanguages(false);
+        $isNewTranslateSystem = $module->isUsingNewTranslationSystem();
+        $link = Context::getContext()->link;
+        $translateLinks = array();
+        foreach ($languages as $lang) {
+            if ($isNewTranslateSystem) {
+                $translateLinks[$lang['iso_code']] = $link->getAdminLink('AdminTranslationSf', true, array(
+                    'lang' => $lang['iso_code'],
+                    'type' => 'modules',
+                    'selected' => $module->name,
+                    'locale' => $lang['locale'],
+                ));
+            } else {
+                $translateLinks[$lang['iso_code']] = $link->getAdminLink('AdminTranslations', true, array(), array(
+                    'type' => 'modules',
+                    'module' => $module->name,
+                    'lang' => $lang['iso_code'],
+                ));
+            }
+        }
+
         $this->context->smarty->assign(array(
             'trad_link' => 'index.php?tab=AdminTranslations&token='.Tools::getAdminTokenLite('AdminTranslations').'&type=modules&module='.Tools::getValue('configure').'&lang=',
-            'module_languages' => Language::getLanguages(false),
-            'module_name' => Tools::getValue('module_name'),
+            'module_languages' => $languages,
+            'module_name' => $module->name,
+            'translateLinks' => $translateLinks,
         ));
 
         $modal_content = $this->context->smarty->fetch('controllers/modules/modal_translation.tpl');

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -221,7 +221,7 @@ class AdminTranslationsControllerCore extends AdminController
             $modules[$module->name] = array(
                 'name' => $module->name,
                 'displayName' => $module->displayName,
-                'urlToTranslate' => !$this->isUsingNewTranslationsSystem($module->name) ? $this->context->link->getAdminLink(
+                'urlToTranslate' => !$module->isUsingNewTranslationSystem() ? $this->context->link->getAdminLink(
                     'AdminTranslations',
                     true,
                     array(),
@@ -256,18 +256,6 @@ class AdminTranslationsControllerCore extends AdminController
         $this->content .= parent::renderView();
 
         return $this->content;
-    }
-
-    private function isUsingNewTranslationsSystem($moduleName)
-    {
-        $domains = array_keys($this->context->getTranslator()->getCatalogue()->all());
-        $moduleName = preg_replace('/^ps_(\w+)/', '$1', $moduleName);
-
-        if (count(preg_grep('/'.$moduleName.'/i', $domains))) {
-            return true;
-        }
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | When you configure a module and you click on "translate" button, you are redirected to the old version of the translation page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3351
| How to test?  | Go to any module configuration page and click on "translate" button, choose any language, then check if it redirects you to the good version of the translation page.

Examples : 
- Module "**cronjobs**" with the legacy translation system.
- Module "**ps_dataprivacy**" with the new translation system.
