### PR TITLE
Prevent undefined id_module error on Modules page

### DIFF
--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -245,6 +245,9 @@ class LegacyHookSubscriber implements EventSubscriberInterface
 
                 if (is_array($modules)) {
                     foreach ($modules as $order => $module) {
+                        if (!isset($module['id_module'])) {
+                            continue;   
+                        }
                         $moduleId = $module['id_module'];
                         $functionName = 'call_' . $id . '_' . $moduleId;
                         $moduleListeners[] = array($functionName, 2000 - $order);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We've noticed that sometimes after update we encounter undefined notice error in this file, id_module is for some reason not available and to prevent having fatal error we need to check if we can rely on id_module or we should continue in the loop
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Hard to reproduce but happend two times after upgraded store with developer mode enabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8463)
<!-- Reviewable:end -->
