### PR TITLE
Fix the warehouse address validation

### DIFF
--- a/controllers/admin/AdminWarehousesController.php
+++ b/controllers/admin/AdminWarehousesController.php
@@ -591,6 +591,9 @@ class AdminWarehousesControllerCore extends AdminController
         /** @var AddressCore $address */
         $address = new Address();
 
+        /** @var array $addressFields - The warehouse address fields */
+        $addressFields = array('alias', 'lastname', 'firstname', 'address1', 'address2', 'postcode', 'phone', 'id_country', 'id_state', 'city');
+
         if (Tools::isSubmit('id_address') && (int)Tools::getValue('id_address') > 0) {
             $address = new Address((int)Tools::getValue('id_address'));
         }
@@ -625,14 +628,20 @@ class AdminWarehousesControllerCore extends AdminController
         // checks address validity
         if (count($validation) > 0) {
             // if not valid
+            $hasAddressError = false;
 
-            foreach ($validation as $item) {
-                $this->errors[] = $item;
+            foreach ($validation as $key => $item) {
+                if (in_array($key, $addressFields)) {
+                    $hasAddressError = true;
+                    $this->errors[] = $item;
+                }
             }
 
-            $this->errors[] = Tools::displayError(
-                'The address is not correct. Please make sure all of the required fields are completed.'
-            );
+            if ($hasAddressError) {
+                $this->errors[] = Tools::displayError(
+                    'The address is not correct. Please make sure all of the required fields are completed.'
+                );
+            }
         } else {
             // valid
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you set up the address with the **company** field is required, you can not add a new wearhouse.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9555
| How to test?  | BO > Customers > Addresses > select the **company** field as required, BO > Stock > add new warehouse and fill all required fields, save and check if the saving successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8723)
<!-- Reviewable:end -->
