### PR TITLE
CustomerAddressFormCore validation was not working fine with hook…

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -106,7 +106,7 @@ class CustomerAddressFormCore extends AbstractForm
 
     public function validate()
     {
-        $is_valid = parent::validate();
+        $is_valid = true;
 
         if (($postcode = $this->getField('postcode'))) {
             if ($postcode->isRequired()) {
@@ -125,11 +125,11 @@ class CustomerAddressFormCore extends AbstractForm
             }
         }
 
-        if (($hookReturn = Hook::exec('actionValidateCustomerAddressForm', array('form' => $this))) != '') {
+        if (($hookReturn = Hook::exec('actionValidateCustomerAddressForm', array('form' => $this))) !== '') {
             $is_valid &= (bool) $hookReturn;
         }
 
-        return $is_valid;
+        return $is_valid && parent::validate();
     }
 
     public function submit()


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | CustomerAddressFormCore validation was not working fine with hooks provided by modules for custom validation.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | 
| How to test?  | Create a module with ActionValidateCustomerAddressForm hook that validate one of the form fields. at the submit will be possible to proceed to addresses page which shows the error message set in context-controller.


<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

In modules you can validate fields adding errors to be validated by AbstractFormCore::validate() allowing core methods to be improved thus reflecting modules validation.

```php    
public function hookActionValidateCustomerAddressForm($params)
    {
        /** @var CustomerAddressForm $form */
        $form = $params['form'];
        $field= $form->getField("fieldname") ? $form->getField('fieldname')->getValue() : null;
        if (!$this->validateModuleHookFunction($field)) {
            $form->getField('fieldname')->addError($this->l('Invalid field label'));
        }
    }
```

