### PR TITLE
Fix shopping cart when allow checkout with unavailable pack items

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4079,4 +4079,136 @@ class CartCore extends ObjectModel
             return $addresses_instance_without_carriers;
         }
     }
+
+    /**
+     * Check if the pack items in the cart are available
+     *
+     * @return bool|Product - Return the product in case it's quantity is unavailable
+     */
+    public function checkPacksItemsQuantities()
+    {
+        if (Configuration::get('PS_PACK_STOCK_TYPE') <= 0) {
+            return true;
+        }
+
+        /** Temporary array of Cart Products */
+        $allCartProducts = $this->getCartProductsFlatList($this->getProducts());
+
+        return $this->validateProductsQuantities($allCartProducts);
+    }
+
+    /**
+     * Extract the packs items
+     *
+     * @param int $idProduct
+     * @param int $packQuantity
+     * @return array - Array of cart products
+     */
+    private function extractPackItems($productId, $packQuantity)
+    {
+        $stockManager = Adapter_ServiceLocator::get('Adapter_StockManager');
+        $items = Pack::getItems((int)$productId, $this->id_lang);
+        $products = array();
+
+        foreach ($items as $item) {
+            /** @var StockAvailable $stockAvailable - the available quantity in stock of the item */
+            $stockAvailable = $stockManager->getStockAvailableByProduct($item, (int)$item->id_pack_product_attribute);
+            $totalQuantity = ($packQuantity * $item->pack_quantity);
+            $product = get_object_vars($item);
+            $product['id_product'] = $item->id;
+            $product['id_product_attribute'] = $item->id_pack_product_attribute;
+            $product['cart_quantity'] = $totalQuantity;
+            $product['stock_quantity'] = $stockAvailable->quantity;
+            $products[] = $product;
+        }
+
+        return $products;
+    }
+
+    /**
+     * Return all the cart products after the extraction of packs items
+     *
+     * @param array $cartProducts - Array of cart products
+     * @return array - Array of cart products
+     */
+    private function getCartProductsFlatList($cartProducts)
+    {
+        $cartProductsTmp = $cartProducts;
+        foreach ($cartProducts as $product) {
+            if (Pack::isPack((int)$product['id_product'])) {
+                /** unset the pack from the temporary cat */
+                $packIndex = $this->getItemIndexInCart($cartProductsTmp, $product);
+                unset($cartProductsTmp[$packIndex]);
+
+                $packItems = $this->extractPackItems($product['id_product'], $product['cart_quantity']);
+                $cartProductsTmp = $this->mergePackItemsInCart(array_values($cartProductsTmp), $packItems);
+            }
+        }
+
+        return $cartProductsTmp;
+    }
+
+    /**
+     * Merge the pack items with the cart products
+     *
+     * @param array $cartProducts - Array of cart products
+     * @param array $packItems - Array of pack items
+     * @return array - Array of cart products
+     */
+    private function mergePackItemsInCart($cartProducts, $packItems)
+    {
+        foreach ($packItems as $item) {
+            $productIndex = $this->getItemIndexInCart($cartProducts, $item);
+
+            /**
+             * if the pack item does not exist in the temporary cart, add it
+             * else increase in the cart quantity
+             */
+            if (false === $productIndex) {
+                $cartProducts[] = $item;
+            } else {
+                $cartProducts[$productIndex]['cart_quantity'] += $item['cart_quantity'];
+            }
+        }
+
+        return $cartProducts;
+    }
+
+    /**
+     * Returns the index of the cart item if it exists
+     *
+     * @param array $cartProducts - Array of cart products
+     * @param array $item - Single cart product
+     * @return bool|int - if the item exists in the Cart, returns the index of the item, else it will return false
+     */
+    private function getItemIndexInCart($cartProducts, $item)
+    {
+        if ((bool)$item['id_product_attribute']) {
+            $cartProductsIds = array_column($cartProducts, 'id_product_attribute');
+            $itemField = $item['id_product_attribute'];
+        } else {
+            $cartProductsIds = array_column($cartProducts, 'id_product');
+            $itemField = $item['id_product'];
+        }
+
+        return array_search($itemField, $cartProductsIds);
+    }
+
+    /**
+     * Check if the quantity of the cart products is available
+     *
+     * @param array $cartProducts - Array of cart products
+     * @return bool|Product - Return the product in case it's quantity is unavailable
+     */
+    private function validateProductsQuantities($cartProducts)
+    {
+        foreach ($cartProducts as $product) {
+            if ((int)$product['out_of_stock'] !== 1
+                && $product['cart_quantity'] > $product['stock_quantity']) {
+                return $product;
+            }
+        }
+
+        return true;
+    }
 }

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -54,20 +54,20 @@ class OrderControllerCore extends ParentOrderController
             $this->errors[] = sprintf(Tools::displayError('An item in your cart is no longer available (%1s). You cannot proceed with your order.'), Product::getProductName((int)$id_product));
         }
 
