### PR TITLE
FO: default-bootstrap should use $base_dir_ssl instead of $base_dir

### DIFF
--- a/themes/default-bootstrap/history.tpl
+++ b/themes/default-bootstrap/history.tpl
@@ -119,7 +119,7 @@
 		</a>
 	</li>
 	<li>
-		<a class="btn btn-default button button-small" href="{$base_dir}">
+		<a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
 			<span><i class="icon-chevron-left"></i> {l s='Home'}</span>
 		</a>
 	</li>

--- a/themes/default-bootstrap/modules/blockwishlist/views/templates/front/mywishlist.tpl
+++ b/themes/default-bootstrap/modules/blockwishlist/views/templates/front/mywishlist.tpl
@@ -133,7 +133,7 @@
 			</a>
 		</li>
 		<li>
-			<a class="btn btn-default button button-small" href="{$base_dir|escape:'html':'UTF-8'}">
+			<a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
 				<span>
 					<i class="icon-chevron-left"></i>{l s='Home' mod='blockwishlist'}
 				</span>

--- a/themes/default-bootstrap/scenes.tpl
+++ b/themes/default-bootstrap/scenes.tpl
@@ -26,7 +26,7 @@
 <div id="scenes">
 	<div>
 		{foreach $scenes as $scene_key=>$scene}
-		<div class="screen_scene" id="screen_scene_{$scene->id}" style="background:transparent url({$base_dir}img/scenes/{$scene->id}-scene_default.jpg); height:{$largeSceneImageType.height}px; width:{$largeSceneImageType.width}px;{if !$scene@first} display:none;{/if}">
+		<div class="screen_scene" id="screen_scene_{$scene->id}" style="background:transparent url({if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}img/scenes/{$scene->id}-scene_default.jpg); height:{$largeSceneImageType.height}px; width:{$largeSceneImageType.width}px;{if !$scene@first} display:none;{/if}">
 			{foreach $scene->products as $product_key=>$product}
 			{if isset($product.id_image)}
 				{assign var=imageIds value="`$product.id_product`-`$product.id_image`"}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | default-bootstrap should use $base_dir_ssl instead of $base_dir with ssl
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-5963
| How to test?  | In a shop with ssl enabled, go to My Account -> Order History and My Wishlist, link to home use http instead of https

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8259)
<!-- Reviewable:end -->
