### PR TITLE
Empty default label for product configuration

### DIFF
--- a/install-dev/langs/en/data/configuration.xml
+++ b/install-dev/langs/en/data/configuration.xml
@@ -23,10 +23,10 @@ Customer service</value>
 Thanks for your patience.</value>
   </configuration>
   <configuration id="PS_LABEL_IN_STOCK_PRODUCTS">
-    <value>In Stock</value>
+    <value></value>
   </configuration>
   <configuration id="PS_LABEL_OOS_PRODUCTS_BOA">
-    <value>Product available for orders</value>
+    <value></value>
   </configuration>
   <configuration id="PS_LABEL_OOS_PRODUCTS_BOD">
     <value>Out-of-Stock</value>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | empty default label on product configuration page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3932
| How to test?  | reinstall store, on BO go to "shop parameters" > "product settings". The 2 labels must be empty

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8413)
<!-- Reviewable:end -->
