### PR TITLE
Fixed bug on save specific price priority for specific product

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1034,7 +1034,7 @@ class AdminProductsControllerCore extends AdminController
         }
         if (!$priorities = Tools::getValue('specificPricePriority')) {
             $this->errors[] = $this->trans('Please specify priorities.', array(), 'Admin.Catalog.Notification');
-        } elseif (Tools::isSubmit('specificPricePriorityToAll')) {
+        } elseif (Tools::isSubmit('specificPricePriorityToAll') && Tools::getValue('specificPricePriorityToAll')) {
             if (!SpecificPrice::setPriorities($priorities)) {
                 $this->errors[] = $this->trans('An error occurred while updating priorities.', array(), 'Admin.Catalog.Notification');
             } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you are saving a specific price priority for a specific product, Prestashop will always save the priority for all products because it checks only if Tools::isSubmit('specificPricePriorityToAll') without checking if the value is true or false.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Try to save the specific price priority from the product page in BO (tab Prices) without selecting the checkbox form_step2_specificPricePriorityToAll.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8234)
<!-- Reviewable:end -->
