### PR TITLE
Fix pagination on the customer group list

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -185,6 +185,10 @@ class AdminGroupsControllerCore extends AdminController
             if (isset($_POST['submitReset'.$this->list_id])) {
                 $this->processResetFilters();
             }
+
+            if (Tools::getIsset('submitFilter' . $this->list_id)) {
+                self::$currentIndex .= '&id_group=' . (int)Tools::getValue('id_group') . '&viewgroup';
+            }
         } else {
             $this->list_id = 'group';
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you try to navigate through differents pages of the customer group list, the pagination will redirect you to the groups list instead of the specified page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9586
| How to test?  | BO > Customers > Groups > choose a group, try to navigate the pagination and check if you will redirect to the correct page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8615)
<!-- Reviewable:end -->
