### PR TITLE
Fix reordering product images on multishop

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1673,7 +1673,21 @@ class AdminProductsControllerCore extends AdminController
             return die(Tools::jsonEncode(array('error' => $this->l('You do not have the right permission'))));
         }
         Image::deleteCover((int)Tools::getValue('id_product'));
-        $img = new Image((int)Tools::getValue('id_image'));
+        $id_image = (int)Tools::getValue('id_image');
+
+        /*
+         * If the the image is not associated with the currently selected shop, the fields that are also in the
+         * image_shop table (like id_product and cover) cannot be loaded properly, so we have to load them separately.
+         */
+        $img = new Image($id_image);
+        $def = $img::$definition;
+        $sql = 'SELECT * FROM `' . _DB_PREFIX_ . $def['table'] . '` WHERE `' . $def['primary'] . '` = ' . $id_image;
+        $fields_from_table = Db::getInstance()->getRow($sql);
+        foreach ($def['fields'] as $key => $value) {
+            if (!$value['lang']) {
+                $img->{$key} = $fields_from_table[$key];
+            }
+        }
         $img->cover = 1;
 
         @unlink(_PS_TMP_IMG_DIR_.'product_'.(int)$img->id_product.'.jpg');

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1585,6 +1585,7 @@ class AdminProductsControllerCore extends AdminController
 
     public function ajaxProcessUpdateProductImageShopAsso()
     {
+        $this->json = true;
         $id_product = Tools::getValue('id_product');
         if (($id_image = Tools::getValue('id_image')) && ($id_shop = (int)Tools::getValue('id_shop'))) {
             if (Tools::getValue('active') == 'true') {
@@ -1630,14 +1631,12 @@ class AdminProductsControllerCore extends AdminController
 
     public function ajaxProcessUpdateImagePosition()
     {
+        $this->json = true;
         if ($this->tabAccess['edit'] === '0') {
             return die(Tools::jsonEncode(array('error' => $this->l('You do not have the right permission'))));
         }
         $res = false;
         if ($json = Tools::getValue('json')) {
-            // If there is an exception, at least the response is in JSON format.
-            $this->json = true;
-
             $res = true;
             $json = stripslashes($json);
             $images = Tools::jsonDecode($json, true);
@@ -1669,6 +1668,7 @@ class AdminProductsControllerCore extends AdminController
 
     public function ajaxProcessUpdateCover()
     {
+        $this->json = true;
         if ($this->tabAccess['edit'] === '0') {
             return die(Tools::jsonEncode(array('error' => $this->l('You do not have the right permission'))));
         }
@@ -1703,6 +1703,7 @@ class AdminProductsControllerCore extends AdminController
     public function ajaxProcessDeleteProductImage()
     {
         $this->display = 'content';
+        $this->json = true;
         $res = true;
         /* Delete product image */
         $image = new Image((int)Tools::getValue('id_image'));

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1642,9 +1642,10 @@ class AdminProductsControllerCore extends AdminController
             $json = stripslashes($json);
             $images = Tools::jsonDecode($json, true);
             foreach ($images as $id => $position) {
-                $img = new Image((int)$id);
-                $img->position = (int)$position;
-                $res &= $img->update();
+                $res &= Db::getInstance()->execute(
+                    'UPDATE `'._DB_PREFIX_.'image` SET `position`= ' . (int) $position .
+                    ' WHERE `id_image` = ' . (int) $id
+                );
             }
         }
         if ($res) {

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1652,7 +1652,7 @@ class AdminProductsControllerCore extends AdminController
                 $sql = 'SELECT * FROM `' . _DB_PREFIX_ . $def['table'] . '` WHERE `' . $def['primary'] . '` = ' . (int)$id;
                 $fields_from_table = Db::getInstance()->getRow($sql);
                 foreach ($def['fields'] as $key => $value) {
-                    if (!$value['lang']) {
+                    if (!isset($value['lang']) || !$value['lang']) {
                         $img->{$key} = $fields_from_table[$key];
                     }
                 }
@@ -1684,7 +1684,7 @@ class AdminProductsControllerCore extends AdminController
         $sql = 'SELECT * FROM `' . _DB_PREFIX_ . $def['table'] . '` WHERE `' . $def['primary'] . '` = ' . $id_image;
         $fields_from_table = Db::getInstance()->getRow($sql);
         foreach ($def['fields'] as $key => $value) {
-            if (!$value['lang']) {
+            if (!isset($value['lang']) || !$value['lang']) {
                 $img->{$key} = $fields_from_table[$key];
             }
         }

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1635,6 +1635,9 @@ class AdminProductsControllerCore extends AdminController
         }
         $res = false;
         if ($json = Tools::getValue('json')) {
+            // If there is an exception, at least the response is in JSON format.
+            $this->json = true;
+
             $res = true;
             $json = stripslashes($json);
             $images = Tools::jsonDecode($json, true);


### PR DESCRIPTION
...on a multishop site.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When reordering images in a product with the multishop active, when an image is disabled in the current context shop, behind the scenes the `Image` object doesn't load properly, because the query does not return all fields because the LEFT JOIN returns only parts of the fields (see https://cl.ly/0r3c0T1x2d2B/mysql-mistery.mp4 for proof)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Enable multishop, add images to a product, disable one of them in a shop and then save the product. Now try to change the order of the images for that product. You might have to look at the browser console for an error message, which is fixed by https://github.com/PrestaShop/PrestaShop/pull/8666/commits/c9e08324c70bed130860ae7d6460ec3943cd82f8 because HTML is being returned to a AJAX request expecting JSON (`SyntaxError: JSON Parse error: Unrecognized token '<'` visible in browser console). The error says `Property Image->id_product is empty`, this error is fixed by https://github.com/PrestaShop/PrestaShop/pull/8666/commits/2051add4f8d64e3c6e2c27936964984d4bf2e8e0. See Description above for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8666)
<!-- Reviewable:end -->
