### PR TITLE
Fix fatal $sql_values string to array

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5845,7 +5845,7 @@ class ProductCore extends ObjectModel
         }
         if ($this->deleteWsTags()) {
             if ($ids) {
-                $sql_values = '';
+                $sql_values = [];
                 $ids = array_map('intval', $ids);
                 foreach ($ids as $position => $id) {
                     $id_lang = Db::getInstance()->getValue('SELECT `id_lang` FROM `'._DB_PREFIX_.'tag` WHERE `id_tag`='.(int)$id);


### PR DESCRIPTION
| Questions | Answers
| -- | --
| Branch? | 1.7.2.x
| Description? | PHP Fatal error:  Uncaught Error: [] operator not supported for strings in | /classes/Product.php:5852
| Type? | bug fix
| Category? | CO
| BC breaks? | no
| Deprecations? | no
| Fixed ticket? | no
| How to test? | Adding products via Webservice cause fatal errors



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8432)
<!-- Reviewable:end -->
