### PR TITLE
Avoid null as caching system in shop params

### DIFF
--- a/src/Adapter/Cache/CachingConfiguration.php
+++ b/src/Adapter/Cache/CachingConfiguration.php
@@ -137,7 +137,10 @@ class CachingConfiguration implements DataConfigurationInterface
             $this->phpParameters->setProperty('parameters.ps_cache_enable', $configuration['use_cache']);
         }
 
-        if ($configuration['caching_system'] !== $this->cachingSystem) {
+        if (
+            !is_null($configuration['caching_system'])
+            && $configuration['caching_system'] !== $this->cachingSystem
+        ) {
             $this->phpParameters->setProperty('parameters.ps_caching', $configuration['caching_system']);
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Avoid the null value for `ps_caching` in parameters.php, as it breaks the execution of some pages (like AdminImports)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4320
| How to test?  | To reproduce the error, go to Advanced parameters > Performances, enable the cache, choose APC, memcache if you can .... Then disable the cache. At that moment, the controller should have written `ps_caching => NULL` in your parameters.php. If yes, check the AdminImports controller and get the error reported on the Jira issue. Once the PR accepted, follow the same process to get rid of the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8507)
<!-- Reviewable:end -->
