### PR TITLE
Show installed modules by default instead of the modules selection

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -728,7 +728,7 @@ class LinkCore
                 break;
 
             case 'AdminModulesSf':
-                $sfRoute = array_key_exists('route', $sfRouteParams) ? $sfRouteParams['route'] : 'admin_module_catalog';
+                $sfRoute = array_key_exists('route', $sfRouteParams) ? $sfRouteParams['route'] : 'admin_module_manage';
 
                 return $sfRouter->generate($sfRoute, $sfRouteParams, UrlGeneratorInterface::ABSOLUTE_URL);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Show installed modules first
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [BOOM-3390](http://forge.prestashop.com/browse/BOOM-3390)
| How to test?  | From the BO click on the Modules' page link from the menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8244)
<!-- Reviewable:end -->
