### PR TITLE
Add a new quick access

### DIFF
--- a/classes/lang/QuickAccessLang.php
+++ b/classes/lang/QuickAccessLang.php
@@ -44,6 +44,7 @@ class QuickAccessLangCore extends DataLangCore
                 md5('New voucher') => $this->translator->trans('New voucher', array(), 'Admin.Navigation.Header', $this->locale),
                 md5('Orders') => $this->translator->trans('Orders', array(), 'Admin.Navigation.Header', $this->locale),
                 md5('Installed modules') => $this->translator->trans('Installed modules', array(), 'Admin.Navigation.Header', $this->locale),
+                md5('Catalog evaluation') => $this->translator->trans('Catalog evaluation', array(), 'Admin.Navigation.Header', $this->locale),
             ),
         );
     }

--- a/install-dev/data/xml/quick_access.xml
+++ b/install-dev/data/xml/quick_access.xml
@@ -20,5 +20,8 @@
     <quick_access id="Installed_modules" new_window="0">
       <link>index.php/module/manage</link>
     </quick_access>
+    <quick_access id="Catalog_evaluation" new_window="0">
+      <link>index.php?controller=AdminStats&amp;module=statscheckup</link>
+    </quick_access>
   </entities>
 </entity_quick_access>

--- a/install-dev/langs/en/data/quick_access.xml
+++ b/install-dev/langs/en/data/quick_access.xml
@@ -7,4 +7,5 @@
   <quick_access id="New_voucher" name="New voucher"/>
   <quick_access id="Orders" name="Orders"/>
   <quick_access id="Installed_modules" name="Installed modules"/>
+  <quick_access id="Catalog_evaluation" name="Catalog evaluation"/>
 </entity_quick_access>

--- a/install-dev/upgrade/php/ps_1730_add_quick_access_evaluation_catalog.php
+++ b/install-dev/upgrade/php/ps_1730_add_quick_access_evaluation_catalog.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+function ps_1730_add_quick_access_evaluation_catalog()
+{
+    $translator = Context::getContext()->getTranslator();
+
+    Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'quick_access` SET link = "index.php?controller=AdminStats&module=statscheckup" ');
+
+    $idQuickAccess = (int) Db::getInstance()->Insert_ID();
+
+    foreach (Language::getLanguages() as $language) {
+        Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'quick_access_lang` SET 
+            `id_quick_access` = '.$idQuickAccess.',
+            `id_lang` = '.(int) $language['id_lang'].',
+            `name` = "'.pSQL($translator->trans('Catalog evaluation', array(), 'Admin.Navigation.Header')).'" ');
+    }
+}

--- a/install-dev/upgrade/php/ps_1730_add_quick_access_evaluation_catalog.php
+++ b/install-dev/upgrade/php/ps_1730_add_quick_access_evaluation_catalog.php
@@ -26,16 +26,23 @@
 
 function ps_1730_add_quick_access_evaluation_catalog()
 {
-    $translator = Context::getContext()->getTranslator();
+    $moduleManagerBuilder = \PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder::getInstance();
+    $moduleManager = $moduleManagerBuilder->build();
 
-    Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'quick_access` SET link = "index.php?controller=AdminStats&module=statscheckup" ');
+    $isStatscheckupInstalled = $moduleManager->isInstalled('statscheckup');
 
-    $idQuickAccess = (int) Db::getInstance()->Insert_ID();
+    if ($isStatscheckupInstalled) {
+        $translator = Context::getContext()->getTranslator();
 
-    foreach (Language::getLanguages() as $language) {
-        Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'quick_access_lang` SET 
-            `id_quick_access` = '.$idQuickAccess.',
-            `id_lang` = '.(int) $language['id_lang'].',
-            `name` = "'.pSQL($translator->trans('Catalog evaluation', array(), 'Admin.Navigation.Header')).'" ');
+        Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'quick_access` SET link = "index.php?controller=AdminStats&module=statscheckup" ');
+
+        $idQuickAccess = (int)Db::getInstance()->Insert_ID();
+
+        foreach (Language::getLanguages() as $language) {
+            Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'quick_access_lang` SET 
+                `id_quick_access` = ' . $idQuickAccess . ',
+                `id_lang` = ' . (int)$language['id_lang'] . ',
+                `name` = "' . pSQL($translator->trans('Catalog evaluation', array(), 'Admin.Navigation.Header')) . '" ');
+        }
     }
 }

--- a/install-dev/upgrade/sql/1.7.3.0.sql
+++ b/install-dev/upgrade/sql/1.7.3.0.sql
@@ -4,4 +4,6 @@ SET NAMES 'utf8';
 UPDATE `PREFIX_tab` SET `position` = 0 WHERE `class_name` = 'AdminZones' AND `position` = '1';
 UPDATE `PREFIX_tab` SET `position` = 1 WHERE `class_name` = 'AdminCountries' AND `position` = '0';
 
+/* PHP:ps_1730_add_quick_access_evaluation_catalog(); */;
+
 /* PHP:ps_1730_move_some_aeuc_configuration_to_core(); */;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As the catalog evaluation has been hugely improved, it adds a new quickaccess link to easier push this feature
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3783
| How to test?  | Install and see if the Catalog Evaluation is in the new quick access

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
