### PR TITLE
Fix the calculation of volume discounts

### DIFF
--- a/themes/default-bootstrap/product.tpl
+++ b/themes/default-bootstrap/product.tpl
@@ -416,7 +416,7 @@
 						<tbody>
 						{foreach from=$quantity_discounts item='quantity_discount' name='quantity_discounts'}
 							{if $quantity_discount.price >= 0 || $quantity_discount.reduction_type == 'amount'}
-								{$realDiscountPrice=$quantity_discount.base_price|floatval-$quantity_discount.real_value|floatval}
+								{$realDiscountPrice=($quantity_discount.base_price|floatval-$quantity_discount.real_value|floatval)|abs}
 							{else}
 								{$realDiscountPrice=$quantity_discount.base_price|floatval*(1 - $quantity_discount.reduction)|floatval}
 							{/if}
@@ -454,9 +454,10 @@
 									{else}
 										{$discountPrice=$productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction)|floatval}
 									{/if}
-									{$discountPrice=$discountPrice * $quantity_discount.quantity}
-									{$qtyProductPrice=$productPriceWithoutReduction|floatval * $quantity_discount.quantity}
-									{convertPrice price=$qtyProductPrice - $discountPrice}
+									{if $quantity_discount.price|floatval < 0 && $quantity_discount.base_price|floatval == 0}
+										{$discountPrice=$quantity_discount.real_value|floatval}
+									{/if}
+									{convertPrice price=$discountPrice * $quantity_discount.quantity}
 								</td>
 							</tr>
 						{/foreach}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you apply a specific price and discount in the customer group, the volume discounts are not displayed correctly.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-4878
| How to test?  | BO > create a new product with basic price 120€ and specific price 110€ for 10 qty, apply 10% discount for customer group. FO > in the product page, chek if the volume discount is displayed correctly (Quantity = 10, price = 99€, you save = 90€)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8632)
<!-- Reviewable:end -->
