### PR TITLE
Fix bulk delete for CMS Category

### DIFF
--- a/controllers/admin/AdminCmsCategoriesController.php
+++ b/controllers/admin/AdminCmsCategoriesController.php
@@ -172,7 +172,7 @@ class AdminCmsCategoriesControllerCore extends AdminController
             }
         }
         /* Delete multiple objects */
-        elseif (Tools::getValue('submitDel'.$this->table) || Tools::getValue('submitBulkdelete'.$this->table)) {
+        elseif (Tools::getValue('submitDel'.$this->table) || Tools::isSubmit('submitBulkdelete'.$this->table)) {
             if ($this->tabAccess['delete'] === '1') {
                 if (Tools::isSubmit($this->table.'Box')) {
                     $cms_category = new CMSCategory();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you want to bulk delete some CMS Category, you always see an error even if it working.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9208
| How to test?  | Create some CMS Categories, use bulk deletion functionality on CMS Categories