### PR TITLE
Fix the continue shopping URL in the cart page

### DIFF
--- a/themes/default-bootstrap/shopping-cart.tpl
+++ b/themes/default-bootstrap/shopping-cart.tpl
@@ -558,7 +558,15 @@
 				<span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span>
 			</a>
 		{/if}
-		<a href="{if (isset($smarty.server.HTTP_REFERER) && ($smarty.server.HTTP_REFERER == $link->getPageLink('order', true) || $smarty.server.HTTP_REFERER == $link->getPageLink('order-opc', true) || strstr($smarty.server.HTTP_REFERER, 'step='))) || !isset($smarty.server.HTTP_REFERER)}{$link->getPageLink('index')}{else}{$smarty.server.HTTP_REFERER|escape:'html':'UTF-8'|secureReferrer}{/if}" class="button-exclusive btn btn-default" title="{l s='Continue shopping'}">
+		{assign var="continueShoppingUrl" value=$smarty.server.HTTP_REFERER|replace:'content_only=1':'content_only=0'}
+		{if (isset($smarty.server.HTTP_REFERER)
+		&& ($smarty.server.HTTP_REFERER == $link->getPageLink('order', true)
+		|| $smarty.server.HTTP_REFERER == $link->getPageLink('order-opc', true)
+		|| strstr($smarty.server.HTTP_REFERER, 'step=')))
+		|| !isset($smarty.server.HTTP_REFERER)}
+			{assign var="continueShoppingUrl" value=$link->getPageLink('index')}
+		{/if}
+		<a href="{$continueShoppingUrl|escape:'html':'UTF-8'|secureReferrer}" class="button-exclusive btn btn-default" title="{l s='Continue shopping'}">
 			<i class="icon-chevron-left"></i>{l s='Continue shopping'}
 		</a>
 	</p>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you use the **Quick View** to order a product, the "continue shopping" URL in the shopping cart page will redirect you to a full-screen "**quick view**" without menus or links to escape this page.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7201
| How to test?  | FO > click on "**quick view**" > **add to the cart**, you will be redirected to the cart >  click on "continue shopping", check if you are redirected to the real product page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8554)
<!-- Reviewable:end -->
