### PR TITLE
Remove product description length limit

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -160,13 +160,7 @@ class ProductInformation extends CommonAbstractType
             'type' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType',
             'options' => [
                 'attr' => array(
-                    'class' => 'autoload_rte',
-                    'counter' => 6000,
-                ),
-                'constraints' => array(
-                    new TinyMceMaxLength(array(
-                        'max' => 6000
-                    ))
+                    'class' => 'autoload_rte'
                 ),
                 'required' => false
             ],

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -160,7 +160,13 @@ class ProductInformation extends CommonAbstractType
             'type' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType',
             'options' => [
                 'attr' => array(
-                    'class' => 'autoload_rte'
+                    'class' => 'autoload_rte',
+                    'counter' => 21844
+                ),
+                'constraints' => array(
+                    new TinyMceMaxLength(array(
+                        'max' => 21844
+                    ))
                 ),
                 'required' => false
             ],


### PR DESCRIPTION
Do not limit product description's length


| Questions?     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Product description length limit is hard coded to 6000 characters.
| Type?         |  improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | --
| How to test?  | Try to save a description with more than 6000 characters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8415)
<!-- Reviewable:end -->
