### PR TITLE
Fix bug js and css cache file name don't change

### DIFF
--- a/classes/assets/CccReducer.php
+++ b/classes/assets/CccReducer.php
@@ -55,8 +55,9 @@ class CccReducerCore
                 unset($cssFileList['external'][$key]);
             }
         }
-
-        $cccFilename = 'theme-'.$this->getFileNameIdentifierFromList($files).'.css';
+        
+        $version = Configuration::get('PS_CCCCSS_VERSION');
+        $cccFilename = 'theme-'.$this->getFileNameIdentifierFromList($files).$version.'.css';
         $destinationPath = $this->cacheDir.$cccFilename;
 
         if (!$this->filesystem->exists($destinationPath)) {
@@ -91,8 +92,9 @@ class CccReducerCore
                 // No file to CCC
                 continue;
             }
-
-            $cccFilename = $position.'-'.$this->getFileNameIdentifierFromList($files).'.js';
+            
+            $version = Configuration::get('PS_CCCJS_VERSION');
+            $cccFilename = $position.'-'.$this->getFileNameIdentifierFromList($files).$version.'.js';
             $destinationPath = $this->cacheDir.$cccFilename;
 
             if (!$this->filesystem->exists($destinationPath)) {


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | - CCC js/css must be enable <br>- clear cache in BO and bottom-***.js name for ex. don't change => browsers keep always the same file in cache and if you change custom.js for example, changes are not apply due to browser cache
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | - CCC js/css must be enable<br> - go to front and see js filename for ex. (bottom-***.js) <br> - got to admin perf, delete cache <br> - go to front : same file name




