### PR TITLE
Fix the unit_price update in the all shops context

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -553,6 +553,11 @@ class ProductCore extends ObjectModel
 
     public function update($null_values = false)
     {
+        if (is_array($this->update_fields)
+            && array_key_exists('unit_price', $this->update_fields)) {
+            $this->update_fields['unit_price_ratio'] = $this->update_fields['unit_price'];
+        }
+
         $return = parent::update($null_values);
         $this->setGroupReduction();
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In tha all shops context, you can't update the unit_price.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9721
| How to test?  | BO > activate the multistore option, create new shop, select the all shops context, BO > Catalog > Products > Edit > Prices Tab > check **Multistore** set the text field **Unit price (tax excl.)** and save. Verify if the unit price is updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8765)
<!-- Reviewable:end -->
