### PR TITLE
Don't show order slips for canceled orders

### DIFF
--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -136,11 +136,13 @@ class OrderSlipCore extends ObjectModel
     public static function getOrdersSlip($customer_id, $order_id = false)
     {
         return Db::getInstance()->executeS('
-		SELECT *
-		FROM `'._DB_PREFIX_.'order_slip`
-		WHERE `id_customer` = '.(int)($customer_id).
-        ($order_id ? ' AND `id_order` = '.(int)($order_id) : '').'
-		ORDER BY `date_add` DESC');
+		SELECT os.*
+		FROM `'._DB_PREFIX_.'order_slip` os
+		LEFT JOIN `'._DB_PREFIX_.'orders` o ON (o.`id_order` = os.`id_order`)
+		WHERE os.`id_customer` = '.(int)($customer_id).
+        ($order_id ? ' AND os.`id_order` = '.(int)($order_id) : '').'
+		AND o.`current_state` != '.(int)Configuration::get('PS_OS_CANCELED').'
+		ORDER BY os.`date_add` DESC');
     }
 
     public static function getOrdersSlipDetail($id_order_slip = false, $id_order_detail = false)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In "My account > Order slips", you can see and download order slips even for canceled orders. You should only see order slips for valid orders (paid and delivered).
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create an order slip for a paid order, then cancel this order. With the customer account, go to "FO > My account > Order slips" and you will be able to download the order slip whereas the order has been canceled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8717)
<!-- Reviewable:end -->
