### PR TITLE
Fixed forms deprecation (Symfony3) on performance page

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -49,8 +49,8 @@ class CachingType extends TranslatorAwareType
         $builder
             ->add('use_cache', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
             ))
@@ -84,7 +84,6 @@ class CachingType extends TranslatorAwareType
                     return $disabled === true ? array('disabled' => $disabled) : array();
                 },
                 'expanded' => true,
-                'choices_as_values' => true,
                 'required' => false,
             ))
         ;

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
@@ -42,24 +42,24 @@ class CombineCompressCacheType extends CommonAbstractType
         $builder
             ->add('smart_cache_css', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,
             ))
             ->add('smart_cache_js', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,
             ))
             ->add('apache_optimization', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -42,24 +42,24 @@ class DebugModeType extends CommonAbstractType
         $builder
             ->add('disable_non_native_modules', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,
             ))
             ->add('disable_overrides', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,
             ))
             ->add('debug_mode', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
@@ -42,24 +42,24 @@ class OptionalFeaturesType extends CommonAbstractType
         $builder
             ->add('combinations', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'disabled' => $options['are_combinations_used'],
             ))
             ->add('features', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,
             ))
             ->add('customer_groups', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'required' => true,
                 'translation_domain' => 'Admin.Advparameters.features',

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
@@ -42,43 +42,40 @@ class SmartyType extends CommonAbstractType
         $builder
             ->add('template_compilation', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    0 => 'Never recompile template files',
-                    1 => 'Recompile templates if the files have been updated',
-                    2 => 'Force compilation'
+                    'Never recompile template files' => 0,
+                    'Recompile templates if the files have been updated' => 1,
+                    'Force compilation' => 2,
                 ),
-                'choices_as_values' => false,
                 'required' => true,
             ))
             ->add('cache', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,
             ))
             ->add('multi_front_optimization', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    false => 'No',
-                    true => 'Yes',
+                    'No' => false,
+                    'Yes' => true,
                 ),
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,
             ))
             ->add('caching_type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    'filesystem' => 'File System',
-                    'mysql' => 'MySQL',
+                    'File System' => 'filesystem',
+                    'MySQL' => 'mysql',
                 ),
-                'choices_as_values' => false,
                 'required' => true,
             ))
             ->add('clear_cache', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices'  => array(
-                    'never' => 'Never clear cache files',
-                    'everytime' => 'Clear cache everytime something has been modified',
+                     'Never clear cache files' => 'never',
+                    'Clear cache everytime something has been modified' => 'everytime',
                 ),
-                'choices_as_values' => false,
                 'required' => true,
             ))
         ;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | `choices_as_values` property of forms is deprecated in Symfony3 and cause debug mode to throw an exception on Performance Page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Access performance page on `develop` and on this branch.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8524)
<!-- Reviewable:end -->
