### PR TITLE
fix unset the $cart_rules when  there is no gift product set

### DIFF
--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -54,7 +54,7 @@ class DiscountControllerCore extends FrontController
                 new Currency((int)$this->context->cart->id_currency)
             );
             
-            if ($discount['gift_product'] !== 0) {
+            if ((int)$discount['gift_product'] !== 0) {
                 $product = new Product((int) $discount['gift_product'], false, (int)$this->context->language->id);
                 if (!Validate::isLoadedObject($product) || !$product->isAssociatedToShop() || !$product->active) {
                     unset($cart_rules[$key]);


### PR DESCRIPTION
it will unset the array value even there is gift product set

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.x
| Description?  | it will unset the array value of $cart_rules even there is no gift product set
| Type?         | bug fix  
| Category?     |  BO
| BC breaks?    | Does it break backward compatibility? yes/no
| Deprecations? | Does it deprecate an existing feature? yes/no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8450)
<!-- Reviewable:end -->
