### PR TITLE
Change all links to PrestaShop Help/Addons/Developers from http to https

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -84,12 +84,12 @@ Enjoy your store :)
 Essential links about PrestaShop:
 
 * User Guide: http://doc.prestashop.com/display/PS17/User+Guide
-* Tech docs (modules & themes): http://developers.prestashop.com/
+* Tech docs (modules & themes): https://developers.prestashop.com/
 * Official blog: https://www.prestashop.com/blog/en/
 * Devteam blog: http://build.prestashop.com/
 * Get community support: http://www.prestashop.com/forums/
 * Get paid support: https://www.prestashop.com/en/support
-* Find modules and themes: http://addons.prestashop.com/
+* Find modules and themes: https://addons.prestashop.com/
 * Contribute with code: https://github.com/PrestaShop/PrestaShop
 * Contribute with translation: http://crowdin.net/project/prestashop-official
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Thank you for downloading and using the PrestaShop Open Source e-commerce soluti
 [6]: CONTRIBUTING.md
 [7]: http://doc.prestashop.com/display/PS16/Contributing+to+PrestaShop
 [8]: https://crowdin.net/project/prestashop-official
-[9]: http://developers.prestashop.com/
-[10]: http://developers.prestashop.com/
+[9]: https://developers.prestashop.com/
+[10]: https://developers.prestashop.com/
 [11]: http://doc.prestashop.com/display/PS17/Getting+Started
 [12]: http://doc.prestashop.com/display/PS17/User+Guide
 [13]: http://doc.prestashop.com/display/PS17/Updating+PrestaShop

--- a/admin-dev/ajax.php
+++ b/admin-dev/ajax.php
@@ -39,7 +39,7 @@ if (Tools::isSubmit('ajaxReferrers')) {
 }
 
 if (Tools::getValue('page') == 'prestastore' && @fsockopen('addons.prestashop.com', 80, $errno, $errst, 3)) {
-    readfile('http://addons.prestashop.com/adminmodules.php?lang='.$context->language->iso_code);
+    readfile('https://addons.prestashop.com/adminmodules.php?lang='.$context->language->iso_code);
 }
 
 if (Tools::isSubmit('getAvailableFields') && Tools::isSubmit('entity')) {

--- a/admin-dev/themes/default/template/controllers/backup/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/controllers/backup/helpers/list/list_header.tpl
@@ -68,7 +68,7 @@
 		{if $host_mode}
 		<div class="alert alert-info">
 			<h4>{l s='How to restore a database backup' d='Admin.Advparameters.Notification'}</h4>
-			{l s='If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>', '[2]' => '<a class="_blank" href="http://addons.prestashop.com/support/16298-support-essentiel-plan.html">', '[/2]' => '</a>'] d='Admin.Advparameters.Notification'}
+			{l s='If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>', '[2]' => '<a class="_blank" href="https://addons.prestashop.com/support/16298-support-essentiel-plan.html">', '[/2]' => '</a>'] d='Admin.Advparameters.Notification'}
 			<br />
 			{l s='Our team will take care of restoring your database safely.' d='Admin.Advparameters.Notification'}
 			<br />

--- a/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
@@ -90,7 +90,7 @@
 		<div class="col-md-8 col-lg-7" id="hookDashboardZoneTwo">
 			{$hookDashboardZoneTwo}
 			<div id="dashaddons" class="row-margin-bottom">
-				<a href="http://addons.prestashop.com/en/209-dashboards?utm_source=back-office&amp;utm_medium=dashboard&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank">
+				<a href="https://addons.prestashop.com/en/209-dashboards?utm_source=back-office&amp;utm_medium=dashboard&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank">
 					<i class="icon-plus"></i> {l s='Add more dashboard modules' d='Admin.Dashboard.Feature'}
 				</a>
 			</div>
@@ -115,7 +115,7 @@
 						<dd>{l s="Connect with the PrestaShop community" d='Admin.Dashboard.Feature'}</dd>
 					</dl>
 					<dl>
-						<dt><a href="http://addons.prestashop.com?utm_source=back-office&amp;utm_medium=dashboard&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank">{l s="PrestaShop Addons" d='Admin.Dashboard.Feature'}</a></dt>
+						<dt><a href="https://addons.prestashop.com?utm_source=back-office&amp;utm_medium=dashboard&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank">{l s="PrestaShop Addons" d='Admin.Dashboard.Feature'}</a></dt>
 						<dd>{l s="Enhance your store with templates & modules" d='Admin.Dashboard.Feature'}</dd>
 					</dl>
 					<dl>

