### PR TITLE
Display the product price in multishop mode

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -444,7 +444,7 @@ class AdminProductsControllerCore extends AdminController
     {
         $result = parent::loadObject($opt);
         if ($result && Validate::isLoadedObject($this->object)) {
-            if (Shop::getContext() == Shop::CONTEXT_SHOP && Shop::isFeatureActive() && !$this->object->isAssociatedToShop()) {
+            if (Shop::isFeatureActive() && !$this->object->isAssociatedToShop()) {
                 $default_product = new Product((int)$this->object->id, false, null, (int)$this->object->id_shop_default);
                 $def = ObjectModel::getDefinition($this->object);
                 foreach ($def['fields'] as $field_name => $row) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In BO the prices of a product that belongs only to the 2nd shop, do not appear when you select "all shops", so I just delete the condition of default shop to display the price.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8834
| How to test?  | enable multishop, create a second shop S2 then create a new product P1 in S2. Choose "all shops" then try to edit P1, access to the price tab, you will see the price is well displayed and not equal 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8158)
<!-- Reviewable:end -->
