### PR TITLE
Fix store hours migration

### DIFF
--- a/install-dev/upgrade/php/ps1700_stores.php
+++ b/install-dev/upgrade/php/ps1700_stores.php
@@ -45,7 +45,7 @@ function ps1700_stores()
 
         $result &= Db::getInstance()->execute('
             UPDATE `'._DB_PREFIX_.'store`
-            SET `hours` = '.$hours.'
+            SET `hours` = \''.$hours.'\'
             WHERE `id_store` = '.$store['id_store']
         );
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | hours are not properly migrated due to problem with " ". Original bug fix by @kpodemski reported on earlier versions (#8556). 
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Upgrade your shop from 1.6 to 1.7 and check the opening times of your store in database 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8670)
<!-- Reviewable:end -->
