### PR TITLE
Fix missing cache invalidation in the backoffice

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1382,7 +1382,7 @@ class CartRuleCore extends ObjectModel
             if ($type == 'cart_rule') {
                 $array = $this->getCartRuleCombinations($offset, $limit, $search_cart_rule_name);
             } else {
-                $resource = Db::getInstance()->query('
+                $resource = Db::getInstance()->executeS('
 				SELECT t.*' . ($i18n ? ', tl.*' : '') . ', IF(crt.id_' . $type . ' IS NULL, 0, 1) as selected
 				FROM `' . _DB_PREFIX_ . $type . '` t
 				' . ($i18n ? 'LEFT JOIN `' . _DB_PREFIX_ . $type . '_lang` tl ON (t.id_' . $type . ' = tl.id_' . $type . ' AND tl.id_lang = ' . (int) Context::getContext()->language->id . ')' : '') . '

--- a/classes/stock/StockManager.php
+++ b/classes/stock/StockManager.php
@@ -349,7 +349,7 @@ class StockManagerCore implements StockManagerInterface
                             continue;
                         }
 
-                        $resource = Db::getInstance(_PS_USE_SQL_SLAVE_)->query('
+                        $resource = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 							SELECT sm.`id_stock_mvt`, sm.`date_add`, sm.`physical_quantity`,
 								IF ((sm2.`physical_quantity` is null), sm.`physical_quantity`, (sm.`physical_quantity` - SUM(sm2.`physical_quantity`))) as qty
 							FROM `'._DB_PREFIX_.'stock_mvt` sm
@@ -357,7 +357,7 @@ class StockManagerCore implements StockManagerInterface
 							WHERE sm.`sign` = 1
 							AND sm.`id_stock` = '.(int)$stock->id.'
 							GROUP BY sm.`id_stock_mvt`
-							ORDER BY sm.`date_add` DESC'
+							ORDER BY sm.`date_add` DESC', false
                         );
 
                         while ($row = Db::getInstance()->nextRow($resource)) {

--- a/classes/stock/StockMvt.php
+++ b/classes/stock/StockMvt.php
@@ -207,7 +207,7 @@ class StockMvtCore extends ObjectModel
         $query->orderBy('date_add DESC');
 
         // gets the result
-        $res = Db::getInstance(_PS_USE_SQL_SLAVE_)->query($query);
+        $res = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false);
 
         // fills the movements array
         while ($row = Db::getInstance(_PS_USE_SQL_SLAVE_)->nextRow($res)) {

--- a/controllers/admin/AdminCarriersController.php
+++ b/controllers/admin/AdminCarriersController.php
@@ -144,7 +144,7 @@ class AdminCarriersControllerCore extends AdminController
 
         // test if need to show header alert.
         $sql = 'SELECT COUNT(1) FROM `'._DB_PREFIX_.'carrier` WHERE deleted = 0 AND id_reference > 2';
-        $showHeaderAlert = (Db::getInstance()->query($sql)->fetchColumn(0) == 0);
+        $showHeaderAlert = (Db::getInstance()->executeS($sql, false)->fetchColumn(0) == 0);
 
         // Assign them in two steps! Because renderModulesList needs it before to be called.
         $this->context->smarty->assign('panel_title', $this->trans('Use one of our recommended carrier modules', array(), 'Admin.Shipping.Feature'));

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -290,7 +290,7 @@ class AdminProductDataUpdater implements ProductInterface
                 product_shop.`date_upd` = "'.date('Y-m-d H:i:s').'"
             WHERE cp.`id_category` = '.(int)$categoryId.' AND cp.`id_product` IN ('.implode(',', array_map('intval', array_keys($productList))).')';
 
-        Db::getInstance()->query($updatePositions);
+        Db::getInstance()->execute($updatePositions);
 
         // Fixes duplicates on all pages
         Db::getInstance()->query('SET @i := 0');
@@ -298,7 +298,7 @@ class AdminProductDataUpdater implements ProductInterface
             SET cp.`position` = (SELECT @i := @i + 1)
             WHERE cp.`id_category` = '.(int)$categoryId.'
             ORDER BY cp.`id_product` NOT IN ('.implode(',', array_map('intval', array_keys($productList))).'), cp.`position` ASC';
-        Db::getInstance()->query($selectPositions);
+        Db::getInstance()->execute($selectPositions);
 
         return true;
     }


### PR DESCRIPTION
execute* function should be used instead, to properly invalidates the cache

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | fix missing cache invalidation in the backoffice
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Enable the cache, (for example memcached). Go into a category in the front office, to cache the info. Then go the BO and change a position of a product in this category. Check the new position is properly reflected in the front office.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8417)
<!-- Reviewable:end -->
