### PR TITLE
Fixed missing translations of Information System page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/AdvancedParameters/system_information.html.twig
@@ -74,7 +74,7 @@
 
         <div class="card">
             <h3 class="card-header">
-                <i class="material-icons">info_outline</i> {{ 'Database information'|trans }}
+                <i class="material-icons">info_outline</i> {{ 'Database information'|trans({}, 'Admin.Advparameters.Feature') }}
             </h3>
             <div class="card-block">
                 <div class="card-text">
@@ -189,7 +189,7 @@
                     <p>
                         <strong>{{ 'Required parameters:'|trans }}</strong>
                     {% if requirements.failRequired == false %}
-                        <span class="text-success">{{ 'Ok'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+                        <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
                     </p>
                     {% else %}
                         <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
@@ -206,7 +206,7 @@
                         <p>
                         <strong>{{ 'Optional parameters:'|trans }}</strong>
                         {% if requirements.failOptional == false %}
-                            <span class="text-success">{{ 'Ok'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+                            <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
                             </p>
                         {% else %}
                             <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | "Ok" and "Database information" keys were not found.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Forge?             | http://forge.prestashop.com/browse/BOOM-3940
| How to test?  | In "dev" mode, visit the System Information page: you shouldn't see any warning in translations section of the Symfony debug toolbar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8391)
<!-- Reviewable:end -->
