### PR TITLE
[1.6.1.x, 1.7.x] Fix slow query search when attributes are involved

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1565,7 +1565,7 @@ CREATE TABLE `PREFIX_product_attribute_shop` (
   `available_date` date NOT NULL DEFAULT '0000-00-00',
   PRIMARY KEY (`id_product_attribute`, `id_shop`),
   UNIQUE KEY `id_product` (`id_product`, `id_shop`, `default_on`),
-  INDEX (`default_on`),
+  INDEX (`default_on`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 
 CREATE TABLE `PREFIX_product_attribute_combination` (

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1564,7 +1564,8 @@ CREATE TABLE `PREFIX_product_attribute_shop` (
   `minimal_quantity` int(10) unsigned NOT NULL DEFAULT '1',
   `available_date` date NOT NULL DEFAULT '0000-00-00',
   PRIMARY KEY (`id_product_attribute`, `id_shop`),
-  UNIQUE KEY `id_product` (`id_product`, `id_shop`, `default_on`)
+  UNIQUE KEY `id_product` (`id_product`, `id_shop`, `default_on`),
+  INDEX (`default_on`),
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 
 CREATE TABLE `PREFIX_product_attribute_combination` (


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x, 1.7.x
| Description?  | Fix slow query search when attributes are involved
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Run EXPLAIN on the query below.

On a shop with 100k products query time went down from ~150s to 500ms.
The query affected is in find() and searchTag() functions of Search class, when using JOIN on prouct_attribute_shop here:
`ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop='.(int)$context->shop->id.')':'').'
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8532)
<!-- Reviewable:end -->
