### PR TITLE
Categories breadcrumbs optimization for Large Category Tree

### DIFF
--- a/src/Adapter/Category/CategoryDataProvider.php
+++ b/src/Adapter/Category/CategoryDataProvider.php
@@ -154,7 +154,7 @@ class CategoryDataProvider
     {
         $context = \ContextCore::getContext();
         
-        return \DbCore::getInstance()->executeS('SELECT cl.`id_category` as "id", cl.`name`, (SELECT GROUP_CONCAT(cl.name SEPARATOR "'.$delimiter.'")
+        return \DbCore::getInstance()->executeS('SELECT cl.`id_category` as "id", cl.`name`, (SELECT GROUP_CONCAT(cl.name ORDER BY c.`nleft` SEPARATOR "'.$delimiter.'")
                                 FROM `'._DB_PREFIX_.'category` c
                                 INNER JOIN `'._DB_PREFIX_.'category_shop` category_shop ON (category_shop.id_category = c.id_category AND category_shop.id_shop = '.$context->shop->id.')
                                 INNER JOIN `'._DB_PREFIX_.'category_lang` cl ON (c.`id_category` = cl.`id_category` AND cl.id_shop = ' . $context->shop->id . ' AND cl.id_lang = ' . $context->language->id . ')

--- a/src/Adapter/Category/CategoryDataProvider.php
+++ b/src/Adapter/Category/CategoryDataProvider.php
@@ -150,12 +150,11 @@ class CategoryDataProvider
      *
      * @return array Categories
      */
-    public function getCategoriesWithBreadCrumb()
+    public function getCategoriesWithBreadCrumb($delimiter = " > ")
     {
         $context = \ContextCore::getContext();
-        $db = \DbCore::getInstance();
         
-        return $db->executeS('SELECT cl.`id_category` as "id", cl.`name`, (SELECT GROUP_CONCAT(cl.name SEPARATOR "'.$delimiter.'")
+        return \DbCore::getInstance()->executeS('SELECT cl.`id_category` as "id", cl.`name`, (SELECT GROUP_CONCAT(cl.name SEPARATOR "'.$delimiter.'")
                                 FROM `'._DB_PREFIX_.'category` c
                                 INNER JOIN `'._DB_PREFIX_.'category_shop` category_shop ON (category_shop.id_category = c.id_category AND category_shop.id_shop = '.$context->shop->id.')
                                 INNER JOIN `'._DB_PREFIX_.'category_lang` cl ON (c.`id_category` = cl.`id_category` AND cl.id_shop = ' . $context->shop->id . ' AND cl.id_lang = ' . $context->language->id . ')


### PR DESCRIPTION
We tested the original solution in a tree with more than 350 categories and result is an Out Of Memory (PHP 7.1, memory_limit = 2G). The proposed solution solves the problem for large category trees (~400ms in the same host).

Every suggestion is really appreciated ;)

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "develop"
| Type?         | improvement
|Description   | The proposed solution redefine the getCategoriesWithBreadCrumb() method in order to retrieve all the breadcrumbs for every category directly from a query, thanks to the binary search attributes.
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Is it possible to compare the current  and the proposed solution with a large Category Tree, accessing in the BackOffice in Product Info page.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8179)
<!-- Reviewable:end -->
