### PR TITLE
Fix the email validator

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -47,7 +47,7 @@ class ValidateCore
      */
     public static function isEmail($email)
     {
-        return !empty($email) && preg_match(Tools::cleanNonUnicodeSupport('/^[a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+(?:[.]?[_a-z\p{L}0-9-])*\.[a-z\p{L}0-9]+$/ui'), $email);
+        return !empty($email) && preg_match(Tools::cleanNonUnicodeSupport('/^[a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+(?:[.]?[_a-z\p{L}0-9-])*\.[a-z\p{L}0-9]+$/i'), $email);
     }
 
     /**

--- a/tests/Unit/classes/ValidateCoreTest.php
+++ b/tests/Unit/classes/ValidateCoreTest.php
@@ -106,7 +106,7 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame($expected, Validate::isInt($input));
     }
-        
+
         // --- providers ---
 
         public function isIp2LongDataProvider()
@@ -154,6 +154,7 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
             array(false, 'john.doe@prestashop'),
             array(false, 123456789),
             array(false, false),
+            array(false, 'pubé@prestashop.com'),
         );
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you activate the **one page checkout**, you can create an account with wrong email which contains special characters.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9282
| How to test?  | BO > Preferences > Orders > set **Order process type** as **One-page checkout**, FO > Cart > in the **New CUSTOMER** block fill the email input with wrong email (example: pubé@prestashop.com) and click save, check if an error message apears

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8531)
<!-- Reviewable:end -->
