### PR TITLE
Fixed Hooks data collector display

### DIFF
--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -105,8 +105,13 @@ final class HookDataCollector extends DataCollector
         foreach ($hooksList as &$hookList) {
             foreach ($hookList as &$hook) {
                 $hook['args'] = $this->varToString($hook['args']);
+
                 foreach ($hook['modules'] as &$modulesByType) {
-                    foreach ($modulesByType as &$module) {
+                    foreach ($modulesByType as $type => &$module) {
+                        if (empty($module)) {
+                            unset($modulesByType[$type]);
+                        }
+
                         if (array_key_exists('args', $module)) {
                             $module['args'] = $this->varToString($module['args']);
                         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | We have 2 types of hooks: `callback` and `widget`. In modules you can have both or only one kind of them, the collector should'nt try to display hooks of a category that is not used.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | In `1.7.3.x` in Product catalog page in debug mode, click on the "Hooks" section: and then do the same test with this branch.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8549)
<!-- Reviewable:end -->
