### PR TITLE
FO: Fix product pagination

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -308,10 +308,10 @@ function paginationButton(nbProductsIn, nbProductOut)
 			var nbPage = parseInt($('div.pagination li.current').children().children().html());
 			var nb_products = nbProductsIn;
 
-			if ($('#nb_item option:selected').length == 0)
+			if ($('#nb_page_items option:selected').length == 0)
 				var nbPerPage = nb_products;
 			else
-				var nbPerPage = parseInt($('#nb_item option:selected').val());
+				var nbPerPage = parseInt($('#nb_page_items option:selected').val());
 
 			isNaN(nbPage) ? nbPage = 1 : nbPage = nbPage;
 			nbPerPage*nbPage < nb_products ? productShowing = nbPerPage*nbPage :productShowing = (nbPerPage*nbPage-nb_products-nbPerPage*nbPage)*-1;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Product pagination text is broken while blocklayered is enabled.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9197
| How to test?  | Set products per page to 2. Product pagination will show wrong text such as "8 - 7 out of 7". 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->