### PR TITLE
Change default file_get_content default timeout

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1950,7 +1950,7 @@ class ToolsCore
         $url,
         $use_include_path = false,
         $stream_context = null,
-        $curl_timeout = 60,
+        $curl_timeout = 5,
         $fallback = false
     ) {
         $is_local_file = !preg_match('/^https?:\/\//', $url);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Tools::file_get_contents() timeout is too high. When a distant service (of PrestaShop or other) is unavailable the PrestaShop instance is blocked because many requests are synchronous.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | try to use your backoffice without internet connection or drop packets to prestashop servers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8572)
<!-- Reviewable:end -->
