### PR TITLE
Fix the tax display for groups

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -197,11 +197,7 @@ class CustomerCore extends ObjectModel
 
     public function __construct($id = null)
     {
-        if ($id) {
-            $this->id_default_group = (int)Configuration::get('PS_CUSTOMER_GROUP');
-        } else {
-            $this->id_default_group = (int)Configuration::get('PS_UNIDENTIFIED_GROUP');
-        }
+        $this->id_default_group = (int)Configuration::get('PS_CUSTOMER_GROUP');
         parent::__construct($id);
     }
 
@@ -342,7 +338,6 @@ class CustomerCore extends ObjectModel
                 $this->{$key} = $value;
             }
         }
-        $this->id_default_group = (int)Configuration::get('PS_CUSTOMER_GROUP');
         return $this;
     }
 

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -197,7 +197,11 @@ class CustomerCore extends ObjectModel
 
     public function __construct($id = null)
     {
-        $this->id_default_group = (int)Configuration::get('PS_CUSTOMER_GROUP');
+        if ($id) {
+            $this->id_default_group = (int)Configuration::get('PS_CUSTOMER_GROUP');
+        } else {
+            $this->id_default_group = (int)Configuration::get('PS_UNIDENTIFIED_GROUP');
+        }
         parent::__construct($id);
     }
 
@@ -338,6 +342,7 @@ class CustomerCore extends ObjectModel
                 $this->{$key} = $value;
             }
         }
+        $this->id_default_group = (int)Configuration::get('PS_CUSTOMER_GROUP');
         return $this;
     }
 

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -221,7 +221,7 @@ if (!defined('_PS_ADMIN_DIR_')) {
         $customer = new Customer();
 
         /* Change the default group */
-        if (Group::isFeatureActive()) {
+        if (Group::isFeatureActive() || $customer->id == null) {
             $customer->id_default_group = (int)Configuration::get('PS_UNIDENTIFIED_GROUP');
         }
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | I add a condition in the construct method if the id is defined it means that the customer is connected. So, we choose PS_CUSTOMER_GROUP as id_default_group value. If not, it means he's not connected, then, we choose PS_UNIDENTIFIED_GROUP 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9196
| How to test?  | BO -> Customer -> Groups -> edit "customer" -> choose "Tax excluded" as value for "Price display method" then "save". Access to FO, while you're connected all prices are "tax excluded". Then, disconnect (access to the FO as visitor), you will see that all prices are displayed "tax included".