### PR TITLE
Enable Save button only when  save action is possible (Product page)

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -75,6 +75,10 @@ $(document).ready(function() {
     $('[data-toggle="tooltip"]').tooltip('hide');
     $('[data-toggle="popover"]').popover('hide');
   });
+
+  /** Save buttons should be active only when everything is loaded  */
+  $('#submit').removeAttr('disabled');
+  $('#create-combinations').removeAttr('disabled');
 });
 
 /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_combinations.html.twig
@@ -46,7 +46,7 @@
           </fieldset>
         </div>
         <div class="col-xl-2 col-lg-3">
-          <button class="btn btn-outline-primary" id="create-combinations">
+          <button class="btn btn-outline-primary" id="create-combinations" disabled>
             Generate
           </button>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/form.html.twig
@@ -1142,6 +1142,7 @@
           value="{{ 'Save'|trans({}, 'Admin.Actions') }}"
           data-toggle="pstooltip"
           title="{{ 'Save the product and stay on the current page: ALT+SHIFT+S'|trans({}, 'Admin.Catalog.Help') }}"
+          disabled
           />
 
           <div class="js-spinner spinner hide btn-primary-reverse onclick mr-1 btn"></div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We have noticed that sometimes, if we save a product very fast, the save fails because all the "required" javascript content is not yet loaded. This patch is about enable save actions only when available.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4115
| How to test?  | Access Product form page and try to save and/or generate multiple combinations. If you connection is bad (try to select 3G connection on Chrome debug toolbar) you should see that the save/generate actions are disabled and then are enabled: you can now save products and generate combinations without errors (except in case of errors already reported by @vincentbz).

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8439)
<!-- Reviewable:end -->
