### PR TITLE
Add the default id_carrier to prevent errors while checking out

### DIFF
--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -124,6 +124,16 @@ class OrderControllerCore extends ParentOrderController
     {
         parent::initContent();
 
+        /* id_carrier is not defined in database before choosing a carrier, set it to a default one to match a potential cart _rule */
+        if (empty($this->context->cart->id_carrier)) {
+            $checked = $this->context->cart->simulateCarrierSelectedOutput();
+            $checked = ((int)Cart::desintifier($checked));
+            $this->context->cart->id_carrier = $checked;
+            $this->context->cart->update();
+            CartRule::autoRemoveFromCart($this->context);
+            CartRule::autoAddToCart($this->context);
+        }
+
         if (Tools::isSubmit('ajax') && Tools::getValue('method') == 'updateExtraCarrier') {
             // Change virtualy the currents delivery options
             $delivery_option = $this->context->cart->getDeliveryOption();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | id_carrier is not defined in database before choosing a carrier, so I set it to a default one. This problem doesn't occur with the default payment module, it happens only with complicated payment module.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8992
| How to test?  | set the order mode with 5 steps -> then go into the bankwire module and edit the file bankwire.php inside the hookPayment method adding (line 149): die(var_dump($params['cart']));  -> then go to FO and add a product in the cart and go to summary cart and then go through order steps -> at the payment list you will get a blank page with the result of var_dump and look if id_carrier has an integer like '11' and not '0'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8156)
<!-- Reviewable:end -->
