### PR TITLE
Fixes wrong images on order confirmation page with simple products

### DIFF
--- a/src/Adapter/Order/OrderPresenter.php
+++ b/src/Adapter/Order/OrderPresenter.php
@@ -131,7 +131,7 @@ class OrderPresenter implements PresenterInterface
             }
 
             foreach ($cartProducts['products'] as $cartProduct) {
-                if ($cartProduct['id_product_attribute'] === $orderProduct['id_product_attribute']) {
+                if (($cartProduct['id_product'] === $orderProduct['id_product']) && ($cartProduct['id_product_attribute'] === $orderProduct['id_product_attribute'])) {
                     if (isset($cartProduct['attributes'])) {
                         $orderProduct['attributes'] = $cartProduct['attributes'];
                     } else {


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes wrong images on order confirmation page with simple products. Only the last image was used for all products
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3695
| How to test?  | Order multiple simple products

