### PR TITLE
Make modules act like Symfony Bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
   # PrestaShop configuration
   - cp tests/parameters.yml.travis app/config/parameters.yml
 
+
 notifications:
   hipchat: ec4e21c5eb82066ba8be5fd1afefde@1184657
 
@@ -46,6 +47,8 @@ script:
   - composer install --prefer-dist --no-interaction --no-progress
   - bash tests/check_file_syntax.sh
   - bash travis-scripts/install-prestashop
+  - php app/console lint:twig src
+  - php app/console lint:twig app
   - composer test
   - composer test-admin
   - composer phpunit-sf

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -78,15 +78,17 @@ class AppKernel extends Kernel
 
         $activeModules = array();
 
-        if ($this->isParametersFile()) {
+        if ($this->parametersFileExists()) {
             try {
                 $this->getConnection()->connect();
                 $activeModules = $this->getActiveModules();
-            } catch (\Exception $e) {}
+            } catch (\Exception $e) {
+            }
         }
 
 
-        return array_merge($kernelParameters,
+        return array_merge(
+            $kernelParameters,
             array('kernel.active_modules' => $activeModules)
         );
     }
@@ -121,9 +123,8 @@ class AppKernel extends Kernel
      */
     private function getParameters()
     {
-        $parametersFile = $this->getRootDir().'/config/parameters.php';
-        if (file_exists($parametersFile)) {
-            $config = require($parametersFile);
+        if ($this->parametersFileExists()) {
+            $config = require($this->getParametersFile());
 
             return $config['parameters'];
         }
@@ -134,11 +135,17 @@ class AppKernel extends Kernel
     /**
      * @var bool
      */
-    private function isParametersFile()
+    private function parametersFileExists()
     {
-        $parametersFile = $this->getRootDir().'/config/parameters.php';
+        return file_exists($this->getParametersFile());
+    }
 
-        return file_exists($parametersFile);
+    /**
+     * @return string filepath to PrestaShop configuration parameters
+     */
+    private function getParametersFile()
+    {
+        return $this->getRootDir().'/config/parameters.php';
     }
 
     /**
@@ -158,5 +165,4 @@ class AppKernel extends Kernel
             'driver' => 'pdo_mysql',
         ));
     }
-
 }

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -24,8 +24,11 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\DriverManager;
+use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\HttpKernel\Kernel;
+use PrestaShopBundle\Kernel\ModuleRepository;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
 class AppKernel extends Kernel
@@ -54,6 +57,9 @@ class AppKernel extends Kernel
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
         }
 
+        /**
+         * @see https://symfony.com/doc/2.8/configuration/external_parameters.html#environment-variables
+         */
         if (extension_loaded('apc')) {
             $_SERVER['SYMFONY__CACHE__DRIVER'] = 'apc';
         } else {
@@ -63,8 +69,94 @@ class AppKernel extends Kernel
         return $bundles;
     }
 
+    /**
+     * @{inheritdoc}
+     */
+    protected function getKernelParameters()
+    {
+        $kernelParameters = parent::getKernelParameters();
+
+        $activeModules = array();
+
+        if ($this->isParametersFile()) {
+            try {
+                $this->getConnection()->connect();
+                $activeModules = $this->getActiveModules();
+            } catch (\Exception $e) {}
+        }
+
+
+        return array_merge($kernelParameters,
+            array('kernel.active_modules' => $activeModules)
+        );
+    }
+
+    /**
+     * @{inheritdoc}
+     */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load($this->getRootDir().'/config/config_'.$this->getEnvironment().'.yml');
     }
+
+    /**
+     * Return all active modules.
+     *
+     * @return array list of modules names.
+     */
+    private function getActiveModules()
+    {
+        $databasePrefix = $this->getParameters()['database_prefix'];
+
+        $modulesRepository = new ModuleRepository(
+            $this->getConnection(),
+            $databasePrefix
+        );
+
+        return $modulesRepository->getActiveModules();
+    }
+
+    /**
+     * @return array The root parameters of PrestaShop
+     */
+    private function getParameters()
+    {
+        $parametersFile = $this->getRootDir().'/config/parameters.php';
+        if (file_exists($parametersFile)) {
+            $config = require($parametersFile);
+
+            return $config['parameters'];
+        }
+
+        return array();
+    }
+
+    /**
+     * @var bool
+     */
+    private function isParametersFile()
+    {
+        $parametersFile = $this->getRootDir().'/config/parameters.php';
+
+        return file_exists($parametersFile);
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Connection
+     */
+    private function getConnection()
+    {
+        $parameters = $this->getParameters();
+
+        return DriverManager::getConnection(array(
+            'dbname' => $parameters['database_name'],
+            'user' => $parameters['database_user'],
+            'password' => $parameters['database_password'],
+            'host' => $parameters['database_host'],
+            'port' => $parameters['database_port'],
+            'charset' => 'utf8',
+            'driver' => 'pdo_mysql',
+        ));
+    }
+
 }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -29,6 +29,7 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 abstract class ModuleCore implements ModuleInterface
 {
@@ -178,6 +179,9 @@ abstract class ModuleCore implements ModuleInterface
     public static $_log_modules_perfs = null;
     /** @var bool Random session for modules perfs logs*/
     public static $_log_modules_perfs_session = null;
+
+    /** @var \Symfony\Component\DependencyInjection\ContainerInterface */
+    private $container;
 
     const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
 
@@ -3186,6 +3190,26 @@ abstract class ModuleCore implements ModuleInterface
     public function isSymfonyContext()
     {
         return !defined('ADMIN_LEGACY_CONTEXT');
+    }
+
+    /**
+     * Access the Symfony Container if we are in Symfony Context.
+     * Note: in this case, we must get a container from SymfonyContainer class.
+     * @param string $serviceName
+     *
+     * @return Object|false if Symfony is not booted, it returns false.
+     */
+    public function get($serviceName)
+    {
+        if ($this->isSymfonyContext()) {
+            if (is_null($this->container)) {
+                $this->container = SymfonyContainer::getInstance();
+            }
+
+            return $this->container->get($serviceName);
+        }
+
+        return false;
     }
 }
 

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -49,6 +49,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $this->headerTabContent = $headerTabContent;
         $this->enableSidebar = $enableSidebar;
         $this->helpLink = $helpLink;
+        $this->php_self = $controllerName;
     }
 
     public function setMedia()

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -540,4 +540,23 @@ class ModuleRepository implements ModuleRepositoryInterface
 
         return $this->getFilteredList($filters);
     }
