### PR TITLE
Display the price based on the feature Customer_Groups

### DIFF
--- a/classes/Group.php
+++ b/classes/Group.php
@@ -135,7 +135,7 @@ class GroupCore extends ObjectModel
         return self::$cache_reduction['group'][$id_group];
     }
 
-    public static function getPriceDisplayMethod($id_group)
+    public static function getPriceDisplayMethodByGroup($id_group)
     {
         if (!isset(Group::$group_price_display_method[$id_group])) {
             self::$group_price_display_method[$id_group] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
@@ -148,7 +148,15 @@ class GroupCore extends ObjectModel
 
     public static function getDefaultPriceDisplayMethod()
     {
-        return Group::getPriceDisplayMethod((int)Configuration::get('PS_CUSTOMER_GROUP'));
+        return Group::getPriceDisplayMethodByGroup((int)Configuration::get('PS_CUSTOMER_GROUP'));
+    }
+
+    public static function getPriceDisplayMethod($id_group)
+    {
+        if (Group::isFeatureActive()) {
+            return Group::getPriceDisplayMethodByGroup($id_group);
+        }
+        return Group::getDefaultPriceDisplayMethod();
     }
 
     public function add($autodate = true, $null_values = false)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | I made a test in getPriceDisplayMethod function to take into consideration the value of the feature "Customer Groups".
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9196
| How to test?  | Enable the feature "Customer Groups" (BO->Advanced Parameters−>Performance->Optional Features::Customer Groups) BO -> Customer -> Groups -> edit "Visitor" -> choose "Tax excluded" as value for "Price display method" then "save". Access to FO, while you're connected all prices are "tax included". Then, disconnect (access to the FO as visitor), you will see that all prices are displayed "tax excluded". If you disable the "Customer Groups" feature, whatever you're connected or not, all the price will be displayed "tax included".
