### PR TITLE
Stay always on same domain

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -750,7 +750,7 @@ class LinkCore
 
         $idLang = Context::getContext()->language->id;
 
-        return $this->getBaseLink().basename(_PS_ADMIN_DIR_).'/'.Dispatcher::getInstance()->createUrl($controller, $idLang, $params, false);
+        return '/'.basename(_PS_ADMIN_DIR_).'/'.Dispatcher::getInstance()->createUrl($controller, $idLang, $params, false);
     }
 
     /**


### PR DESCRIPTION
When Shop Context changes, getAdminLink changed the domain and you need to login again, etc.., etc..

We need to stay on the same domain, so we don't need to login again

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When Shop Context changes, getAdminLink changed the domain and you need to login again, etc.., etc.. We need to stay on the same domain, so we don't need to login again
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a multishop, and change shop context, links will always change without this bug fix

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8374)
<!-- Reviewable:end -->
