### PR TITLE
CO: Fixed attribute value using attribute separator when presenting cart

### DIFF
--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -81,8 +81,11 @@ class CartPresenter implements PresenterInterface
             $attributesArray = array();
 
             foreach ($rawProduct['attributes'] as $attribute) {
-                list($key, $value) = explode(':', $attribute);
-                $attributesArray[trim($key)] = ltrim($value);
+                $groupAndAttribute = explode(':', $attribute);
+                if (count($groupAndAttribute) > 1) {
+                    list($key, $value) = $groupAndAttribute;
+                    $attributesArray[trim($key)] = ltrim($value);
+                }
             }
 
             $rawProduct['attributes'] = $attributesArray;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On Prestashop 1.7, The character used in PS_ATTRIBUTE_ANCHOR_SEPARATOR can be used in an attribute value. It shouldn't happen obviously but when it does, a broken attribute is displayed on the cart page and a php notice is triggered
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | <ul><li>http://forge.prestashop.com/browse/BOOM-3172</li><li>http://forge.prestashop.com/browse/BOOM-3861</li></ul>
| How to test?  | Add an attribute value containing the attribute anchor separator ("-" by default), affect it to a combination, add that combination to your cart. Attributes are not displayed correctly for this combination and a PHP notice is triggered. After applying this commit, no notice is triggered and that attribute is displayed correctly minus whatever is after the separator.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8422)
<!-- Reviewable:end -->
