### PR TITLE
Integrate RTL CSS generation in the core

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1368,25 +1368,24 @@ class LanguageCore extends ObjectModel
             } else {
                 $adminDir = _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'admin';
                 $adminDir = (is_dir($adminDir)) ? $adminDir : ($adminDir.'-dev');
-                $adminDir .= DIRECTORY_SEPARATOR;
             }
 
             if (!is_dir($adminDir)) {
                 throw new Exception("Cannot generate BO themes: \"$adminDir\" is not a directory");
             }
 
-            $generator->generateFromDirectory($adminDir.'themes');
+            $generator->generateInDirectory($adminDir.DIRECTORY_SEPARATOR.'themes');
         }
 
         // generate stylesheets for BO themes
         if ($foTheme) {
             $frontDir = _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.'themes'.DIRECTORY_SEPARATOR;
 
-            $generator->generateFromDirectory($frontDir.($themeName?$themeName:'classic'));
+            $generator->generateInDirectory($frontDir.($themeName?$themeName:'classic'));
         }
 
         if ($path && is_dir($path)) {
-            $generator->generateFromDirectory($path);
+            $generator->generateInDirectory($path);
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "phpoffice/phpexcel": "~1.8",
         "guzzlehttp/guzzle": "~5.0",
         "csa/guzzle-bundle": "~1.3",
-        "ipresta/localize-fixture": "~v1.0",
         "paragonie/random_compat": "^1.4|^2.0",
         "prestashop/smarty": "dev-master",
         "prestashop/blockreassurance": "^3",
@@ -97,8 +96,15 @@
         "beberlei/DoctrineExtensions": "^1.0",
         "composer/ca-bundle": "^1.0",
         "nikic/php-parser": "^2.1",
-        "prestashop/decimal": "^1.0.0"
+        "prestashop/decimal": "^1.0.0",
+        "cssjanus/cssjanus": "dev-patch-1"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/prestashop/php-cssjanus"
+        }
+    ],
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "symfony/phpunit-bridge": "~3.1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4bc36d34c2512ab8c9fc63a4492908d",
+    "content-hash": "b0fcc9b01c1cdeab61574a29544c92a6",
     "packages": [
         {
             "name": "beberlei/DoctrineExtensions",
@@ -275,6 +275,50 @@
             ],
             "description": "A bundle integrating GuzzleHttp >= 4.0",
             "time": "2015-11-17T00:02:55+00:00"
+        },
+        {
+            "name": "cssjanus/cssjanus",
+            "version": "dev-patch-1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShop/php-cssjanus.git",
+                "reference": "7866b8a6f7ad8ba8c7f4eb9f87b084452a41d8e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShop/php-cssjanus/zipball/7866b8a6f7ad8ba8c7f4eb9f87b084452a41d8e5",
+                "reference": "7866b8a6f7ad8ba8c7f4eb9f87b084452a41d8e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "0.8.*",
+                "phpunit/phpunit": "4.8.*",
+                "squizlabs/php_codesniffer": "2.3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "": "src/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "parallel-lint . --exclude vendor",
+                    "phpunit",
+                    "phpcs -p"
+                ]
+            },
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Convert CSS stylesheets between left-to-right and right-to-left.",
+            "support": {
+                "source": "https://github.com/PrestaShop/php-cssjanus/tree/patch-1"
+            },
+            "time": "2018-01-08T09:57:29+00:00"
         },
         {
             "name": "curl/curl",
@@ -1608,36 +1652,6 @@
                 "parameters management"
             ],
             "time": "2015-11-10T17:04:01+00:00"
-        },
-        {
-            "name": "ipresta/localize-fixture",
-            "version": "v1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/iPresta/localize-fixture.git",
-                "reference": "5e24bcece3d88f4b53b844588763990f6ed20a6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/iPresta/localize-fixture/zipball/5e24bcece3d88f4b53b844588763990f6ed20a6a",
-                "reference": "5e24bcece3d88f4b53b844588763990f6ed20a6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT License"
-            ],
-            "description": "Generate RTL CSS for PrestaShop",
-            "time": "2017-09-25T17:46:09+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -3711,7 +3725,7 @@
             ],
             "description": "PrestaShop Smarty version",
             "homepage": "https://github.com/PrestaShop/smarty",
