### PR TITLE
Allow to setup the shop with SSL by default using CLI installer

### DIFF
--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -154,7 +154,12 @@ class Datas
         'theme' => array(
             'name' => 'theme',
             'default' => ''
-        )
+        ),
+        'enable_ssl' => array(
+            'name' => 'ssl',
+            'default' => 0,
+            'help' => 'enable SSL for PrestaShop'
+        ),
     );
 
     protected $datas = array();

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -254,6 +254,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
             'admin_email' =>            $this->datas->admin_email,
             'configuration_agrement' =>    true,
             'send_informations' => true,
+            'enable_ssl' => $this->datas->enable_ssl,
         ));
     }
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -698,6 +698,7 @@ class Install extends AbstractInstall
             'smtp_encryption' => 'off',
             'smtp_port' => 25,
             'rewrite_engine' => false,
+            'enable_ssl' => false,
         );
 
         foreach ($default_data as $k => $v) {
@@ -722,6 +723,10 @@ class Install extends AbstractInstall
         Configuration::updateGlobalValue('PS_LOCALE_COUNTRY', $data['shop_country']);
         Configuration::updateGlobalValue('PS_TIMEZONE', $data['shop_timezone']);
         Configuration::updateGlobalValue('PS_CONFIGURATION_AGREMENT', (int)$data['configuration_agrement']);
+
+        // Set SSL configuration
+        Configuration::updateGlobalValue('PS_SSL_ENABLED', (int)$data['enable_ssl']);
+        Configuration::updateGlobalValue('PS_SSL_ENABLED_EVERYWHERE', (int)$data['enable_ssl']);
 
         // Set mails configuration
         Configuration::updateGlobalValue('PS_MAIL_METHOD', ($data['use_smtp']) ? 2 : 1);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Added ability to setup Prestashop with SSL when installing using CLI controller. 
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [BOOM-2775](http://forge.prestashop.com/browse/BOOM-2775)
| How to test?  | Install Prestashop using index_cli.php with --ssl=1

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8668)
<!-- Reviewable:end -->
