### PR TITLE
Recalculate the sales stats in dashboard when we get a refund

### DIFF
--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -200,36 +200,89 @@ class AdminStatsControllerCore extends AdminStatsTabController
         if ($granularity == 'day') {
             $sales = array();
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
-			SELECT LEFT(`invoice_date`, 10) as date, SUM(total_paid_tax_excl / o.conversion_rate) as sales
+			SELECT LEFT(`invoice_date`, 10) as date, SUM((o.total_paid_tax_excl - coalesce(osl.total_products_tax_excl,0)) / o.conversion_rate) as sales
 			FROM `'._DB_PREFIX_.'orders` o
 			LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
+			LEFT JOIN `'._DB_PREFIX_.'order_slip` osl ON o.id_order = osl.id_order
 			WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND os.logable = 1
 			'.Shop::addSqlRestriction(false, 'o').'
-			GROUP BY LEFT(`invoice_date`, 10)');
+			GROUP BY date');
+
+            $resultSlip = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
+            SELECT LEFT(`invoice_date`, 10) as date, SUM((o.total_paid_tax_excl - osl.total_products_tax_excl) / o.conversion_rate) as sales
+            FROM `'._DB_PREFIX_.'orders` o
+            LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
+            INNER JOIN `'._DB_PREFIX_.'order_slip` osl ON o.id_order = osl.id_order
+            WHERE o.date_upd BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND (os.logable = 0 OR os.paid = 0)
+            '.Shop::addSqlRestriction(false, 'o').'
+            GROUP BY date');
+
             foreach ($result as $row) {
                 $sales[strtotime($row['date'])] = $row['sales'];
             }
+
+            foreach ($resultSlip as $row) {
+                $date = strtotime($row['date']);
+                if (!isset($sales[$date])) {
+                    $sales[$date] = $row['sales'];
+                } else {
+                    $sales[$date] += $row['sales'];
+                }
+            }
+
             return $sales;
         } elseif ($granularity == 'month') {
             $sales = array();
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
-			SELECT LEFT(`invoice_date`, 7) as date, SUM(total_paid_tax_excl / o.conversion_rate) as sales
+			SELECT LEFT(`invoice_date`, 7) as date, SUM((o.total_paid_tax_excl - coalesce(osl.total_products_tax_excl,0) / o.conversion_rate) as sales
 			FROM `'._DB_PREFIX_.'orders` o
 			LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
+			LEFT JOIN `'._DB_PREFIX_.'order_slip` osl ON o.id_order = osl.id_order
 			WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND os.logable = 1
 			'.Shop::addSqlRestriction(false, 'o').'
-			GROUP BY LEFT(`invoice_date`, 7)');
+			GROUP BY date');
+
+            $resultSlip = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
+            SELECT LEFT(`invoice_date`, 7) as date, SUM((o.total_paid_tax_excl - osl.total_products_tax_excl) / o.conversion_rate) as sales
+            FROM `'._DB_PREFIX_.'orders` o
+            LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
+            INNER JOIN `'._DB_PREFIX_.'order_slip` osl ON o.id_order = osl.id_order
+            WHERE o.date_upd BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND (os.logable = 0 OR os.paid = 0)
+            '.Shop::addSqlRestriction(false, 'o').'
+            GROUP BY date');
+
             foreach ($result as $row) {
                 $sales[strtotime($row['date'].'-01')] = $row['sales'];
             }
+
+            foreach ($resultSlip as $row) {
+                $date = strtotime($row['date'] . '-01');
+                if (!isset($sales[$date])) {
+                    $sales[$date] = $row['sales'];
+                } else {
+                    $sales[$date] += $row['sales'];
+                }
+            }
+
             return $sales;
         } else {
-            return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
-			SELECT SUM(total_paid_tax_excl / o.conversion_rate)
+            $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+			SELECT SUM((o.total_paid_tax_excl - coalesce(osl.total_products_tax_excl,0)) / o.conversion_rate)
 			FROM `'._DB_PREFIX_.'orders` o
 			LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
+			LEFT JOIN `'._DB_PREFIX_.'order_slip` osl ON o.id_order = osl.id_order
 			WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND os.logable = 1
 			'.Shop::addSqlRestriction(false, 'o'));
+
+            $resultSlip = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+            SELECT SUM((o.total_paid_tax_excl - osl.total_products_tax_excl) / o.conversion_rate) as sales
+            FROM `'._DB_PREFIX_.'orders` o
+            LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
+            INNER JOIN `'._DB_PREFIX_.'order_slip` osl ON o.id_order = osl.id_order
+            WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND (os.logable = 0 OR os.paid = 0)
+            '.Shop::addSqlRestriction(false, 'o'));
+
+            return $result + $resultSlip;
         }
     }
 
@@ -257,10 +310,29 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
 			WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND os.logable = 1
 			'.Shop::addSqlRestriction(false, 'o').'
