### PR TITLE
Refacto of module permission checks

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -51,7 +51,10 @@ class AdminModuleDataProvider implements ModuleInterface
 
     const _DAY_IN_SECONDS_ = 86400; /* Cache for One Day */
 
-    protected $module_actions = array('install', 'uninstall', 'enable', 'disable', 'enable_mobile', 'disable_mobile', 'reset', 'upgrade');
+    /**
+     * @var array of defined and callable module actions
+     */
+    protected $moduleActions = array('install', 'uninstall', 'enable', 'disable', 'enable_mobile', 'disable_mobile', 'reset', 'upgrade');
 
     private $languageISO;
     private $logger;
@@ -131,15 +134,15 @@ class AdminModuleDataProvider implements ModuleInterface
      * Check the permissions of the current context (CLI or employee) for a module
      *
      * @param array $actions Actions to check
-     * @param string $name The module nale
+     * @param string $name The module name
      * @return array of allowed actions
      */
     protected function filterAllowedActions(array $actions, $name = '')
     {
         $allowedActions = array();
-        foreach (array_keys($actions) as $action_name) {
-            if ($this->allowedAccess($action_name, $name)) {
-                $allowedActions[$action_name] = $actions[$action_name];
+        foreach (array_keys($actions) as $actionName) {
+            if ($this->isAllowedAccess($actionName, $name)) {
+                $allowedActions[$actionName] = $actions[$actionName];
             }
         }
         return $allowedActions;
@@ -152,7 +155,7 @@ class AdminModuleDataProvider implements ModuleInterface
      * @param string $name (Optionnal for 'install') The module name to check
      * @return boolean
      */
-    public function allowedAccess($action, $name = '')
+    public function isAllowedAccess($action, $name = '')
     {
         if (Tools::isPHPCLI()) {
             return true;
@@ -173,7 +176,7 @@ class AdminModuleDataProvider implements ModuleInterface
     {
         foreach ($addons as &$addon) {
             $urls = array();
-            foreach ($this->module_actions as $action) {
+            foreach ($this->moduleActions as $action) {
                 $urls[$action] = $this->router->generate('admin_module_manage_action', array(
                     'action' => $action,
                     'module_name' => $addon->attributes->get('name'),

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -250,7 +250,7 @@ class AdminModuleDataProvider implements ModuleInterface
             $addon->attributes->set('urls', $urls);
             if ($specific_action && array_key_exists($specific_action, $urls)) {
                 $addon->attributes->set('url_active', $specific_action);
-            } elseif (array_key_exists($url_active, $urls)) {
+            } elseif ($url_active === 'buy' || array_key_exists($url_active, $urls)) {
                 $addon->attributes->set('url_active', $url_active);
             } else {
                 $addon->attributes->set('url_active', key($urls));

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -158,7 +158,7 @@ class AdminModuleDataProvider implements ModuleInterface
             return true;
         }
 
-        if ('install' === $action) {
+        if (in_array($action, array('install', 'upgrade'))) {
             return $this->employee->can('add', 'AdminModulessf');
         }
 

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -131,10 +131,13 @@ class ModuleDataProvider
      */
     public function can($action, $name)
     {
-        return LegacyModule::getPermissionStatic(
-            LegacyModule::getModuleIdByName($name),
-            $action
-        );
+        $module_id = LegacyModule::getModuleIdByName($name);
+
+        if (empty($module_id)) {
+            return false;
+        }
+        
+        return LegacyModule::getPermissionStatic($module_id, $action);
     }
 
     /**

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -85,7 +85,7 @@ class ModuleManager implements AddonManagerInterface
     private $dispatcher;
 
     /**
-     * @param AdminModuleDataProvider $adminModulesProvider
+     * @param AdminModuleDataProvider $adminModuleProvider
      * @param ModuleDataProvider $modulesProvider
      * @param ModuleDataUpdater $modulesUpdater
      * @param ModuleRepository $moduleRepository
@@ -94,7 +94,7 @@ class ModuleManager implements AddonManagerInterface
      * @param Employee|null $employee
      */
     public function __construct(
-        AdminModuleDataProvider $adminModulesProvider,
+        AdminModuleDataProvider $adminModuleProvider,
         ModuleDataProvider $modulesProvider,
         ModuleDataUpdater $modulesUpdater,
         ModuleRepository $moduleRepository,
@@ -102,8 +102,9 @@ class ModuleManager implements AddonManagerInterface
         TranslatorInterface $translator,
         EventDispatcherInterface $dispatcher,
         Employee $employee = null
-    ) {
-        $this->adminModuleProvider = $adminModulesProvider;
+        )
+    {
+        $this->adminModuleProvider = $adminModuleProvider;
         $this->moduleProvider = $modulesProvider;
         $this->moduleUpdater = $modulesUpdater;
         $this->moduleRepository = $moduleRepository;
@@ -202,7 +203,7 @@ class ModuleManager implements AddonManagerInterface
     public function install($source)
     {
         // in CLI mode, there is no employee set up
-        if (!$this->allowedAccess(__FUNCTION__)) {
+        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to install modules.',
@@ -246,7 +247,7 @@ class ModuleManager implements AddonManagerInterface
         // Check permissions:
         // * Employee can delete
         // * Employee can delete this specific module
-        if (!$this->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to uninstall this module.',
@@ -280,7 +281,7 @@ class ModuleManager implements AddonManagerInterface
     */
     public function upgrade($name, $version = 'latest', $source = null)
     {
-        if (!$this->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to upgrade this module.',
@@ -317,7 +318,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function disable($name)
     {
-        if (!$this->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to disable this module.',
@@ -354,7 +355,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function enable($name)
     {
-        if (!$this->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to enable this module.',
@@ -403,7 +404,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function disableMobile($name)
     {
-        if (!$this->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to disable this module on mobile.',
@@ -451,7 +452,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function enableMobile($name)
     {
-        if (!$this->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to enable this module on mobile.',
@@ -483,7 +484,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function reset($name, $keep_data = false)
     {
-        if (!$this->allowedAccess('install') || !$this->allowedAccess('uninstall', $name)) {
+        if (!$this->adminModuleProvider->allowedAccess('install') || !$this->adminModuleProvider->allowedAccess('uninstall', $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to reset this module.',
@@ -591,32 +592,6 @@ class ModuleManager implements AddonManagerInterface
                     'The module %module% must be installed first',
                     array('%module%' => $name),
                 'Admin.Modules.Notification'));
-        }
-    }
-
-    /**
-     * Check the permissions of the current context (CLI or employee) for a specified action
-     *
-     * @param string $action The action called in ModuleManager
-     * @param string $name (Optionnal for 'install') The module name to check
-     * @return boolean
-     */
-    private function allowedAccess($action, $name = '')
-    {
-        if (Tools::isPHPCLI()) {
-            return true;
-        }
-
-        if ('install' === $action) {
-            return $this->employee->can('edit', 'AdminModulessf');
-        }
-
-        if ('uninstall' === $action) {
-            return ($this->employee->can('delete', 'AdminModulessf') && $this->moduleProvider->can('uninstall', $name));
-        }
-
-        if (in_array($action, array('upgrade', 'disable', 'enable', 'disable_mobile', 'enable_mobile'))) {
-            return ($this->employee->can('edit', 'AdminModulessf') && $this->moduleProvider->can('configure', $name));
         }
     }
 }

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -203,7 +203,7 @@ class ModuleManager implements AddonManagerInterface
     public function install($source)
     {
         // in CLI mode, there is no employee set up
-        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__)) {
+        if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to install modules.',
@@ -247,7 +247,7 @@ class ModuleManager implements AddonManagerInterface
         // Check permissions:
         // * Employee can delete
         // * Employee can delete this specific module
-        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to uninstall this module.',
@@ -281,7 +281,7 @@ class ModuleManager implements AddonManagerInterface
     */
     public function upgrade($name, $version = 'latest', $source = null)
     {
-        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to upgrade this module.',
@@ -318,7 +318,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function disable($name)
     {
-        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to disable this module.',
@@ -355,7 +355,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function enable($name)
     {
-        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to enable this module.',
@@ -404,7 +404,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function disableMobile($name)
     {
-        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to disable this module on mobile.',
@@ -452,7 +452,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function enableMobile($name)
     {
-        if (!$this->adminModuleProvider->allowedAccess(__FUNCTION__, $name)) {
+        if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to enable this module on mobile.',
@@ -484,7 +484,7 @@ class ModuleManager implements AddonManagerInterface
      */
     public function reset($name, $keep_data = false)
     {
-        if (!$this->adminModuleProvider->allowedAccess('install') || !$this->adminModuleProvider->allowedAccess('uninstall', $name)) {
+        if (!$this->adminModuleProvider->isAllowedAccess('install') || !$this->adminModuleProvider->isAllowedAccess('uninstall', $name)) {
             throw new Exception(
                 $this->translator->trans(
                     'You are not allowed to reset this module.',

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -188,6 +188,7 @@ class ModuleManagerBuilder
                 self::$legacyLogger,
                 self::$addonsDataProvider,
                 self::$categoriesProvider,
+                self::$moduleDataProvider,
                 self::$cacheProvider
             );
             self::$adminModuleDataProvider->setRouter($this->getSymfonyRouter());

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -183,6 +183,7 @@ class ModuleManagerBuilder
         self::$lecacyContext = new LegacyContext();
 
         if (is_null(self::$adminModuleDataProvider)) {
+            self::$moduleDataProvider = new ModuleDataProvider(self::$legacyLogger, self::$translator);
             self::$adminModuleDataProvider = new AdminModuleDataProvider(
                 self::$translator,
                 self::$legacyLogger,
@@ -201,7 +202,6 @@ class ModuleManagerBuilder
                 self::$lecacyContext,
                 self::$legacyLogger,
                 self::$translator);
-            self::$moduleDataProvider = new ModuleDataProvider(self::$legacyLogger, self::$translator);
         }
     }
 

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -78,7 +78,9 @@ services:
              - "@logger"
              - "@prestashop.core.admin.data_provider.addons_interface"
              - "@prestashop.categories_provider"
+             - "@prestashop.adapter.data_provider.module"
              - "@doctrine.cache.provider"
+             - "@=service('prestashop.adapter.legacy.context').getContext().employee"
         calls:
             - [ setRouter, ['@router']]
         decorates: prestashop.core.admin.data_provider.module_interface

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -31,18 +31,17 @@
   module.attributes.name
 %}
 
-{% if level > constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_READ') %}
   {% if url_active == 'buy' %}
   <div class="form-action-button-container">
     <a class="btn btn-primary btn-primary-reverse btn-block btn-outline-primary light-button module_action_menu_go_to_addons" href="{{ url }}" target="_blank">
       {{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}
     </a>
   </div>
-  {% else %}
+  {% elseif urls|length %}
   <div class="btn-group form-action-button-container">
     <form class="btn-group form-action-button" method="post" action="{{ urls[url_active] }}">
       <button type="submit" class="btn btn-primary-reverse btn-outline-primary light-button module_action_menu_{{ url_active }}"
-          data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}" {% if (level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) or (level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_DELETE') and (url_active not in ['configure', 'install', 'upgrade'])) %} disabled="disabled" {% endif %}>
+          data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">
           {{ url_active|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions') }}
       </button>
       {% if urls|length > 1 %}
@@ -50,15 +49,13 @@
       {% endif %}
     </form>
     {% if (urls|length > 1) %}
-      {% if (level > constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_CREATE')) or ((('configure' in urls|keys) and ('upgrade' in urls|keys)) and  url_active in ['configure', 'install', 'upgrade']) %}
-          <button type="button" class="btn btn-outline-primary  dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <button type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="caret"></span>
             <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
           </button>
           <div class="dropdown-menu">
             {% for module_action, module_url in urls %}
               {% if module_action != url_active %}
-                {% if ((level >= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_DELETE')) or ((level < constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_DELETE')) and (module_action in ['configure', 'install', 'upgrade']))) %}
                   <li>
                     <form method="post" action="{{ module_url }}">
                       <button type="submit" class="dropdown-item module_action_menu_{{ module_action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">
@@ -66,12 +63,9 @@
                       </button>
                     </form>
                   </li>
-                {% endif %}
               {% endif %}
             {% endfor %}
           </div>
-      {% endif %}
     {% endif %}
   </div>
   {% endif %}
-{% endif %}

--- a/tests/Unit/Adapter/Module/AdminModuleDataProviderTest.php
+++ b/tests/Unit/Adapter/Module/AdminModuleDataProviderTest.php
@@ -38,6 +38,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
     private $addonsDataProviderS;
     private $categoriesProviderS;
     private $adminModuleDataProvider;
+    private $moduleDataProviderS;
 
     public function setUp()
     {
@@ -63,6 +64,10 @@ class AdminModuleDataProviderTest extends UnitTestCase
         $this->categoriesProviderS = $this->getMockBuilder('PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider')
             ->disableOriginalConstructor()
             ->getmock();
+
+        $this->moduleDataProviderS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         /* The module catalog will contains only 5 modules for theses tests */
         $fakeModules = array(
@@ -107,6 +112,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
             $this->logger,
             $this->addonsDataProviderS,
             $this->categoriesProviderS,
+            $this->moduleDataProviderS,
             $this->cacheProviderS
         );
     }
@@ -161,6 +167,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
                 'logger' => $this->logger,
                 'addonsDataProvider' => $this->addonsDataProviderS,
                 'categoriesProvider' => $this->categoriesProviderS,
+                'moduleDataProvider' => $this->moduleDataProviderS,
                 'cacheProvider' => $this->cacheProviderS,
             )
         );

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -183,7 +183,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
             ->method('findByName')
             ->will($this->returnValueMap($findByNameReturnValues));
         $this->adminModuleProviderS
-            ->method('allowedAccess')
+            ->method('isAllowedAccess')
             ->willReturn(true);
     }
 

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -143,8 +143,8 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
 
     private function initMocks()
     {
-        $this->mockAdminModuleProvider();
         $this->mockModuleProvider();
+        $this->mockAdminModuleProvider();
         $this->mockModuleUpdater();
         $this->mockModuleRepository();
         $this->mockModuleZipManager();
@@ -158,6 +158,8 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
         $this->adminModuleProviderS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->adminModuleProviderS;
 
         $installedModule = [
             self::INSTALLED_MODULE, [
@@ -180,6 +182,9 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
         $this->adminModuleProviderS
             ->method('findByName')
             ->will($this->returnValueMap($findByNameReturnValues));
+        $this->adminModuleProviderS
+            ->method('allowedAccess')
+            ->willReturn(true);
     }
 
     private function mockModuleProvider()

--- a/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleRepositoryTest.php
@@ -109,7 +109,7 @@ class ModuleRepositoryTest extends UnitTestCase
 
         $this->adminModuleDataProviderStub = $this->getMock('PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider',
             array('getCatalogModulesNames'),
-            array($this->translatorStub, $this->logger, $this->addonsDataProviderS, $this->categoriesProviderS)
+            array($this->translatorStub, $this->logger, $this->addonsDataProviderS, $this->categoriesProviderS, $this->moduleDataProviderStub)
         );
 
         $this->adminModuleDataProviderStub
@@ -128,7 +128,8 @@ class ModuleRepositoryTest extends UnitTestCase
                         $this->translatorStub,
                         $this->logger,
                         $this->addonsDataProviderS,
-                        $this->categoriesProviderS
+                        $this->categoriesProviderS,
+                        $this->moduleDataProviderStub
                     )
                 ),
                 new FakeLogger(),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It appeared some module actions were displayed even if the employee was not allowed to use it.In this PR, we merge the permissions checks for the links to display and for the action execution. This means if a button is not displayed, I can be sure the action would not pass if called manually. This PR also updated the **upgrade** action, which is now related to "add".
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Yes
| Fixed ticket? | /
| How to test?  | Play with the permissions related to the modules and checks the available actions on the module page are properly updated. ping @rGaillard 