### PR TITLE
Added reference column on main variants products.

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3767,7 +3767,7 @@ class ProductCore extends ObjectModel
 
         $check_stock = !Configuration::get('PS_DISP_UNAVAILABLE_ATTR');
         if (!$res = Db::getInstance()->executeS('
-			SELECT pa.`id_product`, a.`color`, pac.`id_product_attribute`, '.($check_stock ? 'SUM(IF(stock.`quantity` > 0, 1, 0))' : '0').' qty, a.`id_attribute`, al.`name`, IF(color = "", a.id_attribute, color) group_by
+			SELECT pa.`id_product`, a.`color`, pac.`id_product_attribute`, '.($check_stock ? 'SUM(IF(stock.`quantity` > 0, 1, 0))' : '0').' qty, a.`id_attribute`, al.`name`, IF(color = "", a.id_attribute, color) group_by, pa.reference
 			FROM `'._DB_PREFIX_.'product_attribute` pa
 			'.Shop::addSqlAssociation('product_attribute', 'pa').
             ($check_stock ? Product::sqlStock('pa', 'pa') : '').'
@@ -3794,7 +3794,7 @@ class ProductCore extends ObjectModel
                 $row['texture'] = _THEME_COL_DIR_.$row['id_attribute'].'.jpg';
             }
 
-            $colors[(int)$row['id_product']][] = array('id_product_attribute' => (int)$row['id_product_attribute'], 'color' => $row['color'], 'texture' => $row['texture'], 'id_product' => $row['id_product'], 'name' => $row['name'], 'id_attribute' => $row['id_attribute']);
+            $colors[(int)$row['id_product']][] = array('id_product_attribute' => (int)$row['id_product_attribute'], 'color' => $row['color'], 'texture' => $row['texture'], 'id_product' => $row['id_product'], 'name' => $row['name'], 'id_attribute' => $row['id_attribute'], 'reference' => $row['reference']);
         }
 
         return $colors;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add column reference of product attribute. When search by reference on search bar, but this reference is of a reference attribute of a product combination, its impossible on select search event filter by this reference and add link to this product attribute and not of principal product.
| Type?         |  improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

PD: Sorry for my English.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8747)
<!-- Reviewable:end -->
