### PR TITLE
Specific price created for a cart is displayed in the front end as the product price

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -337,9 +337,7 @@ class SpecificPriceCore extends ObjectModel
             $query_extra .= self::filterOutField('id_product_attribute', $id_product_attribute);
         }
 
-        if ($id_cart !== null) {
-            $query_extra .= self::filterOutField('id_cart', $id_cart);
-        }
+        $query_extra .= self::filterOutField('id_cart', $id_cart);
 
         if ($ending == $now && $beginning == $now) {
             $key = __FUNCTION__.'-'.$first_date.'-'.$last_date;

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -322,6 +322,7 @@ class SpecificPriceCore extends ObjectModel
             $ending = $now;
         }
         $id_customer = (int)$id_customer;
+        $id_cart = (int)$id_cart;
 
         $query_extra = '';
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | I fixed this same bug in Prestashop 1.6, but it seems you've migrated the specific price code to 1.7 prior to my fix being applied it doesn't include an id_cart value 0 in the where cluase and returns any cart specific prices
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4832
| How to test?  | Create a specificprice for a cart, after applying this fix the specificprice won't be shown on the front end for all users

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8762)
<!-- Reviewable:end -->
