### PR TITLE
Calculate the unit_price for webservice uses

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -475,6 +475,7 @@ class ProductCore extends ObjectModel
     public function __construct($id_product = null, $full = false, $id_lang = null, $id_shop = null, Context $context = null)
     {
         parent::__construct($id_product, $id_lang, $id_shop);
+        $this->unit_price = (($this->unit_price_ratio != 0) ? ($this->price / $this->unit_price_ratio) : 0);
         if ($full && $this->id) {
             if (!$context) {
                 $context = Context::getContext();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | while using a webservice, $full is setd to FALSE cause there's no cart created. So, we can't get in the clause "if", that's why we need to calculate the "unit_price" outside the condition.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9188
| How to test?  | create a webservice mentioned in the ticket's description and access to it, the unit_price value will be displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8358)
<!-- Reviewable:end -->
