### PR TITLE
Fix the search of word with dash

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -107,7 +107,9 @@ class SearchCore
         $string = preg_replace('/['.PREG_CLASS_SEARCH_EXCLUDE.']+/u', ' ', $string);
 
         if ($indexation) {
+            $fullWord = (preg_match('/[._-]+/', $string)) ? $string : "";
             $string = preg_replace('/[._-]+/', ' ', $string);
+            $string = empty($fullWord) ? $string : $string . ' ' . $fullWord;
         } else {
             $words = explode(' ', $string);
             $processed_words = array();
@@ -121,10 +123,6 @@ class SearchCore
                 }
             }
             $string = implode(' ', $processed_words);
-            $string = preg_replace('/[._]+/', '', $string);
-            $string = ltrim(preg_replace('/([^ ])-/', '$1 ', ' '.$string));
-            $string = preg_replace('/[._]+/', '', $string);
-            $string = preg_replace('/[^\s]-+/', '', $string);
         }
 
         $blacklist = Tools::strtolower(Configuration::get('PS_SEARCH_BLACKLIST', $id_lang));
@@ -212,6 +210,8 @@ class SearchCore
 
                 if ($word[0] != '-') {
                     $score_array[] = 'sw.word LIKE \''.$start_search.pSQL(Tools::substr($word, 0, PS_SEARCH_MAX_WORD_LENGTH)).$end_search.'\'';
+                } else {
+                    $score_array[] = 'sw.word LIKE \'' . $start_search . pSQL(Tools::substr($word, 1, PS_SEARCH_MAX_WORD_LENGTH)) . $end_search . '\'';
                 }
             } else {
                 unset($words[$key]);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | index the whole word and both parts who are separated by "." or "_" or "-" to get better results while searching.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9041
| How to test?  | Create two Products "BKR5EIX-11PS" and "ZFR6FIX-11PS", then go to Preference -> General parameters and click on the link "rebuild index". FO, make a search with "-11PS", both products will be displayed.Now, make a search with "BKR5EIX-11PS", only this product will be displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8330)
<!-- Reviewable:end -->
