### PR TITLE
Add eslint config to extend airbnb rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+**/public/
+**/vendor/
+modules/
+admin-dev/filemanager/
+themes/classic/assets/js/
+**/*jquery/*.js
+**/jquery*.js
+themes/core.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,22 +1,20 @@
 {
-  "ecmaFeatures": {
-    "modules": true
-  },
+  "extends": "airbnb",
   "env": {
     "es6": true,
     "browser": true
   },
   "parserOptions": {
     "ecmaVersion": 6,
-    "sourceType": "module"
+    "sourceType": "module",
+    "impliedStrict": true,
+    "ecmaFeatures": {
+      "modules": true
+    }
   },
   "rules": {
-    "semi": 2,
-    "eqeqeq": 2,
-    "no-undef": 2,
     "no-unused-vars": 1,
-    "no-use-before-define": 0,
-    "max-depth": [2, 3],
-    "no-loop-func": 2
+    "no-use-before-define": 2,
+    "max-depth": [2, 3]
   }
 }

--- a/install-dev/theme/.eslintrc.json
+++ b/install-dev/theme/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": "airbnb",
+  "env": {
+    "browser": true
+  },
+  "parser": "babel-eslint",
+  "rules": {
+    "no-use-before-define": 1,
+    "max-depth": [2, 3]
+  }
+}

--- a/js/.eslintignore
+++ b/js/.eslintignore
@@ -1,0 +1,7 @@
+jquery
+tiny_mce
+vendor
+cropper
+date.js
+fileuploader.js
+validate.js

--- a/js/.eslintrc.json
+++ b/js/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": "airbnb",
+  "env": {
+    "browser": true
+  },
+  "parser": "babel-eslint",
+  "rules": {
+    "no-use-before-define": 1,
+    "max-depth": [2, 3]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,5 +9,14 @@
         "test-verbose": "cd tests/js && grunt --stack test-verbose"
     },
     "author": "PrestaShop",
-    "license": "OSL-3.0"
+    "license": "OSL-3.0",
+    "devDependencies": {
+      "eslint": "^4.4.1",
+      "eslint-config-airbnb": "^15.1.0",
+      "eslint-config-airbnb-base": "^11.3.1",
+      "eslint-plugin-jsx-a11y": "^5.1.1",
+      "eslint-plugin-import": "^2.7.0",
+      "eslint-plugin-react": "^7.2.0",
+      "babel-eslint": "^7.2.3"
+    }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | This PR add the eslint configuration file for both ES5 and ES6 (ES6 more strict than ES5) so contributors can configure their IDE To follow the airbnb standards or javascript files.
| Type?         | new feature
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | run "npm install" in the root directory, in your IDE settings -> "Language & Frameworks"  -> Code quality Tools" -> "Eslint" -> enable it and specify ESLint package (the one created innode_modules) and select the option to search for .eslintrc. In your JS files you see errors and warnings reported by eslint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8276)
<!-- Reviewable:end -->
