### PR TITLE
Remove risky and useless sprintf() calls

### DIFF
--- a/classes/ValidateConstraintTranslator.php
+++ b/classes/ValidateConstraintTranslator.php
@@ -64,13 +64,10 @@ class ValidateConstraintTranslatorCore
             );
         }
 
-        return sprintf(
-            $this->translator->trans(
-                'Invalid format.',
-                array(),
-                'Shop.Forms.Errors'
-            ),
-            $validator
+        return $this->translator->trans(
+            'Invalid format.',
+            array(),
+            'Shop.Forms.Errors'
         );
     }
 }

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -109,15 +109,13 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
                 $taxLabel .= ' tax excl.';
             }
 
-            return sprintf(
-                $this->getTranslator()->trans(
-                    ' (additional cost of %giftcost% %taxlabel%)',
-                    array(
-                        '%giftcost%' => $priceFormatter->convertAndFormat($this->getGiftCost()),
-                        '%taxlabel%' => $taxLabel,
-                    ),
-                    'Shop.Theme.Checkout'
-                )
+            return $this->getTranslator()->trans(
+                ' (additional cost of %giftcost% %taxlabel%)',
+                array(
+                    '%giftcost%' => $priceFormatter->convertAndFormat($this->getGiftCost()),
+                    '%taxlabel%' => $taxLabel,
+                ),
+                'Shop.Theme.Checkout'
             );
         }
 

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -96,21 +96,15 @@ class DeliveryOptionsFinderCore
                                 if ($include_taxes) {
                                     $carrier['price'] = $this->priceFormatter->format($carriers_list['total_price_with_tax']);
                                     if ($display_taxes_label) {
-                                        $carrier['price'] = sprintf(
-                                            $this->translator->trans(
-                                                '%s tax incl.', array(), 'Shop.Theme.Checkout'
-                                            ),
-                                            $carrier['price']
+                                        $carrier['price'] = $this->translator->trans(
+                                            '%price% tax incl.', array('%price%' => $carrier['price']), 'Shop.Theme.Checkout'
                                         );
                                     }
                                 } else {
                                     $carrier['price'] = $this->priceFormatter->format($carriers_list['total_price_without_tax']);
                                     if ($display_taxes_label) {
-                                        $carrier['price'] = sprintf(
-                                            $this->translator->trans(
-                                                '%s tax excl.', array(), 'Shop.Theme.Checkout'
-                                            ),
-                                            $carrier['price']
+                                        $carrier['price'] = $this->translator->trans(
+                                            '%price% tax excl.', array('%price%' => $carrier['price']), 'Shop.Theme.Checkout'
                                         );
                                     }
                                 }

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -97,14 +97,18 @@ class DeliveryOptionsFinderCore
                                     $carrier['price'] = $this->priceFormatter->format($carriers_list['total_price_with_tax']);
                                     if ($display_taxes_label) {
                                         $carrier['price'] = $this->translator->trans(
-                                            '%price% tax incl.', array('%price%' => $carrier['price']), 'Shop.Theme.Checkout'
+                                            '%price% tax incl.',
+                                            array('%price%' => $carrier['price']),
+                                            'Shop.Theme.Checkout'
                                         );
                                     }
                                 } else {
                                     $carrier['price'] = $this->priceFormatter->format($carriers_list['total_price_without_tax']);
                                     if ($display_taxes_label) {
                                         $carrier['price'] = $this->translator->trans(
-                                            '%price% tax excl.', array('%price%' => $carrier['price']), 'Shop.Theme.Checkout'
+                                            '%price% tax excl.',
+                                            array('%price%' => $carrier['price']),
+                                            'Shop.Theme.Checkout'
                                         );
                                     }
                                 }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3677,11 +3677,9 @@ class AdminControllerCore extends Controller
                     $value = Tools::getValue($field.'_'.$default_language->id);
                     // !isset => not exist || "" == $value can be === 0 (before, empty $value === 0 returned true)
                     if (!isset($value) || "" == $value) {
-                        $this->errors[$field.'_'.$default_language->id] = sprintf(
-                            $this->trans('The field %1$s is required at least in %2$s.', array(), 'Admin.Notifications.Error'),
-                            $object->displayFieldName($field, $class_name),
-                            $default_language->name
-                        );
+                        $this->errors[$field.'_'.$default_language->id] = $this->trans('The field %field_name% is required at least in %lang%.',
+                            array('%field_name%' => $object->displayFieldName($field, $class_name), '%lang%' => $default_language->name),
+                            'Admin.Notifications.Error');
                     }
                 }
 
@@ -3712,11 +3710,9 @@ class AdminControllerCore extends Controller
                             $res = Validate::$function($value);
                         }
                         if (!$res) {
-                            $this->errors[$field_lang.'_'.$language['id_lang']] = sprintf(
-                                $this->trans('The %1$s field (%2$s) is invalid.', array(), 'Admin.Notifications.Error'),
-                                call_user_func(array($class_name, 'displayFieldName'), $field_lang, $class_name),
-                                $language['name']
-                            );
+                            $this->errors[$field_lang.'_'.$language['id_lang']] = $this->trans('The %field_name% field (%lang%) is invalid.',
+                                array('%field_name%' => call_user_func(array($class_name, 'displayFieldName'), $field_lang, $class_name), '%lang%' => $language['name']),
+                                'Admin.Notifications.Error');
                         }
                     }
                 }
@@ -4040,7 +4036,7 @@ class AdminControllerCore extends Controller
                     if ($delete_ok) {
                         PrestaShopLogger::addLog(sprintf($this->l('%s deletion', 'AdminTab', false, false), $this->className), 1, null, $this->className, (int)$to_delete->id, true, (int)$this->context->employee->id);
                     } else {
-                        $this->errors[] = sprintf($this->trans('Can\'t delete #%d', array(), 'Admin.Notifications.Error'), $id);
+                        $this->errors[] = $this->trans('Can\'t delete #%id%', array('%id%' => $id), 'Admin.Notifications.Error');
                     }
                 }
                 if ($result) {

--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -114,12 +114,9 @@ class CustomerAddressFormCore extends AbstractForm
                 if (!$country->checkZipCode($postcode->getValue())) {
                     // FIXME: the translator adapter is crap at the moment,
                     // but once it is not, the sprintf needs to go away.
-                    $postcode->addError(sprintf(
-                        $this->translator->trans(
-                            'Invalid postcode - should look like "%1$s"', [], 'Shop.Forms.Errors'
-                        ),
-                        $country->zip_code_format
-                    ));
+                    $postcode->addError($this->translator->trans('Invalid postcode - should look like "%zipcode%"',
+                        array('%zipcode%' => $country->zip_code_format),
+                        'Shop.Forms.Errors'));
                     $is_valid = false;
                 }
             }

