### PR TITLE
Fix type warning in order detail

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/_customized_data.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_customized_data.tpl
@@ -22,6 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
+{assign var="currencySymbolBeforeAmount" value=$currency->format[0] === '¤'}
 {if $product['customizedDatas']}
 {* Assign product price *}
 {if ($order->getTaxCalculationMethod() == $smarty.const.PS_TAX_EXC)}
@@ -49,17 +50,17 @@
 				<div class="form-group">
 					<div class="fixed-width-xl">
 						<div class="input-group">
-							{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+							{if $currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 							<input type="text" name="product_price_tax_excl" class="edit_product_price_tax_excl edit_product_price" value="{Tools::ps_round($product['unit_price_tax_excl'], 2)}" size="5" />
-							{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+							{if !$currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 						</div>
 					</div>
 					<br/>
 					<div class="fixed-width-xl">
 						<div class="input-group">
-							{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+							{if $currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 							<input type="text" name="product_price_tax_incl" class="edit_product_price_tax_incl edit_product_price" value="{Tools::ps_round($product['unit_price_tax_incl'], 2)}" size="5" />
-							{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+							{if $currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 						</div>
 					</div>
 				</div>
@@ -214,9 +215,9 @@
 								<small class="text-muted">({$smarty.capture.TaxMethod})</small>
 							</label>
 							<div class="input-group">
-								{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign}</div>{/if}
+								{if $currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign}</div>{/if}
 								<input onchange="checkPartialRefundProductAmount(this)" type="text" name="partialRefundProduct[{$product['id_order_detail']|intval}]" />
-								{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign}</div>{/if}
+								{if !$currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign}</div>{/if}
 							</div>
 							<p class="help-block"><i class="icon-warning-sign"></i> {l s='(Max %amount_refundable% %tax_method%)' sprintf=[ '%amount_refundable%' => Tools::displayPrice(Tools::ps_round($amount_refundable, 2), $currency->id), '%tax_method%' => $smarty.capture.TaxMethod] d='Admin.Orderscustomers.Help'}</p>
 						</div>

--- a/admin-dev/themes/default/template/controllers/orders/_customized_data.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_customized_data.tpl
@@ -49,17 +49,17 @@
 				<div class="form-group">
 					<div class="fixed-width-xl">
 						<div class="input-group">
-							{if $currency->format % 2}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+							{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 							<input type="text" name="product_price_tax_excl" class="edit_product_price_tax_excl edit_product_price" value="{Tools::ps_round($product['unit_price_tax_excl'], 2)}" size="5" />
-							{if !($currency->format % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+							{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 						</div>
 					</div>
 					<br/>
 					<div class="fixed-width-xl">
 						<div class="input-group">
-							{if $currency->format % 2}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+							{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 							<input type="text" name="product_price_tax_incl" class="edit_product_price_tax_incl edit_product_price" value="{Tools::ps_round($product['unit_price_tax_incl'], 2)}" size="5" />
-							{if !($currency->format % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+							{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 						</div>
 					</div>
 				</div>
@@ -214,9 +214,9 @@
 								<small class="text-muted">({$smarty.capture.TaxMethod})</small>
 							</label>
 							<div class="input-group">
-								{if $currency->format % 2}<div class="input-group-addon">{$currency->sign}</div>{/if}
+								{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign}</div>{/if}
 								<input onchange="checkPartialRefundProductAmount(this)" type="text" name="partialRefundProduct[{$product['id_order_detail']|intval}]" />
-								{if !($currency->format % 2)}<div class="input-group-addon">{$currency->sign}</div>{/if}
+								{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign}</div>{/if}
 							</div>
 							<p class="help-block"><i class="icon-warning-sign"></i> {l s='(Max %amount_refundable% %tax_method%)' sprintf=[ '%amount_refundable%' => Tools::displayPrice(Tools::ps_round($amount_refundable, 2), $currency->id), '%tax_method%' => $smarty.capture.TaxMethod] d='Admin.Orderscustomers.Help'}</p>
 						</div>

--- a/admin-dev/themes/default/template/controllers/orders/_new_product.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_new_product.tpl
@@ -22,6 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
+{assign var="currencySymbolBeforeAmount" value=$currency->format[0] === '¤'}
 <tr id="new_product" style="display:none">
 	<td style="display:none;" colspan="2">
 		<input type="hidden" id="add_product_product_id" name="add_product[product_id]" value="0" />
@@ -50,17 +51,17 @@
 	<td style="display:none;">
 		<div class="row">
 			<div class="input-group fixed-width-xl">
-				{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+				{if $currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 				<input type="text" name="add_product[product_price_tax_excl]" id="add_product_product_price_tax_excl" value="" disabled="disabled" />
-				{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+				{if !$currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 			</div>
 		</div>
 		<br/>
 		<div class="row">
 			<div class="input-group fixed-width-xl">
-				{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+				{if $currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 				<input type="text" name="add_product[product_price_tax_incl]" id="add_product_product_price_tax_incl" value="" disabled="disabled" />
-				{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+				{if !$currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 			</div>
 		</div>
 	</td>

--- a/admin-dev/themes/default/template/controllers/orders/_new_product.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_new_product.tpl
@@ -50,17 +50,17 @@
 	<td style="display:none;">
 		<div class="row">
 			<div class="input-group fixed-width-xl">
-				{if $currency->format % 2}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+				{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 				<input type="text" name="add_product[product_price_tax_excl]" id="add_product_product_price_tax_excl" value="" disabled="disabled" />
-				{if !($currency->format % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+				{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 			</div>
 		</div>
 		<br/>
 		<div class="row">
 			<div class="input-group fixed-width-xl">
-				{if $currency->format % 2}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+				{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 				<input type="text" name="add_product[product_price_tax_incl]" id="add_product_product_price_tax_incl" value="" disabled="disabled" />
-				{if !($currency->format % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+				{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 			</div>
 		</div>
 	</td>

--- a/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
@@ -56,17 +56,17 @@
 			<div class="form-group">
 				<div class="fixed-width-xl">
 					<div class="input-group">
-						{if $currency->format % 2}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+						{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 						<input type="text" name="product_price_tax_excl" class="edit_product_price_tax_excl edit_product_price" value="{Tools::ps_round($product['unit_price_tax_excl'], 2)}"/>
-						{if !($currency->format % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+						{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 					</div>
 				</div>
 				<br/>
 				<div class="fixed-width-xl">
 					<div class="input-group">
-						{if $currency->format % 2}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+						{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 						<input type="text" name="product_price_tax_incl" class="edit_product_price_tax_incl edit_product_price" value="{Tools::ps_round($product['unit_price_tax_incl'], 2)}"/>
-						{if !($currency->format % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+						{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 					</div>
 				</div>
 			</div>
@@ -184,9 +184,9 @@
 					<small class="text-muted">({$smarty.capture.TaxMethod})</small>
 				</label>
 				<div class="input-group">
-					{if $currency->format % 2}<div class="input-group-addon">{$currency->sign}</div>{/if}
+					{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign}</div>{/if}
 					<input onchange="checkPartialRefundProductAmount(this)" type="text" name="partialRefundProduct[{$product['id_order_detail']}]" />
-					{if !($currency->format % 2)}<div class="input-group-addon">{$currency->sign}</div>{/if}
+					{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign}</div>{/if}
 				</div>
         <p class="help-block"><i class="icon-warning-sign"></i> {l s='(Max %amount_refundable% %tax_method%)' sprintf=[ '%amount_refundable%' => Tools::displayPrice(Tools::ps_round($amount_refundable, 2), $currency->id), '%tax_method%' => $smarty.capture.TaxMethod] d='Admin.Orderscustomers.Help'}</p>
 			</div>

--- a/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-
+{assign var="currencySymbolBeforeAmount" value=$currency->format[0] === '¤'}
 {* Assign product price *}
 {if ($order->getTaxCalculationMethod() == $smarty.const.PS_TAX_EXC)}
 	{assign var=product_price value=($product['unit_price_tax_excl'] + $product['ecotax'])}
@@ -56,17 +56,17 @@
 			<div class="form-group">
 				<div class="fixed-width-xl">
 					<div class="input-group">
-						{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+						{if $currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 						<input type="text" name="product_price_tax_excl" class="edit_product_price_tax_excl edit_product_price" value="{Tools::ps_round($product['unit_price_tax_excl'], 2)}"/>
-						{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
+						{if !$currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax excl.' d='Admin.Global'}</div>{/if}
 					</div>
 				</div>
 				<br/>
 				<div class="fixed-width-xl">
 					<div class="input-group">
-						{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+						{if $currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 						<input type="text" name="product_price_tax_incl" class="edit_product_price_tax_incl edit_product_price" value="{Tools::ps_round($product['unit_price_tax_incl'], 2)}"/>
-						{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
+						{if !$currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign} {l s='tax incl.' d='Admin.Global'}</div>{/if}
 					</div>
 				</div>
 			</div>
@@ -184,9 +184,9 @@
 					<small class="text-muted">({$smarty.capture.TaxMethod})</small>
 				</label>
 				<div class="input-group">
-					{if $currency->format|intval % 2}<div class="input-group-addon">{$currency->sign}</div>{/if}
+					{if $currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign}</div>{/if}
 					<input onchange="checkPartialRefundProductAmount(this)" type="text" name="partialRefundProduct[{$product['id_order_detail']}]" />
-					{if !($currency->format|intval % 2)}<div class="input-group-addon">{$currency->sign}</div>{/if}
+					{if !$currencySymbolBeforeAmount}<div class="input-group-addon">{$currency->sign}</div>{/if}
 				</div>
         <p class="help-block"><i class="icon-warning-sign"></i> {l s='(Max %amount_refundable% %tax_method%)' sprintf=[ '%amount_refundable%' => Tools::displayPrice(Tools::ps_round($amount_refundable, 2), $currency->id), '%tax_method%' => $smarty.capture.TaxMethod] d='Admin.Orderscustomers.Help'}</p>
 			</div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | A type warning was being raised when opening an the order detail page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3860
| How to test?  | Using PHP 7.1, place an order as a guest, and choose to pay by check (I'm not sure if the guest thing or the payment method changes anything, but still). Then go to the order detail page in the backoffice. Without this PR, you should get a warning similar to the one below. With this PR, you shouldn't get a warning message.

Warning I was getting:
![screen shot 2017-12-14 at 17 24 43](https://user-images.githubusercontent.com/1009343/34003241-1a9f1d8c-e0f5-11e7-8772-7ddacf1efd2c.png)

Explanation of the problem: https://stackoverflow.com/a/42044413/13275

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8618)
<!-- Reviewable:end -->

  