### PR TITLE
Fix tab position not honored when set on add.

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -91,7 +91,10 @@ class TabCore extends ObjectModel
         self::$_cache_tabs = array();
 
         // Set good position for new tab
-        (is_int($this->position) && $this->position > 0) ? $requestedPosition = $this->position : $requestedPosition = null;
+        $requestedPosition = null;
+        if (is_int($this->position) && $this->position > 0) {
+            $requestedPosition = $this->position;
+        }
         $this->position = Tab::getNewLastPosition($this->id_parent);
         $this->module = Tools::strtolower($this->module);
 
@@ -619,7 +622,11 @@ class TabCore extends ObjectModel
 
         $res = parent::update($nullValues);
 
-        if ($res && is_int($requestedPosition) && $requestedPosition > 0 && $requestedPosition < Tab::getNewLastPosition($this->id_parent)) {
+        if ($res
+            && is_int($requestedPosition)
+            && $requestedPosition > 0
+            && $requestedPosition < Tab::getNewLastPosition($this->id_parent)
+        ) {
             ($requestedPosition < $this->position) ? $way = false : $way = true;
             $this->updatePosition($way, $requestedPosition);
         }

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -627,7 +627,7 @@ class TabCore extends ObjectModel
             && $requestedPosition > 0
             && $requestedPosition < Tab::getNewLastPosition($this->id_parent)
         ) {
-            ($requestedPosition < $this->position) ? $way = false : $way = true;
+            $way = $requestedPosition >= $this->position;
             $this->updatePosition($way, $requestedPosition);
         }
 

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -91,7 +91,9 @@ class TabCore extends ObjectModel
         self::$_cache_tabs = array();
 
         // Set good position for new tab
-        $this->position = Tab::getNewLastPosition($this->id_parent);
+        if (!is_int($this->position)) {
+            $this->position = Tab::getNewLastPosition($this->id_parent);
+        }
         $this->module = Tools::strtolower($this->module);
 
         // Add tab

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -92,7 +92,7 @@ class TabCore extends ObjectModel
 
         // Set good position for new tab
         $requestedPosition = null;
-        if (is_int($this->position) && $this->position > 0) {
+        if (is_int($this->position) && $this->position >= 0) {
             $requestedPosition = $this->position;
         }
         $this->position = Tab::getNewLastPosition($this->id_parent);
@@ -624,7 +624,7 @@ class TabCore extends ObjectModel
 
         if ($res
             && is_int($requestedPosition)
-            && $requestedPosition > 0
+            && $requestedPosition >= 0
             && $requestedPosition < Tab::getNewLastPosition($this->id_parent)
         ) {
             $way = $requestedPosition >= $this->position;
@@ -720,7 +720,8 @@ class TabCore extends ObjectModel
     }
 
     /**
-     * Get position before a tab by class name
+     * Get position before a tab by class name.
+     * Note: If you want to move into the position before a tab, technically you want that tabs current position.
      * @param $className
      * @return bool|int
      */
@@ -728,11 +729,7 @@ class TabCore extends ObjectModel
     {
         $position = Tab::getPositionByClassName($className);
         if (is_numeric($position)) {
-            $newPosition = (int)$position - 1;
-            if ($newPosition <= 0) {
-                $newPosition = 1;
-            }
-            return $newPosition;
+            return (int)$position;
         }
 
         return false;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When adding a new tab any position set is not honored, resulting tab being added with lowest position.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Have a module create a new tab with a position preset.  Before fix, the new tab will always be on bottom.  After fix, it will show where you expect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8431)
<!-- Reviewable:end -->
