### PR TITLE
Fix empty module return on actionEmailSendBefore breaks all email send

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -109,7 +109,7 @@ class MailCore extends ObjectModel
             $idShop = Context::getContext()->shop->id;
         }
 
-        $skip = array_reduce(Hook::exec(
+        $keepGoing = array_reduce(Hook::exec(
            'actionEmailSendBefore',
             array(
                 'idLang' => &$idLang,
@@ -131,10 +131,10 @@ class MailCore extends ObjectModel
             null,
             true
         ), function ($carry, $item) {
-            return $carry && $item;
+            return ($item === false) ? false : $carry;
         }, true);
 
-        if (!$skip) {
+        if (!$keepGoing) {
             return true;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | At the start of Mail::Send, the actionEmailSendBefore hook allowing for module override of emails blocks PS emails in case of a false-ish return. Modules like multiblocks break all emails send being hooked on this hook and not returning anything. This commit expects a strict false to block emails.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a module hooked on actionEmailSendBefore returning a false-ish value but not false (not returning anything for example). Without this commit, no email can go through. With this commit, emails are fine.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8462)
<!-- Reviewable:end -->
