### PR TITLE
Fix pack stock issues

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1141,35 +1141,76 @@ class CartCore extends ObjectModel
      * @param int $id_customization Customization ID
      * @param int $id_address_delivery Delivery Address ID
      *
-     * @return array|bool|null|object Whether the Cart contains the Product
-     *                                Result comes directly from the database
+     * @return array quantity index     : number of product in cart without counting those of pack in cart
+     *               deep_quantity index: number of product in cart counting those of pack in cart
      */
-    public function containsProduct($id_product, $id_product_attribute = 0, $id_customization = 0, $id_address_delivery = 0)
+    public function getProductQuantity($id_product, $id_product_attribute = 0, $id_customization = 0, $id_address_delivery = 0)
     {
-        $sql = 'SELECT cp.`quantity` FROM `'._DB_PREFIX_.'cart_product` cp';
+        $firstUnionSql = 'SELECT cp.`quantity` as first_level_quantity, 0 as pack_quantity 
+          FROM `'._DB_PREFIX_.'cart_product` cp';
+        $secondUnionSql = 'SELECT 0 as first_level_quantity, cp.`quantity` * p.`quantity` as pack_quantity
+          FROM `'._DB_PREFIX_.'cart_product` cp' .
+            ' JOIN `'._DB_PREFIX_.'pack` p ON cp.`id_product` = p.`id_product_pack`';
 
         if ($id_customization) {
-            $sql .= '
+            $customizationJoin = '
                 LEFT JOIN `'._DB_PREFIX_.'customization` c ON (
                     c.`id_product` = cp.`id_product`
                     AND c.`id_product_attribute` = cp.`id_product_attribute`
                 )';
+            $firstUnionSql .= $customizationJoin;
+            $secondUnionSql .= $customizationJoin;
         }
-
-        $sql .= '
-            WHERE cp.`id_product` = '.(int)$id_product.'
-            AND cp.`id_product_attribute` = '.(int)$id_product_attribute.'
+        $commonWhere = '
+            WHERE cp.`id_product_attribute` = '.(int)$id_product_attribute.'
             AND cp.`id_customization` = '.(int)$id_customization.'
             AND cp.`id_cart` = '.(int)$this->id;
+        $firstUnionSql .=  $commonWhere;
+        $firstUnionSql .= ' AND cp.`id_product` = ' . (int) $id_product;
+        $secondUnionSql .= $commonWhere;
+        $secondUnionSql .= ' AND p.`id_product_item` = ' . (int) $id_product;
+
         if (Configuration::get('PS_ALLOW_MULTISHIPPING') && $this->isMultiAddressDelivery()) {
-            $sql .= ' AND cp.`id_address_delivery` = '.(int)$id_address_delivery;
+            $firstUnionSql .= ' AND cp.`id_address_delivery` = '.(int)$id_address_delivery;
+            $secondUnionSql .= ' AND cp.`id_address_delivery` = '.(int)$id_address_delivery;
         }
 
         if ($id_customization) {
-            $sql .= ' AND c.`id_customization` = '.(int)$id_customization;
+            $firstUnionSql .= ' AND c.`id_customization` = '.(int)$id_customization;
+            $secondUnionSql .= ' AND c.`id_customization` = '.(int)$id_customization;
+        }
+        $parentSql = 'SELECT 
+            COALESCE(SUM(first_level_quantity) + SUM(pack_quantity), 0) as deep_quantity,
+            COALESCE(SUM(first_level_quantity), 0) as quantity 
+          FROM (' . $firstUnionSql . ' UNION ' . $secondUnionSql . ') as q';
+        $result = Db::getInstance()->getRow($parentSql);
+
+        return Db::getInstance()->getRow($parentSql);
+    }
+
+    /**
+     * Check if the Cart contains the given Product (Attribute)
+     *
+     * @deprecated 1.7.3.1
+     * @see Cart::getProductQuantity()
+     *
+     * @param int $id_product Product ID
+     * @param int $id_product_attribute ProductAttribute ID
+     * @param int $id_customization Customization ID
+     * @param int $id_address_delivery Delivery Address ID
+     *
+     * @return array|bool Whether the Cart contains the Product
+     *                                Result comes directly from the database
+     */
+    public function containsProduct($id_product, $id_product_attribute = 0, $id_customization = 0, $id_address_delivery = 0)
+    {
+        $result = $this->getProductQuantity($id_product, $id_product_attribute, $id_customization, $id_address_delivery);
+
+        if (empty($result['quantity'])) {
+            return false;
         }
 
-        return Db::getInstance()->getRow($sql);
+        return array('quantity' => $result['quantity']);
     }
 
     /**
@@ -1260,49 +1301,32 @@ class CartCore extends ObjectModel
             return false;
         } else {
             /* Check if the product is already in the cart */
-            $result = $this->containsProduct($id_product, $id_product_attribute, (int)$id_customization, (int)$id_address_delivery);
+            $cartProductQuantity = $this->getProductQuantity($id_product, $id_product_attribute, (int)$id_customization, (int)$id_address_delivery);
 
             /* Update quantity if product already exist */
