### PR TITLE
Use proper folder for theme templates

### DIFF
--- a/install-dev/controllers/http/smarty_compile.php
+++ b/install-dev/controllers/http/smarty_compile.php
@@ -32,7 +32,7 @@ if (Tools::getValue('bo')) {
     define('_PS_ADMIN_DIR_', _PS_ROOT_DIR_.'/admin/');
     $directory = _PS_ADMIN_DIR_.'themes/default/';
 } else {
-    $directory = _PS_THEME_DIR_;
+    $directory = _PS_THEME_DIR_.'templates/';
 }
 
 require_once(_PS_ROOT_DIR_.'/config/smarty.config.inc.php');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On PrestaShop 1.7, templates are stored in the subfolder `templates`of the theme. During the installation, the pre-compilation is done (ajax request), but takes a long time. This is because Smarty is looking for files he cannot find, every time he tries (= each installation page).
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | The request `install-dev/index.php?compile_templates=1&bo=0` still returns HTTP code 200 but should be executed faster.