### PR TITLE
Admin permission detection of Role classe name

### DIFF
--- a/classes/Profile.php
+++ b/classes/Profile.php
@@ -214,7 +214,7 @@ class ProfileCore extends ObjectModel
     private static function findIdTabByAuthSlug($authSlug)
     {
         preg_match(
-            '/ROLE_MOD_[A-Z]+_(?P<classname>[A-Z]+)_(?P<auth>[A-Z]+)/',
+            '/ROLE_MOD_[A-Z]+_(?P<classname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)_(?P<auth>[A-Z]+)/',
             $authSlug,
             $matches
         );

--- a/classes/Profile.php
+++ b/classes/Profile.php
@@ -214,7 +214,7 @@ class ProfileCore extends ObjectModel
     private static function findIdTabByAuthSlug($authSlug)
     {
         preg_match(
-            '/ROLE_MOD_[A-Z]+_(?P<classname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)_(?P<auth>[A-Z]+)/',
+            '/ROLE_MOD_[A-Z]+_(?P<classname>[A-Z][A-Z0-9]*)_(?P<auth>[A-Z]+)/',
             $authSlug,
             $matches
         );


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a back office tab is created, Roles and permissions depends of php class name of the tab, as module can  create them also, the check should accept them
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | see bellow please

-----------
How to test
Create a module Who register a BO tab, ( an example can be found on  ps_linklist : https://github.com/PrestaShop/ps_linklist/blob/master/ps_linklist.php#L87 )
name the tab class for instances AdminLink2_Widget , 

then look at your bo menu, , before this pach, permissions could not be checked, so only super profile had access to the tab.

----------
Where i find this rexep ?
this regexp came from Php docs, and seem to be the recommanded rexexp to check a Class name
http://php.net/manual/en/language.oop5.basic.php

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8700)
<!-- Reviewable:end -->
