### PR TITLE
Introduced a consistent method to get route name if Hooks dispatched in modern pages

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4723,14 +4723,4 @@ class AdminControllerCore extends Controller
             return 0;
         }
     }
-
-    /**
-     * Returns the route name (this allow to identify the page)
-     *
-     * @return string
-     */
-    public function getRoute()
-    {
-        return get_class($this);
-    }
 }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4723,4 +4723,14 @@ class AdminControllerCore extends Controller
             return 0;
         }
     }
+
+    /**
+     * Returns the route name (this allow to identify the page)
+     *
+     * @return string
+     */
+    public function getRoute()
+    {
+        return get_class($this);
+    }
 }

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -27,7 +27,6 @@
 class AdminLegacyLayoutControllerCore extends AdminController
 {
     public $outPutHtml = '';
-    private $routeName = '';
     private $headerToolbarBtn = array();
     private $title;
     private $showContentHeader = true;
@@ -35,7 +34,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
     private $enableSidebar = false;
     private $helpLink;
 
-    public function __construct($controllerName = '', $title = '', $headerToolbarBtn = array(), $displayType = '', $showContentHeader = true, $headerTabContent = '', $enableSidebar = false, $helpLink = '', $routeName = '')
+    public function __construct($controllerName = '', $title = '', $headerToolbarBtn = array(), $displayType = '', $showContentHeader = true, $headerTabContent = '', $enableSidebar = false, $helpLink = '')
     {
         parent::__construct($controllerName, 'new-theme');
 
@@ -51,7 +50,6 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $this->enableSidebar = $enableSidebar;
         $this->helpLink = $helpLink;
         $this->php_self = $controllerName;
-        $this->routeName = $routeName;
     }
 
     public function setMedia()
@@ -112,16 +110,6 @@ class AdminLegacyLayoutControllerCore extends AdminController
     public function initPageHeaderToolbar()
     {
         parent::initPageHeaderToolbar();
-    }
-
-    /**
-     * Returns the route name (this allow to identify the page)
-     *
-     * @return string
-     */
-    public function getRoute()
-    {
-        return $this->routeName;
     }
 
     public function display()

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -150,8 +150,7 @@ class LegacyContext
         $showContentHeader,
         $headerTabContent,
         $enableSidebar,
-        $helpLink = '',
-        $routeName = ''
+        $helpLink = ''
     ) {
         $originCtrl = new AdminLegacyLayoutControllerCore(
             $controllerName,
@@ -161,8 +160,7 @@ class LegacyContext
             $showContentHeader,
             $headerTabContent,
             $enableSidebar,
-            $helpLink,
-            $routeName
+            $helpLink
         );
         $originCtrl->run();
 

--- a/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
@@ -31,8 +31,7 @@ layoutDisplayType is defined ? layoutDisplayType : '',
 showContentHeader is defined ? showContentHeader : true,
 headerTabContent is defined ? headerTabContent : '',
 enableSidebar is defined ? enableSidebar : false,
-help_link is defined ? help_link : '',
-app.request.attributes.get('_route')
+help_link is defined ? help_link : ''
 )
 )) %}
 

--- a/src/PrestaShopBundle/Service/Hook/HookEvent.php
+++ b/src/PrestaShopBundle/Service/Hook/HookEvent.php
@@ -54,7 +54,7 @@ class HookEvent extends Event
      *
      * More values than the param set is returned:
      * - _ps_version contains PrestaShop version, and is here only if the Hook is triggered by Symfony architecture.
-     * These values can either be overriden by szetHookParameters using the same parameter key.
+     * These values can either be overriden by setHookParameters using the same parameter key.
      *
      * @return array The array of hook parameters, more default fixed values.
      */
@@ -64,7 +64,9 @@ class HookEvent extends Event
 
         $sfContainer = SymfonyContainer::getInstance();
         if (!is_null($sfContainer) && !is_null($sfContainer->get('request_stack')->getCurrentRequest())) {
-            $globalParameters['request'] = $sfContainer->get('request');
+            $request = $sfContainer->get('request_stack')->getCurrentRequest();
+            $globalParameters['request'] = $request;
+            $globalParameters['route'] = $request->get('_route');
         }
 
         return array_merge($globalParameters, $this->hookParameters);

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -143,8 +143,7 @@ class LayoutExtension extends \Twig_Extension implements \Twig_Extension_Globals
         $showContentHeader = true,
         $headerTabContent = '',
         $enableSidebar = false,
-        $helpLink = '',
-        $routeName = ''
+        $helpLink = ''
     ) {
         if ($this->environment == 'test') {
             return <<<EOF
@@ -173,8 +172,7 @@ EOF;
             $showContentHeader,
             $headerTabContent,
             $enableSidebar,
-            $helpLink,
-            $routeName
+            $helpLink
         );
 
         //test if legacy template from "content.tpl" has '{$content}'


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Sounds like https://github.com/PrestaShop/PrestaShop/pull/8470 is incomplete for Product page because we still call the legacy controller with Symfony, so we need to make `getRoute()` function available for legacy Admin controllers too. Also, sometimes "even" in Product page the `getRoute()` equals to 'AdminProducts' instead of the real route because the legacy controller is still called. So I advice you to access to the route value directly from $hook parameters in Symfony context until the migration of Product page will be totally done.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Install the `ps_test` module (https://github.com/mickaelandrieu/ps_test) and switch on `xml-serializer` branch. On `1.7.3.x` branch, the product catalog page is broken, with this pull request the rendering is OK.

### Exemple of use

```php
public function hookDisplayDashboardToolbarIcons($hookParams)
{
  if ($this->isSymfonyContext() && $hookParams['route'] === 'admin_product_catalog') {
    $products = $this->get('product_repository')->findAllByLangId(1);

    $productsXml = $this->get('serializer')->serialize($products, 'xml', [
        'xml_root_node_name' => 'products',
        'xml_format_output' => true,
    ]);
    $this->get('filesystem')->dumpFile(_PS_UPLOAD_DIR_.'products.xml', $productsXml);
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8550)
<!-- Reviewable:end -->
