### PR TITLE
CO: Fixed a trouble in SpecificPrice when the shop has more than 1000…

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -214,47 +214,48 @@ class SpecificPriceCore extends ObjectModel
      * @param string $field_name
      * @param int $field_value
      * @param int $threshold
+     * @param bool $checkDates
      * @return string
      * @throws PrestaShopDatabaseException
      */
-    protected static function filterOutField($field_name, $field_value, $threshold = 1000, $check_dates = true)
+    protected static function filterOutField($field_name, $field_value, $threshold = 1000, $checkDates = true)
     {
         $name = Db::getInstance()->escape($field_name, false, true);
-        $query_extra = 'AND `'.$name.'` = 0 ';
+        $threshold = (int) $threshold;
+        if ($threshold <= 0) { //If it is incorrect, set the default value
+            $threshold = 1000;
+		}
+        $query_extra = 'AND `' . $name . '` = 0 ';
         if ($field_value == 0 || array_key_exists($field_name, self::$_no_specific_values)) {
             return $query_extra;
         }
-        $key_cache     = __FUNCTION__.'-'.$field_name.'-'.$threshold;
+        $key_cache = __FUNCTION__ . '-' . $field_name . '-' . $threshold;
         $specific_list = array();
         if (!array_key_exists($key_cache, SpecificPrice::$_filterOutCache)) {
             //First we need a base sql sentence
-            $base_sql = ' FROM `'._DB_PREFIX_.'specific_price` WHERE `'.$name.'` != 0';
-            if($check_dates) {
-                $base_sql .= ' AND ( (`from` = \'0000-00-00 00:00:00\' OR `from` <= CURDATE() ) AND (`to` = \'0000-00-00 00:00:00\' OR `to` >= CURDATE() ))';
+            $baseSql = ' FROM `' . _DB_PREFIX_ . 'specific_price` WHERE `' . $name . '` != 0';
+            if ($checkDates) {
+                $baseSql .= ' AND ( (`from` = \'0000-00-00 00:00:00\' OR `from` <= CURDATE() ) AND (`to` = \'0000-00-00 00:00:00\' OR `to` >= CURDATE() ))';
             }
-                
-            $query_count    = 'SELECT COUNT(DISTINCT `'.$name.'`)'.$base_sql;
-            $specific_count = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query_count);
+
+            $queryCount = 'SELECT COUNT(DISTINCT `' . $name . '`)' . $baseSql;
+            $specific_count = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($queryCount);
             if ($specific_count == 0) {
                 self::$_no_specific_values[$field_name] = true;
 
                 return $query_extra;
             }
-            
-            //Checking bad values
-            $threshold = (int)$threshold;
-            if($threshold <= 0) //If it is inccorrect, set the default value
-                $threshold = 1000;
+
             $page = 0; //Init page value
             do { //Lets play with threshold value in pagination mode in order to prevent an ddbb overloaded
-                $query             = 'SELECT DISTINCT `'.$name.'`'.$base_sql.' LIMIT '.$page.','.(int)$threshold;
+                $query = 'SELECT DISTINCT `' . $name . '`' . $baseSql . ' LIMIT ' . $page . ',' . (int) $threshold;
                 $tmp_specific_list = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
                 foreach ($tmp_specific_list as $key => $value) {
                     $specific_list[] = $value[$field_name];
                 }
                 $page++;
-            } while(!empty($tmp_specific_list));
-            
+            } while (!empty($tmp_specific_list));
+
             SpecificPrice::$_filterOutCache[$key_cache] = $specific_list;
         } else {
             $specific_list = SpecificPrice::$_filterOutCache[$key_cache];
@@ -262,9 +263,9 @@ class SpecificPriceCore extends ObjectModel
 
         // $specific_list is empty if the threshold is reached
         if (empty($specific_list) || in_array($field_value, $specific_list)) {
-            $query_extra = 'AND `'.$name.'` '.self::formatIntInQuery(0, $field_value).' ';
+            $query_extra = 'AND `' . $name . '` ' . self::formatIntInQuery(0, $field_value) . ' ';
         }
-        
+
         return $query_extra;
     }
 

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -217,7 +217,7 @@ class SpecificPriceCore extends ObjectModel
      * @return string
      * @throws PrestaShopDatabaseException
      */
-    protected static function filterOutField($field_name, $field_value, $threshold = 1000)
+    protected static function filterOutField($field_name, $field_value, $threshold = 1000, $check_dates = true)
     {
         $name = Db::getInstance()->escape($field_name, false, true);
         $query_extra = 'AND `'.$name.'` = 0 ';
@@ -227,20 +227,34 @@ class SpecificPriceCore extends ObjectModel
         $key_cache     = __FUNCTION__.'-'.$field_name.'-'.$threshold;
         $specific_list = array();
         if (!array_key_exists($key_cache, SpecificPrice::$_filterOutCache)) {
-            $query_count    = 'SELECT COUNT(DISTINCT `'.$name.'`) FROM `'._DB_PREFIX_.'specific_price` WHERE `'.$name.'` != 0';
+            //First we need a base sql sentence
+            $base_sql = ' FROM `'._DB_PREFIX_.'specific_price` WHERE `'.$name.'` != 0';
+            if($check_dates) {
+                $base_sql .= ' AND ( (`from` = \'0000-00-00 00:00:00\' OR `from` <= CURDATE() ) AND (`to` = \'0000-00-00 00:00:00\' OR `to` >= CURDATE() ))';
+            }
+                
+            $query_count    = 'SELECT COUNT(DISTINCT `'.$name.'`)'.$base_sql;
             $specific_count = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query_count);
             if ($specific_count == 0) {
                 self::$_no_specific_values[$field_name] = true;
 
                 return $query_extra;
             }
-            if ($specific_count < $threshold) {
-                $query             = 'SELECT DISTINCT `'.$name.'` FROM `'._DB_PREFIX_.'specific_price` WHERE `'.$name.'` != 0';
+            
+            //Checking bad values
+            $threshold = (int)$threshold;
+            if($threshold <= 0) //If it is inccorrect, set the default value
+                $threshold = 1000;
+            $page = 0; //Init page value
+            do { //Lets play with threshold value in pagination mode in order to prevent an ddbb overloaded
+                $query             = 'SELECT DISTINCT `'.$name.'`'.$base_sql.' LIMIT '.$page.','.(int)$threshold;
                 $tmp_specific_list = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
                 foreach ($tmp_specific_list as $key => $value) {
                     $specific_list[] = $value[$field_name];
                 }
-            }
+                $page++;
+            } while(!empty($tmp_specific_list));
+            
             SpecificPrice::$_filterOutCache[$key_cache] = $specific_list;
         } else {
             $specific_list = SpecificPrice::$_filterOutCache[$key_cache];
@@ -250,7 +264,7 @@ class SpecificPriceCore extends ObjectModel
         if (empty($specific_list) || in_array($field_value, $specific_list)) {
             $query_extra = 'AND `'.$name.'` '.self::formatIntInQuery(0, $field_value).' ';
         }
-
+        
         return $query_extra;
     }
 


### PR DESCRIPTION
… different entries

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop.
| Description?  | version 1.7.2 (dev) class SpecificPrice method filterOutField
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3093.
| How to test?  | You have to add 1000 SpecificPrice entries with different id_product to recreate it.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
