### PR TITLE
Handle booleans on hook actionValidateCustomerAddressForm

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -125,9 +125,14 @@ class CustomerAddressFormCore extends AbstractForm
             }
         }
 
-        if (($hookReturn = Hook::exec('actionValidateCustomerAddressForm', array('form' => $this))) != '') {
-            $is_valid &= (bool) $hookReturn;
-        }
+        // All modules hooked on actionValidateCustomerAddressForm must
+        // return true in order to validate the form
+        $is_valid &= array_reduce(
+            Hook::exec('actionValidateCustomerAddressForm', array('form' => $this), null, true),
+            function ($carry, $item) {
+                return $carry && (bool)$item;
+            },
+            true);
 
         return $is_valid;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR is a follow up of #8223, where boolean values are not properly handled by the form validation.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Please use the following module to test the functionality. When enabled, you **cannot** save an address for any customer.

## Module hookcustomer

```php
<?php

class HookCustomer extends Module
{
    public function __construct()
    {
        $this->name = 'hookcustomer';
        $this->tab = 'administration';
        $this->author = 'PrestaShop';
        $this->version = '1.0.1';

        $this->bootstrap = true;
        parent::__construct();

        $this->displayName = $this->trans('Hooks for customer validation form', array(), 'Modules.Autoupgrade.Admin');
        $this->description = $this->trans('Provides a hook for the customer address form (validation).', array(), 'Modules.Autoupgrade.Admin');
    }

    public function install()
    {
        parent::install();

        $this->registerHook('actionValidateCustomerAddressForm');
        return true;
    }

    public function hookActionValidateCustomerAddressForm($params)
    {
        return $this->executeHook(__FUNCTION__, $params);
    }

    public function executeHook($name, $params)
    {
        dump(__CLASS__ .': '. $name, $params);
        return false;
    }
}
```

## Result

![capture du 2017-08-07 19-16-40](https://user-images.githubusercontent.com/6768917/29039895-04070cf2-7ba5-11e7-8d37-086da955a61d.png)
