### PR TITLE
Add the spam protection option in the preference page

### DIFF
--- a/controllers/admin/AdminPreferencesController.php
+++ b/controllers/admin/AdminPreferencesController.php
@@ -124,6 +124,13 @@ class AdminPreferencesControllerCore extends AdminController
                     'default' => '0',
                     'visibility' => Shop::CONTEXT_ALL
                 ),
+                'PS_SPAM_PROTECTION' => array(
+                    'title' => $this->l('Use spam protection'),
+                    'desc' => $this->l('Allow spam protection in the contact form.'),
+                    'validation' => 'isBool',
+                    'cast' => 'intval',
+                    'type' => 'bool',
+                ),
                 'PS_ALLOW_HTML_IFRAME' => array(
                     'title' => $this->l('Allow iframes on HTML fields'),
                     'desc' => $this->l('Allow iframes on text fields like product description. We recommend that you leave this option disabled.'),

--- a/controllers/front/ContactController.php
+++ b/controllers/front/ContactController.php
@@ -53,7 +53,12 @@ class ContactControllerCore extends FrontController
                 $this->errors[] = Tools::displayError('An error occurred during the file-upload process.');
             } elseif (!empty($file_attachment['name']) && !in_array(Tools::strtolower(substr($file_attachment['name'], -4)), $extension) && !in_array(Tools::strtolower(substr($file_attachment['name'], -5)), $extension)) {
                 $this->errors[] = Tools::displayError('Bad file extension');
-            } elseif ($url === false || !empty($url) || $saveContactKey != (Tools::getValue('contactKey'))) {
+            } elseif (
+                Configuration::get('PS_SPAM_PROTECTION')
+                && ($url === false
+                    || !empty($url)
+                    || $saveContactKey != (Tools::getValue('contactKey')))
+                ) {
                 $this->errors[] = Tools::displayError('An error occurred while sending the message.');
             } else {
                 $customer = $this->context->customer;

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -847,5 +847,8 @@ Country</value>
     <configuration id="PS_ADVANCED_PAYMENT_API" name="PS_ADVANCED_PAYMENT_API">
       <value>0</value>
     </configuration>
+	<configuration id="PS_SPAM_PROTECTION" name="PS_SPAM_PROTECTION">
+	  <value>1</value>
+	</configuration>
   </entities>
 </entity_configuration>

--- a/install-dev/upgrade/sql/1.6.1.18.sql
+++ b/install-dev/upgrade/sql/1.6.1.18.sql
@@ -1,0 +1,3 @@
+SET NAMES 'utf8';
+
+INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_SPAM_PROTECTION', '0', NOW(), NOW());


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | We add the spam protection option in the preference page, if the option is activated then the spam protection solution proposed in this PR (https://github.com/PrestaShop/PrestaShop/pull/8168) will be applied
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9466
| How to test?  | 

![general prestashop 1 6](https://user-images.githubusercontent.com/17438504/31623232-b64a6d00-b296-11e7-86b8-8a8010687144.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8420)
<!-- Reviewable:end -->
