### PR TITLE
Fix the calculation of the combination specific price

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2828,6 +2828,7 @@ class ProductCore extends ObjectModel
 				FROM `'._DB_PREFIX_.'cart_product`
 				WHERE `id_product` = '.(int)$id_product.'
 				AND `id_cart` = '.(int)$id_cart;
+                $sql .= $id_product_attribute ? " AND `id_product_attribute` = " . (int)$id_product_attribute : '';
                 $cart_quantity = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
                 Cache::store($cache_id, $cart_quantity);
             } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you order two combinations of the same product and it has specific prices based on amount and attribute, the calculation of the unit price is wrong even when you try to increase or decrease the ordered quantity in the cart page.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9641
| How to test?  | BO > create a new product with two combination (red, yellow) and the red combination has specific parices (quantity >=2 with unit price = 5) & (quantity >=3 with unit price = 2). FO > try to order (red quantity = 2) and (yellow quantity = 1), check if the red combination's unit price  = 5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8609)
<!-- Reviewable:end -->
