### PR TITLE
On CLI, display simple information on PrestaShopException

### DIFF
--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -39,7 +39,10 @@ class PrestaShopExceptionCore extends Exception
         }
 
         header('HTTP/1.1 500 Internal Server Error');
-        if (_PS_MODE_DEV_ || defined('_PS_ADMIN_DIR_')) {
+        if (ToolsCore::isPHPCLI()) { 
+            echo get_class($this).' in '. $this->getFile() .' line '. $this->getLine()."\n";
+            echo $this->getTraceAsString()."\n";
+        } elseif (_PS_MODE_DEV_ || defined('_PS_ADMIN_DIR_')) {
             // Display error message
             echo '<style>
                 #psException{font-family: Verdana; font-size: 14px}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On composer install / update, if your shop is supposed to be installed but the MySQL server unavailable, a PrestaShopException will be thrown. Even if we are in CLI, data in HTML will be displayed on your terminal, and your RAM will be saturated. In my case, I have to reboot my computer every time it happens... This PR add the Cli case and only display the exception class, file & line, a finally a small stack trace.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Make your MySQL server unreachable by turning it off or modifying the credentials in your file `app/config/parameters.php`. Then try a `composer update`

## Result:
![capture du 2017-12-05 10-34-29](https://user-images.githubusercontent.com/6768917/33603004-0969b25a-d9a9-11e7-8a12-ccadff5de597.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8582)
<!-- Reviewable:end -->
