### PR TITLE
Fix the update of customized product in the order details page

### DIFF
--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -684,9 +684,9 @@ function init()
 			var element_list = $('.customized-' + $(this).parent().parent().find('.edit_product_id_order_detail').val());
 			query = 'ajax=1&token='+token+'&action=editProductOnOrder&id_order='+id_order+'&';
 			if (element_list.length)
-				query += element_list.parent().parent().find('input:visible, select:visible, .edit_product_id_order_detail').serialize();
+				query += element_list.closest('tr').find('input:visible, select:visible, .edit_product_id_order_detail').serialize();
 			else
-				query += element.parent().parent().find('input:visible, select:visible, .edit_product_id_order_detail').serialize();
+				query += element.closest('tr').find('input:visible, select:visible, .edit_product_id_order_detail').serialize();
 
 			$.ajax({
 				type: 'POST',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | BO, if you try to update the quantity or the price of an ordered product with a customizable propertie, then it applies the wrong modification.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7236
| How to test?  | FO > order two products (product 1 with **customizable propertie**), BO > order details > try to update the product with the customizable propertie and check if it applies the correct modification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8655)
<!-- Reviewable:end -->
