### PR TITLE
Move submit button to the right in sf forms

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/AdvancedParameters/administration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/AdvancedParameters/administration.html.twig
@@ -62,7 +62,9 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                 {{ form_rest(generalForm) }}
                 </div>
@@ -95,7 +97,9 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                     {{ form_rest(uploadQuotaForm) }}
                 </div>
@@ -132,7 +136,9 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                     {{ form_rest(notificationsForm) }}
                 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
@@ -70,7 +70,9 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -102,7 +104,9 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -144,7 +148,9 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -179,7 +185,9 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -216,7 +224,9 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -244,7 +254,9 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig
@@ -58,7 +58,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="card-footer">
+                    <div class="d-flex justify-content-end">
                         <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
                     </div>
                 </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR moves all "submit" buttons on the right.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Check a page freshly migrated on Symfony. Submit buttons must be on the right.

![capture du 2018-01-12 16-19-33](https://user-images.githubusercontent.com/6768917/34884413-948949d0-f7b4-11e7-97ec-9c2f5758510a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8672)
<!-- Reviewable:end -->
