### PR TITLE
Fix modal backdrop not removed when uninstalling a module

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module_card.js
+++ b/admin-dev/themes/default/js/bundle/module/module_card.js
@@ -164,8 +164,17 @@ var AdminModuleCard = function () {
         $(document).on('click', this.moduleActionModalResetLinkSelector, function () {
             return _this.requestToController('reset', $(_this.moduleActionMenuResetLinkSelector, $("div.module-item-list[data-tech-name='" + $(this).attr("data-tech-name") + "']")));
         });
-        $(document).on('click', this.moduleActionModalUninstallLinkSelector, function () {
-            return _this.requestToController('uninstall', $(_this.moduleActionMenuUninstallLinkSelector, $("div.module-item-list[data-tech-name='" + $(this).attr("data-tech-name") + "']")), $(this).attr("data-deletion"));
+        $(document).on('click', this.moduleActionModalUninstallLinkSelector, function (e) {
+            jQuery(e.target).parents('.modal').on('hidden.bs.modal', function(event) {
+                return _this.requestToController(
+                    'uninstall',
+                    jQuery(
+                        _this.moduleActionMenuUninstallLinkSelector,
+                        jQuery("div.module-item-list[data-tech-name='" + jQuery(e.target).attr("data-tech-name") + "']")
+                    ),
+                    jQuery(e.target).attr("data-deletion")
+                );
+            }.bind(e));
         });
     };
 

--- a/admin-dev/themes/default/js/bundle/module/module_card.js
+++ b/admin-dev/themes/default/js/bundle/module/module_card.js
@@ -165,14 +165,14 @@ var AdminModuleCard = function () {
             return _this.requestToController('reset', $(_this.moduleActionMenuResetLinkSelector, $("div.module-item-list[data-tech-name='" + $(this).attr("data-tech-name") + "']")));
         });
         $(document).on('click', this.moduleActionModalUninstallLinkSelector, function (e) {
-            jQuery(e.target).parents('.modal').on('hidden.bs.modal', function(event) {
+            $(e.target).parents('.modal').on('hidden.bs.modal', function(event) {
                 return _this.requestToController(
                     'uninstall',
-                    jQuery(
+                    $(
                         _this.moduleActionMenuUninstallLinkSelector,
-                        jQuery("div.module-item-list[data-tech-name='" + jQuery(e.target).attr("data-tech-name") + "']")
+                        $("div.module-item-list[data-tech-name='" + $(e.target).attr("data-tech-name") + "']")
                     ),
-                    jQuery(e.target).attr("data-deletion")
+                    $(e.target).attr("data-deletion")
                 );
             }.bind(e));
         });


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Fix issue modal backdrop not removed when uninstalling a module.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [BOOM-4448](http://forge.prestashop.com/secure/RapidBoard.jspa?rapidView=94&view=detail&selectedIssue=BOOM-4448)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8648)
<!-- Reviewable:end -->
