### PR TITLE
Improve getContextualValue performances by reducing the number of calls to getOrderTotal

### DIFF
--- a/tests/Integration/classes/CartGetOrderTotalTest.php
+++ b/tests/Integration/classes/CartGetOrderTotalTest.php
@@ -493,4 +493,32 @@ class CartGetOrderTotalTest extends IntegrationTestCase
         $this->assertEquals($preTax, $cart->getOrderTotal(false, Cart::ONLY_SHIPPING, null, $id_carrier));
         $this->assertEquals(5, $cart->getOrderTotal(true, Cart::ONLY_SHIPPING, null, $id_carrier));
     }
+
+    /**
+     * Check getOrderTotal return the same value with and without when PS_TAX is disable
+     */
+    public function testSameTotalWithoutTax()
+    {
+        Configuration::set('PS_TAX', false);
+        $product = self::makeProduct('Hello Product', 10, self::getIdTaxRulesGroup(20));
+        $cart = self::makeCart();
+
+        $cart->updateQty(1, $product->id);
+
+        $this->assertEquals(
+            $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS),
+            $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
+
+        $this->assertEquals(
+            $cart->getOrderTotal(false, Cart::BOTH),
+            $cart->getOrderTotal(true, Cart::BOTH));
+
+        $this->assertEquals(
+            $cart->getOrderTotal(false, Cart::ONLY_SHIPPING),
+            $cart->getOrderTotal(true, Cart::ONLY_SHIPPING));
+
+        $this->assertEquals(
+            $cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS),
+            $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS));
+    }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | improve getContextualValue (calls for example in order history) by implementing a local cache and reducing the call to getOrderTotal
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | run tests. Load the command history page

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8410)
<!-- Reviewable:end -->
