### PR TITLE
Fixed issue with empty locale

### DIFF
--- a/classes/Smarty/TemplateFinder.php
+++ b/classes/Smarty/TemplateFinder.php
@@ -53,7 +53,7 @@ class TemplateFinderCore
 
         foreach ($this->directories as $dir) {
             foreach ($templates as $tpl) {
-                if (is_file($dir.$locale.DIRECTORY_SEPARATOR.$tpl.$this->extension)) {
+                if (is_file($dir.$locale.DIRECTORY_SEPARATOR.$tpl.$this->extension) && !empty($locale)) {
                     return $locale.DIRECTORY_SEPARATOR.$tpl.$this->extension;
                 }
                 if (is_file($dir.$tpl.$this->extension)) {

--- a/classes/Smarty/TemplateFinder.php
+++ b/classes/Smarty/TemplateFinder.php
@@ -53,7 +53,7 @@ class TemplateFinderCore
 
         foreach ($this->directories as $dir) {
             foreach ($templates as $tpl) {
-                if (is_file($dir.$locale.DIRECTORY_SEPARATOR.$tpl.$this->extension) && !empty($locale)) {
+                if (!empty($locale) && is_file($dir.$locale.DIRECTORY_SEPARATOR.$tpl.$this->extension)) {
                     return $locale.DIRECTORY_SEPARATOR.$tpl.$this->extension;
                 }
                 if (is_file($dir.$tpl.$this->extension)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Get error message about missed template if the `$locale` variable is missed <br/> `is_file()` - return true to the path `/var/www/web862/html/weinneu/themes/ZOneTheme/templates//catalog/_partials/facets.tpl` but notice that there is dubled `//` symbol because of missed localization. <br/> Please see attached image about error.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Open catalog page with facets search and switch the language

