### PR TITLE
Fix pagination in attributes-values page

### DIFF
--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -807,6 +807,12 @@ class AdminAttributesGroupsControllerCore extends AdminController
                 {
                     AttributeGroup::cleanPositions();
                 }
+                $id_attribute_group = Tools::getValue('id_attribute_group');
+                if (Tools::getValue('page') && $id_attribute_group && (int)Tools::getValue('submitFilter' . $this->list_id)) {
+                    $this->setRedirectAfter(self::$currentIndex . '&token=' . $this->token
+                        . ((Tools::isSubmit('submitFilter' . $this->list_id)) ? '&submitFilter' . $this->list_id . '=' . (int)Tools::getValue('submitFilter' . $this->list_id) : '')
+                        . '&id_attribute_group=' . (int)$id_attribute_group . '&viewattribute_group');
+                }
             }
         }
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Add redirect if submitFilter (used when there's pagination or search) has a value.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7871
| How to test?  | BO->Catalog->Product Attributes, create an attribute with more than 20 values. Then,  click on button "view" of the "created_attribute", and test the pagination.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8286)
<!-- Reviewable:end -->
