### PR TITLE
Fix multiple SQL queries to cart_product table

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3100,12 +3100,13 @@ class ProductCore extends ObjectModel
 
         $cart_quantity = 0;
         if ((int)$id_cart) {
-            $cache_id = 'Product::getPriceStatic_'.(int)$id_product.'-'.(int)$id_cart;
+            $cache_id = 'Product::getPriceStatic_'.(int)$id_product.'-'.$id_product_attribute.'-'.(int)$id_cart;
             if (!Cache::isStored($cache_id) || ($cart_quantity = Cache::retrieve($cache_id) != (int)$quantity)) {
                 $sql = 'SELECT SUM(`quantity`)
 				FROM `'._DB_PREFIX_.'cart_product`
 				WHERE `id_product` = '.(int)$id_product.'
-				AND `id_cart` = '.(int)$id_cart;
+				AND `id_cart` = '.(int)$id_cart.'
+				AND `id_product_attribute` = '.(int)$id_product_attribute;
                 $cart_quantity = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
                 Cache::store($cache_id, $cart_quantity);
             } else {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The "id_product_attribute" was not being cached when checking the quantity of each product in the cart, making multiple calls to the "cart_product" table and lowering the store's performance.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4368 & Fixes #9803
| How to test?  | Many products with many combinations in the cart, for example : 77 products in the shopping cart

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8542)
<!-- Reviewable:end -->
