### PR TITLE
Use precise build of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: precise
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ php:
   - 5.6
   - 7.0
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - php: 7.0
-
 before_install:
   - sudo apt-get update
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | PrestaShop 1.6 must work on PHP 5.3, but the new build of Travis does not support it. We need to remain of the deprecated build in order to run the tests on PHP 5.3
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Check Travis results