### PR TITLE
Split width of summary invoice pdf

### DIFF
--- a/pdf/invoice.total-tab.tpl
+++ b/pdf/invoice.total-tab.tpl
@@ -25,10 +25,10 @@
 <table id="total-tab" width="100%">
 
 	<tr>
-		<td class="grey" width="70%">
+		<td class="grey" width="50%">
 			{l s='Total Products' pdf='true'}
 		</td>
-		<td class="white" width="30%">
+		<td class="white" width="50%">
 			{displayPrice currency=$order->id_currency price=$footer.products_before_discounts_tax_excl}
 		</td>
 	</tr>
@@ -36,10 +36,10 @@
 	{if $footer.product_discounts_tax_excl > 0}
 
 		<tr>
-			<td class="grey" width="70%">
+			<td class="grey" width="50%">
 				{l s='Total Discounts' pdf='true'}
 			</td>
-			<td class="white" width="30%">
+			<td class="white" width="50%">
 				- {displayPrice currency=$order->id_currency price=$footer.product_discounts_tax_excl}
 			</td>
 		</tr>
@@ -47,10 +47,10 @@
 	{/if}
 	{if !$order->isVirtual()}
 	<tr>
-		<td class="grey" width="70%">
+		<td class="grey" width="50%">
 			{l s='Shipping Cost' pdf='true'}
 		</td>
-		<td class="white" width="30%">
+		<td class="white" width="50%">
 			{if $footer.shipping_tax_excl > 0}
 				{displayPrice currency=$order->id_currency price=$footer.shipping_tax_excl}
 			{else}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fix width of column too small of pdf invoice
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-2432 (Ticket is for 1.7, but this also an issue in 1.6)
| How to test?  | See ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8579)
<!-- Reviewable:end -->
