### PR TITLE
BO: make sure shop list in header is scrollable with lot of items

### DIFF
--- a/admin-dev/themes/default/sass/partials/_header.sass
+++ b/admin-dev/themes/default/sass/partials/_header.sass
@@ -253,6 +253,9 @@ $header-height: 36px
 	@include ltr
 	@include rtl
 		@extend .navbar-right
+	.dropdown-menu
+		overflow-y: auto
+		max-height: 500px
 
 #ajax_running
 	position: absolute

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -110,6 +110,8 @@
   .items-list {
     list-style: none;
     padding-left: 0;
+    overflow-y: auto;
+    max-height: 500px;
     li:first-child a {
       color: $brand-primary;
       &:hover {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This small PR ads 2 new styles to shop list in the backend (in both default and new theme) `overflow-y: auto;` and `max-height: 500px`. This change won't affect any user that have less than 15 shops (14 or less shops list shouldn't render outside our container with `max-height` set to `500px`) on one instance (multistore enabled). So when the list will be much longer (we have atm. ~ 500 shops) thanks to this change shop list will render scrollbar on the rightside that will allow admins to scroll the list. Before this chnage with long list shop users were unable to reach items rendered outside of visible website area. Please check posted link to ticket on Forge where you can see on 2 screenshots how the list behaves without and with proposed chnages.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3016
| How to test?  | Create 15 or more shops in multistore mode, apply styles added in the commits to admin themes, toggle shop list in backend header when there is less than 15 shops and when there is 15 shops or more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8426)
<!-- Reviewable:end -->