+        // If some products have disappear
+        if (is_array($product)) {
+            $this->step = 0;
+            $this->errors[] = sprintf(Tools::displayError('An item (%1s) in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.'), $product['name']);
+        }
+
         // Check if the packs items in the cart are available
         $packProduct = $this->context->cart->checkPacksItemsQuantities();
-        if (true !== $packProduct) {
+        if (true !== $packProduct && empty($this->errors)) {
             $this->step = 0;
             $this->errors[] = sprintf(
                 Tools::displayError('An item (%1s) in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.'),
                 $packProduct['name']
             );
-        }
-
-        // If some products have disappear
-        if (is_array($product)) {
-            $this->step = 0;
-            $this->errors[] = sprintf(Tools::displayError('An item (%1s) in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.'), $product['name']);
         }
 
         // Check minimal amount

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -54,6 +54,16 @@ class OrderControllerCore extends ParentOrderController
             $this->errors[] = sprintf(Tools::displayError('An item in your cart is no longer available (%1s). You cannot proceed with your order.'), Product::getProductName((int)$id_product));
         }
 
+        // Check if the packs items in the cart are available
+        $packProduct = $this->context->cart->checkPacksItemsQuantities();
+        if (true !== $packProduct) {
+            $this->step = 0;
+            $this->errors[] = sprintf(
+                Tools::displayError('An item (%1s) in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.'),
+                $packProduct['name']
+            );
+        }
+
         // If some products have disappear
         if (is_array($product)) {
             $this->step = 0;

--- a/themes/default-bootstrap/js/cart-summary.js
+++ b/themes/default-bootstrap/js/cart-summary.js
@@ -1030,27 +1030,27 @@ function updateExtraCarrier(id_delivery_option, id_address)
  * @param {string[]} errors - Array of errors
  */
 var displayError = function displayError(errors) {
-	if (errors.length > 0) {
-		var errorsMsg = '';
-		for (var error in errors) {
-			//IE6 bug fix
-			if (error !== 'indexOf') {
-				errorsMsg += $('<div />').html(errors[error]).text() + "\n";
-			}
-		}
-		if (!!$.prototype.fancybox) {
-			$.fancybox.open([
-					{
-						type: 'inline',
-						autoScale: true,
-						minHeight: 30,
-						content: '<p class="fancybox-error">' + errorsMsg + '</p>'
-					}],
-				{
-					padding: 0
-				});
-		} else {
-			alert(errorsMsg);
-		}
-	}
+    if (errors.length > 0) {
+        var errorsMsg = '';
+        for (var error in errors) {
+            //IE6 bug fix
+            if (error !== 'indexOf') {
+                errorsMsg += $('<div />').html(errors[error]).text() + "\n";
+            }
+        }
+        if (typeof($.prototype.fancybox) !== "undefined") {
+            $.fancybox.open([
+                {
+                    type: 'inline',
+                    autoScale: true,
+                    minHeight: 30,
+                    content: '<p class="fancybox-error">' + errorsMsg + '</p>'
+                }
+            ], {
+                padding: 0
+            });
+        } else {
+            alert(errorsMsg);
+        }
+    }
 };

--- a/themes/default-bootstrap/js/cart-summary.js
+++ b/themes/default-bootstrap/js/cart-summary.js
@@ -436,24 +436,7 @@ function deleteProductFromSummary(id)
 		{
 			if (jsonData.hasError)
 			{
-				var errors = '';
-				for(var error in jsonData.errors)
-					//IE6 bug fix
-					if(error !== 'indexOf')
-						errors += $('<div />').html(jsonData.errors[error]).text() + "\n";
-									if (!!$.prototype.fancybox)
-											$.fancybox.open([
-													{
-															type: 'inline',
-															autoScale: true,
-															minHeight: 30,
-															content: '<p class="fancybox-error">' + errors + '</p>'
-													}],
-													{
-															padding: 0
-													});
-									else
-											alert(errors);
+				displayError(jsonData.errors);
 			}
 			else
 			{
@@ -528,6 +511,7 @@ function deleteProductFromSummary(id)
 					getCarrierListAndUpdate();
 				if (typeof(updatePaymentMethodsDisplay) !== 'undefined')
 					updatePaymentMethodsDisplay();
+				displayError(jsonData.ajaxError);
 			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
@@ -616,24 +600,7 @@ function upQuantity(id, qty)
 		{
 			if (jsonData.hasError)
 			{
-				var errors = '';
-				for(var error in jsonData.errors)
-					//IE6 bug fix
-					if(error !== 'indexOf')
-						errors += $('<div />').html(jsonData.errors[error]).text() + "\n";
-				if (!!$.prototype.fancybox)
-				    $.fancybox.open([
-			        {
-			            type: 'inline',
-			            autoScale: true,
-			            minHeight: 30,
-			            content: '<p class="fancybox-error">' + errors + '</p>'
-			        }],
-					{
-				        padding: 0
-				    });
-				else
-				    alert(errors);
+				displayError(jsonData.errors);
 				$('input[name=quantity_'+ id +']').val($('input[name=quantity_'+ id +'_hidden]').val());
 			}
 			else
@@ -651,6 +618,7 @@ function upQuantity(id, qty)
 					getCarrierListAndUpdate();
 				if (typeof(updatePaymentMethodsDisplay) !== 'undefined')
 					updatePaymentMethodsDisplay();
+				displayError(jsonData.ajaxError);
 			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
@@ -728,24 +696,7 @@ function downQuantity(id, qty)
 			{
 				if (jsonData.hasError)
 				{
-					var errors = '';
-					for(var error in jsonData.errors)
-						//IE6 bug fix
-						if(error !== 'indexOf')
-							errors += $('<div />').html(jsonData.errors[error]).text() + "\n";
-                    if (!!$.prototype.fancybox)
-                        $.fancybox.open([
-                            {
-                                type: 'inline',
-                                autoScale: true,
-                                minHeight: 30,
-                                content: '<p class="fancybox-error">' + errors + '</p>'
-                            }],
-                            {
-                                padding: 0
-                            });
-                    else
-                        alert(errors);
+					displayError(jsonData.errors);
 					$('input[name=quantity_' + id + ']').val($('input[name=quantity_' + id + '_hidden]').val());
 				}
 				else
@@ -768,6 +719,7 @@ function downQuantity(id, qty)
 						getCarrierListAndUpdate();
 					if (typeof(updatePaymentMethodsDisplay) !== 'undefined')
 						updatePaymentMethodsDisplay();
+					displayError(jsonData.ajaxError);
 				}
 			},
 			error: function(XMLHttpRequest, textStatus, errorThrown) {
@@ -1072,3 +1024,33 @@ function updateExtraCarrier(id_delivery_option, id_address)
 		}
 	});
 }
