### PR TITLE
Some rounding correction 1.6.x

### DIFF
--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -293,10 +293,14 @@ class OrderSlipCore extends ObjectModel
             $tax_calculator = $carrier->getTaxCalculator($address);
             $order_slip->{'total_shipping_tax_'.$inc_or_ex_1} = ($shipping_cost === null ? $order->{'total_shipping_tax_'.$inc_or_ex_1} : (float)$shipping_cost);
 
-            if ($tax_calculator instanceof TaxCalculator) {
-                $order_slip->{'total_shipping_tax_'.$inc_or_ex_2} = Tools::ps_round($tax_calculator->{$add_or_remove.'Taxes'}($order_slip->{'total_shipping_tax_'.$inc_or_ex_1}), _PS_PRICE_COMPUTE_PRECISION_);
+            if ($shipping_cost === null) {
+                $order_slip->{'total_shipping_tax_'.$inc_or_ex_2} = $order->{'total_shipping_tax_'.$inc_or_ex_2};
             } else {
-                $order_slip->{'total_shipping_tax_'.$inc_or_ex_2} = $order_slip->{'total_shipping_tax_'.$inc_or_ex_1};
+                if ($tax_calculator instanceof TaxCalculator) {
+                    $order_slip->{'total_shipping_tax_'.$inc_or_ex_2} = Tools::ps_round($tax_calculator->{$add_or_remove.'Taxes'}($order_slip->{'total_shipping_tax_'.$inc_or_ex_1}), _PS_PRICE_COMPUTE_PRECISION_);
+                } else {
+                    $order_slip->{'total_shipping_tax_'.$inc_or_ex_2} = $order_slip->{'total_shipping_tax_'.$inc_or_ex_1};
+                }
             }
         } else {
             $order_slip->shipping_cost = false;
@@ -380,8 +384,8 @@ class OrderSlipCore extends ObjectModel
         }
 
         $order_slip->{'total_products_tax_'.$inc_or_ex_2} -= (float)$amount && !$amount_choosen ? (float)$amount : 0;
-        $order_slip->amount = $amount_choosen ? (float)$amount : $order_slip->{'total_products_tax_'.$inc_or_ex_1};
-        $order_slip->shipping_cost_amount = $order_slip->total_shipping_tax_incl;
+        $order_slip->amount = $amount_choosen ? (float)$amount : $order_slip->{'total_products_tax_'.$inc_or_ex_2};
+        $order_slip->shipping_cost_amount = $order_slip->{'total_shipping_tax_'.$inc_or_ex_2};
 
         if ((float)$amount && !$amount_choosen) {
             $order_slip->order_slip_type = 1;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When we are creating a slip with total shipping_cost refund, we should use the calculated taxes in the order, to avoid rounding errors and differences between the order and the slip. The amount should also be the tax included amount
| Type?         | improvement
| Category?     | CO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Pull Request #3834  Redo for 1.6.x
| How to test?  | Create Slip

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8151)
<!-- Reviewable:end -->
