### PR TITLE
Don't display error if AdminShopGroup doesn't exist

### DIFF
--- a/controllers/admin/AdminPreferencesController.php
+++ b/controllers/admin/AdminPreferencesController.php
@@ -246,7 +246,9 @@ class AdminPreferencesControllerCore extends AdminController
         Configuration::updateValue('PS_MULTISHOP_FEATURE_ACTIVE', $value);
 
         $tab = Tab::getInstanceFromClassName('AdminShopGroup');
-        $tab->active = (bool)Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');
-        $tab->update();
+        if (Validate::isLoadedObject($tab)) {
+            $tab->active = (bool)Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');
+            $tab->update();
+        }
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | if the tab AdminShopGroup don't exist, it will try to update an empty tab
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | delete the AdminShopGroup tab and try to save the AdminPreference tab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8481)
<!-- Reviewable:end -->
