### PR TITLE
Moved Advanced Parameters section to Configure section

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -9,6 +9,7 @@ parameters:
     AdapterSecurityAdminClass: PrestaShop\PrestaShop\Adapter\Security\Admin
     translator.class: PrestaShopBundle\Translation\Translator
     translator.data_collector: PrestaShopBundle\Translation\DataCollectorTranslator
+    admin_page: "%kernel.root_dir%/../src/PrestaShopBundle/Resources/views/Admin"
 
 framework:
     assets:
@@ -57,6 +58,8 @@ twig:
         - 'PrestaShopBundle:Admin/TwigTemplateForm:bootstrap_3_horizontal_layout.html.twig'
     globals:
         webpack_server:   false
+    paths:
+        '%admin_page%/Configure/AdvancedParameters': AdvancedParameters
 
 # Doctrine Configuration
 doctrine:

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Controller\Admin\AdvancedParameters;
+namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Adapter\Cache\MemcacheServerManager;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Controller\Admin\AdvancedParameters;
+namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Voter\PageVoter;
@@ -66,7 +66,7 @@ class PerformanceController extends FrameworkBundleAdminController
             'servers' => $this->get('prestashop.adapter.memcache_server.manager')->getServers(),
         );
 
-        return $this->render('PrestaShopBundle:Admin/AdvancedParameters:performance.html.twig', $twigValues);
+        return $this->render('@AdvancedParameters/performance.html.twig', $twigValues);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Controller\Admin\AdvancedParameters;
+namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -65,7 +65,7 @@ class SystemInformationController extends FrameworkBundleAdminController
             'userAgent' => $request->headers->get('User-Agent'),
         );
 
-        return $this->render('PrestaShopBundle:Admin/AdvancedParameters:system_information.html.twig', $twigValues);
+        return $this->render('@AdvancedParameters/system_information.html.twig', $twigValues);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/admin/routing_advanced_parameters.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/routing_advanced_parameters.yml
@@ -2,14 +2,14 @@ admin_system_information:
     path: system_information
     methods: [GET]
     defaults:
-        _controller: 'PrestaShopBundle\Controller\Admin\AdvancedParameters\SystemInformationController::indexAction'
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\SystemInformation:index'
         _legacy_controller: AdminInformation
 
 admin_system_information_check_files:
     path: system_information/files
     methods: [POST]
     defaults:
-        _controller: 'PrestaShopBundle\Controller\Admin\AdvancedParameters\SystemInformationController::displayCheckFilesAction'
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\SystemInformation:displayCheckFiles'
         _legacy_controller: AdminInformation
     condition: "request.isXmlHttpRequest()"
 
@@ -17,28 +17,28 @@ admin_performance:
     path: performance
     methods: [GET]
     defaults:
-        _controller: 'PrestaShopBundle:Admin\AdvancedParameters\Performance:index'
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Performance:index'
         _legacy_controller: AdminPerformance
 
 admin_performance_save:
     path: performance
     methods: [POST]
     defaults:
-        _controller: 'PrestaShopBundle:Admin\AdvancedParameters\Performance:processForm'
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Performance:processForm'
         _legacy_controller: AdminPerformance
 
 admin_clear_cache:
     path: clear_cache
     methods: [GET]
     defaults:
-        _controller: 'PrestaShopBundle:Admin\AdvancedParameters\Performance:clearCache'
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Performance:clearCache'
         _legacy_controller: AdminPerformance
 
 admin_servers:
     path: memcache/servers
     methods: [GET]
     defaults:
-        _controller: 'PrestaShopBundle:Admin\AdvancedParameters\MemcacheServer:list'
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\MemcacheServer:list'
         _legacy_controller: AdminPerformance
     condition: 'request.isXmlHttpRequest()'
 
@@ -46,7 +46,7 @@ admin_servers_add:
     path: memcache/servers
     methods: [POST]
     defaults:
-        _controller: 'PrestaShopBundle:Admin\AdvancedParameters\MemcacheServer:add'
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\MemcacheServer:add'
         _legacy_controller: AdminPerformance
     condition: 'request.isXmlHttpRequest()'
 
@@ -54,7 +54,7 @@ admin_servers_delete:
     path: memcache/servers
     methods: [DELETE]
     defaults:
-        _controller: 'PrestaShopBundle:Admin\AdvancedParameters\MemcacheServer:delete'
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\MemcacheServer:delete'
         _legacy_controller: AdminPerformance
     condition: 'request.isXmlHttpRequest()'
 
@@ -62,7 +62,7 @@ admin_servers_test:
     path: memcache/servers/test
     methods: [GET]
     defaults:
-        _controller: 'PrestaShopBundle:Admin\AdvancedParameters\MemcacheServer:test'
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\MemcacheServer:test'
         _legacy_controller: AdminPerformance
     condition: 'request.isXmlHttpRequest()'
 

--- a/src/PrestaShopBundle/Resources/config/admin/routing_configure.yml
+++ b/src/PrestaShopBundle/Resources/config/admin/routing_configure.yml
@@ -1,0 +1,3 @@
+_admin_advanced_parameters_routing:
+    resource: "routing_advanced_parameters.yml"
+    prefix: /advanced/

--- a/src/PrestaShopBundle/Resources/config/routing_admin.yml
+++ b/src/PrestaShopBundle/Resources/config/routing_admin.yml
@@ -51,9 +51,9 @@ _admin_stock_routing:
     resource: "admin/routing_stock.yml"
     prefix: /stock
 
-_admin_advanced_parameters_routing:
-    resource: "admin/routing_advanced_parameters.yml"
-    prefix: /configure/advanced/
+_admin_configure_routing:
+    resource: "admin/routing_configure.yml"
+    prefix: /configure
 
 # include common routes for Admin interface
 admin_common_pagination:

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig
@@ -1,3 +1,27 @@
+{#**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
 {% trans_default_domain "Admin.Advparameters.Feature" %}
 
 {% block perfs_memcache_servers %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain "Admin.Advparameters.Feature" %}
 
 {%
@@ -240,7 +240,7 @@
                                 {{ form_errors(cachingForm.caching_system) }}
                                 {{ form_widget(cachingForm.caching_system) }}
                             </div>
-                            {{ include('@PrestaShop/Admin/AdvancedParameters/memcache_servers.html.twig', {'form': memcacheForm}) }}
+                            {{ include('@AdvancedParameters/memcache_servers.html.twig', {'form': memcacheForm}) }}
                         </div>
                     </div>
                     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain "Admin.Advparameters.Feature" %}
 
 {% block content %}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Modern pages migrated were located in `Advanced Parameters` when they should be into `Configure > Advanced Parameters` section, the URIs have been updated accordingly.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Performance and Information system pages should be still available, and the url prefix should be `configure/advanced` for both.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8574)
<!-- Reviewable:end -->
