### PR TITLE
Change the price display method based on the feature Customer_Group

### DIFF
--- a/classes/Group.php
+++ b/classes/Group.php
@@ -137,6 +137,10 @@ class GroupCore extends ObjectModel
 
     public static function getPriceDisplayMethod($id_group)
     {
+        // if the feature "Customer Groups" is disabled so we need to change the id_group to PS_CUSTOMER_GROUP **default behavior**
+        if (!Group::isFeatureActive()) {
+            $id_group = (int)Configuration::get('PS_CUSTOMER_GROUP');
+        }
         if (!isset(Group::$group_price_display_method[$id_group])) {
             self::$group_price_display_method[$id_group] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 			SELECT `price_display_method`


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | I made a test in getPriceDisplayMethod function to take into consideration the value of the feature "Customer Groups".
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9196
| How to test?  | Enable the feature "Customer Groups" (BO->Advanced Parameters−>Performance->Optional Features::Customer Groups) BO -> Customer -> Groups -> edit "Visitor" -> choose "Tax excluded" as value for "Price display method" then "save". Access to FO, while you're connected all prices are "tax included". Then, disconnect (access to the FO as visitor), you will see that all prices are displayed "tax excluded". If you disable the "Customer Groups" feature, whatever you're connected or not, all the price will be displayed "tax included".