### PR TITLE
Generate RTL stylsheets when installation language is RTL

### DIFF
--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -94,6 +94,7 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
             // download and install language pack
             Language::downloadAndInstallLanguagePack($this->session->lang);
         } elseif (Tools::getValue('configureShop') && !empty($this->session->process_validated['populateDatabase'])) {
+            Language::installRtlStylesheets(false, true, 'classic', $this->session->lang, true);
             $this->processConfigureShop();
         } elseif (Tools::getValue('installFixtures') && !empty($this->session->process_validated['configureShop'])) {
             $this->processInstallFixtures();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "rtl"
| Description?  | Generate RTL stylsheets when installation language is RTL
| Type?         | new feature
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Select RTL language (e.g persian, arabic) in PrestaShop installer.

This PR contains:
- Add "Language::installRtlStylesheets" to the installation process