+
+    /**
+     * Returns installed module filepaths
+     * @return array
+     */
+    public function getInstalledModulesPaths()
+    {
+        $paths = array();
+        $modulesFiles = Finder::create()->directories()->in(__DIR__.'/../../../../modules')->depth(0);
+        $installedModules = array_keys($this->getInstalledModules());
+
+        foreach ($modulesFiles as $moduleFile) {
+            if (in_array($moduleFile->getFilename(), $installedModules)) {
+                $paths[] = $moduleFile->getPathname();
+            }
+        }
+
+        return $paths;
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -53,7 +53,7 @@ class CommonController extends FrameworkBundleAdminController
      * {% render controller('PrestaShopBundle\\Controller\\Admin\\CommonController::paginationAction',
      *   {'limit': limit, 'offset': offset, 'total': product_count, 'caller_parameters': pagination_parameters}) %}
      *
-     * @Template
+     * @Template("@PrestaShop/Admin/Common/pagination.html.twig")
      * @param Request $request
      * @param integer $limit
      * @param integer $offset
@@ -149,7 +149,7 @@ class CommonController extends FrameworkBundleAdminController
     /**
      * This will allow you to retrieve an HTML code with a list of recommended modules depending on the domain.
      *
-     * @Template
+     * @Template("@PrestaShop/Admin/Common/recommendedModules.html.twig")
      * @param string $domain
      * @param integer $limit
      * @param integer $randomize
@@ -200,7 +200,7 @@ class CommonController extends FrameworkBundleAdminController
     {
         $tools = $this->container->get('prestashop.adapter.tools');
 
-        return $this->render('PrestaShopBundle:Admin:Common/_partials/_sidebar.html.twig', [
+        return $this->render('@PrestaShop/Admin/Common/_partials/_sidebar.html.twig', [
             'footer' => $tools->purifyHTML($footer),
             'title' => $title,
             'url' => urldecode($url),

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -75,7 +75,7 @@ class ProductController extends FrameworkBundleAdminController
      *
      * URL example: /product/catalog/40/20/id_product/asc
      *
-     * @Template
+     * @Template("@PrestaShop/Admin/Product/catalog.html.twig")
      * @param Request $request
      * @param integer $limit The size of the listing
      * @param integer $offset The offset of the listing
@@ -250,7 +250,7 @@ class ProductController extends FrameworkBundleAdminController
      * The full page that shows products list will subcall this action (from catalogAction).
      * URL example: /product/list/html/40/20/id_product/asc
      *
-     * @Template
+     * @Template("@PrestaShop/Admin/Product/list.html.twig")
      * @param Request $request
      * @param integer $limit The size of the listing
      * @param integer $offset The offset of the listing
@@ -374,7 +374,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Product form
      *
-     * @Template
+     * @Template("@PrestaShop/Admin/Product/form.html.twig")
      * @param int $id The product ID
      * @param Request $request
      * @return array|Response Template vars

--- a/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
@@ -110,7 +110,7 @@ class ProductImageController extends FrameworkBundleAdminController
     /**
      * Manage form image
      *
-     * @Template
+     * @Template("@PrestaShop/Admin/ProductImage/form.html.twig")
      * @param $idImage
      * @param Request $request
      * @return array|JsonResponse|Response

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -56,11 +56,11 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
         $installedModules = $container->getParameter('kernel.active_modules');
 
         foreach ($this->getModulesPaths() as $modulePath) {
-            if (in_array($modulePath->getFilename(), $installedModules)) {
-                if (file_exists($modulePath.'/config/services.yml')) {
-                    $loader = new YamlFileLoader($container, new FileLocator($modulePath.'/config/'));
-                    $loader->load('services.yml');
-                }
+            if (in_array($modulePath->getFilename(), $installedModules)
+                && file_exists($modulePath.'/config/services.yml')
+            ) {
+                $loader = new YamlFileLoader($container, new FileLocator($modulePath.'/config/'));
+                $loader->load('services.yml');
             }
         }
     }

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShopBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Config\Resource\FileExistenceResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Config\FileLocator;
+
+/**
+ * Load services stored in installed modules.
+ */
+class LoadServicesFromModulesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->registerServicesFromModules($container);
+    }
+
+    /**
+     * Load all services registered in every module.
+     *
+     * @param ContainerBuilder $container
+     * @return void
+     */
+    private function registerServicesFromModules(ContainerBuilder $container)
+    {
+        $installedModules = $container->getParameter('kernel.active_modules');
+
+        foreach ($this->getModulesPaths() as $modulePath) {
+            if (in_array($modulePath->getFilename(), $installedModules)) {
+                if (file_exists($modulePath.'/config/services.yml')) {
+                    $loader = new YamlFileLoader($container, new FileLocator($modulePath.'/config/'));
+                    $loader->load('services.yml');
+                }
+            }
+        }
+    }
+
+    /**
+     * @return \Iterator
+     */
+    private function getModulesPaths()
+    {
+        return Finder::create()->directories()->in(__DIR__.'/../../../../modules')->depth(0);
+    }
+}

