### PR TITLE
Fix the pagination and the redirection in the product attributes page

### DIFF
--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -470,6 +470,13 @@ class AdminAttributesGroupsControllerCore extends AdminController
             return;
         }
 
+        /** Reset the old search */
+        if (Tools::getIsset('viewattribute_group')
+            && !Tools::getIsset('submitReset' . $this->list_id)
+            && !Tools::getIsset('submitFilter')) {
+            $this->processResetFilters();
+        }
+
         // toolbar (save, cancel, new, ..)
         $this->initTabModuleList();
         $this->initToolbar();
@@ -640,8 +647,12 @@ class AdminAttributesGroupsControllerCore extends AdminController
         if (Tools::getIsset('viewattribute_group')) {
             $this->list_id = 'attribute_values';
 
-            if (isset($_POST['submitReset'.$this->list_id])) {
+            if (Tools::getIsset('submitReset' . $this->list_id)) {
                 $this->processResetFilters();
+            }
+
+            if (Tools::getIsset('submitFilterattribute_values')) {
+                self::$currentIndex .= '&id_attribute_group=' . (int)Tools::getValue('id_attribute_group') . '&viewattribute_group';
             }
         } else {
             $this->list_id = 'attribute_group';

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -473,7 +473,7 @@ class AdminAttributesGroupsControllerCore extends AdminController
         /** Reset the old search */
         if (Tools::getIsset('viewattribute_group')
             && !Tools::getIsset('submitReset' . $this->list_id)
-            && !Tools::getIsset('submitFilter')) {
+            && !Tools::getIsset('submitFilter' . $this->list_id)) {
             $this->processResetFilters();
         }
 
@@ -651,7 +651,8 @@ class AdminAttributesGroupsControllerCore extends AdminController
                 $this->processResetFilters();
             }
 
-            if (Tools::getIsset('submitFilterattribute_values')) {
+            if (Tools::getIsset('submitFilterattribute_values')
+                || Tools::getIsset('deleteattribute')) {
                 self::$currentIndex .= '&id_attribute_group=' . (int)Tools::getValue('id_attribute_group') . '&viewattribute_group';
             }
         } else {
@@ -734,6 +735,7 @@ class AdminAttributesGroupsControllerCore extends AdminController
 
         // If it's an attribute, load object Attribute()
         if (Tools::getValue('updateattribute') || Tools::isSubmit('deleteattribute') || Tools::isSubmit('submitAddattribute')) {
+            $this->redirect_after = self::$currentIndex . '&id_attribute_group=' . (int)Tools::getValue('id_attribute_group') . '&viewattribute_group' . '&token=' . $this->token;
             if ($this->tabAccess['edit'] !== '1') {
                 $this->errors[] = Tools::displayError('You do not have permission to edit this.');
             } elseif (!$object = new Attribute((int)Tools::getValue($this->identifier))) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you try to navigate through differents pages of the attribute values list, the pagination will redirect you to the groups list instead of the specified page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8341
| How to test?  | BO > Catalog > Product Attributes > choose a group, try to navigate the pagination or edit/delete value and check if you will redirect to the correct page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8638)
<!-- Reviewable:end -->
