### PR TITLE
Fix menu collapse button alignment

### DIFF
--- a/admin-dev/themes/new-theme/template/components/layout/nav_bar.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/nav_bar.tpl
@@ -104,7 +104,7 @@
     {/foreach}
   </ul>
 
-  <span class="menu-collapse d-none d-md-inline-block">
+  <span class="menu-collapse d-none d-md-block">
     <i class="material-icons">&#xE8EE;</i>
   </span>
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | This PR fixes the alignment of the collapse (hamburger) button on the left hand menu
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4328
| How to test?  | Go to a symfony-ported page, the hamburger icon on the menu should be correctly centered now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8512)
<!-- Reviewable:end -->
