### PR TITLE
CO: Fixed bug while removing product from stock

### DIFF
--- a/classes/stock/StockManager.php
+++ b/classes/stock/StockManager.php
@@ -386,7 +386,7 @@ class StockManagerCore implements StockManagerInterface
                             $timestamp = $date->format('U');
 
                             // history of the mvt
-                            $stock_history_qty_available[$timestamp] = array(
+                            $stock_history_qty_available[$timestamp.'_'.$row['id_stock_mvt']] = array(
                                 'id_stock' => $stock->id,
                                 'id_stock_mvt' => (int)$row['id_stock_mvt'],
                                 'qty' => (int)$row['qty']


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  "1.6.1.x" 
| Description?  | Array $stock_history_qty_available  stores available quantities using the key which is a timestamp. It might happen ( it happened in my store), that to different id_stock where added in the same time moment. In that case latter value will overwrite the first one. I added id_stock_mvt  to the array key, what should guarantee that no data will be overwritten in $stock_history_qty_available  array. id_stock_mvt is in GROUP BY clause of sql query, so it should be unique.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | One should have a product available on two different stocks. The stocks should have the same date_add in id_stock_mvt table. It can be achieved in various ways.<br><br> Example: <br> 1) Create an order for 20 items of a product available on two different stocks, e.g.:8 pieces on stock number id_stock=1, and 12 pieces avaialble on stock number id_stock= 2.   <br>2) Mark the order as shipped. After that products should be taken from the stock.  <br>3) Cancel the order. 20 items should occur again on the stock, but both records (for each stock) should have the same date_add time in id_stock_mvt table.  <br>4) Making another order for this product in quantity of 20, would cause overlapping data in $stock_history_qty_available   array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8504)
<!-- Reviewable:end -->
