### PR TITLE
Fix stock available after add product in order

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -468,10 +468,7 @@ class OrderDetailCore extends ObjectModel
     protected function checkProductStock($product, $id_order_state)
     {
         if ($id_order_state != Configuration::get('PS_OS_CANCELED') && $id_order_state != Configuration::get('PS_OS_ERROR')) {
-            $update_quantity = true;
-            if (!StockAvailable::dependsOnStock($product['id_product'])) {
-                $update_quantity = StockAvailable::updateQuantity($product['id_product'], $product['id_product_attribute'], -(int)$product['cart_quantity']);
-            }
+            $update_quantity = StockAvailable::updateQuantity($product['id_product'], $product['id_product_attribute'], -(int)$product['cart_quantity']);
 
             if ($update_quantity) {
                 $product['stock_quantity'] -= $product['cart_quantity'];

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2106,10 +2106,7 @@ class AdminOrdersControllerCore extends AdminController
             $order->total_shipping_tax_incl = $order_invoice->total_shipping_tax_incl;
             $order->total_shipping_tax_excl = $order_invoice->total_shipping_tax_excl;
         }
-
-        // Update product available quantity
-        StockAvailable::updateQuantity($order_detail->product_id, $order_detail->product_attribute_id, ($order_detail->product_quantity * -1), $order->id_shop);
-
+        
         // discount
         $order->total_discounts += (float)abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS));
         $order->total_discounts_tax_excl += (float)abs($cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS));


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fix the product's available quantity, also call "updateQuantity" function regardless the value of "Available quantities" option (in product->edit->quantities tab)
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9230
| How to test?  | View an order in BO, add a new product in this order, set a quantity  for this product, and check if the available quantity of product is correct or not after adding this product.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8233)
<!-- Reviewable:end -->
