### PR TITLE
Fixed product backoffice image hover alt text

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -961,6 +961,8 @@ var form = (function() {
   }
 
   function switchLanguage(iso_code) {
+    $('#form_switch_language option[value!="' + iso_code + '"]').attr('selected', false);
+    $('#form_switch_language option[value="' + iso_code + '"]').attr('selected', true);
     $('div.translations.tabbable > div > div.tab-pane:not(.translation-label-' + iso_code + ')').removeClass('active');
     $('div.translations.tabbable > div > div.tab-pane.translation-label-' + iso_code).addClass('active');
   }

--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -247,10 +247,12 @@ var combinations = (function() {
 
           /** Add title on product's combination image */
           $(function() {
-              $('#combination_form_' + contentElem.attr('data')).find("img").each(function() {
-                  title = $(this).attr('src').split('/').pop();
-                  $(this).attr('title',title);
-              });
+            let idLang = parseInt($('#form_switch_language option:selected').data('idlang'));
+            $('#combination_form_' + contentElem.attr('data')).find('img').each(function() {
+              let legend = $(this).data('legend' + idLang);
+              $(this).attr('alt', legend);
+              $(this).attr('title', legend);
+            });
           });
 
           $('#form-nav, #form_content').hide();

--- a/admin-dev/themes/new-theme/js/product-page/combination.js
+++ b/admin-dev/themes/new-theme/js/product-page/combination.js
@@ -102,9 +102,14 @@ export default function() {
       $imagesElem.html('');
 
       $.each(combinationsImages[value], function(key, image) {
+        let legend = '';
+        $.each(image.legend, function(k, value) {
+          legend = legend + ' data-legend' + k + '="' + value.replace('"', '') + '"';
+        });
+
         $imagesElem.append(`<div class="product-combination-image ${(image.id_image_attr ? 'img-highlight' : '')}">
           <input type="checkbox" name="combination_${$index}[id_image_attr][]" value="${image.id}" ${(image.id_image_attr ? 'checked="checked"' : '')}>
-          <img src="${image.base_image_url}-small_default.${image.format}" alt="" />
+          <img src="${image.base_image_url}-small_default.${image.format}" alt="" ${legend}>
         </div>`);
       });
 

--- a/admin-dev/themes/new-theme/public/main.bundle.js
+++ b/admin-dev/themes/new-theme/public/main.bundle.js
@@ -59,7 +59,7 @@
 /******/ 	
 /******/ 	
 /******/ 	var hotApplyOnUpdate = true;
-/******/ 	var hotCurrentHash = "4171b75f826c4fbc2df0"; // eslint-disable-line no-unused-vars
+/******/ 	var hotCurrentHash = "d5ced403aacbd16aeb7c"; // eslint-disable-line no-unused-vars
 /******/ 	var hotCurrentModuleData = {};
 /******/ 	var hotCurrentChildModule; // eslint-disable-line no-unused-vars
 /******/ 	var hotCurrentParents = []; // eslint-disable-line no-unused-vars
@@ -43556,9 +43556,14 @@ let setNotificationsNumber = function (id, number) {
       $imagesElem.html('');
 
       __WEBPACK_IMPORTED_MODULE_0_jquery___default.a.each(combinationsImages[value], function(key, image) {
+        let legend = '';
+        __WEBPACK_IMPORTED_MODULE_0_jquery___default.a.each(image.legend, function(k, value) {
+          legend = legend + ' data-legend' + k + '="' + value.replace('"', '') + '"';
+        });
+
         $imagesElem.append(`<div class="product-combination-image ${(image.id_image_attr ? 'img-highlight' : '')}">
           <input type="checkbox" name="combination_${$index}[id_image_attr][]" value="${image.id}" ${(image.id_image_attr ? 'checked="checked"' : '')}>
-          <img src="${image.base_image_url}-small_default.${image.format}" alt="" />
+          <img src="${image.base_image_url}-small_default.${image.format}" alt="" ${legend}>
         </div>`);
       });
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -53,7 +53,7 @@
             <div class="{{ languages|length == 1 ? 'hide' : '' }}">
               <select id="form_switch_language" class="form-control" data-toggle="select2">
                 {% for language in languages %}
-                  <option value="{{ language.iso_code }}" {% if default_language_iso == language.iso_code %}selected="selected"{% endif %}>{{ language.iso_code }}</option>
+                  <option data-idlang={{ language.id_lang }}" value="{{ language.iso_code }}" {% if default_language_iso == language.iso_code %}selected="selected"{% endif %}>{{ language.iso_code }}</option>
                 {% endfor %}
               </select>
             </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | Fixed product backoffice image hover alt text
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3544
| How to test?  | add legend in yours images product, and see your combination form like explain in the BOOM ticket

I'm not a big fan of this solution, the JS is very tricky, i can't find any else solution to find the id_lang of the page..