### PR TITLE
Fix robots.txt, exclude order param

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2572,8 +2572,8 @@ FileETag none
         }
 
         $tab['GB'] = array(
-            '?orderby=','?orderway=','?tag=','?id_currency=','?search_query=','?back=','?n=',
-            '&orderby=','&orderway=','&tag=','&id_currency=','&search_query=','&back=','&n='
+            '?order=','?tag=','?id_currency=','?search_query=','?back=','?n=',
+            '&order=','&tag=','&id_currency=','&search_query=','&back=','&n='
         );
 
         foreach ($disallow_controllers as $controller) {

--- a/robots.txt
+++ b/robots.txt
@@ -13,15 +13,13 @@ Allow: */modules/*.js
 Allow: */modules/*.png
 Allow: */modules/*.jpg
 # Private pages
-Disallow: /*?orderby=
-Disallow: /*?orderway=
+Disallow: /*?order=
 Disallow: /*?tag=
 Disallow: /*?id_currency=
 Disallow: /*?search_query=
 Disallow: /*?back=
 Disallow: /*?n=
-Disallow: /*&orderby=
-Disallow: /*&orderway=
+Disallow: /*&order=
 Disallow: /*&tag=
 Disallow: /*&id_currency=
 Disallow: /*&search_query=


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The new param for ordering in ps 1.7 is order, not anymore orderby.<br>Robots are actually indexing page with order in params, it could consume crawl budget <br>Orderway is also useless for 1.7
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | open robots.txt (http://fo.demo.prestashop.com/robots.txt), you will find Disallow: /*?orderby= <br> Now, order a product list page by price asc for ex. and you will see order in params

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8488)
<!-- Reviewable:end -->
