### PR TITLE
Fixed link_rewrite argument for getImageLink().

### DIFF
--- a/classes/order/OrderCarrier.php
+++ b/classes/order/OrderCarrier.php
@@ -108,13 +108,14 @@ class OrderCarrierCore extends ObjectModel
 
             //try to get the first image for the purchased combination
             $img = $prod_obj->getCombinationImages($order->id_lang);
+            $link_rewrite = $prod_obj->link_rewrite[$order->id_lang];
             $combination_img = $img[$product['product_attribute_id']][0]['id_image'];
             if ($combination_img != null) {
-                $img_url = $link->getImageLink($prod_obj->link_rewrite, $combination_img, 'large_default');
+                $img_url = $link->getImageLink($link_rewrite, $combination_img, 'large_default');
             } else {
                 //if there is no combination image, then get the product cover instead
                 $img = $prod_obj->getCover($prod_obj->id);
-                $img_url = $link->getImageLink($prod_obj->link_rewrite, $img['id_image']);
+                $img_url = $link->getImageLink($link_rewrite, $img['id_image']);
             }
             $prod_url = $prod_obj->getLink();
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | if you look at the parameters it is obvious that it was that wrong type used as the first parameter for getImageLink()
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Does it break backward compatibility? yes/no
| Deprecations? | Does it deprecate an existing feature? yes/no
| Fixed ticket? | [BOOM-4650](http://forge.prestashop.com/browse/BOOM-4650)
| How to test?  | if you look at the parameters it is obvious that it was that wrong type used as the first parameter for getImageLink()
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8685)
<!-- Reviewable:end -->
