### PR TITLE
Check if CMS Category is associated to shop

### DIFF
--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -76,7 +76,7 @@ class CmsControllerCore extends FrontController
             } else {
                 $this->assignCase = 1;
             }
-        } elseif (Validate::isLoadedObject($this->cms_category) && $this->cms_category->active) {
+        } elseif (Validate::isLoadedObject($this->cms_category) && $this->cms_category->active && $this->cms_category->isAssociatedToShop()) {
             $this->assignCase = 2;
         } else {
             header('HTTP/1.1 404 Not Found');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Check if CMS Category is associated to current shop in FO. We can choose in BO which shop is associated with CMS Category but actuality we can access to it on every shop.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9207
| How to test?  | Enable multishop, create a second shop, create a CMS Category and associate it to one shop. Try to access in FO to it with all shop.