### PR TITLE
CustomerAddressFormatter states were queried without the status (active) check causing disabling states in BO useless

### DIFF
--- a/classes/State.php
+++ b/classes/State.php
@@ -203,7 +203,7 @@ class StateCore extends ObjectModel
      * @param bool $active true if the state must be active
      * @return array|false|mysqli_result|null|PDOStatement|resource
      */
-    public static function getStatesByIdCountry($idCountry, $active=false)
+    public static function getStatesByIdCountry($idCountry, $active = false)
     {
         if (empty($idCountry)) {
             die(Tools::displayError());
@@ -212,7 +212,7 @@ class StateCore extends ObjectModel
         return Db::getInstance()->executeS('
 			SELECT *
 			FROM `'._DB_PREFIX_.'state` s
-			WHERE s.`id_country` = '.(int) $idCountry . ($active ?  ' AND s.active =1' : "")
+			WHERE s.`id_country` = '.(int) $idCountry . ($active ?  ' AND s.active = 1' : "")
         );
     }
 

--- a/classes/State.php
+++ b/classes/State.php
@@ -200,10 +200,10 @@ class StateCore extends ObjectModel
      * Get states by Country ID
      *
      * @param int $idCountry Country ID
-     *
+     * @param bool $active true if the state must be active
      * @return array|false|mysqli_result|null|PDOStatement|resource
      */
-    public static function getStatesByIdCountry($idCountry)
+    public static function getStatesByIdCountry($idCountry, $active=false)
     {
         if (empty($idCountry)) {
             die(Tools::displayError());
@@ -212,7 +212,7 @@ class StateCore extends ObjectModel
         return Db::getInstance()->executeS('
 			SELECT *
 			FROM `'._DB_PREFIX_.'state` s
-			WHERE s.`id_country` = '.(int) $idCountry
+			WHERE s.`id_country` = '.(int) $idCountry . ($active ?  ' AND s.active =1' : "")
         );
     }
 

--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -119,7 +119,7 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                     }
                 } elseif ($entity === 'State') {
                     if ($this->country->contains_states) {
-                        $states = State::getStatesByIdCountry($this->country->id);
+                        $states = State::getStatesByIdCountry($this->country->id, true);
                         foreach ($states as $state) {
                             $formField->addAvailableValue(
                                 $state['id_state'],


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.3.x
| Description?  |  State::getStatesByIdCountry was fetching database without taking into account if the state is actually active in BO, causing frontend address form to display disabled states.
| Type?         |  bug fix
| Category?     | CO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | 
| How to test?  | In BO disable a state (set active column to 0) then in FO go to address form. The disabled state will be shown. (without my correction)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8277)
<!-- Reviewable:end -->

  