### PR TITLE
Add show_price to allowed properties in ajax

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -505,7 +505,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
             'link_rewrite', 'name', 'manufacturer_name', 'position', 'cover', 'url', 'canonical_url', 'add_to_cart_url',
             'has_discount', 'discount_type', 'discount_percentage', 'discount_percentage_absolute', 'discount_amount',
             'price_amount', 'regular_price_amount', 'regular_price', 'discount_to_display', 'labels', 'main_variants',
-            'unit_price', 'tax_name', 'rate'
+            'unit_price', 'tax_name', 'rate', 'show_price'
         );
         foreach ($products as $product_key => $product) {
             foreach ($product as $product_property => $data) {


### PR DESCRIPTION

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | It is needed for autocomplete search with price showed on results. Without this it is not possible to determine if price shpuld be showed for user or not. Example it show price for visitor groups when show price value is set to not for this group
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | nono
| Fixed ticket? | 
| How to test?  | print with console.log results returned in ajax search

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8650)
<!-- Reviewable:end -->
