### PR TITLE
Fix custom content link opening in the same page

### DIFF
--- a/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -44,7 +44,9 @@
                 id="{$link.id}-{$linkBlock.id}"
                 class="{$link.class}"
                 href="{$link.url}"
-                title="{$link.description}">
+                title="{$link.description}"
+                {if isset($link.target) && $link.target} target="_blank" {/if}
+            >
               {$link.title}
             </a>
           </li>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | In link widget, when you add an external  link, it is opened in the same page.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3340
| How to test?  | BO > Design > Link Widget, add a custom content external link , go to FO > click on it and check if it is opened in a new tab.