### PR TITLE
CO: Re-use existing getInvoiceNumberFormatted logic for pdf filename

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -502,17 +502,8 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
     {
         $id_lang = Context::getContext()->language->id;
         $id_shop = (int)$this->order->id_shop;
-        $format = '%1$s%2$06d';
 
-        if (Configuration::get('PS_INVOICE_USE_YEAR')) {
-            $format = Configuration::get('PS_INVOICE_YEAR_POS') ? '%1$s%3$s-%2$06d' : '%1$s%2$06d-%3$s';
-        }
-
-        return sprintf(
-            $format,
-            Configuration::get('PS_INVOICE_PREFIX', $id_lang, null, $id_shop),
-            $this->order_invoice->number,
-            date('Y', strtotime($this->order_invoice->date_add))
-        ).'.pdf';
+        $number = $this->order_invoice->getInvoiceNumberFormatted($id_lang, $id_shop);
+        return str_replace('/', '-', $number) . '.pdf';
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The pdf for an invoice should have the invoice number as filename. Currently there is a inconsistency as the 'formatting' of the invoice number has been duplicated in the invoice template, but without calling the `actionInvoiceNumberFormatted` hook. As the only reason for the duplicate implementation appears to be the use of `/` when adding a year to the invoice number, we can also just retrieve the formatted invoice number from OrderInvoice and use `str_replace`. This gives the extra benefit that all `/` are replaced (eg also the once the user adds in his hook). <br/><br/>Due to this issue I also noticed that when sending the invoice as pdf attachment per email, the pdf filename is also not consistent. It would be best I think to add a `getFilename` method in `PDFCore` but that's beyond the scope of this bug for the moment.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | na
| How to test?  | Add a module with an actionInvoiceNumberFormatted hook that returns a custom invoice number and check in admin->orders if the downloaded pdf file also uses that custom invoice number

Btw, am I correct there are no test cases for individual hook implementations? If there are then I missed them at least and will add a test case for this :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8727)
<!-- Reviewable:end -->
