### PR TITLE
Fix error 500, result of built-in function in write context

### DIFF
--- a/tools/tar/Archive_Tar.php
+++ b/tools/tar/Archive_Tar.php
@@ -690,7 +690,7 @@ class Archive_Tar extends PEAR
         }
 
         // ----- Get the arguments
-        $v_att_list = & func_get_args();
+        $v_att_list = func_get_args();
 
         // ----- Read the attributes
         $i = 0;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | While installing PrestaShop during the last step. Progress bar stopped at 23% due to an error 500. Behind the error, the log says : `PHP Fatal error:  Cannot use result of built-in function in write context in /var/www/html/tools/tar/Archive_Tar.php on line 693`.  PHP Version is `7.2`, I'm using Docker with `php:7-apache` as a base image. Beside, looking at the code itself and in this case, the reference is useless.
Type?         | bug fix
| Category?     | CO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | I didn't look if there is any about it
| How to test?  | Simply start a new PrestaShop installation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8682)
<!-- Reviewable:end -->
