### PR TITLE
Hide the password in the confirmation email

### DIFF
--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -759,7 +759,8 @@ class AuthControllerCore extends FrontController
                 '{firstname}' => $customer->firstname,
                 '{lastname}' => $customer->lastname,
                 '{email}' => $customer->email,
-                '{passwd}' => Tools::getValue('passwd')),
+                '{passwd}' => str_repeat('*', strlen(Tools::getValue('passwd'))),
+            ),
             $customer->email,
             $customer->firstname.' '.$customer->lastname
         );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When customers sign up, they receive their password in plain text in the confirmation email, but these must be hidden.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9597
| How to test?  | FO > Sign in > create an account, after registration, check if the password in the confirmation email is hidden.

**The improvement is to replace the password with stars :**
![pscsx-9597](https://user-images.githubusercontent.com/17438504/33371359-b7d75602-d4fa-11e7-96a5-0fbd292e24b3.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8564)
<!-- Reviewable:end -->