--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -112,8 +112,6 @@ class CustomerAddressFormCore extends AbstractForm
             if ($postcode->isRequired()) {
                 $country = $this->formatter->getCountry();
                 if (!$country->checkZipCode($postcode->getValue())) {
-                    // FIXME: the translator adapter is crap at the moment,
-                    // but once it is not, the sprintf needs to go away.
                     $postcode->addError($this->translator->trans('Invalid postcode - should look like "%zipcode%"',
                         array('%zipcode%' => $country->zip_code_format),
                         'Shop.Forms.Errors'));

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -102,11 +102,8 @@ class CustomerFormCore extends AbstractForm
         $id_customer = Customer::customerExists($emailField->getValue(), true, true);
         $customer = $this->getCustomer();
         if ($id_customer && $id_customer != $customer->id) {
-            $emailField->addError(sprintf(
-                $this->translator->trans(
-                    'The email "%s" is already used, please choose another one or sign in', array(), 'Shop.Notifications.Error'
-                ),
-                $emailField->getValue()
+            $emailField->addError($this->translator->trans(
+                'The email "%mail%" is already used, please choose another one or sign in', array('%mail%' => $emailField->getValue()), 'Shop.Notifications.Error'
             ));
         }
 

--- a/controllers/admin/AdminAdminPreferencesController.php
+++ b/controllers/admin/AdminAdminPreferencesController.php
@@ -94,7 +94,7 @@ class AdminAdminPreferencesControllerCore extends AdminController
                 'fields' => array(
                     'PS_ATTACHMENT_MAXIMUM_SIZE' => array(
                         'title' => $this->trans('Maximum size for attached files', array(), 'Admin.Advparameters.Feature'),
-                        'hint' =>  sprintf($this->trans('Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %s MB).', array(), 'Admin.Advparameters.Help'), $upload_mb),
+                        'hint' =>  $this->trans('Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).', array('%size%' => $upload_mb), 'Admin.Advparameters.Help'),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'text',
@@ -103,7 +103,7 @@ class AdminAdminPreferencesControllerCore extends AdminController
                     ),
                     'PS_LIMIT_UPLOAD_FILE_VALUE' => array(
                         'title' => $this->trans('Maximum size for a downloadable product', array(), 'Admin.Advparameters.Feature'),
-                        'hint' => sprintf($this->trans('Define the upload limit for a downloadable product (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %s MB).', array(), 'Admin.Advparameters.Help'), $upload_mb),
+                        'hint' => $this->trans('Define the upload limit for a downloadable product (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).', array('%size%' => $upload_mb), 'Admin.Advparameters.Help'),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'text',
@@ -112,7 +112,7 @@ class AdminAdminPreferencesControllerCore extends AdminController
                     ),
                     'PS_LIMIT_UPLOAD_IMAGE_VALUE' => array(
                         'title' => $this->trans('Maximum size for a product\'s image', array(), 'Admin.Advparameters.Feature'),
-                        'hint' => sprintf($this->trans('Define the upload limit for an image (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %s MB).', array('%s' => $upload_mb), 'Admin.Advparameters.Help')),
+                        'hint' => $this->trans('Define the upload limit for an image (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).', array('%size%' => $upload_mb), 'Admin.Advparameters.Help'),
                         'validation' => 'isInt',
                         'cast' => 'intval',
                         'type' => 'text',

--- a/controllers/admin/AdminAttachmentsController.php
+++ b/controllers/admin/AdminAttachmentsController.php
@@ -241,14 +241,9 @@ class AdminAttachmentsControllerCore extends AdminController
                     $max_upload = (int)ini_get('upload_max_filesize');
                     $max_post = (int)ini_get('post_max_size');
                     $upload_mb = min($max_upload, $max_post);
-                    $this->errors[] = sprintf(
-                        $this->trans(
-                            'The file %1$s exceeds the size allowed by the server. The limit is set to %2$d MB.',
-                            array(),
-                            'Admin.Catalog.Notification'),
-                        '<b>'.$_FILES['file']['name'].'</b> ',
-                        '<b>'.$upload_mb.'</b>'
-                    );
+                    $this->errors[] = $this->trans('The file %file% exceeds the size allowed by the server. The limit is set to %size% MB.',
+                        array('%file%' => '<b>'.$_FILES['file']['name'].'</b> ', '%size%' => '<b>'.$upload_mb.'</b>'),
+                        'Admin.Catalog.Notification');
                 } elseif (!isset($a) || (isset($a) && !file_exists(_PS_DOWNLOAD_DIR_.$a->file))) {
                     $this->errors[] = $this->trans('Upload error. Please check your server configurations for the maximum upload size allowed.', array(), 'Admin.Catalog.Notification');
                 }

--- a/controllers/admin/AdminAttributeGeneratorController.php
+++ b/controllers/admin/AdminAttributeGeneratorController.php
@@ -234,7 +234,7 @@ class AdminAttributeGeneratorControllerCore extends AdminController
 
             $url = '<a href="'.$adminPerformanceUrl.'#featuresDetachables">'.
                     $this->trans('Performance', array(), 'Admin.Global').'</a>';
-            $this->displayWarning(sprintf($this->trans('This feature has been disabled. You can activate it here: %s.', array('%s' => $url), 'Admin.Catalog.Notification')));
+            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %link%.', array('%link%' => $url), 'Admin.Catalog.Notification'));
             return;
         }
 

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -492,7 +492,7 @@ class AdminAttributesGroupsControllerCore extends AdminController
         } else {
             $adminPerformanceUrl = $this->context->link->getAdminLink('AdminPerformance');
             $url = '<a href="'.$adminPerformanceUrl.'#featuresDetachables">'.$this->trans('Performance', array(), 'Admin.Global').'</a>';
-            $this->displayWarning(sprintf($this->trans('This feature has been disabled. You can activate it here: %s.', array('%s' => $url), 'Admin.Catalog.Notification')));
+            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %link%.', array('%link%' => $url), 'Admin.Catalog.Notification'));
         }
 
         $this->context->smarty->assign(array(

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -185,7 +185,7 @@ class AdminCarrierWizardControllerCore extends AdminController
                         'name' => 'name',
                         'required' => true,
                         'hint' => array(
-                            sprintf($this->trans('Allowed characters: letters, spaces and "%s".', array(), 'Admin.Shipping.Help'), '().-'),
+                            $this->trans('Allowed characters: letters, spaces and "%special_chars%".', array('%special_chars%' => '().-'), 'Admin.Shipping.Help'),
                             $this->trans('The carrier\'s name will be displayed during checkout.', array(), 'Admin.Shipping.Help'),
                             $this->trans('For in-store pickup, enter 0 to replace the carrier name with your shop name.', array(), 'Admin.Shipping.Help')
                         )

--- a/controllers/admin/AdminCarriersController.php
+++ b/controllers/admin/AdminCarriersController.php
@@ -172,7 +172,7 @@ class AdminCarriersControllerCore extends AdminController
                     'name' => 'name',
                     'required' => true,
                     'hint' => array(
-                        sprintf($this->trans('Allowed characters: letters, spaces and %s', array(), 'Admin.Shipping.Help'), '().-'),
+                        $this->trans('Allowed characters: letters, spaces and "%special_chars%".', array('%special_chars%' => '().-'), 'Admin.Shipping.Help'),
                         $this->trans('Carrier name displayed during checkout', array(), 'Admin.Shipping.Help'),
                         $this->trans('For in-store pickup, enter 0 to replace the carrier name with your shop name.', array(), 'Admin.Shipping.Help')
                     )

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -456,9 +456,9 @@ class AdminCategoriesControllerCore extends AdminController
         $guest = new Group(Configuration::get('PS_GUEST_GROUP'));
         $default = new Group(Configuration::get('PS_CUSTOMER_GROUP'));
 
-        $unidentified_group_information = sprintf($this->trans('%s - All people without a valid customer account.', array(), 'Admin.Catalog.Feature'), '<b>'.$unidentified->name[$this->context->language->id].'</b>');
-        $guest_group_information = sprintf($this->trans('%s - Customer who placed an order with the guest checkout.', array(), 'Admin.Catalog.Feature'), '<b>'.$guest->name[$this->context->language->id].'</b>');
-        $default_group_information = sprintf($this->trans('%s - All people who have created an account on this site.', array(), 'Admin.Catalog.Feature'), '<b>'.$default->name[$this->context->language->id].'</b>');
+        $unidentified_group_information = $this->trans('%group_name% - All people without a valid customer account.', array('%group_name%' => '<b>'.$unidentified->name[$this->context->language->id].'</b>'), 'Admin.Catalog.Feature');
+        $guest_group_information = $this->trans('%group_name% - Customer who placed an order with the guest checkout.', array('%group_name%' => '<b>'.$guest->name[$this->context->language->id].'</b>'), 'Admin.Catalog.Feature');
+        $default_group_information = $this->trans('%group_name% - All people who have created an account on this site.', array('%group_name%' => '<b>'.$default->name[$this->context->language->id].'</b>'), 'Admin.Catalog.Feature');
 
         if (!($obj = $this->loadObject(true))) {
             return;

--- a/controllers/admin/AdminCurrenciesController.php
+++ b/controllers/admin/AdminCurrenciesController.php
@@ -323,7 +323,7 @@ class AdminCurrenciesControllerCore extends AdminController
             $cronJobs = new CronJobs();
             $cronJobs->addOneShotTask(
                 $cronJobUrl,
-                sprintf($this->trans('Live exchange Rate for %s', array(), 'Admin.International.Feature'), Configuration::get('PS_SHOP_NAME'))
+                $this->trans('Live exchange Rate for %shop_name%', array('%shop_name%' => Configuration::get('PS_SHOP_NAME')), 'Admin.International.Feature')
             );
 
             Configuration::updateValue('PS_ACTIVE_CRONJOB_EXCHANGE_RATE', Db::getInstance()->Insert_ID(), false, null, $this->context->shop->id);

--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -249,7 +249,7 @@ class AdminCustomersControllerCore extends AdminController
                 /** @var Customer $customer */
                 if (($customer = $this->loadObject(true)) && Validate::isLoadedObject($customer)) {
                     array_pop($this->toolbar_title);
-                    $this->toolbar_title[] = sprintf($this->trans('Information about customer %s', array(), 'Admin.Orderscustomers.Feature'), Tools::substr($customer->firstname, 0, 1).'. '.$customer->lastname);
+                    $this->toolbar_title[] = $this->trans('Information about customer %name%', array('%name%' => Tools::substr($customer->firstname, 0, 1).'. '.$customer->lastname), 'Admin.Orderscustomers.Feature');
                 }
                 break;
             case 'add':
@@ -257,7 +257,7 @@ class AdminCustomersControllerCore extends AdminController
                 array_pop($this->toolbar_title);
                 /** @var Customer $customer */
                 if (($customer = $this->loadObject(true)) && Validate::isLoadedObject($customer)) {
-                    $this->toolbar_title[] = sprintf($this->trans('Editing customer %s', array(), 'Admin.Orderscustomers.Feature'), Tools::substr($customer->firstname, 0, 1).'. '.$customer->lastname);
+                    $this->toolbar_title[] = $this->trans('Editing customer %name%', array('%name%' => Tools::substr($customer->firstname, 0, 1).'. '.$customer->lastname), 'Admin.Orderscustomers.Feature');
                 } else {
                     $this->toolbar_title[] = $this->trans('Creating a new Customer', array(), 'Admin.Orderscustomers.Feature');
                 }
@@ -397,7 +397,7 @@ class AdminCustomersControllerCore extends AdminController
                     'required' => ($obj->id ? false : true),
                     'col' => '4',
                     'hint' => ($obj->id ? $this->trans('Leave this field blank if there\'s no change.', array(), 'Admin.Orderscustomers.Help') :
-                        sprintf($this->trans('Password should be at least %s characters long.', array(), 'Admin.Orderscustomers.Help'), Validate::PASSWORD_LENGTH))
+                        $this->trans('Password should be at least %length% characters long.', array('%length%' => Validate::PASSWORD_LENGTH), 'Admin.Orderscustomers.Help'))
                 ),
                 array(
                     'type' => 'birthday',
@@ -682,10 +682,10 @@ class AdminCustomersControllerCore extends AdminController
         $gender_image = $gender->getImage();
 
         $customer_stats = $customer->getStats();
-        $sql = 'SELECT SUM(total_paid_real) FROM '._DB_PREFIX_.'orders WHERE id_customer = %d AND valid = 1';
-        if ($total_customer = Db::getInstance()->getValue(sprintf($sql, $customer->id))) {
-            $sql = 'SELECT SQL_CALC_FOUND_ROWS COUNT(*) FROM '._DB_PREFIX_.'orders WHERE valid = 1 AND id_customer != '.(int)$customer->id.' GROUP BY id_customer HAVING SUM(total_paid_real) > %d';
-            Db::getInstance()->getValue(sprintf($sql, (int)$total_customer));
+        $sql = 'SELECT SUM(total_paid_real) FROM '._DB_PREFIX_.'orders WHERE id_customer = '.(int)$customer->id.' AND valid = 1';
+        if ($total_customer = Db::getInstance()->getValue($sql)) {
+            $sql = 'SELECT SQL_CALC_FOUND_ROWS COUNT(*) FROM '._DB_PREFIX_.'orders WHERE valid = 1 AND id_customer != '.(int)$customer->id.' GROUP BY id_customer HAVING SUM(total_paid_real) > '.(int)$total_customer;
+            Db::getInstance()->getValue($sql);
             $count_better_customers = (int)Db::getInstance()->getValue('SELECT FOUND_ROWS()') + 1;
         } else {
             $count_better_customers = '-';

--- a/controllers/admin/AdminEmployeesController.php
+++ b/controllers/admin/AdminEmployeesController.php
@@ -259,14 +259,14 @@ class AdminEmployeesControllerCore extends AdminController
                     'type' => 'html',
                     'name' => 'employee_avatar',
                     'html_content' => '<div id="employee-thumbnail"><a href="http://www.prestashop.com/forums/index.php?app=core&amp;module=usercp" target="_blank" style="background-image:url('.$obj->getImage().')"></a></div>
-					<div id="employee-avatar-thumbnail" class="alert alert-info">'.sprintf($this->trans(
+					<div id="employee-avatar-thumbnail" class="alert alert-info">'.$this->trans(
                         'Your avatar in PrestaShop 1.7.x is your profile picture on %url%. To change your avatar, log in to PrestaShop.com with your email %email% and follow the on-screen instructions.',
                         array(
                             '%url%' => '<a href="http://www.prestashop.com/forums/index.php?app=core&amp;module=usercp" class="alert-link" target="_blank">PrestaShop.com</a>',
                             '%email%' => $obj->email,
                         ),
                         'Admin.Advparameters.Help'
-                        )).'
+                        ).'
                     </div>',
                 ),
                 array(
@@ -595,8 +595,7 @@ class AdminEmployeesControllerCore extends AdminController
         $employee = new Employee((int)Tools::getValue('id_employee'));
 
         if (!Validate::isLoadedObject($employee) && !Validate::isPasswd(Tools::getvalue('passwd'), Validate::ADMIN_PASSWORD_LENGTH)) {
-            return !($this->errors[] = sprintf($this->trans('The password must be at least %s characters long.', array(), 'Admin.Advparameters.Notification'),
-                Validate::ADMIN_PASSWORD_LENGTH));
+            return !($this->errors[] = $this->trans('The password must be at least %length% characters long.', array('%length%' => Validate::ADMIN_PASSWORD_LENGTH), 'Admin.Advparameters.Notification'));
         }
 
         return parent::validateRules($class_name);

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -432,7 +432,7 @@ class AdminFeaturesControllerCore extends AdminController
         } else {
             $adminPerformanceUrl = $this->context->link->getAdminLink('AdminPerformance');
             $url = '<a href="'.$adminPerformanceUrl.'#featuresDetachables">'.$this->trans('Performance', array(), 'Admin.Global').'</a>';
-            $this->displayWarning(sprintf($this->trans('This feature has been disabled. You can activate it here: %s.', array(), 'Admin.Catalog.Notification'), $url));
+            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %url%.', array('%url%' => $url), 'Admin.Catalog.Notification'));
         }
 
         $this->context->smarty->assign(array(

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -568,18 +568,9 @@ class AdminGroupsControllerCore extends AdminController
         $guest = new Group(Configuration::get('PS_GUEST_GROUP'));
         $default = new Group(Configuration::get('PS_CUSTOMER_GROUP'));
 
-        $unidentified_group_information = sprintf(
-            $this->trans('%s - All persons without a customer account or customers that are not logged in.', array(), 'Admin.Shopparameters.Help'),
-            '<b>'.$unidentified->name[$this->context->language->id].'</b>'
-        );
-        $guest_group_information = sprintf(
-            $this->trans('%s - All persons who placed an order through Guest Checkout.', array(), 'Admin.Shopparameters.Help'),
-            '<b>'.$guest->name[$this->context->language->id].'</b>'
-        );
-        $default_group_information = sprintf(
-            $this->trans('%s - All persons who created an account on this site.', array(), 'Admin.Shopparameters.Help'),
-            '<b>'.$default->name[$this->context->language->id].'</b>'
-        );
+        $unidentified_group_information = $this->trans('%group_name% - All persons without a customer account or customers that are not logged in.', array('%group_name%' => '<b>'.$unidentified->name[$this->context->language->id].'</b>'), 'Admin.Shopparameters.Help');
+        $guest_group_information = $this->trans('%group_name% - All persons who placed an order through Guest Checkout.', array('%group_name%' => '<b>'.$guest->name[$this->context->language->id].'</b>'), 'Admin.Shopparameters.Help');
+        $default_group_information = $this->trans('%group_name% - All persons who created an account on this site.', array('%group_name%' => '<b>'.$default->name[$this->context->language->id].'</b>'), 'Admin.Shopparameters.Help');
 
         $this->displayInformation($this->trans('PrestaShop has three default customer groups:', array(), 'Admin.Shopparameters.Help'));
         $this->displayInformation($unidentified_group_information);

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -335,7 +335,7 @@ class AdminImagesControllerCore extends AdminController
     {
         // When moving images, if duplicate images were found they are moved to a folder named duplicates/
         if (file_exists(_PS_PROD_IMG_DIR_.'duplicates/')) {
-            $this->warnings[] = sprintf($this->trans('Duplicate images were found when moving the product images. This is likely caused by unused demonstration images. Please make sure that the folder %s only contains demonstration images, and then delete it.', array(), 'Admin.Design.Notification'), _PS_PROD_IMG_DIR_.'duplicates/');
+            $this->warnings[] = $this->trans('Duplicate images were found when moving the product images. This is likely caused by unused demonstration images. Please make sure that the folder %folder% only contains demonstration images, and then delete it.', array('%folder%' => _PS_PROD_IMG_DIR_.'duplicates/'), 'Admin.Design.Notification');
         }
 
         if (Tools::isSubmit('submitRegenerate'.$this->table)) {

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1355,11 +1355,9 @@ class AdminImportControllerCore extends AdminController
                     $category->id_parent = $category_to_create->id;
                 } else {
                     if (!$validateOnly) {
-                        $this->errors[] = sprintf(
-                            $this->trans('%1$s (ID: %2$s) cannot be saved', array(), 'Admin.Advparameters.Notification'),
-                            $category_to_create->name[$id_lang],
-                            (isset($category_to_create->id) && !empty($category_to_create->id))? $category_to_create->id : 'null'
-                        );
+                        $this->errors[] =$this->trans('%category_name% (ID: %id%) cannot be saved', array(
+                            '%category_name%' => $category_to_create->name[$id_lang],
+                            '%id%' => (isset($category_to_create->id) && !empty($category_to_create->id))? $category_to_create->id : 'null'), 'Admin.Advparameters.Notification');
                     }
                     if ($field_error !== true || isset($lang_field_error) && $lang_field_error !== true) {
                         $this->errors[] = ($field_error !== true ? $field_error : '').(isset($lang_field_error) && $lang_field_error !== true ? $lang_field_error : '').

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1385,7 +1385,7 @@ class AdminImportControllerCore extends AdminController
             $category->link_rewrite = Tools::link_rewrite($category->name[$default_language_id]);
             if ($category->link_rewrite == '') {
                 $category->link_rewrite = 'friendly-url-autogeneration-failed';
-                $this->warnings[] = sprintf($this->trans('URL rewriting failed to auto-generate a friendly URL for: %s', array(), 'Admin.Advparameters.Notification'), $category->name[$default_language_id]);
+                $this->warnings[] = $this->trans('URL rewriting failed to auto-generate a friendly URL for: %category_name%', array('%category_name%' => $category->name[$default_language_id]), 'Admin.Advparameters.Notification');
             }
             $category->link_rewrite = AdminImportController::createMultiLangField($category->link_rewrite);
         }
@@ -2132,7 +2132,7 @@ class AdminImportControllerCore extends AdminController
                             $image->associateTo($shops);
                             if (!AdminImportController::copyImg($product->id, $image->id, $url, 'products', !$regenerate)) {
                                 $image->delete();
-                                $this->warnings[] = sprintf($this->trans('Error copying image: %s', array(), 'Admin.Advparameters.Notification'), $url);
+                                $this->warnings[] = $this->trans('Error copying image: %url%', array('%url%' => $url), 'Admin.Advparameters.Notification');
                             }
                         } else {
                             $error = true;
@@ -2142,7 +2142,7 @@ class AdminImportControllerCore extends AdminController
                     }
 
                     if ($error) {
-                        $this->warnings[] = sprintf($this->trans('Product #%1$d: the picture (%2$s) cannot be saved.', array(), 'Admin.Advparameters.Notification'), $image->id_product, $url);
+                        $this->warnings[] = $this->trans('Product #%id%: the picture (%url%) cannot be saved.', array('%id%' => $image->id_product, '%url%'  => $url), 'Admin.Advparameters.Notification');
                     }
                 }
             }
@@ -2186,9 +2186,9 @@ class AdminImportControllerCore extends AdminController
             // set advanced stock managment
             if (!$validateOnly && isset($product->advanced_stock_management)) {
                 if ($product->advanced_stock_management != 1 && $product->advanced_stock_management != 0) {
-                    $this->warnings[] = sprintf($this->trans('Advanced stock management has incorrect value. Not set for product %1$s ', array(), 'Admin.Advparameters.Notification'), $product->name[$default_language_id]);
+                    $this->warnings[] = $this->trans('Advanced stock management has incorrect value. Not set for product %name% ', array('%name%' => $product->name[$default_language_id]), 'Admin.Advparameters.Notification');
                 } elseif (!Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') && $product->advanced_stock_management == 1) {
-                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, cannot enable on product %1$s ', array(), 'Admin.Advparameters.Notification'), $product->name[$default_language_id]);
+                    $this->warnings[] = $this->trans('Advanced stock management is not enabled, cannot enable on product %name% ', array('%name%' => $product->name[$default_language_id]), 'Admin.Advparameters.Notification');
                 } elseif ($update_advanced_stock_management_value) {
                     $product->setAdvancedStockManagement($product->advanced_stock_management);
                 }
@@ -2201,7 +2201,7 @@ class AdminImportControllerCore extends AdminController
             // Check if warehouse exists
             if (isset($product->warehouse) && $product->warehouse) {
                 if (!Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
-                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, warehouse not set on product %1$s ', array(), 'Admin.Advparameters.Notification'), $product->name[$default_language_id]);
+                    $this->warnings[] = $this->trans('Advanced stock management is not enabled, warehouse not set on product %name% ', array('%name%' => $product->name[$default_language_id]), 'Admin.Advparameters.Notification');
                 } elseif (!$validateOnly) {
                     if (Warehouse::exists($product->warehouse)) {
                         // Get already associated warehouses
@@ -2221,7 +2221,7 @@ class AdminImportControllerCore extends AdminController
                         }
                         StockAvailable::synchronize($product->id);
                     } else {
-                        $this->warnings[] = sprintf($this->trans('Warehouse did not exist, cannot set on product %1$s.', array(), 'Admin.Advparameters.Notification'), $product->name[$default_language_id]);
+                        $this->warnings[] = $this->trans('Warehouse did not exist, cannot set on product  %name% ', array('%name%' => $product->name[$default_language_id]), 'Admin.Advparameters.Notification');
                     }
                 }
             }
@@ -2229,9 +2229,9 @@ class AdminImportControllerCore extends AdminController
             // stock available
             if (isset($product->depends_on_stock)) {
                 if ($product->depends_on_stock != 0 && $product->depends_on_stock != 1) {
-                    $this->warnings[] = sprintf($this->trans('Incorrect value for "Depends on stock" for product %1$s ', array(), 'Admin.Advparameters.Notification'), $product->name[$default_language_id]);
+                    $this->warnings[] = $this->trans('Incorrect value for "Depends on stock" for product %name% ', array('%name%' => $product->name[$default_language_id]), 'Admin.Advparameters.Notification');
                 } elseif ((!$product->advanced_stock_management || $product->advanced_stock_management == 0) && $product->depends_on_stock == 1) {
-                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, cannot set "Depends on stock" for product %1$s ', array(), 'Admin.Advparameters.Notification'), $product->name[$default_language_id]);
+                    $this->warnings[] = $this->trans('Advanced stock management is not enabled, cannot set "Depends on stock" for product %name% ', array('%name%' => $product->name[$default_language_id]), 'Admin.Advparameters.Notification');
                 } elseif (!$validateOnly) {
                     StockAvailable::setProductDependsOnStock($product->id, $product->depends_on_stock);
                 }
@@ -2449,7 +2449,7 @@ class AdminImportControllerCore extends AdminController
                         $image->associateTo($id_shop_list);
                         // FIXME: 2s/image !
                         if (!AdminImportController::copyImg($product->id, $image->id, $url, 'products', !$regenerate)) {
-                            $this->warnings[] = sprintf($this->trans('Error copying image: %s', array(), 'Admin.Advparameters.Notification'), $url);
+                            $this->warnings[] = $this->trans('Error copying image: %url%', array('%url%' => $url), 'Admin.Advparameters.Notification');
                             $image->delete();
                         } else {
                             $id_image[] = (int)$image->id;
@@ -2608,7 +2608,7 @@ class AdminImportControllerCore extends AdminController
                     $info['available_date'] = Validate::isDate($info['available_date']) ? $info['available_date'] : null;
 
                     if (!Validate::isEan13($info['ean13'])) {
-                        $this->warnings[] = sprintf($this->trans('EAN13 "%1s" has incorrect value for product with id %2d.', array(), 'Admin.Advparameters.Notification'), $info['ean13'], $product->id);
+                        $this->warnings[] = $this->trans('EAN13 "%ean13%" has incorrect value for product with id %id%.', array('%ean13%' => $info['ean13'], '%id%' => $product->id), 'Admin.Advparameters.Notification');
                         $info['ean13'] = '';
                     }
 
@@ -2725,9 +2725,9 @@ class AdminImportControllerCore extends AdminController
             // set advanced stock managment
             if (isset($info['advanced_stock_management'])) {
                 if ($info['advanced_stock_management'] != 1 && $info['advanced_stock_management'] != 0) {
-                    $this->warnings[] = sprintf($this->trans('Advanced stock management has incorrect value. Not set for product with id %d.', array(), 'Admin.Advparameters.Notification'), $product->id);
+                    $this->warnings[] = $this->trans('Advanced stock management has incorrect value. Not set for product with id %id%.', array('%id%' => $product->id), 'Admin.Advparameters.Notification');
                 } elseif (!Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') && $info['advanced_stock_management'] == 1) {
-                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, cannot enable on product with id %d.', array(), 'Admin.Advparameters.Notification'), $product->id);
+                    $this->warnings[] = $this->trans('Advanced stock management is not enabled, cannot enable on product with id %id%.', array('%id%' => $product->id), 'Admin.Advparameters.Notification');
                 } elseif (!$validateOnly) {
                     $product->setAdvancedStockManagement($info['advanced_stock_management']);
                 }
@@ -2740,7 +2740,7 @@ class AdminImportControllerCore extends AdminController
             // Check if warehouse exists
             if (isset($info['warehouse']) && $info['warehouse']) {
                 if (!Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
-                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, warehouse is not set on product with id %d.', array(), 'Admin.Advparameters.Notification'), $product->id);
+                    $this->warnings[] = $this->trans('Advanced stock management is not enabled, warehouse is not set on product with id %id%.', array('%id%' => $product->id), 'Admin.Advparameters.Notification');
                 } else {
                     if (Warehouse::exists($info['warehouse'])) {
                         $warehouse_location_entity = new WarehouseProductLocation();
@@ -2756,7 +2756,7 @@ class AdminImportControllerCore extends AdminController
                             StockAvailable::synchronize($product->id);
                         }
                     } else {
-                        $this->warnings[] = sprintf($this->trans('Warehouse did not exist, cannot set on product %1$s.', array(), 'Admin.Advparameters.Notification'), $product->name[$default_language]);
+                        $this->warnings[] = $this->trans('Warehouse did not exist, cannot set on product %name%.', array('%name%' => $product->name[$default_language]), 'Admin.Advparameters.Notification');
                     }
                 }
             }
@@ -2764,9 +2764,9 @@ class AdminImportControllerCore extends AdminController
             // stock available
             if (isset($info['depends_on_stock'])) {
                 if ($info['depends_on_stock'] != 0 && $info['depends_on_stock'] != 1) {
-                    $this->warnings[] = sprintf($this->trans('Incorrect value for "Depends on stock" for product %1$s ', array(), 'Admin.Notifications.Error'), $product->name[$default_language]);
+                    $this->warnings[] = $this->trans('Incorrect value for "Depends on stock" for product %name% ', array('%name%' => $product->name[$default_language]), 'Admin.Notifications.Error');
                 } elseif ((!$info['advanced_stock_management'] || $info['advanced_stock_management'] == 0) && $info['depends_on_stock'] == 1) {
-                    $this->warnings[] = sprintf($this->trans('Advanced stock management is not enabled, cannot set "Depends on stock" for product %1$s ', array(), 'Admin.Advparameters.Notification'), $product->name[$default_language]);
+                    $this->warnings[] = $this->trans('Advanced stock management is not enabled, cannot set "Depends on stock" for product %name% ', array('%name%' => $product->name[$default_language]), 'Admin.Advparameters.Notification');
                 } elseif (!$validateOnly) {
                     StockAvailable::setProductDependsOnStock($product->id, $info['depends_on_stock'], null, $id_product_attribute);
                 }
@@ -3228,7 +3228,7 @@ class AdminImportControllerCore extends AdminController
                     }
                 }
             } else {
-                $this->errors[] = sprintf($this->trans('"%s" is not a valid email address.', array(), 'Admin.Advparameters.Notification'), $address->customer_email);
+                $this->errors[] = $this->trans('"%email%" is not a valid email address.', array('%email%' => $address->customer_email), 'Admin.Advparameters.Notification');
                 return;
             }
         } elseif (isset($address->id_customer) && !empty($address->id_customer)) {
@@ -3916,33 +3916,35 @@ class AdminImportControllerCore extends AdminController
         $error = '';
         // checks parameters
         if (!Supplier::supplierExists($id_supplier)) {
-            $error = sprintf($this->trans('Supplier ID (%d) is not valid (at line %d).', array(), 'Admin.Advparameters.Notification'), $id_supplier, $current_line + 1);
+            $error = $this->trans('Supplier ID (%id%) is not valid (at line %line%).', array('%id%' => $id_supplier, '%line%' => $current_line + 1), 'Admin.Advparameters.Notification');
         }
         if (!Language::getLanguage($id_lang)) {
-            $error = sprintf($this->trans('Lang ID (%d) is not valid (at line %d).', array(), 'Admin.Advparameters.Notification'), $id_lang, $current_line + 1);
+            $error = $this->trans('Lang ID (%id%) is not valid (at line %line%).', array('%id%' => $id_lang, '%line%' => $current_line + 1), 'Admin.Advparameters.Notification');
         }
         if (!Warehouse::exists($id_warehouse)) {
-            $error = sprintf($this->trans('Warehouse ID (%d) is not valid (at line %d).', array(), 'Admin.Advparameters.Notification'), $id_warehouse, $current_line + 1);
+            $error = $this->trans('Warehouse ID (%id%) is not valid (at line %line%).', array('%id%' => $id_warehouse, '%line%' => $current_line + 1), 'Admin.Advparameters.Notification');
         }
         if (!Currency::getCurrency($id_currency)) {
-            $error = sprintf($this->trans('Currency ID (%d) is not valid (at line %d).', array(), 'Admin.Advparameters.Notification'), $id_currency, $current_line + 1);
+            $error = $this->trans('Currency ID (%id%) is not valid (at line %line%).', array('%id%' => $id_currency, '%line%' => $current_line + 1), 'Admin.Advparameters.Notification');
         }
         if (empty($supply_order->reference) && SupplyOrder::exists($reference)) {
-            $error = sprintf($this->trans('Reference (%s) already exists (at line %d).', array(), 'Admin.Advparameters.Notification'), $reference, $current_line + 1);
+            $error = $this->trans('Reference (%ref%) already exists (at line %line%).', array('%ref%' => $reference, '%line%' => $current_line + 1), 'Admin.Advparameters.Notification');
         }
         if (!empty($supply_order->reference) && ($supply_order->reference != $reference && SupplyOrder::exists($reference))) {
-            $error = sprintf($this->trans('Reference (%s) already exists (at line %d).', array(), 'Admin.Advparameters.Notification'), $reference, $current_line + 1);
+            $error = $this->trans('Reference (%ref%) already exists (at line %line%).', array('%ref%' => $reference, '%line%' => $current_line + 1), 'Admin.Advparameters.Notification');
         }
         if (!Validate::isDateFormat($date_delivery_expected)) {
-            $error = sprintf($this->trans('Date format (%s) is not valid (at line %d). It should be: %s.', array(), 'Admin.Advparameters.Notification'), $date_delivery_expected, $current_line + 1, $this->trans('YYYY-MM-DD', array(), 'Admin.Advparameters.Notification'));
+            $error = $this->trans('Date format (%date%) is not valid (at line %line%). It should be: %date_format%.', array('%date%' => $date_delivery_expected, '%line%' => $current_line + 1, '%date_format%' => $this->trans('YYYY-MM-DD', array(), 'Admin.Advparameters.Notification')), 'Admin.Advparameters.Notification');
         } elseif (new DateTime($date_delivery_expected) <= new DateTime('yesterday')) {
-            $error = sprintf($this->trans('Date (%s) cannot be in the past (at line %d). Format: %s.', array(), 'Admin.Advparameters.Notification'), $date_delivery_expected, $current_line + 1, $this->trans('YYYY-MM-DD', array(), 'Admin.Advparameters.Notification'));
+            $error = $this->trans('Date (%date%) cannot be in the past (at line %line%). Format: %date_format%.', array('%date%' => $date_delivery_expected, '%line%' => $current_line + 1, '%date_format%' => $this->trans('YYYY-MM-DD', array(), 'Admin.Advparameters.Notification')), 'Admin.Advparameters.Notification');
         }
         if ($discount_rate < 0 || $discount_rate > 100) {
-            $error = sprintf($this->trans('Discount rate (%d) is not valid (at line %d). %s.', array(), 'Admin.Advparameters.Notification'), $discount_rate, $current_line + 1, $this->trans('Format: Between 0 and 100', array(), 'Admin.Advparameters.Notification'));
+            $error = $this->trans('Discount rate (%rate%) is not valid (at line %line%). %format%.',
+                array('%rate%' => $discount_rate, '%line%' => $current_line + 1, '%format%' => $this->trans('Format: Between 0 and 100', array(), 'Admin.Advparameters.Notification')),
+                'Admin.Advparameters.Notification');
         }
         if ($supply_order->id > 0 && !$supply_order->isEditable()) {
-            $error = sprintf($this->trans('Supply Order (%d) is not editable (at line %d).', array(), 'Admin.Advparameters.Notification'), $supply_order->id, $current_line + 1);
+            $error = $this->trans('Supply Order (%id%) is not editable (at line %line%).', array('%id%' => $supply_order->id, '%line%' => $current_line + 1), 'Admin.Advparameters.Notification');
         }
 
         // if no errors, sets supply order
@@ -3973,7 +3975,7 @@ class AdminImportControllerCore extends AdminController
 
             // errors
             if (!$res) {
-                $this->errors[] = sprintf($this->trans('Supply Order could not be saved (at line %d).', array(), 'Admin.Advparameters.Notification'), $current_line + 1);
+                $this->errors[] = $this->trans('Supply Order could not be saved (at line %line%).', array('%line%' => $current_line + 1), 'Admin.Advparameters.Notification');
             }
         } else {
             $this->errors[] = $error;

--- a/controllers/admin/AdminLanguagesController.php
+++ b/controllers/admin/AdminLanguagesController.php
@@ -170,7 +170,7 @@ class AdminLanguagesControllerCore extends AdminController
                     'label' => $this->trans('Date format', array(), 'Admin.International.Feature'),
                     'name' => 'date_format_lite',
                     'required' => true,
-                    'hint' => sprintf($this->trans('Short date format (e.g., %s).', array(), 'Admin.International.Help'), 'Y-m-d')
+                    'hint' => $this->trans('Short date format (e.g., Y-m-d).', array(), 'Admin.International.Help'),
                     /* TO DO - ajouter les liens dans le hint ? */
                     /*'desc' => sprintf($this->trans('Short date format (e.g., %s)'), '<a href="http://php.net/date" target="_blank">Y-m-d</a>')*/
                 ),
@@ -179,7 +179,7 @@ class AdminLanguagesControllerCore extends AdminController
                     'label' => $this->trans('Date format (full)', array(), 'Admin.International.Feature'),
                     'name' => 'date_format_full',
                     'required' => true,
-                    'hint' => sprintf($this->trans('Full date format (e.g., %s).', array(), 'Admin.International.Help'), 'Y-m-d H:i:s')
+                    'hint' => $this->trans('Full date format (e.g., Y-m-d H:i:s).', array(), 'Admin.International.Help'),
                     /* TO DO - ajouter les liens dans le hint ? */
                     /*'desc' => sprintf($this->trans('Full date format (e.g., %s)'), '<a href="http://php.net/date" target="_blank">Y-m-d H:i:s</a>')*/
                 ),

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -206,7 +206,7 @@ class AdminLoginControllerCore extends AdminController
                 $this->errors[] = $this->trans('This employee does not manage the shop anymore (either the shop has been deleted or permissions have been revoked).', array(), 'Admin.Login.Notification');
                 $this->context->employee->logout();
             } else {
-                PrestaShopLogger::addLog(sprintf($this->trans('Back office connection from %s', array(), 'Admin.Advparameters.Feature'), Tools::getRemoteAddr()), 1, null, '', 0, true, (int)$this->context->employee->id);
+                PrestaShopLogger::addLog($this->trans('Back office connection from %ip%', array('%ip%' => Tools::getRemoteAddr()), 'Admin.Advparameters.Feature'), 1, null, '', 0, true, (int)$this->context->employee->id);
 
                 $this->context->employee->remote_addr = (int)ip2long(Tools::getRemoteAddr());
                 // Update cookie
@@ -256,10 +256,7 @@ class AdminLoginControllerCore extends AdminController
             if (!$employee->getByEmail($email) || !$employee) {
                 $this->errors[] = $this->trans('This account does not exist.', array(), 'Admin.Login.Notification');
             } elseif ((strtotime($employee->last_passwd_gen.'+'.Configuration::get('PS_PASSWD_TIME_BACK').' minutes') - time()) > 0) {
-                $this->errors[] = sprintf(
-                    $this->trans('You can reset your password every %d minute(s) only. Please try again later.', array(), 'Admin.Login.Notification'),
-                    Configuration::get('PS_PASSWD_TIME_BACK')
-                );
+                $this->errors[] = $this->trans('You can reset your password every %interval% minute(s) only. Please try again later.', array('%interval%' => Configuration::get('PS_PASSWD_TIME_BACK')), 'Admin.Login.Notification');
             }
         }
 
@@ -336,10 +333,7 @@ class AdminLoginControllerCore extends AdminController
             if (!$employee->getByEmail($reset_email) || !$employee || $employee->id != $id_employee) { // check matching employee id with its email
                 $this->errors[] = $this->trans('This account does not exist.', array(), 'Admin.Login.Notification');
             } elseif ((strtotime($employee->last_passwd_gen.'+'.Configuration::get('PS_PASSWD_TIME_BACK').' minutes') - time()) > 0) {
-                $this->errors[] = sprintf(
-                    $this->trans('You can reset your password every %d minute(s) only. Please try again later.', array(), 'Admin.Login.Notification'),
-                    Configuration::get('PS_PASSWD_TIME_BACK')
-                );
+                $this->errors[] = $this->trans('You can reset your password every %interval% minute(s) only. Please try again later.', array('%interval%' => Configuration::get('PS_PASSWD_TIME_BACK')), 'Admin.Login.Notification');
             } elseif ($employee->getValidResetPasswordToken() !== $reset_token_value) {
                 // To update password, we must have the temporary reset token that matches.
                 $this->errors[] = $this->trans('Your password reset request expired. Please start again.', array(), 'Admin.Login.Notification');

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -264,7 +264,7 @@ class AdminMetaControllerCore extends AdminController
 
         $this->fields_options['routes']['fields']['PS_ROUTE_'.$route_id] = array(
             'title' =>    $title,
-            'desc' => sprintf($this->trans('Keywords: %s', array(), 'Admin.Shopparameters.Feature'), implode(', ', $keywords)),
+            'desc' => $this->trans('Keywords: %keywords%', array('%keywords%' => implode(', ', $keywords)), 'Admin.Shopparameters.Feature'),
             'validation' => 'isString',
             'type' => 'text',
             'size' => 70,

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -377,7 +377,7 @@ class AdminOrdersControllerCore extends AdminController
                 $order_state = new OrderState($id_order_state);
 
                 if (!Validate::isLoadedObject($order_state)) {
-                    $this->errors[] = sprintf($this->trans('Order status #%d cannot be loaded', array(), 'Admin.Orderscustomers.Notification'), $id_order_state);
+                    $this->errors[] = $this->trans('Order status #%id% cannot be loaded', array('%id%' => $id_order_state), 'Admin.Orderscustomers.Notification');
                 } else {
                     foreach (Tools::getValue('orderBox') as $id_order) {
                         $order = new Order((int)$id_order);
@@ -1718,7 +1718,7 @@ class AdminOrdersControllerCore extends AdminController
         );
         if (Shop::isFeatureActive()) {
             $shop = new Shop((int)$order->id_shop);
-            $this->toolbar_title .= ' - '.sprintf($this->trans('Shop: %s', array(), 'Admin.Orderscustomers.Feature'), $shop->name);
+            $this->toolbar_title .= ' - '.$this->trans('Shop: %shop_name%', array('%shop_name%' => $shop->name), 'Admin.Orderscustomers.Feature');
         }
 
         // gets warehouses to ship products, if and only if advanced stock management is activated

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2003,10 +2003,7 @@ class AdminProductsControllerCore extends AdminController
                 if (Tools::getValue('id_'.$this->table) && $field == 'passwd') {
                     continue;
                 }
-                $this->errors[] = sprintf(
-                    $this->trans('The %s field is required.', array(), 'Admin.Notifications.Error'),
-                    call_user_func(array($this->className, 'displayFieldName'), $field, $this->className)
-                );
+                $this->errors[] = $this->trans('The %name% field is required.', array('%name%' => call_user_func(array($this->className, 'displayFieldName'), $field, $this->className)), 'Admin.Notifications.Error');
             }
         }
 

--- a/controllers/admin/AdminQuickAccessesController.php
+++ b/controllers/admin/AdminQuickAccessesController.php
@@ -189,7 +189,7 @@ class AdminQuickAccessesControllerCore extends AdminController
                     ' <b>'.$this->table.' ('.Db::getInstance()->getMsgError().')</b>';
             } elseif (($_POST[$this->identifier] = $this->object->id) && $this->postImage($this->object->id) && !count($this->errors) && $this->_redirect) {
                 // voluntary do affectation here
-                PrestaShopLogger::addLog(sprintf($this->trans('%s addition', array(), 'Admin.Advparameters.Feature'), $this->className), 1, null, $this->className, (int)$this->object->id, true, (int)$this->context->employee->id);
+                PrestaShopLogger::addLog($this->trans('%class_name% addition', array('%class_name%' => $this->className), 'Admin.Advparameters.Feature'), 1, null, $this->className, (int)$this->object->id, true, (int)$this->context->employee->id);
                 $this->afterAdd($this->object);
             }
         }

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -516,11 +516,11 @@ class AdminRequestSqlControllerCore extends AdminController
                     break;
 
                 case 'testedRequired':
