### PR TITLE
Be able to identify a modern page in modules

### DIFF
--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -27,6 +27,7 @@
 class AdminLegacyLayoutControllerCore extends AdminController
 {
     public $outPutHtml = '';
+    private $routeName = '';
     private $headerToolbarBtn = array();
     private $title;
     private $showContentHeader = true;
@@ -34,7 +35,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
     private $enableSidebar = false;
     private $helpLink;
 
-    public function __construct($controllerName = '', $title = '', $headerToolbarBtn = array(), $displayType = '', $showContentHeader = true, $headerTabContent = '', $enableSidebar = false, $helpLink = '')
+    public function __construct($controllerName = '', $title = '', $headerToolbarBtn = array(), $displayType = '', $showContentHeader = true, $headerTabContent = '', $enableSidebar = false, $helpLink = '', $routeName = '')
     {
         parent::__construct($controllerName, 'new-theme');
 
@@ -50,6 +51,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $this->enableSidebar = $enableSidebar;
         $this->helpLink = $helpLink;
         $this->php_self = $controllerName;
+        $this->routeName = $routeName;
     }
 
     public function setMedia()
@@ -110,6 +112,16 @@ class AdminLegacyLayoutControllerCore extends AdminController
     public function initPageHeaderToolbar()
     {
         parent::initPageHeaderToolbar();
+    }
+
+    /**
+     * Returns the route name (this allow to identify the page)
+     *
+     * @return string
+     */
+    public function getRoute()
+    {
+        return $this->routeName;
     }
 
     public function display()

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -150,7 +150,8 @@ class LegacyContext
         $showContentHeader,
         $headerTabContent,
         $enableSidebar,
-        $helpLink = ''
+        $helpLink = '',
+        $routeName = ''
     ) {
         $originCtrl = new AdminLegacyLayoutControllerCore(
             $controllerName,
@@ -160,7 +161,8 @@ class LegacyContext
             $showContentHeader,
             $headerTabContent,
             $enableSidebar,
-            $helpLink
+            $helpLink,
+            $routeName
         );
         $originCtrl->run();
 

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -240,7 +240,8 @@ class ProductController extends FrameworkBundleAdminController
                 'enableSidebar' => true,
                 'help_link' => $this->generateSidebarLink('AdminProducts'),
                 'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
-                'permission_error' => $permissionError
+                'permission_error' => $permissionError,
+                'layoutTitle' => $this->trans('Products', 'Admin.Global'),
             )
         );
     }
@@ -615,6 +616,7 @@ class ProductController extends FrameworkBundleAdminController
             'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
             'editable' => $this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_'),
             'drawerModules' => $drawerModules,
+            'layoutTitle' => $this->trans('Product', 'Admin.Global'),
         );
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
@@ -31,7 +31,8 @@ layoutDisplayType is defined ? layoutDisplayType : '',
 showContentHeader is defined ? showContentHeader : true,
 headerTabContent is defined ? headerTabContent : '',
 enableSidebar is defined ? enableSidebar : false,
-help_link is defined ? help_link : ''
+help_link is defined ? help_link : '',
+app.request.attributes.get('_route')
 )
 )) %}
 

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -143,7 +143,8 @@ class LayoutExtension extends \Twig_Extension implements \Twig_Extension_Globals
         $showContentHeader = true,
         $headerTabContent = '',
         $enableSidebar = false,
-        $helpLink = ''
+        $helpLink = '',
+        $routeName = ''
     ) {
         if ($this->environment == 'test') {
             return <<<EOF
@@ -172,7 +173,8 @@ EOF;
             $showContentHeader,
             $headerTabContent,
             $enableSidebar,
-            $helpLink
+            $helpLink,
+            $routeName
         );
 
         //test if legacy template from "content.tpl" has '{$content}'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There is no way to distinct a specific page using Controller name with new controllers, for instance you can't apply a hook on product catalog page and not in product page itself.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | You need to create a minimal module that hook on "displayAdminAfterHeader". Using `$this->context->controller->php_self` you'll have the same value for "Products" and "Product page (this is a normal and logic behavior). If you want to hook only on "Product page" you'll need the new `$this->context->controller->getRoute()` and get the route name from the Symfony debug toolbar.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

```php
    /**
     * Don't forget to register the hook
     */
    public function hookDisplayAdminAfterHeader()
    {
        if ($this->context->controller->getRoute() === 'admin_product_form') {
            return '<button class="btn btn-primary float-right">Hooked only on Product Page</button>';
        }
    }
```

> As without it creating a module on modern pages is not really possible I consider it's more a bug fix than a feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8470)
<!-- Reviewable:end -->
