### PR TITLE
Fix the currency display in supply order

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_content.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_content.tpl
@@ -98,7 +98,11 @@
 							{/if}
 						{/if}
 					{elseif isset($params.type) && $params.type == 'price'}
-						{displayPrice price=$tr.$key}
+						{if isset($tr.id_currency)}
+							{displayPrice price=$tr.$key currency=$tr.id_currency}
+						{else}
+							{displayPrice price=$tr.$key}
+						{/if}
 					{elseif isset($params.float)}
 						{$tr.$key}
 					{elseif isset($params.type) && $params.type == 'date'}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | The currency wasn't called in "displayPrice" and that's why the default currency used to be displayed instead of the chosen one, while creating the supply order. So, I made a test, if the currency exists then I display it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3760
| How to test?  | Let's choose "euro" as the default currency. Then, try to create a new Supply order and choose "dollar" as a currency, save it. Back to the supply orders list, click on the new created to view the details. You will see the "dollar" is displayed as a currency and not the "euro", OK.
