### PR TITLE
BO: fix wrong robots.txt generation

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2575,6 +2575,56 @@ FileETag none
         return true;
     }
 
+    /**
+     * Get Robots.txt section content
+     *
+     * @return array
+     */
+    public static function getRobotsContent()
+    {
+        $tab = array();
+
+        // Special allow directives
+        $tab['Allow'] = array('*/modules/*.css', '*/modules/*.js');
+
+        // Directories
+        $tab['Directories'] = array('classes/', 'config/', 'download/', 'mails/', 'modules/', 'translations/', 'tools/');
+
+        // Files
+        $disallow_controllers = array(
+            'addresses', 'address', 'authentication', 'cart', 'discount', 'footer',
+            'get-file', 'header', 'history', 'identity', 'images.inc', 'init', 'my-account', 'order', 'order-opc',
+            'order-slip', 'order-detail', 'order-follow', 'order-return', 'order-confirmation', 'pagination', 'password',
+            'pdf-invoice', 'pdf-order-return', 'pdf-order-slip', 'product-sort', 'search', 'statistics','attachment', 'guest-tracking'
+        );
+
+        // Rewrite files
+        $tab['Files'] = array();
+        if (Configuration::get('PS_REWRITING_SETTINGS')) {
+            $sql = 'SELECT DISTINCT ml.url_rewrite, l.iso_code
+					FROM '._DB_PREFIX_.'meta m
+					INNER JOIN '._DB_PREFIX_.'meta_lang ml ON ml.id_meta = m.id_meta
+					INNER JOIN '._DB_PREFIX_.'lang l ON l.id_lang = ml.id_lang
+					WHERE ml.url_rewrite != \'\' AND l.active = 1 AND m.page IN (\''.implode('\', \'', $disallow_controllers).'\')';
+            if ($results = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql)) {
+                foreach ($results as $row) {
+                    $tab['Files'][$row['iso_code']][] = $row['url_rewrite'];
+                }
+            }
+        }
+
+        $tab['GB'] = array(
+            '?orderby=','?orderway=','?tag=','?id_currency=','?search_query=','?back=','?n=',
+            '&orderby=','&orderway=','&tag=','&id_currency=','&search_query=','&back=','&n='
+        );
+
+        foreach ($disallow_controllers as $controller) {
+            $tab['GB'][] = 'controller='.$controller;
+        }
+
+        return $tab;
+    }
+
     public static function generateIndex()
     {
         if (defined('_DB_PREFIX_') && Configuration::get('PS_DISABLE_OVERRIDES')) {

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -46,7 +46,7 @@ class AdminMetaControllerCore extends AdminController
         $this->identifier_name = 'page';
         $this->ht_file = _PS_ROOT_DIR_.'/.htaccess';
         $this->rb_file = _PS_ROOT_DIR_.'/robots.txt';
-        $this->rb_data = $this->getRobotsContent();
+        $this->rb_data = Tools::getRobotsContent();
 
         $this->explicitSelect = true;
         $this->addRowAction('edit');
@@ -764,46 +764,6 @@ class AdminMetaControllerCore extends AdminController
 
     public function getRobotsContent()
     {
-        $tab = array();
-
-        // Special allow directives
-        $tab['Allow'] = array('*/modules/*.css', '*/modules/*.js');
-
-        // Directories
-        $tab['Directories'] = array('classes/', 'config/', 'download/', 'mails/', 'modules/', 'translations/', 'tools/');
-
-        // Files
-        $disallow_controllers = array(
-            'addresses', 'address', 'authentication', 'cart', 'discount', 'footer',
-            'get-file', 'header', 'history', 'identity', 'images.inc', 'init', 'my-account', 'order', 'order-opc',
-            'order-slip', 'order-detail', 'order-follow', 'order-return', 'order-confirmation', 'pagination', 'password',
-            'pdf-invoice', 'pdf-order-return', 'pdf-order-slip', 'product-sort', 'search', 'statistics','attachment', 'guest-tracking'
-        );
-
-        // Rewrite files
-        $tab['Files'] = array();
-        if (Configuration::get('PS_REWRITING_SETTINGS')) {
-            $sql = 'SELECT ml.url_rewrite, l.iso_code
-					FROM '._DB_PREFIX_.'meta m
-					INNER JOIN '._DB_PREFIX_.'meta_lang ml ON ml.id_meta = m.id_meta
-					INNER JOIN '._DB_PREFIX_.'lang l ON l.id_lang = ml.id_lang
-					WHERE l.active = 1 AND m.page IN (\''.implode('\', \'', $disallow_controllers).'\')';
-            if ($results = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql)) {
-                foreach ($results as $row) {
-                    $tab['Files'][$row['iso_code']][] = $row['url_rewrite'];
-                }
-            }
-        }
-
-        $tab['GB'] = array(
-            '?orderby=','?orderway=','?tag=','?id_currency=','?search_query=','?back=','?n=',
-            '&orderby=','&orderway=','&tag=','&id_currency=','&search_query=','&back=','&n='
-        );
-
-        foreach ($disallow_controllers as $controller) {
-            $tab['GB'][] = 'controller='.$controller;
-        }
-
-        return $tab;
+        return Tools::getRobotsContent();
     }
 }

--- a/tests/Unit/classes/ToolsCoreTest.php
+++ b/tests/Unit/classes/ToolsCoreTest.php
@@ -219,7 +219,7 @@ class ToolsCoreTest extends PHPUnit_Framework_TestCase
 
         $url_rewrite = \Db::getInstance()->getValue('SELECT url_rewrite FROM ' .
             _DB_PREFIX_ . 'meta_lang WHERE id_meta=' . $idMeta);
-        \Db::getInstance()->update('meta_lang', array('url_rewrite' => ''),'id_meta=' . $idMeta);
+        \Db::getInstance()->update('meta_lang', array('url_rewrite' => ''), 'id_meta=' . $idMeta);
 
         $robots = Tools::getRobotsContent();
         $fileSection = $robots['Files'];

--- a/tests/Unit/classes/ToolsCoreTest.php
+++ b/tests/Unit/classes/ToolsCoreTest.php
@@ -208,7 +208,8 @@ class ToolsCoreTest extends PHPUnit_Framework_TestCase
     {
         $oldValue = Configuration::get('PS_REWRITING_SETTINGS');
         Configuration::set('PS_REWRITING_SETTINGS', 1);
-        $idMeta = \Db::getInstance()->getValue('SELECT id_meta FROM '._DB_PREFIX_.'meta WHERE page=\'address\'');
+        $idMeta = \Db::getInstance()->getValue('SELECT id_meta FROM ' .
+            _DB_PREFIX_ . 'meta WHERE page=\'address\'');
         $robots = Tools::getRobotsContent();
         $fileSection = $robots['Files'];
         $firstLang = current($fileSection);
@@ -216,14 +217,16 @@ class ToolsCoreTest extends PHPUnit_Framework_TestCase
 
         $this->assertNotContains('', $firstLang);
 
-        $url_rewrite = \Db::getInstance()->getValue('SELECT url_rewrite FROM '._DB_PREFIX_.'meta_lang WHERE id_meta='.$idMeta);
-        \Db::getInstance()->update('meta_lang', array('url_rewrite' => ''),  'id_meta='.$idMeta);
+        $url_rewrite = \Db::getInstance()->getValue('SELECT url_rewrite FROM ' .
+            _DB_PREFIX_ . 'meta_lang WHERE id_meta=' . $idMeta);
+        \Db::getInstance()->update('meta_lang', array('url_rewrite' => ''),'id_meta=' . $idMeta);
 
         $robots = Tools::getRobotsContent();
         $fileSection = $robots['Files'];
         $firstLang = current($fileSection);
 
-        \Db::getInstance()->update('meta_lang', array('url_rewrite' => $url_rewrite),  'id_meta='.$idMeta);
+        \Db::getInstance()->update('meta_lang', array('url_rewrite' => $url_rewrite),
+            'id_meta=' . $idMeta);
         $this->assertNotContains('', $firstLang);
         $this->assertEquals(($count - 1), count($firstLang));
         Configuration::set('PS_REWRITING_SETTINGS', $oldValue);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | If a disallowed path is associated with empty rewrite_url, it generates a wrong entry in the robots.txt which could exclude the whole domain for a given language
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | run the test inside this PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8240)
<!-- Reviewable:end -->
