### PR TITLE
[CO] better check shouldEnableAddToCartButton

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -214,6 +214,10 @@ class ProductPresenter
 
     protected function shouldEnableAddToCartButton(array $product, ProductPresentationSettings $settings)
     {
+        if($product['active'] == 0) {
+            return false;
+        }
+        
         if (($product['customizable'] == 2 || !empty($product['customization_required']))) {
             $shouldEnable = false;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In some case, we need to show product info; ex : in a wishlist, we have to show also inactive products but disallow add to cart.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | just dump a presented inactive product and you will see add_to_cart_url ppty not null

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8771)
<!-- Reviewable:end -->