--- a/admin-dev/themes/default/template/controllers/modules/content-legacy.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/content-legacy.tpl
@@ -39,7 +39,7 @@
 							<img class="img-responsive" alt="PrestaShop Addons" src="themes/default/img/prestashop-addons-logo.png">
 						</div>
 						<div class="col-lg-4 col-lg-offset-1 col-md-4 col-sm-7 col-xs-12 addons-style-search-bar">
-							<form id="addons-search-form" method="get" action="http://addons.prestashop.com/{$iso_code}/search" class="float">
+							<form id="addons-search-form" method="get" action="https://addons.prestashop.com/{$iso_code}/search" class="float">
 							<label>{l s='Search on PrestaShop Marketplace:'}</label>
 							<div class="input-group">
 								<input id="addons-search-box" class="form-control" type="text" autocomplete="off" name="query" value="" placeholder="Search on PrestaShop Marketplace">
@@ -50,7 +50,7 @@
 							</form>
 						</div>
 						<div class="col-lg-3 col-md-4 col-sm-5 col-xs-12 addons-see-all-themes">
-							{l s='Or'}<a href="http://addons.prestashop.com/{$iso_code}/2-modules-prestashop" class="btn btn-primary" onclick="return !window.open(this.href)">{l s='See all modules'}</a>
+							{l s='Or'}<a href="https://addons.prestashop.com/{$iso_code}/2-modules-prestashop" class="btn btn-primary" onclick="return !window.open(this.href)">{l s='See all modules'}</a>
 						</div>
 					</div>
 				</div>

--- a/admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl
@@ -40,7 +40,7 @@
 	</p>
 	<p>
 		{l s='If you are unsure about this module, you can look for similar modules on the official marketplace.'}
-		<a class="_blank" href="http://addons.prestashop.com/">{l s='Click here to browse PrestaShop Addons.'}</a>
+		<a class="_blank" href="https://addons.prestashop.com/">{l s='Click here to browse PrestaShop Addons.'}</a>
 	</p>
 </div>
 

--- a/admin-dev/themes/default/template/controllers/modules/tab_modules_list.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/tab_modules_list.tpl
@@ -66,5 +66,5 @@
 	</div>
 {/if}
 <div class="alert alert-addons row-margin-top">
-	<a href="http://addons.prestashop.com/?utm_source=back-office&amp;utm_medium=dispatch&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}{if $admin_list_from_source}&amp;utm_term={$admin_list_from_source}{/if}" onclick="return !window.open(this.href);">{l s='More modules on addons.prestashop.com'}</a>
+	<a href="https://addons.prestashop.com/?utm_source=back-office&amp;utm_medium=dispatch&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}{if $admin_list_from_source}&amp;utm_term={$admin_list_from_source}{/if}" onclick="return !window.open(this.href);">{l s='More modules on addons.prestashop.com'}</a>
 </div>