-			GROUP BY LEFT(`invoice_date`, 10)');
+			GROUP BY date');
+
+            $resultSlip = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
+            SELECT LEFT(`invoice_date`, 10) as date, COUNT(*) as orders
+            FROM `' . _DB_PREFIX_ . 'orders` o
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
+            WHERE o.date_upd BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND (os.logable = 0 OR os.paid = 0)
+            ' . Shop::addSqlRestriction(false, 'o') . '
+            GROUP BY date');
+
             foreach ($result as $row) {
                 $orders[strtotime($row['date'])] = $row['orders'];
             }
+
+            foreach ($resultSlip as $row) {
+                $date = strtotime($row['date']);
+                if (!isset($orders[$date])) {
+                    $orders[$date] = $row['orders'];
+                } else {
+                    $orders[$date] += $row['orders'];
+                }
+            }
+
             return $orders;
         } elseif ($granularity == 'month') {
             $orders = array();
@@ -270,10 +342,29 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
 			WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND os.logable = 1
 			'.Shop::addSqlRestriction(false, 'o').'
-			GROUP BY LEFT(`invoice_date`, 7)');
+			GROUP BY date');
+
+            $resultSlip = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
+            SELECT LEFT(`invoice_date`, 7) as date, COUNT(*) as orders
+            FROM `' . _DB_PREFIX_ . 'orders` o
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
+            WHERE o.date_upd BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND (os.logable = 0 OR os.paid = 0)
+            ' . Shop::addSqlRestriction(false, 'o') . '
+            GROUP BY date');
+
             foreach ($result as $row) {
-                $orders[strtotime($row['date'].'-01')] = $row['orders'];
+                $orders[strtotime($row['date'] . '-01')] = $row['orders'];
             }
+
+            foreach ($resultSlip as $row) {
+                $date = strtotime($row['date']);
+                if (!isset($orders[$date])) {
+                    $orders[$date] = $row['orders'];
+                } else {
+                    $orders[$date] += $row['orders'];
+                }
+            }
+
             return $orders;
         } else {
             $orders = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
@@ -282,9 +373,17 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
 			WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND os.logable = 1
 			'.Shop::addSqlRestriction(false, 'o'));
+
+            $orderSlip = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+            SELECT  COUNT(*) as orders
+            FROM `' . _DB_PREFIX_ . 'orders` o
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
+            INNER JOIN `' . _DB_PREFIX_ . 'order_slip` osl ON o.id_order = osl.id_order
+            WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND (os.logable = 0 OR os.paid = 0)
+            ' . Shop::addSqlRestriction(false, 'o'));
         }
 
-        return $orders;
+        return $orders + $orderSlip;
     }
 
     public static function getEmptyCategories()
@@ -430,33 +529,78 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
 			SELECT
 				LEFT(`invoice_date`, 10) as date,
-				SUM(od.`product_quantity` * IF(
+				SUM((od.product_quantity - coalesce(osd.product_quantity,0) * IF(
 					od.`purchase_supplier_price` > 0,
 					od.`purchase_supplier_price` / `conversion_rate`,
-					od.`original_product_price` * '.(int)Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN').' / 100
+					od.`original_product_price` * ' . (int)Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN') . ' / 100
 				)) as total_purchase_price
 			FROM `'._DB_PREFIX_.'orders` o
 			LEFT JOIN `'._DB_PREFIX_.'order_detail` od ON o.id_order = od.id_order
 			LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
+			LEFT JOIN `' . _DB_PREFIX_ . 'order_slip_detail` osd ON osd.id_order_detail = od.id_order_detail
 			WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND os.logable = 1
 			'.Shop::addSqlRestriction(false, 'o').'
-			GROUP BY LEFT(`invoice_date`, 10)');
+			GROUP BY date');
+
+            $resultSlip = Db::getInstance(_PS_USE_SQL_SLAVE_)->ExecuteS('
+            SELECT
+               LEFT(`invoice_date`, 10) as date,
+               SUM((od.product_quantity - osd.product_quantity) * IF(
+                  od.`purchase_supplier_price` > 0,
+                  od.`purchase_supplier_price` / `conversion_rate`,
+                  od.`original_product_price` * ' . (int)Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN') . ' / 100
+               )) as total_purchase_price
+            FROM `' . _DB_PREFIX_ . 'orders` o
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
+            INNER JOIN `' . _DB_PREFIX_ . 'order_slip_detail` osd ON osd.id_order_detail = od.id_order_detail
+            WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND (os.logable = 0 OR os.paid = 0)
+            ' . Shop::addSqlRestriction(false, 'o') . '
+            GROUP BY date');
+
             foreach ($result as $row) {
                 $purchases[strtotime($row['date'])] = $row['total_purchase_price'];
             }
+
+            foreach ($resultSlip as $row) {
+                $date = strtotime($row['date']);
+                if (!isset($purchases[$date])) {
+                    $purchases[$date] = $row['total_purchase_price'];
+                } else {
+                    $purchases[$date] += $row['total_purchase_price'];
+                }
+            }
+
             return $purchases;
         } else {
-            return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
-			SELECT SUM(od.`product_quantity` * IF(
+            $resultOrders = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+			SELECT SUM((od.product_quantity - coalesce(osd.product_quantity,0) * IF(
 				od.`purchase_supplier_price` > 0,
 				od.`purchase_supplier_price` / `conversion_rate`,
-				od.`original_product_price` * '.(int)Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN').' / 100
+				od.`original_product_price` * ' . (int)Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN') . ' / 100
 			)) as total_purchase_price
 			FROM `'._DB_PREFIX_.'orders` o
 			LEFT JOIN `'._DB_PREFIX_.'order_detail` od ON o.id_order = od.id_order
 			LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
+			LEFT JOIN `' . _DB_PREFIX_ . 'order_slip_detail` osd ON osd.id_order_detail = od.id_order_detail
 			WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND os.logable = 1
 			'.Shop::addSqlRestriction(false, 'o'));
+
+            $resultSlip = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+            SELECT
+               SUM((od.product_quantity - osd.product_quantity) * IF(
+                  od.`purchase_supplier_price` > 0,
+                  od.`purchase_supplier_price` / `conversion_rate`,
+                  od.`original_product_price` * ' . (int)Configuration::get('CONF_AVERAGE_PRODUCT_MARGIN') . ' / 100
+               )) as total_purchase_price
+            FROM `' . _DB_PREFIX_ . 'orders` o
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
+            INNER JOIN `' . _DB_PREFIX_ . 'order_slip_detail` osd ON osd.id_order_detail = od.id_order_detail
+            WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND (os.logable = 0 OR os.paid = 0)
+            ' . Shop::addSqlRestriction(false, 'o'));
+
+            return $resultOrders + $resultSlip;
         }
     }
 
