### PR TITLE
Restore tooltips on performance symfony page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/AdvancedParameters/performance.html.twig
@@ -85,17 +85,17 @@
                     <div class="card-block">
                         <div class="card-text">
                             <div class="form-group">
-                                <label class="form-control-label">{{ 'Disable non PrestaShop modules'|trans }}</label>
+                                {{ ps.label_with_help(('Disable non PrestaShop modules'|trans), ('Enable or disable non PrestaShop Modules.'|trans({}, 'Admin.Advparameters.Feature'))) }}
                                 {{ form_errors(debugModeForm.disable_non_native_modules) }}
                                 {{ form_widget(debugModeForm.disable_non_native_modules) }}
                             </div>
                             <div class="form-group">
-                                <label class="form-control-label">{{ 'Disable all overrides'|trans }}</label>
+                                {{ ps.label_with_help(('Disable all overrides'|trans), ('Enable or disable all classes and controllers overrides.'|trans({}, 'Admin.Advparameters.Feature'))) }}
                                 {{ form_errors(debugModeForm.disable_overrides) }}
                                 {{ form_widget(debugModeForm.disable_overrides) }}
                             </div>
                             <div class="form-group">
-                                <label class="form-control-label">{{ 'Debug mode'|trans }}</label>
+                                {{ ps.label_with_help(('Debug mode'|trans), ('Enable or disable debug mode.'|trans({}, 'Admin.Advparameters.Help'))) }}
                                 {{ form_errors(debugModeForm.debug_mode) }}
                                 {{ form_widget(debugModeForm.debug_mode) }}
                             </div>
@@ -122,7 +122,7 @@
                             {{ ps.infotip('Some features can be disabled in order to improve performance.'|trans({}, 'Admin.Advparameters.Help')) }}
 
                             <div class="form-group">
-                                <label class="form-control-label">{{ 'Combinations'|trans({}, 'Admin.Global') }}</label>
+                                {{ ps.label_with_help(('Combinations'|trans({}, 'Admin.Global')), ('Choose "No" to disable Product Combinations.'|trans({}, 'Admin.Advparameters.Help'))) }}
                                 {{ form_errors(optionalFeaturesForm.combinations) }}
                                 {{ form_widget(optionalFeaturesForm.combinations) }}
                             </div>
@@ -132,12 +132,12 @@
                             {% endif %}
 
                             <div class="form-group">
-                                <label class="form-control-label">{{ 'Features'|trans({}, 'Admin.Global') }}</label>
+                                {{ ps.label_with_help(('Features'|trans({}, 'Admin.Global')), ('Choose "No" to disable Product Features.'|trans({}, 'Admin.Advparameters.Help'))) }}
                                 {{ form_errors(optionalFeaturesForm.features) }}
                                 {{ form_widget(optionalFeaturesForm.features) }}
                             </div>
                             <div class="form-group">
-                                <label class="form-control-label">{{ 'Customer groups'|trans }}</label>
+                                {{ ps.label_with_help(('Customer groups'|trans), ('Enable or disable debug mode.'|trans({}, 'Admin.Advparameters.Help'))) }}
                                 {{ form_errors(optionalFeaturesForm.customer_groups) }}
                                 {{ form_widget(optionalFeaturesForm.customer_groups) }}
                             </div>
@@ -199,17 +199,17 @@
                             {{ ps.infotip('You must enter another domain, or subdomain, in order to use cookieless static content.'|trans({}, 'Admin.Advparameters.Feature')) }}
 
                             <div class="form-group">
-                                <label class="form-control-label">{{ 'Media server #1'|trans }}</label>
+                                {{ ps.label_with_help(('Media server #1'|trans({}, 'Admin.Advparameters.Feature')), ('Name of the second domain of your shop, (e.g. myshop-media-server-1.com). If you do not have another domain, leave this field blank.'|trans({}, 'Admin.Advparameters.Help'))) }}
                                 {{ form_errors(mediaServersForm.media_server_one) }}
                                 {{ form_widget(mediaServersForm.media_server_one) }}
                             </div>
                             <div class="form-group">
-                                <label class="form-control-label">{{ 'Media server #2'|trans }}</label>
+                                {{ ps.label_with_help(('Media server #2'|trans({}, 'Admin.Advparameters.Feature')), ('Name of the third domain of your shop, (e.g. myshop-media-server-2.com). If you do not have another domain, leave this field blank.'|trans({}, 'Admin.Advparameters.Help'))) }}
                                 {{ form_errors(mediaServersForm.media_server_two) }}
                                 {{ form_widget(mediaServersForm.media_server_two) }}
                             </div>
                             <div class="form-group">
-                                <label class="form-control-label">{{ 'Media server #3'|trans }}</label>
+                                {{ ps.label_with_help(('Media server #3'|trans({}, 'Admin.Advparameters.Feature')), ('Name of the fourth domain of your shop, (e.g. myshop-media-server-3.com). If you do not have another domain, leave this field blank.'|trans({}, 'Admin.Advparameters.Help'))) }}
                                 {{ form_errors(mediaServersForm.media_server_three) }}
                                 {{ form_widget(mediaServersForm.media_server_three) }}
                             </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/AdvancedParameters/performance.html.twig
@@ -137,7 +137,7 @@
                                 {{ form_widget(optionalFeaturesForm.features) }}
                             </div>
                             <div class="form-group">
-                                {{ ps.label_with_help(('Customer groups'|trans), ('Enable or disable debug mode.'|trans({}, 'Admin.Advparameters.Help'))) }}
+                                {{ ps.label_with_help(('Customer groups'|trans), ('Choose "No" to disable Customer Groups.'|trans({}, 'Admin.Advparameters.Help'))) }}
                                 {{ form_errors(optionalFeaturesForm.customer_groups) }}
                                 {{ form_widget(optionalFeaturesForm.customer_groups) }}
                             </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | some tooltips were dropped on symfony migration . It restore them on performance BO page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4376
| How to test?  | open BO > performance. Check tooltips are here, and correctly translated ;)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8555)
<!-- Reviewable:end -->