-            "time": "2017-05-11 08:29:53"
+            "time": "2017-05-11T08:29:53+00:00"
         },
         {
             "name": "prestashop/statsbestcategories",
@@ -6843,6 +6857,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "prestashop/smarty": 20,
+        "cssjanus/cssjanus": 20,
         "phake/phake": 0
     },
     "prefer-stable": false,

--- a/src/Core/Localization/RTL/Exception/GenerationException.php
+++ b/src/Core/Localization/RTL/Exception/GenerationException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Localization\RTL\Exception;
+
+class GenerationException extends \Exception
+{
+}

--- a/src/Core/Localization/RTL/StylesheetGenerator.php
+++ b/src/Core/Localization/RTL/StylesheetGenerator.php
@@ -85,7 +85,7 @@ class StylesheetGenerator
      *
      * @throws GenerationException
      */
-    public function generateFromDirectory($directory, $regenerate = false)
+    public function generateInDirectory($directory, $regenerate = false)
     {
         $allFiles = $this->getFilesInDirectory($directory);
 

--- a/src/Core/Localization/RTL/StylesheetGenerator.php
+++ b/src/Core/Localization/RTL/StylesheetGenerator.php
@@ -110,8 +110,8 @@ class StylesheetGenerator
             strpos($file, '/node_modules/') === false
             // does not end with .rtlfix
             && substr(rtrim($file, '.'.$this->fileType), -4) !== $this->rtlSuffix
-            // RTL file does not exist and we aren't regenerating them
-            && (!$regenerate && !file_exists($this->getRtlFileName($file)))
+            // RTL file does not exist or we are regenerating them
+            && ($regenerate || !file_exists($this->getRtlFileName($file)))
         );
     }
 

