### PR TITLE
Allow modifying IdentityController to save personal information without password

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -39,7 +39,7 @@ class CustomerFormCore extends AbstractForm
 
     private $customerPersister;
     private $guest_allowed;
-    private $password_required = true;
+    private $passwordRequired = true;
 
     public function __construct(
         Smarty $smarty,
@@ -68,9 +68,10 @@ class CustomerFormCore extends AbstractForm
         return $this;
     }
 
-    public function setPasswordRequired($password_required)
+    public function setPasswordRequired($passwordRequired)
     {
-        $this->password_required = $password_required;
+        $this->passwordRequired = $passwordRequired;
+        
         return $this;
     }
 
@@ -195,7 +196,7 @@ class CustomerFormCore extends AbstractForm
                 $this->getCustomer(),
                 $clearTextPassword,
                 $newPassword,
-                $this->password_required
+                $this->passwordRequired
             );
 
             if (!$ok) {

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -39,6 +39,7 @@ class CustomerFormCore extends AbstractForm
 
     private $customerPersister;
     private $guest_allowed;
+    private $password_required = true;
 
     public function __construct(
         Smarty $smarty,
@@ -64,6 +65,12 @@ class CustomerFormCore extends AbstractForm
         $this->formatter->setPasswordRequired(!$guest_allowed);
         $this->guest_allowed = $guest_allowed;
 
+        return $this;
+    }
+
+    public function setPasswordRequired($password_required)
+    {
+        $this->password_required = $password_required;
         return $this;
     }
 
@@ -187,7 +194,8 @@ class CustomerFormCore extends AbstractForm
             $ok = $this->customerPersister->save(
                 $this->getCustomer(),
                 $clearTextPassword,
-                $newPassword
+                $newPassword,
+                $this->password_required
             );
 
             if (!$ok) {

--- a/classes/form/CustomerPersister.php
+++ b/classes/form/CustomerPersister.php
@@ -53,18 +53,18 @@ class CustomerPersisterCore
         return $this->errors;
     }
 
-    public function save(Customer $customer, $clearTextPassword, $newPassword = '', $password_required = true)
+    public function save(Customer $customer, $clearTextPassword, $newPassword = '', $passwordRequired = true)
     {
         if ($customer->id) {
-            return $this->update($customer, $clearTextPassword, $newPassword, $password_required);
+            return $this->update($customer, $clearTextPassword, $newPassword, $passwordRequired);
         } else {
             return $this->create($customer, $clearTextPassword);
         }
     }
 
-    private function update(Customer $customer, $clearTextPassword, $newPassword, $password_required = true)
+    private function update(Customer $customer, $clearTextPassword, $newPassword, $passwordRequired = true)
     {
-        if (!$customer->is_guest && $password_required && !$this->crypto->checkHash(
+        if (!$customer->is_guest && $passwordRequired && !$this->crypto->checkHash(
             $clearTextPassword,
             $customer->passwd,
             _COOKIE_KEY_
@@ -86,7 +86,7 @@ class CustomerPersisterCore
             );
         }
 
-        if ($customer->is_guest || !$password_required) {
+        if ($customer->is_guest || !$passwordRequired) {
             // TODO SECURITY: Audit requested
             if ($customer->id != $this->context->customer->id) {
 

--- a/classes/form/CustomerPersister.php
+++ b/classes/form/CustomerPersister.php
@@ -53,18 +53,18 @@ class CustomerPersisterCore
         return $this->errors;
     }
 
-    public function save(Customer $customer, $clearTextPassword, $newPassword = '')
+    public function save(Customer $customer, $clearTextPassword, $newPassword = '', $password_required = true)
     {
         if ($customer->id) {
-            return $this->update($customer, $clearTextPassword, $newPassword);
+            return $this->update($customer, $clearTextPassword, $newPassword, $password_required);
         } else {
             return $this->create($customer, $clearTextPassword);
         }
     }
 
-    private function update(Customer $customer, $clearTextPassword, $newPassword)
+    private function update(Customer $customer, $clearTextPassword, $newPassword, $password_required = true)
     {
-        if (!$customer->is_guest && !$this->crypto->checkHash(
+        if (!$customer->is_guest && $password_required && !$this->crypto->checkHash(
             $clearTextPassword,
             $customer->passwd,
             _COOKIE_KEY_
@@ -86,7 +86,7 @@ class CustomerPersisterCore
             );
         }
 
-        if ($customer->is_guest) {
+        if ($customer->is_guest || !$password_required) {
             // TODO SECURITY: Audit requested
             if ($customer->id != $this->context->customer->id) {
 

--- a/controllers/front/IdentityController.php
+++ b/controllers/front/IdentityController.php
@@ -31,7 +31,7 @@ class IdentityControllerCore extends FrontController
     public $authRedirection = 'identity';
     public $ssl = true;
 
-    public $password_required = true;
+    public $passwordRequired = true;
 
     /**
      * Assign template vars related to page content
@@ -41,13 +41,13 @@ class IdentityControllerCore extends FrontController
     {
         $should_redirect = false;
 
-        $customer_form = $this->makeCustomerForm()->setPasswordRequired($this->password_required);
+        $customer_form = $this->makeCustomerForm()->setPasswordRequired($this->passwordRequired);
         $customer = new Customer();
 
         $customer_form->getFormatter()
             ->setAskForNewPassword(true)
-            ->setAskForPassword($this->password_required)
-            ->setPasswordRequired($this->password_required)
+            ->setAskForPassword($this->passwordRequired)
+            ->setPasswordRequired($this->passwordRequired)
             ->setPartnerOptinRequired($customer->isFieldRequired('optin'))
         ;
 

--- a/controllers/front/IdentityController.php
+++ b/controllers/front/IdentityController.php
@@ -31,6 +31,8 @@ class IdentityControllerCore extends FrontController
     public $authRedirection = 'identity';
     public $ssl = true;
 
+    public $password_required = true;
+
     /**
      * Assign template vars related to page content
      * @see FrontController::initContent()
@@ -39,12 +41,13 @@ class IdentityControllerCore extends FrontController
     {
         $should_redirect = false;
 
-        $customer_form = $this->makeCustomerForm();
+        $customer_form = $this->makeCustomerForm()->setPasswordRequired($this->password_required);
         $customer = new Customer();
 
         $customer_form->getFormatter()
             ->setAskForNewPassword(true)
-            ->setPasswordRequired(true)
+            ->setAskForPassword($this->password_required)
+            ->setPasswordRequired($this->password_required)
             ->setPartnerOptinRequired($customer->isFieldRequired('optin'))
         ;
 


### PR DESCRIPTION
Allow modifying IdentityController to save personal information without password

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Note: This should NOT be viewed as completely deactivating password check on the personal informations page.<br/><br/>It is currently mandatory to enter your password to save personal information.<br/>We have been trying to modify that behaviour for some customers, and some code have been implemented in that sense but not all the way through:<br/>-In IdentityController::initContent(), setting ->setPasswordRequired to false on the customer form should work but doesn't, we get an error message for Invalid password<br/>-Setting ->setAskForPassword to false seemed like the logical next step so the field is not checked and not displayed, and it does remove the field but submitting only end in a 500 Fatal Error <br/><br/>Code in IdentityController to reproduce:<br/>$customer_form->getFormatter()<br/>    ->setAskForNewPassword(true)<br/>    ->setPasswordRequired(false)<br/>    ->setAskForPassword(false)<br/>    ->setPartnerOptinRequired($customer->isFieldRequired('optin'))<br/>;<br/><br/>Our goal was to allow third-party login on a shop we're working on. The customer logs in using Facebook, a customer account is created with a random password he is unaware of, and he thus cannot modify his personal information without using password recovery.<br/>It seems like bad practice that a customer using third-party login should use a password at all as the third-party is ensuring security here and our only concern should be that he is connected.<br/><br/>This fixes some of the partially implemented code to allow a simpler override to change that setting, possibly adding a Configuration value in the future on that setting, or in our case adding a Hook for the third-party login module to allow or disallow saving without password depending on the current user.<br/><br/>We have tested trying to save on a different id_customer, replacing an existing email address... and all security tests were OK.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3709
| How to test?  | Set $password_required = false at top of IdentityController. You may now change personal information without entering your password.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8270)
<!-- Reviewable:end -->
