### PR TITLE
Update loaded details from database on module action

### DIFF
--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -215,6 +215,8 @@ class Module implements ModuleInterface
 
         $result = $this->instance->install();
         $this->database->set('installed', $result);
+        $this->database->set('active', $result);
+        $this->database->set('version', $this->attributes->get('version'));
         return $result;
     }
 
@@ -237,6 +239,7 @@ class Module implements ModuleInterface
      */
     public function onUpgrade($version)
     {
+        $this->database->set('version', $this->attributes->get('version_available'));
         return true;
     }
 

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -329,7 +329,7 @@ class ModuleManager implements AddonManagerInterface
         $module = $this->moduleRepository->getModule($name);
 
         // Load and execute upgrade files
-        $result = $this->moduleUpdater->upgrade($name);
+        $result = $this->moduleUpdater->upgrade($name) && $module->onUpgrade($version);
         $this->dispatch(ModuleManagementEvent::UPGRADE, $module);
 
         return $result;

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -264,6 +264,9 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
             ->method('onInstall')
             ->willReturn(true);
         $moduleS
+            ->method('onUpgrade')
+            ->willReturn(true);
+        $moduleS
             ->method('onUninstall')
             ->willReturn(true);
         $moduleS


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Update module details during request to avoid wrong action buttons to be displayed.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? |Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4721
| How to test?  | Installing / upgrading a module should not display "upgrade" anymore as the next step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8714)
<!-- Reviewable:end -->
