### PR TITLE
Fix search relevance wrong sort order

### DIFF
--- a/src/Core/Product/Search/SortOrderFactory.php
+++ b/src/Core/Product/Search/SortOrderFactory.php
@@ -41,7 +41,7 @@ class SortOrderFactory
     public function getDefaultSortOrders()
     {
         return [
-            (new SortOrder('product', 'position', 'asc'))->setLabel(
+            (new SortOrder('product', 'position', 'desc'))->setLabel(
                 $this->translator->trans('Relevance', array(), 'Shop.Theme.Catalog')
             ),
             (new SortOrder('product', 'name', 'asc'))->setLabel(


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | BOOM-3915 Relevance search wrong sort order
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3915
| How to test?  | Search for "printed dress" in the demo shop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8399)
<!-- Reviewable:end -->
