### PR TITLE
Force query build arg_separator to &

### DIFF
--- a/src/PrestaShopBundle/Service/Routing/Router.php
+++ b/src/PrestaShopBundle/Service/Routing/Router.php
@@ -73,6 +73,6 @@ class Router extends BaseRouter
 
         $queryParams['_token'] = $token;
 
-        return $baseUrl.'?'.http_build_query($queryParams);
+        return $baseUrl.'?'.http_build_query($queryParams, '', '&');
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The http_build_query uses by default the arg_separator.output value of PHP. So we have to force it because in some cases the default arg_separator.output is : &amp;
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | You can reproduce this bug only if "arg_separator.output" is defined to "&amp;" in your php configuration.Try a phpinfo(), I think you have "&" value configured. _After your "arg_separator.output" defined to "&amp;" you can reproduce this bug on AdminTranslations back office page. Try to update translations of classic template : unable to access (browser error)_


Similar to https://github.com/PrestaShop/PrestaShop/pull/7779 : fixed some time ago.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8459)
<!-- Reviewable:end -->
