### PR TITLE
avoid PHP warning

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -797,7 +797,7 @@ class WebserviceRequestCore
 
     protected function shopExists($params)
     {
-        if (count(self::$shopIDs)) {
+        if (!empty(self::$shopIDs)&&count(self::$shopIDs)) {
             return true;
         }
 


### PR DESCRIPTION
create_function is deprecated in PHP 7.2.0 (http://php.net/manual/en/function.create-function.php), so replacing it by anonymous function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8783)
<!-- Reviewable:end -->