+
+/**
+ * Display the alert of errors
+ * @param {string[]} errors - Array of errors
+ */
+var displayError = function displayError(errors) {
+	if (errors.length > 0) {
+		var errorsMsg = '';
+		for (var error in errors) {
+			//IE6 bug fix
+			if (error !== 'indexOf') {
+				errorsMsg += $('<div />').html(errors[error]).text() + "\n";
+			}
+		}
+		if (!!$.prototype.fancybox) {
+			$.fancybox.open([
+					{
+						type: 'inline',
+						autoScale: true,
+						minHeight: 30,
+						content: '<p class="fancybox-error">' + errorsMsg + '</p>'
+					}],
+				{
+					padding: 0
+				});
+		} else {
+			alert(errorsMsg);
+		}
+	}
+};

--- a/themes/default-bootstrap/js/order-opc.js
+++ b/themes/default-bootstrap/js/order-opc.js
@@ -324,29 +324,56 @@ function updateDisplayPrice(json) {
 
 function updatePaymentMethodsDisplay()
 {
-	var checked = '';
-	if ($('#cgv:checked').length !== 0)
-		checked = 1;
-	else
-		checked = 0;
-	$('#opc_payment_methods-overlay').fadeIn('slow', function(){
-		$.ajax({
-			type: 'POST',
-			headers: { "cache-control": "no-cache" },
-			url: orderOpcUrl + '?rand=' + new Date().getTime(),
-			async: true,
-			cache: false,
-			dataType : "json",
-			data: 'ajax=true&method=updateTOSStatusAndGetPayments&checked=' + checked + '&token=' + static_token,
-			success: function(json)
-			{
-				updatePaymentMethods(json);
-				if (typeof bindUniform !=='undefined')
-					bindUniform();
-			}
-		});
-		$(this).fadeOut('slow');
-	});
+    var checked = ($('#cgv:checked').length !== 0) ? 1 : 0;
+
+    $('#opc_payment_methods-overlay').fadeIn('slow', function () {
+        $.ajax({
+            type: 'POST',
+            headers: {"cache-control": "no-cache"},
+            url: orderOpcUrl + '?rand=' + new Date().getTime(),
+            async: true,
+            cache: false,
+            dataType: "json",
+            data: 'ajax=true&method=updateTOSStatusAndGetPayments&checked=' + checked + '&token=' + static_token,
+            success: function (json) {
+                var $cgvCheckBox = $('#cgv');
+                if (json.hasError) {
+                    if (0 === $('.fancybox-error').length) {
+                        var errors = '';
+                        for (var error in json.errors) {
+                            //IE6 bug fix
+                            if (error !== 'indexOf') {
+                                errors += $('<div />').html(json.errors[error]).text() + "\n";
+                            }
+                        }
+                        if (typeof($.prototype.fancybox) !== "undefined") {
+                            $.fancybox.open([
+                                {
+                                    type: 'inline',
+                                    autoScale: true,
+                                    minHeight: 30,
+                                    content: '<p class="fancybox-error">' + errors + '</p>'
+                                }
+                            ], {
+                                padding: 0
+                            });
+                        } else {
+                            alert(errors);
+                        }
+                    }
+
+                    $cgvCheckBox.closest("span").removeClass('checked');
+                    $cgvCheckBox.attr('checked', false);
+                } else {
+                    updatePaymentMethods(json);
+                    if (typeof bindUniform !== 'undefined') {
+                        bindUniform();
+                    }
+                }
+            }
+        });
+        $(this).fadeOut('slow');
+    });
 }
 
 function updateAddressSelection(is_adv_api)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | The shopping cart allows checkout with unavailable pack items.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7170
| How to test?  | BO > preferences > products > choose decrease both for packs, create a product A with a stock of 50, create a product B with a stock of 5 (this product is a pack of 10 products A), order 50 products A and 5 products B, FO > shopping cart and check if an error message appears.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8457)
<!-- Reviewable:end -->