-            if ($result) {
+            if (!empty($cartProductQuantity['quantity'])) {
+                $productQuantity = Product::getQuantity($id_product, $id_product_attribute);
+
                 if ($operator == 'up') {
-                    $sql = 'SELECT stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity
-                            FROM '._DB_PREFIX_.'product p
-                            '.Product::sqlStock('p', $id_product_attribute, true, $shop).'
-                            WHERE p.id_product = '.$id_product;
+                    $updateQuantity = '+ ' . $quantity;
+                    $newProductQuantity = $productQuantity - $quantity;
 
-                    $result2 = Db::getInstance()->getRow($sql);
-                    $product_qty = (int)$result2['quantity'];
-                    // Quantity for product pack
-                    if (Pack::isPack($id_product)) {
-                        $product_qty = Pack::getQuantity($id_product, $id_product_attribute);
+                    if ($newProductQuantity < 0) {
+                        return false;
                     }
-                    $new_qty = (int)$result['quantity'] + (int)$quantity;
-                    $qty = '+ '.(int)$quantity;
-
-                    if (!$skipAvailabilityCheckOutOfStock && !Product::isAvailableWhenOutOfStock((int)$result2['out_of_stock'])) {
-                        if ($new_qty > $product_qty) {
-                            return false;
-                        }
-                    }
-                } elseif ($operator == 'down') {
-                    $qty = '- '.(int)$quantity;
-                    $new_qty = (int)$result['quantity'] - (int)$quantity;
-                    if ($new_qty < $minimal_quantity && $minimal_quantity > 1) {
-                        return -1;
-                    }
+                } else if ($operator == 'down') {
+                    $updateQuantity = '- ' . $quantity;
+                    $newProductQuantity = $productQuantity + $quantity;
                 } else {
                     return false;
                 }
 
-                /* Delete product from cart */
-                if ($new_qty <= 0) {
+                if ($newProductQuantity < 0) {
                     return $this->deleteProduct((int)$id_product, (int)$id_product_attribute, (int)$id_customization);
-                } elseif ($new_qty < $minimal_quantity) {
-                    return -1;
                 } else {
                     Db::getInstance()->execute(
                         'UPDATE `'._DB_PREFIX_.'cart_product`
-                        SET `quantity` = `quantity` '.$qty.'
+                        SET `quantity` = `quantity` ' . $updateQuantity . '
                         WHERE `id_product` = '.(int)$id_product.
                         ' AND `id_customization` = '.(int)$id_customization.
                         (!empty($id_product_attribute) ? ' AND `id_product_attribute` = '.(int)$id_product_attribute : '').'

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -772,7 +772,9 @@ class CartRuleCore extends ObjectModel
                 if ($otherCartRule['id_cart_rule'] == $this->id && !$alreadyInCart) {
                     return (!$display_error) ? false : $this->trans('This voucher is already in your cart', array(), 'Shop.Notifications.Error');
                 }
-                if ($otherCartRule['gift_product'] && $context->cart->containsProduct($otherCartRule['gift_product'], $otherCartRule['gift_product_attribute']) > 0) {
+                $giftProductQuantity = $context->cart->getProductQuantity($otherCartRule['gift_product'], $otherCartRule['gift_product_attribute']);
+
+                if ($otherCartRule['gift_product'] && !empty($giftProductQuantity['quantity'])) {
                     --$nb_products;
                 }
 

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -26,6 +26,34 @@
 
 class PackCore extends Product
 {
+    /**
+     * Only decrement pack quantity
+     *
+     * @var string
+     */
+    CONST STOCK_TYPE_PACK_ONLY = 0;
+
+    /**
+     * Only decrement pack products quantities
+     *
+     * @var string
+     */
+    CONST STOCK_TYPE_PRODUCTS_ONLY = 1;
+
+    /**
+     * Decrement pack quantity and pack products quantities
+     *
+     * @var string
+     */
+    CONST STOCK_TYPE_PACK_BOTH = 2;
+
+    /**
+     * Use pack quantity default setting
+     *
+     * @var string
+     */
+    CONST STOCK_TYPE_DEFAULT = 3;
+
     protected static $cachePackItems = array();
     protected static $cacheIsPack = array();
     protected static $cacheIsPacked = array();
@@ -158,33 +186,31 @@ class PackCore extends Product
     /**
      * Is the pack in stock and his associated products?
      *
+     * @todo actually return true even if the pack feature is not active.
+     *       Should throws an exception instead.
+     *       Developers should first test if product is a pack
+     *       and next if it's in stock.
+     *
+     * @inheritdoc
      * @param int|null $id_product
      * @param int|null $wantedQuantity
+     * @param Cart|null $cart
      * @return bool
      */
-    public static function isInStock($id_product, $wantedQuantity = null)
+    public static function isInStock($id_product, $wantedQuantity = 1, Cart $cart = null)
     {
         if (!Pack::isFeatureActive()) {
             return true;
         }
         $id_product = (int) $id_product;
         $wantedQuantity = (int) $wantedQuantity;
-        $items = Pack::getItems((int)$id_product, Configuration::get('PS_LANG_DEFAULT'));
+        $product = new Product($id_product, false);
+        $packQuantity = self::getQuantity($id_product, null, null, $cart);
 
-        if ($wantedQuantity === null
-            || ((int) $wantedQuantity <= 0)
-        ) {
-            $wantedQuantity = Tools::getValue('quantity_wanted', 1);
-        }
-
-        foreach ($items as $item) {
-            /** @var Product $item */
-            // Updated for 1.5.0
-            if (Product::getQuantity($item->id) < ($item->pack_quantity * $wantedQuantity)
-                && !$item->isAvailableWhenOutOfStock((int)$item->out_of_stock)
-            ) {
-                return false;
-            }
+        if ($product->isAvailableWhenOutOfStock($product->out_of_stock)) {
+            return true;
+        } else if ($wantedQuantity > $packQuantity) {
+            return false;
         }
 
         return true;
@@ -196,11 +222,16 @@ class PackCore extends Product
      * @param int $id_product Product id
      * @param int $id_product_attribute Product attribute id (optional)
      * @param bool|null $cache_is_pack
+     * @param Cart $cart
      * @return int
      * @throws PrestaShopException
      */
-    public static function getQuantity($id_product, $id_product_attribute = null, $cache_is_pack = null)
-    {
+    public static function getQuantity(
+        $id_product,
+        $id_product_attribute = null,
+        $cache_is_pack = null,
+        Cart $cart = null
+    ) {
         $id_product = (int) $id_product;
         $id_product_attribute = (int) $id_product_attribute;
         $cache_is_pack = (bool) $cache_is_pack;
@@ -208,24 +239,66 @@ class PackCore extends Product
         if (!self::isPack($id_product)) {
             throw new PrestaShopException("Product with id $id_product is not a pack");
         }
-        $packQuantity = StockAvailable::getQuantityAvailableByProduct($id_product, $id_product_attribute);
-        $cart = Context::getContext()->cart;
 
-        if (!empty($cart)) {
+        // Initialize
+        $product = new Product($id_product, false);
+        $packQuantity = 0;
+        $packQuantityInStock = StockAvailable::getQuantityAvailableByProduct(
+            $id_product,
+            $id_product_attribute
+        );
+        $packStockType = $product->pack_stock_type;
+        $allPackStockType = array(
+            self::STOCK_TYPE_PACK_ONLY,
+            self::STOCK_TYPE_PRODUCTS_ONLY,
+            self::STOCK_TYPE_PACK_BOTH,
+            self::STOCK_TYPE_DEFAULT
+        );
+
+        if (!in_array($packStockType, $allPackStockType)) {
+            throw new PrestaShopException('Unknown pack stock type');
+        }
+
+        // If no pack stock or shop default, set it
+        if (empty($packStockType)
+            || $packStockType == self::STOCK_TYPE_DEFAULT
+        ) {
+            $packStockType = Configuration::get('PS_PACK_STOCK_TYPE');
+        }
+
+        // Initialize with pack quantity if not only products
+        if (in_array($packStockType, array(self::STOCK_TYPE_PACK_ONLY, self::STOCK_TYPE_PACK_BOTH))) {
+            $packQuantity = $packQuantityInStock;
+        }
+
+        // Set pack quantity to the minimum quantity of pack, or
+        // product pack
+        if (in_array($packStockType, array(self::STOCK_TYPE_PACK_BOTH, self::STOCK_TYPE_PRODUCTS_ONLY))) {
+            $items = array_values(Pack::getItems($id_product, Configuration::get('PS_LANG_DEFAULT')));
+
+            foreach ($items as $index => $item) {
+                $itemQuantity = Product::getQuantity($item->id, null, null, $cart);
+                $nbPackAvailableForItem = (int) ($itemQuantity / $item->pack_quantity);
+
+                // Initialize packQuantity with the first product quantity
+                // if pack decrement stock type is products only
+                if ($index === 0
+                    && $packStockType == self::STOCK_TYPE_PRODUCTS_ONLY
+                ) {
+                    $packQuantity = $nbPackAvailableForItem;
+
+                    continue;
+                }
+
+                if ($nbPackAvailableForItem < $packQuantity) {
+                    $packQuantity = $nbPackAvailableForItem;
+                }
+            }
+        } else if (!empty($cart)) {
             $cartProduct = $cart->getProductQuantity($id_product);
 
             if (!empty($cartProduct['deep_quantity'])) {
                 $packQuantity -= $cartProduct['deep_quantity'];
-            }
-        }
-        $items = Pack::getItems($id_product, Configuration::get('PS_LANG_DEFAULT'));
-
-        foreach ($items as $item) {
-            $itemQuantity = Product::getQuantity($item->id);
-            $nbPackAvailableForItem = (int) ($itemQuantity / $item->pack_quantity);
-
-            if ($nbPackAvailableForItem < $packQuantity) {
-                $packQuantity = $nbPackAvailableForItem;
             }
         }
 

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -184,28 +184,29 @@ class PackCore extends Product
     }
 
     /**
-     * Is the pack in stock and his associated products?
+     * Indicates if a pack and its associated products are available for orders in the desired quantity.
      *
-     * @todo actually return true even if the pack feature is not active.
-     *       Should throws an exception instead.
+     * @todo This method returns true even if the pack feature is not active.
+     *       Should throw an exception instead.
      *       Developers should first test if product is a pack
-     *       and next if it's in stock.
+     *       and then if it's in stock.
      *
-     * @inheritdoc
-     * @param int|null $id_product
-     * @param int|null $wantedQuantity
+     * @param int $idProduct
+     * @param int $wantedQuantity
      * @param Cart|null $cart
+     *
      * @return bool
+     * @throws PrestaShopException
      */
-    public static function isInStock($id_product, $wantedQuantity = 1, Cart $cart = null)
+    public static function isInStock($idProduct, $wantedQuantity = 1, Cart $cart = null)
     {
         if (!Pack::isFeatureActive()) {
             return true;
         }
-        $id_product = (int) $id_product;
+        $idProduct = (int) $idProduct;
         $wantedQuantity = (int) $wantedQuantity;
-        $product = new Product($id_product, false);
-        $packQuantity = self::getQuantity($id_product, null, null, $cart);
+        $product = new Product($idProduct, false);
+        $packQuantity = self::getQuantity($idProduct, null, null, $cart);
 
         if ($product->isAvailableWhenOutOfStock($product->out_of_stock)) {
             return true;

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -30,6 +30,13 @@ class PackCore extends Product
     protected static $cacheIsPack = array();
     protected static $cacheIsPacked = array();
 
+    public static function resetStaticCache()
+    {
+        self::$cachePackItems = array();
+        self::$cacheIsPack = array();
+        self::$cacheIsPacked = array();
+    }
+
     /**
      * Is product a pack?
      *

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -31,28 +31,28 @@ class PackCore extends Product
      *
      * @var string
      */
-    CONST STOCK_TYPE_PACK_ONLY = 0;
+    const STOCK_TYPE_PACK_ONLY = 0;
 
     /**
      * Only decrement pack products quantities
      *
      * @var string
      */
-    CONST STOCK_TYPE_PRODUCTS_ONLY = 1;
+    const STOCK_TYPE_PRODUCTS_ONLY = 1;
 
     /**
      * Decrement pack quantity and pack products quantities
      *
      * @var string
      */
-    CONST STOCK_TYPE_PACK_BOTH = 2;
+    const STOCK_TYPE_PACK_BOTH = 2;
 
     /**
      * Use pack quantity default setting
      *
      * @var string
      */
-    CONST STOCK_TYPE_DEFAULT = 3;
+    const STOCK_TYPE_DEFAULT = 3;
 
     protected static $cachePackItems = array();
     protected static $cacheIsPack = array();

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -158,8 +158,8 @@ class PackCore extends Product
     /**
      * Is the pack in stock and his associated products?
      *
-     * @param mixed $id_product
-     * @param mixed $wantedQuantity
+     * @param int|null $id_product
+     * @param int|null $wantedQuantity
      * @return bool
      */
     public static function isInStock($id_product, $wantedQuantity = null)

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -197,7 +197,7 @@ class PackCore extends Product
      * @param int $id_product_attribute Product attribute id (optional)
      * @param bool|null $cache_is_pack
      * @return int
-     * @throws PrestaShopExceptionCore
+     * @throws PrestaShopException
      */
     public static function getQuantity($id_product, $id_product_attribute = null, $cache_is_pack = null)
     {
@@ -206,7 +206,7 @@ class PackCore extends Product
         $cache_is_pack = (bool) $cache_is_pack;
 
         if (!self::isPack($id_product)) {
-            throw new PrestaShopExceptionCore("Product with id $id_product is not a pack");
+            throw new PrestaShopException("Product with id $id_product is not a pack");
         }
         $packQuantity = StockAvailable::getQuantityAvailableByProduct($id_product, $id_product_attribute);
         $cart = Context::getContext()->cart;

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -191,7 +191,7 @@ class PackCore extends Product
     }
 
     /**
-     * Return the minimum item quantity found in the pack
+     * Returns the available quantity of a given pack
      *
      * @param int $id_product Product id
      * @param int $id_product_attribute Product attribute id (optional)

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -148,21 +148,35 @@ class PackCore extends Product
         return self::$cachePackItems[$id_product];
     }
 
-    public static function isInStock($id_product)
+    /**
+     * Is the pack in stock and his associated products?
+     *
+     * @param $id_product
+     * @return bool
+     */
+    public static function isInStock($id_product, $wantedQuantity = null)
     {
         if (!Pack::isFeatureActive()) {
             return true;
         }
-
         $items = Pack::getItems((int)$id_product, Configuration::get('PS_LANG_DEFAULT'));
+
+        if ($wantedQuantity === null
+            || ((int) $wantedQuantity <= 0)
+        ) {
+            $wantedQuantity = Tools::getValue('quantity_wanted', 1);
+        }
 
         foreach ($items as $item) {
             /** @var Product $item */
             // Updated for 1.5.0
-            if (Product::getQuantity($item->id) < $item->pack_quantity && !$item->isAvailableWhenOutOfStock((int)$item->out_of_stock)) {
+            if (Product::getQuantity($item->id) < ($item->pack_quantity * $wantedQuantity)
+                && !$item->isAvailableWhenOutOfStock((int)$item->out_of_stock)
+            ) {
                 return false;
             }
         }
+
         return true;
     }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3698,10 +3698,8 @@ class ProductCore extends ObjectModel
     /**
      * Check product availability
      *
-     * True if available, false otherwise
-     *
      * @param int $qty Quantity desired
-     * @return bool True if product is available with this quantity
+     * @return bool True if product is available with this quantity, false otherwise
      */
     public function checkQty($qty)
     {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3598,9 +3598,22 @@ class ProductCore extends ObjectModel
                 return 0;
             }
         }
+        $availableQuantity = StockAvailable::getQuantityAvailableByProduct($id_product, $id_product_attribute);
+        $nbProductInCart = 0;
+        $cart = Context::getContext()->cart;
+
+        if (!empty($cart)) {
+            $cartProduct = $cart->containsProduct($id_product);
+
+            if (isset($cartProduct['quantity'])
+                && $cartProduct['quantity'] > 0
+            ) {
+                $nbProductInCart = $cartProduct['quantity'];
+            }
+        }
 
         // @since 1.5.0
-        return (StockAvailable::getQuantityAvailableByProduct($id_product, $id_product_attribute));
+        return $availableQuantity - $nbProductInCart;
     }
 
     /**

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -668,7 +668,7 @@ class OrderDetailCore extends ObjectModel
         $this->product_weight = $product['id_product_attribute'] ? (float)$product['weight_attribute'] : (float)$product['weight'];
         $this->id_warehouse = $id_warehouse;
 
-        $product_quantity = (int)Product::getQuantity($this->product_id, $this->product_attribute_id);
+        $product_quantity = (int)Product::getQuantity($this->product_id, $this->product_attribute_id, null, $cart);
         $this->product_quantity_in_stock = ($product_quantity - (int)$product['cart_quantity'] < 0) ?
             $product_quantity : (int)$product['cart_quantity'];
 

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -140,7 +140,11 @@ class StockAvailableCore extends ObjectModel
         //if product is pack sync recursivly product in pack
         if (Pack::isPack($id_product)) {
             if (Validate::isLoadedObject($product = new Product((int)$id_product))) {
-                if ($product->pack_stock_type == 1 || $product->pack_stock_type == 2 || ($product->pack_stock_type == 3 && Configuration::get('PS_PACK_STOCK_TYPE') > 0)) {
+                if ($product->pack_stock_type == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                    || $product->pack_stock_type == Pack::STOCK_TYPE_PACK_BOTH
+                    || ($product->pack_stock_type == Pack::STOCK_TYPE_DEFAULT
+                        && Configuration::get('PS_PACK_STOCK_TYPE') > 0)
+                ) {
                     $products_pack = Pack::getItems($id_product, (int)Configuration::get('PS_LANG_DEFAULT'));
                     foreach ($products_pack as $product_pack) {
                         StockAvailable::synchronize($product_pack->id, $order_id_shop);

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2850,7 +2850,11 @@ class AdminOrdersControllerCore extends AdminController
                 $left_to_reinject -= $quantity_to_reinject;
                 if (Pack::isPack((int)$product->id)) {
                     // Gets items
-                    if ($product->pack_stock_type == 1 || $product->pack_stock_type == 2 || ($product->pack_stock_type == 3 && Configuration::get('PS_PACK_STOCK_TYPE') > 0)) {
+                    if ($product->pack_stock_type == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                        || $product->pack_stock_type == Pack::STOCK_TYPE_PACK_BOTH
+                        || ($product->pack_stock_type == Pack::STOCK_TYPE_DEFAULT
+                            && Configuration::get('PS_PACK_STOCK_TYPE') > 0)
+                    ) {
                         $products_pack = Pack::getItems((int)$product->id, (int)Configuration::get('PS_LANG_DEFAULT'));
                         // Foreach item
                         foreach ($products_pack as $product_pack) {
@@ -2867,8 +2871,14 @@ class AdminOrdersControllerCore extends AdminController
                             }
                         }
                     }
-                    if ($product->pack_stock_type == 0 || $product->pack_stock_type == 2 ||
-                            ($product->pack_stock_type == 3 && (Configuration::get('PS_PACK_STOCK_TYPE') == 0 || Configuration::get('PS_PACK_STOCK_TYPE') == 2))) {
+
+                    if ($product->pack_stock_type == Pack::STOCK_TYPE_PACK_ONLY
+                        || $product->pack_stock_type == Pack::STOCK_TYPE_PACK_BOTH
+                        || ($product->pack_stock_type == Pack::STOCK_TYPE_DEFAULT
+                            && (Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PACK_ONLY
+                                || Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PACK_BOTH)
+                        )
+                    ) {
                         $manager->addProduct(
                                 $order_detail->product_id,
                                 $order_detail->product_attribute_id,

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2945,9 +2945,19 @@ class AdminProductsControllerCore extends AdminController
                 if (!$product->advanced_stock_management && (int)Tools::getValue('value') == 1) {
                     die(json_encode(array('error' =>  'Not possible if advanced stock management is disabled.')));
                 }
-                if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') && (int)Tools::getValue('value') == 1 && (Pack::isPack($product->id) && !Pack::allUsesAdvancedStockManagement($product->id)
-                    && ($product->pack_stock_type == 2 || $product->pack_stock_type == 1 ||
-                        ($product->pack_stock_type == 3 && (Configuration::get('PS_PACK_STOCK_TYPE') == 1 || Configuration::get('PS_PACK_STOCK_TYPE') == 2))))) {
+                if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')
+                    && (int)Tools::getValue('value') == 1
+                    && (Pack::isPack($product->id)
+                        && !Pack::allUsesAdvancedStockManagement($product->id)
+                        && ($product->pack_stock_type == Pack::STOCK_TYPE_PACK_BOTH
+                            || $product->pack_stock_type == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                            || ($product->pack_stock_type == Pack::STOCK_TYPE_DEFAULT
+                                && (Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                                    || Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PACK_BOTH)
+                            )
+                        )
+                    )
+                ) {
                     die(json_encode(array('error' => 'You cannot use advanced stock management for this pack because'.'<br />'.
                         '- advanced stock management is not enabled for these products'.'<br />'.
                         '- you have chosen to decrement products quantities.')));
@@ -2965,8 +2975,16 @@ class AdminProductsControllerCore extends AdminController
                     && (int)$value != 2 && (int)$value != 3) {
                     die(json_encode(array('error' =>  'Incorrect value')));
                 }
-                if ($product->depends_on_stock && !Pack::allUsesAdvancedStockManagement($product->id) && ((int)$value == 1
-                    || (int)$value == 2 || ((int)$value == 3 && (Configuration::get('PS_PACK_STOCK_TYPE') == 1 || Configuration::get('PS_PACK_STOCK_TYPE') == 2)))) {
+                if ($product->depends_on_stock
+                    && !Pack::allUsesAdvancedStockManagement($product->id)
+                    && ((int)$value == 1
+                        || (int)$value == 2
+                        || ((int)$value == 3
+                            && (Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                                || Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PACK_BOTH)
+                        )
+                    )
+                ) {
                     die(json_encode(array('error' => 'You cannot use this stock management option because:'.'<br />'.
                         '- advanced stock management is not enabled for these products'.'<br />'.
                         '- advanced stock management is enabled for the pack')));

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -533,11 +533,11 @@ class CartControllerCore extends FrontController
         if (($this->id_product_attribute)) {
             return (!Product::isAvailableWhenOutOfStock($product->out_of_stock)
                 && !Attribute::checkAttributeQty($this->id_product_attribute, $qtyToCheck));
-        } else {
-            return (!$product->checkQty($qtyToCheck));
+        } elseif (Product::isAvailableWhenOutOfStock($product->out_of_stock)) {
+            return false;
         }
 
-        return false;
+        return !$product->checkQty($qtyToCheck);
     }
 
     /**

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -210,7 +210,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function initContent()
     {
         if (!$this->errors) {
-            if (Pack::isPack((int) $this->product->id) && !Pack::isInStock((int) $this->product->id)) {
+            if (Pack::isPack((int) $this->product->id)
+                && !Pack::isInStock((int) $this->product->id, $this->product->minimal_quantity, $this->context->cart)
+            ) {
                 $this->product->quantity = 0;
             }
 

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -430,18 +430,18 @@ class ProductPresenter
         Language $language
     ) {
         $show_price = $this->shouldShowPrice($settings, $product);
-
         $show_availability = $show_price && $settings->stock_management_enabled;
-
         $presentedProduct['show_availability'] = $show_availability;
+        $product['quantity_wanted'] = (int) Tools::getValue('quantity_wanted', 1);
 
         if (isset($product['available_date']) && '0000-00-00' == $product['available_date']) {
             $product['available_date'] = null;
         }
 
         if ($show_availability) {
-            if ($product['quantity'] > 0) {
+            if ($product['quantity'] - $product['quantity_wanted'] >= 0) {
                 $presentedProduct['availability_date'] = $product['available_date'];
+
                 if ($product['quantity'] < $settings->lastRemainingItems) {
                     $presentedProduct = $this->applyLastItemsInStockDisplayRule($product, $settings, $presentedProduct);
                 } else {
@@ -452,9 +452,7 @@ class ProductPresenter
                 $presentedProduct['availability_message'] = $product['available_later'] ? $product['available_later'] : Configuration::get('PS_LABEL_OOS_PRODUCTS_BOA', $language->id);
                 $presentedProduct['availability_date'] = $product['available_date'];
                 $presentedProduct['availability'] = 'available';
-            } else if (!empty($product['quantity_wanted'])
-                && ($product['quantity'] + $product['quantity_wanted'] > 0)
-            ) {
+            } elseif ($product['quantity_wanted'] > 0 && $product['quantity'] >= 0) {
                 $presentedProduct['availability_message'] = $this->translator->trans(
                     'There are not enough products in stock',
                     array(),

--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -460,7 +460,7 @@ class ProductPresenter
                 );
                 $presentedProduct['availability'] = 'unavailable';
                 $presentedProduct['availability_date'] = null;
-            } elseif (!empty($product['quantity_all_versions'])) {
+            } elseif (!empty($product['quantity_all_versions']) && $product['quantity_all_versions'] > 0) {
                 $presentedProduct['availability_message'] = $this->translator->trans(
                     'Product available with different options',
                     array(),

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -32,6 +32,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Pack;
 
 /**
  * This form class is responsible to generate the product quantity form.
@@ -254,9 +255,9 @@ class ProductQuantity extends CommonAbstractType
                 //Manage out_of_stock field with contextual values/label
                 $pack_stock_type = $this->configuration->get('PS_PACK_STOCK_TYPE');
                 $defaultChoiceLabel = $this->translator->trans('Default', array(), 'Admin.Global').': ';
-                if ($pack_stock_type == 0) {
+                if ($pack_stock_type == Pack::STOCK_TYPE_PACK_ONLY) {
                     $defaultChoiceLabel .= $this->translator->trans('Decrement pack only.', array(), 'Admin.Catalog.Feature');
-                } elseif ($pack_stock_type == 1) {
+                } elseif ($pack_stock_type == Pack::STOCK_TYPE_PRODUCTS_ONLY) {
                     $defaultChoiceLabel .= $this->translator->trans('Decrement products in pack only.', array(), 'Admin.Catalog.Feature');
                 } else {
                     $defaultChoiceLabel .= $this->translator->trans('Decrement both.', array(), 'Admin.Catalog.Feature');

--- a/tests/Unit/ContextMocker.php
+++ b/tests/Unit/ContextMocker.php
@@ -40,6 +40,7 @@ use Product;
 use Shop;
 use Smarty;
 use Tools;
+use Pack;
 
 /**
  * This helper class provides methods to initialize context for front controller tests
@@ -84,6 +85,7 @@ class ContextMocker
         Carrier::resetStaticCache();
         CartRule::resetStaticCache();
         Shop::resetContext();
+        Pack::resetStaticCache();
 
         $this->contextBackup = Context::getContext();
         $context             = clone($this->contextBackup);

--- a/tests/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests/Unit/Core/Cart/AbstractCartTest.php
@@ -177,6 +177,9 @@ abstract class AbstractCartTest extends IntegrationTestCase
             }
             $this->products[$k] = $product;
         }
+
+        // Fix issue pack cache is set when adding products.
+        \Pack::resetStaticCache();
     }
 
     protected function addProductsToCart($productData)

--- a/tests/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests/Unit/Core/Cart/AbstractCartTest.php
@@ -68,6 +68,8 @@ abstract class AbstractCartTest extends IntegrationTestCase
         2 => array('price' => 32.388),
         3 => array('price' => 31.188),
         4 => array('price' => 35.567, 'outOfStock' => true),
+        5 => array('price' => 23.86, 'quantity' => 50),
+        6 => array('price' => 12.34, 'quantity' => 10, 'is_pack' => true, 'pack_items' => array(array('id_product_fixture' => 5, 'quantity' => 10))),
     ];
 
     protected $cartRuleFixtures = [
@@ -148,16 +150,30 @@ abstract class AbstractCartTest extends IntegrationTestCase
             $product           = new Product;
             $product->price    = $productFixture['price'];
             $product->name     = 'product name';
-            $product->quantity = 1000;
+            $product->quantity = !empty($productFixture['quantity']) ? $productFixture['quantity'] : 1000;
+
             if (!empty($productFixture['outOfStock'])) {
                 $product->out_of_stock = 0;
                 $product->quantity     = 0;
             }
             $product->add();
+
+            if (isset($productFixture['is_pack'])
+                && $productFixture['is_pack'] === true
+            ) {
+                foreach ($productFixture['pack_items'] as $packItem) {
+                    \Pack::addItem(
+                        $product->id,
+                        $this->products[$packItem['id_product_fixture']]->id,
+                        $packItem['quantity']
+                    );
+                }
+            }
+
             if (!empty($productFixture['outOfStock'])) {
                 StockAvailable::setProductOutOfStock((int) $product->id, 0);
             } else {
-                StockAvailable::setQuantity((int) $product->id, 0, 1000);
+                StockAvailable::setQuantity((int) $product->id, 0, $product->quantity);
             }
             $this->products[$k] = $product;
         }

--- a/tests/Unit/Core/Cart/Adding/Product/AddPackTest.php
+++ b/tests/Unit/Core/Cart/Adding/Product/AddPackTest.php
@@ -30,6 +30,22 @@ use PrestaShop\PrestaShop\Tests\Unit\Core\Cart\AbstractCartTest;
 
 class AddPackTest extends AbstractCartTest
 {
+    public function testProductQuantity()
+    {
+        $idProductInPackFixture = 5;
+        $idPackFixture = 6;
+        $pack = $this->getProductFromFixtureId($idPackFixture);
+        $productPack = $this->getProductFromFixtureId($idProductInPackFixture);
+        $idPack = $pack->id;
+        $idProductInPack = $productPack->id;
+        $nbPack = \Product::getQuantity($idPack);
+        $nbProduct = \Product::getQuantity($idProductInPack);
+        $this->assertEquals(10, $nbPack);
+        $this->assertEquals(50, $nbProduct);
+        $this->assertTrue(\Pack::isInStock($idPack));
+        $this->assertTrue(\Pack::isInStock($idProductInPack));
+    }
+
     public function testPackInCart()
     {
         $idProductInPackFixture = 5;
@@ -44,8 +60,8 @@ class AddPackTest extends AbstractCartTest
         $this->assertTrue($this->cart->updateQty(3, $idPack));
         $this->assertTrue($this->cart->updateQty(30, $idProductInPack));
 
-        $nbPackInCart = $this->cart->containsProduct($idPack);
-        $nbProductInCart = $this->cart->containsProduct($idProductInPack);
+        $nbPackInCart = $this->cart->getProductQuantity($idPack);
+        $nbProductInCart = $this->cart->getProductQuantity($idProductInPack);
         $cartProducts = $this->cart->getProducts(true);
 
         $this->assertCount(2, $cartProducts);

--- a/tests/Unit/Core/Cart/Adding/Product/AddPackTest.php
+++ b/tests/Unit/Core/Cart/Adding/Product/AddPackTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Tests\Unit\Core\Cart\Adding\CartRule;
+
+use PrestaShop\PrestaShop\Tests\Unit\Core\Cart\AbstractCartTest;
+
+class AddPackTest extends AbstractCartTest
+{
+    public function testPackInCart()
+    {
+        $idProductInPackFixture = 5;
+        $idPackFixture = 6;
+        $pack = $this->getProductFromFixtureId($idPackFixture);
+        $productPack = $this->getProductFromFixtureId($idProductInPackFixture);
+        $idPack = $pack->id;
+        $idProductInPack = $productPack->id;
+
+        // Simple tests
+        $this->assertTrue(\Pack::isPack($idPack));
+        $this->assertTrue($this->cart->updateQty(3, $idPack));
+        $this->assertTrue($this->cart->updateQty(30, $idProductInPack));
+
+        $nbPackInCart = $this->cart->containsProduct($idPack);
+        $nbProductInCart = $this->cart->containsProduct($idProductInPack);
+        $cartProducts = $this->cart->getProducts(true);
+
+        $this->assertCount(2, $cartProducts);
+        $this->assertEquals(3, $nbPackInCart['quantity']);
+        $this->assertEquals(30, $nbProductInCart['quantity']);
+
+        foreach ($cartProducts as $cartProduct) {
+            $this->assertContains($cartProduct['id_product'], array($idPack, $idProductInPack));
+        }
+
+        // Unable to add more than in stock
+        $this->resetCart();
+
+        if (!$pack->isAvailableWhenOutOfStock((int) $pack->out_of_stock)) {
+            $this->assertFalse($this->cart->updateQty(11, $idPack));
+        } else {
+            $this->assertTrue($this->cart->updateQty(11, $idPack));
+        }
+
+        if (!$productPack->isAvailableWhenOutOfStock((int) $productPack->out_of_stock)) {
+            $this->assertFalse($this->cart->updateQty(60, $idProductInPack));
+        } else {
+            $this->assertTrue($this->cart->updateQty(60, $idProductInPack));
+        }
+
+        // Unable to add pack with product out of stock
+        $this->resetCart();
+        $this->assertTrue($this->cart->updateQty(40, $idProductInPack));
+        $this->assertFalse(\Pack::isInStock($idPack, 2));
+        $this->assertTrue(\Pack::isInStock($idPack, 1));
+    }
+}

--- a/tests/Unit/Core/Cart/Adding/Product/AddPackTest.php
+++ b/tests/Unit/Core/Cart/Adding/Product/AddPackTest.php
@@ -40,10 +40,10 @@ class AddPackTest extends AbstractCartTest
         $idProductInPack = $productPack->id;
         $nbPack = \Product::getQuantity($idPack);
         $nbProduct = \Product::getQuantity($idProductInPack);
-        $this->assertEquals(10, $nbPack);
+        $this->assertEquals(5, $nbPack);
         $this->assertEquals(50, $nbProduct);
-        $this->assertTrue(\Pack::isInStock($idPack));
-        $this->assertTrue(\Pack::isInStock($idProductInPack));
+        $this->assertTrue(\Pack::isInStock($idPack, 5));
+        $this->assertFalse(\Pack::isInStock($idPack, 6));
     }
 
     public function testPackInCart()
@@ -57,7 +57,7 @@ class AddPackTest extends AbstractCartTest
 
         // Simple tests
         $this->assertTrue(\Pack::isPack($idPack));
-        $this->assertTrue($this->cart->updateQty(3, $idPack));
+        $this->assertTrue($this->cart->updateQty(2, $idPack));
         $this->assertTrue($this->cart->updateQty(30, $idProductInPack));
 
         $nbPackInCart = $this->cart->getProductQuantity($idPack);
@@ -65,11 +65,13 @@ class AddPackTest extends AbstractCartTest
         $cartProducts = $this->cart->getProducts(true);
 
         $this->assertCount(2, $cartProducts);
-        $this->assertEquals(3, $nbPackInCart['quantity']);
+        $this->assertEquals(2, $nbPackInCart['quantity']);
         $this->assertEquals(30, $nbProductInCart['quantity']);
+        $this->assertEquals(50, $nbProductInCart['deep_quantity']);
 
         foreach ($cartProducts as $cartProduct) {
             $this->assertContains($cartProduct['id_product'], array($idPack, $idProductInPack));
+            $this->assertEquals(0, \Product::getQuantity($cartProduct['id_product']));
         }
 
         // Unable to add more than in stock

--- a/tests/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
+++ b/tests/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
@@ -4369,9 +4369,19 @@ class AdminProductsController extends AdminProductsControllerCore
                 if (!$product->advanced_stock_management && (int)Tools::getValue('value') == 1) {
                     die(json_encode(array('error' =>  $this->l('Not possible if advanced stock management is disabled. '))));
                 }
-                if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') && (int)Tools::getValue('value') == 1 && (Pack::isPack($product->id) && !Pack::allUsesAdvancedStockManagement($product->id)
-                    && ($product->pack_stock_type == 2 || $product->pack_stock_type == 1 ||
-                        ($product->pack_stock_type == 3 && (Configuration::get('PS_PACK_STOCK_TYPE') == 1 || Configuration::get('PS_PACK_STOCK_TYPE') == 2))))) {
+                if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')
+                    && (int)Tools::getValue('value') == 1
+                    && (Pack::isPack($product->id)
+                        && !Pack::allUsesAdvancedStockManagement($product->id)
+                        && ($product->pack_stock_type == Pack::STOCK_TYPE_PACK_BOTH
+                            || $product->pack_stock_type == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                            || ($product->pack_stock_type == Pack::STOCK_TYPE_DEFAULT
+                                && (Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                                    || Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PACK_BOTH)
+                            )
+                        )
+                    )
+                ) {
                     die(json_encode(array('error' => $this->l('You cannot use advanced stock management for this pack because').'</br>'.
                         $this->l('- advanced stock management is not enabled for these products').'</br>'.
                         $this->l('- you have chosen to decrement products quantities.'))));
@@ -4387,8 +4397,16 @@ class AdminProductsController extends AdminProductsControllerCore
                     && (int)$value != 2 && (int)$value != 3) {
                     die(json_encode(array('error' =>  $this->l('Incorrect value'))));
                 }
-                if ($product->depends_on_stock && !Pack::allUsesAdvancedStockManagement($product->id) && ((int)$value == 1
-                    || (int)$value == 2 || ((int)$value == 3 && (Configuration::get('PS_PACK_STOCK_TYPE') == 1 || Configuration::get('PS_PACK_STOCK_TYPE') == 2)))) {
+                if ($product->depends_on_stock
+                    && !Pack::allUsesAdvancedStockManagement($product->id)
+                    && ((int)$value == 1
+                        || (int)$value == 2
+                        || ((int)$value == 3
+                            && (Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                                || Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PACK_BOTH)
+                        )
+                    )
+                ) {
                     die(json_encode(array('error' => $this->l('You cannot use this stock management option because:').'</br>'.
                         $this->l('- advanced stock management is not enabled for these products').'</br>'.
                         $this->l('- advanced stock management is enabled for the pack'))));

--- a/tests/resources/module/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/resources/module/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -4390,9 +4390,19 @@ class AdminProductsController extends AdminProductsControllerCore
                 if (!$product->advanced_stock_management && (int)Tools::getValue('value') == 1) {
                     die(json_encode(array('error' =>  $this->l('Not possible if advanced stock management is disabled. '))));
                 }
-                if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') && (int)Tools::getValue('value') == 1 && (Pack::isPack($product->id) && !Pack::allUsesAdvancedStockManagement($product->id)
-                    && ($product->pack_stock_type == 2 || $product->pack_stock_type == 1 ||
-                        ($product->pack_stock_type == 3 && (Configuration::get('PS_PACK_STOCK_TYPE') == 1 || Configuration::get('PS_PACK_STOCK_TYPE') == 2))))) {
+                if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')
+                    && (int)Tools::getValue('value') == 1
+                    && (Pack::isPack($product->id)
+                        && !Pack::allUsesAdvancedStockManagement($product->id)
+                        && ($product->pack_stock_type == Pack::STOCK_TYPE_PACK_BOTH
+                            || $product->pack_stock_type == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                            || ($product->pack_stock_type == Pack::STOCK_TYPE_DEFAULT
+                                && (Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                                    || Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PACK_BOTH)
+                            )
+                        )
+                    )
+                ) {
                     die(json_encode(array('error' => $this->l('You cannot use advanced stock management for this pack because').'</br>'.
                         $this->l('- advanced stock management is not enabled for these products').'</br>'.
                         $this->l('- you have chosen to decrement products quantities.'))));
@@ -4410,8 +4420,16 @@ class AdminProductsController extends AdminProductsControllerCore
                     && (int)$value != 2 && (int)$value != 3) {
                     die(json_encode(array('error' =>  $this->l('Incorrect value'))));
                 }
-                if ($product->depends_on_stock && !Pack::allUsesAdvancedStockManagement($product->id) && ((int)$value == 1
-                    || (int)$value == 2 || ((int)$value == 3 && (Configuration::get('PS_PACK_STOCK_TYPE') == 1 || Configuration::get('PS_PACK_STOCK_TYPE') == 2)))) {
+                if ($product->depends_on_stock
+                    && !Pack::allUsesAdvancedStockManagement($product->id)
+                    && ((int)$value == 1
+                        || (int)$value == 2
+                        || ((int)$value == 3
+                            && (Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PRODUCTS_ONLY
+                                || Configuration::get('PS_PACK_STOCK_TYPE') == Pack::STOCK_TYPE_PACK_BOTH)
+                        )
+                    )
+                ) {
                     die(json_encode(array('error' => $this->l('You cannot use this stock management option because:').'</br>'.
                         $this->l('- advanced stock management is not enabled for these products').'</br>'.
                         $this->l('- advanced stock management is enabled for the pack'))));


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x.
| Description?  | Fix issue with pack quantity.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [BOOM-4361](http://forge.prestashop.com/browse/BOOM-4361), [BOOM-3487](http://forge.prestashop.com/browse/BOOM-3487)
| How to test?  | 1) in preferences > products > choose decrease both for packs <br>2) Don't allow to order out of stock product <br>3) create a product A with a stock of 50 <br>4) create a product B with a stock of 5, this product is a pack of 10 products A <br>5) You cannot order 50 products A and 5 products B.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8607)
<!-- Reviewable:end -->
