### PR TITLE
Fix the total price when the currency decimals are turned off in the cart

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2897,6 +2897,9 @@ class ProductCore extends ObjectModel
             $cart_quantity
         );
 
+        $currencyDecimals = (int)Currency::getCurrent()->decimals;
+        $return = (bool)$currencyDecimals ? $return : Tools::ps_round($return, $currencyDecimals * _PS_PRICE_COMPUTE_PRECISION_);
+
         return $return;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When currency decimals are disabled, the total price in the cart is incorrect.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-5088
| How to test?  | BO > Localization > Currencies > edit currency and disable the currency decimals, create new product with price = 1.3 (with tax), FO > order the product and check the total price in the cart if it is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8634)
<!-- Reviewable:end -->
