### PR TITLE
Fix low-stock display

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -285,8 +285,8 @@ class StockRepository extends StockManagementRepository
             ) AS product_low_stock_threshold,
              IF (
                 COALESCE(pa.id_product_attribute, 0) > 0,
-                IF (sa.quantity < pas.low_stock_threshold, 1, 0),
-                IF (sa.quantity < ps.low_stock_threshold, 1, 0)
+                IF (sa.quantity <= pas.low_stock_threshold, 1, 0),
+                IF (sa.quantity <= ps.low_stock_threshold, 1, 0)
              ) AS product_low_stock_alert,
             COALESCE(product_attributes.attributes, "") AS product_attributes,
             COALESCE(product_features.features, "") AS product_features


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | fix low stock alert display on stock page (was <, need <=)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3981
| How to test?  | have a product with a stock quantity EQUAL the low-stock alert. It was not highlited. This PR fix it

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8406)
<!-- Reviewable:end -->
