### PR TITLE
Fix the update of cover image in multishop mode

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -678,9 +678,11 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
 
                 if ($shop_exists) {
                     if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
-                        foreach ($fields as $key => $val) {
-                            if (!array_key_exists($key, $this->update_fields)) {
-                                unset($fields[$key]);
+                        if (is_array($this->update_fields)) {
+                            foreach ($fields as $key => $val) {
+                                if (!array_key_exists($key, $this->update_fields)) {
+                                    unset($fields[$key]);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | I add a condition to see if the update_fields is an array or null. Cause if it's null, there's no need to check the fields.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9255
| How to test?  | With multistore enabled, while in the context "All Shops", try to edit a product and change its cover image. A notification will be displayed says "saved", refresh the page, you will see that the choosen cover image is well saved and selected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8251)
<!-- Reviewable:end -->
