### PR TITLE
Do no rely on external URL for tests (Returns different content) (1.7.3.x)

### DIFF
--- a/tests/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
+++ b/tests/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
@@ -150,8 +150,8 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
 
         // Check files are equals
         $this->assertEquals(
-            file_get_contents(__DIR__.'/../../../../resources/modules/ganalytics/avatar.jpg'),
-            file_get_contents('https://avatars0.githubusercontent.com/u/2815696?v=3&u=5e6a82beeff1d799c28bf31e25540d334ae40435&s=400')
+            file_get_contents(__DIR__.'/../../../../resources/modules/ganalytics/another-logo.png'),
+            file_get_contents('http://localhost/img/logo.png')
         );
         $this->assertEquals(
             file_get_contents(__DIR__.'/../../../../resources/modules/ganalytics/ganalytics.php'),

--- a/tests/resources/module-self-config-files/moduleConfExampleFilesStep.yml
+++ b/tests/resources/module-self-config-files/moduleConfExampleFilesStep.yml
@@ -3,5 +3,5 @@ files:
     - source: "../modules/ganalytics/ganalytics.php"
       dest: "../modules/ganalytics/ganalytics_copy.php"
       
-    - source: "https://avatars0.githubusercontent.com/u/2815696?v=3&u=5e6a82beeff1d799c28bf31e25540d334ae40435&s=400"
-      dest: "../modules/ganalytics/avatar.jpg"
+    - source: "http://localhost/img/logo.png"
+      dest: "../modules/ganalytics/another-logo.png"


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Github avatar returns now different content at each call, which breaks the test. We now rely on a local asset
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Travis must pass

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8630)
<!-- Reviewable:end -->
