### PR TITLE
Invalid path to look at config.defines.inc file permissions

### DIFF
--- a/src/PrestaShopBundle/Resources/config/admin/services.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/services.yml
@@ -1,6 +1,6 @@
 parameters:
     ps_root_dir:              "%kernel.root_dir%/../"
-    ps_config_dir:            "%kernel.root_dir%/config"
+    ps_config_dir:            "%ps_root_dir%config"
     translations_dir:         "%kernel.root_dir%/Resources/translations"
     themes_translations_dir:  "%kernel.cache_dir%/themes"
     themes_dir:               "%kernel.root_dir%/../themes"


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In debug mode, you can't update debug mode because PrestaShop look at `config.defines.php` file into the wrong folder.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | None, but it's part of Performance page migration :)
| How to test?  | Switch into dev mode, then prod mode, then dev mode again. Note this is not a regression as "before" the migration the file perms were just "ignored" ...

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8440)
<!-- Reviewable:end -->