-                    $this->errors[] = sprintf($this->trans('"%s" does not exist.', array(), 'Admin.Notifications.Error'), $e[$key]);
+                    $this->errors[] = $this->trans('"%key%" does not exist.', array('%key%' => $e[$key]), 'Admin.Notifications.Error');
                     break;
 
                 case 'testedUnauthorized':
-                    $this->errors[] = sprintf($this->trans('"%s" is an unauthorized keyword.', array(), 'Admin.Advparameters.Notification'), $e[$key]);
+                    $this->errors[] = $this->trans('"%key%" is an unauthorized keyword.', array('%key%' => $e[$key]), 'Admin.Advparameters.Notification');
                     break;
             }
         }

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -762,7 +762,7 @@ class AdminShopControllerCore extends AdminController
                         'icon' => 'themes/'.$this->context->employee->bo_theme.'/img/tree-multishop-groups.png',
                         'attr' => array(
                             'href' => $this->context->link->getAdminLink('AdminShop').'&id_shop_group='.$id_shop_group,
-                            'title' => sprintf($this->trans('Click here to display the shops in the %s shop group', array(), 'Admin.Advparameters.Help'), $row['group_name']),
+                            'title' => $this->trans('Click here to display the shops in the %name% shop group', array('%name%' => $row['group_name']), 'Admin.Advparameters.Help'),
                         ),
                     ),
                     'attr' => array(
@@ -784,7 +784,7 @@ class AdminShopControllerCore extends AdminController
                         'icon' => 'themes/'.$this->context->employee->bo_theme.'/img/tree-multishop-shop.png',
                         'attr' => array(
                             'href' => $this->context->link->getAdminLink('AdminShopUrl').'&shop_id='.(int)$id_shop,
-                            'title' => sprintf($this->trans('Click here to display the URLs of the %s shop', array(), 'Admin.Advparameters.Help'), $row['shop_name']),
+                            'title' => $this->trans('Click here to display the URLs of the %name% shop', array('%name%' => $row['shop_name']), 'Admin.Advparameters.Help'),
                         )
                     ),
                     'attr' => array(

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -364,8 +364,12 @@ class AdminShopControllerCore extends AdminController
                 array(
                     'type' => 'text',
                     'label' => $this->trans('Shop name', array(), 'Admin.Shopparameters.Feature'),
-                    'desc' => array($this->trans('This field does not refer to the shop name visible in the front office.', array(), 'Admin.Shopparameters.Help'),
-                            sprintf($this->trans('Follow %sthis link%s to edit the shop name used on the front office.', array(), 'Admin.Shopparameters.Help'), '<a href="'.$this->context->link->getAdminLink('AdminStores').'#store_fieldset_general">', '</a>')),
+                    'desc' => array(
+                        $this->trans('This field does not refer to the shop name visible in the front office.', array(), 'Admin.Shopparameters.Help'),
+                        $this->trans('Follow [1]this link[/1] to edit the shop name used on the front office.', array(
+                            '[1]' => '<a href="'.$this->context->link->getAdminLink('AdminStores').'#store_fieldset_general">',
+                            '[/1]' => '</a>'
+                        ), 'Admin.Shopparameters.Help')),
                     'name' => 'name',
                     'required' => true,
                 )
@@ -430,7 +434,10 @@ class AdminShopControllerCore extends AdminController
         $this->fields_form['input'][] = array(
             'type' => 'select',
             'label' => $this->trans('Category root', array(), 'Admin.Catalog.Feature'),
-            'desc' => sprintf($this->trans('This is the root category of the store that you\'ve created. To define a new root category for your store, %splease click here%s.', array(), 'Admin.Shopparameters.Help'), '<a href="'.$this->context->link->getAdminLink('AdminCategories').'&addcategoryroot" target="_blank">', '</a>'),
+            'desc' => $this->trans('This is the root category of the store that you\'ve created. To define a new root category for your store, [1]please click here[/1].', array(
+                '[1]' => '<a href="'.$this->context->link->getAdminLink('AdminCategories').'&addcategoryroot" target="_blank">',
+                '[/1]' => '</a>',
+            ), 'Admin.Shopparameters.Help'),
             'name' => 'id_category',
             'options' => array(
                 'query' => $categories,

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -806,13 +806,10 @@ class AdminStatsControllerCore extends AdminStatsTabController
                 break;
 
             case 'avg_msg_response_time':
-                $value = sprintf(
-                    $this->trans('%.1f hours', array(), 'Admin.Stats.Feature'),
-                    AdminStatsController::getAverageMessageResponseTime(
-                        date('Y-m-d', strtotime('-31 day')),
-                        date('Y-m-d', strtotime('-1 day'))
-                    )
-                );
+                $value = $this->trans('%average% hours', array('%average%' => AdminStatsController::getAverageMessageResponseTime(
+                    date('Y-m-d', strtotime('-31 day')),
+                    date('Y-m-d', strtotime('-1 day'))
+                )), 'Admin.Stats.Feature');
                 ConfigurationKPI::updateValue('AVG_MSG_RESPONSE_TIME', $value);
                 ConfigurationKPI::updateValue('AVG_MSG_RESPONSE_TIME_EXPIRE', strtotime('+4 hour'));
                 break;

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -713,8 +713,8 @@ class AdminStatsControllerCore extends AdminStatsTabController
             case 'percent_product_out_of_stock':
                 $value = AdminStatsController::getPercentProductOutOfStock();
                 $tooltip = $this->trans(
-                    '%s of your products for sale are out of stock.',
-                    array($value),
+                    '%value% of your products for sale are out of stock.',
+                    array('%value%' => $value),
                     'Admin.Stats.Help'
                 );
                 ConfigurationKPI::updateValue('PERCENT_PRODUCT_OUT_OF_STOCK', $value);
@@ -724,8 +724,8 @@ class AdminStatsControllerCore extends AdminStatsTabController
             case 'product_avg_gross_margin':
                 $value = AdminStatsController::getProductAverageGrossMargin();
                 $tooltip = $this->trans(
-                    'Gross margin expressed in percentage assesses how cost-effectively you sell your goods. Out of $100, you will retain $%s to cover profit and expenses.',
-                    array(str_replace('%', '', $value)),
+                    'Gross margin expressed in percentage assesses how cost-effectively you sell your goods. Out of $100, you will retain $%value% to cover profit and expenses.',
+                    array('%value%' => $value),
                     'Admin.Stats.Help'
                 );
                 ConfigurationKPI::updateValue('PRODUCT_AVG_GROSS_MARGIN', $value);
@@ -743,13 +743,10 @@ class AdminStatsControllerCore extends AdminStatsTabController
                         100 * AdminStatsController::getDisabledProducts() / AdminStatsController::getTotalProducts(),
                         2
                     ).'%';
-                $tooltip = sprintf(
-                    $this->trans(
-                        '%s of your products are disabled and not visible to your customers',
-                        array(),
-                        'Admin.Stats.Help'
-                    ),
-                    $value
+                $tooltip = $this->trans(
+                    '%value% of your products are disabled and not visible to your customers',
+                    array('%value%' => $value),
+                    'Admin.Stats.Help'
                 );
                 ConfigurationKPI::updateValue('DISABLED_PRODUCTS', $value);
                 ConfigurationKPI::updateValue('DISABLED_PRODUCTS_EXPIRE', strtotime('+2 hour'));
@@ -757,15 +754,12 @@ class AdminStatsControllerCore extends AdminStatsTabController
 
             case '8020_sales_catalog':
                 $value = AdminStatsController::get8020SalesCatalog(date('Y-m-d', strtotime('-30 days')), date('Y-m-d'));
-                $tooltip = sprintf(
-                    $this->trans(
-                        'Within your catalog, %s of your products have had sales in the last 30 days',
-                        array(),
-                        'Admin.Stats.Help'
-                    ),
-                    $value
+                $tooltip = $this->trans(
+                    'Within your catalog, %value% of your products have had sales in the last 30 days',
+                    array('%value%' => $value),
+                    'Admin.Stats.Help'
                 );
-                $value = sprintf($this->trans('%d%% of your Catalog', array(), 'Admin.Stats.Feature'), $value);
+                $value = $this->trans('%value%% of your Catalog', array('%value%' => $value), 'Admin.Stats.Feature');
                 ConfigurationKPI::updateValue('8020_SALES_CATALOG', $value);
                 ConfigurationKPI::updateValue('8020_SALES_CATALOG_EXPIRE', strtotime('+12 hour'));
                 break;
@@ -782,20 +776,11 @@ class AdminStatsControllerCore extends AdminStatsTabController
                 if ($value === false) {
                     $value = $this->trans('No customers', array(), 'Admin.Stats.Feature');
                 } elseif ($value['type'] == 'female') {
-                    $value = sprintf(
-                        $this->trans('%d%% Female Customers', array(), 'Admin.Stats.Feature'),
-                        $value['value']
-                    );
+                    $value = $this->trans('%percentage%% Female Customers', array('%percentage%' => $value['value']), 'Admin.Stats.Feature');
                 } elseif ($value['type'] == 'male') {
-                    $value = sprintf(
-                        $this->trans('%d%% Male Customers', array(), 'Admin.Stats.Feature'),
-                        $value['value']
-                    );
+                    $value = $this->trans('%percentage%% Male Customers', array('%percentage%' => $value['value']), 'Admin.Stats.Feature');
                 } else {
-                    $value = sprintf(
-                        $this->trans('%d%% Neutral Customers', array(), 'Admin.Stats.Feature'),
-                        $value['value']
-                    );
+                    $value = $this->trans('%percentage%% Neutral Customers', array('%percentage%' => $value['value']), 'Admin.Stats.Feature');
                 }
 
                 ConfigurationKPI::updateValue('CUSTOMER_MAIN_GENDER', array($this->context->language->id => $value));
@@ -806,11 +791,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
                 break;
 
             case 'avg_customer_age':
-                $value = sprintf(
-                    $this->trans('%d years', array(), 'Admin.Stats.Feature'),
-                    AdminStatsController::getAverageCustomerAge(),
-                    1
-                );
+                $value = $this->trans('%value% years', array('%value%' => AdminStatsController::getAverageCustomerAge()), 'Admin.Stats.Feature');
                 ConfigurationKPI::updateValue('AVG_CUSTOMER_AGE', array($this->context->language->id => $value));
                 ConfigurationKPI::updateValue(
                     'AVG_CUSTOMER_AGE_EXPIRE',

--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -331,7 +331,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
                             'label' => $this->trans('No Tax', array(), 'Admin.International.Help')
                         )
                     ),
-                    'hint' => sprintf($this->trans('(Total tax: %s)', array(), 'Admin.International.Help'), '9%')
+                    'hint' => $this->trans('(Total tax: 9%)', array(), 'Admin.International.Help'),
                 ),
                 array(
                     'type' => 'text',

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -537,7 +537,7 @@ class AdminThemesControllerCore extends AdminController
         $other_themes = $this->theme_repository->getListExcluding([$this->context->shop->theme->getName()]);
         if (!empty($other_themes)) {
             $this->fields_options['theme'] = array(
-                'title' => sprintf($this->trans('Select a theme for the "%s" shop', array(), 'Admin.Design.Feature'), $this->context->shop->name),
+                'title' => $this->trans('Select a theme for the "%name%" shop', array('%name%' => $this->context->shop->name), 'Admin.Design.Feature'),
                 'description' => (!$this->can_display_themes) ? $this->trans('You must select a shop from the above list if you wish to choose a theme.', array(), 'Admin.Design.Help') : '',
                 'fields' => array(
                     'theme_for_shop' => array(

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -110,7 +110,7 @@ class AdminTranslationsControllerCore extends AdminController
             if (method_exists($this, $method_name)) {
                 $this->content = $this->initForm($method_name);
             } else {
-                $this->errors[] = sprintf($this->trans('"%s" does not exist.', array(), 'Admin.Notifications.Error'), $this->type_selected);
+                $this->errors[] = $this->trans('"%type%" does not exist.', array('%type%' => $this->type_selected), 'Admin.Notifications.Error');
                 $this->content = $this->initMain();
             }
         } else {
@@ -300,7 +300,7 @@ class AdminTranslationsControllerCore extends AdminController
         if (!file_exists($path)) {
             if (!mkdir($path, 0777, true)) {
                 $bool &= false;
-                $this->errors[] = sprintf($this->trans('Cannot create the folder "%s". Please check your directory writing permissions.', array(), 'Admin.International.Notification'), $path);
+                $this->errors[] = $this->trans('Cannot create the folder "%folder%". Please check your directory writing permissions.', array('%folder%' => $path), 'Admin.International.Notification');
             }
         }
 
@@ -333,9 +333,9 @@ class AdminTranslationsControllerCore extends AdminController
 
         if ($file_path && !file_exists($file_path)) {
             if (!file_exists(dirname($file_path)) && !mkdir(dirname($file_path), 0777, true)) {
-                throw new PrestaShopException(sprintf($this->trans('Directory "%s" cannot be created', array(), 'Admin.Notifications.Error'), dirname($file_path)));
+                throw new PrestaShopException($this->trans('Directory "%folder%" cannot be created', array('%folder%' => dirname($file_path)), 'Admin.Notifications.Error'));
             } elseif (!touch($file_path)) {
-                throw new PrestaShopException(sprintf($this->trans('File "%s" cannot be created', array(), 'Admin.Notifications.Error'), $file_path));
+                throw new PrestaShopException($this->trans('File "%file%" cannot be created', array("%file%" => $file_path), 'Admin.Notifications.Error'));
             }
         }
 
@@ -385,7 +385,7 @@ class AdminTranslationsControllerCore extends AdminController
                 $this->redirect();
             }
         } else {
-            throw new PrestaShopException(sprintf($this->trans('Cannot write this file: "%s"', array(), 'Admin.Notifications.Error'), $file_path));
+            throw new PrestaShopException($this->trans('Cannot write this file: "%folder%"', array('%folder%' => $file_path), 'Admin.Notifications.Error'));
         }
     }
 
@@ -421,12 +421,12 @@ class AdminTranslationsControllerCore extends AdminController
         $items = Language::getFilesList($from_lang, $from_theme, $to_lang, $to_theme, false, false, true);
         foreach ($items as $source => $dest) {
             if (!$this->checkDirAndCreate($dest)) {
-                $this->errors[] = sprintf($this->trans('Impossible to create the directory "%s".', array(), 'Admin.International.Notification'), $dest);
+                $this->errors[] = $this->trans('Impossible to create the directory "%folder%".', array('%folder%' => $dest), 'Admin.International.Notification');
             } elseif (!copy($source, $dest)) {
-                $this->errors[] = sprintf($this->trans('Impossible to copy "%s" to "%s".', array(), 'Admin.International.Notification'), $source, $dest);
+                $this->errors[] = $this->trans('Impossible to copy "%source%" to "%dest%".', array('%source%' => $source, '%dest%' => $dest), 'Admin.International.Notification');
             } elseif (strpos($dest, 'modules') && basename($source) === $from_lang.'.php' && $bool !== false) {
                 if (!$this->changeModulesKeyTranslation($dest, $from_theme, $to_theme)) {
-                    $this->errors[] = sprintf($this->trans('Impossible to translate "$dest".', array(), 'Admin.International.Notification'), $dest);
+                    $this->errors[] = $this->trans('Impossible to translate "%dest%".', array('%dest%' => $dest), 'Admin.International.Notification');
                 }
             }
         }
@@ -512,7 +512,7 @@ class AdminTranslationsControllerCore extends AdminController
             throw new PrestaShopException('File "'.$path.'" does not exist and cannot be created in '.$dir);
         }
         if (!is_writable($path)) {
-            $this->displayWarning(sprintf($this->trans('This file must be writable: %s', array(), 'Admin.Notifications.Error'), $path));
+            $this->displayWarning($this->trans('This file must be writable: %file%', array('%file%' => $path), 'Admin.Notifications.Error'));
         }
     }
 
@@ -778,10 +778,10 @@ class AdminTranslationsControllerCore extends AdminController
 
                         if (preg_match('@^[0-9a-z-_/\\\\]+\.php$@i', $file2check['filename'])) {
                             if (!@filemtime($sandbox.$file2check['filename']) || !AdminTranslationsController::checkTranslationFile(file_get_contents($sandbox.$file2check['filename']))) {
-                                $this->errors[] = sprintf($this->trans('Validation failed for: %s', array(), 'Admin.International.Notification'), $file2check['filename']);
+                                $this->errors[] = $this->trans('Validation failed for: %file%', array('%file%' => $file2check['filename']), 'Admin.International.Notification');
                             }
                         } elseif (!preg_match('@mails[0-9a-z-_/\\\\]+\.(html|tpl|txt)$@i', $file2check['filename'])) {
-                            $this->errors[] = sprintf($this->trans('Unidentified file found: %s', array(), 'Admin.International.Notification'), $file2check['filename']);
+                            $this->errors[] = $this->trans('Unidentified file found: %file%', array('%file%' => $file2check['filename']), 'Admin.International.Notification');
                         }
                     }
                     Tools::deleteDirectory($sandbox, true);
@@ -792,7 +792,7 @@ class AdminTranslationsControllerCore extends AdminController
                 foreach ($files_paths as $files_path) {
                     $path = dirname($files_path);
                     if (is_dir(_PS_TRANSLATIONS_DIR_.'../'.$path) && !is_writable(_PS_TRANSLATIONS_DIR_.'../'.$path) && !in_array($path, $tmp_array)) {
-                        $this->errors[] = (!$i++? $this->trans('The archive cannot be extracted.', array(), 'Admin.International.Notification').' ' : '').$this->trans('The server does not have permissions for writing.', array(), 'Admin.Notifications.Error').' '.sprintf($this->trans('Please check rights for %s', array(), 'Admin.Notifications.Error'), $path);
+                        $this->errors[] = (!$i++? $this->trans('The archive cannot be extracted.', array(), 'Admin.International.Notification').' ' : '').$this->trans('The server does not have permissions for writing.', array(), 'Admin.Notifications.Error').' '.$this->trans('Please check rights for %file%', array('%file%' => $path), 'Admin.Notifications.Error');
                         $tmp_array[] = $path;
                     }
                 }
@@ -845,7 +845,7 @@ class AdminTranslationsControllerCore extends AdminController
                 }
                 $this->errors[] = $this->trans('The archive cannot be extracted.', array(), 'Admin.International.Notification');
             } else {
-                $this->errors[] = sprintf($this->trans('ISO CODE invalid "%1$s" for the following file: "%2$s"', array(), 'Admin.International.Notification'), $iso_code, $filename);
+                $this->errors[] = $this->trans('ISO CODE invalid "%iso_code%" for the following file: "%file%"', array('%iso_code%' => $iso_code, '%file%' => $filename), 'Admin.International.Notification');
             }
         }
     }
