### PR TITLE
PHP 7.2 compat - Fix fatal error

### DIFF
--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -150,7 +150,7 @@ class AdminLoginControllerCore extends AdminController
      *
      * @return bool
      */
-    public function viewAccess()
+    public function viewAccess($disable = false)
     {
         return true;
     }

--- a/controllers/admin/AdminNotFoundController.php
+++ b/controllers/admin/AdminNotFoundController.php
@@ -37,7 +37,7 @@ class AdminNotFoundControllerCore extends AdminController
         return true;
     }
 
-    public function viewAccess()
+    public function viewAccess($disable = false)
     {
         return true;
     }

--- a/controllers/admin/AdminPatternsController.php
+++ b/controllers/admin/AdminPatternsController.php
@@ -37,7 +37,7 @@ class AdminPatternsControllerCore extends AdminController
         parent::__construct();
     }
 
-    public function viewAccess()
+    public function viewAccess($disable = false)
     {
         return true;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fix PHP fatal error.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Try to access admin login page. It might be specific to PHP 7.2.

```
Fatal error: Declaration of AdminLoginControllerCore::viewAccess() must be compatible with AdminControllerCore::viewAccess($disable = false) in <path>\www\controllers\admin\AdminLoginController.php on line 27
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8724)
<!-- Reviewable:end -->
