### PR TITLE
Fix the payment restrictions per customer group

### DIFF
--- a/controllers/admin/AdminPaymentController.php
+++ b/controllers/admin/AdminPaymentController.php
@@ -204,7 +204,7 @@ class AdminPaymentControllerCore extends AdminController
                           'identifier' => 'id_currency',
                           'icon' => 'icon-money',
                     ),
-                    array('items' => Group::getGroups($this->context->language->id),
+                    array('items' => Group::getGroups($this->context->language->id, $this->context->shop->id),
                           'title' => $this->l('Group restrictions'),
                           'desc' => $this->l('Please mark each checkbox for the customer group(s), in which you want the payment module(s) to be available.'),
                           'name_id' => 'group',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | On the Modules > Payment page where you configure the payment restrictions per customer group, all the customer groups are showing, but these customer groups must be filtered by current shop selected.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-5238
| How to test?  | Enable the multistore, create two shops, assign a new group to the second shop, BO > Modules and Services > Payment > GROUP RESTRICTIONS, check if all the displayed groups belong to the current shop (current shop = the first shop).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8598)
<!-- Reviewable:end -->
