### PR TITLE
Display the order action block after updating the order product

### DIFF
--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -712,6 +712,7 @@ function init()
 						$('.add_product_fields').hide();
 						$('.row-editing-warning').hide();
 						$('td.product_action').attr('colspan', 3);
+						$('.cancel_product_change_link').trigger('click');
 					}
 					else
 						jAlert(data.error);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you modify an order product, the **Add a products** or **Add a new discount** buttons disappear. So to add more products, you have to refresh the order detail page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9598 & fixes #15716
| How to test?  | BO > Order > edit  an order > edit an order product and click on **update**, check if order action block (the **Add a products** and **Add a new discount** buttons) is appear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8510)
<!-- Reviewable:end -->