--- a/src/PrestaShopBundle/Kernel/ModuleRepository.php
+++ b/src/PrestaShopBundle/Kernel/ModuleRepository.php
@@ -43,12 +43,12 @@ final class ModuleRepository
     /**
      * @var string the `modules` table name.
      */
-    private $databaseName;
+    private $tableName;
 
     public function __construct(Connection $connection, $databasePrefix)
     {
         $this->connection = $connection;
-        $this->databaseName = $databasePrefix.'module';
+        $this->tableName = $databasePrefix.'module';
     }
 
     /**
@@ -56,7 +56,7 @@ final class ModuleRepository
      */
     public function getActiveModules()
     {
-        $sth = $this->connection->query('SELECT name FROM '. $this->databaseName. ' WHERE active = 1');
+        $sth = $this->connection->query('SELECT name FROM '. $this->tableName. ' WHERE active = 1');
 
         return $sth->fetchAll(\PDO::FETCH_COLUMN);
     }

--- a/src/PrestaShopBundle/Kernel/ModuleRepository.php
+++ b/src/PrestaShopBundle/Kernel/ModuleRepository.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Kernel;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Before booting the PrestaShop application in Symfony context,
+ * we register every installed modules.
+ */
+final class ModuleRepository
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string the `modules` table name.
+     */
+    private $databaseName;
+
+    public function __construct(Connection $connection, $databasePrefix)
+    {
+        $this->connection = $connection;
+        $this->databaseName = $databasePrefix.'module';
+    }
+
+    /**
+     * @return array the list of installed modules.
+     */
+    public function getActiveModules()
+    {
+        $sth = $this->connection->query('SELECT name FROM '. $this->databaseName. ' WHERE active = 1');
+
+        return $sth->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * Returns installed module filepaths
+     * @return array
+     */
+    public function getActiveModulesPaths()
+    {
+        $paths = array();
+        $modulesFiles = Finder::create()->directories()->in(__DIR__.'/../../../modules')->depth(0);
+        $activeModules = array_keys($this->getActiveModules());
+        foreach ($modulesFiles as $moduleFile) {
+            if (in_array($moduleFile->getFilename(), $activeModules)) {
+                $paths[] = $moduleFile->getPathname();
+            }
+        }
+        return $paths;
+    }
+}

