### PR TITLE
Fix JS error on Performance page

### DIFF
--- a/admin-dev/themes/default/js/bundle/admin_parameters/performancePageUI.js
+++ b/admin-dev/themes/default/js/bundle/admin_parameters/performancePageUI.js
@@ -25,9 +25,9 @@
 var PerformancePageUI = {
     displaySmartyCache: function() {
         var CACHE_ENABLED = '1';
-        var smartyCacheSelected = document.getElementById('form_smarty_cache').value;
+        var smartyCacheSelected = document.getElementById('form_smarty_cache');
         var smartyCacheOptions = document.querySelectorAll('.smarty-cache-option');
-        if (smartyCacheSelected === CACHE_ENABLED) {
+        if (smartyCacheSelected && smartyCacheSelected.value === CACHE_ENABLED) {
           for(var i = 0; i < smartyCacheOptions.length; i++) {
             smartyCacheOptions[i].style.display = 'block';
           }
@@ -58,10 +58,10 @@ var PerformancePageUI = {
     displayMemcacheServers: function() {
         var CACHE_ENABLED = '1';
         var cacheEnabledInput = document.getElementById('form_caching_use_cache');
-        var cacheSelected = document.querySelector('input[name="form[caching][caching_system]"]:checked').value;
+        var cacheSelected = document.querySelector('input[name="form[caching][caching_system]"]:checked');
         var memcacheServersListBlock = document.getElementById('servers-list');
         var newServerBtn = document.getElementById('new-server-btn');
-        var isMemcache = cacheSelected === "CacheMemcache" || cacheSelected === "CacheMemcached";
+        var isMemcache = cacheSelected && (cacheSelected.value === "CacheMemcache" || cacheSelected.value === "CacheMemcached");
 
         if (isMemcache && cacheEnabledInput.value === CACHE_ENABLED) {
             memcacheServersListBlock.style.display = "block";

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -53,7 +53,6 @@ class CachingType extends TranslatorAwareType
                     true => 'Yes',
                 ),
                 'choice_translation_domain' => 'Admin.Global',
-                'required' => true,
             ))
             ->add('caching_system', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
@@ -86,7 +85,7 @@ class CachingType extends TranslatorAwareType
                 },
                 'expanded' => true,
                 'choices_as_values' => true,
-                'required' => true,
+                'required' => false,
             ))
         ;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When the additional cache is disabled, we cannot send anymore the performance form. This PR fixes a JS error and the form submission.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Try to send the form without cache server selected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8456)
<!-- Reviewable:end -->
