### PR TITLE
Fix duplicate url for supplier list when try to access a supplier

### DIFF
--- a/controllers/front/SupplierController.php
+++ b/controllers/front/SupplierController.php
@@ -58,7 +58,7 @@ class SupplierControllerCore extends FrontController
         if ($id_supplier = (int)Tools::getValue('id_supplier')) {
             $this->supplier = new Supplier($id_supplier, $this->context->language->id);
 
-            if (!Validate::isLoadedObject($this->supplier) || !$this->supplier->active) {
+            if (!Validate::isLoadedObject($this->supplier) || !$this->supplier->active || !$this->supplier->isAssociatedToShop()) {
                 header('HTTP/1.1 404 Not Found');
                 header('Status: 404 Not Found');
                 $this->errors[] = Tools::displayError('The chosen supplier does not exist.');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In multishop context, if you associate some suppliers to specific shop, you can't access them to FO but no message is displayed and you see the list of suppliers but you are not redirect to correct URL. So the suppliers list can be associate to multiple URL so is can be assimilate to duplicate content. For manufacturers, an error is displayed.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9209
| How to test?  | Enabled multishop, create some shops, create some suppliers, associate them to some shop, try to access to it in FO with all shops url.