### PR TITLE
Wrong gift display in My Voucher page in My Account

### DIFF
--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -43,30 +43,53 @@ class DiscountControllerCore extends FrontController
         $nb_cart_rules = count($cart_rules);
 
         foreach ($cart_rules as $key => &$discount ) {
+
             if ($discount['quantity_for_user'] === 0) {
                 unset($cart_rules[$key]);
             }
 
-
             $discount['value'] = Tools::convertPriceFull(
-                                            $discount['value'],
-                                            new Currency((int)$discount['reduction_currency']),
-                                            new Currency((int)$this->context->cart->id_currency)
-                                        );
+                $discount['value'],
+                new Currency((int)$discount['reduction_currency']),
+                new Currency((int)$this->context->cart->id_currency)
+            );
+            
             if ($discount['gift_product'] !== 0) {
-                $product = new Product((int) $discount['gift_product']);
-                if (isset($product->name)) {
-                    $discount['gift_product_name'] = current($product->name);
+                $product = new Product((int) $discount['gift_product'], false, (int)$this->context->language->id);
+                if (!Validate::isLoadedObject($product) || !$product->isAssociatedToShop() || !$product->active) {
+                    unset($cart_rules[$key]);
                 }
+                if (Combination::isFeatureActive() && $discount['gift_product_attribute'] !== 0) {
+                    $attributes = $product->getAttributeCombinationsById((int)$discount['gift_product_attribute'], (int)$this->context->language->id);
+                    $giftAttributes = array();
+                    foreach ($attributes as $attribute) {
+                        $giftAttributes[] = $attribute['group_name'] . ' : ' . $attribute['attribute_name'];
+                    }
+                    $discount['gift_product_attributes'] = implode(', ', $giftAttributes);
+                }
+                $discount['gift_product_name'] = $product->name;
+                $discount['gift_product_link'] = $this->context->link->getProductLink(
+                    $product,
+                    $product->link_rewrite,
+                    $product->category,
+                    $product->ean13,
+                    $this->context->language->id,
+                    $this->context->shop->id,
+                    $discount['gift_product_attribute'],
+                    false,
+                    false,
+                    true
+                );
             }
         }
 
         $this->context->smarty->assign(array(
-                                            'nb_cart_rules' => (int)$nb_cart_rules,
-                                            'cart_rules' => $cart_rules,
-                                            'discount' => $cart_rules,
-                                            'nbDiscounts' => (int)$nb_cart_rules)
-                                        );
+            'nb_cart_rules' => (int)$nb_cart_rules,
+            'cart_rules' => $cart_rules,
+            'discount' => $cart_rules, // retro compatibility
+            'nbDiscounts' => (int)$nb_cart_rules // retro compatibility
+        ));
+
         $this->setTemplate(_PS_THEME_DIR_.'discount.tpl');
     }
 }

--- a/themes/default-bootstrap/discount.tpl
+++ b/themes/default-bootstrap/discount.tpl
@@ -28,14 +28,14 @@
 	{l s='My vouchers'}
 </h1>
 
-{if isset($cart_rules) && count($cart_rules) && $nb_cart_rules}
+{if isset($cart_rules) && $nb_cart_rules}
 	<table class="discount table table-bordered footab">
 		<thead>
 			<tr>
 				<th data-sort-ignore="true" class="discount_code first_item">{l s='Code'}</th>
 				<th data-sort-ignore="true" class="discount_description item">{l s='Description'}</th>
 				<th class="discount_quantity item">{l s='Quantity'}</th>
-				<th data-sort-ignore="true" data-hide="phone,tablet" class="discount_value item">{l s='Value'}*</th>
+				<th data-sort-ignore="true" data-hide="phone,tablet" class="discount_value item">{l s='Value'}</th>
 				<th data-hide="phone,tablet" class="discount_minimum item">{l s='Minimum'}</th>
 				<th data-sort-ignore="true" data-hide="phone,tablet" class="discount_cumulative item">{l s='Cumulative'}</th>
 				<th data-hide="phone" class="discount_expiration_date last_item">{l s='Expiration date'}</th>
@@ -60,8 +60,13 @@
 							{l s='Free shipping'}
 						{/if}
 						{if $discountDetail.gift_product > 0}
-							{if $discountDetail.reduction_percent > 0 || $discountDetail.reduction_amount > 0 || $discountDetail.gift_product} + {/if}
-							{$discountDetail.gift_product_name} {l s='Free %s!' sprintf=$discountDetail.gift_product_name}!
+							{if $discountDetail.reduction_percent > 0 || $discountDetail.reduction_amount > 0} + {/if}
+							<a href="{$discountDetail.gift_product_link|escape:'html':'UTF-8'}">
+								{$discountDetail.gift_product_name|escape:'html':'UTF-8'}
+								{if isset($discountDetail.gift_product_attributes) && $discountDetail.gift_product_attributes|count_characters}
+								 ({$discountDetail.gift_product_attributes|escape:'html':'UTF-8'})
+								{/if}
+							</a>
 						{/if}
 					</td>
 					<td class="discount_minimum" data-value="{if $discountDetail.minimal == 0}0{else}{$discountDetail.minimal}{/if}">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | There are a wrong display in My Account -> My Voucher in case with product gift ; The name of the product appear twice and the symbol "+" is still there even if no free shipping or reduction is set. ; If product has attributes, they are not displayed ; Missing link to product page for more details ; By the way, in case of multiple languages, all values are retrieved even if we display only in the customer language. Because missing lang parameter in call of Product constructor.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9217
| How to test?  | Create a cart rule associate to a customer with gift product attribute and go to FO -> My Account -> My Vouchers