### PR TITLE
Do not call search::indexation at each entity creation

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -264,6 +264,19 @@ class ConfigurationTestCore
         return true;
     }
 
+    public static function __callStatic($name, $arguments)
+    {
+        static $recursiveTests = [
+            'test_img_dir',
+            'test_module_dir',
+            'test_mails_dir',
+            'test_translations_dir',
+            'test_config_sf2_dir'
+        ];
+
+        return ConfigurationTest::test_dir($arguments[0], in_array($name, $recursiveTests));
+    }
+
     public static function test_file($file_relative)
     {
         $file = _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.$file_relative;
@@ -271,74 +284,9 @@ class ConfigurationTestCore
         return file_exists($file) && is_writable($file);
     }
 
-    public static function test_config_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
-    }
-
     public static function test_sitemap($dir)
     {
         return ConfigurationTest::test_file($dir);
-    }
-
-    public static function test_root_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
-    }
-
-    public static function test_log_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
-    }
-
-    public static function test_admin_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
-    }
-
-    public static function test_img_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir, true);
-    }
-
-    public static function test_module_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir, true);
-    }
-
-    public static function test_cache_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir, true);
-    }
-
-    public static function test_tools_v2_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
-    }
-
-    public static function test_cache_v2_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
-    }
-
-    public static function test_download_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
-    }
-
-    public static function test_mails_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir, true);
-    }
-
-    public static function test_translations_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir, true);
-    }
-
-    public static function test_config_sf2_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir, true);
     }
 
     public static function test_theme_lang_dir($dir)
@@ -369,16 +317,6 @@ class ConfigurationTestCore
         }
 
         return ConfigurationTest::test_dir($dir, true);
-    }
-
-    public static function test_customizable_products_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
-    }
-
-    public static function test_virtual_products_dir($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
     }
 
     public static function test_mbstring()
@@ -422,10 +360,5 @@ class ConfigurationTestCore
         }
 
         return true;
-    }
-
-    public static function test_translations_sf2($dir)
-    {
-        return ConfigurationTest::test_dir($dir);
     }
 }

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -264,19 +264,6 @@ class ConfigurationTestCore
         return true;
     }
 
-    public static function __callStatic($name, $arguments)
-    {
-        static $recursiveTests = [
-            'test_img_dir',
-            'test_module_dir',
-            'test_mails_dir',
-            'test_translations_dir',
-            'test_config_sf2_dir'
-        ];
-
-        return ConfigurationTest::test_dir($arguments[0], in_array($name, $recursiveTests));
-    }
-
     public static function test_file($file_relative)
     {
         $file = _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.$file_relative;
@@ -284,9 +271,74 @@ class ConfigurationTestCore
         return file_exists($file) && is_writable($file);
     }
 
+    public static function test_config_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
+    }
+
     public static function test_sitemap($dir)
     {
         return ConfigurationTest::test_file($dir);
+    }
+
+    public static function test_root_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
+    }
+
+    public static function test_log_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
+    }
+
+    public static function test_admin_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
+    }
+
+    public static function test_img_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir, true);
+    }
+
+    public static function test_module_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir, true);
+    }
+
+    public static function test_cache_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir, true);
+    }
+
+    public static function test_tools_v2_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
+    }
+
+    public static function test_cache_v2_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
+    }
+
+    public static function test_download_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
+    }
+
+    public static function test_mails_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir, true);
+    }
+
+    public static function test_translations_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir, true);
+    }
+
+    public static function test_config_sf2_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir, true);
     }
 
     public static function test_theme_lang_dir($dir)
@@ -317,6 +369,16 @@ class ConfigurationTestCore
         }
 
         return ConfigurationTest::test_dir($dir, true);
+    }
+
+    public static function test_customizable_products_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
+    }
+
+    public static function test_virtual_products_dir($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
     }
 
     public static function test_mbstring()
@@ -360,5 +422,10 @@ class ConfigurationTestCore
         }
 
         return true;
+    }
+
+    public static function test_translations_sf2($dir)
+    {
+        return ConfigurationTest::test_dir($dir);
     }
 }

--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -224,7 +224,9 @@ class InstallControllerHttp
                 break;
             }
 
