### PR TITLE
Fix the calculation of the unit price impact on the combinations

### DIFF
--- a/themes/default-bootstrap/js/product.js
+++ b/themes/default-bootstrap/js/product.js
@@ -683,7 +683,7 @@ function updatePrice()
 	// 0 by default, +x if price is inscreased, -x if price is decreased
 	basePriceWithoutTax = basePriceWithoutTax + +combination.price;
 	basePriceWithTax = basePriceWithTax + +combination.price * (taxRate/100 + 1);
-	
+
 
 	var priceWithDiscountsWithoutTax = basePriceWithoutTax;
 	var priceWithDiscountsWithTax = basePriceWithTax;
@@ -779,7 +779,7 @@ function updatePrice()
 			baseUnitPrice = productBasePriceTaxExcl / productUnitPriceRatio;
 			unit_price = baseUnitPrice + unit_impact;
 
-			if (!noTaxForThisProduct || !customerGroupWithoutTax)
+			if (displayPrice !== 1 && (!noTaxForThisProduct || !customerGroupWithoutTax))
 				unit_price = unit_price * (taxRate/100 + 1);
 		}
 		else


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you use the **price display method** as **excluded tax**, the calculation of the impact of the unit price on the combinations is incorrect in the product page FO.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9419
| How to test?  | See the description in the ticket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8590)
<!-- Reviewable:end -->
