### PR TITLE
Layout broken by cache clear

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -247,16 +247,16 @@ class AdminControllerCore extends Controller
     /** @var HelperList */
     protected $helper;
 
-    /** @var array Cache for translations */
+    /** @var int DELETE access level */
     const LEVEL_DELETE = 4;
 
-    /** @var array Cache for translations */
-    const LEVEL_EDIT = 2;
-
-    /** @var array Cache for translations */
+    /** @var int ADD access level */
     const LEVEL_ADD = 3;
 
-    /** @var array Cache for translations */
+    /** @var int EDIT access level */
+    const LEVEL_EDIT = 2;
+
+    /** @var int VIEW access level */
     const LEVEL_VIEW = 1;
 
     /**

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -1095,7 +1095,7 @@ class AdminThemesControllerCore extends AdminController
             $this->errors[] = $e->getMessage();
             $this->addErrorToRedirectAfter();
         } catch (Exception $e) {
-            $this->addErrorToRedirectAfter();
+            $this->errors[] = $e->getMessage();
         }
     }
 }

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -24,7 +24,9 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
 use PrestaShop\PrestaShop\Core\Shop\LogoUploader;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
@@ -38,10 +40,14 @@ class AdminThemesControllerCore extends AdminController
     const CACHE_FILE_MUST_HAVE_THEMES_LIST = '/config/xml/must_have_themes_list.xml';
 
     /**
-    * @var object ThemeManager
+    * @var ThemeManager
     */
     public $theme_manager;
 
+    /**
+     * @var ThemeRepository
+     */
+    protected $theme_repository;
     protected $toolbar_scroll = false;
     protected $authAccesses = array();
     private $img_error;
