### PR TITLE
Fix encoded back URL

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2542,7 +2542,7 @@ class AdminControllerCore extends Controller
             $helper->tpl_vars = $this->getTemplateFormVars();
             $helper->show_cancel_button = (isset($this->show_form_cancel_button)) ? $this->show_form_cancel_button : ($this->display == 'add' || $this->display == 'edit');
 
-            $back = Tools::safeOutput(Tools::getValue('back', ''));
+            $back = urldecode(Tools::getValue('back', ''));
             if (empty($back)) {
                 $back = self::$currentIndex.'&token='.$this->token;
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix bug #PSCSX-9103, invalid security token on cancel in Firefox browser. This PR suggests another fix for related in #8089 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9103
| How to test?  | Pressing Cancel button on Customer page does not affect Invalid security token error (see *Video attached* to the ticket to reproduce this bug).