### PR TITLE
Make PS compatible with PHP 7.2 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ dist: trusty
 php:
   - 5.6
   - 7.0
+  - 7.2
 
 env:
     global:
@@ -29,6 +30,8 @@ matrix:
   include:
     - php: 7.1
       env: EXTRA_TESTS=functional
+  allow_failures:
+    - php: 7.2
 
 before_install:
   # Apache & php-fpm configuration

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
   include:
     - php: 7.1
       env: EXTRA_TESTS=functional
-  allow_failures:
-    - php: 7.2
 
 before_install:
   # Apache & php-fpm configuration

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,3 +71,4 @@ after_failure:
   - sudo ls -l /var/log/apache2
   - sudo cat /var/log/apache2/other_vhosts_access.log
   - bash ./travis-scripts/base64-screenshots # As we cannot upload file, we display the base64 encoded content of the screenshots
+  - cat $TRAVIS_BUILD_DIR/var/log/dev.log

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3241,7 +3241,7 @@ class CartCore extends ObjectModel
 
         if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_invoice') {
             $address_id = (int)$this->id_address_invoice;
-        } elseif (count($product_list)) {
+        } elseif (is_array($product_list) && count($product_list)) {
             $prod = current($product_list);
             $address_id = (int)$prod['id_address_delivery'];
         } else {
@@ -3565,7 +3565,7 @@ class CartCore extends ObjectModel
                 SELECT SUM((p.`weight` + pa.`weight`) * cp.`quantity`) as nb
                 FROM `' . _DB_PREFIX_ . 'cart_product` cp
                 LEFT JOIN `' . _DB_PREFIX_ . 'product` p ON (cp.`id_product` = p.`id_product`)
-                LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute` pa 
+                LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute` pa
                 ON (cp.`id_product_attribute` = pa.`id_product_attribute`)
                 WHERE (cp.`id_product_attribute` IS NOT NULL AND cp.`id_product_attribute` != 0)
                 AND cp.`id_cart` = ' . $productId);

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -499,12 +499,12 @@ class CurrencyCore extends ObjectModel
      * @param int  $idModule Module ID
      * @param null $idShop   Shop ID
      *
-     * @return array|bool|false|mysqli_result|null|PDOStatement|resource
+     * @return array|null|PDOStatement|resource
      */
     public static function checkPaymentCurrencies($idModule, $idShop = null)
     {
         if (empty($idModule)) {
-            return false;
+            return array();
         }
 
         if (is_null($idShop)) {
@@ -517,7 +517,8 @@ class CurrencyCore extends ObjectModel
         $sql->where('mc.`id_module` = '.(int) $idModule);
         $sql->where('mc.`id_shop` = '.(int) $idShop);
 
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+        $currencies = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+        return $currencies ? $currencies : array();
     }
 
     /**

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -517,7 +517,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         if (Shop::isTableAssociated($this->def['table'])) {
             $id_shop_list = Shop::getContextListShopID();
-            if (count($this->id_shop_list) > 0) {
+            if (is_array($this->id_shop_list) && count($this->id_shop_list) > 0) {
                 $id_shop_list = $this->id_shop_list;
             }
         }
@@ -683,7 +683,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         }
 
         $id_shop_list = Shop::getContextListShopID();
-        if (count($this->id_shop_list) > 0) {
+        if (is_array($this->id_shop_list) && count($this->id_shop_list) > 0) {
             $id_shop_list = $this->id_shop_list;
         }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -62,7 +62,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     /** @var int Shop ID */
     protected $id_shop = null;
 
-    /** @var array|null List of shop IDs */
+    /** @var array List of shop IDs */
     public $id_shop_list = array();
 
     /** @var bool */

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -63,7 +63,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     protected $id_shop = null;
 
     /** @var array|null List of shop IDs */
-    public $id_shop_list = null;
+    public $id_shop_list = array();
 
     /** @var bool */
     protected $get_shop_from_context = true;
@@ -517,7 +517,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         if (Shop::isTableAssociated($this->def['table'])) {
             $id_shop_list = Shop::getContextListShopID();
-            if (is_array($this->id_shop_list) && count($this->id_shop_list) > 0) {
+            if (count($this->id_shop_list)) {
                 $id_shop_list = $this->id_shop_list;
             }
         }
@@ -683,7 +683,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         }
 
         $id_shop_list = Shop::getContextListShopID();
-        if (is_array($this->id_shop_list) && count($this->id_shop_list) > 0) {
+        if (count($this->id_shop_list)) {
             $id_shop_list = $this->id_shop_list;
         }
 
@@ -739,7 +739,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                     // If this table is linked to multishop system, update / insert for all shops from context
                     if ($this->isLangMultishop()) {
                         $id_shop_list = Shop::getContextListShopID();
-                        if (count($this->id_shop_list) > 0) {
+                        if (count($this->id_shop_list)) {
                             $id_shop_list = $this->id_shop_list;
                         }
                         foreach ($id_shop_list as $id_shop) {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3841,7 +3841,7 @@ exit;
             return;
         }
 
-        $sort_function = create_function('$a, $b', "return \$b['$column'] > \$a['$column'] ? 1 : -1;");
+        $sort_function = function($a, $b) use ($column) { return $b[$column] > $a[$column] ? 1 : -1; };
 
         uasort($rows, $sort_function);
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -567,7 +567,7 @@ class AdminControllerCore extends Controller
      */
     public function initBreadcrumbs($tab_id = null, $tabs = null)
     {
-        if (is_array($tabs) || count($tabs)) {
+        if (is_array($tabs)) {
             $tabs = array();
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3487,11 +3487,11 @@ class AdminControllerCore extends Controller
      */
     public function getModulesList($filter_modules_list, $tracking_source = false)
     {
-        if (!is_array($filter_modules_list)) {
+        if (!is_array($filter_modules_list) && !is_null($filter_modules_list)) {
             $filter_modules_list = array($filter_modules_list);
         }
 
-        if (!count($filter_modules_list)) {
+        if (is_null($filter_modules_list) || !count($filter_modules_list)) {
             return false;
         } //if there is no modules to display just return false;
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -563,19 +563,14 @@ class AdminControllerCore extends Controller
      * Set breadcrumbs array for the controller page
      *
      * @param int|null $tab_id
-     * @param array|null $tabs
      */
-    public function initBreadcrumbs($tab_id = null, $tabs = null)
+    public function initBreadcrumbs($tab_id = null)
     {
-        if (is_array($tabs) || count($tabs)) {
-            $tabs = array();
-        }
-
         if (is_null($tab_id)) {
             $tab_id = $this->id;
         }
 
-        $tabs = Tab::recursiveTab($tab_id, $tabs);
+        $tabs = Tab::recursiveTab($tab_id, array());
 
         $dummy = array('name' => '', 'href' => '', 'icon' => '');
         $breadcrumbs2 = array(
@@ -3492,7 +3487,7 @@ class AdminControllerCore extends Controller
      */
     public function getModulesList($filter_modules_list, $tracking_source = false)
     {
-        if (!is_array($filter_modules_list) && !is_null($filter_modules_list)) {
+        if (!is_array($filter_modules_list)) {
             $filter_modules_list = array($filter_modules_list);
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -563,14 +563,19 @@ class AdminControllerCore extends Controller
      * Set breadcrumbs array for the controller page
      *
      * @param int|null $tab_id
+     * @param array|null $tabs
      */
-    public function initBreadcrumbs($tab_id = null)
+    public function initBreadcrumbs($tab_id = null, $tabs = null)
     {
+        if (is_array($tabs) || count($tabs)) {
+            $tabs = array();
+        }
+
         if (is_null($tab_id)) {
             $tab_id = $this->id;
         }
 
-        $tabs = Tab::recursiveTab($tab_id, array());
+        $tabs = Tab::recursiveTab($tab_id, $tabs);
 
         $dummy = array('name' => '', 'href' => '', 'icon' => '');
         $breadcrumbs2 = array(

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -203,7 +203,7 @@ class HelperListCore extends Helper
                 $position_group_identifier = Category::getRootCategory()->id;
             }
 
-            $positions = array_map(create_function('$elem', 'return (int)($elem[\'position\']);'), $this->_list);
+            $positions = array_map(function($elem) { return (int)($elem['position']); }, $this->_list);
             sort($positions);
         }
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1506,7 +1506,7 @@ abstract class ModuleCore implements ModuleInterface
             }
         }
 
-        usort($module_list, create_function('$a,$b', 'return strnatcasecmp($a->displayName, $b->displayName);'));
+        usort($module_list, function ($a, $b) { return strnatcasecmp($a->displayName, $b->displayName); });
         if ($errors) {
             if (!isset(Context::getContext()->controller) && !Context::getContext()->controller->controller_name) {
                 echo '<div class="alert error"><h3>'.Context::getContext()->getTranslator()->trans('The following module(s) could not be loaded', array(), 'Admin.Modules.Notification').':</h3><ol>';

--- a/controllers/admin/AdminAttachmentsController.php
+++ b/controllers/admin/AdminAttachmentsController.php
@@ -83,9 +83,9 @@ class AdminAttachmentsControllerCore extends AdminController
         );
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
 
         $this->addJs(_PS_JS_DIR_.'/admin/attachments.js');
         Media::addJsDefL('confirm_text', $this->trans('This file is associated with the following products, do you really want to  delete it?', array(), 'Admin.Catalog.Notification'));

--- a/controllers/admin/AdminAttributeGeneratorController.php
+++ b/controllers/admin/AdminAttributeGeneratorController.php
@@ -76,7 +76,7 @@ class AdminAttributeGeneratorControllerCore extends AdminController
     public static function createCombinations($list)
     {
         if (count($list) <= 1) {
-            return count($list) ? array_map(create_function('$v', 'return (array($v));'), $list[0]) : $list;
+            return count($list) ? array_map(function ($v) { return (array($v)); }, $list[0]) : $list;
         }
         $res = array();
         $first = array_pop($list);

--- a/controllers/admin/AdminAttributeGeneratorController.php
+++ b/controllers/admin/AdminAttributeGeneratorController.php
@@ -46,9 +46,9 @@ class AdminAttributeGeneratorControllerCore extends AdminController
         parent::__construct();
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJS(_PS_JS_DIR_.'admin/attributes.js');
     }
 

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -56,9 +56,9 @@ class AdminCarrierWizardControllerCore extends AdminController
         $this->tabAccess = Profile::getProfileAccess($this->context->employee->id_profile, Tab::getIdFromClassName('AdminCarriers'));
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryPlugin('smartWizard');
         $this->addJqueryPlugin('typewatch');
         $this->addJs(_PS_JS_DIR_.'admin/carrier_wizard.js');

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -122,9 +122,9 @@ class AdminCartRulesControllerCore extends AdminController
         echo json_encode(array('html' => $html, 'next_link' => $next_link));
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryPlugin(array('typewatch', 'fancybox', 'autocomplete'));
     }
 

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -428,7 +428,7 @@ class AdminCartsControllerCore extends AdminController
                     }
                 }
             }
-            $this->setMedia();
+            $this->setMedia($isNewTheme = false);
             $this->initFooter();
             $this->context->smarty->assign(array('customization_errors' => implode('<br />', $errors),
                                                             'css_files' => $this->css_files));

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -428,7 +428,7 @@ class AdminCartsControllerCore extends AdminController
                     }
                 }
             }
-            $this->setMedia($isNewTheme = false);
+            $this->setMedia(false);
             $this->initFooter();
             $this->context->smarty->assign(array('customization_errors' => implode('<br />', $errors),
                                                             'css_files' => $this->css_files));

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -202,9 +202,9 @@ class AdminCategoriesControllerCore extends AdminController
         parent::initContent();
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryUi('ui.widget');
         $this->addJqueryPlugin('tagify');
     }

--- a/controllers/admin/AdminCmsContentController.php
+++ b/controllers/admin/AdminCmsContentController.php
@@ -211,9 +211,9 @@ class AdminCmsContentControllerCore extends AdminController
         }
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryUi('ui.widget');
         $this->addJqueryPlugin('tagify');
     }

--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -130,8 +130,8 @@ class AdminCountriesControllerCore extends AdminController
     }
 
     /**
-     * AdminController::setMedia($isNewTheme = false) override
-     * @see AdminController::setMedia($isNewTheme = false)
+     * AdminController::setMedia() override
+     * @see AdminController::setMedia()
      */
     public function setMedia($isNewTheme = false)
     {

--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -130,12 +130,12 @@ class AdminCountriesControllerCore extends AdminController
     }
 
     /**
-     * AdminController::setMedia() override
-     * @see AdminController::setMedia()
+     * AdminController::setMedia($isNewTheme = false) override
+     * @see AdminController::setMedia($isNewTheme = false)
      */
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
 
         $this->addJqueryPlugin('fieldselection');
     }

--- a/controllers/admin/AdminEmailsController.php
+++ b/controllers/admin/AdminEmailsController.php
@@ -226,9 +226,9 @@ class AdminEmailsControllerCore extends AdminController
         ksort($this->fields_options['email']['fields']['PS_MAIL_METHOD']['choices']);
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
 
         $this->addJs(_PS_JS_DIR_.'/admin/email.js');
 

--- a/controllers/admin/AdminEmployeesController.php
+++ b/controllers/admin/AdminEmployeesController.php
@@ -172,9 +172,9 @@ class AdminEmployeesControllerCore extends AdminController
         }
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJS(__PS_BASE_URI__.$this->admin_webpath.'/themes/'.$this->bo_theme.'/js/vendor/jquery-passy.js');
         $this->addjQueryPlugin('validate');
         $this->addJS(_PS_JS_DIR_.'jquery/plugins/validate/localization/messages_'.$this->context->language->iso_code.'.js');

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -139,9 +139,9 @@ class AdminGroupsControllerCore extends AdminController
         }
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryPlugin('fancybox');
         $this->addJqueryUi('ui.sortable');
     }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -588,7 +588,7 @@ class AdminImportControllerCore extends AdminController
         $this->multiple_value_separator = ($separator = Tools::substr(strval(trim(Tools::getValue('multiple_value_separator'))), 0, 1)) ? $separator :  ',';
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
         $bo_theme = ((Validate::isLoadedObject($this->context->employee)
             && $this->context->employee->bo_theme) ? $this->context->employee->bo_theme : 'default');
