### PR TITLE
Fixed product url preview

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1038,7 +1038,7 @@ var form = (function() {
       });
 
       /** on save with duplicate|new|preview */
-      $('.btn-submit', elem).click(function(event) {
+      $('.btn-submit, .preview', elem).click(function(event) {
         event.preventDefault();
         send($(this).attr('data-redirect'), $(this).attr('target'));
       });
@@ -1055,10 +1055,11 @@ var form = (function() {
         $('.for-switch.online-title').toggle(active);
         $('.for-switch.offline-title').toggle(!active);
         // update link preview
-        var urlActive = $('#product_form_preview_btn').attr('data-redirect');
-        var urlDeactive = $('#product_form_preview_btn').attr('data-url_deactive');
-        $('#product_form_preview_btn').attr('data-redirect', urlDeactive);
-        $('#product_form_preview_btn').attr('data-url_deactive', urlActive);
+        var previewButton = $('#product_form_preview_btn');
+        var urlActive = previewButton.attr('data-redirect');
+        var urlDeactive = previewButton.attr('data-url-deactive');
+        previewButton.attr('data-redirect', urlDeactive);
+        previewButton.attr('data-url-deactive', urlActive);
         // update product
         send();
       });

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -1077,7 +1077,7 @@
         <a
           href=""
           data-redirect="{{ preview_link }}"
-          data-url_deactive="{{ preview_link_deactivate }}"
+          data-url-deactive="{{ preview_link_deactivate }}"
           target="_blank"
           class="btn btn-secondary preview"
           data-toggle="pstooltip"


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The preview button wasn't working
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4112
| How to test?  | When a product is enabled or disabled, click on "preview" button.

@PrestaShop/prestashop-product-team someone from QA team: would you mind to add one more integration test to ensure the preview link is working and will work forever please? :heart:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8438)
<!-- Reviewable:end -->
