### PR TITLE
Fix the redirection after saving and deleting a features value

### DIFF
--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -481,6 +481,7 @@ class AdminFeaturesControllerCore extends AdminController
         if ($this->table == 'feature_value' && ($this->action == 'save' || $this->action == 'delete' || $this->action == 'bulkDelete')) {
             Hook::exec('displayFeatureValuePostProcess',
                 array('errors' => &$this->errors));
+            $this->redirect_after = self::$currentIndex . '&id_feature=' . (int)Tools::getValue('id_feature') . '&viewfeature' . '&token=' . $this->token;
         } // send errors as reference to allow displayFeatureValuePostProcess to stop saving process
         else {
             Hook::exec('displayFeaturePostProcess',

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -463,6 +463,10 @@ class AdminFeaturesControllerCore extends AdminController
             if (isset($_POST['submitReset'.$this->list_id])) {
                 $this->processResetFilters();
             }
+
+            if (Tools::getIsset('deletefeature_value')) {
+                self::$currentIndex = self::$currentIndex . '&id_feature=' . (int)Tools::getValue('id_feature') . '&viewfeature';
+            }
         } else {
             $this->list_id = 'feature';
             $this->_defaultOrderBy = 'position';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you try to **edit** or **delete** a feature value in the feature values list page , you will be redirected to the features list instead of the feature values list .
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9639
| How to test?  | BO > Catalog > Product Features > View a feature and try to **edit** or **delete**, check if you will be redirected to the right list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8603)
<!-- Reviewable:end -->
