### PR TITLE
Add the shop address in the credit slip PDF

### DIFF
--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -154,7 +154,8 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
             'invoice_address' => $formatted_invoice_address,
             'addresses' => array('invoice' => $invoice_address, 'delivery' => $delivery_address),
             'tax_excluded_display' => $tax_excluded_display,
-            'total_cart_rule' => $total_cart_rule
+            'total_cart_rule' => $total_cart_rule,
+            'shopAddress' => OrderInvoice::getCurrentFormattedShopAddress((int)$this->order->id_shop),
         ));
 
         $tpls = array(

--- a/pdf/invoice.addresses-tab.tpl
+++ b/pdf/invoice.addresses-tab.tpl
@@ -25,7 +25,11 @@
 <table id="addresses-tab" cellspacing="0" cellpadding="0">
 	<tr>
 		<td width="33%"><span class="bold"> </span><br/><br/>
-			{if isset($order_invoice)}{$order_invoice->shop_address}{/if}
+			{if isset($order_invoice)}
+				{$order_invoice->shop_address}
+			{elseif isset($shopAddress)}
+				{$shopAddress}
+			{/if}
 		</td>
 		<td width="33%">{if $delivery_address}<span class="bold">{l s='Delivery Address' pdf='true'}</span><br/><br/>
 				{$delivery_address}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | The credit slip doesn't contains any shop information.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9709
| How to test?  | BO > generate the credit slip PDF and check if it's contains the shop information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8715)
<!-- Reviewable:end -->
