### PR TITLE
Fix the taxes calculation in the invoice

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1194,7 +1194,7 @@ class OrderCore extends ObjectModel
                 FROM `'._DB_PREFIX_.'order_invoice`'.(Configuration::get('PS_INVOICE_RESET') ?
                 ' WHERE DATE_FORMAT(`date_add`, "%Y") = '.(int)date('Y') : '');
             $new_number = DB::getInstance()->getValue($new_number_sql);
-            
+
             $sql .= (int)$new_number;
         }
 
@@ -2282,8 +2282,9 @@ class OrderCore extends ObjectModel
                 $order_discount_tax_excl -= $order_cart_rule['value_tax_excl'];
             }
         }
-        
-        $expected_total_tax = $this->total_products_wt - $this->total_products;
+
+        $shippingTax = $this->total_shipping_tax_incl - $this->total_shipping_tax_excl;
+        $expected_total_tax = $this->total_paid_tax_incl - $this->total_paid_tax_excl - $shippingTax;
         $actual_total_tax = 0;
         $actual_total_base = 0;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you applied a voucher to an order and tried to generate the invoice, you can see the wrong tax in the tax detail, in the other hand the Total tab's tax is correct.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9578
| How to test?  | Add a voucher (apply a discount of -10€ for example), create an order and apply the voucher, modify the order status to "**Payment accepted**", generate the invoice and check if the taxes in the tax detail tab is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8621)
<!-- Reviewable:end -->
