### PR TITLE
Fix/suppliers block refresh

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/SupplierController.php
@@ -26,6 +26,7 @@
 namespace PrestaShopBundle\Controller\Admin;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use PrestaShopBundle\Model\Product\AdminModelAdapter as ProductAdminModelAdapter;
 
 /**
@@ -84,7 +85,7 @@ class SupplierController extends FrameworkBundleAdminController
         $allFormData = $modelMapper->getFormData();
 
         $form = $this->createFormBuilder($allFormData);
-        $simpleSubForm = $form->create('step6', 'form');
+        $simpleSubForm = $form->create('step6', FormType::class);
 
         foreach ($suppliers as $idSupplier) {
             if ($idSupplier == 0 || !is_numeric($idSupplier)) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In Product Page > Options Tab, when you unselect/select a supplier, the "references" block is not rendered.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | See description

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

![test](https://user-images.githubusercontent.com/1247388/34001236-c63fe8ca-e0ef-11e7-8157-8959469e9097.png)

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8617)
<!-- Reviewable:end -->