@@ -599,7 +599,7 @@ class AdminImportControllerCore extends AdminController
         }
 
         // We need to set parent media first, so that jQuery is loaded before the dependant plugins
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
 
         $this->addJs(__PS_BASE_URI__.$this->admin_webpath.'/themes/'.$bo_theme.'/js/jquery.iframe-transport.js');
         $this->addJs(__PS_BASE_URI__.$this->admin_webpath.'/themes/'.$bo_theme.'/js/jquery.fileupload.js');

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -52,12 +52,12 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $this->php_self = $controllerName;
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
         parent::setMedia(true);
     }
 
-    public function viewAccess()
+    public function viewAccess($disable = false)
     {
         return true;
     }

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -44,7 +44,7 @@ class AdminLoginControllerCore extends AdminController
         }
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
         $this->addJquery();
         $this->addjqueryPlugin('validate');
@@ -142,7 +142,7 @@ class AdminLoginControllerCore extends AdminController
             }
         }
 
-        $this->setMedia();
+        $this->setMedia($isNewTheme = false);
         $this->initHeader();
         parent::initContent();
         $this->initFooter();
@@ -161,7 +161,7 @@ class AdminLoginControllerCore extends AdminController
      *
      * @return bool
      */
-    public function viewAccess()
+    public function viewAccess($disable = false)
     {
         return true;
     }

