### PR TITLE
Fixed bug enable and disable module

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -758,6 +758,10 @@ abstract class ModuleCore
             }
         }
 
+        if(count($items) == Shop::getTotalShops()){
+            $force_all = true;
+        }
+
         if ($force_all && $this->getOverrides() != null) {
             // Install overrides
             try {
@@ -863,6 +867,11 @@ abstract class ModuleCore
     public function disable($force_all = false)
     {
         $result = true;
+
+        if(count(Shop::getContextListShopID()) == Shop::getTotalShops()){
+            $force_all = true;
+        }
+
         if ($force_all && $this->getOverrides() != null) {
             $result &= $this->uninstallOverrides();
         }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -758,7 +758,7 @@ abstract class ModuleCore
             }
         }
 
-        if(count($items) == Shop::getTotalShops()){
+        if (count($items) == Shop::getTotalShops()) {
             $force_all = true;
         }
 
@@ -868,7 +868,7 @@ abstract class ModuleCore
     {
         $result = true;
 
-        if(count(Shop::getContextListShopID()) == Shop::getTotalShops()){
+        if (count(Shop::getContextListShopID()) == Shop::getTotalShops()) {
             $force_all = true;
         }
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -758,7 +758,7 @@ abstract class ModuleCore
             }
         }
 
-        if ($this->getOverrides() != null) {
+        if ($force_all && $this->getOverrides() != null) {
             // Install overrides
             try {
                 $this->installOverrides();
@@ -863,7 +863,7 @@ abstract class ModuleCore
     public function disable($force_all = false)
     {
         $result = true;
-        if ($this->getOverrides() != null) {
+        if ($force_all && $this->getOverrides() != null) {
             $result &= $this->uninstallOverrides();
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If you have installed a module that has some overrides and you are in a multishop configuration and you try to disable the module on one shop because you don't need it in that shop you will lose the overrides causing the malfunction of the module on the other shop. This solution makes the Module Class to uninstall/install overrides if the disable/enable action is called for all shops. It should be a good practice of the programmer to check in the overridden methods if the module is enabled or not. 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | Go to the Admin Modules page, select a shop in case of multishop configuration and disable or enable a module that has some overrides.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8187)
<!-- Reviewable:end -->