--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -25,8 +25,10 @@
  */
 namespace PrestaShopBundle;
 
+use PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass;
 use PrestaShopBundle\DependencyInjection\Compiler\RemoveXmlCompiledContainerPass;
 use PrestaShopBundle\DependencyInjection\Compiler\PopulateTranslationProvidersPass;
+use PrestaShopBundle\DependencyInjection\Compiler\OverrideServiceCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -54,8 +56,9 @@ class PrestaShopBundle extends Bundle
     {
         $container->addCompilerPass(new DynamicRolePass());
         $container->addCompilerPass(new PopulateTranslationProvidersPass());
+        $container->addCompilerPass(new LoadServicesFromModulesPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new RemoveXmlCompiledContainerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RouterPass(), PassConfig::TYPE_AFTER_REMOVING);
-        $container->addCompilerPass(new DependencyInjection\Compiler\OverrideServiceCompilerPass());
+        $container->addCompilerPass(new OverrideServiceCompilerPass());
     }
 }

--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -267,10 +267,22 @@ services:
         calls:
             - [ setExportDir, ["%kernel.cache_dir%/export"]]
 
+
     # EVENT MANAGEMENT
     prestashop.dispatcher.legacy_hooks.subscriber:
         class: 'PrestaShopBundle\EventListener\ActionDispatcherLegacyHooksSubscriber'
         arguments: ['@prestashop.hook.dispatcher']
         tags:
             - { name: kernel.event_subscriber }
+
+    # Custom Twig loader
+    prestashop.module_kernel.repository:
+        class: 'PrestaShopBundle\Kernel\ModuleRepository'
+        arguments: ['@doctrine.dbal.default_connection', '%database_prefix%']
+
+    prestashop.twig.modules.loader:
+        class: 'PrestaShopBundle\Twig\Locator\ModuleTemplateLoader'
+        arguments: ['@=service("prestashop.module_kernel.repository").getActiveModulesPaths()']
+        tags:
+          - { name: twig.loader, priority: 1}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/catalog.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block javascripts %}
     {{ parent() }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block javascripts %}
     {{ parent() }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block javascripts %}
     {{ parent() }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 {% form_theme categories _self %}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block javascripts %}
   {{ parent() }}