@@ -1379,7 +1379,7 @@ class AdminTranslationsControllerCore extends AdminController
         if (($theme = Tools::getValue('selected-theme')) && !is_array($theme)) {
             $theme_exists = $this->theme_exists($theme);
             if (!$theme_exists) {
-                throw new PrestaShopException(sprintf($this->trans('Invalid theme "%s"', array(), 'Admin.International.Notification'), Tools::safeOutput($theme)));
+                throw new PrestaShopException($this->trans('Invalid theme "%theme%"', array('%theme%' => Tools::safeOutput($theme)), 'Admin.International.Notification'));
             }
             $this->theme_selected = Tools::safeOutput($theme);
         }
@@ -1401,7 +1401,7 @@ class AdminTranslationsControllerCore extends AdminController
             $iso_code = Tools::getValue('lang') ? Tools::getValue('lang') : Tools::getValue('iso_code');
 
             if (!Validate::isLangIsoCode($iso_code) || !in_array($iso_code, $this->all_iso_lang)) {
-                throw new PrestaShopException(sprintf($this->trans('Invalid iso code "%s"', array(), 'Admin.International.Notification'), Tools::safeOutput($iso_code)));
+                throw new PrestaShopException($this->trans('Invalid iso code "%iso_code%"', array('%iso_code%' => Tools::safeOutput($iso_code)), 'Admin.International.Notification'));
             }
 
             $this->lang_selected = new Language((int)Language::getIdByIso($iso_code));
