### PR TITLE
create_function is deprecated

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2052,7 +2052,9 @@ class ToolsCore
         if ($catapitalise_first_char) {
             $str = Tools::ucfirst($str);
         }
-        return preg_replace_callback('/_+([a-z])/', create_function('$c', 'return strtoupper($c[1]);'), $str);
+        return preg_replace_callback('/_+([a-z])/', function ($c) {
+            return strtoupper($c[1]);
+        }, $str);
     }
 
     /**


### PR DESCRIPTION
create_function is deprecated in PHP 7.2.0 (http://php.net/manual/en/function.create-function.php), so replacing it by anonymous function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8782)
<!-- Reviewable:end -->
