### PR TITLE
Fix the display of "add to cart" button

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -367,7 +367,7 @@ class StockAvailableCore extends ObjectModel
         $key = 'StockAvailable::getQuantityAvailableByProduct_'.(int)$id_product.'-'.(int)$id_product_attribute.'-'.(int)$id_shop;
         if (!Cache::isStored($key)) {
             $query = new DbQuery();
-            $query->select('SUM(quantity)');
+            $query->select('SUM(IF(`quantity` < 0, 0, `quantity`)) as quantity');
             $query->from('stock_available');
 
             // if null, it's a product without attributes
@@ -375,7 +375,10 @@ class StockAvailableCore extends ObjectModel
                 $query->where('id_product = '.(int)$id_product);
             }
 
-            $query->where('id_product_attribute = '.(int)$id_product_attribute);
+            if ($id_product_attribute) {
+                $query->where('`id_product_attribute` = ' . (int)$id_product_attribute);
+            }
+
             $query = StockAvailable::addSqlShopRestriction($query, $id_shop);
             $result = (int)Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
             Cache::store($key, $result);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | if we have a product A with two combinations C1 and C2, within quantities: C1=1 and C2=-1, then you try to order product A with C1, the button will be not displayed cause the made test check only the product's quantity and not the combinations quantity. 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9166
| How to test?  | BO> create a new product with two combinations (combination 1: quantity = 1, combination 2: quantity = -1), FO> the product page, check if the Add to Cart button is displayed in combination 1 and disappears in the combination 2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8635)
<!-- Reviewable:end -->
