### PR TITLE
Fix the main category creation in multi-shop context

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1232,4 +1232,22 @@ class ShopCore extends ObjectModel
             ($delete ? ' AND entity.deleted = 0' : '')
         );
     }
+
+    /**
+     * Check if the store has more than one root category
+     *
+     * @return bool -return true if the store has more than one root category
+     */
+    public function hasManyRootCategories()
+    {
+        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+            'SELECT COUNT(`id_category`)
+            FROM `' . _DB_PREFIX_ . 'category`
+            WHERE `active` = 1 
+            AND `is_root_category` = 1',
+            false
+        );
+
+        return ($result > 1);
+    }
 }

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -474,6 +474,11 @@ class AdminCategoriesControllerCore extends AdminController
         }
 
         $thumb_size = file_exists($thumb) ? filesize($thumb) / 1000 : false;
+        $sohpsList = Shop::getContextListShopID();
+        $hasManyRootCategories = (
+            (is_array($sohpsList) && sizeof($sohpsList) > 1)
+            && $context->shop->hasManyRootCategories()
+        );
 
         $this->fields_form = array(
             'tinymce' => true,
@@ -518,7 +523,7 @@ class AdminCategoriesControllerCore extends AdminController
                         'id'                  => 'categories-tree',
                         'selected_categories' => $selected_categories,
                         'disabled_categories' => (!Tools::isSubmit('add'.$this->table) && !Tools::isSubmit('submitAdd'.$this->table)) ? array($this->_category->id) : null,
-                        'root_category'       => $context->shop->getCategory()
+                        'root_category'       => $hasManyRootCategories ? Configuration::get('PS_ROOT_CATEGORY') : $context->shop->getCategory()
                     )
                 ),
                 array(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In a multi-store context, when you have many root categories, you can not add a new category under the new root categories
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-7481
| How to test?  | BO > activate the multi-shop, create new shop, select "**All shops**" context, BO > Catalog, Categories > add new root category (**Cat2**), try to add new category and verify in the "**Parent category**" if the root category **Cat2** is displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8753)
<!-- Reviewable:end -->
