### PR TITLE
BO: Fix menu overflow

### DIFF
--- a/admin-dev/themes/default/sass/partials/_nav.sass
+++ b/admin-dev/themes/default/sass/partials/_nav.sass
@@ -4,6 +4,7 @@ $menu-item-size: 34px
 $min-height: 950px
 
 #nav-sidebar
+  overflow: auto;
 	position: fixed
 	width: $widthSidebarNav
 	height: 100%


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | If merchant use smaller screen resolution and if he has more tabs in sidebar, these tabs are not visible because there is no enough space and it is not possible to scroll the navbar
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | 
| How to test?  | Add a few tabs to the back office sidebar menu, and decrease browser resolution, If there are more tabs than available height, now scrollbar will be shown.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
