### PR TITLE
FO Don't display shipping method for virtual cart

### DIFF
--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -55,7 +55,7 @@
       </div>
     </div>
   </div>
-
+{if !$cart.is_virtual}
   <div class="row">
     <div class="col-md-12">
       <h4 class="h4">
@@ -87,7 +87,7 @@
       </div>
     </div>
   </div>
-
+{/if}
   <div class="row">
     {block name='order_confirmation_table'}
       {include file='checkout/_partials/order-final-summary-table.tpl'

--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -55,39 +55,41 @@
       </div>
     </div>
   </div>
-{if !$cart.is_virtual}
-  <div class="row">
-    <div class="col-md-12">
-      <h4 class="h4">
-      {l s='Shipping Method' d='Shop.Theme.Checkout'}
-        <span class="step-edit step-to-delivery js-edit-delivery"><i class="material-icons edit">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
-      </h4>
 
-      <div class="col-md-12 summary-selected-carrier">
-        <div class="row">
-          <div class="col-md-2">
-            <div class="logo-container">
-              {if $selected_delivery_option.logo}
-                <img src="{$selected_delivery_option.logo}" alt="{$selected_delivery_option.name}" loading="lazy">
-              {else}
-                &nbsp;
-              {/if}
+  {if !$cart.is_virtual}
+    <div class="row">
+      <div class="col-md-12">
+        <h4 class="h4">
+          {l s='Shipping Method' d='Shop.Theme.Checkout'}
+          <span class="step-edit step-to-delivery js-edit-delivery"><i class="material-icons edit">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
+        </h4>
+
+        <div class="col-md-12 summary-selected-carrier">
+          <div class="row">
+            <div class="col-md-2">
+              <div class="logo-container">
+                {if $selected_delivery_option.logo}
+                  <img src="{$selected_delivery_option.logo}" alt="{$selected_delivery_option.name}" loading="lazy">
+                {else}
+                  &nbsp;
+                {/if}
+              </div>
             </div>
-          </div>
-          <div class="col-md-4">
-            <span class="carrier-name">{$selected_delivery_option.name}</span>
-          </div>
-          <div class="col-md-4">
-            <span class="carrier-delay">{$selected_delivery_option.delay}</span>
-          </div>
-          <div class="col-md-2">
-            <span class="carrier-price">{$selected_delivery_option.price}</span>
+            <div class="col-md-4">
+              <span class="carrier-name">{$selected_delivery_option.name}</span>
+            </div>
+            <div class="col-md-4">
+              <span class="carrier-delay">{$selected_delivery_option.delay}</span>
+            </div>
+            <div class="col-md-2">
+              <span class="carrier-price">{$selected_delivery_option.price}</span>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-{/if}
+  {/if}
+
   <div class="row">
     {block name='order_confirmation_table'}
       {include file='checkout/_partials/order-final-summary-table.tpl'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you have virtual cart, the shipping method is display in payment section, if you have "Enable final summary"
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fix #19963
| How to test?  |  1 Bo > Preference > Order, check "Enable final summary", 2 Buy a virtual product, 3 In payment section, the shipping method section **is not displayed**.  <br/> 1 Bo > Preference > Order, check "Enable final summary", 2 Buy a virtual product and a standard product, 3 In payment section, the shipping method section **is not displayed**<br/> 1 Bo > Preference > Order, check "Enable final summary", 2 Buy 2 virtual product, 3 In payment section the shipping method section **is displayed**
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8738)
<!-- Reviewable:end -->
