### PR TITLE
Add DB prefix in delete() method all time $add_prefix is set to true

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -571,7 +571,7 @@ abstract class DbCore
      */
     public function delete($table, $where = '', $limit = 0, $use_cache = true, $add_prefix = true)
     {
-        if (_DB_PREFIX_ && !preg_match('#^'._DB_PREFIX_.'#i', $table) && $add_prefix) {
+        if ($add_prefix) {
             $table = _DB_PREFIX_.$table;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | While you set up your shop with the DB prefix as "pr", you will have some errors occuring while using the delete() method of Db class cause this one will try to include the prefix only and only if this one do not start the name of the table. Eg: pr is the beginning of products, so while you try a delete() on products table, it will be an error (the prefix will not be included).
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Install a shop with "pr" DB prefix and made a delete() on table "products" with/without this change.


Eg: Set the shop with a DB prefix as this one: cu
Try to make this call:  Db::getInstance()->delete('customer_group', '`id_customer` = 1', 1);
The delete() method will start like that: DELETE FROM `customer_group`

Now, set the show with a Db Prefix as this one: cu_
The same call and you will have that: DELETE FROM `cu_customer_group`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8329)
<!-- Reviewable:end -->
