### PR TITLE
Allow developers to add items to breadcrumb from tpl

### DIFF
--- a/themes/classic/templates/_partials/breadcrumb.tpl
+++ b/themes/classic/templates/_partials/breadcrumb.tpl
@@ -24,15 +24,17 @@
  *}
 <nav data-depth="{$breadcrumb.count}" class="breadcrumb hidden-sm-down">
   <ol itemscope itemtype="http://schema.org/BreadcrumbList">
-    {foreach from=$breadcrumb.links item=path name=breadcrumb}
-      {block name='breadcrumb_item'}
-        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-          <a itemprop="item" href="{$path.url}">
-            <span itemprop="name">{$path.title}</span>
-          </a>
-          <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
-        </li>
-      {/block}
-    {/foreach}
+    {block name='breadcrumb'}
+      {foreach from=$breadcrumb.links item=path name=breadcrumb}
+        {block name='breadcrumb_item'}
+          <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            <a itemprop="item" href="{$path.url}">
+              <span itemprop="name">{$path.title}</span>
+            </a>
+            <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
+          </li>
+        {/block}
+      {/foreach}
+    {/block}
   </ol>
 </nav>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | sometimes we need to add additional items to breadcrumb from .tpl, not controller, especially when we use some legacy modules which not support new breadcrumb mechanism
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | try to add breadcrumb to manufacturers page or contact page directly by editing their tpl file not controller
| Sponsor company | impSolutions

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8474)
<!-- Reviewable:end -->
