### PR TITLE
Update shopping-cart-product-line.tpl

### DIFF
--- a/themes/default-bootstrap/shopping-cart-product-line.tpl
+++ b/themes/default-bootstrap/shopping-cart-product-line.tpl
@@ -49,7 +49,7 @@
 				{if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies}
                 	<li class="price-percent-reduction small">
             			{if !$priceDisplay}
-            				{if isset($product.reduction_type) && $product.reduction_type == 'amount'}
+            				{if isset($product.reduction_type) && $product.reduction_type === 'amount'}
                     			{assign var='priceReduction' value=($product.price_wt - $product.price_without_specific_price)}
                     			{assign var='symbol' value=$currency->sign}
                     		{else}
@@ -57,7 +57,7 @@
                     			{assign var='symbol' value='%'}
                     		{/if}
 						{else}
-							{if isset($product.reduction_type) && $product.reduction_type == 'amount'}
+							{if isset($product.reduction_type) && $product.reduction_type === 'amount'}
 								{assign var='priceReduction' value=($product.price - $product.price_without_specific_price)}
 								{assign var='symbol' value=$currency->sign}
 							{else}


### PR DESCRIPTION
we need to use identical === instead of equal ==
if we use $product.reduction_type == 'amount' and $product.reduction_type = 0 then this will be true, because (int)'amount' is 0.
this also causes the cart to load the discount in amount, and when we change the product quantity, it will change to percentage.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.8
| Description?  | If product redution is in percentage, it would show in amount in shopping-cart.tpl when first load.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | Does it deprecate an existing feature? yes/no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Create a product with a specific price with percentage reduction. Add product to cart in FO. Go to shopping-cart.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8800)
<!-- Reviewable:end -->
