### PR TITLE
Fix array declaration

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -669,7 +669,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         $normal_image_sizes = ImageType::getImagesTypes($this->imageType);
         if (empty($this->wsObject->urlSegment[2])) {
             $results = Db::getInstance()->executeS('SELECT DISTINCT `id_cart` FROM `'._DB_PREFIX_.'customization`');
-            $ids = [];
+            $ids = array();
             foreach ($results as $result) {
                 $ids[] = $result['id_cart'];
             }

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -669,6 +669,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         $normal_image_sizes = ImageType::getImagesTypes($this->imageType);
         if (empty($this->wsObject->urlSegment[2])) {
             $results = Db::getInstance()->executeS('SELECT DISTINCT `id_cart` FROM `'._DB_PREFIX_.'customization`');
+            $ids = [];
             foreach ($results as $result) {
                 $ids[] = $result['id_cart'];
             }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | [PHP Warning #1] asort() expects parameter 1 to be array, null given (/classes/webservice/WebserviceSpecificManagementImages.php, line 675)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Working with images via Webservice causes PHP warnings and WS break on error

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8511)
<!-- Reviewable:end -->
