### PR TITLE
Fix RTL generation failing on PHP >= 7

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -25,6 +25,7 @@
  */
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShop\PrestaShop\Core\Cldr\Repository as cldrRepository;
+use PrestaShop\PrestaShop\Core\Localization\RTL\StylesheetGenerator;
 
 class LanguageCore extends ObjectModel
 {
@@ -185,7 +186,7 @@ class LanguageCore extends ObjectModel
         if (!parent::add($autodate, $nullValues)) {
             return false;
         }
-        
+
         if ($this->is_rtl) {
             self::installRtlStylesheets(true, false, null, null, (defined('PS_INSTALLATION_IN_PROGRESS') ? true : false));
         }
@@ -199,17 +200,17 @@ class LanguageCore extends ObjectModel
 
         return true;
     }
-    
+
     public function update($nullValues = false)
     {
         if (!parent::update($nullValues)) {
             return false;
         }
-        
+
         if ($this->is_rtl) {
              self::installRtlStylesheets(true, false);
         }
- 
+
         return true;
     }
 
@@ -1335,7 +1336,7 @@ class LanguageCore extends ObjectModel
             }
         }
     }
-    
+
     /**
      * Language::installRtlStylesheets()
      * @param bool $bo_theme
@@ -1355,17 +1356,19 @@ class LanguageCore extends ObjectModel
                 return;
             }
         }
-        
+
+        $generator = new StylesheetGenerator();
+
         if ($bo_theme) {
-            \RTLGenerator::generate($admin_dir.'themes');
+            $generator->generateFromDirectory($admin_dir.'themes');
         }
-        
+
         if ($fo_theme) {
-            \RTLGenerator::generate($front_dir.($theme_name?$theme_name:'classic'));
+            $generator->generateFromDirectory($front_dir.($theme_name?$theme_name:'classic'));
         }
-        
+
         if ($path && is_dir($path)) {
-            \RTLGenerator::generate($path);
+            $generator->generateFromDirectory($path);
         }
     }
 }

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1339,19 +1339,21 @@ class LanguageCore extends ObjectModel
 
     /**
      * Language::installRtlStylesheets()
-     * @param bool $bo_theme
-     * @param bool $fo_theme
-     * @param null $theme_name
-     * @param null $iso
+     *
+     * @param bool $boTheme
+     * @param bool $foTheme
+     * @param string|null $themeName
+     * @param string|null $iso
      * @param bool $install
-     * @param null $path
+     * @param string|null $path
+     *
+     * @throws \PrestaShop\PrestaShop\Core\Localization\RTL\Exception\GenerationException
+     * @throws Exception
      */
