### PR TITLE
Add cover to allowed properties in ajax requests

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -502,7 +502,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
     protected function prepareProductArrayForAjaxReturn(array $products)
     {
         $allowed_properties = array('id_product', 'price', 'reference', 'active', 'description_short', 'link',
-            'link_rewrite', 'name', 'manufacturer_name', 'position', 'url', 'canonical_url', 'add_to_cart_url',
+            'link_rewrite', 'name', 'manufacturer_name', 'position', 'cover', 'url', 'canonical_url', 'add_to_cart_url',
             'has_discount', 'discount_type', 'discount_percentage', 'discount_percentage_absolute', 'discount_amount',
             'price_amount', 'regular_price_amount', 'regular_price', 'discount_to_display', 'labels', 'main_variants',
             'unit_price', 'tax_name', 'rate'


### PR DESCRIPTION
Cover attribute is widely used by theme developers for ajax search

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Latest upgrade 1.7.2.4 added PR #8433 which remove some data from ajax query. It also removed cover attribute
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8447)
<!-- Reviewable:end -->
