### PR TITLE
Prevent cache invalidation caused by a random variable

### DIFF
--- a/admin-dev/themes/new-theme/js/header.js
+++ b/admin-dev/themes/new-theme/js/header.js
@@ -51,7 +51,6 @@ export default class Header {
       if (method === 'add' && name || method === 'remove') {
         let postLink = $(e.target).data('post-link');
         let quickLinkId = $(e.target).data('quicklink-id');
-        let rand = $(e.target).data('rand');
         let url = $(e.target).data('url');
         let icon = $(e.target).data('icon');
 
@@ -61,7 +60,7 @@ export default class Header {
             "cache-control": "no-cache"
           },
           async: true,
-          url: `${postLink}&action=GetUrl&rand=${rand}&ajax=1&method=${method}&id_quick_access=${quickLinkId}`,
+          url: `${postLink}&action=GetUrl&ajax=1&method=${method}&id_quick_access=${quickLinkId}`,
           data: {
             "url": url,
             "name": name,

--- a/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
@@ -18,7 +18,6 @@
         href="#"
         data-method="remove"
         data-quicklink-id="{$matchQuickLink}"
-        data-rand="{1|rand:200}"
         data-icon="{$quick_access_current_link_icon}"
         data-url="{$link->getQuickLink($smarty.server['REQUEST_URI']|escape:'javascript')}"
         data-post-link="{$link->getAdminLink('AdminQuickAccesses')}"
@@ -32,7 +31,6 @@
       <a
         class="dropdown-item js-quick-link"
         href="#"
-        data-rand="{1|rand:200}"
         data-icon="{$quick_access_current_link_icon}"
         data-method="add"
         data-url="{$link->getQuickLink($smarty.server['REQUEST_URI']|escape:'javascript')}"


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Unused random variable is constantly invalidating the page cache
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Add a page to quick access in BO, it should still work without the rand variable

I noticed that the page cache is getting invalidated with no apparent reason. 
I tested on the product edit page.
After some investigation, I found that there is a random variable that is changing between loads and causing invalidation. Thus, the whole page is written to cache every time. 
This made the cache always grow bigger as well as a minor performance hit
**The cache also gets invalidated due to the dynamic messages in the notification panel**, but the number of combinations of these messages is not as large as the rand variable variations

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8728)
<!-- Reviewable:end -->
