### PR TITLE
Critical Error in Checkout process - Context.php

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -322,9 +322,10 @@ class ContextCore
             $this->cart->id_carrier = 0;
             $this->cart->setDeliveryOption(null);
 
-            $addressId = (int) Address::getFirstCustomerAddressId((int) ($customer->id));            
+            $addressId = (int) Address::getFirstCustomerAddressId((int) ($customer->id));           
+            unset(this->cart->id_address_invoice);
+            unset(this->cart->id_address_delivery);
             $this->cart->updateAddressId($this->cart->id_address_delivery, $addressId);
-            $this->cart->id_address_invoice = $addressId;
         }
         $this->cart->id_customer = (int) $customer->id;
 

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -323,8 +323,8 @@ class ContextCore
             $this->cart->setDeliveryOption(null);
 
             $addressId = (int) Address::getFirstCustomerAddressId((int) ($customer->id));           
-            unset(this->cart->id_address_invoice);
-            unset(this->cart->id_address_delivery);
+            unset($this->cart->id_address_invoice);
+            unset($this->cart->id_address_delivery);
             $this->cart->updateAddressId($this->cart->id_address_delivery, $addressId);
         }
         $this->cart->id_customer = (int) $customer->id;

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -322,18 +322,19 @@ class ContextCore
             $this->cart->id_carrier = 0;
             $this->cart->setDeliveryOption(null);
             
-//            ok to shortly put it: 
-//
-//do checkout with guest user, add two addresses. go to step 3 delivery. return to step 1 and continue with same account. It will throw error at step 3: 
-//Unfortunately, there are no carriers available for your delivery address.
-//
-//This is because the updateCustomer was called and it did not updated ps_cart_product delivery addresses for each item whihc is needed to get correct carriers.
-//
-//Cheers.
+            // ok to shortly put it:
+            // do checkout with guest user, add two addresses. go to step 3 delivery. return to step 1 and continue with same account. It will throw error at step 3: 
+            // Unfortunately, there are no carriers available for your delivery address.
+            //
+            // This is because the updateCustomer was called and it did not updated ps_cart_product delivery addresses for each item whihc is needed to get correct carriers.
+            //
+            // Cheers.
             
-            // this is wrong. It does not update ps_cart_products id_address_delivery as well. Otherwise the third step will throw error. Created pull request since the comments and issues are closed. 
+            // this is wrong. It does not update ps_cart_products id_address_delivery as well. Otherwise the third step will throw error.
             $this->cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
             $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
+            
+            
         }
         $this->cart->id_customer = (int) $customer->id;
 

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -321,11 +321,8 @@ class ContextCore
             $idCarrier = (int) $this->cart->id_carrier;
             $this->cart->id_carrier = 0;
             $this->cart->setDeliveryOption(null);
-
-            $addressId = (int) Address::getFirstCustomerAddressId((int) ($customer->id));           
-            unset($this->cart->id_address_invoice);
-            unset($this->cart->id_address_delivery);
-            $this->cart->updateAddressId($this->cart->id_address_delivery, $addressId);
+            $this->cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
+            $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
         }
         $this->cart->id_customer = (int) $customer->id;
 
@@ -338,6 +335,20 @@ class ContextCore
         $this->cookie->id_cart = (int) $this->cart->id;
         $this->cookie->write();
         $this->cart->autosetProductAddress();
+        
+
+        if ($this->cart->id > 0) {
+            $idAddressDelivery = Db::getInstance()->getValue('SELECT id_address_delivery FROM `'._DB_PREFIX_.'cart` WHERE id_cart = ' . (int)$this->cart->id);
+            $sql = 'UPDATE `'._DB_PREFIX_.'cart_product`
+                SET `id_address_delivery` = ' . (int)$idAddressDelivery . ' 
+                WHERE `id_cart` = '.(int)$this->cart->id;
+            Db::getInstance()->execute($sql);
+
+            $sql = 'UPDATE `'._DB_PREFIX_.'customization`
+                SET `id_address_delivery` = ' . (int)$idAddressDelivery . ' 
+                WHERE `id_cart` = '.(int)$this->cart->id;
+            Db::getInstance()->execute($sql);
+        }
     }
 
     /**

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -331,7 +331,7 @@ class ContextCore
             // Cheers.
             
             // this is wrong. It does not update ps_cart_products id_address_delivery as well. Otherwise the third step will throw error.
-            $this->cart->updateAddressId(null, (int) Address::getFirstCustomerAddressId((int) ($customer->id)));
+            $this->cart->updateAddressId($this->cart->id_address_delivery, (int) Address::getFirstCustomerAddressId((int) ($customer->id)));
             $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
             
             

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -331,7 +331,7 @@ class ContextCore
             // Cheers.
             
             // this is wrong. It does not update ps_cart_products id_address_delivery as well. Otherwise the third step will throw error.
-            $this->cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
+            $this->cart->updateAddressId(null, (int) Address::getFirstCustomerAddressId((int) ($customer->id)));
             $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
             
             

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -321,20 +321,10 @@ class ContextCore
             $idCarrier = (int) $this->cart->id_carrier;
             $this->cart->id_carrier = 0;
             $this->cart->setDeliveryOption(null);
-            
-            // ok to shortly put it:
-            // do checkout with guest user, add two addresses. go to step 3 delivery. return to step 1 and continue with same account. It will throw error at step 3: 
-            // Unfortunately, there are no carriers available for your delivery address.
-            //
-            // This is because the updateCustomer was called and it did not updated ps_cart_product delivery addresses for each item whihc is needed to get correct carriers.
-            //
-            // Cheers.
-            
-            // this is wrong. It does not update ps_cart_products id_address_delivery as well. Otherwise the third step will throw error.
-            $this->cart->updateAddressId($this->cart->id_address_delivery, (int) Address::getFirstCustomerAddressId((int) ($customer->id)));
-            $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
-            
-            
+
+            $addressId = (int) Address::getFirstCustomerAddressId((int) ($customer->id));            
+            $this->cart->updateAddressId($this->cart->id_address_delivery, $addressId);
+            $this->cart->id_address_invoice = $addressId;
         }
         $this->cart->id_customer = (int) $customer->id;
 

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -322,6 +322,15 @@ class ContextCore
             $this->cart->id_carrier = 0;
             $this->cart->setDeliveryOption(null);
             
+//            ok to shortly put it: 
+//
+//do checkout with guest user, add two addresses. go to step 3 delivery. return to step 1 and continue with same account. It will throw error at step 3: 
+//Unfortunately, there are no carriers available for your delivery address.
+//
+//This is because the updateCustomer was called and it did not updated ps_cart_product delivery addresses for each item whihc is needed to get correct carriers.
+//
+//Cheers.
+            
             // this is wrong. It does not update ps_cart_products id_address_delivery as well. Otherwise the third step will throw error. Created pull request since the comments and issues are closed. 
             $this->cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
             $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -321,6 +321,8 @@ class ContextCore
             $idCarrier = (int) $this->cart->id_carrier;
             $this->cart->id_carrier = 0;
             $this->cart->setDeliveryOption(null);
+            
+            // this is wrong. It does not update ps_cart_products id_address_delivery as well. Otherwise the third step will throw error. Created pull request since the comments and issues are closed. 
             $this->cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
             $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
         }


### PR DESCRIPTION
bug in customer update

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | all
| Description?  | bug in checkout process
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  
| How to test?  | do checkout with guest user, add two addresses. go to step 3 delivery. return to step 1 and continue with same account. It will throw error at step 3: Unfortunately, there are no carriers available for your delivery address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8619)
<!-- Reviewable:end -->
