### PR TITLE
BO: Add Order - Reset button if there are delivery option

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -614,6 +614,9 @@
 				$("button[name=\"submitAddOrder\"]").attr("disabled", "disabled");
 			}
 		}
+		else if (delivery_option_list.length > 0) {
+			$("button[name=\"submitAddOrder\"]").removeAttr("disabled");
+		}
 	}
 
 	function searchProducts()


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When I add an order in BO, the submitAddOrder button remains disabled even if I have a possible delivery mode and selected. It's a regression of https://github.com/PrestaShop/PrestaShop/commit/62b0e96bacc42d3e2d6eb31f731ecd288b176769#diff-ccfa47864bd3c12a5ae7c95225a0b37a
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Create an order in BO. No delivery method should be proposed at the beginning. Select an address. The button must be clickable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8448)
<!-- Reviewable:end -->
