### PR TITLE
Product name error if not english

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -89,7 +89,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
                         $product = $this->productAdapter->getProduct($id);
                         $collection[] = array(
                             'id' => $id,
-                            'name' => $product->name[(int)\Context::getContext->language->id].' (ref:'.$product->reference.')',
+                            'name' => reset($product->name).' (ref:'.$product->reference.')',
                             'image' => $product->image,
                         );
                         break;

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -89,7 +89,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
                         $product = $this->productAdapter->getProduct($id);
                         $collection[] = array(
                             'id' => $id,
-                            'name' => $product->name[1].' (ref:'.$product->reference.')',
+                            'name' => $product->name[(int)\Context::getContext->language->id].' (ref:'.$product->reference.')',
                             'image' => $product->image,
                         );
                         break;


### PR DESCRIPTION
Value 1 means english, but if store delete or change this language code get a fatal error.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7
| Description?  | An store without english installed, english was deleted from available languages, then get a fatal error when get product data
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/DOC-538
| How to test?  | delete english language, open a product and you get error if language id_lang = 1 is not available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8694)
<!-- Reviewable:end -->
