### PR TITLE
Fix error while reaching AdminModules

### DIFF
--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1395,32 +1395,35 @@ class AdminModulesControllerCore extends AdminController
     {
         parent::initModal();
 
-        $module = Module::getInstanceByName(Tools::getValue('configure'));
         $languages = Language::getLanguages(false);
-        $isNewTranslateSystem = $module->isUsingNewTranslationSystem();
-        $link = Context::getContext()->link;
         $translateLinks = array();
-        foreach ($languages as $lang) {
-            if ($isNewTranslateSystem) {
-                $translateLinks[$lang['iso_code']] = $link->getAdminLink('AdminTranslationSf', true, array(
-                    'lang' => $lang['iso_code'],
-                    'type' => 'modules',
-                    'selected' => $module->name,
-                    'locale' => $lang['locale'],
-                ));
-            } else {
-                $translateLinks[$lang['iso_code']] = $link->getAdminLink('AdminTranslations', true, array(), array(
-                    'type' => 'modules',
-                    'module' => $module->name,
-                    'lang' => $lang['iso_code'],
-                ));
+        
+        if (Tools::getIsset('configure')) {
+            $module = Module::getInstanceByName(Tools::getValue('configure'));
+            $isNewTranslateSystem = $module->isUsingNewTranslationSystem();
+            $link = Context::getContext()->link;
+            foreach ($languages as $lang) {
+                if ($isNewTranslateSystem) {
+                    $translateLinks[$lang['iso_code']] = $link->getAdminLink('AdminTranslationSf', true, array(
+                        'lang' => $lang['iso_code'],
+                        'type' => 'modules',
+                        'selected' => $module->name,
+                        'locale' => $lang['locale'],
+                    ));
+                } else {
+                    $translateLinks[$lang['iso_code']] = $link->getAdminLink('AdminTranslations', true, array(), array(
+                        'type' => 'modules',
+                        'module' => $module->name,
+                        'lang' => $lang['iso_code'],
+                    ));
+                }
             }
         }
 
         $this->context->smarty->assign(array(
             'trad_link' => 'index.php?tab=AdminTranslations&token='.Tools::getAdminTokenLite('AdminTranslations').'&type=modules&module='.Tools::getValue('configure').'&lang=',
             'module_languages' => $languages,
-            'module_name' => $module->name,
+            'module_name' => Tools::getValue('configure'),
             'translateLinks' => $translateLinks,
         ));
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | When we want to be redirected to the module page after login, we have to use the old controller AdminModules. Unfortunately, with #8141, the core was trying to load data from a unspecified module name, throwing a fatal error.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Try to login with the redirect to the module page (Your URL must be like this: `http://<shop_url>/admin-dev/index.php?controller=AdminLogin&redirect=AdminModules`. With this PR, you should not have fatal errors anymore