### PR TITLE
Request module zip for upgrade ONLY when the version available is higher

### DIFF
--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -356,6 +356,11 @@ class Module implements ModuleInterface
         }
     }
 
+    /**
+     * Inform the merchant an upgrade is wating to be applied from the disk or the marketplace
+     *
+     * @return boolean
+     */
     public function canBeUpgraded()
     {
         if ($this->database->get('installed') == 0) {
@@ -363,12 +368,22 @@ class Module implements ModuleInterface
         }
 
         // Potential update from API
-        if ($this->attributes->get('version_available') !== 0
-            && version_compare($this->database->get('version'), $this->attributes->get('version_available'), '<')) {
+        if ($this->canBeUpgradedFromAddons()) {
             return true;
         }
 
         // Potential update from disk
         return version_compare($this->database->get('version'), $this->disk->get('version'), '<');
+    }
+
+    /**
+     * Only check if an upgrade is available on the marketplace
+     *
+     * @return boolean
+     */
+    public function canBeUpgradedFromAddons()
+    {
+        return $this->attributes->get('version_available') !== 0
+            && version_compare($this->database->get('version'), $this->attributes->get('version_available'), '<');
     }
 }

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -314,19 +314,18 @@ class ModuleManager implements AddonManagerInterface
         }
 
         $this->checkIsInstalled($name);
+        $module = $this->moduleRepository->getModule($name);
 
         // Get new module
         // 1- From source
         if ($source != null) {
             $this->moduleZipManager->storeInModulesFolder($source);
-        } else {
+        } elseif ($module->canBeUpgradedFromAddons()) {
             // 2- From Addons
             // This step is not mandatory (in case of local module),
             // we do not check the result
             $this->moduleUpdater->setModuleOnDiskFromAddons($name);
         }
-
-        $module = $this->moduleRepository->getModule($name);
 
         // Load and execute upgrade files
         $result = $this->moduleUpdater->upgrade($name);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Add a check to avoid download of non-latest module revisions from the PrestaShop Marketplace
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Currently, you can upgrade your module `welcome` locally to the version 4.0.0. If you do not have the PR applied yet, clicking on the upgrade button will download the version 3.0.0 from Addons and overwrite the local changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8631)
<!-- Reviewable:end -->