-            if (!$check_step->getControllerInstance()->validate()) {
+            // no need to validate several time the system step
+            if (!(($check_step->getControllerInstance()) instanceof InstallControllerHttpSystem)
+                && !$check_step->getControllerInstance()->validate()) {
                 self::$steps->setOffset($key);
                 $session->step = $session->last_step = self::$steps->current()->getName();
                 break;

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -290,50 +290,39 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
      */
     public function display()
     {
-        // The installer SHOULD take less than 32M, but may take up to 35/36M sometimes. So 42M is a good value :)
-        $low_memory = Tools::getMemoryLimit() < Tools::getOctets('42M');
-
         // We fill the process step used for Ajax queries
         $this->process_steps[] = array('key' => 'generateSettingsFile', 'lang' => $this->translator->trans('Create file parameters', array(), 'Install'));
         $this->process_steps[] = array('key' => 'installDatabase', 'lang' => $this->translator->trans('Create database tables', array(), 'Install'));
         $this->process_steps[] = array('key' => 'installDefaultData', 'lang' => $this->translator->trans('Create default shop and languages', array(), 'Install'));
 
-        // If low memory, create subtasks for populateDatabase step (entity per entity)
         $populate_step = array('key' => 'populateDatabase', 'lang' => $this->translator->trans('Populate database tables', array(), 'Install'));
-        if ($low_memory) {
-            $populate_step['subtasks'] = array();
-            $xml_loader = new XmlLoader();
-            $xml_loader->setTranslator($this->translator);
+        $populate_step['subtasks'] = array();
+        $xml_loader = new XmlLoader();
+        $xml_loader->setTranslator($this->translator);
 
-            foreach ($xml_loader->getSortedEntities() as $entity) {
-                $populate_step['subtasks'][] = array('entity' => $entity);
-            }
+        foreach ($xml_loader->getSortedEntities() as $entity) {
+            $populate_step['subtasks'][] = array('entity' => $entity);
         }
 
         $this->process_steps[] = $populate_step;
         $this->process_steps[] = array('key' => 'configureShop', 'lang' => $this->translator->trans('Configure shop information', array(), 'Install'));
 
         if ($this->session->install_type == 'full') {
-            // If low memory, create subtasks for installFixtures step (entity per entity)
             $fixtures_step = array('key' => 'installFixtures', 'lang' => $this->translator->trans('Install demonstration data', array(), 'Install'));
-            if ($low_memory) {
-                $fixtures_step['subtasks'] = array();
-                $xml_loader = new XmlLoader();
-                $xml_loader->setTranslator($this->translator);
-                $xml_loader->setFixturesPath();
+            $fixtures_step['subtasks'] = array();
+            $xml_loader = new XmlLoader();
+            $xml_loader->setTranslator($this->translator);
+            $xml_loader->setFixturesPath();
 
-                foreach ($xml_loader->getSortedEntities() as $entity) {
-                    $fixtures_step['subtasks'][] = array('entity' => $entity);
-                }
+            foreach ($xml_loader->getSortedEntities() as $entity) {
+                $fixtures_step['subtasks'][] = array('entity' => $entity);
             }
             $this->process_steps[] = $fixtures_step;
         }
 
         $install_modules = array('key' => 'installModules', 'lang' => $this->translator->trans('Install modules', array(), 'Install'));
-        if ($low_memory) {
-            foreach ($this->model_install->getModulesList() as $module) {
-                $install_modules['subtasks'][] = array('module' => $module);
-            }
+        foreach ($this->model_install->getModulesList() as $module) {
+            $install_modules['subtasks'][] = array('module' => $module);
         }
         $this->process_steps[] = $install_modules;
 
@@ -347,11 +336,10 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
             'version' => _PS_INSTALL_VERSION_
         );
 
-        if ($low_memory) {
-            foreach ($this->model_install->getAddonsModulesList($params) as $module) {
-                $install_modules['subtasks'][] = array('module' => (string)$module['name'], 'id_module' => (string)$module['id_module']);
-            }
+        foreach ($this->model_install->getAddonsModulesList($params) as $module) {
+            $install_modules['subtasks'][] = array('module' => (string)$module['name'], 'id_module' => (string)$module['id_module']);
         }
+
         $this->process_steps[] = $install_modules;
 
         $this->process_steps[] = array('key' => 'installTheme', 'lang' => $this->translator->trans('Install theme', array(), 'Install'));

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -276,6 +276,7 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
     public function processInstallTheme()
     {
         $this->initializeContext();
+        Search::indexation(true);
         $this->model_install->installTheme();
         if ($this->model_install->getErrors()) {
             $this->ajaxJsonAnswer(false, $this->model_install->getErrors());

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1096,7 +1096,9 @@ class Install extends AbstractInstall
         $this->xml_loader_ids = $xml_loader->getIds();
         unset($xml_loader);
 
-        Search::indexation(true);
+        if ($entity === null) {
+            Search::indexation(true);
+        }
 
         // Update fixtures lang
         foreach ($languages as $lang) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | see title
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4896
| How to test?  | should speed up a bit the current install. Check if the search index is properly computed at the end of the install + demo products

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8789)
<!-- Reviewable:end -->
