### PR TITLE
Fix the wrong rounding in the invoice

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2372,12 +2372,12 @@ class OrderCore extends ObjectModel
             $order_ecotax_tax = Tools::ps_round($order_ecotax_tax, _PS_PRICE_COMPUTE_PRECISION_, $this->round_mode);
 
             $tax_rounding_error = $expected_total_tax - $actual_total_tax - $order_ecotax_tax;
-            if ($tax_rounding_error !== 0) {
+            if ($tax_rounding_error !== 0 && (int)$round_type !== Order::ROUND_TOTAL) {
                 Tools::spreadAmount($tax_rounding_error, _PS_PRICE_COMPUTE_PRECISION_, $order_detail_tax_rows, 'total_amount');
             }
 
             $base_rounding_error = $expected_total_base - $actual_total_base;
-            if ($base_rounding_error !== 0) {
+            if ($base_rounding_error !== 0 && (int)$round_type !== Order::ROUND_TOTAL) {
                 Tools::spreadAmount($base_rounding_error, _PS_PRICE_COMPUTE_PRECISION_, $order_detail_tax_rows, 'total_tax_base');
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you choose  **Round on the total** as a value of the **Round type**, the total tax is displayed wrongly in the generated invoice.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9251 and maybe #9779 ?
| How to test?  | BO > Perferences > General > set the options ( **Round mode** => `Round down to the nearest value`, **Round type** => `Round on the total`, **Number of decimals** => `3`), and create an order with any product with (quantity > 1), generate the invoice and check if the **total tax** is displayed correctly without rounding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8443)
<!-- Reviewable:end -->
