### PR TITLE
SEO - Add hreflang links for multilang pages

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -454,12 +454,6 @@ class FrontControllerCore extends Controller
             }
         }
 
-        $languages = Language::getLanguages(true, $this->context->shop->id);
-        $meta_language = array();
-        foreach ($languages as $lang) {
-            $meta_language[] = $lang['iso_code'];
-        }
-
         /*
          * These shortcuts are DEPRECATED as of version 1.5.0.1
          * Use the Context to access objects instead.
@@ -1495,6 +1489,8 @@ class FrontControllerCore extends Controller
         $pages['order_login'] = $this->context->link->getPageLink('order', true, null, array('login' => '1'));
         $urls['pages'] = $pages;
 
+        $urls['alternative_langs'] = $this->getAlternativeLangsUrl();
+
         $urls['theme_assets'] = __PS_BASE_URI__.'themes/'.$this->context->shop->theme->getName().'/assets/';
 
         $urls['actions'] = array(
@@ -1949,5 +1945,24 @@ class FrontControllerCore extends Controller
         $container->compile();
 
         return $container;
+    }
+
+    /**
+     * @return array containing the URLs of the same page but for different languages
+     */
+    protected function getAlternativeLangsUrl()
+    {
+        $alternativeLangs = array();
+        $languages = Language::getLanguages(true, $this->context->shop->id);
+
+        if ($languages < 2) {
+            // No need to display alternative lang if there is only one enabled
+            return $alternativeLangs;
+        }
+
+        foreach ($languages as $lang) {
+            $alternativeLangs[$lang['language_code']] = $this->context->link->getLanguageLink($lang['id_lang']);
+        }
+        return $alternativeLangs;
     }
 }

--- a/themes/classic/templates/_partials/head.tpl
+++ b/themes/classic/templates/_partials/head.tpl
@@ -39,6 +39,11 @@
   {if $page.canonical}
     <link rel="canonical" href="{$page.canonical}">
   {/if}
+  {block name='head_hreflang'}
+      {foreach from=$urls.alternative_langs item=pageUrl key=code}
+            <link rel="alternate" href="{$pageUrl}" hreflang="{$code}">
+      {/foreach}
+  {/block}
 {/block}
 
 {block name='head_viewport'}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | List all equivalent URLs for all enabled langs on the shop in the `<head>` tag.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/FF-159
| How to test?  | Check the `<head>` of a front-office page. You should see this kind of content being displayed:

```html
<link rel="alternate" href="http://localhost/PrestaShop/fr/connexion?back=my-account" hreflang="fr">
<link rel="alternate" href="http://localhost/PrestaShop/gb/login?back=my-account" hreflang="en-gb">
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8652)
<!-- Reviewable:end -->
