### PR TITLE
Added displayDashboardToolbarTopMenu and displayDashboardToolbarIcons hooks

### DIFF
--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -28,6 +28,7 @@
 
   {block name=toolbarBox}
     <div class="toolbar-icons">
+      {hook h='displayDashboardToolbarTopMenu'}
       {foreach from=$toolbar_btn item=btn key=k}
         {if $k != 'back' && $k != 'modules-list'}
           {* TODO: REFACTOR ALL THIS THINGS *}

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -748,13 +748,13 @@
     </hook>
     <hook id="displayDashboardToolbarTopMenu">
       <name>displayDashboardToolbarTopMenu</name>
-      <title>Display new elements in back office products listing page, on top Menu</title>
-      <description>This hook launches modules when the back office product listing page is displayed</description>
+      <title>Display new elements in back office page with a dashboard, on top Menu</title>
+      <description>This hook launches modules when a page with a dashboard is displayed</description>
     </hook>
     <hook id="displayDashboardToolbarIcons">
       <name>displayDashboardToolbarIcons</name>
-      <title>Display new elements in back office products listing page, on icons list</title>
-      <description>This hook launches modules when the back office product listing page is displayed</description>
+      <title>Display new elements in back office page with dashboard, on icons list</title>
+      <description>This hook launches modules when the back office with dashboard is displayed</description>
     </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -746,5 +746,15 @@
       <title>Display new elements in back office product page, Combination tab</title>
       <description>This hook launches modules when the back office product page is displayed</description>
     </hook>
+    <hook id="displayDashboardToolbarTopMenu">
+      <name>displayDashboardToolbarTopMenu</name>
+      <title>Display new elements in back office products listing page, on top Menu</title>
+      <description>This hook launches modules when the back office product listing page is displayed</description>
+    </hook>
+    <hook id="displayDashboardToolbarIcons">
+      <name>displayDashboardToolbarIcons</name>
+      <title>Display new elements in back office products listing page, on icons list</title>
+      <description>This hook launches modules when the back office product listing page is displayed</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.3.0.sql
+++ b/install-dev/upgrade/sql/1.7.3.0.sql
@@ -46,4 +46,6 @@ ALTER TABLE `PREFIX_feature_product` DROP PRIMARY KEY, ADD PRIMARY KEY (`id_feat
 ALTER TABLE `PREFIX_customization_field` ADD `is_deleted` TINYINT(1) NOT NULL DEFAULT '0';
 
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
-  (NULL, 'displayAdminCustomersAddressesItemAction', 'Display new elements in the Back Office, tab AdminCustomers, Addresses actions', 'This hook launches modules when the Addresses list into the AdminCustomers tab is displayed in the Back Office', '1');
+  (NULL, 'displayAdminCustomersAddressesItemAction', 'Display new elements in the Back Office, tab AdminCustomers, Addresses actions', 'This hook launches modules when the Addresses list into the AdminCustomers tab is displayed in the Back Office', '1'),
+  (NULL, 'displayDashboardToolbarTopMenu', 'Display new elements in back office products listing page, on top Menu', 'This hook launches modules when the back office product listing page is displayed', '1'),
+  (NULL, 'displayDashboardToolbarIcons', 'Display new elements in back office products listing page, on icons list', 'This hook launches modules when the back office product page listing is displayed', '1');

--- a/install-dev/upgrade/sql/1.7.3.0.sql
+++ b/install-dev/upgrade/sql/1.7.3.0.sql
@@ -47,5 +47,5 @@ ALTER TABLE `PREFIX_customization_field` ADD `is_deleted` TINYINT(1) NOT NULL DE
 
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'displayAdminCustomersAddressesItemAction', 'Display new elements in the Back Office, tab AdminCustomers, Addresses actions', 'This hook launches modules when the Addresses list into the AdminCustomers tab is displayed in the Back Office', '1'),
-  (NULL, 'displayDashboardToolbarTopMenu', 'Display new elements in back office products listing page, on top Menu', 'This hook launches modules when the back office product listing page is displayed', '1'),
-  (NULL, 'displayDashboardToolbarIcons', 'Display new elements in back office products listing page, on icons list', 'This hook launches modules when the back office product page listing is displayed', '1');
+  (NULL, 'displayDashboardToolbarTopMenu', 'Display new elements in back office page with a dashboard, on top Menu', 'This hook launches modules when a page with a dashboard is displayed', '1'),
+  (NULL, 'displayDashboardToolbarIcons', 'Display new elements in back office page with dashboard, on icons list', 'This hook launches modules when the back office with dashboard is displayed', '1');

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/catalog.html.twig
@@ -57,6 +57,7 @@
       <div class="row">
         <div class="col-md-12">
           <div class="float-right">
+            {{ renderhook('displayDashboardToolbarIcons', {}) }}
             <a id="desc-product-export" class="list-toolbar-btn" href="{{ path('admin_product_export_action') }}">
               {{ ps.tooltip(("Export"|trans({}, 'Admin.Actions')), 'cloud_upload') }}
             </a>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Some hooks are missings and until now you can't enrich the menus of Product Catalogue page without override all the template. So I propose 2 new hooks: `displayDashboardToolbarTopMenu` and `displayDashboardToolbarIcons`.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | I don't know
| How to test?  | Re-install the shop to get the new hooks and then you should see 2 new hooks in the hook debug toolbar. To display them you need a module and to register a display for the 2 new hooks.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

### Before
![block_opened](https://user-images.githubusercontent.com/1247388/32518702-afe82274-c40a-11e7-9298-8b5d9737fde4.png)

### After

![new_hooks](https://user-images.githubusercontent.com/1247388/32518742-cf54827e-c40a-11e7-82fc-a839cacc9877.png)

> So, you can add your own buttons and icons in this page using theses hooks.



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8477)
<!-- Reviewable:end -->
