### PR TITLE
Fix the sorting by price in the products filtering page

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -773,11 +773,24 @@ class CategoryCore extends ObjectModel
                     .($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '')
                     .($id_supplier ? ' AND p.id_supplier = '.(int)$id_supplier : '');
 
+        $limitOffset = 0;
+        $limitLength = (int)$random_number_products;
+        $isOrderByPrice = ($order_by === 'orderprice');
+
         if ($random === true) {
-            $sql .= ' ORDER BY RAND() LIMIT '.(int)$random_number_products;
+            $sql .= ' ORDER BY RAND()';
+
+            if (!$isOrderByPrice) {
+                $sql .= ' LIMIT ' . $limitLength;
+            }
         } else {
-            $sql .= ' ORDER BY '.(!empty($order_by_prefix) ? $order_by_prefix.'.' : '').'`'.bqSQL($order_by).'` '.pSQL($order_way).'
-			LIMIT '.(((int)$p - 1) * (int)$n).','.(int)$n;
+            $limitLength = (int)$n;
+            $limitOffset = (((int)$p - 1) * $limitLength);
+            $sql .= ' ORDER BY ' . (!empty($order_by_prefix) ? $order_by_prefix . '.' : '') . '`' . bqSQL($order_by) . '` ' . pSQL($order_way);
+
+            if (!$isOrderByPrice) {
+                $sql .= ' LIMIT ' . $limitOffset . ',' . $limitLength;
+            }
         }
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql, true, false);
@@ -786,8 +799,9 @@ class CategoryCore extends ObjectModel
             return array();
         }
 
-        if ($order_by == 'orderprice') {
+        if ($isOrderByPrice) {
             Tools::orderbyPrice($result, $order_way);
+            $result = array_splice($result, $limitOffset, $limitLength);
         }
 
         /** Modify SQL result */


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | The sorting by price does not work correctly with pagination, when there are discounts on products.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7452
| How to test?  | BO > apply a discount to product, disable the blocklayered module, FO > category page, try to sort the products by price and check if the products are displayed in order in all pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8699)
<!-- Reviewable:end -->
