### PR TITLE
Rename old paths of cache and logs for SF 3

### DIFF
--- a/.t9n.yml
+++ b/.t9n.yml
@@ -12,8 +12,8 @@ paths:
 exclude_files:
   - src/PrestaShopBundle/Tests
   - classes/PrestaShopAutoload.php
-  - app/cache/
-  - app/logs
+  - var/cache/
+  - var/logs
   - node_modules
   - vendor
   - tools

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -152,7 +152,7 @@ class PrestaShopExceptionCore extends Exception
     protected function logError()
     {
         $logger = new FileLogger();
-        $logger->setFilename(_PS_ROOT_DIR_.'/app/logs/'.date('Ymd').'_exception.log');
+        $logger->setFilename(_PS_ROOT_DIR_.'/var/logs/'.date('Ymd').'_exception.log');
         $logger->logError($this->getExtendedMessage(false));
     }
 

--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -48,7 +48,7 @@ require_once(dirname(__FILE__).'/../init.php');
 Upgrade::migrateSettingsFile();
 require_once(_PS_CONFIG_DIR_.'bootstrap.php');
 
-$logDir = _PS_ROOT_DIR_.'/app/logs/'.(_PS_MODE_DEV_ ? 'dev' : 'prod').'/';
+$logDir = _PS_ROOT_DIR_.'/var/logs/'.(_PS_MODE_DEV_ ? 'dev' : 'prod').'/';
 @mkdir($logDir, 0777, true);
 
 $upgrade = new Upgrade($logDir, dirname(dirname(__FILE__)).'/');
@@ -133,7 +133,7 @@ function displayHelp()
 PrestaShop upgrade
 
 This script can be called directly and is used by the 1-click upgrade module. It ouputs xml in the first case and json data for the module.
-It is mainly used for the database migration of your shop. Logs will be registered in your app/logs/<env> folder.
+It is mainly used for the database migration of your shop. Logs will be registered in your var/logs/<env> folder.
 ------------------
 Options
 --help               Display this message

--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -460,12 +460,12 @@ class ReleaseCreator
      */
     protected function createAndRenameFolders()
     {
-        if (!file_exists($this->tempProjectPath . '/app/cache/')) {
-            mkdir($this->tempProjectPath . '/app/cache', 0777, true);
+        if (!file_exists($this->tempProjectPath . '/var/cache/')) {
+            mkdir($this->tempProjectPath . '/var/cache', 0777, true);
         }
 
-        if (!file_exists($this->tempProjectPath . '/app/logs/')) {
-            mkdir($this->tempProjectPath . '/app/logs', 0777, true);
+        if (!file_exists($this->tempProjectPath . '/var/logs/')) {
+            mkdir($this->tempProjectPath . '/var/logs', 0777, true);
         }
         $itemsToRename = ['admin-dev' => 'admin', 'install-dev' => 'install'];
         $basePath = $this->tempProjectPath;

--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -33,7 +33,7 @@ This will:
 * Export project with git archive to a temp location
 * Define constants (`_PS_MODE_DEV_` to false etc...)
 * Concatenate all licence files into one unique in {project_root}/LICENCES
-* Create somes folders (app/cache, app/logs...)
+* Create somes folders (var/cache, var/logs...)
 * Clean project files and directories
 * Zip release if no --no-zip arg
 * Add the installer if no --no-installer arg


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | By migrating to Symfony 3.x, some paths like `app/cache` & `app/logs` were updated, but not every occurrences of them in the code were changed.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | /
| How to test?  | You can check the release creator tool does not generate the old folders.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8674)
<!-- Reviewable:end -->
