### PR TITLE
Display errors on change password (lost)

### DIFF
--- a/themes/classic/templates/customer/password-new.tpl
+++ b/themes/classic/templates/customer/password-new.tpl
@@ -30,7 +30,18 @@
 
 {block name='page_content'}
     <form action="{$urls.pages.password}" method="post">
-
+    <ul class="ps-alert-error">
+      {foreach $errors as $error}
+        <li class="item">
+          <i>
+            <svg viewBox="0 0 24 24">
+              <path fill="#fff" d="M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z"></path>
+            </svg>
+          </i>
+          <p>{$error}</p>
+        </li>
+      {/foreach}
+    </ul>
       <section class="form-fields renew-password">
 
         <div class="email">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When user submit a new passwod (reset password), if there is an error (ex: less than 5 characters), no errors are displayed
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | ask reset password, clink link in your email=>fill the form new password with an error (ex: less than 5 char.)=>submit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8331)
<!-- Reviewable:end -->
