### PR TITLE
Added methods to check in which context module is executed

### DIFF
--- a/admin-dev/index.php
+++ b/admin-dev/index.php
@@ -87,6 +87,7 @@ try {
     $response->send();
     $kernel->terminate($request, $response);
 } catch (NotFoundHttpException $rnfe) {
+    define('ADMIN_LEGACY_CONTEXT', true);
     // correct Apache charset (except if it's too late)
     if (!headers_sent()) {
         header('Content-Type: text/html; charset=utf-8');

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3165,6 +3165,28 @@ abstract class ModuleCore implements ModuleInterface
 
         return false;
     }
+
+    /**
+     * Check if the module is executed in Admin Legacy context.
+     *
+     * To be removed - because useless - when the migration will be done.
+     * @return bool
+     */
+    public function isAdminLegacyContext()
+    {
+        return defined('ADMIN_LEGACY_CONTEXT');
+    }
+
+    /**
+     * Check if the module is executed in Symfony context.
+     *
+     * To be removed - because useless - when the migration will be done.
+     * @return bool
+     */
+    public function isSymfonyContext()
+    {
+        return !defined('ADMIN_LEGACY_CONTEXT');
+    }
 }
 
 function ps_module_version_sort($a, $b)


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In Back office modules, we can be in admin legacy context (old pages) or in Symfony context (new pages), but as a modules developer we have no way to know in which context we are. This contribution solves this issue.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | You need to create a module and execute a hook available in both legacy and new pages (`displayBackOfficeHeader` for instance) and return differents values :)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8347)
<!-- Reviewable:end -->
