### PR TITLE
Added a new collector for Hooks

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -25,6 +25,7 @@
  */
 
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 class HookCore extends ObjectModel
 {
@@ -705,6 +706,14 @@ class HookCore extends ObjectModel
             return;
         }
 
+        $hookRegistry = self::getHookRegistry();
+        $isRegistry = !is_null($hookRegistry);
+
+        if ($isRegistry) {
+            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+            $hookRegistry->selectHook($hook_name, $hook_args, $backtrace[0]['file'], $backtrace[0]['line']);
+        }
+
         // $chain & $array_return are incompatible so if chained is set to true, we disable the array_return option
         if (true === $chain) {
             $array_return = false;
@@ -723,6 +732,9 @@ class HookCore extends ObjectModel
         // If no modules associated to hook_name or recompatible hook name, we stop the function
 
         if (!$module_list = Hook::getHookModuleExecList($hook_name)) {
+            if ($isRegistry) {
+                $hookRegistry->collect();
+            }
             if ($array_return) {
                 return array();
             } else {
@@ -732,6 +744,9 @@ class HookCore extends ObjectModel
 
         // Check if hook exists
         if (!$id_hook = Hook::getIdByName($hook_name)) {
+            if ($isRegistry) {
+                $hookRegistry->collect();
+            }
             if ($array_return) {
                 return array();
             } else {
@@ -827,6 +842,10 @@ class HookCore extends ObjectModel
                 continue;
             }
 
+            if ($isRegistry) {
+                $hookRegistry->hookedByModule($moduleInstance);
+            }
+
             if (Hook::isHookCallableOn($moduleInstance, $hook_name)) {
                 $hook_args['altern'] = ++$altern;
 
@@ -849,6 +868,9 @@ class HookCore extends ObjectModel
                         $output .= $display;
                     }
                 }
+                if ($isRegistry) {
+                    $hookRegistry->hookedByCallback($moduleInstance, $hook_args);
+                }
             } elseif (Hook::isDisplayHookName($hook_name)) {
                 if ($moduleInstance instanceof WidgetInterface) {
 
@@ -868,6 +890,10 @@ class HookCore extends ObjectModel
                         }
                     }
                 }
+
+                if ($isRegistry) {
+                    $hookRegistry->hookedByWidget($moduleInstance, $hook_args);
+                }
             }
         }
 
@@ -885,6 +911,11 @@ class HookCore extends ObjectModel
             }
         }
 
+        if ($isRegistry) {
+            $hookRegistry->hookWasCalled();
+            $hookRegistry->collect();
+        }
+
         return $output;
     }
 
@@ -896,5 +927,18 @@ class HookCore extends ObjectModel
     public static function coreRenderWidget($module, $hook_name, $params)
     {
         return $module->renderWidget($hook_name, $params);
+    }
+
+    /**
+     * @return null|\PrestaShopBundle\DataCollector\HookRegistry
+     */
+    private static function getHookRegistry()
+    {
+        $sfContainer = SymfonyContainer::getInstance();
+        if (!is_null($sfContainer) && "dev" === $sfContainer->getParameter('kernel.environment')) {
+            return $sfContainer->get('prestashop.hooks_registry');
+        }
+
+        return null;
     }
 }

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -707,9 +707,9 @@ class HookCore extends ObjectModel
         }
 
         $hookRegistry = self::getHookRegistry();
-        $isRegistry = !is_null($hookRegistry);
+        $isRegistryEnabled = !is_null($hookRegistry);
 
