### PR TITLE
Fix the phone number validator

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -536,7 +536,7 @@ class ValidateCore
     {
         $phoneNumber = preg_replace("/[+. ()-]/", "", $number);
 
-        return preg_match('/^[0-9]{7,15}$/', $phoneNumber);
+        return (bool)preg_match('/^[0-9]{7,15}$/', $phoneNumber);
     }
 
     /**

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -534,7 +534,9 @@ class ValidateCore
      */
     public static function isPhoneNumber($number)
     {
-        return preg_match('/^[+0-9. ()-]*$/', $number);
+        $phoneNumber = preg_replace("/[+. ()-]/", "", $number);
+
+        return preg_match('/^[0-9]{7,15}$/', $phoneNumber);
     }
 
     /**

--- a/tests/Unit/classes/ValidateCoreTest.php
+++ b/tests/Unit/classes/ValidateCoreTest.php
@@ -106,16 +106,24 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame($expected, Validate::isInt($input));
     }
-        
-        // --- providers ---
 
-        public function isIp2LongDataProvider()
-        {
-            return array(
+    /**
+     * @dataProvider isPhoneNumberDataProvider
+     */
+    public function testIsPhoneNumber($expected, $input)
+    {
+        $this->assertSame($expected, Validate::isPhoneNumber($input));
+    }
+
+    // --- providers ---
+
+    public function isIp2LongDataProvider()
+    {
+        return array(
             array(false, 'toto'),
             array(true, '123')
         );
-        }
+    }
 
     public function isMd5DataProvider()
     {
@@ -226,6 +234,22 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
             array(false, null),
             array(false, ''),
             array(true, false),
+        );
+    }
+
+    public function isPhoneNumberDataProvider()
+    {
+        return array(
+            'Country France, version 1' => array(true, '+33 5 12 34 56 78'),
+            'Country USA, version 1' => array(true, '+1-900-253-0000'),
+            'Country Germany, version 1' => array(true, '+49 291 12345678'),
+            'Country Germany, version 2' => array(true, '(+49) 291-12345678'),
+            'Test when the phone number is too short' => array(false, '02-1234'),
+            'Test when the phone number is too long' => array(false, '+1 123 4567 8963 0000'),
+            'Test when phone number contains a special characters' => array(false, '+49 30/1234'),
+            'Test when phone number contains an alphabetical characters' => array(false, '1-800-SIX-flag'),
+            'Test when phone number is empty' => array(false, ' '),
+            'Test when phone number is null' => array(false, null),
         );
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When creating a new address, we can save it into the DB even the phone number is just a whitespace.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8348
| How to test?  | BO > Customers > Addresses > Set required fields for this section > make the phone required, FO > Sign in > My addresses > Add a new address > fill the phone number with whitespace and "Save", check if the error message is displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8446)
<!-- Reviewable:end -->
