### PR TITLE
Fix the blank page when no currency defined in the shop

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -620,9 +620,9 @@ class ToolsCore
             return $currency;
         } else {
             // get currency from context
-            $currency = Shop::getEntityIds('currency', Context::getContext()->shop->id, true, true);
-            if (isset($currency[0]) && $currency[0]['id_currency']) {
-                $cookie->id_currency = $currency[0]['id_currency'];
+            $currentCurrency = Shop::getEntityIds('currency', Context::getContext()->shop->id, true, true);
+            if (isset($currentCurrency[0]) && $currentCurrency[0]['id_currency']) {
+                $cookie->id_currency = $currentCurrency[0]['id_currency'];
                 return Currency::getCurrencyInstance((int)$cookie->id_currency);
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When visiting the shop without any currency defined, you got a blank page (with error 500).
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7314
| How to test?  | BO > activate multistore, create a new shop without importing the currencies, FO > check if you can visit the new store.

**Important:** It is necessary to define a currency for the proper functioning of the store.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8686)
<!-- Reviewable:end -->
