### PR TITLE
Replace serialize with json_encode

### DIFF
--- a/admin-dev/functions.php
+++ b/admin-dev/functions.php
@@ -488,11 +488,11 @@ function runAdminTab($tab, $ajax_mode = false)
                                 if (is_array($admin_obj->table)) {
                                     foreach ($admin_obj->table as $table) {
                                         if (strncmp($key, $table.'Filter_', 7) === 0 || strncmp($key, 'submitFilter', 12) === 0) {
-                                            $cookie->$key = !is_array($value) ? $value : serialize($value);
+                                            $cookie->$key = !is_array($value) ? $value : json_encode($value);
                                         }
                                     }
                                 } elseif (strncmp($key, $admin_obj->table.'Filter_', 7) === 0 || strncmp($key, 'submitFilter', 12) === 0) {
-                                    $cookie->$key = !is_array($value) ? $value : serialize($value);
+                                    $cookie->$key = !is_array($value) ? $value : json_encode($value);
                                 }
                             }
                         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3034,7 +3034,7 @@ class CartCore extends ObjectModel
             $this->id_carrier = $this->getIdCarrierFromDeliveryOption($delivery_option);
         }
 
-        $this->delivery_option = serialize($delivery_option);
+        $this->delivery_option = json_encode($delivery_option);
     }
 
     /**
@@ -3080,18 +3080,20 @@ class CartCore extends ObjectModel
 
         // The delivery option was selected
         if (isset($this->delivery_option) && $this->delivery_option != '') {
-            $delivery_option = Tools::unSerialize($this->delivery_option);
+            $delivery_option = json_decode($this->delivery_option, true);
             $validated = true;
-            foreach ($delivery_option as $id_address => $key) {
-                if (!isset($delivery_option_list[$id_address][$key])) {
-                    $validated = false;
-                    break;
+            if (is_array($delivery_option)) {
+                foreach ($delivery_option as $id_address => $key) {
+                    if (!isset($delivery_option_list[$id_address][$key])) {
+                        $validated = false;
+                        break;
+                    }
                 }
-            }
+                if ($validated) {
+                    $cache[$cache_id] = $delivery_option;
 
-            if ($validated) {
-                $cache[$cache_id] = $delivery_option;
-                return $delivery_option;
+                    return $delivery_option;
+                }
             }
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -689,7 +689,7 @@ class AdminControllerCore extends Controller
                         if (isset($t['type']) && $t['type'] == 'bool') {
                             $filter_value = ((bool)$val) ? $this->l('yes') : $this->l('no');
                         } elseif (isset($t['type']) && $t['type'] == 'date' || isset($t['type']) && $t['type'] == 'datetime') {
-                            $date = Tools::unSerialize($val);
+                            $date = json_decode($val, true);
                             if (isset($date[0])) {
                                 $filter_value = $date[0];
                                 if (isset($date[1]) && !empty($date[1])) {
@@ -817,17 +817,17 @@ class AdminControllerCore extends Controller
                 if ($value === '') {
                     unset($this->context->cookie->{$prefix.$key});
                 } elseif (stripos($key, $this->list_id.'Filter_') === 0) {
-                    $this->context->cookie->{$prefix.$key} = !is_array($value) ? $value : serialize($value);
+                    $this->context->cookie->{$prefix.$key} = !is_array($value) ? $value : json_encode($value);
                 } elseif (stripos($key, 'submitFilter') === 0) {
-                    $this->context->cookie->$key = !is_array($value) ? $value : serialize($value);
+                    $this->context->cookie->$key = !is_array($value) ? $value : json_encode($value);
                 }
             }
 
             foreach ($_GET as $key => $value) {
                 if (stripos($key, $this->list_id.'Filter_') === 0) {
-                    $this->context->cookie->{$prefix.$key} = !is_array($value) ? $value : serialize($value);
+                    $this->context->cookie->{$prefix.$key} = !is_array($value) ? $value : json_encode($value);
                 } elseif (stripos($key, 'submitFilter') === 0) {
-                    $this->context->cookie->$key = !is_array($value) ? $value : serialize($value);
+                    $this->context->cookie->$key = !is_array($value) ? $value : json_encode($value);
                 }
                 if (stripos($key, $this->list_id.'Orderby') === 0 && Validate::isOrderBy($value)) {
                     if ($value === '' || $value == $this->_defaultOrderBy) {
@@ -862,7 +862,7 @@ class AdminControllerCore extends Controller
                 if ($field = $this->filterToField($key, $filter)) {
                     $type = (array_key_exists('filter_type', $field) ? $field['filter_type'] : (array_key_exists('type', $field) ? $field['type'] : false));
                     if (($type == 'date' || $type == 'datetime') && is_string($value)) {
-                        $value = Tools::unSerialize($value);
+                        $value = json_decode($value, true);
                     }
                     $key = isset($tmp_tab[1]) ? $tmp_tab[0].'.`'.$tmp_tab[1].'`' : '`'.$tmp_tab[0].'`';
 

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -662,7 +662,7 @@ class HelperListCore extends Helper
                 case 'date':
                 case 'datetime':
                     if (is_string($value)) {
-                        $value = Tools::unSerialize($value);
+                        $value = json_decode($value, true);
                     }
                     if (!Validate::isCleanHtml($value[0]) || !Validate::isCleanHtml($value[1])) {
                         $value = '';

--- a/install-dev/fixtures/fashion/data/cart.xml
+++ b/install-dev/fixtures/fashion/data/cart.xml
@@ -18,23 +18,23 @@
   </fields>
   <entities>
     <cart id="cart_1" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
     <cart id="cart_2" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
     <cart id="cart_3" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
     <cart id="cart_4" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
     <cart id="cart_5" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
   </entities>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.2.x
| Description?  | Use json_encode() instead of serialize(). Many thanks to ROBIN PERAGLIE from RIPS TECHNOLOGIES
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4804
| How to test?  | test if there is no regression: change of delivery option on cart / filter (especialy date one) still works on AdminOrders

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8772)
<!-- Reviewable:end -->
