### PR TITLE
Currency exchange fixes on product page

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -947,6 +947,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);
         $product['extraContent'] = $extraContentFinder->addParams(array('product' => $this->product))->present();
+        $product['ecotax'] = Tools::convertPrice((float) $product['ecotax'], $this->context->currency, true, $this->context);
 
         $product_full = Product::getProductProperties($this->context->language->id, $product, $this->context);
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -817,6 +817,16 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
     }
 
+    /**
+     * Calculation of currency-converted discounts for specific prices on product
+     *
+     * @param array $specific_prices array of specific prices definitions (DEFAULT currency)
+     * @param float $price           current price in CURRENT currency
+     * @param float $tax_rate        in percents
+     * @param float $ecotax_amount   in DEFAULT currency, with tax
+     *
+     * @return array
+     */
     protected function formatQuantityDiscounts($specific_prices, $price, $tax_rate, $ecotax_amount)
     {
         $priceFormatter = new PriceFormatter();
@@ -826,25 +836,30 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             if ($row['price'] >= 0) {
                 // The price may be directly set
 
-                $cur_price = (!$row['reduction_tax'] ? $row['price'] : $row['price'] * (1 + $tax_rate / 100)) + (float) $ecotax_amount;
+                /** @var float $currentPriceDefaultCurrency current price with taxes in default currency */
+                $currentPriceDefaultCurrency = (!$row['reduction_tax'] ? $row['price'] : $row['price'] * (1 + $tax_rate / 100)) + (float) $ecotax_amount;
+                // Since this price is set in default currency,
+                // we need to convert it into current currency
+                $row['id_currency'];
+                $currentPriceCurrentCurrency = Tools::convertPrice($currentPriceDefaultCurrency, $this->context->currency, true, $this->context);
 
                 if ($row['reduction_type'] == 'amount') {
-                    $cur_price -= ($row['reduction_tax'] ? $row['reduction'] : $row['reduction'] / (1 + $tax_rate / 100));
+                    $currentPriceCurrentCurrency -= ($row['reduction_tax'] ? $row['reduction'] : $row['reduction'] / (1 + $tax_rate / 100));
                     $row['reduction_with_tax'] = $row['reduction_tax'] ? $row['reduction'] : $row['reduction'] / (1 + $tax_rate / 100);
                 } else {
-                    $cur_price *= 1 - $row['reduction'];
+                    $currentPriceCurrentCurrency *= 1 - $row['reduction'];
                 }
-                $row['real_value'] = $price > 0 ? $price - $cur_price : $cur_price;
+                $row['real_value'] = $price > 0 ? $price - $currentPriceCurrentCurrency : $currentPriceCurrentCurrency;
                 $discountPrice = $price - $row['real_value'];
 
                 if (Configuration::get('PS_DISPLAY_DISCOUNT_PRICE')) {
                     if ($row['reduction_tax'] == 0 && !$row['price']) {
-                        $row['discount'] = $priceFormatter->convertAndFormat($price - ($price * $row['reduction_with_tax']));
+                        $row['discount'] = $priceFormatter->format($price - ($price * $row['reduction_with_tax']));
                     } else {
-                        $row['discount'] = $priceFormatter->convertAndFormat($price - $row['real_value']);
+                        $row['discount'] = $priceFormatter->format($price - $row['real_value']);
                     }
                 } else {
-                    $row['discount'] = $priceFormatter->convertAndFormat($row['real_value']);
+                    $row['discount'] = $priceFormatter->format($row['real_value']);
                 }
             } else {
                 if ($row['reduction_type'] == 'amount') {
@@ -857,21 +872,21 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                     $discountPrice = $price - $row['real_value'];
                     if (Configuration::get('PS_DISPLAY_DISCOUNT_PRICE')) {
                         if ($row['reduction_tax'] == 0 && !$row['price']) {
-                            $row['discount'] = $priceFormatter->convertAndFormat($price - ($price * $row['reduction_with_tax']));
+                            $row['discount'] = $priceFormatter->format($price - ($price * $row['reduction_with_tax']));
                         } else {
-                            $row['discount'] = $priceFormatter->convertAndFormat($price - $row['real_value']);
+                            $row['discount'] = $priceFormatter->format($price - $row['real_value']);
                         }
                     } else {
-                        $row['discount'] = $priceFormatter->convertAndFormat($row['real_value']);
+                        $row['discount'] = $priceFormatter->format($row['real_value']);
                     }
                 } else {
                     $row['real_value'] = $row['reduction'] * 100;
                     $discountPrice = $price - $price * $row['reduction'];
                     if (Configuration::get('PS_DISPLAY_DISCOUNT_PRICE')) {
                         if ($row['reduction_tax'] == 0) {
-                            $row['discount'] = $priceFormatter->convertAndFormat($price - ($price * $row['reduction_with_tax']));
+                            $row['discount'] = $priceFormatter->format($price - ($price * $row['reduction_with_tax']));
                         } else {
-                            $row['discount'] = $priceFormatter->convertAndFormat($price - ($price * $row['reduction']));
+                            $row['discount'] = $priceFormatter->format($price - ($price * $row['reduction']));
                         }
                     } else {
                         $row['discount'] = $row['real_value'].'%';
@@ -879,7 +894,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 }
             }
 
-            $row['save'] = $priceFormatter->convertAndFormat((($price * $row['quantity']) - ($discountPrice * $row['quantity'])));
+            $row['save'] = $priceFormatter->format((($price * $row['quantity']) - ($discountPrice * $row['quantity'])));
             $row['nextQuantity'] = (isset($specific_prices[$key + 1]) ? (int) $specific_prices[$key + 1]['from_quantity'] : -1);
         }
 

--- a/tests/Unit/controller/FrontController/ProductControllerTest.php
+++ b/tests/Unit/controller/FrontController/ProductControllerTest.php
@@ -27,34 +27,31 @@
 namespace PrestaShop\PrestaShop\Tests\Unit\Controller\FrontController;
 
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Tests\TestCase\IntegrationTestCase;
+use PrestaShop\PrestaShop\Tests\Unit\ContextMocker;
 
-class ProductControllerTest extends \PrestaShop\PrestaShop\Tests\TestCase\IntegrationTestCase
+class ProductControllerTest extends IntegrationTestCase
 {
+
+    /**
+     * @var ContextMocker
+     */
+    protected $contextMocker;
+
     private $controller;
-    private $contextBackup;
 
     public function setUp()
     {
         parent::setUp();
-        $this->contextBackup = \Context::getContext();
-        $context             = clone($this->contextBackup);
-        \Context::setInstanceForTesting($context);
-        $context->shop       = new \Shop((int) \Configuration::get('PS_SHOP_DEFAULT'));
-        $context->language   = new \Language;
-        $protocol_link       = (\Tools::usingSecureMode() && \Configuration::get('PS_SSL_ENABLED'))
-            ? 'https://' : 'http://';
-        $protocol_content    = (\Tools::usingSecureMode() && \Configuration::get('PS_SSL_ENABLED'))
-            ? 'https://' : 'http://';
-        $context->link       = new \Link($protocol_link, $protocol_content);
-        $context->smarty     = new \Smarty();
+        $this->contextMocker = new ContextMocker();
+        $this->contextMocker->mockContext();
         $this->controller = new \ProductControllerCore();
     }
 
     public function tearDown()
     {
         parent::tearDown();
-
-        \Context::setInstanceForTesting($this->contextBackup);
+        $this->contextMocker->resetContext();
     }
 
     /**

--- a/tests/Unit/controller/FrontController/ProductControllerTest.php
+++ b/tests/Unit/controller/FrontController/ProductControllerTest.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Tests\Unit\Controller\FrontController;
+
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+
+class ProductControllerTest extends \PrestaShop\PrestaShop\Tests\TestCase\IntegrationTestCase
+{
+    private $controller;
+    private $contextBackup;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->contextBackup = \Context::getContext();
+        $context             = clone($this->contextBackup);
+        \Context::setInstanceForTesting($context);
+        $context->shop       = new \Shop((int) \Configuration::get('PS_SHOP_DEFAULT'));
+        $context->language   = new \Language;
+        $protocol_link       = (\Tools::usingSecureMode() && \Configuration::get('PS_SSL_ENABLED'))
+            ? 'https://' : 'http://';
+        $protocol_content    = (\Tools::usingSecureMode() && \Configuration::get('PS_SSL_ENABLED'))
+            ? 'https://' : 'http://';
+        $context->link       = new \Link($protocol_link, $protocol_content);
+        $context->smarty     = new \Smarty();
+        $this->controller = new \ProductControllerCore();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        \Context::setInstanceForTesting($this->contextBackup);
+    }
+
+    /**
+     * Call protected/private method of a class.
+     *
+     * @param object $object     Instantiated object that we will run method on.
+     * @param string $methodName Method name to call
+     * @param array  $parameters Array of parameters to pass into method.
+     *
+     * @return mixed Method return.
+     */
+    public function invokeMethod($object, $methodName, array $parameters = [])
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method     = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+
+    /**
+     * here we test that for a given dataset of specific prices, currency, ecotax... we get the correct discount result
+     *
+     * @dataProvider specificPricesProvider
+     *
+     * @param array $data data provided by method specificPricesProvider()
+     */
+    public function testFormatQuantityDiscounts(array $data)
+    {
+        $class    = new \ReflectionClass(get_class($this->controller));
+        $property = $class->getProperty("context");
+        $property->setAccessible(true);
+
+        $currency                  = new \Currency;
+        $currency->active          = true;
+        $currency->conversion_rate = $data['currency']['conversion_rate'];
+        $currency->sign            = $data['currency']['sign'];
+        $currency->iso_code        = $data['currency']['code'];
+
+        /** @var \Context $context */
+        $context            = $property->getValue($this->controller);
+        $context->currency  = $currency;
+        $language           = new \Language();
+        $language->iso_code = 'EN';
+        $context->language  = $language;
+        $result             = $this->invokeMethod(
+            $this->controller,
+            'formatQuantityDiscounts',
+            [
+                $data['specific_prices'],
+                $data['price'],
+                $data['tax_rate'],
+                $data['ecotax_amount'],
+            ]
+        );
+
+        $priceFormatter = new PriceFormatter();
+
+        foreach ($data['expected'] as $expectedLevel => $expectedValues) {
+            $this->assertArrayHasKey($expectedLevel, $result);
+            foreach ($expectedValues as $expectedKey => $expectedValue) {
+                $this->assertArrayHasKey($expectedKey, $result[$expectedLevel]);
+                $this->assertEquals($priceFormatter->format($expectedValue), $result[$expectedLevel][$expectedKey]);
+            }
+        }
+    }
+
+    public function specificPricesProvider()
+    {
+        return [
+            // EUR to USD, without ecotax
+            [
+                [
+                    'price'           => 31.2,
+                    'tax_rate'        => 20,
+                    'ecotax_amount'   => 0,
+                    'currency'        => [
+                        'conversion_rate' => 1.3,
+                        'sign'            => '$',
+                        'code'            => 'USD',
+                    ],
+                    'specific_prices' => [
+                        0 => [
+                            'id_specific_price'      => '9',
+                            'id_specific_price_rule' => '0',
+                            'id_cart'                => '0',
+                            'id_product'             => '10',
+                            'id_shop'                => '1',
+                            'id_shop_group'          => '0',
+                            'id_currency'            => '0',
+                            'id_country'             => '0',
+                            'id_group'               => '0',
+                            'id_customer'            => '0',
+                            'id_product_attribute'   => '0',
+                            'price'                  => '15.000000',
+                            'from_quantity'          => '15',
+                            'reduction'              => 0,
+                            'reduction_tax'          => '1',
+                            'reduction_type'         => 'amount',
+                            'from'                   => '0000-00-00 00:00:00',
+                            'to'                     => '0000-00-00 00:00:00',
+                            'score'                  => '48',
+                            'quantity'               => '15',
+                            'reduction_with_tax'     => 0,
+                            'nextQuantity'           => -1,
+                        ],
+                    ],
+                    'expected'        => [
+                        [
+                            'discount' => 7.80,
+                            'save'     => 117.00,
+                        ],
+                    ],
+                ],
+            ],
+            // EUR to EUR, without ecotax
+            [
+                [
+                    'price'           => 24,
+                    'tax_rate'        => 20,
+                    'ecotax_amount'   => 0,
+                    'currency'        => [
+                        'conversion_rate' => 1.0,
+                        'sign'            => '€',
+                        'code'            => 'EUR',
+                    ],
+                    'specific_prices' => [
+                        0 => [
+                            'id_specific_price'      => '9',
+                            'id_specific_price_rule' => '0',
+                            'id_cart'                => '0',
+                            'id_product'             => '10',
+                            'id_shop'                => '1',
+                            'id_shop_group'          => '0',
+                            'id_currency'            => '0',
+                            'id_country'             => '0',
+                            'id_group'               => '0',
+                            'id_customer'            => '0',
+                            'id_product_attribute'   => '0',
+                            'price'                  => '15.000000',
+                            'from_quantity'          => '15',
+                            'reduction'              => 0,
+                            'reduction_tax'          => '1',
+                            'reduction_type'         => 'amount',
+                            'from'                   => '0000-00-00 00:00:00',
+                            'to'                     => '0000-00-00 00:00:00',
+                            'score'                  => '48',
+                            'quantity'               => '15',
+                            'reduction_with_tax'     => 0,
+                            'nextQuantity'           => -1,
+                        ],
+                    ],
+                    'expected'        => [
+                        [
+                            'discount' => 6.00,
+                            'save'     => 90.00,
+                        ],
+                    ],
+                ],
+            ],
+            // EUR to USD, with ecotax
+            [
+                [
+                    'price'           => 31.2,
+                    'tax_rate'        => 20,
+                    'ecotax_amount'   => 0.9,
+                    'currency'        => [
+                        'conversion_rate' => 1.3,
+                        'sign'            => '$',
+                        'code'            => 'USD',
+                    ],
+                    'specific_prices' => [
+                        0 => [
+                            'id_specific_price'      => '9',
+                            'id_specific_price_rule' => '0',
+                            'id_cart'                => '0',
+                            'id_product'             => '10',
+                            'id_shop'                => '1',
+                            'id_shop_group'          => '0',
+                            'id_currency'            => '0',
+                            'id_country'             => '0',
+                            'id_group'               => '0',
+                            'id_customer'            => '0',
+                            'id_product_attribute'   => '0',
+                            'price'                  => '15.000000',
+                            'from_quantity'          => '15',
+                            'reduction'              => 0,
+                            'reduction_tax'          => '1',
+                            'reduction_type'         => 'amount',
+                            'from'                   => '0000-00-00 00:00:00',
+                            'to'                     => '0000-00-00 00:00:00',
+                            'score'                  => '48',
+                            'quantity'               => '15',
+                            'reduction_with_tax'     => 0,
+                            'nextQuantity'           => -1,
+                        ],
+                    ],
+                    'expected'        => [
+                        [
+                            'discount' => 6.63,
+                            'save'     => 99.45,
+                        ],
+                    ],
+                ],
+            ],
+            // EUR to EUR, with ecotax
+            [
+                [
+                    'price'           => 24,
+                    'tax_rate'        => 20,
+                    'ecotax_amount'   => 0.9,
+                    'currency'        => [
+                        'conversion_rate' => 1.0,
+                        'sign'            => '€',
+                        'code'            => 'EUR',
+                    ],
+                    'specific_prices' => [
+                        0 => [
+                            'id_specific_price'      => '9',
+                            'id_specific_price_rule' => '0',
+                            'id_cart'                => '0',
+                            'id_product'             => '10',
+                            'id_shop'                => '1',
+                            'id_shop_group'          => '0',
+                            'id_currency'            => '0',
+                            'id_country'             => '0',
+                            'id_group'               => '0',
+                            'id_customer'            => '0',
+                            'id_product_attribute'   => '0',
+                            'price'                  => '15.000000',
+                            'from_quantity'          => '15',
+                            'reduction'              => 0,
+                            'reduction_tax'          => '1',
+                            'reduction_type'         => 'amount',
+                            'from'                   => '0000-00-00 00:00:00',
+                            'to'                     => '0000-00-00 00:00:00',
+                            'score'                  => '48',
+                            'quantity'               => '15',
+                            'reduction_with_tax'     => 0,
+                            'nextQuantity'           => -1,
+                        ],
+                    ],
+                    'expected'        => [
+                        [
+                            'discount' => 5.10,
+                            'save'     => 76.50,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/controller/FrontController/ProductControllerTest.php
+++ b/tests/Unit/controller/FrontController/ProductControllerTest.php
@@ -63,7 +63,7 @@ class ProductControllerTest extends IntegrationTestCase
      *
      * @return mixed Method return.
      */
-    public function invokeMethod($object, $methodName, array $parameters = [])
+    public function invokeMethod($object, $methodName, array $parameters = array())
     {
         $reflection = new \ReflectionClass(get_class($object));
         $method     = $reflection->getMethod($methodName);
@@ -121,187 +121,109 @@ class ProductControllerTest extends IntegrationTestCase
 
     public function specificPricesProvider()
     {
-        return [
+
+        $specificPrices = array(
+            0 => array(
+                'id_specific_price'      => '9',
+                'id_specific_price_rule' => '0',
+                'id_cart'                => '0',
+                'id_product'             => '10',
+                'id_shop'                => '1',
+                'id_shop_group'          => '0',
+                'id_currency'            => '0',
+                'id_country'             => '0',
+                'id_group'               => '0',
+                'id_customer'            => '0',
+                'id_product_attribute'   => '0',
+                'price'                  => '15.000000',
+                'from_quantity'          => '15',
+                'reduction'              => 0,
+                'reduction_tax'          => '1',
+                'reduction_type'         => 'amount',
+                'from'                   => '0000-00-00 00:00:00',
+                'to'                     => '0000-00-00 00:00:00',
+                'score'                  => '48',
+                'quantity'               => '15',
+                'reduction_with_tax'     => 0,
+                'nextQuantity'           => -1,
+            ),
+        );
+        $currencyEur = array(
+            'conversion_rate' => 1.0,
+            'sign'            => '€',
+            'code'            => 'EUR',
+        );
+        $currencyDol = array(
+            'conversion_rate' => 1.3,
+            'sign'            => '$',
+            'code'            => 'USD',
+        );
+
+        return array(
             // EUR to USD, without ecotax
-            [
-                [
+            array(
+                array(
                     'price'           => 31.2,
                     'tax_rate'        => 20,
                     'ecotax_amount'   => 0,
-                    'currency'        => [
-                        'conversion_rate' => 1.3,
-                        'sign'            => '$',
-                        'code'            => 'USD',
-                    ],
-                    'specific_prices' => [
-                        0 => [
-                            'id_specific_price'      => '9',
-                            'id_specific_price_rule' => '0',
-                            'id_cart'                => '0',
-                            'id_product'             => '10',
-                            'id_shop'                => '1',
-                            'id_shop_group'          => '0',
-                            'id_currency'            => '0',
-                            'id_country'             => '0',
-                            'id_group'               => '0',
-                            'id_customer'            => '0',
-                            'id_product_attribute'   => '0',
-                            'price'                  => '15.000000',
-                            'from_quantity'          => '15',
-                            'reduction'              => 0,
-                            'reduction_tax'          => '1',
-                            'reduction_type'         => 'amount',
-                            'from'                   => '0000-00-00 00:00:00',
-                            'to'                     => '0000-00-00 00:00:00',
-                            'score'                  => '48',
-                            'quantity'               => '15',
-                            'reduction_with_tax'     => 0,
-                            'nextQuantity'           => -1,
-                        ],
-                    ],
-                    'expected'        => [
-                        [
+                    'currency'        => $currencyDol,
+                    'specific_prices' => $specificPrices,
+                    'expected'        => array(
+                        array(
                             'discount' => 7.80,
                             'save'     => 117.00,
-                        ],
-                    ],
-                ],
-            ],
+                        ),
+                    ),
+                ),
+            ),
             // EUR to EUR, without ecotax
-            [
-                [
+            array(
+                array(
                     'price'           => 24,
                     'tax_rate'        => 20,
                     'ecotax_amount'   => 0,
-                    'currency'        => [
-                        'conversion_rate' => 1.0,
-                        'sign'            => '€',
-                        'code'            => 'EUR',
-                    ],
-                    'specific_prices' => [
-                        0 => [
-                            'id_specific_price'      => '9',
-                            'id_specific_price_rule' => '0',
-                            'id_cart'                => '0',
-                            'id_product'             => '10',
-                            'id_shop'                => '1',
-                            'id_shop_group'          => '0',
-                            'id_currency'            => '0',
-                            'id_country'             => '0',
-                            'id_group'               => '0',
-                            'id_customer'            => '0',
-                            'id_product_attribute'   => '0',
-                            'price'                  => '15.000000',
-                            'from_quantity'          => '15',
-                            'reduction'              => 0,
-                            'reduction_tax'          => '1',
-                            'reduction_type'         => 'amount',
-                            'from'                   => '0000-00-00 00:00:00',
-                            'to'                     => '0000-00-00 00:00:00',
-                            'score'                  => '48',
-                            'quantity'               => '15',
-                            'reduction_with_tax'     => 0,
-                            'nextQuantity'           => -1,
-                        ],
-                    ],
-                    'expected'        => [
-                        [
+                    'currency'        => $currencyEur,
+                    'specific_prices' => $specificPrices,
+                    'expected'        => array(
+                        array(
                             'discount' => 6.00,
                             'save'     => 90.00,
-                        ],
-                    ],
-                ],
-            ],
+                        ),
+                    ),
+                ),
+            ),
             // EUR to USD, with ecotax
-            [
-                [
+            array(
+                array(
                     'price'           => 31.2,
                     'tax_rate'        => 20,
                     'ecotax_amount'   => 0.9,
-                    'currency'        => [
-                        'conversion_rate' => 1.3,
-                        'sign'            => '$',
-                        'code'            => 'USD',
-                    ],
-                    'specific_prices' => [
-                        0 => [
-                            'id_specific_price'      => '9',
-                            'id_specific_price_rule' => '0',
-                            'id_cart'                => '0',
-                            'id_product'             => '10',
-                            'id_shop'                => '1',
-                            'id_shop_group'          => '0',
-                            'id_currency'            => '0',
-                            'id_country'             => '0',
-                            'id_group'               => '0',
-                            'id_customer'            => '0',
-                            'id_product_attribute'   => '0',
-                            'price'                  => '15.000000',
-                            'from_quantity'          => '15',
-                            'reduction'              => 0,
-                            'reduction_tax'          => '1',
-                            'reduction_type'         => 'amount',
-                            'from'                   => '0000-00-00 00:00:00',
-                            'to'                     => '0000-00-00 00:00:00',
-                            'score'                  => '48',
-                            'quantity'               => '15',
-                            'reduction_with_tax'     => 0,
-                            'nextQuantity'           => -1,
-                        ],
-                    ],
-                    'expected'        => [
-                        [
+                    'currency'        => $currencyDol,
+                    'specific_prices' => $specificPrices,
+                    'expected'        => array(
+                        array(
                             'discount' => 6.63,
                             'save'     => 99.45,
-                        ],
-                    ],
-                ],
-            ],
+                        ),
+                    ),
+                ),
+            ),
             // EUR to EUR, with ecotax
-            [
-                [
+            array(
+                array(
                     'price'           => 24,
                     'tax_rate'        => 20,
                     'ecotax_amount'   => 0.9,
-                    'currency'        => [
-                        'conversion_rate' => 1.0,
-                        'sign'            => '€',
-                        'code'            => 'EUR',
-                    ],
-                    'specific_prices' => [
-                        0 => [
-                            'id_specific_price'      => '9',
-                            'id_specific_price_rule' => '0',
-                            'id_cart'                => '0',
-                            'id_product'             => '10',
-                            'id_shop'                => '1',
-                            'id_shop_group'          => '0',
-                            'id_currency'            => '0',
-                            'id_country'             => '0',
-                            'id_group'               => '0',
-                            'id_customer'            => '0',
-                            'id_product_attribute'   => '0',
-                            'price'                  => '15.000000',
-                            'from_quantity'          => '15',
-                            'reduction'              => 0,
-                            'reduction_tax'          => '1',
-                            'reduction_type'         => 'amount',
-                            'from'                   => '0000-00-00 00:00:00',
-                            'to'                     => '0000-00-00 00:00:00',
-                            'score'                  => '48',
-                            'quantity'               => '15',
-                            'reduction_with_tax'     => 0,
-                            'nextQuantity'           => -1,
-                        ],
-                    ],
-                    'expected'        => [
-                        [
+                    'currency'        => $currencyEur,
+                    'specific_prices' => $specificPrices,
+                    'expected'        => array(
+                        array(
                             'discount' => 5.10,
                             'save'     => 76.50,
-                        ],
-                    ],
-                ],
-            ],
-        ];
+                        ),
+                    ),
+                ),
+            ),
+        );
     }
 }

--- a/tests/Unit/controller/FrontController/ProductControllerTest.php
+++ b/tests/Unit/controller/FrontController/ProductControllerTest.php
@@ -77,19 +77,30 @@ class ProductControllerTest extends IntegrationTestCase
      *
      * @dataProvider specificPricesProvider
      *
-     * @param array $data data provided by method specificPricesProvider()
+     * @param $price
+     * @param $taxRate
+     * @param $ecotaxAmount
+     * @param $currencyData
+     * @param $specificPrices
+     * @param $expected
      */
-    public function testFormatQuantityDiscounts(array $data)
-    {
+    public function testFormatQuantityDiscounts(
+        $price,
+        $taxRate,
+        $ecotaxAmount,
+        $currencyData,
+        $specificPrices,
+        $expected
+    ) {
         $class    = new \ReflectionClass(get_class($this->controller));
         $property = $class->getProperty("context");
         $property->setAccessible(true);
 
         $currency                  = new \Currency;
         $currency->active          = true;
-        $currency->conversion_rate = $data['currency']['conversion_rate'];
-        $currency->sign            = $data['currency']['sign'];
-        $currency->iso_code        = $data['currency']['code'];
+        $currency->conversion_rate = $currencyData['conversion_rate'];
+        $currency->sign            = $currencyData['sign'];
+        $currency->iso_code        = $currencyData['code'];
 
         /** @var \Context $context */
         $context            = $property->getValue($this->controller);
@@ -100,17 +111,17 @@ class ProductControllerTest extends IntegrationTestCase
         $result             = $this->invokeMethod(
             $this->controller,
             'formatQuantityDiscounts',
-            [
-                $data['specific_prices'],
-                $data['price'],
-                $data['tax_rate'],
-                $data['ecotax_amount'],
-            ]
+            array(
+                $specificPrices,
+                $price,
+                $taxRate,
+                $ecotaxAmount,
+            )
         );
 
         $priceFormatter = new PriceFormatter();
 
-        foreach ($data['expected'] as $expectedLevel => $expectedValues) {
+        foreach ($expected as $expectedLevel => $expectedValues) {
             $this->assertArrayHasKey($expectedLevel, $result);
             foreach ($expectedValues as $expectedKey => $expectedValue) {
                 $this->assertArrayHasKey($expectedKey, $result[$expectedLevel]);
@@ -148,79 +159,67 @@ class ProductControllerTest extends IntegrationTestCase
                 'nextQuantity'           => -1,
             ),
         );
-        $currencyEur = array(
+        $currencyEur    = array(
             'conversion_rate' => 1.0,
             'sign'            => '€',
             'code'            => 'EUR',
         );
-        $currencyDol = array(
+        $currencyDol    = array(
             'conversion_rate' => 1.3,
             'sign'            => '$',
             'code'            => 'USD',
         );
 
         return array(
-            // EUR to USD, without ecotax
-            array(
-                array(
-                    'price'           => 31.2,
-                    'tax_rate'        => 20,
-                    'ecotax_amount'   => 0,
-                    'currency'        => $currencyDol,
-                    'specific_prices' => $specificPrices,
-                    'expected'        => array(
-                        array(
-                            'discount' => 7.80,
-                            'save'     => 117.00,
-                        ),
+            'EUR to USD, without ecotax' => array(
+                'price'           => 31.2,
+                'tax_rate'        => 20,
+                'ecotax_amount'   => 0,
+                'currency'        => $currencyDol,
+                'specific_prices' => $specificPrices,
+                'expected'        => array(
+                    array(
+                        'discount' => 7.80,
+                        'save'     => 117.00,
                     ),
                 ),
             ),
-            // EUR to EUR, without ecotax
-            array(
-                array(
-                    'price'           => 24,
-                    'tax_rate'        => 20,
-                    'ecotax_amount'   => 0,
-                    'currency'        => $currencyEur,
-                    'specific_prices' => $specificPrices,
-                    'expected'        => array(
-                        array(
-                            'discount' => 6.00,
-                            'save'     => 90.00,
-                        ),
+            'EUR to EUR, without ecotax' => array(
+                'price'           => 24,
+                'tax_rate'        => 20,
+                'ecotax_amount'   => 0,
+                'currency'        => $currencyEur,
+                'specific_prices' => $specificPrices,
+                'expected'        => array(
+                    array(
+                        'discount' => 6.00,
+                        'save'     => 90.00,
                     ),
                 ),
             ),
-            // EUR to USD, with ecotax
-            array(
-                array(
-                    'price'           => 31.2,
-                    'tax_rate'        => 20,
-                    'ecotax_amount'   => 0.9,
-                    'currency'        => $currencyDol,
-                    'specific_prices' => $specificPrices,
-                    'expected'        => array(
-                        array(
-                            'discount' => 6.63,
-                            'save'     => 99.45,
-                        ),
+            'EUR to USD, with ecotax'    => array(
+                'price'           => 31.2,
+                'tax_rate'        => 20,
+                'ecotax_amount'   => 0.9,
+                'currency'        => $currencyDol,
+                'specific_prices' => $specificPrices,
+                'expected'        => array(
+                    array(
+                        'discount' => 6.63,
+                        'save'     => 99.45,
                     ),
                 ),
             ),
-            // EUR to EUR, with ecotax
-            array(
-                array(
-                    'price'           => 24,
-                    'tax_rate'        => 20,
-                    'ecotax_amount'   => 0.9,
-                    'currency'        => $currencyEur,
-                    'specific_prices' => $specificPrices,
-                    'expected'        => array(
-                        array(
-                            'discount' => 5.10,
-                            'save'     => 76.50,
-                        ),
+            'EUR to EUR, with ecotax'    => array(
+                'price'           => 24,
+                'tax_rate'        => 20,
+                'ecotax_amount'   => 0.9,
+                'currency'        => $currencyEur,
+                'specific_prices' => $specificPrices,
+                'expected'        => array(
+                    array(
+                        'discount' => 5.10,
+                        'save'     => 76.50,
                     ),
                 ),
             ),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | Fixes on FO product page : fix the displayed discount whith specific prices on another currency than default one, fix the displayed ecotax on another currency than default one
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3275 http://forge.prestashop.com/browse/BOOM-3739
| How to test?  | *Discount calculation* Add another currency than default one, with an exchange rate different from 1. In BO, on a product, set specific discount price (fixed one) with minimal quantity. Return on FO product page, switch currency from default one to the second one. Discount values are expected to be correctly converted. *Ecotax exchange* Now activate ecotax and set a not-null value on the product. Check on FO product page that the ecotax is correctly converted when changing currency.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
