### PR TITLE
Fix missing product limit/offset when ordering by price on Sale page

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -493,10 +493,10 @@ class LinkCore
     /**
      * Create a link to a CMS page.
      *
-     * @param CMS    $cms     CMS object
-     * @param string $alias
-     * @param bool   $ssl
-     * @param int    $idLang
+     * @param CMS|int $cms     CMS object
+     * @param string  $alias
+     * @param bool    $ssl
+     * @param int     $idLang
      *
      * @return string
      */

--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -153,6 +153,7 @@ class ProductSaleCore
 
         if ($finalOrderBy == 'price') {
             Tools::orderbyPrice($result, $orderWay);
+            $result = array_slice($result, (int) (($pageNumber-1) * $nbProducts), (int) $nbProducts);
         }
         if (!$result) {
             return false;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | Performances & bugfix : product list is not limited on sales page when ordering by price
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket | http://forge.prestashop.com/browse/BOOM-3698
| How to test?  | Display the sale page & order by price
