### PR TITLE
Voucher issue fix

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -607,7 +607,6 @@ abstract class PaymentModuleCore extends Module
                             $voucher->quantity = 1;
                             $voucher->reduction_currency = $order->id_currency;
                             $voucher->quantity_per_user = 1;
-                            $voucher->free_shipping = 0;
                             if ($voucher->add()) {
                                 // If the voucher has conditions, they are now copied to the new voucher
                                 CartRule::copyConditions($cart_rule['obj']->id, $voucher->id);
@@ -639,6 +638,10 @@ abstract class PaymentModuleCore extends Module
 
                             $values['tax_incl'] = $order->total_products_wt - $total_reduction_value_ti;
                             $values['tax_excl'] = $order->total_products - $total_reduction_value_tex;
+                            if (1 == $voucher->free_shipping) {
+                                 $values['tax_incl'] += $order->total_shipping_tax_incl;
+                                 $values['tax_excl'] += $order->total_shipping_tax_excl;  
+                            }
                         }
                         $total_reduction_value_ti += $values['tax_incl'];
                         $total_reduction_value_tex += $values['tax_excl'];


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | Voucher fix, when voucher value is calculated on order creation, shipping cost is not added if free shipping was used on the voucher and it has remaining amount that is carried over to new voucher. Also, the free shipping settings was always reset.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3553
| How to test?  | Create a cart rule with, 1000 euro discount and free shipping and partial use allowed.
make an order for less than 1000 euro. 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
