### PR TITLE
Fixes bug in multishop

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/AttributeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeRepository.php
@@ -50,11 +50,13 @@ class AttributeRepository extends \Doctrine\ORM\EntityRepository
             ->addSelect('al.name AS attributeName')
             ->join('a.attributeGroup', 'ag')
             ->join('a.shops', 's')
+            ->join('ag.shops', 'gs')
             ->join('a.attributeLangs', 'al')
             ->join('ag.attributeGroupLangs', 'agl')
             ->where('al.lang = :idLang')
             ->andWhere('agl.lang = :idLang')
             ->andWhere('s.id = :idShop')
+            ->andWhere('gs.id = :idShop')
             ->orderBy('attributePosition')
             ->addOrderBy('attributeGroupPosition')
             ->setParameters(array(


### PR DESCRIPTION
When attribute groups have different shops assigned than the attributes, we need to test completely to be shure not to include groups that are not available in this shop.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When attribute groups have different shops assigned than the attributes, we need to test completely to be shure not to include groups that are not available in this shop.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a multishop PrestaShop, add a group that is available in shop A but not in shop B, in this group create an attribute available in both shops. Without this bug fix the group will always be displayed in both shops, even if not associated with shop B.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8340)
<!-- Reviewable:end -->
