### PR TITLE
Remove duplicate call to trans for modules

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1887,11 +1887,7 @@ abstract class ModuleCore implements ModuleInterface
             return $string;
         }
 
-        if (($translation = Context::getContext()->getTranslator()->trans($string, array(), null, $locale)) !== $string) {
-            return $translation;
-        }
-
-        return Translate::getModuleTranslation($this, $string, ($specific) ? $specific : $this->name, null, false, $locale);
+        return Translate::getModuleTranslation($this, $string, ($specific) ? $specific : $this->name);
     }
 
     /*


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR follows #7275, where we wanted to check the module translations before the core catalog. The removed content was a duplicate from the end of Translate::getModuleTranslation
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  |

The deleted call is anyway done here:
https://github.com/PrestaShop/PrestaShop/blob/8898412bbb673ef7a79f8f08862a7fefe5344b1a/classes/Translate.php#L272-L278

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8265)
<!-- Reviewable:end -->
