### PR TITLE
Adjust the quantity of packs after creating order

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -473,6 +473,8 @@ class OrderDetailCore extends ObjectModel
                 $update_quantity = StockAvailable::updateQuantity($product['id_product'], $product['id_product_attribute'], -(int)$product['cart_quantity']);
             }
 
+            $update_quantity &= StockAvailable::adjustAvailablePacksQuantity($product['id_product'], $product['id_product_attribute']);
+
             if ($update_quantity) {
                 $product['stock_quantity'] -= $product['cart_quantity'];
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When ordering a pack, the quantity of other packs with the same items is not reduced.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8367
| How to test?  | BO > Create product (P1)[quantity = 10], create tow packs (C1 , C2) that contains the product (P1) with quantity (C1 [quantity P1= 2], C2 [quantity P1= 5]),  FO > ordered pack (C1) and check in the BO > catalog > products, if the quantity of the other pack (C2) is adjust.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8482)
<!-- Reviewable:end -->
