### PR TITLE
Fix custom content link opening in the same page

### DIFF
--- a/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -45,7 +45,7 @@
                 class="{$link.class}"
                 href="{$link.url}"
                 title="{$link.description}"
-                {if isset($link.target) && $link.target} target="_blank" {/if}
+                {if !empty($link.target)} target="{$link.target}" {/if}
             >
               {$link.title}
             </a>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | In link widget, when you add an external  link, it is opened in the same page.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3340
| How to test?  | BO > Design > Link Widget, add a custom content external link , go to FO > click on it and check if it is opened in a new tab.

- [x]  Merge https://github.com/PrestaShop/ps_linklist/pull/42