### PR TITLE
Fix redirection when filtering customers in the customer's group page

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -182,8 +182,12 @@ class AdminGroupsControllerCore extends AdminController
         if (Tools::getIsset('viewgroup')) {
             $this->list_id = 'customer_group';
 
-            if (isset($_POST['submitReset'.$this->list_id])) {
+            if (Tools::getIsset('submitReset' . $this->list_id)) {
                 $this->processResetFilters();
+            }
+
+            if (Tools::getIsset('submitFilter')) {
+                self::$currentIndex .= '&id_group=' . (int)Tools::getValue('id_group') . '&viewgroup';
             }
         } else {
             $this->list_id = 'group';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you try to search a customer with its name in the **customers group** page , you will be redirected to the groups list and the results won't be displayed. 
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9553
| How to test?  | BO > Customers > Groups > View a group > try to search a customer, check if the search result is displayed correctly and not redirect to groups list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8567)
<!-- Reviewable:end -->
