### PR TITLE
Fix Category Miniature

### DIFF
--- a/admin-dev/themes/default/template/controllers/categories/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/categories/helpers/form/form.tpl
@@ -43,7 +43,8 @@
 	{/if}
 	{if in_array($input.name, ['image', 'thumb'])}
 		<div class="col-lg-6">
-			<div class="help-block">{l s='Recommended dimensions (for the default theme): %1spx x %2spx' sprintf=[$input.format.width, $input.format.height]}
+			<div class="help-block">{l s='Recommended dimensions (for the default theme): %1spx x %2spx' sprintf=[$input.format.width, $input.format.height]},
+				{if ($input.name == 'thumb')}{$labelTypeImageMiniature}{/if}
 			</div>
 		</div>
 	{/if}

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -605,6 +605,7 @@ class AdminCategoriesControllerCore extends AdminController
         $this->tpl_form_vars['shared_category'] = Validate::isLoadedObject($obj) && $obj->hasMultishopEntries();
         $this->tpl_form_vars['PS_ALLOW_ACCENTED_CHARS_URL'] = (int)Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL');
         $this->tpl_form_vars['displayBackOfficeCategory'] = Hook::exec('displayBackOfficeCategory');
+        $this->tpl_form_vars['labelTypeImageMiniature'] = $this->l('Name for the image type', 'AdminImages').': '.ImageType::getFormatedName('medium');
 
         // Display this field only if multistore option is enabled
         if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && Tools::isSubmit('add'.$this->table.'root')) {


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.6.1.x.
| Description?  | Under the file upload box "Category thumbnail", display the type of image used to resize the miniature
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9092
| How to test?  | access to page edit category, than check if the type of image is displayed under the file upload box "Category thumbnail".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8216)
<!-- Reviewable:end -->
