### PR TITLE
Fix translator in prod mode

### DIFF
--- a/install-dev/missing_requirement.php
+++ b/install-dev/missing_requirement.php
@@ -113,7 +113,7 @@
     <?php endif; ?>
         <?php if (!is_writable(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'cache')): ?>
       <li>
-          PrestaShop installation needs to write critical files in the folder app/var.
+          PrestaShop installation needs to write critical files in the folder var/cache.
           <i>Please review the permissions on your server.</i>
       </li>
     <?php endif; ?>

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
@@ -33,6 +33,9 @@ class OverrideServiceCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        $definition = $container->getDefinition('translator.default');
+        $definition->setClass($container->getParameter('translator.class'));
+
         if (!in_array($container->getParameter("kernel.environment"), array('dev', 'test'))) {
             return;
         }

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideTranslatorServiceCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideTranslatorServiceCompilerPass.php
@@ -29,6 +29,11 @@ namespace PrestaShopBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * On Symfony 3.x, the parameters like `translator.class` are not used anymore and cannot override the original services.
+ * This made the translations unavailable in prod mode, and the module page was crashing.
+ * This class replaces the symfony translator with PrestaShop's extended one when in prod mode.
+ */
 class OverrideTranslatorServiceCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideTranslatorServiceCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideTranslatorServiceCompilerPass.php
@@ -29,7 +29,7 @@ namespace PrestaShopBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class OverrideServiceCompilerPass implements CompilerPassInterface
+class OverrideTranslatorServiceCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {

--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -28,7 +28,7 @@ namespace PrestaShopBundle;
 use PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass;
 use PrestaShopBundle\DependencyInjection\Compiler\RemoveXmlCompiledContainerPass;
 use PrestaShopBundle\DependencyInjection\Compiler\PopulateTranslationProvidersPass;
-use PrestaShopBundle\DependencyInjection\Compiler\OverrideServiceCompilerPass;
+use PrestaShopBundle\DependencyInjection\Compiler\OverrideTranslatorServiceCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -59,6 +59,6 @@ class PrestaShopBundle extends Bundle
         $container->addCompilerPass(new LoadServicesFromModulesPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new RemoveXmlCompiledContainerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RouterPass(), PassConfig::TYPE_AFTER_REMOVING);
-        $container->addCompilerPass(new OverrideServiceCompilerPass());
+        $container->addCompilerPass(new OverrideTranslatorServiceCompilerPass());
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On Symfony 3.x, the parameters like `translator.class` are not used anymore and cannot override the original services. This made the translations unavailable in prod mode, and the module page was crashing. The objective of this PR is to use the existing OverrideServiceCompilerPass in order to replace the symfony translator by our extended one.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Switch off the debug mode, and reach the module page. Check also translations are available.

Please note I'm probably not following the best practice (see https://github.com/symfony/symfony/issues/17957#issuecomment-195034781), however this is the only that worked for now. Open for imoprovements!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8689)
<!-- Reviewable:end -->
