### PR TITLE
BO: Removing RTL.js it breaks image uploads

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2269,7 +2269,6 @@ class AdminControllerCore extends Controller
         //rtl.js overrides inline styles
         //iso_code.css overrides default fonts for every language (optional)
         if ($this->context->language->is_rtl) {
-            $this->addJS(_PS_JS_DIR_.'rtl.js');
             $this->addCSS(__PS_BASE_URI__.$this->admin_webpath.'/themes/'.$this->bo_theme.'/css/'.$this->context->language->iso_code.'.css', 'all', false);
         }
 


### PR DESCRIPTION
rtl.js breaks image uploads among other things and makes the backend not usable in hebrew.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7
| Description?  | Removing rtl.js, it breaks image uploads and other things
| Type?         | bug fix
| Category?     | BO
| How to test?  | Switch the admin language to hebrew and see that you can upload images now

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8325)
<!-- Reviewable:end -->
