### PR TITLE
Improve order presenter performance

### DIFF
--- a/src/Adapter/Order/OrderPresenter.php
+++ b/src/Adapter/Order/OrderPresenter.php
@@ -83,9 +83,11 @@ class OrderPresenter implements PresenterInterface
             throw new \Exception('OrderPresenter can only present instance of Order');
         }
 
-        return array(
-            'products' => $this->getProducts($order),
-            'products_count' => count($this->getProducts($order)),
+        $products = $this->getProducts($order);
+
+        return [
+            'products' => $products,
+            'products_count' => count($products),
             'totals' => $this->getAmounts($order)['totals'],
             'subtotals' => $this->getAmounts($order)['subtotals'],
             'details' => $this->getDetails($order),
@@ -98,7 +100,7 @@ class OrderPresenter implements PresenterInterface
             'id_address_delivery' => $order->id_address_delivery,
             'id_address_invoice' => $order->id_address_invoice,
             'labels' => $this->getLabels(),
-        );
+        ];
     }
 
     /**

--- a/src/Adapter/Order/OrderPresenter.php
+++ b/src/Adapter/Order/OrderPresenter.php
@@ -84,12 +84,13 @@ class OrderPresenter implements PresenterInterface
         }
 
         $products = $this->getProducts($order);
+        $amounts = $this->getAmounts($order);
 
-        return [
+        return array(
             'products' => $products,
             'products_count' => count($products),
-            'totals' => $this->getAmounts($order)['totals'],
-            'subtotals' => $this->getAmounts($order)['subtotals'],
+            'totals' => $amounts['totals'],
+            'subtotals' => $amounts['subtotals'],
             'details' => $this->getDetails($order),
             'history' => $this->getHistory($order),
             'messages' => $this->getMessages($order),
@@ -100,7 +101,7 @@ class OrderPresenter implements PresenterInterface
             'id_address_delivery' => $order->id_address_delivery,
             'id_address_invoice' => $order->id_address_invoice,
             'labels' => $this->getLabels(),
-        ];
+        );
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Improves order presenter performance since $this->getProducts() (which performs a lot of processing) was called second time just to get number of products.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | See PR.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8453)
<!-- Reviewable:end -->
