### PR TITLE
Enable the create_order button when ordering virtual products & there's no available carriers

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -591,13 +591,28 @@
 			$('#carrier_form').show();
 			$('#delivery_option').html(html);
 			$('#carriers_err').hide();
-			$("button[name=\"submitAddOrder\"]").removeAttr("disabled");
 		}
 		else
 		{
 			$('#carrier_form').hide();
 			$('#carriers_err').show().html('{l s='No carrier can be applied to this order'}');
-			$("button[name=\"submitAddOrder\"]").attr("disabled", "disabled");
+		}
+	}
+
+	function checkVirtualProduct(products, delivery_option_list) {
+		if (delivery_option_list.length == 0 && products.length > 0) {
+			var find = 1;
+			$.each(products, function () {
+				if (find == 1) {
+					this.is_virtual == 1 ? find = 1 : find = 0;
+				}
+			});
+			if (find == 1) {
+				$("button[name=\"submitAddOrder\"]").removeAttr("disabled");
+			}
+			else {
+				$("button[name=\"submitAddOrder\"]").attr("disabled", "disabled");
+			}
 		}
 	}
 
@@ -815,6 +830,7 @@
 			$('#carriers_part,#summary_part').show();
 
 		updateDeliveryOptionList(jsonSummary.delivery_option_list);
+		checkVirtualProduct(jsonSummary.summary.products,jsonSummary.delivery_option_list);
 
 		if (jsonSummary.cart.gift == 1)
 			$('#order_gift').attr('checked', true);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Usually, when there's no available carriers, the button "create the order" will be disabled. So, I add a method "checkVirtualProduct" to check if there's only virtual product(s) in the cart, cause we do not need a carrier to ship the virtual product(s), so the button "create the order" will be enabled.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8777
| How to test?  | BO -> disable all the carriers. Then, try to create a new order with a virtual product, the button "create the order" is enabled. If you try to add a standard product, the button will be disabled, if you remove it from the order, the button will be enabled again.