### PR TITLE
 Fix Customer shown address of another user

### DIFF
--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -463,12 +463,17 @@ class AuthControllerCore extends FrontController
                         }
 
                         $this->updateContext($customer);
+                        $this->context->cart->id_address_delivery = (int)Address::getFirstCustomerAddressId((int)$customer->id);
+                        $this->context->cart->id_address_invoice = (int)Address::getFirstCustomerAddressId((int)$customer->id);
 
-                        $this->context->cart->update();
                         Hook::exec('actionCustomerAccountAdd', array(
                                 '_POST' => $_POST,
                                 'newCustomer' => $customer
                             ));
+                        $id_guest = Guest::getFromCustomer($customer->id);
+                        $this->context->cookie->id_guest = $id_guest;
+                        $this->context->cart->id_guest = $id_guest;
+                        $this->context->cart->update();
                         if ($this->ajax) {
                             $return = array(
                                 'hasError' => !empty($this->errors),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Update of the delivery / invoice address in the cart table when passing of creation a guest count to the customer account
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7854
| How to test?  | See below

### How to test ?

Login to BO and visit Preferences -> orders and enable guest checkout.
In the shop add an item to the cart and proceed to the checkout.
Fill in the Instant Checkout form. Step 1 "Summary" of the checkout process shows that the guest account has been created, with the delivery and invoice addresses displaying the same address as provided when completing the Instant Checkout form.
Now click "Sign in" and create a full customer account.
When the account has been created the user is returned to Step 1, the summary page of the checkout, and is incorrectly shown the address from the guest account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8272)
<!-- Reviewable:end -->
