### PR TITLE
[BO] Fix messages not visible on order page

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1746,7 +1746,7 @@ class AdminOrdersControllerCore extends AdminController
             'returns' => OrderReturn::getOrdersReturn($order->id_customer, $order->id),
             'customer_thread_message' => CustomerThread::getCustomerMessages($order->id_customer, null, $order->id),
             'orderMessages' => OrderMessage::getOrderMessages($order->id_lang),
-            'messages' => Message::getMessagesByOrderId($order->id, true),
+            'messages' => CustomerMessage::getMessagesByOrderId($order->id, true),
             'carrier' => new Carrier($order->id_carrier),
             'history' => $history,
             'states' => OrderState::getOrderStates($this->context->language->id),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6
| Description?  | Messages related to order are not visible on the order page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8466)
<!-- Reviewable:end -->