--- a/controllers/admin/AdminManufacturersController.php
+++ b/controllers/admin/AdminManufacturersController.php
@@ -98,9 +98,9 @@ class AdminManufacturersControllerCore extends AdminController
         );
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryUi('ui.widget');
         $this->addJqueryPlugin('tagify');
     }

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -248,9 +248,9 @@ class AdminMetaControllerCore extends AdminController
         }
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryUi('ui.widget');
         $this->addJqueryPlugin('tagify');
     }

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -159,9 +159,9 @@ class AdminModulesControllerCore extends AdminController
         return (bool)($a['name'] > $b['name']);
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryPlugin(array('autocomplete', 'fancybox', 'tablefilter'));
 
         if ($this->context->mode == Context::MODE_HOST && Tools::isSubmit('addnewmodule')) {

--- a/controllers/admin/AdminNotFoundController.php
+++ b/controllers/admin/AdminNotFoundController.php
@@ -37,7 +37,7 @@ class AdminNotFoundControllerCore extends AdminController
         return true;
     }
 
-    public function viewAccess()
+    public function viewAccess($disable = false)
     {
         return true;
     }

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -327,9 +327,9 @@ class AdminOrdersControllerCore extends AdminController
         return $res;
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
 
         $this->addJqueryUI('ui.datepicker');
         $this->addJS(_PS_JS_DIR_.'vendor/d3.v3.min.js');

