### PR TITLE
Array-check in additional form fields from modules

### DIFF
--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -212,6 +212,10 @@ class CustomerFormatterCore implements FormFormatterInterface
 
         if (is_array($additionalCustomerFormFields)) {
             foreach ($additionalCustomerFormFields as $moduleName => $additionnalFormFields) {
+                if (!is_array($additionnalFormFields)) {
+                    continue;
+                }
+                
                 foreach ($additionnalFormFields as $formField) {
                     $formField->moduleName = $moduleName;
                     $format[$moduleName.'_'.$formField->getName()] = $formField;


### PR DESCRIPTION
It could happen that some modules does not have a correct list of additional form fields, i.e. they return an empty string.
This patch ensures that fields list is, at least, an array.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PS 1.7.2.2
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create a simple module listening hook "additionalCustomerFormFields", return an empty string in this module. Some Prestashop Addons modules, i.e. multiblocks, causes an exception in the Form because of they don't have correct fields.