### PR TITLE
Prefer Hook::coreRenderWidget

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -79,7 +79,11 @@ function withWidget($params, callable $cb)
 function smartyWidget($params, &$smarty)
 {
     return withWidget($params, function ($widget, $params) {
-        return $widget->renderWidget(isset($params['hook']) ? $params['hook'] : null, $params);
+        return Hook::coreRenderWidget(
+            $widget,
+            isset($params['hook']) ? $params['hook'] : null,
+            $params
+        );
     });
 }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On PS1.7 We should call Hook::coreRenderWidget method to allow developpers of modules to override this behavior. It exists so it must be called here.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | already existing widget tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8744)
<!-- Reviewable:end -->
