### PR TITLE
Calculate the unit_price to be used in webservice

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -475,6 +475,7 @@ class ProductCore extends ObjectModel
     public function __construct($id_product = null, $full = false, $id_lang = null, $id_shop = null, Context $context = null)
     {
         parent::__construct($id_product, $id_lang, $id_shop);
+        $this->unit_price = (!empty($this->unit_price_ratio)) ? ($this->price / $this->unit_price_ratio) : 0;
         if ($full && $this->id) {
             if (!$context) {
                 $context = Context::getContext();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Calculate the "unit_price" outside of the condition cause if we use a webservice, we can't  set $full to TRUE ($full means a cart was created and assigned to an user).
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9188
| How to test?  | See the description in the ticket.