### PR TITLE
Improved syntax check file tests output

### DIFF
--- a/tests/check_file_syntax.sh
+++ b/tests/check_file_syntax.sh
@@ -24,7 +24,9 @@ php app/console lint:yaml .t9n.yml
 yaml_trad=$?
 
 if [[ "$php" == "0" && "$twig_src" == "0" && "$twig_app" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad == 0" ]]; then
+  echo -e "\e[92mSYNTAX TESTS OK"
   exit 0;
 else
+  echo -e "\e[91mSYNTAX TESTS FAILED"
   exit 255;
 fi


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | add visual information that check file tests have failed, it's useful only for PHP checks as Yaml and Twig linting is already throwing a meaning full exception.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| How to test?  | execute `bash ./tests/check_file_syntax.sh`

![checknok](https://user-images.githubusercontent.com/1247388/30655108-4dee019c-9e30-11e7-98d2-90b977769d9f.png)
![checkok](https://user-images.githubusercontent.com/1247388/30655107-4deb4f42-9e30-11e7-8690-00471a133221.png)