@@ -466,9 +610,10 @@ class AdminStatsControllerCore extends AdminStatsTabController
 
         $orders = Db::getInstance()->ExecuteS('
 		SELECT
+		    o.id_order,
 			LEFT(`invoice_date`, 10) as date,
-			total_paid_tax_incl / o.conversion_rate as total_paid_tax_incl,
-			total_shipping_tax_excl / o.conversion_rate as total_shipping_tax_excl,
+			((o.total_paid_tax_incl - coalesce(osl.total_products_tax_incl,0)) / o.conversion_rate) as total_paid_tax_incl,
+			((o.total_shipping_tax_excl - coalesce(osl.total_shipping_tax_excl,0)) / o.conversion_rate) as total_shipping_tax_excl,
 			o.module,
 			a.id_country,
 			o.id_currency,
@@ -477,8 +622,26 @@ class AdminStatsControllerCore extends AdminStatsTabController
 		LEFT JOIN `'._DB_PREFIX_.'address` a ON o.id_address_delivery = a.id_address
 		LEFT JOIN `'._DB_PREFIX_.'carrier` c ON o.id_carrier = c.id_carrier
 		LEFT JOIN `'._DB_PREFIX_.'order_state` os ON o.current_state = os.id_order_state
+		LEFT JOIN `' . _DB_PREFIX_ . 'order_slip` osl ON o.id_order = osl.id_order
 		WHERE `invoice_date` BETWEEN "'.pSQL($date_from).' 00:00:00" AND "'.pSQL($date_to).' 23:59:59" AND os.logable = 1
+		UNION
+            SELECT
+               o.id_order,
+               LEFT(`invoice_date`, 10) as date,
+               ((o.total_paid_tax_incl - osl.total_products_tax_incl) / o.conversion_rate) as total_paid_tax_incl,
+               ((o.total_shipping_tax_excl - osl.total_shipping_tax_excl) / o.conversion_rate) as total_shipping_tax_excl,
+               o.module,
+               a.id_country,
+               o.id_currency,
+               c.id_reference as carrier_reference
+            FROM `' . _DB_PREFIX_ . 'orders` o
+            LEFT JOIN `' . _DB_PREFIX_ . 'address` a ON o.id_address_delivery = a.id_address
+            LEFT JOIN `' . _DB_PREFIX_ . 'carrier` c ON o.id_carrier = c.id_carrier
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
+            INNER JOIN `' . _DB_PREFIX_ . 'order_slip` osl ON o.id_order = osl.id_order
+            WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND (os.logable = 0 OR os.paid = 0)
 		'.Shop::addSqlRestriction(false, 'o'));
+
         foreach ($orders as $order) {
             // Add flat fees for this order
             $flat_fees = Configuration::get('CONF_ORDER_FIXED') + (
@@ -511,6 +674,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
                 $expenses += $flat_fees + $var_fees + $shipping_fees;
             }
         }
+
         return $expenses;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | I adopt the solution proposed in this [PR](https://github.com/PrestaShop/PrestaShop/pull/8116) and I return the result_slips array with result_orders 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7579
| How to test?  | make an order with 2 products at 50 euros each, order = 100 euros. Then, change the order's status to "payement accepted" and check the sales stats in dashboard, you will see 100 euros. Afterward, make a partial refund and return one of two products and check the sales stats in dashboard page, you will see that the sales amount get reduced and turn up to 50 euros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8196)
<!-- Reviewable:end -->