@@ -1640,11 +1640,11 @@ class AdminTranslationsControllerCore extends AdminController
                     if ($module_name_pipe_pos) {
                         $module_name = substr($mail_name, 0, $module_name_pipe_pos);
                         if (!Validate::isModuleName($module_name)) {
-                            throw new PrestaShopException(sprintf($this->trans('Invalid module name "%s"', array(), 'Admin.International.Notification'), Tools::safeOutput($module_name)));
+                            throw new PrestaShopException($this->trans('Invalid module name "%module%"', array('%module%' => Tools::safeOutput($module_name)), 'Admin.International.Notification'));
                         }
                         $mail_name = substr($mail_name, $module_name_pipe_pos + 1);
                         if (!Validate::isTplName($mail_name)) {
-                            throw new PrestaShopException(sprintf($this->trans('Invalid mail name "%s"', array(), 'Admin.International.Notification'), Tools::safeOutput($mail_name)));
+                            throw new PrestaShopException($this->trans('Invalid mail name "%mail%"', array('%mail%' => Tools::safeOutput($mail_name)), 'Admin.International.Notification'));
                         }
                     }
 
@@ -1666,7 +1666,7 @@ class AdminTranslationsControllerCore extends AdminController
                             $path = str_replace('{module}', $module_name, $path);
                         }
                         if (!file_exists($path) && !mkdir($path, 0777, true)) {
-                            throw new PrestaShopException(sprintf($this->trans('Directory "%s" cannot be created', array(), 'Admin.International.Notification'), dirname($path)));
+                            throw new PrestaShopException($this->trans('Directory "%folder%" cannot be created', array('%folder%' => dirname($path)), 'Admin.International.Notification'));
                         }
 
                         if ($type_content == 'tpl') {
@@ -1788,7 +1788,7 @@ class AdminTranslationsControllerCore extends AdminController
     public function initFormFront()
     {
         if (!$this->theme_exists(Tools::getValue('theme'))) {
-            $this->errors[] = sprintf($this->trans('Invalid theme "%s"', array(), 'Admin.International.Notification'), Tools::getValue('theme'));
+            $this->errors[] = $this->trans('Invalid theme "%theme%"', array('%theme%' => Tools::getValue('theme')), 'Admin.International.Notification');
             return;
         }
 
@@ -1821,7 +1821,7 @@ class AdminTranslationsControllerCore extends AdminController
                         /* Get string translation */
                         foreach ($matches as $key) {
                             if (empty($key)) {
-                                $this->errors[] = sprintf($this->trans('Empty string found, please edit: "%s"', array(), 'Admin.International.Notification'), $file_path);
+                                $this->errors[] = $this->trans('Empty string found, please edit: "%file%"', array('%file%' => $file_path), 'Admin.International.Notification');
                                 $new_lang[$key] = '';
                             } else {
                                 // Caution ! front has underscore between prefix key and md5, back has not
@@ -2090,7 +2090,7 @@ class AdminTranslationsControllerCore extends AdminController
                     /* Get string translation for each tpl file */
                     foreach ($matches as $english_string) {
                         if (empty($english_string)) {
-                            $this->errors[] = sprintf($this->trans('There is an error in template, an empty string has been found. Please edit: "%s"', array(), 'Admin.International.Notification'), $file_path);
+                            $this->errors[] = $this->trans('There is an error in template, an empty string has been found. Please edit: "%file%"', array('%file%' => $file_path), 'Admin.International.Notification');
                             $new_lang[$english_string] = '';
                         } else {
                             $trans_key = $prefix_key.md5($english_string);
@@ -2409,8 +2409,9 @@ class AdminTranslationsControllerCore extends AdminController
                 }
             }
         } else {
-            $this->warnings[] = sprintf($this->trans('A mail directory exists for the "%1$s" language, but not for the default language (%3$s) in %2$s', array(), 'Admin.International.Notification'),
-                $this->lang_selected->iso_code, str_replace(_PS_ROOT_DIR_, '', dirname($dir)), $default_language);
+            $this->warnings[] = $this->trans('A mail directory exists for the "%iso_code%" language, but not for the default language (%language%) in %folder%',
+                array('%iso_code%' => $this->lang_selected->iso_code, '%folder%' => str_replace(_PS_ROOT_DIR_, '', dirname($dir)), '%language%' => $default_language),
+                'Admin.International.Notification');
         }
         return $arr_return;
     }
@@ -2485,7 +2486,7 @@ class AdminTranslationsControllerCore extends AdminController
                             $value_subject_mail = isset($mails['subject'][$subject_mail]) ? $mails['subject'][$subject_mail] : '';
                             $str_return .= '
                             <div class="label-subject row">
-                                <label class="control-label col-lg-3">'.sprintf($this->trans('Email subject', array(), 'Admin.International.Feature'));
+                                <label class="control-label col-lg-3">'.$this->trans('Email subject', array(), 'Admin.International.Feature');
                             if (isset($value_subject_mail['use_sprintf']) && $value_subject_mail['use_sprintf']) {
                                 $str_return .= '<span class="useSpecialSyntax" title="'.$this->trans('This expression uses a special syntax:', array(), 'Admin.International.Notification').' '.$value_subject_mail['use_sprintf'].'">
                                     <i class="icon-exclamation-triangle"></i>
@@ -2503,7 +2504,7 @@ class AdminTranslationsControllerCore extends AdminController
                     } else {
                         $str_return .= '
                             <hr><div class="alert alert-info">'
-                            .sprintf($this->trans('No Subject was found for %s in the database.', array(), 'Admin.International.Notification'), $mail_name)
+                            .$this->trans('No Subject was found for %mail_name% in the database.', array('%mail_name%' => $mail_name), 'Admin.International.Notification')
                             .'</div>';
                     }
                     // tab menu
@@ -2926,7 +2927,7 @@ class AdminTranslationsControllerCore extends AdminController
             fwrite($fd, "\n?>");
             fclose($fd);
         } else {
-            throw new PrestaShopException(sprintf($this->trans('Cannot write language file for email subjects. Path is: %s', array(), 'Admin.International.Notification'), $path));
+            throw new PrestaShopException($this->trans('Cannot write language file for email subjects. Path is: %folder%', array('%folder%' => $path), 'Admin.International.Notification'));
         }
     }
 
