### PR TITLE
Fixed foreach warning on empty hook return

### DIFF
--- a/src/PrestaShopBundle/Service/Hook/HookFinder.php
+++ b/src/PrestaShopBundle/Service/Hook/HookFinder.php
@@ -103,6 +103,9 @@ class HookFinder
         $presentedContents = array();
 
         foreach ($hookContent as $moduleName => $moduleContents) {
+            if (!is_array($moduleContents)) {
+                continue;
+            }
             foreach ($moduleContents as $content) {
                 if (!$content instanceof HookContentClassInterface) {
                     throw new \Exception('The class returned must implement HookContentClassInterface to be presented');


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | is_array check in find() was missing in present(), triggered warning on empty $moduleContents
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | BOOM-3147 BOOM-3427
| How to test?  | Warning happened on product page FO with module multiblocks because of hook displayProductExtraContent

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
