### PR TITLE
Prevent Shopname in Header from breaking elements

### DIFF
--- a/admin-dev/themes/default/sass/partials/_header.sass
+++ b/admin-dev/themes/default/sass/partials/_header.sass
@@ -24,6 +24,10 @@
 #header_shopname
 	@extend .navbar-brand
 	text-decoration: none
+	max-width: 150px
+	overflow: hidden
+	white-space: nowrap
+	text-overflow: ellipsis
 
 #header_notifs_icon_wrapper
 	@extend .nav


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fixed the width size of ShopName in Header, since on shops with a long shop name can break the remaining elements on the right.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| How to test?  | Add a long shop name with more than 30 characters and you will see the elements on the right to break there position.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8716)
<!-- Reviewable:end -->
