### PR TITLE
CO: Bad Siret Validation BOOM-3955

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1091,11 +1091,10 @@ class ValidateCore
      */
     public static function isSiret($siret)
     {
-		if (empty($siret)) { 
-			return true; 
-		}
-		
-		if (Tools::strlen($siret) != 14) {
+        if (empty($siret)) {
+            return true;
+        }
+        if (Tools::strlen($siret) != 14) {
             return false;
         }
         $sum = 0;

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1091,7 +1091,11 @@ class ValidateCore
      */
     public static function isSiret($siret)
     {
-        if (Tools::strlen($siret) != 14) {
+		if (empty($siret)) { 
+			return true; 
+		}
+		
+		if (Tools::strlen($siret) != 14) {
             return false;
         }
         $sum = 0;


### PR DESCRIPTION
Branch: develop
Description: Bug fix for BOOM-3955 report. isSiret validation method is buggy with empty value.
Type: bug fix
Category: CO
BC breaks: no
Deprecations: no
Fixed ticket: http://forge.prestashop.com/browse/BOOM-3955
How to test: Try to update a customer throw webservice. With patch you can update it, even Siret field is empty, like all other fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8516)
<!-- Reviewable:end -->
