### PR TITLE
An error on servers with PHP 7+

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1200,7 +1200,7 @@ class FrontControllerCore extends Controller
         foreach ($libraries as $library) {
             if ($assets = PrestashopAssetsLibraries::getAssetsLibraries($library)) {
                 foreach ($assets as $asset) {
-                    $this->$asset['type']($library, $asset['path'], $asset['params']);
+                    $this->{$asset['type']}($library, $asset['path'], $asset['params']);
                 }
             }
         }


### PR DESCRIPTION
An error occurred on PHP 7+ when attempt to add assets('font-awesome' etc.). It befalls because PHP 7 has a slightly different way of dealing with dynamic variables, which results in a different outcome in some cases.
PHP5 interpretation : $this->{$asset['type']}();
PHP7 interpretation : $this->{$asset}['type']();

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | An error occurred on PHP 7+ when attempt to add assets('font-awesome' etc.). It befalls because PHP 7 has a slightly different way of dealing with dynamic variables, which results in a different outcome in some cases.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8636)
<!-- Reviewable:end -->
