### PR TITLE
BO: Domain name of the back office should not depend from FO domain(s)

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -759,7 +759,7 @@ class LinkCore
         }
 
         $idLang = Context::getContext()->language->id;
-        
+
         return '/'.basename(_PS_ADMIN_DIR_).'/'.Dispatcher::getInstance()->createUrl($controller, $idLang, $params, false);
     }
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -759,8 +759,8 @@ class LinkCore
         }
 
         $idLang = Context::getContext()->language->id;
-
-        return $this->getBaseLink().basename(_PS_ADMIN_DIR_).'/'.Dispatcher::getInstance()->createUrl($controller, $idLang, $params, false);
+        
+        return '/'.basename(_PS_ADMIN_DIR_).'/'.Dispatcher::getInstance()->createUrl($controller, $idLang, $params, false);
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Domain name of the back office should not depend from FO domain(s) ( more description bellow)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | see bellow please

-------------
On legacy 1.7's router , BO link are generated with full domain name ,
this cause two disagrements :
- On multishop context, if you use differents domain name for each shop, as BO Main menu urls target both current url ( new sf router ) or shop url + vitual uri ( legacy router ), when you change shop usung bo shop selector, you need to reconnect bo session on the other domain.
- You can not use a BO domain not declared as a front FO url and secure more your BO. ( other advantages of an other bo domain are also affected, if you move your shop, you need to adjust shop'url directly on dtabase before accessing your bo and change theme easily).



-------------


Apply the patch, on your hosting or server, configure an other domain name for you BO or a multishop, them test your bo ( both leagy and new page)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8759)
<!-- Reviewable:end -->
