### PR TITLE
Show unit price within a tax in order confirmation e-mail

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -507,8 +507,8 @@ abstract class PaymentModuleCore extends Module
                         );
 
                         if (isset($product['price']) && $product['price']) {
-                            $product_var_tpl['unit_price'] = Tools::displayPrice($product['price'], $this->context->currency, false);
-                            $product_var_tpl['unit_price_full'] = Tools::displayPrice($product['price'], $this->context->currency, false)
+                            $product_var_tpl['unit_price'] = Tools::displayPrice($product_price, $this->context->currency, false);
+                            $product_var_tpl['unit_price_full'] = Tools::displayPrice($product_price, $this->context->currency, false)
                                 .' '.$product['unity'];
                         } else {
                             $product_var_tpl['unit_price'] = $product_var_tpl['unit_price_full'] = '';


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | we need unit price to be displayed within a tax when it's needed, this is fix for that
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | for sure ([BOOM-4889](http://forge.prestashop.com/browse/BOOM-4889))
| How to test?  | make an order, check unit price for a product without a combination, it's tax exluced even tho you'll have tax enabled
| Sponsor company  | impSolutions

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

please cherry pick this to 1.7.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8766)
<!-- Reviewable:end -->
