### PR TITLE
Fix the deletion of the product search indexes

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1888,14 +1888,25 @@ class ProductCore extends ObjectModel
     */
     public function deleteSearchIndexes()
     {
-        return (
-            Db::getInstance()->execute(
-                'DELETE `'._DB_PREFIX_.'search_index`, `'._DB_PREFIX_.'search_word`
-				FROM `'._DB_PREFIX_.'search_index` JOIN `'._DB_PREFIX_.'search_word`
-				WHERE `'._DB_PREFIX_.'search_index`.`id_product` = '.(int)$this->id.'
-						AND `'._DB_PREFIX_.'search_word`.`id_word` = `'._DB_PREFIX_.'search_index`.id_word'
-            )
+        /** Delete the index word if it is not used in other products */
+        $return = Db::getInstance()->execute(
+            'DELETE `' . _DB_PREFIX_ . 'search_word` 
+            FROM `' . _DB_PREFIX_ . 'search_word` 
+            JOIN `' . _DB_PREFIX_ . 'search_index` 
+            WHERE `' . _DB_PREFIX_ . 'search_index`.`id_product` = ' . (int)$this->id . ' 
+            AND `' . _DB_PREFIX_ . 'search_word`.`id_word` = `' . _DB_PREFIX_ . 'search_index`.`id_word` 
+            AND (SELECT COUNT(si.`id_word`) 
+                FROM `' . _DB_PREFIX_ . 'search_index` si 
+                WHERE si.`id_word` = `' . _DB_PREFIX_ . 'search_index`.`id_word`) < 2'
         );
+
+        /** Delete the product search indexes */
+        $return &= Db::getInstance()->execute('
+            DELETE FROM `' . _DB_PREFIX_ . 'search_index` 
+            WHERE `' . _DB_PREFIX_ . 'search_index`.`id_product` = ' . (int)$this->id
+        );
+
+        return $return;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When deleting one product, all products with similar names, have been deleted from the search index.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8239
| How to test?  | BO > create two products (Test Product 1, Test Product 2), delete the product "**Product Test 1**". FO > try to search the "**test**" key, check if the product "**Product test 2**" appears in the result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8624)
<!-- Reviewable:end -->
