### PR TITLE
Fix displaying empty zip code of tax rule

### DIFF
--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -408,6 +408,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
     protected function processCreateRule()
     {
         $zip_code = Tools::getValue('zipcode');
+        $zip_code = ("" === $zip_code) ? 0 : $zip_code;
         $id_rule = (int)Tools::getValue('id_tax_rule');
         $id_tax = (int)Tools::getValue('id_tax');
         $id_tax_rules_group = (int)Tools::getValue('id_tax_rules_group');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | After deleting zip code for a tax rule, 0 is displayed istead of --
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-256
| How to test?  | Go to International -> Tax -> Tax rule -> edit a rule -> edit country and leave the zip code empty. 