--- a/controllers/admin/AdminPatternsController.php
+++ b/controllers/admin/AdminPatternsController.php
@@ -37,7 +37,7 @@ class AdminPatternsControllerCore extends AdminController
         parent::__construct();
     }
 
-    public function viewAccess()
+    public function viewAccess($disable = false)
     {
         return true;
     }
@@ -419,9 +419,9 @@ class AdminPatternsControllerCore extends AdminController
         return parent::renderForm();
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addjQueryPlugin('tagify', null, false);
     }
 

--- a/controllers/admin/AdminPaymentController.php
+++ b/controllers/admin/AdminPaymentController.php
@@ -61,9 +61,9 @@ class AdminPaymentControllerCore extends AdminController
         return parent::initContent();
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryPlugin('fancybox');
     }
 

--- a/controllers/admin/AdminPaymentPreferencesController.php
+++ b/controllers/admin/AdminPaymentPreferencesController.php
@@ -211,9 +211,9 @@ class AdminPaymentPreferencesControllerCore extends AdminController
         return parent::initContent();
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryPlugin('fancybox');
     }
 

--- a/controllers/admin/AdminReferrersController.php
+++ b/controllers/admin/AdminReferrersController.php
@@ -160,9 +160,9 @@ class AdminReferrersControllerCore extends AdminController
         );
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->context->controller->addJqueryUI('ui.datepicker');
     }
 

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -314,9 +314,9 @@ class AdminSearchControllerCore extends AdminController
         );
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryPlugin('highlight');
     }
 

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -69,9 +69,9 @@ class AdminSuppliersControllerCore extends AdminController
         );
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJqueryUi('ui.widget');
         $this->addJqueryPlugin('tagify');
     }

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -654,9 +654,9 @@ class AdminThemesControllerCore extends AdminController
         return $helper->generateForm($fields_form);
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
         $this->addJS(_PS_JS_DIR_.'admin/themes.js');
 
         if ($this->context->mode == Context::MODE_HOST && Tools::getValue('action') == 'importtheme') {

--- a/src/PrestaShopBundle/Api/QueryParamsCollection.php
+++ b/src/PrestaShopBundle/Api/QueryParamsCollection.php
@@ -678,6 +678,10 @@ abstract class QueryParamsCollection
             return $filters;
         }
 
