### PR TITLE
Fix the display of tax in the order details page

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2229,7 +2229,8 @@ class AdminOrdersControllerCore extends AdminController
             'documents_html' => $this->createTemplate('_documents.tpl')->fetch(),
             'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch(),
             'discount_form_html' => $this->createTemplate('_discount_form.tpl')->fetch(),
-            'refresh' => $refresh
+            'refresh' => $refresh,
+            'displayExcludedTaxMethod' => (bool)Group::getPriceDisplayMethod($this->context->customer->id_default_group),
         )));
     }
 
@@ -2481,7 +2482,8 @@ class AdminOrdersControllerCore extends AdminController
             'invoices' => $invoice_array,
             'documents_html' => $this->createTemplate('_documents.tpl')->fetch(),
             'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch(),
-            'customized_product' => is_array(Tools::getValue('product_quantity'))
+            'customized_product' => is_array(Tools::getValue('product_quantity')),
+            'displayExcludedTaxMethod' => (bool)Group::getPriceDisplayMethod($this->context->customer->id_default_group),
         )));
     }
 
@@ -2560,7 +2562,8 @@ class AdminOrdersControllerCore extends AdminController
             'order' => $order,
             'invoices' => $invoice_array,
             'documents_html' => $this->createTemplate('_documents.tpl')->fetch(),
-            'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch()
+            'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch(),
+            'displayExcludedTaxMethod' => (bool)Group::getPriceDisplayMethod($this->context->customer->id_default_group),
         )));
     }
 

--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -232,26 +232,30 @@ function refreshProductLineView(element, view)
 	});
 }
 
-function updateAmounts(order)
+function updateAmounts(order, displayExcludedTaxMethod)
 {
 	$('#total_products td.amount').fadeOut('slow', function() {
-		$(this).html(formatCurrency(parseFloat(order.total_products_wt), currency_format, currency_sign, currency_blank));
+		var totalProducts = displayExcludedTaxMethod ? order.total_products : order.total_products_wt;
+		$(this).html(formatCurrency(parseFloat(totalProducts), currency_format, currency_sign, currency_blank));
 		$(this).fadeIn('slow');
 	});
 	$('#total_discounts td.amount').fadeOut('slow', function() {
-		$(this).html(formatCurrency(parseFloat(order.total_discounts_tax_incl), currency_format, currency_sign, currency_blank));
+		var totalDiscounts = displayExcludedTaxMethod ? order.total_discounts_tax_excl : order.total_discounts_tax_incl;
+		$(this).html(formatCurrency(parseFloat(totalDiscounts), currency_format, currency_sign, currency_blank));
 		$(this).fadeIn('slow');
 	});
 	if (order.total_discounts_tax_incl > 0)
 		$('#total_discounts').slideDown('slow');
 	$('#total_wrapping td.amount').fadeOut('slow', function() {
-		$(this).html(formatCurrency(parseFloat(order.total_wrapping_tax_incl), currency_format, currency_sign, currency_blank));
+		var totalWrapping = displayExcludedTaxMethod ? order.total_wrapping_tax_excl : order.total_wrapping_tax_incl;
+		$(this).html(formatCurrency(parseFloat(totalWrapping), currency_format, currency_sign, currency_blank));
 		$(this).fadeIn('slow');
 	});
 	if (order.total_wrapping_tax_incl > 0)
 		$('#total_wrapping').slideDown('slow');
 	$('#total_shipping td.amount').fadeOut('slow', function() {
-		$(this).html(formatCurrency(parseFloat(order.total_shipping_tax_incl), currency_format, currency_sign, currency_blank));
+		var totalShipping = displayExcludedTaxMethod ? order.total_shipping_tax_excl : order.total_shipping_tax_incl;
+		$(this).html(formatCurrency(parseFloat(totalShipping), currency_format, currency_sign, currency_blank));
 		$(this).fadeIn('slow');
 	});
 	$('#total_order td.amount').fadeOut('slow', function() {
@@ -270,6 +274,11 @@ function updateAmounts(order)
 	});
 	$('#shipping_table .weight').fadeOut('slow', function() {
 		$(this).html(order.weight);
+		$(this).fadeIn('slow');
+	});
+	$('#total_taxes td.amount').fadeOut('slow', function() {
+		var totalTaxes = parseFloat(order.total_paid_tax_incl) - parseFloat(order.total_paid_tax_excl);
+		$(this).html(formatCurrency(totalTaxes, currency_format, currency_sign, currency_blank));
 		$(this).fadeIn('slow');
 	});
 }
@@ -504,7 +513,7 @@ function init()
 							}
 							go = false;
 							addViewOrderDetailRow(data.view);
-							updateAmounts(data.order);
+							updateAmounts(data.order, data.displayExcludedTaxMethod);
 							updateInvoice(data.invoices);
 							updateDocuments(data.documents_html);
 							updateShipping(data.shipping_html);
@@ -699,7 +708,7 @@ function init()
 					if (data.result)
 					{
 						refreshProductLineView(element, data.view);
-						updateAmounts(data.order);
+						updateAmounts(data.order, data.displayExcludedTaxMethod);
 						updateInvoice(data.invoices);
 						updateDocuments(data.documents_html);
 						updateDiscountForm(data.discount_form_html);
@@ -774,7 +783,7 @@ function init()
 					tr_product.fadeOut('slow', function() {
 						$(this).remove();
 					});
-					updateAmounts(data.order);
+					updateAmounts(data.order, data.displayExcludedTaxMethod);
 					updateInvoice(data.invoices);
 					updateDocuments(data.documents_html);
 					updateDiscountForm(data.discount_form_html);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Configuration > customer group, set **tax excluded** as value for **Price display method** and edit the quantity of any product in the order. After saving the modification, the total product price and total tax are not displayed correctly. The total prices section is displayed with tax included, instead of tax excluded and recalculate the tax separately.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8144 & Fixes #15528
| How to test?  | BO > Customers > Groups > set the customer group **Price display method** to **Tax excluded**, BO > Orders > edit order > edit product quantity and save, check if the total prices section is displayed correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8493)
<!-- Reviewable:end -->
