### PR TITLE
Fix already defined class during upgrade process from 1.6 to 1.7

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -53,7 +53,7 @@ use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShopBundle\Cache\LocalizationWarmer;
 use Symfony\Component\Yaml\Yaml;
 use PhpEncryption;
-use PrestaShopBundle\Service\Database\Upgrade;
+use PrestaShopBundle\Service\Database\Upgrade as UpgradeDatabase;
 
 class Install extends AbstractInstall
 {
@@ -271,7 +271,7 @@ class Install extends AbstractInstall
      */
     public function generateSf2ProductionEnv()
     {
-        $schemaUpgrade = new Upgrade();
+        $schemaUpgrade = new UpgradeDatabase();
         $schemaUpgrade->addDoctrineSchemaUpdate();
         $output = $schemaUpgrade->execute();
 


### PR DESCRIPTION
Solved error:
Cannot use PrestaShopBundle\Service\Database\Upgrade as Upgrade because the name is already in use

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | couldn't update 1.6 to 1.7 without this change
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | try to update 1.6.1.17 to 1.7
| Sponsor company | impSolutions