### PR TITLE
Fix bug in BO search multishop

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -535,12 +535,13 @@ class CustomerCore extends ObjectModel
      */
     public static function searchByIp($ip)
     {
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+        $sql = '
 		SELECT DISTINCT c.*
-		FROM `'._DB_PREFIX_.'customer` c
-		LEFT JOIN `'._DB_PREFIX_.'guest` g ON g.id_customer = c.id_customer
-		LEFT JOIN `'._DB_PREFIX_.'connections` co ON g.id_guest = co.id_guest
-		WHERE co.`ip_address` = \''.(int)ip2long(trim($ip)).'\'');
+		FROM `' . _DB_PREFIX_ . 'customer` c
+		LEFT JOIN `' . _DB_PREFIX_ . 'guest` g ON g.id_customer = c.id_customer
+		LEFT JOIN `' . _DB_PREFIX_ . 'connections` co ON g.id_guest = co.id_guest
+		WHERE co.`ip_address` = \'' . (int)ip2long(trim($ip)) . '\'' . Shop::addSqlRestriction(false, 'co');
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3806,6 +3806,26 @@ class ProductCore extends ObjectModel
     }
 
     /**
+     * Admin panel product search
+     * @param int $id_product Id
+     * @return array Matching products
+     */
+    public static function searchById($id_product)
+    {
+        $query = new DbQuery();
+        $query->select('DISTINCT(p.`id_product`)');
+        $query->from('product', 'p');
+        $query->join('INNER JOIN `' . _DB_PREFIX_ . 'product_shop` ps ON ps.`id_product` = p.`id_product`');
+        $query->where('p.id_product = ' . $id_product . Shop::addSqlRestriction(false, 'ps'));
+        $products = Db::getInstance()->executeS($query);
+        if (!$products) {
+            return false;
+        }
+        return $products[0]['id_product'];
+    }
+
+
+    /**
     * Duplicate attributes when duplicating a product
     *
     * @param int $id_product_old Old product id

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -860,4 +860,12 @@ class SearchCore
 
         return Product::getProductsProperties((int)$id_lang, $result);
     }
+
+    public static function searchByShops($table, $field, $valueField)
+    {
+        $results = new PrestaShopCollection($table);
+        $results->where($field, '=', $valueField);
+        $results->where('id_shop', 'IN', Shop::getContextListShopID(false));
+        return $results;
+    }
 }

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -153,7 +153,7 @@ class OrderInvoiceCore extends ObjectModel
             $id_invoice = (int)$id_invoice;
         } elseif (is_string($id_invoice)) {
             $matches = array();
-            if (preg_match('/^(?:'.Configuration::get('PS_INVOICE_PREFIX', Context::getContext()->language->id).')\s*([0-9]+)$/i', $id_invoice, $matches)) {
+            if (preg_match('/^(?:' . Configuration::get('PS_INVOICE_PREFIX', Context::getContext()->language->id) . ')\s*([0-9]+)$/i', $id_invoice, $matches)) {
                 $id_invoice = $matches[1];
             }
         }
@@ -162,9 +162,10 @@ class OrderInvoiceCore extends ObjectModel
         }
 
         $id_order_invoice = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
-			SELECT `id_order_invoice`
-			FROM `'._DB_PREFIX_.'order_invoice`
-			WHERE number = '.(int)$id_invoice);
+			SELECT i.`id_order_invoice`
+			FROM `' . _DB_PREFIX_ . 'order_invoice` i 
+			INNER JOIN `' . _DB_PREFIX_ . 'orders` o ON o.id_order = i.id_order
+			WHERE i.number = ' . (int)$id_invoice . Shop::addSqlRestriction(false, 'o'));
 
         return ($id_order_invoice ? new OrderInvoice($id_order_invoice) : false);
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Search in the selected store and not for all the shops in BO
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8105
| How to test?  | In multishop installation, In a specific shop context (dropdown selection) search for a number that matches the id of an order from a different shop. So, The results will show that order, even though the order does not belong to current shop. This result is the same for othor search type: Product, Customer, Invoive, Cart.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8267)
<!-- Reviewable:end -->