--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -168,7 +168,7 @@ $(function() {
 		</tbody>
 			<tfoot>
 				<tr>
-					<td colspan="2" class="text-center"><a href="http://addons.prestashop.com/search.php?search_query={$query|urlencode}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank"><strong>{l s='Show more results...' d='Admin.Navigation.Search'}</strong></a></td>
+					<td colspan="2" class="text-center"><a href="https://addons.prestashop.com/search.php?search_query={$query|urlencode}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank"><strong>{l s='Show more results...' d='Admin.Navigation.Search'}</strong></a></td>
 				</tr>
 			</tfoot>
 		</table>
@@ -186,7 +186,7 @@ $(function() {
 	<div class="col-lg-4">
 		<div class="panel">
 			<h3>{l s='Search addons.prestashop.com' d='Admin.Navigation.Search'}</h3>
-			<a href="http://addons.prestashop.com/search.php?search_query={$query}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="btn btn-default _blank">{l s='Go to Addons' d='Admin.Navigation.Search'}</a>
+			<a href="https://addons.prestashop.com/search.php?search_query={$query}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="btn btn-default _blank">{l s='Go to Addons' d='Admin.Navigation.Search'}</a>
 		</div>
 	</div>
 	<div class="col-lg-4">

--- a/admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl
@@ -36,7 +36,7 @@
 						<img class="img-responsive" alt="PrestaShop Addons" src="themes/default/img/prestashop-addons-logo.png">
 					</div>
 					<div class="col-lg-4 col-lg-offset-1 col-md-4 col-sm-7 col-xs-12 addons-style-search-bar">
-						<form id="addons-search-form" method="get" action="http://addons.prestashop.com/{$iso_code}/search" class="float">
+						<form id="addons-search-form" method="get" action="https://addons.prestashop.com/{$iso_code}/search" class="float">
 						<label>{l s='Search on PrestaShop Marketplace:'}</label>
 						<div class="input-group">
 							<input id="addons-search-box" class="form-control" type="text" autocomplete="off" name="query" value="" placeholder="Search on PrestaShop Marketplace">
@@ -47,7 +47,7 @@
 						</form>
 					</div>
 					<div class="col-lg-3 col-md-4 col-sm-5 col-xs-12 addons-see-all-themes">
-						{l s='Or'}<a href="http://addons.prestashop.com/{$iso_code}/3-templates-prestashop" class="btn btn-primary" onclick="return !window.open(this.href)p">{l s='See all themes'}</a>
+						{l s='Or'}<a href="https://addons.prestashop.com/{$iso_code}/3-templates-prestashop" class="btn btn-primary" onclick="return !window.open(this.href)p">{l s='See all themes'}</a>
 					</div>
 				</div>
 			</div>

--- a/admin-dev/themes/default/template/footer.tpl
+++ b/admin-dev/themes/default/template/footer.tpl
@@ -67,7 +67,7 @@
 				{l s='Forum' d='Admin.Navigation.Footer'}
 			</a>
 			/&nbsp;
-			<a href="http://addons.prestashop.com/?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
+			<a href="https://addons.prestashop.com/?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
 				<i class="icon-puzzle-piece"></i>
 				{l s='Addons' d='Admin.Navigation.Footer'}
 			</a>

--- a/app/Resources/translations/default/Install.xlf
+++ b/app/Resources/translations/default/Install.xlf
@@ -1187,8 +1187,8 @@ File: install-dev/classes/controllerHttp.php:378
  Comment: Link to localized video tutorial (if available)</note>
       </trans-unit>
       <trans-unit id="7d9e68227c2ab19838a46b6b4f3e44be">
-        <source>http://addons.prestashop.com/en/388-support</source>
-        <target>http://addons.prestashop.com/en/388-support</target>
+        <source>https://addons.prestashop.com/en/388-support</source>
+        <target>https://addons.prestashop.com/en/388-support</target>
         <note>Context:
 File: install-dev/classes/controllerHttp.php:389
  Comment: Link to support on addons</note>

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1559,7 +1559,7 @@ class AdminControllerCore extends Controller
 
         $this->addPageHeaderToolBarModulesListButton();
 
-        $this->context->smarty->assign('help_link', 'http://help.prestashop.com/'.Language::getIsoById($this->context->employee->id_lang).'/doc/'
+        $this->context->smarty->assign('help_link', 'https://help.prestashop.com/'.Language::getIsoById($this->context->employee->id_lang).'/doc/'
             .Tools::getValue('controller').'?version='._PS_VERSION_.'&country='.Language::getIsoById($this->context->employee->id_lang));
     }
 
@@ -2321,7 +2321,7 @@ class AdminControllerCore extends Controller
         $this->modals[] = array(
             'modal_id' => 'modal_addons_connect',
             'modal_class' => 'modal-md',
-            'modal_title' => '<i class="icon-puzzle-piece"></i> <a target="_blank" href="http://addons.prestashop.com/'
+            'modal_title' => '<i class="icon-puzzle-piece"></i> <a target="_blank" href="https://addons.prestashop.com/'
             .'?utm_source=back-office&utm_medium=modules'
             .'&utm_campaign=back-office-'.Tools::strtoupper($this->context->language->iso_code)
             .'&utm_content='.(defined('_PS_HOST_MODE_') ? 'cloud' : 'download').'">PrestaShop Addons</a>',

--- a/controllers/admin/AdminThemesCatalogController.php
+++ b/controllers/admin/AdminThemesCatalogController.php
@@ -39,7 +39,7 @@ class AdminThemesCatalogControllerCore extends AdminController
         $iso_currency = $this->context->currency->iso_code;
         $iso_country = $this->context->country->iso_code;
         $activity = Configuration::get('PS_SHOP_ACTIVITY');
-        $addons_url = 'http://addons.prestashop.com/iframe/search-1.7.php?psVersion='._PS_VERSION_.'&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain.'&onlyThemes=1';
+        $addons_url = 'https://addons.prestashop.com/iframe/search-1.7.php?psVersion='._PS_VERSION_.'&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain.'&onlyThemes=1';
         $addons_content = Tools::file_get_contents($addons_url);
 
         $this->context->smarty->assign(array(

--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -386,7 +386,7 @@ class InstallControllerHttp
     public function getTailoredHelp()
     {
         /* Link to support on addons */
-        return $this->translator->trans('http://addons.prestashop.com/en/388-support', array(), 'Install');
+        return $this->translator->trans('https://addons.prestashop.com/en/388-support', array(), 'Install');
     }
 
     /**

--- a/install-dev/theme/views/process.php
+++ b/install-dev/theme/views/process.php
@@ -127,7 +127,7 @@ var admin = '<?php echo(file_exists('../admin-dev') ? '../admin-dev' : '../admin
 
 <?php if (@fsockopen('addons.prestashop.com', 80, $errno, $errst, 3)): ?>
 	<iframe src="https://addons.prestashop.com/psinstall1541.php?version=2&lang=<?php echo $this->language->getLanguageIso() ?>&activity=<?php echo $this->session->shop_activity ?>&country=<?php echo $this->session->shop_country ?>" scrolling="no" id="prestastore">
-		<p><a href="http://addons.prestashop.com/" target="_blank"><?php echo $this->translator->trans('Check out PrestaShop Addons to add that little something extra to your store!', array(), 'Install'); ?></a></p>
+		<p><a href="https://addons.prestashop.com/" target="_blank"><?php echo $this->translator->trans('Check out PrestaShop Addons to add that little something extra to your store!', array(), 'Install'); ?></a></p>
 	</iframe>
 <?php endif; ?>
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -840,7 +840,7 @@ $(document).ready(function()
 		var moduleLink = $(this).data('link');
 		var authorUri = $(this).data('author-uri');
 		var isValidUri = /(https?):\/\/([a-z0-9\.]*)?(prestashop.com).*/gi;
-		var addonsSearchLink = 'http://addons.prestashop.com/en/search?search_query='+encodeURIComponent(moduleDisplayName)+'&utm_source=back-office&utm_medium=addons-certified&utm_campaign=back-office-'+iso_user.toUpperCase();
+		var addonsSearchLink = 'https://addons.prestashop.com/en/search?search_query='+encodeURIComponent(moduleDisplayName)+'&utm_source=back-office&utm_medium=addons-certified&utm_campaign=back-office-'+iso_user.toUpperCase();
 
 		$('.modal #untrusted-module-logo').attr('src', moduleImage);
 		$('.modal .module-display-name-placeholder').text(moduleDisplayName);

--- a/js/admin/addons.js
+++ b/js/admin/addons.js
@@ -24,7 +24,7 @@
  */
 function sendSearchQuery() {
 	pattern = $('#addons-search-box').val();
-	url = 'http://addons.prestashop.com/en/search.php?search_query='+pattern+'&amp;utm_source=back-office&amp;utm_medium=recherche-theme&amp;utm_campaign=back-office-EN';
+	url = 'https://addons.prestashop.com/en/search.php?search_query='+pattern+'&amp;utm_source=back-office&amp;utm_medium=recherche-theme&amp;utm_campaign=back-office-EN';
 	window.open(url, '_blank');
 }
 
@@ -101,7 +101,7 @@ $(document).ready(function() {
 			$("#addons-search-results").remove();
 			ajaxSearch = $.ajax({
 				type: 'POST',
-				url: 'http://addons.prestashop.com/search.php',
+				url: 'https://addons.prestashop.com/search.php',
 				crossDomain: true,
 				dataType:'jsonp',
 				data: {

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -162,7 +162,7 @@ class FrameworkBundleAdminController extends Controller
             $title = $this->trans('Help', 'Admin.Global');
         }
 
-        $docLink = urlencode('http://help.prestashop.com/'.$legacyContext->getEmployeeLanguageIso().'/doc/'
+        $docLink = urlencode('https://help.prestashop.com/'.$legacyContext->getEmployeeLanguageIso().'/doc/'
             .$section.'?version='._PS_VERSION_.'&country='.$legacyContext->getEmployeeLanguageIso());
 
         return $this->generateUrl('admin_common_sidebar', [

--- a/src/PrestaShopBundle/Controller/Admin/Improve/AddonsStoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/AddonsStoreController.php
@@ -74,6 +74,6 @@ class AddonsStoreController extends FrameworkBundleAdminController
         $countryCode = $context->country->iso_code;
         $activity = (int) $this->get('prestashop.adapter.legacy.configuration')->get('PS_SHOP_ACTIVITY');
 
-        return "http://addons.prestashop.com/iframe/search-1.7.php?psVersion=$psVersion&isoLang=$languageCode&isoCurrency=$currencyCode&isoCountry=$countryCode&activity=$activity&parentUrl=$parent_domain";
+        return "https://addons.prestashop.com/iframe/search-1.7.php?psVersion=$psVersion&isoLang=$languageCode&isoCurrency=$currencyCode&isoCountry=$countryCode&activity=$activity&parentUrl=$parent_domain";
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/recommendedModules.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/recommendedModules.html.twig
@@ -33,15 +33,15 @@
             }
         %}
     {% else %}
-        <a href="http://addons.prestashop.com/" target="_blank" class="col-lg-12">
+        <a href="https://addons.prestashop.com/" target="_blank" class="col-lg-12">
             <img class="img-responsive center-block" src="{{ asset('themes/default/img/bundle/pub_conversion_EN.gif') }}" />
         </a>
         <div class="clearfix">&nbsp;</div>
-        <a href="http://addons.prestashop.com/" target="_blank" class="col-lg-12">
+        <a href="https://addons.prestashop.com/" target="_blank" class="col-lg-12">
             <img class="img-responsive center-block" src="{{ asset('themes/default/img/bundle/pub_loyalty_EN.gif') }}" />
         </a>
         <div class="clearfix">&nbsp;</div>
-        <a href="http://addons.prestashop.com/" target="_blank" class="col-lg-12">
+        <a href="https://addons.prestashop.com/" target="_blank" class="col-lg-12">
             <img class="img-responsive center-block" src="{{ asset('themes/default/img/bundle/pub_trafic_EN.gif') }}" />
         </a>
         <div class="clearfix">&nbsp;</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig
@@ -46,7 +46,7 @@
               <div class="col-md-12">
                   <p>
                       {{ "Link your shop to your Addons account to automatically receive important updates for the modules you purchased. Don't have an account yet?"|trans({}, 'Admin.Modules.Feature') }}
-                      <a href="http://addons.prestashop.com/authentication.php" target="_blank">{{ 'Sign up now'|trans({}, 'Admin.Modules.Feature') }}</a>
+                      <a href="https://addons.prestashop.com/authentication.php" target="_blank">{{ 'Sign up now'|trans({}, 'Admin.Modules.Feature') }}</a>
                   </p>
                   <form id="addons-connect-form"  action="{{ path('admin_addons_login') }}" method="POST">
                   <div class="form-group">
@@ -66,7 +66,7 @@
                   <div id="addons_login_btn" class="spinner" style="display:none;"></div>
                 </form>
                 <p>
-                    <a href="http://addons.prestashop.com/password.php" target="_blank">{{ 'Forgot your password?'|trans({}, 'Admin.Global') }}</a>
+                    <a href="https://addons.prestashop.com/password.php" target="_blank">{{ 'Forgot your password?'|trans({}, 'Admin.Global') }}</a>
                 </p>
               </div>
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
@@ -67,6 +67,6 @@
 {% endif %}
 <div class="alert alert-addons row-margin-top" role="alert">
   <p class="alert-text">
-    <a href="http://addons.prestashop.com/?utm_source=back-office&amp;utm_medium=dispatch&amp;utm_campaign=back-office-{{ app.request.locale }}&amp;utm_content=download{% if adminListFromSource is defined %}&amp;utm_term={{ adminListFromSource }}{% endif %}" onclick="return !window.open(this.href);">{{ 'More modules on addons.prestashop.com'|trans({}) }}</a>
+    <a href="https://addons.prestashop.com/?utm_source=back-office&amp;utm_medium=dispatch&amp;utm_campaign=back-office-{{ app.request.locale }}&amp;utm_content=download{% if adminListFromSource is defined %}&amp;utm_term={{ adminListFromSource }}{% endif %}" onclick="return !window.open(this.href);">{{ 'More modules on addons.prestashop.com'|trans({}) }}</a>
   </p>
 </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The help link on the product edit page displays "mixed active content" on console on https websites. This PR fix that.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4290
| How to test?  | -

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8764)
<!-- Reviewable:end -->
