### PR TITLE
Fixed admin category tree radio buttons positioning

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_category_tree.scss
+++ b/admin-dev/themes/new-theme/scss/components/_category_tree.scss
@@ -29,6 +29,7 @@ ul.category-tree {
   .category-label {
     display: block;
     padding-left: 0;
+    position: relative;
     .category {
       cursor: pointer;
       position: absolute;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |1.7.3.x
| Description?  | Bug : in admin "Products" page, when trying to filter by category, the sub categories radio buttons were not displayed correctly. They looked like unavailable but they were actually all piled together over the parent category radio button.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [BOOM-4283](http://forge.prestashop.com/browse/BOOM-4283)
| How to test?  | Check the category tree radio buttons after applying this fix (`npm run build` needed in local under `new-theme` folder)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8491)
<!-- Reviewable:end -->
