### PR TITLE
Added new gitignore directives about translation packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ themes/default-bootstrap/modules/*/mails/*
 
 /bin/
 /.web-server-pid
+/app/Resources/translations/*
+!/app/Resources/translations/default
 /app/config/parameters.yml
 /app/config/parameters.php
 /build/

--- a/tests/sf-tests.xml
+++ b/tests/sf-tests.xml
@@ -8,7 +8,7 @@
   bootstrap                   = "bootstrap-sf.php"
 >
   <php>
-    <server name="KERNEL_DIR" value="../app" />
+    <server name="KERNEL_DIR" value="app" />
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
   </php>
 

--- a/tests/sf-tests.xml
+++ b/tests/sf-tests.xml
@@ -8,7 +8,7 @@
   bootstrap                   = "bootstrap-sf.php"
 >
   <php>
-    <server name="KERNEL_DIR" value="app" />
+    <server name="KERNEL_DIR" value="../app" />
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
   </php>
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | After SF migration was merged to develop, `.gitignore` directives about `app/Resources/translations/*` were lost.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8576)
<!-- Reviewable:end -->