@@ -70,7 +70,6 @@
 {%- endblock choice_tree_item_widget %}
 
 {% block content %}
-
   <div class="products-catalog">
 
     {{ renderhook('legacy_block_kpi', {'kpi_controller': 'AdminProductsController'}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog_empty.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog_empty.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
   <div class="col-md-12 text-md-center">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/formDisable.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/formDisable.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
     <div class="col-md-12">

--- a/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Translations/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Translations/overview.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
     <div id="translations-app"></div>

--- a/src/PrestaShopBundle/Twig/Locator/ModuleTemplateLoader.php
+++ b/src/PrestaShopBundle/Twig/Locator/ModuleTemplateLoader.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShopBundle\Twig\Locator;
+
+use Twig\Loader\FilesystemLoader;
+
+/**
+ * Loads templates from PrestaShop modules.
+ */
+class ModuleTemplateLoader extends FilesystemLoader
+{
+    /**
+     * {@inheritdoc}
+     */
+    private $rootPath;
+
+    /**
+     * @param string|array $paths    A path or an array of paths where to look for templates
+     * @param string|null  $rootPath The root path common to all relative paths (null for getcwd())
+     * @param string|null  $namespace A path namespace
+     */
+    public function __construct($paths = array(), $rootPath = null, $namespace = 'PrestaShop')
+    {
+        $this->rootPath = (null === $rootPath ? getcwd() : $rootPath).DIRECTORY_SEPARATOR;
+        if (false !== $realPath = realpath($rootPath)) {
+            $this->rootPath = $realPath.DIRECTORY_SEPARATOR;
+        }
+
+        if ($paths) {
+            $templatePaths = array();
+
+            foreach ($paths as $path) {
+                if (is_dir($dir = $path . '/views/'. $namespace)) {
+                    $templatePaths[] = $dir;
+                }
+            }
+            $this->setPaths($templatePaths, $namespace);
+        }
+    }
+}

--- a/tests/check_file_syntax.sh
+++ b/tests/check_file_syntax.sh
@@ -3,13 +3,6 @@
 ! (find . -name "*.php" ! -path "./vendor/*" ! -path "./tools/*" -print0 | xargs -0 -n1 -P4 php -l | grep -q "Parse error")
 php=$?
 
-#twig tests
-php app/console lint:twig src
-twig_src=$?
-
-php app/console lint:twig app
-twig_app=$?
-
 #yml tests
 php app/console lint:yaml src
 yaml_src=$?
@@ -23,7 +16,7 @@ yaml_themes=$?
 php app/console lint:yaml .t9n.yml
 yaml_trad=$?
 
-if [[ "$php" == "0" && "$twig_src" == "0" && "$twig_app" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad == 0" ]]; then
+if [[ "$php" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad == 0" ]]; then
   echo -e "\e[92mSYNTAX TESTS OK"
   exit 0;
 else


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | From a module you can now override a new page template and declare your own Symfony parameters and services! You also have access to Symfony services inside modules used in "Symfony" context like `twig`, `doctrine`, `logger` or all services used by the Core.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | a lot
| How to test?  | creates `modules/{moduleName}/config/services.yml` && creates `modules/{moduleName}/views/PrestaShop/{path/to/your/twig/template}`in a module, like in this [test module provided for free :p](https://github.com/mickaelandrieu/ps_test). Docs => https://gist.github.com/mickaelandrieu/4a02ea05bb1113718aec5432ad418ee5 && https://gist.github.com/mickaelandrieu/ea6d199e3bdd2044de3e29288d4c0b32

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8342)
<!-- Reviewable:end -->

> Next feature to come: be able to create your own modern pages using Symfony, Twig and PrestaShop UI Kit.