### PR TITLE
Fix the type of tax calculation method in the order details page

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -282,12 +282,9 @@ class OrderCore extends ObjectModel
     {
         parent::__construct($id, $id_lang);
 
-        $is_admin = (is_object(Context::getContext()->controller) && Context::getContext()->controller->controller_type == 'admin');
-        if ($this->id_customer && !$is_admin) {
+        if ($this->id_customer) {
             $customer = new Customer((int)$this->id_customer);
             $this->_taxCalculationMethod = Group::getPriceDisplayMethod((int)$customer->id_default_group);
-        } else {
-            $this->_taxCalculationMethod = Group::getDefaultPriceDisplayMethod();
         }
     }
 
@@ -1194,7 +1191,7 @@ class OrderCore extends ObjectModel
                 FROM `'._DB_PREFIX_.'order_invoice`'.(Configuration::get('PS_INVOICE_RESET') ?
                 ' WHERE DATE_FORMAT(`date_add`, "%Y") = '.(int)date('Y') : '');
             $new_number = DB::getInstance()->getValue($new_number_sql);
-            
+
             $sql .= (int)$new_number;
         }
 
@@ -2282,7 +2279,7 @@ class OrderCore extends ObjectModel
                 $order_discount_tax_excl -= $order_cart_rule['value_tax_excl'];
             }
         }
-        
+
         $expected_total_tax = $this->total_products_wt - $this->total_products;
         $actual_total_tax = 0;
         $actual_total_base = 0;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | The price is displayed with tax included when the customer group is configured with tax excluded in the order details page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9680 and Fixes #15528
| How to test?  | BO > create new customer group (**G1**) with **Price display method** = **Tax excluded**, FO > create a new customer with his group and default group are **G1**, create a new order, BO > the order details and check if the prices is displayed with tax excluded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8692)
<!-- Reviewable:end -->
