### PR TITLE
Change default group when transform guest to customer

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -769,10 +769,13 @@ class CustomerCore extends ObjectModel
             return false;
         }
 
+        $customerGroupId = (int)Configuration::get('PS_CUSTOMER_GROUP');
         $this->is_guest = 0;
         $this->passwd = Tools::encrypt($password);
         $this->cleanGroups();
-        $this->addGroups(array(Configuration::get('PS_CUSTOMER_GROUP'))); // add default customer group
+        $this->addGroups(array($customerGroupId));
+        /** Change default customer group */
+        $this->id_default_group = $customerGroupId;
         if ($this->update()) {
             $vars = array(
                 '{firstname}' => $this->firstname,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | After ordering with **guest account**, when try to transform a **Guest** account to **Customer**, the default group "Guest"  does not change to "Customer".
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9731
| How to test?  | BO > Preferences > Orders > Enable guest checkout, FO > order with a guest account and transform the guest account to customer, BO > Customers, check if the default customer group is chenged to **Customer**.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8721)
<!-- Reviewable:end -->
