### PR TITLE
Fix undefined offset on new products

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -850,7 +850,7 @@ class ProductPresenter
         // features can either be "raw" (id_feature, id_product_id_feature_value)
         // or "full" (id_feature, name, value)
         // grouping can only be performed if they are "full"
-        if (empty($productFeatures) || !array_key_exists('name', $productFeatures[0])) {
+        if (empty($productFeatures) || !array_key_exists('name', reset($productFeatures))) {
             return array();
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Fixes a notice on the new products list, as we were always considering the first element of an array to be at the offset 0.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4295
| How to test?  | Go to the new products list (you can find the link in your shop footer)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8490)
<!-- Reviewable:end -->
