### PR TITLE
BO: Fixed filtering Combinable Cart Rules

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1238,7 +1238,8 @@ class CartRuleCore extends ObjectModel
 			WHERE 1
 			'.($active_only ? 'AND t.active = 1' : '').'
 			'.(in_array($type, array('carrier', 'shop')) ? ' AND t.deleted = 0' : '').'
-			'.($type == 'cart_rule' ? 'AND t.id_cart_rule != '.(int)$this->id : '').
+			'.($type == 'cart_rule' ? 'AND t.id_cart_rule != '.(int)$this->id : '').'
+			'.($type == 'cart_rule' && !empty($search_cart_rule_name) ? 'AND tl.name LIKE \'%'.pSQL($search_cart_rule_name).'%\'' : '').
             $shop_list.
             (in_array($type, array('carrier', 'shop')) ? ' ORDER BY t.name ASC ' : '').
             (in_array($type, array('country', 'group', 'cart_rule')) && $i18n ? ' ORDER BY tl.name ASC ' : '').


### PR DESCRIPTION
A client complained that on unsaved cart rules, or cart rules with no
uncombinable cart rules, the filtering on the Combinable cart rules list did
not work.

To reproduce:
- Go to create a new cart rule and switch to the conditions tab
- Tick Compatibility with other cart rules
- Attempt to filter existing cart rules under Combinable cart rules
- You should see that although the list refreshes it does not filter the cart rules.

I was able to reproduce this with the 1.6.1.x head.


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description? | A client complained that on unsaved cart rules, or cart rules with no uncombinable cart rules, the filtering on the Combinable cart rules list did not work.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed issue? | Fixes #15526
| How to test?  | I created a fresh install of PrestaShop and created a number of cart rules, then used the reproduction steps above to test the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8434)
<!-- Reviewable:end -->
