### PR TITLE
Default AJAX Relevance search sort order is wrong

### DIFF
--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -66,7 +66,7 @@ class SearchControllerCore extends ProductListingFrontController
     {
         $query = new ProductSearchQuery();
         $query
-            ->setSortOrder(new SortOrder('product', Tools::getProductsOrder('by'), Tools::getProductsOrder('way')))
+            ->setSortOrder(new SortOrder('product', Tools::getProductsOrder('by', 4), Tools::getProductsOrder('way', 1)))
             ->setSearchString($this->search_string)
             ->setSearchTag($this->search_tag);
 

--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -66,7 +66,7 @@ class SearchControllerCore extends ProductListingFrontController
     {
         $query = new ProductSearchQuery();
         $query
-            ->setSortOrder(new SortOrder('product', Tools::getProductsOrder('by', 4), Tools::getProductsOrder('way', 1)))
+            ->setSortOrder(new SortOrder('product', 'position', 'desc'))
             ->setSearchString($this->search_string)
             ->setSearchTag($this->search_tag);
 

--- a/src/Core/Product/Search/SortOrderFactory.php
+++ b/src/Core/Product/Search/SortOrderFactory.php
@@ -41,7 +41,7 @@ class SortOrderFactory
     public function getDefaultSortOrders()
     {
         return [
-            (new SortOrder('product', 'position', 'asc'))->setLabel(
+            (new SortOrder('product', 'position', 'desc'))->setLabel(
                 $this->translator->trans('Relevance', array(), 'Shop.Theme.Catalog')
             ),
             (new SortOrder('product', 'name', 'asc'))->setLabel(


### PR DESCRIPTION
This PR is a cherry-pick from: https://github.com/PrestaShop/PrestaShop/pull/8458 and https://github.com/PrestaShop/PrestaShop/pull/8399

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | default AJAX Product search Relevance sort order is wrong
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | search for "summer" in demo store. All products with the "summer" in the product name should appear at the first lines in the AJAX search results, but I see them at the 3rd and 4th positions (results shown immediately but in the ASC relevance order instead of DESC). This error is continuation of the pull request #8399. The issue was not fixed in full. as an addition to the fix in pull request #8399 I suggest the following change in the controllers/front/listing/SearchController.php:   ->setSortOrder(new SortOrder('product', Tools::getProductsOrder('by', 4), Tools::getProductsOrder('way', 1))) instead of ->setSortOrder(new SortOrder('product', Tools::getProductsOrder('by'), Tools::getProductsOrder('way')))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8711)
<!-- Reviewable:end -->
