### PR TITLE
Fix the name validator

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -156,7 +156,11 @@ class ValidateCore
      */
     public static function isName($name)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:]*$/u'), stripslashes($name));
+        $name = trim($name);
+
+        return (empty($name))
+            ? false
+            : preg_match(Tools::cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:]*$/u'), stripslashes($name));
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When creating a new account, we can save it into the DB even the last name or the first name are just a whitespace.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7423
| How to test?  | FO > account creation > fill the first name or the last name with whitespace and "Register", check if the error message is displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8430)
<!-- Reviewable:end -->
