### PR TITLE
BO: Fix method overrride with different number of parameters

### DIFF
--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -40,7 +40,7 @@ class AdminDashboardControllerCore extends AdminController
         }
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme=false)
     {
         parent::setMedia();
 


### PR DESCRIPTION
Affect PHP 7.2 (crash), don't crash in 7.1but violates LSP and should be fixed.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | "develop" 
| Description?  | Invalid parameter of overrided method (should have the same number of paramters).
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Just run the admin dashboard, affect nothing as the $isNewTheme is not used in the overrided method.
