### PR TITLE
Fix modal display on product page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
@@ -28,8 +28,8 @@
             {% block header %}
                 {% if title is defined %}
                     <div class="modal-header">
-                        {% if closable is defined and closable == true %}<button type="button" class="close" data-dismiss="modal">&times;</button>{% endif %}
                         <h4 class="modal-title">{{ title }}</h4>
+                        {% if closable is defined and closable == true %}<button type="button" class="close" data-dismiss="modal">&times;</button>{% endif %}
                     </div>
                 {% endif %}
             {% endblock %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | The closing button was not properly displayed on the product pages modals.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4270
| How to test?  | Check the modal for bulk deletion / duplication

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8520)
<!-- Reviewable:end -->
