### PR TITLE
Fix the web service filter with many languages fields

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1068,12 +1068,16 @@ class WebserviceRequestCore
                                     if (!is_array($url_param)) {
                                         $url_param = array($url_param);
                                     }
-                                    $sql_join .= 'LEFT JOIN `'.bqSQL(_DB_PREFIX_.$this->resourceConfiguration['retrieveData']['table']).'_lang` AS main_i18n ON (main.`'.pSQL($this->resourceConfiguration['fields']['id']['sqlId']).'` = main_i18n.`'.bqSQL($this->resourceConfiguration['fields']['id']['sqlId']).'`)'."\n";
+
+                                    $join = 'LEFT JOIN `' . bqSQL(_DB_PREFIX_ . $this->resourceConfiguration['retrieveData']['table']) . '_lang` AS main_i18n ON (main.`' . pSQL($this->resourceConfiguration['fields']['id']['sqlId']) . '` = main_i18n.`' . bqSQL($this->resourceConfiguration['fields']['id']['sqlId']) . '`)' . "\n";
+                                    $sql_join .= (false === strpos($sql_join, $join)) ? $join : '';
+
                                     foreach ($url_param as $field2 => $value) {
                                         $linked_field = $this->resourceConfiguration['fields'][$field];
                                         $sql_filter .= $this->getSQLRetrieveFilter($linked_field['sqlId'], $value, 'main_i18n.');
-                                        $language_filter = '['.implode('|', $this->_available_languages).']';
-                                        $sql_filter .= $this->getSQLRetrieveFilter('id_lang', $language_filter, 'main_i18n.');
+                                        $language_filter = '[' . implode('|', $this->_available_languages) . ']';
+                                        $langFilter = $this->getSQLRetrieveFilter('id_lang', $language_filter, 'main_i18n.');
+                                        $sql_filter .= (false === strpos($sql_filter, $langFilter)) ? $langFilter : '';
                                     }
                                 }
                                 // if there are filters on linked tables but there are no linked table


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you try to filter the products by name and description, you will not have the expected results.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7936
| How to test?  | BO > Advanced Parameters > Webservice > enable prestashop's webservice, create a new webservice account, try to execute this WS **/api/products/?display=[name,description]&filter[description]=%[Fashion]%&filter[name]=%[Printed]%** and check if it returns the correct results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8578)
<!-- Reviewable:end -->
