### PR TITLE
Fixing problem with AJAX fetch and missing General Purpose Variables

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -532,6 +532,10 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
     protected function doProductSearch($template, $params = array(), $locale = null)
     {
         if ($this->ajax) {
+
+			// When the products are fetched through AJAX the "General Purpose Variables" are not assigned, which leads to following problems (like bugs when trying to implement the AJAX Cart on category pages or other list of products).
+			$this->assignGeneralPurposeVariables();
+
             ob_end_clean();
             header('Content-Type: application/json');
             $this->ajaxDie(json_encode($this->getAjaxProductSearchVariables()));


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop.
| Description?  | **Fixing problem with AJAX fetch and missing General Purpose Variables**. I had a problem when I tried to implement the AJAX "Add to cart" at the categories page: sometimes data was passed at the popup, sometimes it wasn't.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Implement the "Add to cart" with AJAX at a product list and, then, verify that the variables are being passed.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8778)
<!-- Reviewable:end -->
