### PR TITLE
Add id_product_attribute to productLink

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1038,7 +1038,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         $breadcrumb['links'][] = array(
             'title' => $this->context->controller->product->name,
-            'url' => $this->context->link->getProductLink($this->context->controller->product),
+            'url' => $this->context->link->getProductLink($this->context->controller->product, null, null, null, null, null, (int) $this->getIdProductAttribute()),
         );
 
         return $breadcrumb;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As now, while you check a product with combinations, the product link inside the breadcrumb do not get the selected attribute and the click on it will make a canonical redirection.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | With debug mode on, you can click on the breadcrumb link while a product has combinations. Fetch this PR and do the same. No canonical redirection will be done.