@@ -79,6 +85,10 @@ class AdminThemesControllerCore extends AdminController
 
     public function downloadAddonsThemes()
     {
+        if (!$this->logged_on_addons) {
+            return false;
+        }
+
         try {
             $this->validateAddAuthorization();
         } catch (Exception $e) {
@@ -249,7 +259,7 @@ class AdminThemesControllerCore extends AdminController
 
         if ('exporttheme' === Tools::getValue('action')) {
             try {
-                $this->validateAddAuthorization();
+                $this->validateAddAuthorization(true);
             } catch (Exception $e) {
                 $this->errors[] = $this->trans(
                     'You do not have permission to edit this.',

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -289,7 +289,7 @@ class AdminThemesControllerCore extends AdminController
 
             // Main Theme page
             default:
-                if (Tools::isSubmit('submitGenerateRTL') && Tools::getValue('PS_GENERATE_RTL')) {
+                if (Tools::isSubmit('submitGenerateRTL')) {
                     $this->postProcessSubmitGenerateRTL();
                 }
 
@@ -1033,16 +1033,18 @@ class AdminThemesControllerCore extends AdminController
      */
     protected function postProcessSubmitGenerateRTL()
     {
-        Language::getRtlStylesheetProcessor()
+        if ((bool)Tools::getValue('PS_GENERATE_RTL')) {
+            Language::getRtlStylesheetProcessor()
             ->setProcessFOThemes(array(Tools::getValue('PS_THEMES_LIST')))
             ->setRegenerate(true)
             ->process();
 
-        $this->confirmations[] = $this->trans(
-            'Your RTL stylesheets has been generated successfully',
-            array(),
-            'Admin.Design.Notification'
-        );
+            $this->confirmations[] = $this->trans(
+                'Your RTL stylesheets has been generated successfully',
+                array(),
+                'Admin.Design.Notification'
+            );
+        }
     }
 
     /**

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -161,7 +161,7 @@ class ThemeManager implements AddonManagerInterface
         }
 
         /* if file exits, remove it and use YAML configuration file instead */
-        @unlink($this->appConfiguration->get('_PS_CACHE_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json');
+        @unlink($this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json');
 
         $theme = $this->themeRepository->getInstanceByName($name);
         if (!$this->themeValidator->isValid($theme)) {
@@ -202,7 +202,7 @@ class ThemeManager implements AddonManagerInterface
 
         $this->doDisableModules($theme->getModulesToDisable());
 
-        @unlink($this->appConfiguration->get('_PS_CACHE_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json');
+        @unlink($this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$name.'/shop'.$this->shop->id.'.json');
 
         return true;
     }
@@ -395,14 +395,20 @@ class ThemeManager implements AddonManagerInterface
         return $this->sandbox;
     }
 
+    /**
+     * @param Theme $theme
+     */
     public function saveTheme($theme)
     {
-        $jsonConfigFolder = $this->appConfiguration->get('_PS_CACHE_DIR_').'themes/'.$theme->getName();
+        $jsonConfigFolder = $this->appConfiguration->get('_PS_CONFIG_DIR_').'themes/'.$theme->getName();
         if (!$this->filesystem->exists($jsonConfigFolder) && !is_dir($jsonConfigFolder)) {
             mkdir($jsonConfigFolder, 0777, true);
         }
 
-        file_put_contents($jsonConfigFolder.'/shop'.$this->shop->id.'.json', json_encode($theme->get(null)));
+        file_put_contents(
+            $jsonConfigFolder.'/shop'.$this->shop->id.'.json',
+            json_encode($theme->get(null))
+        );
     }
 
     /**

--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -54,7 +54,7 @@ class ThemeRepository implements AddonRepositoryInterface
         $dir = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_') . $name;
 
         $confDir = $this->appConfiguration->get('_PS_CONFIG_DIR_') . 'themes/' . $name;
-        $jsonConf = '';
+        $jsonConf = $confDir . '/theme.json';
         if ($this->shop) {
             $jsonConf = $confDir . '/shop' . $this->shop->id . '.json';
         }

--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -51,22 +51,27 @@ class ThemeRepository implements AddonRepositoryInterface
 
     public function getInstanceByName($name)
     {
-        $dir = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_').$name;
-        $themeCachePath = $this->appConfiguration->get(
-                '_PS_CACHE_DIR_'
-            ) . 'themes/' . $name;
+        $dir = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_') . $name;
 
+        $confDir = $this->appConfiguration->get('_PS_CONFIG_DIR_') . 'themes/' . $name;
+        $jsonConf = '';
         if ($this->shop) {
-            $jsonConf = $themeCachePath . '/shop' . $this->shop->id . '.json';
-        } else {
-            $jsonConf = $themeCachePath . '/theme.json';
+            $jsonConf = $confDir . '/shop' . $this->shop->id . '.json';
         }
 
         if ($this->filesystem->exists($jsonConf)) {
             $data = $this->getConfigFromFile($jsonConf);
         } else {
-            $data = $this->getConfigFromFile($dir.'/config/theme.yml');
-            $this->filesystem->dumpFile($jsonConf, json_encode($data));
+            $data = $this->getConfigFromFile($dir . '/config/theme.yml');
+
+            // Write parsed yml data into json conf (faster parsing next time)
+            if (!$this->filesystem->exists($confDir) && !is_dir($confDir)) {
+                mkdir($confDir, 0777, true);
+            }
+            file_put_contents(
+                $jsonConf,
+                json_encode($data)
+            );
         }
 
         $data['directory'] = $dir;
@@ -130,7 +135,10 @@ class ThemeRepository implements AddonRepositoryInterface
     private function getConfigFromFile($file)
     {
         if (!$this->filesystem->exists($file)) {
-            throw new PrestaShopException(sprintf('[ThemeRepository] Theme configuration file not found for theme at `%s`.', $file));
+            throw new PrestaShopException(sprintf(
+                '[ThemeRepository] Theme configuration file not found for theme at `%s`.',
+                $file
+            ));
         }
 
         $content = file_get_contents($file);

--- a/src/Core/Addon/Theme/ThemeRepository.php
+++ b/src/Core/Addon/Theme/ThemeRepository.php
@@ -65,13 +65,7 @@ class ThemeRepository implements AddonRepositoryInterface
             $data = $this->getConfigFromFile($dir . '/config/theme.yml');
 
             // Write parsed yml data into json conf (faster parsing next time)
-            if (!$this->filesystem->exists($confDir) && !is_dir($confDir)) {
-                mkdir($confDir, 0777, true);
-            }
-            file_put_contents(
-                $jsonConf,
-                json_encode($data)
-            );
+            $this->filesystem->dumpFile($jsonConf, json_encode($data), 0777);
         }
 
         $data['directory'] = $dir;

--- a/src/PrestaShopBundle/Cache/CacheWarmer.php
+++ b/src/PrestaShopBundle/Cache/CacheWarmer.php
@@ -46,7 +46,6 @@ class CacheWarmer implements CacheWarmerInterface
             $cacheDir.DIRECTORY_SEPARATOR.'push',
             $cacheDir.DIRECTORY_SEPARATOR.'sandbox',
             $cacheDir.DIRECTORY_SEPARATOR.'tcpdf',
-            $cacheDir.DIRECTORY_SEPARATOR.'themes',
         );
 
         $this->fileSystem->mkdir($legacyDirs);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Cache clear leads to reset of theme configuration (including layouts).
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [BOOM-3222](http://forge.prestashop.com/browse/BOOM-3222)
| How to test?  | Change some page layout. For example, set index as a 3 columns layout. Check it out in FO. Then clear PrestaShop cache, then refresh FO index page. Layout should still be 3 columns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8543)
<!-- Reviewable:end -->
