### PR TITLE
Display generic exception message when error occurs on cli installation 

### DIFF
--- a/install-dev/index_cli.php
+++ b/install-dev/index_cli.php
@@ -40,5 +40,7 @@ try {
     exit(0);
 } catch (PrestashopInstallerException $e) {
     $e->displayMessage();
+} catch (Exception $e) {
+    echo $e->getMessage();
 }
 exit(1);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | We do not catch all exception when we launch the installation on CLI. Depending on the PHP configuration, the message can be hidden regarding its configuration. This PR display them at all times.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8484)
<!-- Reviewable:end -->
