### PR TITLE
Remove obsolete unescaping on JSON output

### DIFF
--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -158,16 +158,8 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
 
     public function overrideContent($content)
     {
-        $content = '';
-        $content .= json_encode($this->content);
-        $content = preg_replace_callback(
-            "/\\\\u([a-f0-9]{4})/",
-            function ($matches) {
-                return iconv('UCS-4LE', 'UTF-8', pack('V', hexdec('U' . $matches[1])));
-            },
-            $content
-        );
-        return $content;
+        $content = json_encode($this->content, JSON_UNESCAPED_UNICODE);
+        return (false !== $content) ? $content : '';
     }
 
     public function setLanguages($languages)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The WS JSON output was unescaped using an obsolete workaround, probably because in PHP < 5.4 it was impossible to send UTF-8 characters without them being escaped. Moreover, this workaround wasn't working for utf8mb4 characters such as emoji. Since PHP 5.4 it's possible to perform JSON encoding without escaping UTF8 characters natively, so this PR changes the workaround for the native solution, which as an added bonus also works for emojis. You can learn more in [this discussion](https://github.com/PrestaShop/PrestaShop/commit/f9aca704052a7d8d6c666daaf0dd2520c41cb9ee#commitcomment-24702362).
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Use the web service to retrieve any element containing an emoji

Kudos to @vavrecan for reporting this issue!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8393)
<!-- Reviewable:end -->
