### PR TITLE
Fix the logo display in the mobile device

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -173,12 +173,12 @@ class ContextCore
                 } else {
                     switch ((int)Configuration::get('PS_ALLOW_MOBILE_DEVICE')) {
                         case 1: // Only for mobile device
-                            if ($this->isMobile() && !$this->isTablet()) {
+                            if ($this->isMobile()) {
                                 $this->mobile_device = true;
                             }
                             break;
                         case 2: // Only for touchpads
-                            if ($this->isTablet() && !$this->isMobile()) {
+                            if ($this->isTablet()) {
                                 $this->mobile_device = true;
                             }
                             break;

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1612,6 +1612,7 @@ class FrontControllerCore extends Controller
     public function initLogoAndFavicon()
     {
         $mobile_device = $this->context->getMobileDevice();
+        $isMobile = ($this->context->getDevice() !== Context::DEVICE_COMPUTER);
 
         if ($mobile_device && Configuration::get('PS_LOGO_MOBILE')) {
             $logo = $this->context->link->getMediaLink(_PS_IMG_.Configuration::get('PS_LOGO_MOBILE').'?'.Configuration::get('PS_IMG_UPDATE_TIME'));
@@ -1623,7 +1624,8 @@ class FrontControllerCore extends Controller
             'favicon_url'       => _PS_IMG_.Configuration::get('PS_FAVICON'),
             'logo_image_width'  => ($mobile_device == false ? Configuration::get('SHOP_LOGO_WIDTH')  : Configuration::get('SHOP_LOGO_MOBILE_WIDTH')),
             'logo_image_height' => ($mobile_device == false ? Configuration::get('SHOP_LOGO_HEIGHT') : Configuration::get('SHOP_LOGO_MOBILE_HEIGHT')),
-            'logo_url'          => $logo
+            'logo_url'          => $logo,
+            'showLogo'         => $isMobile ? $mobile_device : true,
         );
     }
 

--- a/themes/default-bootstrap/header.tpl
+++ b/themes/default-bootstrap/header.tpl
@@ -102,11 +102,13 @@
 					<div>
 						<div class="container">
 							<div class="row">
-								<div id="header_logo">
-									<a href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{$shop_name|escape:'html':'UTF-8'}">
-										<img class="logo img-responsive" src="{$logo_url}" alt="{$shop_name|escape:'html':'UTF-8'}"{if isset($logo_image_width) && $logo_image_width} width="{$logo_image_width}"{/if}{if isset($logo_image_height) && $logo_image_height} height="{$logo_image_height}"{/if}/>
-									</a>
-								</div>
+								{if $showLogo}
+									<div id="header_logo">
+										<a href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{$shop_name|escape:'html':'UTF-8'}">
+											<img class="logo img-responsive" src="{$logo_url}" alt="{$shop_name|escape:'html':'UTF-8'}"{if isset($logo_image_width) && $logo_image_width} width="{$logo_image_width}"{/if}{if isset($logo_image_height) && $logo_image_height} height="{$logo_image_height}"{/if}/>
+										</a>
+									</div>
+								{/if}
 								{if isset($HOOK_TOP)}{$HOOK_TOP}{/if}
 							</div>
 						</div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you disable the header logo for the mobile device, the logo remains displayed.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9289
| How to test?  | BO > Preferences > Themes > YOUR CURRENT THEME > in the **mobile** tab, set   "**I'd like to disable it.**" as value for **Enable the mobile theme**, FO > check if the logo is not appeared for mobile device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8684)
<!-- Reviewable:end -->
