### PR TITLE
[CO] Fixed return value of Customer toggleStatus method

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1064,13 +1064,14 @@ class CustomerCore extends ObjectModel
      */
     public function toggleStatus()
     {
-        parent::toggleStatus();
+        $statusUpdated = parent::toggleStatus();
+        if ($statusUpdated) {
+            Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.bqSQL($this->def['table']).'`
+                SET `date_upd` = NOW()
+                WHERE `'.bqSQL($this->def['primary']).'` = '.(int) $this->id);
+        }
 
-        /* Change status to active/inactive */
-        return Db::getInstance()->execute('
-        UPDATE `'._DB_PREFIX_.bqSQL($this->def['table']).'`
-        SET `date_upd` = NOW()
-        WHERE `'.bqSQL($this->def['primary']).'` = '.(int) $this->id);
+        return $statusUpdated;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | developp
| Description?  | Customer' `toggleStatus()` method must return a bool indicated that customer status was updated. But today the method verify that `date_upd` was updated.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Put `return false;` in `ObjectModelCore` `toggleStatus()` method. And try to update customer status from customer list : there is no error message but status is unchanged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8464)
<!-- Reviewable:end -->
