### PR TITLE
Use PS_GUEST_CHECKOUT_ENABLED ... only in checkout

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -187,8 +187,6 @@ class FrontControllerCore extends Controller
             $this->ssl = true;
         }
 
-        $this->guestAllowed = Configuration::get('PS_GUEST_CHECKOUT_ENABLED');
-
         if (isset($useSSL)) {
             $this->ssl = $useSSL;
         } else {
@@ -1838,6 +1836,7 @@ class FrontControllerCore extends Controller
 
     protected function makeCustomerForm()
     {
+        $guestAllowedCheckout = Configuration::get('PS_GUEST_CHECKOUT_ENABLED');
         $form = new CustomerForm(
             $this->context->smarty,
             $this->context,
@@ -1847,12 +1846,12 @@ class FrontControllerCore extends Controller
                 $this->context,
                 $this->get('hashing'),
                 $this->getTranslator(),
-                $this->guestAllowed
+                $guestAllowedCheckout
             ),
             $this->getTemplateVarUrls()
         );
 
-        $form->setGuestAllowed($this->guestAllowed);
+        $form->setGuestAllowed($guestAllowedCheckout);
 
         $form->setAction($this->getCurrentURL());
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | <p>While trying to find the actual fix for #8195, we discovered a configuration value created especially for the checkout process but used on the whole front office. `$guestAllowed` is an attribute of the class `FrontController`, stating if a guest is allowed to reach a controller. <br/>This variable was giving access to all pages once the checkout process started as a guest, and @maximebiloe fixed this issue with #5608. <br/><br/>But it brought another issue ... The guest was then refused on all controllers requiring an authentication, even if the value of `$guestAllowed` was true (as described in http://forge.prestashop.com/browse/BOOM-2057). </p>
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2057
| How to test?  | The checkout must be available for guests & logged customer. When you started the checkout process as a guest, try to reach `?controller=my-account`. You **must** have a login form.