### PR TITLE
Catch Throwable errors on CLI install and check Theme instance in context

### DIFF
--- a/install-dev/classes/controllerConsole.php
+++ b/install-dev/classes/controllerConsole.php
@@ -64,6 +64,11 @@ abstract class InstallControllerConsole
     protected $model_install;
 
     /**
+     * @var \PrestaShopBundle\Install\Database
+     */
+    protected $model_database;
+
+    /**
      * Validate current step.
      */
     abstract public function validate();
@@ -140,7 +145,10 @@ abstract class InstallControllerConsole
 
     public function printErrors()
     {
-        $errors = $this->model_install->getErrors();
+        $errors = array_merge(
+            $this->model_database->getErrors(),
+            $this->model_install->getErrors()
+        );
         if (count($errors)) {
             if (!is_array($errors)) {
                 $errors = array($errors);

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -29,7 +29,6 @@ use PrestaShopBundle\Install\Database;
 class InstallControllerConsoleProcess extends InstallControllerConsole implements HttpConfigureInterface
 {
 
-    protected $model_database;
     public $process_steps = array();
     public $previous_button = false;
 

--- a/install-dev/index_cli.php
+++ b/install-dev/index_cli.php
@@ -40,6 +40,10 @@ try {
     exit(0);
 } catch (PrestashopInstallerException $e) {
     $e->displayMessage();
+} catch (Throwable $t) {
+    // Executed only in PHP 7, will not match in PHP 5.
+    // Allows `Error` classes to be catched, without throwing an error on PHP 5.
+    echo $t->getMessage();
 } catch (Exception $e) {
     echo $e->getMessage();
 }

--- a/src/PrestaShopBundle/Install/AbstractInstall.php
+++ b/src/PrestaShopBundle/Install/AbstractInstall.php
@@ -54,7 +54,7 @@ abstract class AbstractInstall
             $errors = array($errors);
         }
 
-        $this->errors[] = $errors;
+        $this->errors = array_merge($this->errors, $errors);
     }
 
     public function getErrors()

--- a/src/PrestaShopBundle/Install/Database.php
+++ b/src/PrestaShopBundle/Install/Database.php
@@ -104,6 +104,9 @@ class Database extends AbstractInstall
             }
         }
 
+        if (count($errors)) {
+            $this->setError($errors);
+        }
         return $errors;
     }
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -536,6 +536,7 @@ class Install extends AbstractInstall
             $this->setError($this->translator->trans('Cannot create shop', array(), 'Install').' / '.Db::getInstance()->getMsgError());
             return false;
         }
+        $shop->setTheme();
         Context::getContext()->shop = $shop;
 
         // Create default shop URL


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | I discovered docker-compose never installed PrestaShop on the first try. It appeared we never catch the new `Error` classes from PHP 7. This PR adds the catch block and fixes some other issues I found.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Load this PR and the repo content in a new folder, then execute `docker-compose up`. PrestaShop must be installed on the first try.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8679)
<!-- Reviewable:end -->
