### PR TITLE
Fix SQL error when product search starts with an hyphen

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -206,6 +206,8 @@ class SearchCore
                 $word = str_replace(array('%', '_'), array('\\%', '\\_'), $word);
                 $start_search = Configuration::get('PS_SEARCH_START') ? '%': '';
                 $end_search = Configuration::get('PS_SEARCH_END') ? '': '%';
+                $start_pos = (int)$word[0] == '-';
+                $sql_param_search = $start_search.pSQL(Tools::substr($word, $start_pos, PS_SEARCH_MAX_WORD_LENGTH)).$end_search;
 
                 $intersect_array[] = 'SELECT DISTINCT si.id_product
 					FROM '._DB_PREFIX_.'search_word sw
@@ -213,14 +215,9 @@ class SearchCore
 					WHERE sw.id_lang = '.(int)$id_lang.'
 						AND sw.id_shop = '.$context->shop->id.'
 						AND sw.word LIKE
-					'.($word[0] == '-'
-                        ? ' \''.$start_search.pSQL(Tools::substr($word, 1, PS_SEARCH_MAX_WORD_LENGTH)).$end_search.'\''
-                        : ' \''.$start_search.pSQL(Tools::substr($word, 0, PS_SEARCH_MAX_WORD_LENGTH)).$end_search.'\''
-                    );
+					\''.$sql_param_search.'\'';
 
-                if ($word[0] != '-') {
-                    $score_array[] = 'sw.word LIKE \''.$start_search.pSQL(Tools::substr($word, 0, PS_SEARCH_MAX_WORD_LENGTH)).$end_search.'\'';
-                }
+                $score_array[] = 'sw.word LIKE \''.$sql_param_search.'\'';
             } else {
                 unset($words[$key]);
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you look for a product on the Front-office, with only one word starting with an hyphen, you get a SQL error because a subrequest was not defined but used anyway later.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Create 2 products: ZFR6FIX-11PS & BKR5EIX-11PS. Refresh the search index then do a search with `-11`. You should not see an error 500 anymore.

### Previous error:

![capture du 2017-09-19 17-12-27](https://user-images.githubusercontent.com/6768917/30602859-c2cee6f8-9d5d-11e7-9fae-18488eedfb88.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8348)
<!-- Reviewable:end -->
