### PR TITLE
Improved how to detect if a module is a payment module

### DIFF
--- a/controllers/admin/AdminPaymentPreferencesController.php
+++ b/controllers/admin/AdminPaymentPreferencesController.php
@@ -44,7 +44,7 @@ class AdminPaymentPreferencesControllerCore extends AdminController
 
         foreach ($modules as $module) {
             $addonModule = $moduleRepository->getModule($module->name);
-            if ($addonModule->attributes->get('parent_class') == 'PaymentModule') {
+            if ($addonModule->attributes->get('is_paymentModule')) {
                 if ($module->id) {
                     if (!get_class($module) == 'SimpleXMLElement') {
                         $module->country = array();

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -82,6 +82,7 @@ class Module implements ModuleInterface
         'need_instance' => 0,
         'limited_countries' => array(),
         'parent_class' => 'Module',
+        'is_paymentModule' => false,
         'productType' => 'module',
         'warning' => '',
         'img' => '',

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -468,6 +468,7 @@ class ModuleRepository implements ModuleRepositoryInterface
                 }
 
                 $main_class_attributes['parent_class'] = get_parent_class($name);
+                $main_class_attributes['is_paymentModule'] = is_subclass_of($name, 'PaymentModule');
                 $main_class_attributes['is_configurable'] = (int) method_exists($tmp_module, 'getContent');
 
                 $disk['is_valid'] = 1;


### PR DESCRIPTION
BO: Improved how detect PaymentModule type

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | check the parent class is not a good solution to the find module payments. In fact old code has important Problem with OOP. this PR fix this problem. for more description please read Forge Ticket.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4300
| How to test?  | before test please clear cache

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8495)
<!-- Reviewable:end -->