-    public static function installRtlStylesheets($bo_theme = false, $fo_theme = false, $theme_name = null, $iso = null, $install = false, $path = null)
+    public static function installRtlStylesheets($boTheme = false, $foTheme = false, $themeName = null, $iso = null, $install = false, $path = null)
     {
-        $admin_dir = ($install) ? _PS_ROOT_DIR_.'/admin/' : _PS_ADMIN_DIR_.'/';
-        $front_dir = _PS_ROOT_DIR_.'/themes/';
         if ($iso) {
-            $lang_pack = Language::getLangDetails($iso);
+            $lang_pack = static::getLangDetails($iso);
             if (!$lang_pack['is_rtl']) {
                 return;
             }
@@ -1359,12 +1361,28 @@ class LanguageCore extends ObjectModel
 
         $generator = new StylesheetGenerator();
 
-        if ($bo_theme) {
-            $generator->generateFromDirectory($admin_dir.'themes');
+        // generate stylesheets for BO themes
+        if ($boTheme) {
+            if (defined('_PS_ADMIN_DIR_')) {
+                $adminDir = _PS_ADMIN_DIR_;
+            } else {
+                $adminDir = _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'admin';
+                $adminDir = (is_dir($adminDir)) ? $adminDir : ($adminDir.'-dev');
+                $adminDir .= DIRECTORY_SEPARATOR;
+            }
+
+            if (!is_dir($adminDir)) {
+                throw new Exception("Cannot generate BO themes: \"$adminDir\" is not a directory");
+            }
+
+            $generator->generateFromDirectory($adminDir.'themes');
         }
 
-        if ($fo_theme) {
-            $generator->generateFromDirectory($front_dir.($theme_name?$theme_name:'classic'));
+        // generate stylesheets for BO themes
+        if ($foTheme) {
+            $frontDir = _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'themes'.DIRECTORY_SEPARATOR;
+
+            $generator->generateFromDirectory($frontDir.($themeName?$themeName:'classic'));
         }
 
         if ($path && is_dir($path)) {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "phpoffice/phpexcel": "~1.8",
         "guzzlehttp/guzzle": "~5.0",
         "csa/guzzle-bundle": "~1.3",
-        "ipresta/localize-fixture": "~v1.0",
         "paragonie/random_compat": "^1.4|^2.0",
         "prestashop/smarty": "dev-master",
         "prestashop/blockreassurance": "^3",
@@ -97,7 +96,8 @@
         "beberlei/DoctrineExtensions": "^1.0",
         "composer/ca-bundle": "^1.0",
         "nikic/php-parser": "^2.1",
-        "prestashop/decimal": "^1.0.0"
+        "prestashop/decimal": "^1.0.0",
+        "prestashop/rtlcss-php": "^2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4bc36d34c2512ab8c9fc63a4492908d",
+    "content-hash": "d7b616c24ec5e2e0a23a38fcf8fe64d7",
     "packages": [
         {
             "name": "beberlei/DoctrineExtensions",
@@ -1610,36 +1610,6 @@
             "time": "2015-11-10T17:04:01+00:00"
         },
         {
-            "name": "ipresta/localize-fixture",
-            "version": "v1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/iPresta/localize-fixture.git",
-                "reference": "5e24bcece3d88f4b53b844588763990f6ed20a6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/iPresta/localize-fixture/zipball/5e24bcece3d88f4b53b844588763990f6ed20a6a",
-                "reference": "5e24bcece3d88f4b53b844588763990f6ed20a6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT License"
-            ],
-            "description": "Generate RTL CSS for PrestaShop",
-            "time": "2017-09-25T17:46:09+00:00"
-        },
-        {
             "name": "ircmaxell/password-compat",
             "version": "v1.0.4",
             "source": {
@@ -2956,6 +2926,50 @@
             "time": "2017-02-20T11:14:52+00:00"
         },
         {
+            "name": "prestashop/php-css-parser",
+            "version": "8.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShop/PHP-CSS-Parser.git",
+                "reference": "4fc2af16da00dd954b41a7d754a9a0b1fccadc1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShop/PHP-CSS-Parser/zipball/4fc2af16da00dd954b41a7d754a9a0b1fccadc1d",
+                "reference": "4fc2af16da00dd954b41a7d754a9a0b1fccadc1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Sabberworm\\CSS": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "http://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "time": "2017-12-28T13:36:06+00:00"
+        },
+        {
             "name": "prestashop/ps_banner",
             "version": "v2.0.2",
             "source": {
@@ -3631,6 +3645,55 @@
             "time": "2017-03-16T10:24:34+00:00"
         },
         {
+            "name": "prestashop/rtlcss-php",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShop/rtlcss-php.git",
+                "reference": "eb26a4c5651ccaddc9e7eecc725367954c6bd1c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShop/rtlcss-php/zipball/eb26a4c5651ccaddc9e7eecc725367954c6bd1c4",
+                "reference": "eb26a4c5651ccaddc9e7eecc725367954c6bd1c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "prestashop/php-css-parser": "^8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PrestaShop\\RtlCss\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frédéric Massart",
+                    "homepage": "https://github.com/FMCorz"
+                },
+                {
+                    "name": "Pablo Borowicz",
+                    "email": "pablo.borowicz@prestashop.com",
+                    "homepage": "https://github.com/eternoendless"
+                }
+            ],
+            "description": "Converts CSS to Right-to-Left",
+            "keywords": [
+                "css",
+                "rtl"
+            ],
+            "time": "2017-12-28T14:27:03+00:00"
+        },
+        {
             "name": "prestashop/sekeywords",
             "version": "v2.0.0",
             "source": {
@@ -3711,7 +3774,7 @@
             ],
             "description": "PrestaShop Smarty version",
             "homepage": "https://github.com/PrestaShop/smarty",
-            "time": "2017-05-11 08:29:53"
+            "time": "2017-05-11T08:29:53+00:00"
         },
         {
             "name": "prestashop/statsbestcategories",

--- a/src/Core/Localization/RTL/Exception/GenerationException.php
+++ b/src/Core/Localization/RTL/Exception/GenerationException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Localization\RTL\Exception;
+
+class GenerationException extends \Exception
+{
+}

--- a/src/Core/Localization/RTL/StylesheetGenerator.php
+++ b/src/Core/Localization/RTL/StylesheetGenerator.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Localization\RTL;
+
+use Exception;
+use PrestaShop\PrestaShop\Core\Localization\RTL\Exception\GenerationException;
+use PrestaShop\RtlCss\RtlCss;
+use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\Parser;
+use \Tools;
+
+/**
+ * Creates RTL versions of LTR CSS files.
+ *
+ * This class creates new files based on the original ones by using CSSJanus first,
+ * then applying an optional .rtlfix file, if one with the same name as the processed file is found.
+ *
+ * Inspired by "Localize Fixture" from Mahdi Shad @ iPresta
+ * @link https://github.com/iPresta/localize-fixture
+ */
+class StylesheetGenerator
+{
+
+    /**
+     * Default file type to look up
+     */
+    const DEFAULT_FILE_TYPE = 'css';
+
+    /**
+     * Default suffix to use for RTL transformed files
+     */
+    const DEFAULT_RTL_SUFFIX = '_rtl';
+
+    /**
+     * Extension of RTL fix files
+     */
+    const RTLFIX_EXTENSION = 'rtlfix';
+
+    /**
+     * @var string
+     */
+    private $fileType;
+
+    /**
+     * @var string
+     */
+    private $rtlSuffix;
+
+    /**
+     * @var OutputFormat
+     */
+    private $outputFormat;
+
+    /**
+     * @param string $fileType [default='css'] File type (CSS or SCSS)
+     * @param string $rtlSuffix [default='_rtl'] Suffix to add to transformed RTL files
+     */
+    public function __construct($fileType = self::DEFAULT_FILE_TYPE, $rtlSuffix = self::DEFAULT_RTL_SUFFIX)
+    {
+        $this->fileType = $fileType;
+        $this->rtlSuffix = $rtlSuffix;
+        $this->outputFormat = OutputFormat::createCompact()
+            ->setKeepComments(true);
+    }
+
+    /**
+     * Creates an RTL version of all the files in the selected path recursively.
+     *
+     * @param string $directory Path to process. All CSS files in this directory will be processed.
+     * @param bool $regenerate [default=false] Indicates if RTL files should be re-generated even if they exist
+     *
+     * @throws GenerationException
+     */
+    public function generateFromDirectory($directory, $regenerate = false)
+    {
+        $allFiles = $this->getFilesInDirectory($directory);
+
+        foreach ($allFiles as $file) {
+            if ($this->shouldProcessFile($directory.'/'.$file, $regenerate)) {
+                $this->processFile($directory.'/'.$file);
+            }
+        }
+    }
+
+    /**
+     * Indicates if a file should be processed or not
+     *
+     * @param string $file File path
+     * @param bool $regenerate Indicates if RTL files should be re-generated even if they exist
+     *
+     * @return bool
+     */
+    private function shouldProcessFile($file, $regenerate)
+    {
+        return (
+            strpos($file, '/node_modules/') === false
+            // does not end with .rtlfix
+            && substr(rtrim($file, '.'.$this->fileType), -4) !== $this->rtlSuffix
+            // RTL file does not exist
+            && (!$regenerate && !file_exists($this->getRtlFileName($file)))
+        );
+    }
+
+    /**
+     * Creates an RTL version of a file.
+     *
+     * @param string $filePath Path to the file to process
+     *
+     * @throws GenerationException
+     */
+    private function processFile($filePath)
+    {
+        $content = file_get_contents($filePath);
+
+        if ($content === false) {
+            throw new GenerationException(
+                sprintf(
+                    "Unable to read CSS file: %s",
+                    $filePath
+                )
+            );
+        }
+
+        try {
+            $parser = new Parser(
+                $this->sanitizeContent($filePath, $content)
+            );
+
+            // free up memory
+            unset($content);
+
+            $tree = $parser->parse();
+
+            (new RtlCss($tree))->flip();
+
+            $rendered = $tree->render($this->outputFormat);
+
+            unset($tree);
+        } catch (Exception $e) {
+            throw new GenerationException(
+                sprintf("Failed to generate RTL CSS from file: %s", $filePath),
+                0,
+                $e
+            );
+        }
+
+        $content = $this->appendRtlFixIfNecessary(
+            $rendered,
+            $filePath
+        );
+
+        $this->saveFile($content, $filePath);
+    }
+
+    /**
+     * @param $filePath
+     * @param $content
+     *
+     * @return string
+     * @throws GenerationException
+     */
+    private function sanitizeContent($filePath, $content)
+    {
+        return $this->fixSassBug(
+            $filePath,
+            $this->removeBomIfPresent($content)
+        );
+    }
+
+    /**
+     * Removes Byte Order Mark from CSS code if found
+     *
+     * @param string $content CSS code
+     *
+     * @return string Sanitized CSS code
+     *
+     * @throws GenerationException If removal fails for any reason
+     */
+    private function removeBomIfPresent($content)
+    {
+        $content = preg_replace('/^\xEF\xBB\xBF/', '', $content);
+
+        if ($content === null) {
+            throw new GenerationException(
+                sprintf(
+                    "Failed to remove Byte order mark from CSS content, PCRE error code: %s",
+                    preg_last_error()
+                )
+            );
+        }
+
+        return $content;
+    }
+
+    /**
+     * Fixes invalid CSS produced by a bug from Sass
+     *
+     * @param string $filePath Path to the file that is being processed
+     * @param string $content CSS content
+     *
+     * @return string Fixed CSS content
+     */
+    private function fixSassBug($filePath, $content)
+    {
+        // Sass misinterprets "@viewport" nested inside a selector
+        if (preg_match('/admin-theme(?:-[\w]+)*.css/', $filePath) !== false) {
+            return str_replace(
+                '@-ms-viewport{.bootstrap{width:device-width}}',
+                '.bootstrap @-ms-viewport{width:device-width}',
+                $content
+            );
+        }
+
+        return $content;
+    }
+
+    /**
+     * Creates a list of all files of the required type in the provided directory recursively.
+     *
+     * @param string $directory Directory to scan
+     *
+     * @return string[] Array of file paths, relative to the provided directory
+     */
+    private function getFilesInDirectory($directory) {
+        return Tools::scandir($directory, $this->fileType, '', true);
+    }
+
+    /**
+     * Removes the file extension from path
+     *
+     * @param string $filePath Path to a file
+     *
+     * @return string
+     */
+    private function getFilePathWithoutExtension($filePath)
+    {
+        $path = pathinfo($filePath);
+        return $path['dirname'].'/'.$path['filename'];
+    }
+
+    /**
+     * Returns the full path for the RTL filename corresponding to the provided base filename
+     *
+     * @param string $baseFileName Base file name
+     *
+     * @return string RTL filename
+     */
+    private function getRtlFileName($baseFileName)
+    {
+        return $this->getFilePathWithoutExtension($baseFileName).$this->rtlSuffix.'.'.$this->fileType;
+    }
+
+    /**
+     * Appends the content of an .rtlfix file to $content.
+     *
+     * @param string $content Base content
+     * @param string $baseFile Path to the processed file
+     *
+     * @return string Content with RTL fix applied
+     *
+     * @throws GenerationException If unable to read from .rtlfix file
+     */
+    private function appendRtlFixIfNecessary($content, $baseFile)
+    {
+        $filePath = $this->getFilePathWithoutExtension($baseFile);
+
+        $rtlFixFilePath = $filePath.'.'.self::RTLFIX_EXTENSION;
+
+        if (file_exists($rtlFixFilePath)) {
+            $rtlFixContent = file_get_contents($rtlFixFilePath);
+
+            if ($rtlFixContent === false) {
+                throw new GenerationException(
+                    sprintf(
+                        "Failed to read from file: %s",
+                        $rtlFixFilePath
+                    )
+                );
+            }
+
+            return $content . PHP_EOL . $rtlFixContent;
+        }
+
+        return $content;
+    }
+
+    /**
+     * Saves $content the appropriate file based on the name of the original file.
+     *
+     * @param string $content Content to save
+     * @param string $baseFile Name of the original file
+     *
+     * @throws GenerationException If unable to write to file
+     */
+    private function saveFile($content, $baseFile)
+    {
+        $rtlFilePath = $this->getRtlFileName($baseFile);
+
+        if (file_exists($rtlFilePath)) {
+            unlink($rtlFilePath);
+        }
+
+        if (false === file_put_contents($rtlFilePath, $content)) {
+            throw new GenerationException(
+                sprintf(
+                    "Unable to write file: %s",
+                    $rtlFilePath
+                )
+            );
+        }
+
+        @chmod($rtlFilePath, 0644);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Generation of RTL stylesheets was failing due to a bug in a library dependency. This PR replaces that library and brings stylesheet generation into the Core.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOGOSS-72
| How to test?  | Test installing an RTL language package and installing PS in an RTL language

Important notes:
- Some graphic bugs may still be unfixed, and new ones may appear due to the library change. Please see [BOOM-4319](http://forge.prestashop.com/browse/BOOM-4319) and update it accordingly.
- Generation is slow, and more so on development environments. Please be patient. Installing a language package may take 30 seconds to 2 minutes. Performance should be better with a release package and in production servers.

![screen shot 2017-12-28 at 17 09 17](https://user-images.githubusercontent.com/1009343/34416054-f6600b86-ebf1-11e7-97ed-e9d186922137.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8642)
<!-- Reviewable:end -->
