### PR TITLE
Fixed bug in AdminGroupsController when adding ModulesRestrictions to group in multishop configuration

### DIFF
--- a/classes/Group.php
+++ b/classes/Group.php
@@ -322,7 +322,13 @@ class GroupCore extends ObjectModel
         }
 
         // Delete all record for this group
-        Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'module_group` WHERE `id_group` = ' . (int) $id_group);
+        Db::getInstance()->execute(
+            'DELETE FROM `' . _DB_PREFIX_.'module_group`
+            WHERE `id_group` = ' . (int) $id_group . '
+            AND `id_shop` IN ('
+              . (implode(',', array_map('intval', $shops)))
+            . ')'
+        );
 
         $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'module_group` (`id_module`, `id_shop`, `id_group`) VALUES ';
         foreach ($modules as $module) {

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -323,7 +323,7 @@ class GroupCore extends ObjectModel
 
         // Delete all record for this group
         Db::getInstance()->execute(
-            'DELETE FROM `' . _DB_PREFIX_.'module_group`
+            'DELETE FROM `' . _DB_PREFIX_ . 'module_group`
             WHERE `id_group` = ' . (int) $id_group . '
             AND `id_shop` IN ('
               . (implode(',', array_map('intval', $shops)))

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2721,7 +2721,7 @@ abstract class ModuleCore implements ModuleInterface
     {
         return Db::getInstance()->executeS(
             'SELECT m.`id_module`, m.`name` FROM `' . _DB_PREFIX_ . 'module_group` mg
-            LEFT JOIN `'._DB_PREFIX_.'module` m ON (m.`id_module` = mg.`id_module`)
+            LEFT JOIN `' . _DB_PREFIX_ . 'module` m ON (m.`id_module` = mg.`id_module`)
             WHERE mg.`id_group` = ' . (int) $group_id . '
             AND `id_shop` IN ('
                 . (implode(',', array_map('intval', $shops)))

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2719,10 +2719,14 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getAuthorizedModules($group_id, $shops = array(1))
     {
-        return Db::getInstance()->executeS('
-        SELECT m.`id_module`, m.`name` FROM `' . _DB_PREFIX_.'module_group` mg
-        LEFT JOIN `'._DB_PREFIX_.'module` m ON (m.`id_module` = mg.`id_module`)
-        WHERE mg.`id_group` = ' . (int)$group_id . ' AND `id_shop` IN (' . (implode(',', $shops)) . ')');
+        return Db::getInstance()->executeS(
+            'SELECT m.`id_module`, m.`name` FROM `' . _DB_PREFIX_ . 'module_group` mg
+            LEFT JOIN `'._DB_PREFIX_.'module` m ON (m.`id_module` = mg.`id_module`)
+            WHERE mg.`id_group` = ' . (int) $group_id . '
+            AND `id_shop` IN ('
+                . (implode(',', array_map('intval', $shops)))
+            . ')'
+        );
     }
 
     /**

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2717,12 +2717,12 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @return array|null
      */
-    public static function getAuthorizedModules($group_id)
+    public static function getAuthorizedModules($group_id, $shops = array(1))
     {
         return Db::getInstance()->executeS('
-        SELECT m.`id_module`, m.`name` FROM `' . _DB_PREFIX_ . 'module_group` mg
-        LEFT JOIN `' . _DB_PREFIX_ . 'module` m ON (m.`id_module` = mg.`id_module`)
-        WHERE mg.`id_group` = ' . (int) $group_id);
+        SELECT m.`id_module`, m.`name` FROM `' . _DB_PREFIX_.'module_group` mg
+        LEFT JOIN `'._DB_PREFIX_.'module` m ON (m.`id_module` = mg.`id_module`)
+        WHERE mg.`id_group` = ' . (int)$group_id . ' AND `id_shop` IN (' . (implode(',', $shops)) . ')');
     }
 
     /**

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -405,8 +405,10 @@ class AdminGroupsControllerCore extends AdminController
         $auth_modules = array();
         $unauth_modules = array();
 
+        $shops = Shop::getContextListShopID();
+
         if ($id_group) {
-            $authorized_modules = Module::getAuthorizedModules($id_group);
+            $authorized_modules = Module::getAuthorizedModules($id_group, $shops);
         }
 
         if (is_array($authorized_modules)) {
@@ -500,11 +502,10 @@ class AdminGroupsControllerCore extends AdminController
         $auth_modules = Tools::getValue('modulesBoxAuth');
         $return = true;
         if ($id_group) {
-            Group::truncateModulesRestrictions((int) $id_group);
-        }
-        $shops = Shop::getShops(true, null, true);
-        if (is_array($auth_modules)) {
-            $return &= Group::addModulesRestrictions($id_group, $auth_modules, $shops);
+            $shops = Shop::getContextListShopID();
+            if (is_array($auth_modules)) {
+                $return &= Group::addModulesRestrictions($id_group, $auth_modules, $shops);
+            }
         }
 
         // update module list by hook cache

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2955,7 +2955,7 @@ class AdminOrdersControllerCore extends AdminController
     public function ajaxProcessChangePaymentMethod()
     {
         $customer = new Customer(Tools::getValue('id_customer'));
-        $modules = Module::getAuthorizedModules($customer->id_default_group);
+        $modules = Module::getAuthorizedModules($customer->id_default_group, [$customer->id_shop]);
         $authorized_modules = array();
 
         if (!Validate::isLoadedObject($customer) || !is_array($modules)) {

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2955,7 +2955,7 @@ class AdminOrdersControllerCore extends AdminController
     public function ajaxProcessChangePaymentMethod()
     {
         $customer = new Customer(Tools::getValue('id_customer'));
-        $modules = Module::getAuthorizedModules($customer->id_default_group, [$customer->id_shop]);
+        $modules = Module::getAuthorizedModules($customer->id_default_group, array($customer->id_shop));
         $authorized_modules = array();
 
         if (!Validate::isLoadedObject($customer) || !is_array($modules)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The issue is that when you are in a multishop context and you try to revoke to a user's group the access to a module, Prestashop will save the information for both the shops (even if the ps_module_group is shop dependent).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Set up a multishop installation, edit one Customer Group for a single shop and disable some modules for that customer group. Then change shop and check that those modules are still enabled for the edited customer group.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8237)
<!-- Reviewable:end -->
