### PR TITLE
Add is_object condition in isInt function to prevent the error 500

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -661,6 +661,9 @@ class ValidateCore
      */
     public static function isInt($value)
     {
+        if (!is_scalar($value)) {
+            return false;
+        }
         return ((string)(int)$value === (string)$value || $value === false);
     }
 

--- a/tests/Unit/classes/ValidateCoreTest.php
+++ b/tests/Unit/classes/ValidateCoreTest.php
@@ -98,6 +98,14 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame($expected, Validate::isOptFloat($input));
     }
+
+    /**
+     * @dataProvider isIntDataProvider
+     */
+    public function testIsInt($expected, $input)
+    {
+        $this->assertSame($expected, Validate::isInt($input));
+    }
         
         // --- providers ---
 
@@ -198,6 +206,26 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
                 array(false, 'A'),
                 array(false, null),
             )
+        );
+    }
+
+    public function isIntDataProvider()
+    {
+        return array(
+            array(true, 0),
+            array(true, 42),
+            array(false, 4.2),
+            array(false, .42),
+            array(true, 42.),
+            array(false, "a42"),
+            array(false, "42a"),
+            array(true, 0x24),
+            array(true, 1337e0),
+            array(false, array()),
+            array(false, new \stdClass()),
+            array(false, null),
+            array(false, ''),
+            array(true, false),
         );
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Add is_object condition in isInt function to prevent the error 500 when we put an object as param in isInt function.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8009
| How to test?  | Check the ticket please 