--- a/src/Core/Localization/RTL/StylesheetGenerator.php
+++ b/src/Core/Localization/RTL/StylesheetGenerator.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Localization\RTL;
+
+use PrestaShop\PrestaShop\Core\Localization\RTL\Exception\GenerationException;
+use \CSSJanus;
+use \Tools;
+
+/**
+ * Creates RTL versions of LTR CSS files.
+ *
+ * This class creates new files based on the original ones by using CSSJanus first,
+ * then applying an optional .rtlfix file, if one with the same name as the processed file is found.
+ *
+ * Inspired by "Localize Fixture" from Mahdi Shad @ iPresta
+ * @link https://github.com/iPresta/localize-fixture
+ */
+class StylesheetGenerator
+{
+
+    /**
+     * Default file type to look up
+     */
+    const DEFAULT_FILE_TYPE = 'css';
+
+    /**
+     * Default suffix to use for RTL transformed files
+     */
+    const DEFAULT_RTL_SUFFIX = '_rtl';
+
+    /**
+     * Extension of RTL fix files
+     */
+    const RTLFIX_EXTENSION = 'rtlfix';
+
+    /**
+     * @var string
+     */
+    private $fileType;
+
+    /**
+     * @var string
+     */
+    private $rtlSuffix;
+
+    /**
+     * @param string $fileType [default='css'] File type (CSS or SCSS)
+     * @param string $rtlSuffix [default='_rtl'] Suffix to add to transformed RTL files
+     */
+    public function __construct($fileType = self::DEFAULT_FILE_TYPE, $rtlSuffix = self::DEFAULT_RTL_SUFFIX)
+    {
+        $this->fileType = $fileType;
+        $this->rtlSuffix = $rtlSuffix;
+    }
+
+    /**
+     * Creates an RTL version of all the files in the selected path recursively.
+     *
+     * @param string $directory Path to process. All CSS files in this directory will be processed.
+     * @param bool $regenerate [default=false] Indicates if RTL files should be re-generated even if they exist
+     *
+     * @throws GenerationException
+     */
+    public function generateFromDirectory($directory, $regenerate = false)
+    {
+        $allFiles = $this->getFilesInDirectory($directory);
+
+        foreach ($allFiles as $file) {
+            if ($this->shouldProcessFile($directory.'/'.$file, $regenerate)) {
+                $this->processFile($directory.'/'.$file);
+            }
+        }
+    }
+
+    /**
+     * Indicates if a file should be processed or not
+     *
+     * @param string $file File path
+     * @param bool $regenerate Indicates if RTL files should be re-generated even if they exist
+     *
+     * @return bool
+     */
+    private function shouldProcessFile($file, $regenerate)
+    {
+        return (
+            strpos($file, '/node_modules/') === false
+            // does not end with .rtlfix
+            && substr(rtrim($file, '.'.$this->fileType), -4) !== $this->rtlSuffix
+            // RTL file does not exist and we aren't regenerating them
+            && (!$regenerate && !file_exists($this->getRtlFileName($file)))
+        );
+    }
+
+    /**
+     * Creates an RTL version of a file.
+     *
+     * @param string $filePath Path to the file to process
+     *
+     * @throws GenerationException
+     */
+    private function processFile($filePath)
+    {
+        $content = file_get_contents($filePath);
+
+        if ($content === false) {
+            throw new GenerationException(
+                sprintf(
+                    "Unable to read from CSS file: %s",
+                    $filePath
+                )
+            );
+        }
+
+        $rendered = CSSJanus::transform($content);
+
+        if (strlen($rendered) === 0 && strlen($content) !== 0) {
+            throw new GenerationException(
+                sprintf("Failed to generate RTL CSS from file: %s", $filePath)
+            );
+        }
+
+        $content = $this->appendRtlFixIfNecessary(
+            $rendered,
+            $filePath
+        );
+
+        $this->saveFile($content, $filePath);
+    }
+
+    /**
+     * Creates a list of all files of the required type in the provided directory recursively.
+     *
+     * @param string $directory Directory to scan
+     *
+     * @return string[] Array of file paths, relative to the provided directory
+     */
+    private function getFilesInDirectory($directory) {
+        return Tools::scandir($directory, $this->fileType, '', true);
+    }
+
+    /**
+     * Removes the file extension from path
+     *
+     * @param string $filePath Path to a file
+     *
+     * @return string
+     */
+    private function getFilePathWithoutExtension($filePath)
+    {
+        $path = pathinfo($filePath);
+        return $path['dirname'].'/'.$path['filename'];
+    }
+
+    /**
+     * Returns the full path for the RTL filename corresponding to the provided base filename
+     *
+     * @param string $baseFileName Base file name
+     *
+     * @return string RTL filename
+     */
+    private function getRtlFileName($baseFileName)
+    {
+        return $this->getFilePathWithoutExtension($baseFileName).$this->rtlSuffix.'.'.$this->fileType;
+    }
+
+    /**
+     * Appends the content of an .rtlfix file to $content.
+     *
+     * @param string $content Base content
+     * @param string $baseFile Path to the processed file
+     *
+     * @return string Content with RTL fix applied
+     *
+     * @throws GenerationException If unable to read from .rtlfix file
+     */
+    private function appendRtlFixIfNecessary($content, $baseFile)
+    {
+        $filePath = $this->getFilePathWithoutExtension($baseFile);
+
+        $rtlFixFilePath = $filePath.'.'.self::RTLFIX_EXTENSION;
+
+        if (file_exists($rtlFixFilePath)) {
+            $rtlFixContent = file_get_contents($rtlFixFilePath);
+
+            if ($rtlFixContent === false) {
+                throw new GenerationException(
+                    sprintf(
+                        "Failed to read from file: %s",
+                        $rtlFixFilePath
+                    )
+                );
+            }
+
+            return $content . PHP_EOL . $rtlFixContent;
+        }
+
+        return $content;
+    }
+
+    /**
+     * Saves $content the appropriate file based on the name of the original file.
+     *
+     * @param string $content Content to save
+     * @param string $baseFile Name of the original file
+     *
+     * @throws GenerationException If unable to write to file
+     */
+    private function saveFile($content, $baseFile)
+    {
+        $rtlFilePath = $this->getRtlFileName($baseFile);
+
+        if (false === file_put_contents($rtlFilePath, $content)) {
+            throw new GenerationException(
+                sprintf(
+                    "Unable to write file to: %s",
+                    $rtlFilePath
+                )
+            );
+        }
+
+        @chmod($rtlFilePath, 0644);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Moved RTL generation from an external dependency into the core while keeping CSSJanus, and added some minor improvements from this other PR: https://github.com/PrestaShop/PrestaShop/pull/8642
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Generating an RTL language should work the same as before

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8657)
<!-- Reviewable:end -->

  