@@ -3125,7 +3126,7 @@ class AdminTranslationsControllerCore extends AdminController
 
         $this->checkDirAndCreate($i18n_file);
         if ((!file_exists($i18n_file) && !is_writable($i18n_dir)) && !is_writable($i18n_file)) {
-            $this->errors[] = sprintf($this->trans('Cannot write into the "%s"', array(), 'Admin.International.Notification'), $i18n_file);
+            $this->errors[] = $this->trans('Cannot write into the "%file%"', array('%file%' => $i18n_file), 'Admin.International.Notification');
         }
 
         @include($i18n_file);

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2542,7 +2542,7 @@ class AdminTranslationsControllerCore extends AdminController
         } else {
             $str_return .= '<p class="error">
                 '.$this->trans('There was a problem getting the mail files.', array(), 'Admin.International.Notification').'<br>
-                '.$this->trans('English language files must exist in [1]%folder%[/1] folder', array(
+                '.$this->trans('English language files must exist in %folder% folder', array(
                     '%folder%' => '<em>'.preg_replace('@/[a-z]{2}(/?)$@', '/en$1', $mails['directory']).'</em>'
                 ), 'Admin.International.Notification').'
             </p>';

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2542,7 +2542,9 @@ class AdminTranslationsControllerCore extends AdminController
         } else {
             $str_return .= '<p class="error">
                 '.$this->trans('There was a problem getting the mail files.', array(), 'Admin.International.Notification').'<br>
-                '.sprintf($this->trans('English language files must exist in %s folder', array(), 'Admin.International.Notification'), '<em>'.preg_replace('@/[a-z]{2}(/?)$@', '/en$1', $mails['directory']).'</em>').'
+                '.$this->trans('English language files must exist in [1]%folder%[/1] folder', array(
+                    '%folder%' => '<em>'.preg_replace('@/[a-z]{2}(/?)$@', '/en$1', $mails['directory']).'</em>'
+                ), 'Admin.International.Notification').'
             </p>';
         }
 

