### PR TITLE
BO: Fix pagination and search in second level and lower (subfeatures, subcategories, ...)

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -915,7 +915,14 @@ class AdminControllerCore extends Controller
                 }
 
                 if (isset($_POST) && count($_POST) && (int)Tools::getValue('submitFilter'.$this->list_id) || Tools::isSubmit('submitReset'.$this->list_id)) {
-                    $this->setRedirectAfter(self::$currentIndex.'&token='.$this->token.(Tools::isSubmit('submitFilter'.$this->list_id) ? '&submitFilter'.$this->list_id.'='.(int)Tools::getValue('submitFilter'.$this->list_id) : '').(isset($_GET['id_'.$this->list_id]) ? '&id_'.$this->list_id.'='.(int)$_GET['id_'.$this->list_id] : ''));
+                    $url = self::$currentIndex.'&token='.$this->token;
+                    if (Tools::isSubmit('view'.$this->table) && Tools::isSubmit('id_'.$this->table)) {
+                        $url .= '&id_'.$this->table.'='.(int)Tools::getValue('id_'.$this->table).'&view'.$this->table;
+                    }
+                    if (Tools::isSubmit('submitFilter'.$this->list_id)) {
+                        $url .= '&submitFilter'.$this->list_id.'='.(int)Tools::getValue('submitFilter'.$this->list_id);
+                    }
+                    $this->setRedirectAfter($url);
                 }
 
                 // If the method named after the action exists, call "before" hooks, then call action method, then call "after" hooks


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fix pagination and search in lists when we are in the second level and lower (subfeatures, subcategories, etc).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Before this change when you use pagination or search while you are in the another level different to the main on subfeatures or subcategories you will be redirected to the root.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8369)
<!-- Reviewable:end -->
