### PR TITLE
Prevent an added product to an order from showing in the FO cart as new order

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3313,6 +3313,7 @@ class CartCore extends ObjectModel
 				FROM '._DB_PREFIX_.'cart c
 				WHERE NOT EXISTS (SELECT 1 FROM '._DB_PREFIX_.'orders o WHERE o.`id_cart` = c.`id_cart`
 									AND o.`id_customer` = '.(int)$id_customer.')
+				AND c.`id_guest` <> 0
 				AND c.`id_customer` = '.(int)$id_customer.'
 					'.Shop::addSqlRestriction(Shop::SHARE_ORDER, 'c').'
 				ORDER BY c.`date_upd` DESC';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | add a condition id_guest not equal 0 to the WHERE clause, to differenciate who add the product to the order/cart, if it's an admin then the id_guest=0 so we don't display the added product.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8554 Fixes #15521
| How to test?  | 1- Add a new product to an existing order from admin (BO). </br>2- Sign in in the FO and open cart. </br>3- The added product appears in your cart as a new order which makes confusion to the customer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8315)
<!-- Reviewable:end -->
