### PR TITLE
Wrong permissions for image folders

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -663,11 +663,12 @@ class ImageCore extends ObjectModel
 
         if (!file_exists(_PS_PROD_IMG_DIR_.$this->getImgFolder())) {
             // Apparently sometimes mkdir cannot set the rights, and sometimes chmod can't. Trying both.
-            $success = @mkdir(_PS_PROD_IMG_DIR_.$this->getImgFolder(), self::$access_rights, true);
-            $chmod = @chmod(_PS_PROD_IMG_DIR_.$this->getImgFolder(), self::$access_rights);
+            $umask = umask(0);
+            $success = mkdir(_PS_PROD_IMG_DIR_.$this->getImgFolder(), self::$access_rights, true);
+            umask($umask);
 
             // Create an index.php file in the new folder
-            if (($success || $chmod)
+            if (($success)
                 && !file_exists(_PS_PROD_IMG_DIR_.$this->getImgFolder().'index.php')
                 && file_exists($this->source_index)) {
                 return @copy($this->source_index, _PS_PROD_IMG_DIR_.$this->getImgFolder().'index.php');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x.
| Description?  | Image folder is being created with wrong permissions, and chmod works only on the last directory. chmod does not recursively change permissions, so mkdir makes dirs with wrong permissions and chmod only changes the last one. Ive seen this solution within PrestaShop files elsewhere, but it is only a suggestion.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to create directory tree for images and watch how permissions work before and after this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8729)
<!-- Reviewable:end -->
