### PR TITLE
Catalog controler wrongly use by default desc sorting instead of "last"

### DIFF
--- a/src/PrestaShopBundle/Resources/config/admin/routing_product.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/routing_product.yml
@@ -7,7 +7,7 @@ admin_product_catalog:
         limit: last
         offset: 0
         orderBy: last
-        sortOrder: desc
+        sortOrder: last
     requirements:
         limit: _limit|last|\d+
         orderBy: last|id_product|name|reference|name_category|price|sav_quantity|position|active|position_ordering


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When sorting by position asc is enabled in the product catalog and the position is changed, the sorting is reset to desc after hitting save & refresh
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | After hitting save & refresh the sorting should remain the same

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8452)
<!-- Reviewable:end -->
