### PR TITLE
Check that $idFeature and/or value is not empty

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -329,12 +329,12 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
 
         //map features
         if (!empty($form_data['features'])) {
-            foreach ($form_data['features'] as $dataFeature) {
-                $idFeature = $dataFeature['feature'];
-                
-                if (empty($idFeature) {
+            foreach ($form_data['features'] as $dataFeature) {                
+                if (empty($dataFeature['feature']) {
                     continue;
                 }
+                    
+                $idFeature = $dataFeature['feature'];
                 
                 //custom value is defined
                 if ($dataFeature['custom_value'][$this->defaultLocale]) {

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -330,7 +330,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         //map features
         if (!empty($form_data['features'])) {
             foreach ($form_data['features'] as $dataFeature) {                
-                if (empty($dataFeature['feature']) {
+                if (empty($dataFeature['feature'])) {
                     continue;
                 }
 

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -332,16 +332,18 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             foreach ($form_data['features'] as $dataFeature) {
                 $idFeature = $dataFeature['feature'];
                 
-                if (!empty($idFeature)) {
-                    //custom value is defined
-                    if ($dataFeature['custom_value'][$this->defaultLocale]) {
-                        foreach ($this->locales as $locale) {
-                            $form_data['feature_'.$idFeature.'_value'] = null;
-                            $form_data['custom_'.$idFeature.'_'.$locale['id_lang']] = $dataFeature['custom_value'][$locale['id_lang']];
-                        }
-                    } elseif ($dataFeature['value']) {
-                        $form_data['feature_'.$idFeature.'_value'] = $dataFeature['value'];
+                if (empty($idFeature) {
+                    continue;
+                }
+                
+                //custom value is defined
+                if ($dataFeature['custom_value'][$this->defaultLocale]) {
+                    foreach ($this->locales as $locale) {
+                        $form_data['feature_'.$idFeature.'_value'] = null;
+                        $form_data['custom_'.$idFeature.'_'.$locale['id_lang']] = $dataFeature['custom_value'][$locale['id_lang']];
                     }
+                } elseif ($dataFeature['value']) {
+                    $form_data['feature_'.$idFeature.'_value'] = $dataFeature['value'];
                 }
             }
         }

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -333,9 +333,9 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
                 if (empty($dataFeature['feature']) {
                     continue;
                 }
-                    
+
                 $idFeature = $dataFeature['feature'];
-                
+
                 //custom value is defined
                 if ($dataFeature['custom_value'][$this->defaultLocale]) {
                     foreach ($this->locales as $locale) {

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -330,7 +330,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         //map features
         if (!empty($form_data['features'])) {
             foreach ($form_data['features'] as $dataFeature) {                
-                if (empty($dataFeature['feature'])) {
+                if (empty($dataFeature['feature']) || (empty($dataFeature['custom_value'][$this->defaultLocale]) && empty($dataFeature['value']))) {
                     continue;
                 }
 

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -331,15 +331,17 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         if (!empty($form_data['features'])) {
             foreach ($form_data['features'] as $dataFeature) {
                 $idFeature = $dataFeature['feature'];
-
-                //custom value is defined
-                if ($dataFeature['custom_value'][$this->defaultLocale]) {
-                    foreach ($this->locales as $locale) {
-                        $form_data['feature_'.$idFeature.'_value'] = null;
-                        $form_data['custom_'.$idFeature.'_'.$locale['id_lang']] = $dataFeature['custom_value'][$locale['id_lang']];
+                
+                if (!empty($idFeature)) {
+                    //custom value is defined
+                    if ($dataFeature['custom_value'][$this->defaultLocale]) {
+                        foreach ($this->locales as $locale) {
+                            $form_data['feature_'.$idFeature.'_value'] = null;
+                            $form_data['custom_'.$idFeature.'_'.$locale['id_lang']] = $dataFeature['custom_value'][$locale['id_lang']];
+                        }
+                    } elseif ($dataFeature['value']) {
+                        $form_data['feature_'.$idFeature.'_value'] = $dataFeature['value'];
                     }
-                } elseif ($dataFeature['value']) {
-                    $form_data['feature_'.$idFeature.'_value'] = $dataFeature['value'];
                 }
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As now, while you edit a product and choose the "Add a feature" option and doesn't choose one / add a value, you will have an error 500 (due to a notice that value doesn't exist).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Edit a product and choose the "Add a feature" option and doesn't choose one / add a value, you will have an error 500 (due to a notice that value doesn't exist). Fetch this commit and do the same. The error will dissapear and the (no-)feature will not be a problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8427)
<!-- Reviewable:end -->
