### PR TITLE
Disallow the negative discounts in orders

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1334,6 +1334,8 @@ class AdminOrdersControllerCore extends AdminController
             if ($this->tabAccess['edit'] === '1') {
                 if (!Tools::getValue('discount_name')) {
                     $this->errors[] = Tools::displayError('You must specify a name in order to create a new discount.');
+                } elseif ((float)Tools::getValue('discount_value') <= 0) {
+                    $this->errors[] = Tools::displayError('The discount value is invalid.');
                 } else {
                     if ($order->hasInvoice()) {
                         // If the discount is for only one invoice


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | add a test on "discount_value" field, if it's empty or negative then an error will be displayed
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7932
| How to test?  | BO, create an order. Then, try to add a negative discount (for exemple "-2" as amount). An error will be displayed.


![order idtvzulbq](https://user-images.githubusercontent.com/23308427/29710443-3c61ede2-8988-11e7-83cd-c86489596d7b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8274)
<!-- Reviewable:end -->
