### PR TITLE
Fix the button of add a new customization field in the product page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -888,7 +888,7 @@
                               </li>
                             {% endfor %}
                           </ul>
-                          <a href="#" class="btn btn-outline-secondary">
+                          <a href="#" class="btn btn-outline-secondary add">
                             <i class="material-icons">add_circle</i>
                             {{ 'Add a customization field'|trans({}, 'Admin.Catalog.Feature') }}
                           </a>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When we click on the "add a customization field" button, the form won't display.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | none
| How to test?  | BO > Catalog > Products > edit product > Options tab, try to add a customization field and check if the form is well displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8414)
<!-- Reviewable:end -->
