### PR TITLE
Provide same hook when a combination is updated or created

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1415,7 +1415,7 @@ class ProductCore extends ObjectModel
             return false;
         }
 
-	Hook::exec('actionProductAttributeUpdate', array('id_product_attribute' => (int)$id_product_attribute));
+        Hook::exec('actionProductAttributeUpdate', array('id_product_attribute' => (int)$id_product_attribute));
 
         return $id_product_attribute;
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1415,6 +1415,8 @@ class ProductCore extends ObjectModel
             return false;
         }
 
+	Hook::exec('actionProductAttributeUpdate', array('id_product_attribute' => (int)$id_product_attribute));
+
         return $id_product_attribute;
     }
 


### PR DESCRIPTION
By default only update combination run a hook to add feature/behavior.
Create action should be follow same way.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.6.1.x
| Description?  | Hook consistency 
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | 
| How to test?  | Provide any module with adding some data in combination values

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8749)
<!-- Reviewable:end -->
