### PR TITLE
Fix fatal on array_merge if query in addMissingProductFields returns no result

### DIFF
--- a/classes/ProductAssembler.php
+++ b/classes/ProductAssembler.php
@@ -79,7 +79,7 @@ class ProductAssemblerCore
 				)
 			) > 0) as new
                 FROM {$prefix}product p
-                INNER JOIN {$prefix}product_lang pl
+                LEFT JOIN {$prefix}product_lang pl
                     ON pl.id_product = p.id_product
                     AND pl.id_shop = $idShop
                     AND pl.id_lang = $idLang
@@ -89,6 +89,9 @@ class ProductAssemblerCore
 			        AND sa.id_shop = $idShop";
 
         $rows = Db::getInstance()->executeS($sql);
+        if ($rows === false) {
+            return $rawProduct;
+        }
 
         return array_merge($rows[0], $rawProduct);
     }


### PR DESCRIPTION
Change the query to make a LEFT JOIN on product_lang instead of an INNER JOIN

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fatal error when a product has no associated translation in the current language
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a product without any corresponding entry in product_lang and try to display it

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8600)
<!-- Reviewable:end -->
