### PR TITLE
Fixed keywords disapear from search index

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1886,17 +1886,23 @@ class ProductCore extends ObjectModel
     *
     * @return array Deletion result
     */
-    public function deleteSearchIndexes()
-    {
-        return (
-            Db::getInstance()->execute(
-                'DELETE `'._DB_PREFIX_.'search_index`, `'._DB_PREFIX_.'search_word`
-				FROM `'._DB_PREFIX_.'search_index` JOIN `'._DB_PREFIX_.'search_word`
-				WHERE `'._DB_PREFIX_.'search_index`.`id_product` = '.(int)$this->id.'
-						AND `'._DB_PREFIX_.'search_word`.`id_word` = `'._DB_PREFIX_.'search_index`.id_word'
-            )
-        );
-    }
+	public function deleteSearchIndexes()
+	{
+		return (
+			Db::getInstance()->execute(
+				'DELETE FROM `'._DB_PREFIX_.'search_index`
+				WHERE `id_product` = '.(int)$this->id
+			)
+			&&
+			Db::getInstance()->execute(
+				'DELETE FROM `'._DB_PREFIX_.'search_word`
+				WHERE `id_word` NOT IN (
+					SELECT id_word
+					FROM `'._DB_PREFIX_.'search_index`
+				)'
+			)
+		);
+	}
 
     /**
     * Add a product attributes combinaison

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1890,10 +1890,16 @@ class ProductCore extends ObjectModel
     {
         return (
             Db::getInstance()->execute(
-                'DELETE `'._DB_PREFIX_.'search_index`, `'._DB_PREFIX_.'search_word`
-				FROM `'._DB_PREFIX_.'search_index` JOIN `'._DB_PREFIX_.'search_word`
-				WHERE `'._DB_PREFIX_.'search_index`.`id_product` = '.(int)$this->id.'
-						AND `'._DB_PREFIX_.'search_word`.`id_word` = `'._DB_PREFIX_.'search_index`.id_word'
+                'DELETE FROM `'._DB_PREFIX_.'search_index`
+				WHERE `id_product` = '.(int)$this->id
+            )
+            &&
+            Db::getInstance()->execute(
+                'DELETE FROM `'._DB_PREFIX_.'search_word`
+				WHERE `id_word` NOT IN (
+					SELECT id_word
+					FROM `'._DB_PREFIX_.'search_index`
+				)'
             )
         );
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1895,11 +1895,9 @@ class ProductCore extends ObjectModel
             )
             &&
             Db::getInstance()->execute(
-                'DELETE FROM `'._DB_PREFIX_.'search_word`
-				WHERE `id_word` NOT IN (
-					SELECT id_word
-					FROM `'._DB_PREFIX_.'search_index`
-				)'
+                'DELETE sw FROM `'._DB_PREFIX_.'search_word` sw
+        LEFT JOIN `'._DB_PREFIX_.'search_index` si ON (sw.id_word=si.id_word)
+        WHERE si.id_word IS NULL;'
             )
         );
     }


### PR DESCRIPTION
http://forge.prestashop.com/browse/PSCSX-8239#

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x (But should be on 1.7 also)
| Description?  | Delete a product, and you delete words that is shared in search_word tabel, make other product disapear from search until next full reindex.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8239#
| How to test?  | see my comment in ticket, link with db Fiddle etc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8587)
<!-- Reviewable:end -->
