### PR TITLE
Fix PHP Warning when updating category with multishop

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -679,7 +679,7 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
                 if ($shop_exists) {
                     if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
                         foreach ($fields as $key => $val) {
-                            if (!array_key_exists($key, $this->update_fields)) {
+                            if (!array_key_exists($key, (array)$this->update_fields)) {
                                 unset($fields[$key]);
                             }
                         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | array_key_exists() was run with a parameter that was null, instead of possibly an empty array. Casting a null to array generates an empty array, yielding the same results in the logic, but solving the PHP Warning.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Enable multishop, try to save a category while in all or group context. It should generate a warning. This fixes it.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8673)
<!-- Reviewable:end -->
