### PR TITLE
Add the order_cart_rules web service to the resources

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -278,6 +278,7 @@ class WebserviceRequestCore
             'order_carriers' => array('description' => 'The Order carriers','class' => 'OrderCarrier'),
             'order_details' => array('description' => 'Details of an order', 'class' => 'OrderDetail'),
             'order_discounts' => array('description' => 'Discounts of an order', 'class' => 'OrderDiscount'),
+            'order_cart_rules' => array('description' => 'The order cart rules','class' => 'OrderCartRule'),
             'order_histories' => array('description' => 'The Order histories','class' => 'OrderHistory'),
             'order_invoices' => array('description' => 'The Order invoices','class' => 'OrderInvoice'),
             'orders' => array('description' => 'The Customers orders','class' => 'Order'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you try to call the web service **api/order_cart_rules/XX**, it generate an error.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-4532
| How to test?  | BO > Advanced Parameters > Webservice > enable prestashop's webservice and create a new webservice key, then try to execute this WS **api/order_discounts**, it will list all the **order_cart_rule** WS links. Now, try to execute one of the list, check if it returns the correct result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8641)
<!-- Reviewable:end -->
