### PR TITLE
Change version phpExcel for PHP7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ircmaxell/password-compat": "1.0.4",
         "ircmaxell/random-lib": "*",
         "shudrum/array-finder": "1.1.0",
-        "phpoffice/phpexcel": "1.8",
+        "phpoffice/phpexcel": "~1.8",
         "guzzlehttp/guzzle": "~5.0",
         "csa/guzzle-bundle": "~1.3",
         "paragonie/random_compat": "^1.4|^2.0",


### PR DESCRIPTION
Change version phpExcel for compatibility with PHP 7.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the old version PhpExcel of the library, an error occurs on the php 7. Fatal error: 'break' not in the 'loop' or 'switch' context in /vendor/phpoffice/phpexcel/Classes/PHPExcel/Calculation/Functions.php on line 581
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | To use PhpExcel lib

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
