### PR TITLE
Fix the display of the cmsinfo block

### DIFF
--- a/themes/default-bootstrap/css/global.css
+++ b/themes/default-bootstrap/css/global.css
@@ -8388,6 +8388,7 @@ div.star.star_hover:after {
     #facebook_block,
     #cmsinfo_block {
       width: 100%;
+      height: 100%;
       min-height: 1px; } }
 
 #facebook_block h4 {
@@ -8411,11 +8412,16 @@ div.star.star_hover:after {
 
 #cmsinfo_block {
   border-left: 1px solid #d9d9d9; }
+  #cmsinfo_block img {
+    width: 100%;
+  }
   @media (max-width: 767px) {
     #cmsinfo_block {
       border: none;
       margin-top: 10px; } }
   #cmsinfo_block > div {
+    height: 100%;
+    overflow: auto;
     padding: 35px 10px 0 0; }
     @media (max-width: 767px) {
       #cmsinfo_block > div {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you add an image in the custom cms information block, the image exceeds the block limits.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9738
| How to test?  | BO > Modules and Services > blockcmsinfo > Configure > try to add an image in custom cms information block, FO > home page, check if the image does not exceed the limit, and check also on the mobile view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8745)
<!-- Reviewable:end -->
