### PR TITLE
Fixed bug when using 2 swap in 1 form

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -289,11 +289,11 @@
 									</script>
 									{/if}
 								{elseif $input.type == 'swap'}
-									<div class="form-group">
+									<div class="form-group swap-container">
 										<div class="col-lg-9">
 											<div class="form-control-static row">
 												<div class="col-xs-6">
-													<select {if isset($input.size)}size="{$input.size|escape:'html':'utf-8'}"{/if}{if isset($input.onchange)} onchange="{$input.onchange|escape:'html':'utf-8'}"{/if} class="{if isset($input.class)}{$input.class|escape:'html':'utf-8'}{/if}" id="availableSwap" name="{$input.name|escape:'html':'utf-8'}_available[]" multiple="multiple">
+													<select {if isset($input.size)}size="{$input.size|escape:'html':'utf-8'}"{/if}{if isset($input.onchange)} onchange="{$input.onchange|escape:'html':'utf-8'}"{/if} class="{if isset($input.class)}{$input.class|escape:'html':'utf-8'}{/if} availableSwap" name="{$input.name|escape:'html':'utf-8'}_available[]" multiple="multiple">
 													{foreach $input.options.query AS $option}
 														{if is_object($option)}
 															{if !in_array($option->$input.options.id, $fields_value[$input.name])}
@@ -308,10 +308,10 @@
 														{/if}
 													{/foreach}
 													</select>
-													<a href="#" id="addSwap" class="btn btn-default btn-block">{l s='Add' d='Admin.Actions'} <i class="icon-arrow-right"></i></a>
+													<a href="#" class="btn btn-default btn-block addSwap">{l s='Add' d='Admin.Actions'} <i class="icon-arrow-right"></i></a>
 												</div>
 												<div class="col-xs-6">
-													<select {if isset($input.size)}size="{$input.size|escape:'html':'utf-8'}"{/if}{if isset($input.onchange)} onchange="{$input.onchange|escape:'html':'utf-8'}"{/if} class="{if isset($input.class)}{$input.class|escape:'html':'utf-8'}{/if}" id="selectedSwap" name="{$input.name|escape:'html':'utf-8'}_selected[]" multiple="multiple">
+													<select {if isset($input.size)}size="{$input.size|escape:'html':'utf-8'}"{/if}{if isset($input.onchange)} onchange="{$input.onchange|escape:'html':'utf-8'}"{/if} class="{if isset($input.class)}{$input.class|escape:'html':'utf-8'}{/if} selectedSwap" name="{$input.name|escape:'html':'utf-8'}_selected[]" multiple="multiple">
 													{foreach $input.options.query AS $option}
 														{if is_object($option)}
 															{if in_array($option->$input.options.id, $fields_value[$input.name])}
@@ -326,7 +326,7 @@
 														{/if}
 													{/foreach}
 													</select>
-													<a href="#" id="removeSwap" class="btn btn-default btn-block"><i class="icon-arrow-left"></i> {l s='Remove'}</a>
+													<a href="#" class="btn btn-default btn-block removeSwap"><i class="icon-arrow-left"></i> {l s='Remove'}</a>
 												</div>
 											</div>
 										</div>

--- a/js/admin.js
+++ b/js/admin.js
@@ -898,15 +898,19 @@ $(document).ready(function()
 		return false;
 	});
 
-	/** make sure that all the swap id is present in the dom to prevent mistake **/
-	if (typeof $('#addSwap') !== undefined && typeof $("#removeSwap") !== undefined &&
-		typeof $('#selectedSwap') !== undefined && typeof $('#availableSwap') !== undefined)
-	{
-		bindSwapButton('add', 'available', 'selected');
-		bindSwapButton('remove', 'selected', 'available');
-
-		$('button:submit').click(bindSwapSave);
-	}
+	$('.swap-container').each(function() {
+		/** make sure that all the swap id is present in the dom to prevent mistake **/
+		if (typeof $('.addSwap', this) !== undefined && typeof $(".removeSwap", this) !== undefined &&
+			typeof $('.selectedSwap', this) !== undefined && typeof $('.availableSwap', this) !== undefined)
+		{
+			bindSwapButton('add', 'available', 'selected', this);
+			bindSwapButton('remove', 'selected', 'available', this);
+		
+			$('button:submit').click(function() {
+				bindSwapSave(this);
+			});
+		}
+	});
 
 	if (typeof host_mode !== 'undefined' && host_mode)
 	{
@@ -933,23 +937,23 @@ $(document).ready(function()
     }
 });
 
-function bindSwapSave()
+function bindSwapSave(context)
 {
-	if ($('#selectedSwap option').length !== 0)
-		$('#selectedSwap option').attr('selected', 'selected');
+	if ($('.selectedSwap option', context).length !== 0)
+		$('.selectedSwap option', context).attr('selected', 'selected');
 	else
-		$('#availableSwap option').attr('selected', 'selected');
+		$('.availableSwap option', context).attr('selected', 'selected');
 }
 
-function bindSwapButton(prefix_button, prefix_select_remove, prefix_select_add)
+function bindSwapButton(prefix_button, prefix_select_remove, prefix_select_add, context)
 {
-	$('#'+prefix_button+'Swap').on('click', function(e) {
+	$('.'+prefix_button+'Swap', context).on('click', function(e) {
 		e.preventDefault();
-		$('#' + prefix_select_remove + 'Swap option:selected').each(function() {
-			$('#' + prefix_select_add + 'Swap').append("<option value='"+$(this).val()+"'>"+$(this).text()+"</option>");
+		$('.' + prefix_select_remove + 'Swap option:selected', context).each(function() {
+			$('.' + prefix_select_add + 'Swap', context).append("<option value='"+$(this).val()+"'>"+$(this).text()+"</option>");
 			$(this).remove();
 		});
-		$('#selectedSwap option').prop('selected', true);
+		$('.selectedSwap option', context).prop('selected', true);
 	});
 }
 


### PR DESCRIPTION
BO: fixed bug when using 2 swap in 1 form

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | when we using 2 or more swap type in 1 form/page, first swap worked but another is not worked because jquery selector written by id and id must be unique. this PR fix this bug and now we can use many swap in 1 page. meanwhile this problem is also on 1.6
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Create new form and add many SWAP type in your form.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8517)
<!-- Reviewable:end -->