--- a/controllers/front/OrderSlipController.php
+++ b/controllers/front/OrderSlipController.php
@@ -63,8 +63,8 @@ class OrderSlipControllerCore extends FrontController
         foreach ($orders_slip as $order_slip) {
             $order = new Order($order_slip['id_order']);
             $credit_slips[$order_slip['id_order_slip']] = $order_slip;
-            $credit_slips[$order_slip['id_order_slip']]['credit_slip_number'] = sprintf($this->trans('#%06d', array(), 'Shop.Theme.Customeraccount'), $order_slip['id_order_slip']);
-            $credit_slips[$order_slip['id_order_slip']]['order_number'] = sprintf($this->trans('#%06d', array(), 'Shop.Theme.Customeraccount'), $order_slip['id_order']);
+            $credit_slips[$order_slip['id_order_slip']]['credit_slip_number'] = $this->trans('#%id%', array('%id%' => $order_slip['id_order_slip']), 'Shop.Theme.Customeraccount');
+            $credit_slips[$order_slip['id_order_slip']]['order_number'] = $this->trans('#%id%', array('%id%' => $order_slip['id_order']), 'Shop.Theme.Customeraccount');
             $credit_slips[$order_slip['id_order_slip']]['order_reference'] = $order->reference;
             $credit_slips[$order_slip['id_order_slip']]['credit_slip_date'] = Tools::displayDate($order_slip['date_add'], null, false);
             $credit_slips[$order_slip['id_order_slip']]['url'] = $this->context->link->getPageLink('pdf-order-slip', true, null, 'id_order_slip='.(int)$order_slip['id_order_slip']);

--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -183,7 +183,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
             $manufacturers_for_display[$manufacturer['id_manufacturer']]['text'] = $manufacturer['short_description'];
             $manufacturers_for_display[$manufacturer['id_manufacturer']]['image'] = $this->context->link->getManufacturerImageLink($manufacturer['id_manufacturer'], 'small_default');
             $manufacturers_for_display[$manufacturer['id_manufacturer']]['url'] = $this->context->link->getmanufacturerLink($manufacturer['id_manufacturer']);
-            $manufacturers_for_display[$manufacturer['id_manufacturer']]['nb_products'] = $manufacturer['nb_products'] > 1 ? ($this->trans('%number% products', array('%number%' => $manufacturer['nb_products']), 'Shop.Theme.Catalog')) : sprintf($this->trans('%number% product', array('%number%' => $manufacturer['nb_products']), 'Shop.Theme.Catalog'));
+            $manufacturers_for_display[$manufacturer['id_manufacturer']]['nb_products'] = $manufacturer['nb_products'] > 1 ? ($this->trans('%number% products', array('%number%' => $manufacturer['nb_products']), 'Shop.Theme.Catalog')) : $this->trans('%number% product', array('%number%' => $manufacturer['nb_products']), 'Shop.Theme.Catalog');
         }
 
         return $manufacturers_for_display;

