### PR TITLE
Fix conflict between two cart rules and a single product cart

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -735,7 +735,7 @@ class CartRuleCore extends ObjectModel
                 if ($otherCartRule['id_cart_rule'] == $this->id && !$alreadyInCart) {
                     return (!$display_error) ? false : $this->trans('This voucher is already in your cart', array(), 'Shop.Notifications.Error');
                 }
-                if ($otherCartRule['gift_product']) {
+                if ($otherCartRule['gift_product'] && $context->cart->containsProduct($otherCartRule['gift_product'], $otherCartRule['gift_product_attribute']) > 0) {
                     --$nb_products;
                 }
 


### PR DESCRIPTION
Fixing this case: two cart rules, one with a free product and other with a percentage discount. The problem is when there is no stock of the free product, the code to load the second cart rule didn't checked if the product was in the cart. If detected that the gift rule was loaded, it substracted one unit from the total quantity cart products. And if the cart had only one product, it generated a "Cart empty" error. Now it checks if the cart contains the cart rule free product.

This is a clone of https://github.com/PrestaShop/PrestaShop/pull/8180
Something went wrong when rebasing it onto 1.7.2.x, so I recreated it here. Full credits go to @Xaconi

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The proposed solution resolves the specific case that combines two cart rules. One, to add a free product automatically. And the second one, to make a percentage discount. I've found a problem when the free product has no stock, and the cart has only one product. The FO gets the "Cart is empty" error. Now, the system checks if the free product is in the cart.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Generate two cart rules. one with a free product, and other with a percentage discount with code. The free product has to be a zero stock product. Then, add a product to customer's cart (it loads the free product cart rule, but it no adds to the cart beacuse don't have stock). Finally, try to add the second rule with the code on the order page. It generates the "Cart is empty error". The fix resolves this case

