### PR TITLE
Improved loading of translations

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/LangRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LangRepository.php
@@ -36,7 +36,12 @@ class LangRepository extends EntityRepository
      */
     public function getLocaleByIsoCode($isoCode)
     {
-        return $this->findOneBy(array('isoCode' => $isoCode))
-            ->getLocale();
+        static $isoCodes = array();
+
+        if (!array_key_exists($isoCode, $isoCodes)) {
+            return $isoCodes[$isoCode] = $this->findOneBy(array('isoCode' => $isoCode))
+                ->getLocale();
+        }
+        return $isoCodes[$isoCode];
     }
 }

--- a/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
@@ -49,10 +49,13 @@ class DatabaseTranslationLoader implements LoaderInterface
      */
     public function load($resource, $locale, $domain = 'messages', $theme = null)
     {
-        $lang = $this->entityManager
-            ->getRepository('PrestaShopBundle:Lang')
-            ->findOneByLocale($locale)
-        ;
+        static $langs = array();
+        if (!array_key_exists($locale, $langs)) {
+            $langs[$locale] = $this->entityManager
+                ->getRepository('PrestaShopBundle:Lang')
+                ->findOneByLocale($locale)
+            ;
+        }
 
         $translationRepository = $this->entityManager
             ->getRepository('PrestaShopBundle:Translation')
@@ -61,7 +64,7 @@ class DatabaseTranslationLoader implements LoaderInterface
         $queryBuilder = $translationRepository
             ->createQueryBuilder('t')
             ->where('t.lang =:lang')
-            ->setParameter('lang', $lang)
+            ->setParameter('lang', $langs[$locale])
         ;
 
         if (!is_null($theme)) {

--- a/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
@@ -57,21 +57,25 @@ class SqlTranslationLoader implements LoaderInterface
      */
     public function load($resource, $locale, $domain = 'messages')
     {
-        $locale = Db::getInstance()->escape($locale, false, true);
-        $localeResult = Db::getInstance()->getRow('
-            SELECT `id_lang`
-            FROM `'._DB_PREFIX_.'lang`
-            WHERE `locale` = "'.$locale.'"'
-        );
+        static $localeResults = array();
 
-        if (empty($localeResult)) {
+        if (!array_key_exists($locale, $localeResults)) {
+            $locale = Db::getInstance()->escape($locale, false, true);
+
+            $localeResults[$locale] = Db::getInstance()->getRow('SELECT `id_lang`
+                FROM `'._DB_PREFIX_.'lang`
+                WHERE `locale` = "'.$locale.'"'
+            );
+        }
+
+        if (empty($localeResults[$locale])) {
             throw new Exception(sprintf('Language not found in database: %s', $locale));
         }
 
         $selectTranslationsQuery = '
             SELECT `key`, `translation`, `domain`
             FROM `'._DB_PREFIX_.'translation`
-            WHERE `id_lang` = '.$localeResult['id_lang']
+            WHERE `id_lang` = '.$localeResults[$locale]['id_lang']
         ;
         $translations = Db::getInstance()->executeS($selectTranslationsQuery);
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Load a translation involves a lot of select queries: in "prod" mode this is cached at first call, but in "dev" mode it's not, let's improve the perfs a little bit.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Forge?           | http://forge.prestashop.com/browse/BOGOSS-54
| How to test?  | In "dev" mode, you should notice a drop of ~50% of database queries done to render the page, for instance in Information System page we go from 344 to 173 Database queries.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
