### PR TITLE
Fixed specific price percentage rounding on front product page

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -165,6 +165,7 @@ class ProductPresenter
             $presAbsoluteReduction = $absoluteReduction->round(2, Rounding::ROUND_HALF_UP);
             $presNegativeReduction = $negativeReduction->round(2, Rounding::ROUND_HALF_UP);
 
+            // TODO: add percent sign according to locale preferences
             $presentedProduct['discount_percentage'] = Tools::displayNumber($presNegativeReduction) . '%';
             $presentedProduct['discount_percentage_absolute'] = Tools::displayNumber($presAbsoluteReduction) . '%';
             // TODO: Fix issue with tax calculation

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -27,6 +27,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Product;
 
+use PrestaShop\Decimal\Number;
+use PrestaShop\Decimal\Operation\Rounding;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
@@ -154,11 +156,17 @@ class ProductPresenter
         }
 
         if ($product['specific_prices']) {
-            $presentedProduct['has_discount'] = (0 != $product['reduction']);
+            $presentedProduct['has_discount']  = (0 != $product['reduction']);
             $presentedProduct['discount_type'] = $product['specific_prices']['reduction_type'];
-            // TODO: format according to locale preferences
-            $presentedProduct['discount_percentage'] = -round(100 * $product['specific_prices']['reduction']).'%';
-            $presentedProduct['discount_percentage_absolute'] = round(100 * $product['specific_prices']['reduction']).'%';
+
+            $absoluteReduction     = new Number($product['specific_prices']['reduction']);
+            $absoluteReduction     = $absoluteReduction->times(new Number('100'));
+            $negativeReduction     = $absoluteReduction->toNegative();
+            $presAbsoluteReduction = $absoluteReduction->round(2, Rounding::ROUND_HALF_UP);
+            $presNegativeReduction = $negativeReduction->round(2, Rounding::ROUND_HALF_UP);
+
+            $presentedProduct['discount_percentage'] = Tools::displayNumber($presNegativeReduction) . '%';
+            $presentedProduct['discount_percentage_absolute'] = Tools::displayNumber($presAbsoluteReduction) . '%';
             // TODO: Fix issue with tax calculation
             $presentedProduct['discount_amount'] = $this->priceFormatter->format(
                 $product['reduction']


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Rounding was set with no decimal. Changed it to 2 decimals. Used PrestaShop/Decimal package for this.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [BOOM-3838](http://forge.prestashop.com/browse/BOOM-3838)
| How to test?  | See Jira ticket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8522)
<!-- Reviewable:end -->
