### PR TITLE
Fix the sorting problem with a descending order in the products filtering page

### DIFF
--- a/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
+++ b/themes/default-bootstrap/js/modules/blocklayered/blocklayered.js
@@ -483,7 +483,7 @@ function reloadContent(params_plus)
 	{
 		type: 'GET',
 		url: baseDir + 'modules/blocklayered/blocklayered-ajax.php',
-		data: data+params_plus+n,
+		data: data + '&' + params_plus + n,
 		dataType: 'json',
 		cache: false, // @todo see a way to use cache and to add a timestamps parameter to refresh cache each 10 minutes for example
 		success: function(result)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1x
| Description?  | When blocklayered is enabled, the sorting in descending order does not work in the products filtering page.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8185
| How to test?  | FO > the products filtering page, sort the products with any filter in descending order (example : Product Name: Z to A) and check if you get the right result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8445)
<!-- Reviewable:end -->
