### PR TITLE
Fix the display of customization area in the product page

### DIFF
--- a/themes/default-bootstrap/css/global.css
+++ b/themes/default-bootstrap/css/global.css
@@ -6658,7 +6658,6 @@ h3.page-product-heading {
   margin: 0 0 20px;
   position: relative;
   border: 1px solid #d6d4d4;
-  border-bottom: none;
   background: #fbfbfb; }
 
 ul.footer_links {

--- a/themes/default-bootstrap/css/product.css
+++ b/themes/default-bootstrap/css/product.css
@@ -913,7 +913,7 @@ ul#text_fields {
 
 .customizationUploadBrowse img + a {
   position: relative;
-  top: -51px; }
+  top: -25px; }
 
 #customizedDatas {
   float: right; }

--- a/themes/default-bootstrap/product.tpl
+++ b/themes/default-bootstrap/product.tpl
@@ -646,7 +646,7 @@
 											{/if}
 											{if $field.required}<sup>*</sup>{/if}
 										</label>
-										<textarea name="textField{$field.id_customization_field}" class="form-control customization_block_input" id="textField{$customizationField}" rows="3" cols="20">{strip}
+										<textarea name="textField{$field.id_customization_field}" class="form-control customization_block_input" id="textField{$customizationField}" rows="3" cols="20" maxlength="255">{strip}
 											{if isset($textFields.$key)}
 												{$textFields.$key|stripslashes}
 											{/if}

--- a/themes/default-bootstrap/sass/_theme_variables.scss
+++ b/themes/default-bootstrap/sass/_theme_variables.scss
@@ -96,6 +96,5 @@ $tr-even-bg:										#fdfdfd;
 	margin: 0 0 20px;
 	position: relative;
 	border: 1px solid $base-border-color;
-	border-bottom: none;
 	background: $base-box-bg;
 }

--- a/themes/default-bootstrap/sass/product.scss
+++ b/themes/default-bootstrap/sass/product.scss
@@ -1036,7 +1036,7 @@ ul#text_fields {
 }
 .customizationUploadBrowse img + a {
 	position: relative;
-	top: -51px;
+	top: -25px;
 }
 #customizedDatas {
 	float: right;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | The customization area of the FO product page is wrongly displayed.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-5989
| How to test?  | BO > create product with two customizable properties (file fields & test fields), FO > product page, check in the customization area, if the **PRODUCT CUSTOMIZATION** displayed with bottom border and when uploading image, the **delete icon** displayed in the same line as the image, and check if **the textarea** is limited by 255 characters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8681)
<!-- Reviewable:end -->
