### PR TITLE
Remove useless method from Customer class

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1058,22 +1058,6 @@ class CustomerCore extends ObjectModel
     }
 
     /**
-     * Toggle Customer status.
-     *
-     * @return bool Indicates whether the status has been successfully toggled
-     */
-    public function toggleStatus()
-    {
-        parent::toggleStatus();
-
-        /* Change status to active/inactive */
-        return Db::getInstance()->execute('
-        UPDATE `'._DB_PREFIX_.bqSQL($this->def['table']).'`
-        SET `date_upd` = NOW()
-        WHERE `'.bqSQL($this->def['primary']).'` = '.(int) $this->id);
-    }
-
-    /**
      * Is the current Customer a Guest?
      *
      * @return bool Indicates whether the Customer is a Guest


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | toggleStatus() already update `date_upd` in `ObjectModelCore` by calling `$this->update(false)`
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | -
| How to test?  | Remove the method and see that `date_upd` still updated after customer' status change.

See https://github.com/PrestaShop/PrestaShop/pull/8464

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8465)
<!-- Reviewable:end -->