-        if ($isRegistry) {
+        if ($isRegistryEnabled) {
             $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
             $hookRegistry->selectHook($hook_name, $hook_args, $backtrace[0]['file'], $backtrace[0]['line']);
         }
@@ -732,7 +732,7 @@ class HookCore extends ObjectModel
         // If no modules associated to hook_name or recompatible hook name, we stop the function
 
         if (!$module_list = Hook::getHookModuleExecList($hook_name)) {
-            if ($isRegistry) {
+            if ($isRegistryEnabled) {
                 $hookRegistry->collect();
             }
             if ($array_return) {
@@ -744,7 +744,7 @@ class HookCore extends ObjectModel
 
         // Check if hook exists
         if (!$id_hook = Hook::getIdByName($hook_name)) {
-            if ($isRegistry) {
+            if ($isRegistryEnabled) {
                 $hookRegistry->collect();
             }
             if ($array_return) {
@@ -842,7 +842,7 @@ class HookCore extends ObjectModel
                 continue;
             }
 
-            if ($isRegistry) {
+            if ($isRegistryEnabled) {
                 $hookRegistry->hookedByModule($moduleInstance);
             }
 
@@ -868,7 +868,7 @@ class HookCore extends ObjectModel
                         $output .= $display;
                     }
                 }
-                if ($isRegistry) {
+                if ($isRegistryEnabled) {
                     $hookRegistry->hookedByCallback($moduleInstance, $hook_args);
                 }
             } elseif (Hook::isDisplayHookName($hook_name)) {
@@ -891,7 +891,7 @@ class HookCore extends ObjectModel
                     }
                 }
 
-                if ($isRegistry) {
+                if ($isRegistryEnabled) {
                     $hookRegistry->hookedByWidget($moduleInstance, $hook_args);
                 }
             }
@@ -911,7 +911,7 @@ class HookCore extends ObjectModel
             }
         }
 
-        if ($isRegistry) {
+        if ($isRegistryEnabled) {
             $hookRegistry->hookWasCalled();
             $hookRegistry->collect();
         }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -28,8 +28,9 @@ use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
+use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
 
-abstract class ModuleCore
+abstract class ModuleCore implements ModuleInterface
 {
     /** @var int Module ID */
     public $id = null;

--- a/src/Core/Module/ModuleInterface.php
+++ b/src/Core/Module/ModuleInterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Module;
+
+/**
+ * Define what should be a module.
+ * Note:We don't typeHint on old Module class to not create hard dependency with Legacy.
+ */
+interface ModuleInterface
+{
+}

--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\DataCollector;
+
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Collect all information about Legacy hooks and make it available
+ * in the Symfony Web profiler.
+ */
+final class HookDataCollector extends DataCollector
+{
+    /**
+     * @var HookRegistry
+     */
+    private $registry;
+
+    public function __construct(HookRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * @{inheritdoc}
+     */
+    public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+        $hooks = $this->registry->getHooks();
+        $calledHooks = $this->registry->getCalledHooks();
+        $notCalledHooks = $this->registry->getNotCalledHooks();
+        $this->data = array(
+            'hooks' => $this->stringifyHookArguments($hooks),
+            'calledHooks' => $this->stringifyHookArguments($calledHooks),
+            'notCalledHooks' => $this->stringifyHookArguments($notCalledHooks),
+        );
+    }
+
+    /**
+     * Return the list of every dispatched legacy hooks during one request.
+     * @return array
+     */
+    public function getHooks()
+    {
+        return $this->data['hooks'];
+    }
+
+    /**
+     * Return the list of every called legacy hooks during one request.
+     * @return array
+     */
+    public function getCalledHooks()
+    {
+        return $this->data['calledHooks'];
+    }
+
+    /**
+     * Return the list of every uncalled legacy hooks during oHookne request.
+     * @return array
+     */
+    public function getNotCalledHooks()
+    {
+        return $this->data['notCalledHooks'];
+    }
+
+    /**
+     * @{inheritdoc}
+     */
+    public function getName()
+    {
+        return 'ps.hooks_collector';
+    }
+
+    /**
+     * @param array $hooksList
+     * @return array a better representation of arguments for HTML rendering.
+     */
+    private function stringifyHookArguments(array &$hooksList)
+    {
+        foreach ($hooksList as &$hookList) {
+            foreach ($hookList as &$hook) {
+                $hook['args'] = $this->varToString($hook['args']);
+                foreach ($hook['modules'] as &$modulesByType) {
+                    foreach ($modulesByType as &$module) {
+                        if (array_key_exists('args', $module)) {
+                            $module['args'] = $this->varToString($module['args']);
+                        }
+                    }
+                }
+            }
+        }
+
+        return $hooksList;
+    }
+}

--- a/src/PrestaShopBundle/DataCollector/HookRegistry.php
+++ b/src/PrestaShopBundle/DataCollector/HookRegistry.php
@@ -157,12 +157,6 @@ final class HookRegistry
             'modules' => $this->currentHook['modules'],
         );
 
-        if (array_key_exists($name, $this->hooks[$status])) {
-            $this->hooks[$status][$name][] = $hook;
-
-            return;
-        }
-
         $this->hooks[$status][$name][] = $hook;
     }
 }

--- a/src/PrestaShopBundle/DataCollector/HookRegistry.php
+++ b/src/PrestaShopBundle/DataCollector/HookRegistry.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\DataCollector;
+
+use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
+
+/**
+ * Collect all hooks information dispatched during a request.
+ */
+final class HookRegistry
+{
+    const HOOK_NOT_CALLED = 'notCalled';
+    const HOOK_CALLED = 'called';
+
+    /**
+     * @var array the current selected hook during the request.
+     */
+    private $currentHook = null;
+
+    /**
+     * @var array the list of hooks data.
+     */
+    private $hooks;
+
+    public function __construct()
+    {
+        $this->hooks = array(
+            self::HOOK_CALLED => array(),
+            self::HOOK_NOT_CALLED => array(),
+        );
+    }
+
+    /**
+     * @param $hookName string
+     * @param $hookArguments array
+     * @param $file string filepath where the "Hook::exec" call have been done.
+     * @param $line string position in file where the "Hook::exec" call have been done.
+     */
+    public function selectHook($hookName, $hookArguments, $file, $line)
+    {
+        $this->currentHook = array(
+            'name' => $hookName,
+            'args' => $hookArguments,
+            'location' => "$file:$line",
+            'status' => self::HOOK_NOT_CALLED,
+            'modules' => array(),
+        );
+    }
+
+    /**
+     * Notify the registry that the selected hook have been called.
+     */
+    public function hookWasCalled()
+    {
+        $this->currentHook['status'] = self::HOOK_CALLED;
+    }
+
+    /**
+     * @param ModuleInterface $module
+     */
+    public function hookedByModule(ModuleInterface $module)
+    {
+        $this->currentHook['modules'][$module->name] = array(
+            'callback' => array(),
+            'widget' => array(),
+        );
+    }
+
+    /**
+     * A callback have been executed by the module during the Hook dispatch.
+     *
+     * @param ModuleInterface $module
+     * @param $args array All arguments passed to the Module callback.
+     */
+    public function hookedByCallback(ModuleInterface $module, $args)
+    {
+        $this->currentHook['modules'][$module->name]['callback'] = array(
+            'args' => $args,
+        );
+    }
+
+    /**
+     * A widget have been rendered by the module during the Hook dispatch.
+     *
+     * @param ModuleInterface $module
+     * @param $args array All arguments passed to the Module callback.
+     */
+    public function hookedByWidget(ModuleInterface $module, $args)
+    {
+        $this->currentHook['modules'][$module->name]['widget'] = array(
+            'args' => $args,
+        );
+    }
+
+    /**
+     * @return array the list of called hooks.
+     */
+    public function getCalledHooks()
+    {
+        return $this->hooks['called'];
+    }
+
+    /**
+     * @return array the list of uncalled hooks.
+     */
+    public function getNotCalledHooks()
+    {
+        return $this->hooks['notCalled'];
+    }
+
+    /**
+     * @return array the list of dispatched hooks.
+     */
+    public function getHooks()
+    {
+        return $this->hooks['called'] + $this->hooks['notCalled'];
+    }
+
+    /**
+     * Persist the selected hook into the list.
+     *
+     * Theses hooks will be used by the HookDataCollector
+     */
+    public function collect()
+    {
+        $name = $this->currentHook['name'];
+        $status = $this->currentHook['status'];
+
+        $hook = array(
+            'args' => $this->currentHook['args'],
+            'name' => $name,
+            'location' => $this->currentHook['location'],
+            'modules' => $this->currentHook['modules'],
+        );
+
+        if (array_key_exists($name, $this->hooks[$status])) {
+            $this->hooks[$status][$name][] = $hook;
+
+            return;
+        }
+
+        $this->hooks[$status][$name][] = $hook;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -478,7 +478,7 @@ services:
         tags:
             - { name: twig.extension }
 
-# Addons API Client
+    # Addons API Client
     prestashop.addons.client_api:
         class: PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient
         arguments:
@@ -487,3 +487,14 @@ services:
             - "@prestashop.adapter.tools"
         calls:
             - [ "setSslVerification", ["%prestashop.addons.api_client.verify_ssl%"]]
+
+    # Data Collectors
+    prestashop.hooks_registry:
+        class: 'PrestaShopBundle\DataCollector\HookRegistry'
+
+    prestashop.hooks_collector:
+        class: 'PrestaShopBundle\DataCollector\HookDataCollector'
+        arguments: ['@prestashop.hooks_registry']
+        public: false
+        tags:
+          - {name: data_collector, template: '@PrestaShop/Admin/WebProfiler/hooks_collector.html.twig', id: 'ps.hooks_collector'}

--- a/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/hooks_collector.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/hooks_collector.html.twig
@@ -1,0 +1,141 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% import _self as helper %}
+
+{% block toolbar %}
+    {% set icon %}
+        {{ include('@WebProfiler/Icon/event.svg') }}
+        <span class="sf-toolbar-value">Hooks ({{ collector.calledHooks|length }})</span>
+    {% endset %}
+
+    {% set text %}
+        <div class="sf-toolbar-info-piece">
+            <div class="sf-toolbar-info-piece">
+                <b class="sf-toolbar-ajax-info">{{ collector.calledHooks|length }} Hooks called</b>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <table class="sf-toolbar-ajax-requests">
+                    <thead>
+                    <tr>
+                        <th>Hook name</th>
+                        <th>Call(s)</th>
+                    </tr>
+                    </thead>
+                    <tbody class="sf-toolbar-ajax-request-list">
+                        {% for hookName, hooks in collector.calledHooks %}
+                            <tr><td>{{ hookName }}</td><td>{{ hooks|length }}</td></tr>
+                        {% else %}
+                            <tr><td colspan="2">No hook dispatched.</td></tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {% endset %}
+
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true }) }}
+
+{% endblock %}
+
+{% block menu %}
+    {# This left-hand menu appears when using the full-screen profiler. #}
+    <span class="label">
+        <span class="icon">{{ include('@WebProfiler/Icon/event.svg') }}</span>
+        <strong>Hooks</strong>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h2>Hooks</h2>
+
+    {% if collector.notCalledHooks is empty %}
+        <div class="empty">
+            <p>No Hooks have been recorded. Check that debugging is enabled in the kernel.</p>
+        </div>
+    {% else %}
+        <div class="sf-tabs">
+            <div class="tab">
+                <h3 class="tab-title">Called Hooks <span class="badge">{{ collector.calledHooks|length }}</span></h3>
+
+                <div class="tab-content">
+                    {{ helper.render_table(collector.calledHooks, true) }}
+                </div>
+            </div>
+
+            <div class="tab">
+                <h3 class="tab-title">Not Called Hooks <span class="badge">{{ collector.notCalledHooks|length }}</span></h3>
+                <div class="tab-content">
+                    {% if collector.notCalledHooks is empty %}
+                        <div class="empty">
+                            <p>
+                                <strong>There are no uncalled hooks</strong>.
+                            </p>
+                            <p>
+                                All hooks were called for this request or an error occurred
+                                when trying to collect uncalled listeners (in which case check the
+                                logs to get more information).
+                            </p>
+                        </div>
+                    {% else %}
+                        {{ helper.render_table(collector.notCalledHooks, false) }}
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% macro render_table(hookList, hookModules) %}
+    {% for hookName, hooks in hookList %}
+        <h3>{{ hookName }}</h3>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>Arguments</th>
+                    <th>Location</th>
+                    {% if hookModules %}
+                        <th>Hooked modules</th>
+                    {% endif %}
+                </tr>
+            </thead>
+            <tbody>
+            {% for position, hook in hooks %}
+            <tr>
+                <td>
+                    {{ hook.args }}
+                </td>
+                <td>
+                    <span class="text-muted">{{ hook.location }}</span>
+                </td>
+                {% if hookModules %}
+                    <td>
+                        {% set modules = hook.modules %}
+                        {% for moduleName, module in modules %}
+                            <h4><b>{{ moduleName|capitalize }}</b></h4>
+                            <table>
+                                <thead>
+                                <tr>
+                                    <th>Module arguments</th>
+                                </tr>
+                                </thead>
+
+                                {% if module.callback is defined %}
+                                <tr>
+                                    <td>{{ module.callback.args }}</td>
+                                </tr>
+                                {% else %}
+                                <tr>
+                                    <td>{{ module.widget.args }}</td>
+                                </tr>
+                                {% endif %}
+                            </table>
+                        {% endfor %}
+                    </td>
+                {% endif %}
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    {% endfor %}
+{% endmacro %}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We now have information about all dispatched hooks in web debug toolbar on Symfony pages.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | partially, I need it to make a good migration and ensure I dont remove (too much?) hooks!
| How to test?  | Access a Symfony page

> I've finally removed the dumped values: for a lot of parameters and objects the time to render the profiler become too long, I think it's up to the developer to dump data in their modules, now they have the right information on modules and hooks dispatched.

<details>
<summary>Some captures</summary>

![hook](https://user-images.githubusercontent.com/1247388/30385244-e16d2c7a-98a6-11e7-9066-348193675bc8.png)


![hook](https://user-images.githubusercontent.com/1247388/30385220-cf23bbce-98a6-11e7-9997-dfefba8fdf80.png)

![hooks_and_modules](https://user-images.githubusercontent.com/1247388/30405577-ea808a78-98ec-11e7-88fa-ec3df496a9b8.png)
</details>