### PR TITLE
Fix the email validation in instant checkout

### DIFF
--- a/themes/default-bootstrap/authentication.tpl
+++ b/themes/default-bootstrap/authentication.tpl
@@ -108,7 +108,7 @@
 					<!-- Account -->
 					<div class="required form-group">
 						<label for="guest_email">{l s='Email address'} <sup>*</sup></label>
-						<input type="text" class="is_required validate form-control" data-validate="isEmail" id="guest_email" name="guest_email" value="{if isset($smarty.post.guest_email)}{$smarty.post.guest_email}{/if}" />
+						<input type="email" class="is_required validate form-control" data-validate="isEmail" id="guest_email" name="guest_email" value="{if isset($smarty.post.guest_email)}{$smarty.post.guest_email}{/if}" />
 					</div>
 					<div class="cleafix gender-line">
 						<label>{l s='Title'}</label>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | I just change the type from "text" to "email"
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9099
| How to test?  | fill your cart, then try to checkout without login. At the second step, you will see the "INSTANT CHECKOUT" block under the login/create_account form. Try to add email with a special caracter like john.deó@presta.com you will see the error pop-up displayed.
