### PR TITLE
Fix dropdown buttons space

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -44,12 +44,10 @@
           data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">
           {{ url_active|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions') }}
       </button>
-      {% if urls|length > 1 %}
-      <input type="hidden" class="btn">
-      {% endif %}
     </form>
     {% if (urls|length > 1) %}
-          <button type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <input type="hidden" class="btn">
+          <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="caret"></span>
             <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
           </button>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | With the latest changes in the UI Kit, the drop-down buttons were not displayed properly. This PR fixes the issue.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Go to the module page > Manage tab and check the dropdown buttons

### Before

![capture du 2017-12-14 15-33-59](https://user-images.githubusercontent.com/6768917/34000634-bf6aad6e-e0e5-11e7-8b84-a5ae55927bc2.png)

### After

![capture du 2017-12-14 15-35-11](https://user-images.githubusercontent.com/6768917/34000652-c5f30b22-e0e5-11e7-9446-cc6a71d5d9ea.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8616)
<!-- Reviewable:end -->
