### PR TITLE
Fixed bug in AdminCartRulesController when limiting the validity …

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -538,6 +538,7 @@ class AdminCartRulesControllerCore extends AdminController
 				OR `firstname` LIKE "%'.pSQL($search_query).'%"
 				OR `lastname` LIKE "%'.pSQL($search_query).'%"
 			)
+			'.Shop::addSqlRestriction(true).'
 			ORDER BY `firstname`, `lastname` ASC
 			LIMIT 50');
             die(json_encode($customers));

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -538,7 +538,7 @@ class AdminCartRulesControllerCore extends AdminController
 				OR `firstname` LIKE "%'.pSQL($search_query).'%"
 				OR `lastname` LIKE "%'.pSQL($search_query).'%"
 			)
-			'.Shop::addSqlRestriction(true).'
+			'.Shop::addSqlRestriction(Shop::SHARE_CUSTOMER).'
 			ORDER BY `firstname`, `lastname` ASC
 			LIMIT 50');
             die(json_encode($customers));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | Fixed bug in AdminCartRulesController when limiting the validity of a CartRule for a specific Customer in Multishop context. If you have a PrestaShop installation configured with more than one shop that does not share customers and you try to create a new CartRule for a specific shop and you look for a specific customer by typing its name inside the input, you will see results coming from all the shops. This solution filters the results based on the SHARE CUSTOMERS option.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 1. Log-in the Back-office and enable the Multishop feature
||2. create a new Shop in the same Shop Group
||3. disable the Share Customers option on the Shop Group
||4. create two customers with similar names or e-mails (one per shop)
||5. select a specific shop
||6. create a new CartRule and limit its validity on a specific customer by start typing the customer name. 
||7. You should see the results for the specific shop you are creating the cart rule for.