### PR TITLE
Add parameter to setMedia

### DIFF
--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -40,9 +40,9 @@ class AdminDashboardControllerCore extends AdminController
         }
     }
 
-    public function setMedia()
+    public function setMedia($isNewTheme = false)
     {
-        parent::setMedia();
+        parent::setMedia($isNewTheme);
 
         $this->addJqueryUI('ui.datepicker');
         $this->addJS(array(


### PR DESCRIPTION
if not Fatal Error with PHP 7.2.0 :
PHP Fatal error:  Declaration of AdminDashboardControllerCore::setMedia() 
must be compatible with AdminControllerCore::setMedia($isNewTheme = false) 
in /prestashop/controllers/admin/AdminDashboardController.php on line 539

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fatal error with PHP 7.2.0 on back-office request
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | ?
| Deprecations? | ?
| Fixed ticket? | 
| How to test?  | Install the last version of PHP 7.2.0 (5/12/2017)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8588)
<!-- Reviewable:end -->
