### PR TITLE
Display the company name in outstanding orders

### DIFF
--- a/controllers/admin/AdminOutstandingController.php
+++ b/controllers/admin/AdminOutstandingController.php
@@ -43,7 +43,8 @@ class AdminOutstandingControllerCore  extends AdminController
 		CONCAT(LEFT(c.`firstname`, 1), \'. \', c.`lastname`) AS `customer`,
 		c.`outstanding_allow_amount`,
 		r.`color`,
-		rl.`name` AS `risk`';
+		rl.`name` AS `risk`,
+		c.`company`';
         $this->_join = 'LEFT JOIN `'._DB_PREFIX_.'orders` o ON (o.`id_order` = a.`id_order`)
 		LEFT JOIN `'._DB_PREFIX_.'customer` c ON (c.`id_customer` = o.`id_customer`)
 		LEFT JOIN `'._DB_PREFIX_.'risk` r ON (r.`id_risk` = c.`id_risk`)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | On the "Outstanding" (placed under customers) the "Company" information is missing.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9321
| How to test?  | Enable B2B mode, set the company name of users, BO > Customers > Outstanding and check if the company name appears in the outstanding list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8487)
<!-- Reviewable:end -->
