### PR TITLE
include deleted into customerExists check

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -507,6 +507,7 @@ class CustomerCore extends ObjectModel
         SELECT `id_customer`
         FROM `'._DB_PREFIX_.'customer`
         WHERE `email` = \''.pSQL($email).'\'
+        AND `deleted` = 0
         '.Shop::addSqlRestriction(Shop::SHARE_CUSTOMER).'
         '.($ignoreGuest ? ' AND `is_guest` = 0' : ''));
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I am not pretty sure why deleted column is being left out when checking customerExists but not in getByEmail. So, I make it uniform.
| Type?         | improvement
| Category?     | CO
| BC breaks?    |
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8750)
<!-- Reviewable:end -->