+        if (!is_array($this->queryParams['filter']['keywords'])) {
+            $this->queryParams['filter']['keywords'] = (array)$this->queryParams['filter']['keywords'];
+        }
+
         $parts = array_map(function ($index) {
             return sprintf(
                 'AND (' .

--- a/tests/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
+++ b/tests/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
@@ -311,12 +311,12 @@ class ConfigurationMock extends Configuration
         return $this;
     }
 
-    public function get($key)
+    public function get($key, $default = null)
     {
-        return isset($this->configurationData[$key])?$this->configurationData[$key]:null;
+        return isset($this->configurationData[$key])?$this->configurationData[$key]:$default;
     }
 
-    public function delete($key)
+    public function remove($key)
     {
         unset($this->configurationData[$key]);
         return $this;

--- a/tests/Unit/ContextMocker.php
+++ b/tests/Unit/ContextMocker.php
@@ -97,6 +97,7 @@ class ContextMocker
         $context->shop = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));
         Shop::setContext(Shop::CONTEXT_SHOP, (int) Context::getContext()->shop->id);
         $context->customer = Phake::mock('Customer');
+        Phake::when($context->customer)->getGroups()->thenReturn(array());
         $context->cookie   = Phake::mock('Cookie');
         $context->country  = Phake::mock('Country');
         $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));

--- a/tools/profiling/Controller.php
+++ b/tools/profiling/Controller.php
@@ -321,7 +321,7 @@ abstract class Controller extends ControllerCore
             $this->array_queries[] = $query_row;
         }
 
-        uasort(ObjectModel::$debug_list, create_function('$a,$b', 'return (count($a) < count($b)) ? 1 : -1;'));
+        uasort(ObjectModel::$debug_list, function ($a, $b) { return (count($a) < count($b)) ? 1 : -1; });
         arsort(Db::getInstance()->tables);
         arsort(Db::getInstance()->uniqQueries);
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When testing PrestaShop with PHP 7.2, many errors appeared in the PHP error log. This PR begins the work to do with this version.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4444
| How to test?  | Test on a server running with PHP 7.2.

Related PRs:
- [x] https://github.com/PrestaShop/ps_facetedsearch/pull/30
- [x] https://github.com/PrestaShop/ps_linklist/pull/47

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8246)
<!-- Reviewable:end -->
