### PR TITLE
Remove file 'fileType' when deleting images

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -589,6 +589,8 @@ class ImageCore extends ObjectModel
         $filesToDelete[] = $this->image_dir . $this->getExistingImgPath() . '-watermark.' . $this->image_format;
         // delete index.php
         $filesToDelete[] = $this->image_dir . $this->getImgFolder() . 'index.php';
+        // delete fileType
+        $filesToDelete[] = $this->image_dir . $this->getImgFolder() . 'fileType';
         // Delete tmp images
         $filesToDelete[] = _PS_TMP_IMG_DIR_ . 'product_' . $this->id_product . '.' . $this->image_format;
         $filesToDelete[] = _PS_TMP_IMG_DIR_ . 'product_mini_' . $this->id_product . '.' . $this->image_format;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When deleting image, in each directory stay file named 'fileType', then directory for image and generated previews cannot be deleted. File 'fileType' contains only text 'jpg' and is not used. When deleting many products, it will be better.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fix #10210
| How to test?  | When deleting image (for product, manufacturer, etc.) in /img/p/... directory is deleted all images, helper files and directory itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8770)
<!-- Reviewable:end -->
