### PR TITLE
BO: add hook before updating options.

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1367,6 +1367,11 @@ class AdminControllerCore extends Controller
     {
         $this->beforeUpdateOptions();
 
+        Hook::exec('action'.$this->controller_name.'OptionsModifier', array(
+            'options'     => &$this->fields_options,
+            'option_vars' => &$this->tpl_option_vars,
+        ));
+
         $languages = Language::getLanguages(false);
 
         $hide_multishop_checkbox = (Shop::getTotalShops(false, null) < 2) ? true : false;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x (may be extended to 1.7.2.x).
| Description?  | Fix broken promise made by [commit e0fd87903](https://github.com/PrestaShop/PrestaShop/commit/e0fd87903769a958d4b9f975b33899b360be12d4#diff-d373723286a172a4ca3d76c4858f565bR1843), whose message is **_"Add some useful hooks to modify the listings/options/forms"_**. It's currently not possible to modify (add) options and have them automatically validated + updated when user submit new values.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Download and install this [POC module](https://github.com/cdoublev/cwpoc). Then try to update "My custom option" in Admin > Orders > Invoices, with and without this fix. The option value should be updated only when this fix is active.

## More info

I will expose two other ways to solve this issue, with their respective pros and cons, as well as for the one I choosed. I'm totally open to other point of views.

**1. Use hookActionAdmin<_Option Page_>UpdateOptionsBefore** (called in `AdminController::postProcess`)

Problem: hooked methods will receive the admin controller instance, but its `fields_options` property is protected.

Pros:
- it already exists
- it could be used to modify forms and listings as well (by mutating `fields_list`, `fields_form`, or `fields_form_override`) but hookAction<_List Object_>ListingFieldsModifier would become useless

Cons:
- either `fields_options` should be defined as public
- or a public `fields_options_override` property (in reference to `fields_form_override`) may be set and merged later with other `fields_options` BEFORE they are processed
- or a setter (eg. `setFieldsOptions()`) should be created

**2. Override `beforeUpdateOptions`**

Pros:
- it already exists

Cons:
- not fixed in core Prestashop

**3. This PR**

Pros:
- minimal change (add 4 lines, no new hook created)

Cons:
- custom fields options will be set twice when their form is submitted (the second time in `renderOptions`), if no control structure exists to verify somehow if they've already been set
- the hook could have been named hookActionAdmin<_Option Page_>OptionsModifierBeforeProcess, which is the same as hookActionAdmin<_Option Page_>UpdateOptionsBefore (see first solution)...
- it doesn't prodive a common solution for registering `fields_list` and `fields_form`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8398)
<!-- Reviewable:end -->
