### PR TITLE
Use DISTINCT in query to improve uninstall() method in Module class

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -663,7 +663,7 @@ abstract class ModuleCore implements ModuleInterface
         }
 
         // Retrieve hooks used by the module
-        $sql = 'SELECT `id_hook` FROM `'._DB_PREFIX_.'hook_module` WHERE `id_module` = '.(int)$this->id;
+        $sql = 'SELECT DISTINCT(`id_hook`) FROM `'._DB_PREFIX_.'hook_module` WHERE `id_module` = '.(int)$this->id;
         $result = Db::getInstance()->executeS($sql);
         foreach ($result as $row) {
             $this->unregisterHook((int)$row['id_hook']);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When module is beeing uninstalled it also removes relation to related hooks and exceptions (from hook_module table). To do this inside `uninstall()` method of `Module` class we are loading hook ids assigned to module. Since the `hook_module` table stores relation for modules and hooks in each shop (if we are using multistore) than the mentioned query will return by default duplicated id_hook values. If we use `DINSTINCT` on selected column we will have unique `id_hook` values and we will not call several times for the same id_hook `unregisterHook()` or `unregisterExceptions()` functions that will do their job only in first call. So this is small improvement to avoid unnecesary forwach calls in module `uninstall()` method.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3970
| How to test?  | Best way to test it is to dump rows returned by modified query before and after change and count foreach calls etc. or enable profiling and check query executing reports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8441)
<!-- Reviewable:end -->
