### PR TITLE
Use regexp instead of simple explode for complex attributes in CartPresenter

### DIFF
--- a/src/Adapter/Cart/CartPresenter.php
+++ b/src/Adapter/Cart/CartPresenter.php
@@ -76,16 +76,7 @@ class CartPresenter implements PresenterInterface
         $settings->showPrices = Configuration::showPrices();
 
         if (isset($rawProduct['attributes']) && is_string($rawProduct['attributes'])) {
-            // return an array of attributes
-            $rawProduct['attributes'] = explode(Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'), $rawProduct['attributes']);
-            $attributesArray = array();
-
-            foreach ($rawProduct['attributes'] as $attribute) {
-                list($key, $value) = explode(':', $attribute);
-                $attributesArray[trim($key)] = ltrim($value);
-            }
-
-            $rawProduct['attributes'] = $attributesArray;
+            $rawProduct['attributes'] = $this->getAttributesArrayFromString($rawProduct['attributes']);
         }
         $rawProduct['remove_from_cart_url'] = $this->link->getRemoveFromCartURL(
             $rawProduct['id_product'],
@@ -494,5 +485,29 @@ class CartPresenter implements PresenterInterface
             'allowed' => (int) CartRule::isFeatureActive(),
             'added' => $vouchers,
         );
+    }
+
+    /**
+     * Receives a string containing a list of attributes affected to the product and returns them as an array
+     *
+     * @param string $attributes
+     * @return array Converted attributes in an array
+     */
+    protected function getAttributesArrayFromString($attributes)
+    {
+        $separator = Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR');
+        $pattern = '/(?>(?P<attribute>[^:]+:[^:]+)'.$separator.'+(?!'.$separator.'([^:'.$separator.'])+:))/';
+        $attributesArray = array();
+        $matches = array();
+        if (!preg_match_all($pattern, $attributes.$separator, $matches)) {
+            return $attributesArray;
+        }
+
+        foreach ($matches['attribute'] as $attribute) {
+            list($key, $value) = explode(':', $attribute);
+            $attributesArray[trim($key)] = ltrim($value);
+        }
+
+        return $attributesArray;
     }
 }

--- a/tests/TestCase/UnitTestCase.php
+++ b/tests/TestCase/UnitTestCase.php
@@ -125,6 +125,7 @@ class UnitTestCase extends PHPUnit_Framework_TestCase
 
         $this->setupContextualTemplateEngineMock();
         $this->setupContextualLanguageMock();
+        $this->setupContextualLinkMock();
         $this->setupContextualEmployeeMock();
         $this->setupContextualCookieMock();
         $this->setupContextualCurrencyMock();
@@ -160,6 +161,13 @@ class UnitTestCase extends PHPUnit_Framework_TestCase
         $this->context->language = Phake::mock('Language');
 
         return $this->context->language;
+    }
+
+    protected function setupContextualLinkMock()
+    {
+        $this->context->link = Phake::mock('Link');
+
+        return $this->context->link;
     }
 
     protected function setupContextualCookieMock() {
@@ -209,5 +217,24 @@ class UnitTestCase extends PHPUnit_Framework_TestCase
         $container_builder = new ContainerBuilder();
         $container = $container_builder->build();
         ServiceLocator::setServiceContainerInstance($container);
+    }
+
+    /**
+    * Call protected/private method of a class.
+    *
+    * @param object &$object    Instantiated object that we will run method on.
+    * @param string $methodName Method name to call
+    * @param array  $parameters Array of parameters to pass into method.
+    *
+    * @return mixed Method return.
+    * @link https://jtreminio.com/2013/03/unit-testing-tutorial-part-3-testing-protected-private-methods-coverage-reports-and-crap/
+    */
+    protected function invokeMethod(&$object, $methodName, array $parameters = array())
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
     }
 }

--- a/tests/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
+++ b/tests/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
@@ -222,23 +222,4 @@ class ModuleTabRegisterTest extends UnitTestCase
         $expectedResult = array(1 => $names['fr'], 2 => $names['en'], 3 => $names['en']);
         $this->assertEquals($expectedResult, $this->invokeMethod($this->tabRegister, 'getTabNames', array($names)));
     }
-
-    /**
-    * Call protected/private method of a class.
-    *
-    * @param object &$object    Instantiated object that we will run method on.
-    * @param string $methodName Method name to call
-    * @param array  $parameters Array of parameters to pass into method.
-    *
-    * @return mixed Method return.
-    * @link https://jtreminio.com/2013/03/unit-testing-tutorial-part-3-testing-protected-private-methods-coverage-reports-and-crap/
-    */
-    protected function invokeMethod(&$object, $methodName, array $parameters = array())
-    {
-        $reflection = new \ReflectionClass(get_class($object));
-        $method = $reflection->getMethod($methodName);
-        $method->setAccessible(true);
-
-        return $method->invokeArgs($object, $parameters);
-    }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix conversion from string -> array of product attributes, when they have the current separator in their label or value
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3861
| How to test?  | Create a new product attribute with the current separator in it (By default: `-`), and use it on a product. Adding it to the cart will throw a notice until you try this PR. Also, it includes unit tests.

This PR is another suggestion from #8422

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8425)
<!-- Reviewable:end -->
