### PR TITLE
BO: Combination dropdown visibility

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -497,7 +497,7 @@ $(document).ready(function() {
 		});
 	}
 	
-	displayProductAttributes();
+    displayProductAttributes();
 });
 
 

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -497,7 +497,7 @@ $(document).ready(function() {
 		});
 	}
 	
-    displayProductAttributes();
+	displayProductAttributes();
 });
 
 

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -496,6 +496,8 @@ $(document).ready(function() {
 			callback: function(text) { combinable_filter('#cart_rule_select_2', text, 'selected'); }
 		});
 	}
+	
+	displayProductAttributes();
 });
 
 


### PR DESCRIPTION
When you load a cart rule with a gift product and the gift product search found more than 1 product, all the combination dropdowns are visible.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Only the product's combination dropdown is displayed
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | 
| How to test?  | Create 2 products with a similar reference (ex. 'AA', 'AAA'). Create a cart rule with gift product 'AA'. Load cart rule.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
