### PR TITLE
Fix updateAttribute method in multishops context

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1578,16 +1578,18 @@ class ProductCore extends ObjectModel
         $combination = new Combination($id_product_attribute);
 
         if (!$update_all_fields) {
-            $combination->setFieldsToUpdate(array(
-                'price' => !is_null($price),
-                'wholesale_price' => !is_null($wholesale_price),
-                'ecotax' => !is_null($ecotax),
-                'weight' => !is_null($weight),
-                'unit_price_impact' => !is_null($unit),
-                'default_on' => !is_null($default),
-                'minimal_quantity' => !is_null($minimal_quantity),
-                'available_date' => !is_null($available_date),
-            ));
+            $fieldsToUpdate = array(
+                'price' => $price,
+                'wholesale_price' => $wholesale_price,
+                'ecotax' => $ecotax,
+                'weight' => $weight,
+                'unit_price_impact' => $unit,
+                'default_on' => $default,
+                'minimal_quantity' => $minimal_quantity,
+                'available_date' => $available_date,
+            );
+            $fieldsToUpdate = array_diff_assoc($fieldsToUpdate, array_filter($fieldsToUpdate, 'is_null'));
+            $combination->setFieldsToUpdate($fieldsToUpdate);
         }
 
         $price = str_replace(',', '.', $price);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1,13 +1,13 @@
 <?php
 /*
-* 2007-2017 PrestaShop
+* 2007-2018 PrestaShop
 *
 * NOTICE OF LICENSE
 *
 * This source file is subject to the Open Software License (OSL 3.0)
 * that is bundled with this package in the file LICENSE.txt.
 * It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/osl-3.0.php
+* https://opensource.org/licenses/osl-3.0.php
 * If you did not receive a copy of the license and are unable to
 * obtain it through the world-wide-web, please send an email
 * to license@prestashop.com so we can send you a copy immediately.
@@ -19,8 +19,8 @@
 * needs please refer to http://www.prestashop.com for more information.
 *
 *  @author PrestaShop SA <contact@prestashop.com>
-*  @copyright  2007-2017 PrestaShop SA
-*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  @copyright  2007-2018 PrestaShop SA
+*  @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 */
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | I change the update method in a way that, if we change/edit an attribute, so we save it, else we don't (in order to keep its old value).
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7776
| How to test?  | 1) In a multishop BO, select "All shops" as context, and open any product. </br>2) Add a combination, activate the checkbox for price impact for all shops and enter a price. </br>3) Save and stay. </br>4) Edit the combination you just added and (for example) add an another attribute. Do not activate price impact change for all shops. </br>5) Save and stay. </br>=> The current price that we put in step 2 is keeped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8313)
<!-- Reviewable:end -->
