### PR TITLE
Fix the address validation when updating/deleting Manufacturers and Suppliers

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -458,4 +458,27 @@ class AddressCore extends ObjectModel
         }
         return array();
     }
+
+    /**
+     * @see ObjectModel::validateFields()
+     */
+    public function validateFields($die = true, $error_return = false)
+    {
+        /** @var array $skippedFields - List of fields that do not check them */
+        $skippedFields = array();
+
+        if ($this->id_manufacturer > 0) {
+            $skippedFields = array('vat_number', 'dni');
+        }
+
+        if (!empty($skippedFields)) {
+            foreach ($this->def['fields'] as $field => $data) {
+                if (in_array($field, $skippedFields)) {
+                    unset($this->def['fields'][$field]);
+                }
+            }
+        }
+
+        parent::validateFields($die, $error_return);
+    }
 }

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -471,8 +471,13 @@ class AddressCore extends ObjectModel
             $skippedFields = array('vat_number', 'dni');
         }
 
+        if ($this->id_supplier > 0) {
+            $skippedFields = array('company', 'vat_number', 'dni');
+        }
+
         if (!empty($skippedFields)) {
-            foreach ($this->def['fields'] as $field => $data) {
+            $fields = array_keys($this->def['fields']);
+            foreach ($fields as $field) {
                 if (in_array($field, $skippedFields)) {
                     unset($this->def['fields'][$field]);
                 }

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -452,6 +452,10 @@ class AdminSuppliersControllerCore extends AdminController
                 return;
             }
 
+            /** @var array $addressFields - The Supplier address fields */
+            $addressFields = array('alias', 'lastname', 'firstname', 'address1', 'address2', 'postcode', 'phone',
+                'phone_mobile', 'id_country', 'id_state', 'city');
+
             // updates/creates address if it does not exist
             if (Tools::isSubmit('id_address') && (int)Tools::getValue('id_address') > 0) {
                 $address = new Address((int)Tools::getValue('id_address'));
@@ -476,10 +480,20 @@ class AdminSuppliersControllerCore extends AdminController
 
             // checks address validity
             if (count($validation) > 0) {
-                foreach ($validation as $item) {
-                    $this->errors[] = $item;
+                $hasAddressError = false;
+
+                foreach ($validation as $field => $item) {
+                    if (in_array($field, $addressFields)) {
+                        $hasAddressError = true;
+                        $this->errors[] = $item;
+                    }
                 }
-                $this->errors[] = Tools::displayError('The address is not correct. Please make sure all of the required fields are completed.');
+
+                if ($hasAddressError) {
+                    $this->errors[] = Tools::displayError(
+                        'The address is not correct. Please make sure all of the required fields are completed.'
+                    );
+                }
             } else {
                 if (Tools::isSubmit('id_address') && Tools::getValue('id_address') > 0) {
                     $address->update();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | After setting the field "**vat_number**" as mandatory, you can't add/delete manufacturers or suppliers.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9736
| How to test?  | BO > Customers > Addresses > set the "**vat_number**" field as required, BO > Catalog > Manufacturers > try to updating or deleting a manufacturer address and check if action success, BO > Catalog > Suppliers > try to updating or deleting a supplier and check if action success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8740)
<!-- Reviewable:end -->
