### PR TITLE
Fixed silenced error

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -436,7 +436,9 @@ class AdminControllerCore extends Controller
         $this->bo_css = ((Validate::isLoadedObject($this->context->employee)
             && $this->context->employee->bo_css) ? $this->context->employee->bo_css : 'admin-theme.css');
 
-        if (!@filemtime(_PS_BO_ALL_THEMES_DIR_.$this->bo_theme.DIRECTORY_SEPARATOR.'css'.DIRECTORY_SEPARATOR.$this->bo_css)) {
+        $adminThemeCSSFile = _PS_BO_ALL_THEMES_DIR_.$this->bo_theme.DIRECTORY_SEPARATOR.'css'.DIRECTORY_SEPARATOR.$this->bo_css;
+
+        if (file_exists($adminThemeCSSFile)) {
             $this->bo_css = 'admin-theme.css';
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | A PHP error is silenced in every Symfony page, there is the fix.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Nothing to do, just review and merge :+1: 

```syslog
filemtime(): stat failed for /admin-dev/themes/new-theme/css/admin-theme.css
Context: { "name": "E_WARNING",
"type":2,
"file": "/home/dev/Projects/PrestaShop/classes/controller/AdminController.php", 
"line":439,"level":28928,"scream":true
}
```