### PR TITLE
Fixed slow query search when attributes are involved

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1647,7 +1647,7 @@ CREATE TABLE `PREFIX_product_attribute_shop` (
   `low_stock_alert` TINYINT(1) NOT NULL DEFAULT 0,
   `available_date` date DEFAULT NULL,
   PRIMARY KEY (`id_product_attribute`, `id_shop`),
-  INDEX (`default_on`),
+  INDEX `default_on` (`default_on`),
   UNIQUE KEY `id_product` (`id_product`, `id_shop`, `default_on`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1647,6 +1647,7 @@ CREATE TABLE `PREFIX_product_attribute_shop` (
   `low_stock_alert` TINYINT(1) NOT NULL DEFAULT 0,
   `available_date` date DEFAULT NULL,
   PRIMARY KEY (`id_product_attribute`, `id_shop`),
+  INDEX (`default_on`),
   UNIQUE KEY `id_product` (`id_product`, `id_shop`, `default_on`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 

--- a/install-dev/upgrade/sql/1.7.4.0.sql
+++ b/install-dev/upgrade/sql/1.7.4.0.sql
@@ -1,0 +1,4 @@
+SET SESSION sql_mode = '';
+SET NAMES 'utf8';
+
+ALTER TABLE `PREFIX_product_attribute_shop` ADD INDEX `default_on` (`default_on`);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Fix slow query search when attributes are involved
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Run EXPLAIN on the query below.

On a shop with 100k products query time went down from ~150s to 500ms.
The query affected is in find() and searchTag() functions of Search class, when using JOIN on prouct_attribute_shop here:
`ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop='.(int)$context->shop->id.')':'').'
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8534)
<!-- Reviewable:end -->
