### PR TITLE
Add the footable JS lib to the discount page

### DIFF
--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -52,7 +52,7 @@ class DiscountControllerCore extends FrontController
                 new Currency((int)$discount['reduction_currency']),
                 new Currency((int)$this->context->cart->id_currency)
             );
-            
+
             if ((int)$discount['gift_product'] !== 0) {
                 $product = new Product((int) $discount['gift_product'], false, (int)$this->context->language->id);
                 if (!Validate::isLoadedObject($product) || !$product->isAssociatedToShop() || !$product->active) {
@@ -92,5 +92,15 @@ class DiscountControllerCore extends FrontController
         ));
 
         $this->setTemplate(_PS_THEME_DIR_.'discount.tpl');
+    }
+
+    /**
+     * Sets controller CSS and JS files.
+     * @see FrontController::setMedia()
+     */
+    public function setMedia()
+    {
+        parent::setMedia();
+        $this->addJqueryPlugin(array('footable'));
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | On mobile devices, in the discount page, some table cells should hide to fit the width of screen. But it doesn't work. does not work.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7285
| How to test?  | FO > My account > My vouchers, check if the vouchers table is displayed correctly on mobile devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8688)
<!-- Reviewable:end -->
