### PR TITLE
Fixing data duplication when using 1-click upgrade multiple times

### DIFF
--- a/install-dev/upgrade/php/add_new_status_stock.php
+++ b/install-dev/upgrade/php/add_new_status_stock.php
@@ -91,6 +91,11 @@ function add_new_status_stock()
     );
 
     foreach ($data as $d) {
+        // We don't want duplicated data
+        if (configuration_exists($d['name'])) {
+            continue;
+        }
+
         // ps_stock_mvt_reason
         Db::getInstance()->execute(
             'INSERT INTO `' . _DB_PREFIX_ . 'stock_mvt_reason` (`sign`, `date_add`, `date_upd`, `deleted`)
@@ -130,4 +135,15 @@ function add_new_status_stock()
             (int)Configuration::get('PS_OS_CANCELED')
         );
     }
+}
+
+function configuration_exists($confName)
+{
+    $count = (int)Db::getInstance()->getValue(
+        'SELECT count(id_configuration)
+        FROM `' . _DB_PREFIX_ . 'configuration` 
+        WHERE `name` = \'' . $confName . '\''
+    );
+
+    return ($count > 0);
 }

--- a/install-dev/upgrade/php/add_new_status_stock.php
+++ b/install-dev/upgrade/php/add_new_status_stock.php
@@ -92,7 +92,7 @@ function add_new_status_stock()
 
     foreach ($data as $d) {
         // We don't want duplicated data
-        if (configuration_exists($d['name'])) {
+        if (configuration_exists($d['conf'])) {
             continue;
         }
 

--- a/install-dev/upgrade/php/add_new_status_stock.php
+++ b/install-dev/upgrade/php/add_new_status_stock.php
@@ -41,11 +41,11 @@ function add_new_status_stock()
             (`id_tab`, `id_parent`, `position`, `module`, `class_name`, `active`, `hide_host_mode`, `icon`)
             VALUES (null, 9, 7, NULL, \'AdminStockManagement\', 1, 0, \'\')'
         );
-        $lastIdTab = Db::getInstance()->insert_id();
+        $lastIdTab = (int)Db::getInstance()->insert_id();
 
         // ps_tab_lang
-        $queryString = "INSERT INTO `%stab_lang` (`id_tab`, `id_lang`, `name`) VALUES (%s, %s, '%s')";
         foreach ($languages as $lang) {
+            $idLang    = (int)$lang['id_lang'];
             $stockName = pSQL(
                 $translator->trans(
                     'Stock',
@@ -55,13 +55,12 @@ function add_new_status_stock()
                 )
             );
             Db::getInstance()->execute(
-                sprintf(
-                    $queryString,
-                    _DB_PREFIX_,
-                    (int)$lastIdTab,
-                    (int)$lang['id_lang'],
-                    $stockName
-                )
+                "INSERT INTO `" . _DB_PREFIX_ . "tab_lang` (`id_tab`, `id_lang`, `name`) 
+                VALUES (
+                  " . $lastIdTab . ", 
+                  " . $idLang . ", 
+                  '" . $stockName . "'
+                )"
             );
         }
     }

--- a/install-dev/upgrade/php/add_new_status_stock.php
+++ b/install-dev/upgrade/php/add_new_status_stock.php
@@ -24,67 +24,100 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-/**
- * Select all current payment modules for the carrier restriction
- */
 function add_new_status_stock()
 {
     $translator = Context::getContext()->getTranslator();
+    $languages  = Language::getLanguages();
 
+    // insert ps_tab AdminStockManagement
+    $count = (int)Db::getInstance()->getValue(
+        'SELECT count(id_tab) FROM `' . _DB_PREFIX_ . 'tab` 
+        WHERE `class_name` = \'AdminStockManagement\'
+        AND `id_parent` = 9'
+    );
+    if (!$count) {
+        Db::getInstance()->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'tab`
+            (`id_tab`, `id_parent`, `position`, `module`, `class_name`, `active`, `hide_host_mode`, `icon`)
+            VALUES (null, 9, 7, NULL, \'AdminStockManagement\', 1, 0, \'\')'
+        );
+        $lastIdTab = Db::getInstance()->insert_id();
+
+        // ps_tab_lang
+        $queryString = "INSERT INTO `%stab_lang` (`id_tab`, `id_lang`, `name`) VALUES (%s, %s, '%s')";
+        foreach ($languages as $lang) {
+            $stockName = pSQL(
+                $translator->trans(
+                    'Stock',
+                    array(),
+                    'Admin.Navigation.Menu',
+                    $lang['locale']
+                )
+            );
+            Db::getInstance()->execute(
+                sprintf(
+                    $queryString,
+                    _DB_PREFIX_,
+                    (int)$lastIdTab,
+                    (int)$lang['id_lang'],
+                    $stockName
+                )
+            );
+        }
+    }
+
+    // Stock movements
     $data = array(
-        0 => array(
+        array(
             'name' => 'Customer Order',
             'sign' => 1,
-            'conf' => 'PS_STOCK_CUSTOMER_ORDER_CANCEL_REASON'
+            'conf' => 'PS_STOCK_CUSTOMER_ORDER_CANCEL_REASON',
         ),
-        1 => array(
+        array(
             'name' => 'Product Return',
             'sign' => 1,
-            'conf' => 'PS_STOCK_CUSTOMER_RETURN_REASON'
+            'conf' => 'PS_STOCK_CUSTOMER_RETURN_REASON',
         ),
-        2 => array(
+        array(
             'name' => 'Employee Edition',
             'sign' => 1,
-            'conf' => 'PS_STOCK_MVT_INC_EMPLOYEE_EDITION'
+            'conf' => 'PS_STOCK_MVT_INC_EMPLOYEE_EDITION',
         ),
-        3 => array(
+        array(
             'name' => 'Employee Edition',
             'sign' => -1,
-            'conf' => 'PS_STOCK_MVT_DEC_EMPLOYEE_EDITION'
+            'conf' => 'PS_STOCK_MVT_DEC_EMPLOYEE_EDITION',
         ),
     );
 
-    $languages = Language::getLanguages();
-
-    // insert ps_tab AdminStockManagement
-    Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'tab` (`id_tab`, `id_parent`, `position`, `module`, `class_name`, `active`, `hide_host_mode`, `icon`)
-      VALUES (null, 9, 7, NULL, \'AdminStockManagement\', 1, 0, \'\')');
-    $lastIdTab = Db::getInstance()->insert_id();
-
-    // ps_tab_lang
-    foreach ($languages as $lang) {
-        Db::getInstance()->execute(
-            'INSERT INTO `'._DB_PREFIX_.'tab_lang` (`id_tab`, `id_lang`, `name`)
-                VALUES ('.(int)$lastIdTab.', '.(int)$lang['id_lang'].', "'.pSQL($translator->trans('Stock', array(), 'Admin.Navigation.Menu', $lang['locale'])).'")');
-    }
-
     foreach ($data as $d) {
         // ps_stock_mvt_reason
-         Db::getInstance()->execute('
-            INSERT INTO `'._DB_PREFIX_.'stock_mvt_reason` (`sign`, `date_add`, `date_upd`, `deleted`)
-            VALUES ('.$d['sign'].', NOW(), NOW(), "0")');
+        Db::getInstance()->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'stock_mvt_reason` (`sign`, `date_add`, `date_upd`, `deleted`)
+            VALUES (' . $d['sign'] . ', NOW(), NOW(), "0")'
+        );
 
         // ps_configuration
         $lastInsertedId = Db::getInstance()->insert_id();
-        Db::getInstance()->execute('
-            INSERT INTO `'._DB_PREFIX_.'configuration` (`name`, `value`, `date_add`, `date_upd`)
-            VALUES ("'.$d['conf'].'", '.(int)$lastInsertedId.', NOW(), NOW())');
+        Db::getInstance()->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'configuration` (`name`, `value`, `date_add`, `date_upd`)
+            VALUES ("' . $d['conf'] . '", ' . (int)$lastInsertedId . ', NOW(), NOW())'
+        );
 
         // ps_stock_mvt_reason_lang
         foreach ($languages as $lang) {
+            $mvtName = pSQL(
+                $translator->trans(
+                    $d['name'],
+                    array(),
+                    'Admin.Catalog.Feature',
+                    $lang['locale']
+                )
+            );
             Db::getInstance()->execute(
-                'INSERT INTO `'._DB_PREFIX_.'stock_mvt_reason_lang` (`id_stock_mvt_reason`, `id_lang`, `name`)
-                VALUES ('.(int)$lastInsertedId.', '.(int)$lang['id_lang'].', "'.pSQL($translator->trans($d['name'], array(), 'Admin.Catalog.Feature', $lang['locale'])).'")');
+                'INSERT INTO `' . _DB_PREFIX_ . 'stock_mvt_reason_lang` (`id_stock_mvt_reason`, `id_lang`, `name`)
+                VALUES (' . (int)$lastInsertedId . ', ' . (int)$lang['id_lang'] . ', "' . $mvtName . '")'
+            );
         }
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When using 1-click upgrade multiple times, an "AdminStockManagement" menu is duplicated again and again. Maybe other data is duplicated too (this bug is hard to reproduce)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [BOOM-3961](http://forge.prestashop.com/browse/BOOM-3961)
| How to test?  | Install a PS version before ASM was re-introduced. Using 1-click upgrade module: Upgrade and keep upgrading for every minor version. Duplicated tab and other duplicated data should not appear anymore after applying this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8461)
<!-- Reviewable:end -->
