### PR TITLE
Fix missing CLDR supplemental directory

### DIFF
--- a/src/Core/Cldr/Composer/Hook.php
+++ b/src/Core/Cldr/Composer/Hook.php
@@ -35,7 +35,7 @@ use Composer\Script\Event;
 class Hook
 {
     /** @var string */
-    const ZIP_CORE_URL = 'https://i18n.prestashop.com/cldr/core.zip';
+    const ZIP_CORE_URL = 'https://i18n.prestashop.com/cldr/cldr.zip';
 
     /**
      * Triggers CLDR download
@@ -51,11 +51,11 @@ class Hook
         }
         $root_dir = realpath(__DIR__ . '/../../../../');
         $cldrFolder = "$root_dir/translations/cldr";
-        $coreFilePath = "$cldrFolder/core.zip";
+        $cldrFilePath = "$cldrFolder/cldr.zip";
         $zipUrl = self::ZIP_CORE_URL;
 
-        if (!file_exists($coreFilePath)) {
-            $fp = fopen($coreFilePath, "w");
+        if (!file_exists($cldrFilePath)) {
+            $fp = fopen($cldrFilePath, "w");
             $ch = curl_init($zipUrl);
             curl_setopt($ch, CURLOPT_FILE, $fp);
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
@@ -67,6 +67,8 @@ class Hook
             if (!empty($error)) {
                 throw new \Exception("Failed to download '$zipUrl', error: '$error'.");
             };
+            exec("cd $cldrFolder && unzip -oqq $cldrFilePath -d .. && cd -");
+            unlink($cldrFilePath);
         }
 
         if ($event) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Fix missing CLDR supplemental directory.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No
| How to test?  | Create a release and check if translations/cldr/datas/supplemental directory exists.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8719)
<!-- Reviewable:end -->
