### PR TITLE
Support Arabic numbers in the Product page

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -46,6 +46,18 @@ var Tools = {
       return parsed;
     }
 
+    // replace arabic numbers by latin
+		value = value
+			// arabic
+			.replace(/[\u0660-\u0669]/g, function(d) {
+				return d.charCodeAt(0) - 1632;
+			})
+			// persian
+			.replace(/[\u06F0-\u06F9]/g, function(d) {
+        return d.charCodeAt(0) - 1776;
+      })
+		;
+
     // remove all non-digit characters
     var split = value.split(/[^\dE-]+/);
 

--- a/src/PrestaShopBundle/Utils/FloatParser.php
+++ b/src/PrestaShopBundle/Utils/FloatParser.php
@@ -32,6 +32,31 @@ namespace PrestaShopBundle\Utils;
  */
 class FloatParser
 {
+    private static $translationTable = array(
+        // arabic numbers
+        "٠" => "0",
+        "١" => "1",
+        "٢" => "2",
+        "٣" => "3",
+        "٤" => "4",
+        "٥" => "5",
+        "٦" => "6",
+        "٧" => "7",
+        "٨" => "8",
+        "٩" => "9",
+        // persian numbers (NOT the same UTF codes!)
+        "۰" => "0",
+        "۱" => "1",
+        "۲" => "2",
+        "۳" => "3",
+        "۴" => "4",
+        "۵" => "5",
+        "۶" => "6",
+        "۷" => "7",
+        "۸" => "8",
+        "۹" => "9",
+    );
+
     /**
      * Constructs a float value from an arbitrarily-formatted string.
      *
@@ -63,6 +88,12 @@ class FloatParser
         if ('' === $value) {
             return 0.0;
         }
+
+        // replace arabic numbers by latin
+        $value = strtr(
+            $value,
+            self::$translationTable
+        );
 
         // remove all non-digit characters
         $split = preg_split('/[^\dE-]+/', $value);

--- a/tests/Unit/PrestaShopBundle/Utils/FloatParserTest.php
+++ b/tests/Unit/PrestaShopBundle/Utils/FloatParserTest.php
@@ -81,6 +81,10 @@ class FloatParserTest extends \PHPUnit_Framework_TestCase
             ['12,345,678', 12345.678],
             ['9.E-10', 9.E-10],
             ['-1,234,567.89', -1234567.89],
+            // persian
+            'persian' => ['۲۰٫۵۰۱۲۳۶۴', 20.5012364],
+            // arabic
+            'arabic' => ['٢٠٫٥٠١٢٣٦٤', 20.5012364],
             // edge cases
             ['1 dot 10', 1.1],
             ['1 hundred and 10 dot 15', 110.15],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | The Product page was not working properly in Arabic or Persian because of its inability to handle Arabic numbers. This PR allows it to handle both Arabic and Persian numbers. Support is probably still buggy, but the foundation is now there. At least you can load the page and save it!
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4319
| How to test?  | Load the Product page in Arabic or Persian, try to input some Arabic numbers in the price, it should be translated to latin numbers immediately.<br>You should also be able to save the page if it's loaded with Arabic numbers and you didn't change anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8704)
<!-- Reviewable:end -->
