### PR TITLE
Fix customizable demo product without customizable field

### DIFF
--- a/classes/CustomizationField.php
+++ b/classes/CustomizationField.php
@@ -39,6 +39,8 @@ class CustomizationFieldCore extends ObjectModel
     public $is_module;
     /** @var string Label for customized field */
     public $name;
+    /** @var bool Soft delete */
+    public $is_deleted;
 
     /**
      * @see ObjectModel::$definition

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -417,7 +417,7 @@
     <value>0</value>
   </configuration>
   <configuration id="PS_CUSTOMIZATION_FEATURE_ACTIVE" name="PS_CUSTOMIZATION_FEATURE_ACTIVE">
-    <value>0</value>
+    <value>1</value>
   </configuration>
   <configuration id="PS_CART_RULE_FEATURE_ACTIVE" name="PS_CART_RULE_FEATURE_ACTIVE">
     <value>0</value>

--- a/install-dev/fixtures/fashion/data/customization_field.xml
+++ b/install-dev/fixtures/fashion/data/customization_field.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<entity_customization_field>
+  <fields id="name" class="CustomizationField">
+    <field name="id_product" relation="product"/>
+    <field name="type"/>
+    <field name="required"/>
+    <field name="is_module"/>
+    <field name="is_deleted"/>
+  </fields>
+  <entities>
+    <customization_field id="Insert_text" id_product="Customizable_mug" type="1" required="1"/>
+  </entities>
+</entity_customization_field>

--- a/install-dev/fixtures/fashion/data/product.xml
+++ b/install-dev/fixtures/fashion/data/product.xml
@@ -115,7 +115,7 @@
       <unity/>
       <location/>
     </product>
-    <product id="Customizable_mug" id_supplier="Fashion_Supplier" id_manufacturer="Studio_Design" id_category_default="Home_Accessories" on_sale="0" online_only="0" ean13="" upc="" ecotax="0.000000" quantity="0" minimal_quantity="1" price="13.900000" wholesale_price="0.000000" unit_price_ratio="0.000000" additional_shipping_cost="0.00" reference="demo_14" supplier_reference="" width="0.000000" height="0.000000" depth="0.000000" weight="0.000000" out_of_stock="2" quantity_discount="0" customizable="2" uploadable_files="0" text_fields="1" active="1" redirect_type="404" id_type_redirected="0" available_for_order="1" available_date="0000-00-00" condition="new" show_price="1" indexed="1" cache_is_pack="0" cache_has_attachments="0" is_virtual="0" cache_default_attribute="0" advanced_stock_management="0">
+    <product id="Customizable_mug" id_supplier="Fashion_Supplier" id_manufacturer="Studio_Design" id_category_default="Home_Accessories" on_sale="0" online_only="0" ean13="" upc="" ecotax="0.000000" quantity="0" minimal_quantity="1" price="13.900000" wholesale_price="0.000000" unit_price_ratio="0.000000" additional_shipping_cost="0.00" reference="demo_14" supplier_reference="" width="0.000000" height="0.000000" depth="0.000000" weight="0.000000" out_of_stock="2" quantity_discount="0" customizable="1" uploadable_files="0" text_fields="1" active="1" redirect_type="404" id_type_redirected="0" available_for_order="1" available_date="0000-00-00" condition="new" show_price="1" indexed="1" cache_is_pack="0" cache_has_attachments="0" is_virtual="0" cache_default_attribute="0" advanced_stock_management="0">
       <unity/>
       <location/>
     </product>

--- a/install-dev/fixtures/fashion/langs/en/data/customization_field.xml
+++ b/install-dev/fixtures/fashion/langs/en/data/customization_field.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list_customization_field>
+  <customization_field id="Insert_text" id_shop="1">
+    <name><![CDATA[Type your text here]]></name>
+  </customization_field>
+</list_customization_field>

--- a/install-dev/fixtures/fashion/langs/fr/data/customization_field.xml
+++ b/install-dev/fixtures/fashion/langs/fr/data/customization_field.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list_customization_field>
+  <customization_field id="Insert_text" id_shop="1">
+    <name><![CDATA[Insérer votre texte ici]]></name>
+  </customization_field>
+</list_customization_field>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | The "customizable mug" demo product didn't have the customization field configured. Now it does.<br>Also: the product customization feature is now enabled by default.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4818
| How to test?  | Install the shop and check out the product in the FO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8794)
<!-- Reviewable:end -->