--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -386,7 +386,7 @@ class CartPresenter implements PresenterInterface
 
         $summary_string = $products_count === 1 ?
             $this->translator->trans('1 item', array(), 'Shop.Theme.Checkout') :
-            sprintf($this->translator->trans('%d items', array(), 'Shop.Theme.Checkout'), $products_count)
+            $this->translator->trans('%count% items', array('%count%' => $products_count), 'Shop.Theme.Checkout')
         ;
 
         $minimalPurchase = $this->priceFormatter->convertAmount((float) Configuration::get('PS_PURCHASE_MINIMUM'));
@@ -433,15 +433,13 @@ class CartPresenter implements PresenterInterface
             'discounts' => $discounts,
             'minimalPurchase' => $minimalPurchase,
             'minimalPurchaseRequired' => ($this->priceFormatter->convertAmount($productsTotalExcludingTax) < $minimalPurchase) ?
-                sprintf(
-                    $this->translator->trans(
-                        'A minimum shopping cart total of %amount% (tax excl.) is required to validate your order. Current cart total is %total% (tax excl.).',
-                        array(
-                            '%amount%' => $this->priceFormatter->convertAndFormat($minimalPurchase),
-                            '%total%' => $this->priceFormatter->convertAndFormat($productsTotalExcludingTax),
-                        ),
-                        'Shop.Theme.Checkout'
-                    )
+                $this->translator->trans(
+                    'A minimum shopping cart total of %amount% (tax excl.) is required to validate your order. Current cart total is %total% (tax excl.).',
+                    array(
+                        '%amount%' => $this->priceFormatter->convertAndFormat($minimalPurchase),
+                        '%total%' => $this->priceFormatter->convertAndFormat($productsTotalExcludingTax),
+                    ),
+                    'Shop.Theme.Checkout'
                 ) :
                 '',
         );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We often receive issues regarding translation, and the concerned translations always have a call to `sprintf()`. The new function `trans()` is already able to replace the placeholders without throwing fatal errors in case of errors. So this PR removes all calls to sprintf where trans can be used alone.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Adding a new `%s` in the concerned messages threw errors with sprintf(). With this PR,  there is no fatal errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8381)
<!-- Reviewable:end -->
