### PR TITLE
Fixed bug in Access::getRoles()

### DIFF
--- a/classes/Access.php
+++ b/classes/Access.php
@@ -105,12 +105,15 @@ class AccessCore extends ObjectModel
         $result =  Db::getInstance()->executeS('
             SELECT r.`slug`
             FROM `'._DB_PREFIX_.'authorization_role` r
-            LEFT JOIN `'._DB_PREFIX_.'access` a
-            ON r.`id_authorization_role` = a.`id_authorization_role`
-            AND a.`id_profile` = "'.$idProfile.'"
-            LEFT JOIN `'._DB_PREFIX_.'module_access` ma
-            ON r.`id_authorization_role` = ma.`id_authorization_role`
-            AND ma.`id_profile` = "'.$idProfile.'"
+            WHERE r.`id_authorization_role` IN (
+                SELECT a.`id_authorization_role`
+                FROM `'._DB_PREFIX_.'access` a
+                WHERE a.`id_profile` = "'.$idProfile.'"
+                union all
+                SELECT ma.`id_authorization_role`
+                FROM `'._DB_PREFIX_.'module_access` ma 
+                WHERE ma.`id_profile` = "'.$idProfile.'"
+            )
         ');
 
         foreach ((array) $result as $key => $role) {


### PR DESCRIPTION
Updated getRoles() so it only returns the roles for the specified profile. Before the fix it would return all the existing authorization_roles in the db, no matter what profile is specified.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Updated getRoles() so it only returns the roles for the specified profile. Before the fix it would return all the existing authorization_roles in the db, no matter what profile is specified.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Run Access::getRoles(**profile_id**) from a test controller. Use a profile_id from a new created profile with no auth rules set, you should get 0 results.. Add one auth role to the profile, now getRoles() should return 1 result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8362)
<!-- Reviewable:end -->
