### PR TITLE
Stop full object exposure on the front end

### DIFF
--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -24,66 +24,114 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
 /**
  * @TODO Move undeclared variables and methods to this (base) class: $errors, $layout, checkLiveEditAccess, etc.
  * @since 1.5.0
  */
 abstract class ControllerCore
 {
-    /** @var Context */
+    /**
+     * @var Context
+     */
     protected $context;
 
-    /** @var array List of CSS files */
+    /**
+     * List of CSS files
+     * @var array
+     */
     public $css_files = array();
 
-    /** @var array List of JavaScript files */
+    /**
+     * List of JavaScript files
+     * @var array
+     */
     public $js_files = array();
 
-    /** @var array List of PHP errors */
+    /**
+     * List of PHP errors
+     * @var array
+     */
     public static $php_errors = array();
 
-    /** @var bool Set to true to display page header */
+    /**
+     * Set to true to display page header
+     * @var bool
+     */
     protected $display_header;
 
-    /** @var bool Set to true to display page header javascript */
+    /**
+     * Set to true to display page header javascript
+     * @var bool
+     */
     protected $display_header_javascript;
 
-    /** @var string Template filename for the page content */
+    /**
+     * Template filename for the page content
+     * @var string
+     */
     protected $template;
 
-    /** @var string Set to true to display page footer */
+    /**
+     * Set to true to display page footer
+     * @var string
+     */
     protected $display_footer;
 
-    /** @var bool Set to true to only render page content (used to get iframe content) */
+    /**
+     * Set to true to only render page content (used to get iframe content)
+     * @var bool
+     */
     protected $content_only = false;
 
-    /** @var bool If AJAX parameter is detected in request, set this flag to true */
+    /**
+     * If AJAX parameter is detected in request, set this flag to true
+     * @var bool
+     */
     public $ajax = false;
 
-    /** @var bool If set to true, page content and messages will be encoded to JSON before responding to AJAX request */
+    /**
+     * If set to true, page content and messages will be encoded to JSON before responding to AJAX request
+     * @var bool
+     */
     protected $json = false;
 
-    /** @var string JSON response status string */
+    /**
+     * JSON response status string
+     * @var string
+     */
     protected $status = '';
 
     /**
+     * Redirect link. If not empty, the user will be redirected after initializing and processing input.
      * @see Controller::run()
-     * @var string|null Redirect link. If not empty, the user will be redirected after initializing and processing input.
+     * @var string|null
      */
     protected $redirect_after = null;
 
-    /** @var string Controller type. Possible values: 'front', 'modulefront', 'admin', 'moduleadmin' */
+    /**
+     * Controller type. Possible values: 'front', 'modulefront', 'admin', 'moduleadmin'
+     * @var string
+     */
     public $controller_type;
 
-    /** @var string Controller name */
+    /**
+     * Controller name
+     * @var string
+     */
     public $php_self;
 
-    /** @var PrestaShopBundle\Translation\Translator */
+    /**
+     * @var PrestaShopBundle\Translation\Translator
+     */
     protected $translator;
 
-    /** @var ContainerBuilder legacy container */
+    /**
+     * Dependency container
+     * @var ContainerBuilder
+     */
     protected $container;
-
 
     /**
      * Check if the controller is available for the current user/visitor
@@ -649,17 +697,36 @@ abstract class ControllerCore
     }
 
     /**
-     * Construct the container of dependencies
+     * Construct the dependency container
+     *
+     * @return ContainerBuilder
      */
     protected function buildContainer()
     {
     }
 
+    /**
+     * Gets a service from the service container.
+     *
+     * @param string $serviceId Service identifier
+     *
+     * @return object The associated service
+     * @throws Exception
+     */
     public function get($serviceId)
     {
         return $this->container->get($serviceId);
     }
 
+    /**
+     * Gets a parameter.
+     *
+     * @param string $parameterId The parameter name
+     *
+     * @return mixed The parameter value
+     *
+     * @throws InvalidArgumentException if the parameter is not defined
+     */
     public function getParameter($parameterId)
     {
         return $this->container->getParameter($parameterId);

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -29,7 +29,6 @@ use PrestaShop\PrestaShop\Adapter\Configuration as ConfigurationAdapter;
 use PrestaShop\PrestaShop\Core\Filter\CollectionFilter;
 use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ConfigurationFilter;
 use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\CustomerFilter;
-use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ProductFilter;
 use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ShopFilter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Debug\Debug;
@@ -1993,15 +1992,10 @@ class FrontControllerCore extends Controller
      * Returns an object that filters the Product list to be sent to the browser
      *
      * @return CollectionFilter
-     *
-     * @throws \PrestaShop\PrestaShop\Core\Filter\FilterException
      */
     protected function getProductListOutputFilter()
     {
-        return (new CollectionFilter())
-            ->queue([
-                new ProductFilter()
-            ]);
+        return $this->get('prestashop.core.filter.front_end_object.product_collection');
     }
 
     /**
@@ -2011,7 +2005,7 @@ class FrontControllerCore extends Controller
      */
     protected function getCustomerOutputFilter()
     {
-        return new CustomerFilter();
+        return $this->get('prestashop.core.filter.front_end_object.customer');
     }
 
     /**
@@ -2021,7 +2015,7 @@ class FrontControllerCore extends Controller
      */
     protected function getShopOutputFilter()
     {
-        return new ShopFilter();
+        return $this->get('prestashop.core.filter.front_end_object.shop');
     }
 
     /**
@@ -2031,6 +2025,6 @@ class FrontControllerCore extends Controller
      */
     protected function getConfigurationOutputFilter()
     {
-        return new ConfigurationFilter();
+        return $this->get('prestashop.core.filter.front_end_object.configuration');
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -535,33 +535,8 @@ class FrontControllerCore extends Controller
      */
     protected function buildFrontEndObject($object)
     {
-        // keep whitelisted cart product data only
-        if (isset($object['cart']['products']) && is_array($object['cart']['products'])) {
-            $object['cart']['products'] = $this
-                ->getProductListOutputFilter()
-                ->filter($object['cart']['products']);
-        }
-
-        // keep whitelisted customer data only
-        if (isset($object['customer']) && is_array($object['customer'])) {
-            $object['customer'] = $this
-                ->getCustomerOutputFilter()
-                ->filter($object['customer']);
-        }
-
-        // keep whitelisted shop data only
-        if (isset($object['shop']) && is_array($object['shop'])) {
-            $object['shop'] = $this
-                ->getShopOutputFilter()
-                ->filter($object['shop']);
-        }
-
-        // keep whitelisted configuration data only
-        if (isset($object['configuration']) && is_array($object['configuration'])) {
-            $object['configuration'] = $this
-                ->getConfigurationOutputFilter()
-                ->filter($object['configuration']);
-        }
+        $object = $this->get('prestashop.core.filter.front_end_object.main')
+            ->filter($object);
 
         Hook::exec('actionBuildFrontEndObject', array(
             'obj' => &$object

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -561,6 +561,10 @@ class FrontControllerCore extends Controller
                 ->filter($object['configuration']);
         }
 
+        Hook::exec('actionBuildFrontEndObject', array(
+            'obj' => &$object
+        ));
+
         return $object;
     }
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -523,44 +523,45 @@ class FrontControllerCore extends Controller
     }
 
     /**
-     * Builds the "prestashop" javascript object that will be inserted in the front end
+     * Builds the "prestashop" javascript object that will be sent to the front end
      *
-     * @param array $templateVars Variables to be inserted in the template (see FrontController::assignGeneralPurposeVariables)
+     * @param array $object Variables inserted in the template (see FrontController::assignGeneralPurposeVariables)
      *
      * @return array Variables to be inserted in the "prestashop" javascript object
      * @throws \PrestaShop\PrestaShop\Core\Filter\FilterException
+     * @throws PrestaShopException
      */
-    protected function buildFrontEndObject($templateVars)
+    protected function buildFrontEndObject($object)
     {
         // keep whitelisted cart product data only
-        if (isset($templateVars['cart']['products']) && is_array($templateVars['cart']['products'])) {
-            $templateVars['cart']['products'] = $this
+        if (isset($object['cart']['products']) && is_array($object['cart']['products'])) {
+            $object['cart']['products'] = $this
                 ->getProductListOutputFilter()
-                ->filter($templateVars['cart']['products']);
+                ->filter($object['cart']['products']);
         }
 
         // keep whitelisted customer data only
-        if (isset($templateVars['customer']) && is_array($templateVars['customer'])) {
-            $templateVars['customer'] = $this
+        if (isset($object['customer']) && is_array($object['customer'])) {
+            $object['customer'] = $this
                 ->getCustomerOutputFilter()
-                ->filter($templateVars['customer']);
+                ->filter($object['customer']);
         }
 
         // keep whitelisted shop data only
-        if (isset($templateVars['shop']) && is_array($templateVars['shop'])) {
-            $templateVars['shop'] = $this
+        if (isset($object['shop']) && is_array($object['shop'])) {
+            $object['shop'] = $this
                 ->getShopOutputFilter()
-                ->filter($templateVars['shop']);
+                ->filter($object['shop']);
         }
 
         // keep whitelisted configuration data only
-        if (isset($templateVars['configuration']) && is_array($templateVars['configuration'])) {
-            $templateVars['configuration'] = $this
+        if (isset($object['configuration']) && is_array($object['configuration'])) {
+            $object['configuration'] = $this
                 ->getConfigurationOutputFilter()
-                ->filter($templateVars['configuration']);
+                ->filter($object['configuration']);
         }
 
-        return $templateVars;
+        return $object;
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -26,10 +26,6 @@
 use PrestaShop\PrestaShop\Adapter\Cart\CartPresenter;
 use PrestaShop\PrestaShop\Adapter\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Configuration as ConfigurationAdapter;
-use PrestaShop\PrestaShop\Core\Filter\CollectionFilter;
-use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ConfigurationFilter;
-use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\CustomerFilter;
-use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ShopFilter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -1968,45 +1964,5 @@ class FrontControllerCore extends Controller
         $container->compile();
 
         return $container;
-    }
-
-    /**
-     * Returns an object that filters the Product list to be sent to the browser
-     *
-     * @return CollectionFilter
-     */
-    protected function getProductListOutputFilter()
-    {
-        return $this->get('prestashop.core.filter.front_end_object.product_collection');
-    }
-
-    /**
-     * Returns an object that filters the Customer object to be sent to the browser
-     *
-     * @return CustomerFilter
-     */
-    protected function getCustomerOutputFilter()
-    {
-        return $this->get('prestashop.core.filter.front_end_object.customer');
-    }
-
-    /**
-     * Returns an object that filters the Shop object to be sent to the browser
-     *
-     * @return ShopFilter
-     */
-    protected function getShopOutputFilter()
-    {
-        return $this->get('prestashop.core.filter.front_end_object.shop');
-    }
-
-    /**
-     * Returns an object that filters the Configuration object to be sent to the browser
-     *
-     * @return ConfigurationFilter
-     */
-    protected function getConfigurationOutputFilter()
-    {
-        return $this->get('prestashop.core.filter.front_end_object.configuration');
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -484,6 +484,8 @@ class FrontControllerCore extends Controller
         $this->iso = $iso;
         $this->context->cart = $cart;
         $this->context->currency = $currency;
+
+        Hook::exec('actionFrontControllerAfterInit');
     }
 
     /**

--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -26,7 +26,6 @@
 
 
 use PrestaShop\PrestaShop\Core\Filter\CollectionFilter;
-use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ProductFilter;
 use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\Pagination;
@@ -506,40 +505,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
      */
     protected function prepareProductArrayForAjaxReturn(array $products)
     {
-        $filter = (new CollectionFilter())
-            ->queue([
-                (new HashMapWhitelistFilter())
-                    ->whitelist([
-                        'id_product',
-                        'price',
-                        'reference',
-                        'active',
-                        'description_short',
-                        'link',
-                        'link_rewrite',
-                        'name',
-                        'manufacturer_name',
-                        'position',
-                        'cover',
-                        'url',
-                        'canonical_url',
-                        'add_to_cart_url',
-                        'has_discount',
-                        'discount_type',
-                        'discount_percentage',
-                        'discount_percentage_absolute',
-                        'discount_amount',
-                        'price_amount',
-                        'regular_price_amount',
-                        'regular_price',
-                        'discount_to_display',
-                        'labels',
-                        'main_variants',
-                        'unit_price',
-                        'tax_name',
-                        'rate',
-                    ])
-            ]);
+        $filter = $this->get('prestashop.core.filter.front_end_object.search_result_product_collection');
 
         return $filter->filter($products);
     }
@@ -553,8 +519,6 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
      * If we're not doing AJAX, then render the whole page with the given template.
      *
      * @param string $template the template for this page
-     *
-     * @return no return
      */
     protected function doProductSearch($template, $params = array(), $locale = null)
     {

--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -25,6 +25,9 @@
  */
 
 
+use PrestaShop\PrestaShop\Core\Filter\CollectionFilter;
+use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ProductFilter;
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\Pagination;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
@@ -478,17 +481,17 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
         $rendered_products = $this->render('catalog/_partials/products', array('listing' => $search));
         $rendered_products_bottom = $this->render('catalog/_partials/products-bottom', array('listing' => $search));
 
-        $data = array(
-            'rendered_products_top' => $rendered_products_top,
-            'rendered_products' => $rendered_products,
-            'rendered_products_bottom' => $rendered_products_bottom,
+        $data = array_merge(
+            array(
+                'rendered_products_top' => $rendered_products_top,
+                'rendered_products' => $rendered_products,
+                'rendered_products_bottom' => $rendered_products_bottom,
+            ),
+            $search
         );
 
-        foreach ($search as $key => $value) {
-            if ($key === 'products') {
-                $value = $this->prepareProductArrayForAjaxReturn($value);
-            }
-            $data[$key] = $value;
+        if (!empty($data['products']) && is_array($data['products'])) {
+            $data['products'] = $this->prepareProductArrayForAjaxReturn($data['products']);
         }
 
         return $data;
@@ -497,24 +500,48 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
     /**
      * Cleans the products array with only whitelisted properties.
      *
-     * @return array
+     * @param array[] $products
+     *
+     * @return array[] Filtered product list
      */
     protected function prepareProductArrayForAjaxReturn(array $products)
     {
-        $allowed_properties = array('id_product', 'price', 'reference', 'active', 'description_short', 'link',
-            'link_rewrite', 'name', 'manufacturer_name', 'position', 'cover', 'url', 'canonical_url', 'add_to_cart_url',
-            'has_discount', 'discount_type', 'discount_percentage', 'discount_percentage_absolute', 'discount_amount',
-            'price_amount', 'regular_price_amount', 'regular_price', 'discount_to_display', 'labels', 'main_variants',
-            'unit_price', 'tax_name', 'rate'
-        );
-        foreach ($products as $product_key => $product) {
-            foreach ($product as $product_property => $data) {
-                if (!in_array($product_property, $allowed_properties)) {
-                    unset($products[$product_key][$product_property]);
-                }
-            }
-        }
-        return $products;
+        $filter = (new CollectionFilter())
+            ->queue([
+                (new HashMapWhitelistFilter())
+                    ->whitelist([
+                        'id_product',
+                        'price',
+                        'reference',
+                        'active',
+                        'description_short',
+                        'link',
+                        'link_rewrite',
+                        'name',
+                        'manufacturer_name',
+                        'position',
+                        'cover',
+                        'url',
+                        'canonical_url',
+                        'add_to_cart_url',
+                        'has_discount',
+                        'discount_type',
+                        'discount_percentage',
+                        'discount_percentage_absolute',
+                        'discount_amount',
+                        'price_amount',
+                        'regular_price_amount',
+                        'regular_price',
+                        'discount_to_display',
+                        'labels',
+                        'main_variants',
+                        'unit_price',
+                        'tax_name',
+                        'rate',
+                    ])
+            ]);
+
+        return $filter->filter($products);
     }
 
     /**

--- a/config/services/front/services_prod.yml
+++ b/config/services/front/services_prod.yml
@@ -3,3 +3,32 @@ parameters:
 services:
     hashing:
         class: PrestaShop\PrestaShop\Core\Crypto\Hashing
+
+    prestashop.core.filter.front_end_object.product:
+        class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ProductFilter
+
+    prestashop.core.filter.front_end_object.search_result_product:
+        class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\SearchResultProductFilter
+
+    prestashop.core.filter.front_end_object.customer:
+        class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\CustomerFilter
+
+    prestashop.core.filter.front_end_object.shop:
+        class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ShopFilter
+
+    prestashop.core.filter.front_end_object.configuration:
+        class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ConfigurationFilter
+
+    prestashop.core.filter.front_end_object.product_collection:
+        class: PrestaShop\PrestaShop\Core\Filter\CollectionFilter
+        calls:
+            - method: queue
+              arguments:
+                - ['@prestashop.core.filter.front_end_object.product']
+
+    prestashop.core.filter.front_end_object.search_result_product_collection:
+        class: PrestaShop\PrestaShop\Core\Filter\CollectionFilter
+        calls:
+            - method: queue
+              arguments:
+                - ['@prestashop.core.filter.front_end_object.search_result_product']

--- a/config/services/front/services_prod.yml
+++ b/config/services/front/services_prod.yml
@@ -7,6 +7,11 @@ services:
     prestashop.core.filter.front_end_object.product:
         class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ProductFilter
 
+    prestashop.core.filter.front_end_object.cart:
+        class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\CartFilter
+        arguments:
+          - '@prestashop.core.filter.front_end_object.product_collection'
+
     prestashop.core.filter.front_end_object.search_result_product:
         class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\SearchResultProductFilter
 

--- a/config/services/front/services_prod.yml
+++ b/config/services/front/services_prod.yml
@@ -4,6 +4,14 @@ services:
     hashing:
         class: PrestaShop\PrestaShop\Core\Crypto\Hashing
 
+    prestashop.core.filter.front_end_object.main:
+        class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\MainFilter
+        arguments:
+            - cart: '@prestashop.core.filter.front_end_object.cart'
+              customer: '@prestashop.core.filter.front_end_object.customer'
+              shop: '@prestashop.core.filter.front_end_object.shop'
+              configuration: '@prestashop.core.filter.front_end_object.configuration'
+
     prestashop.core.filter.front_end_object.product:
         class: PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ProductFilter
 

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -133,7 +133,7 @@ class CartControllerCore extends FrontController
             $presentedCart = $cartPresenter->present($this->context->cart);
 
             // filter product output
-            $presentedCart['products'] = $this->getProductListOutputFilter()
+            $presentedCart['products'] = $this->get('prestashop.core.filter.front_end_object.product_collection')
                 ->filter($presentedCart['products']);
 
             $this->ajaxDie(Tools::jsonEncode([

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -25,6 +25,8 @@
  */
 
 use PrestaShop\PrestaShop\Adapter\Cart\CartPresenter;
+use PrestaShop\PrestaShop\Core\Filter\CollectionFilter;
+use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\ProductFilter;
 
 class CartControllerCore extends FrontController
 {
@@ -128,12 +130,18 @@ class CartControllerCore extends FrontController
 
         if (!$this->errors) {
             $cartPresenter = new CartPresenter();
+            $presentedCart = $cartPresenter->present($this->context->cart);
+
+            // filter product output
+            $presentedCart['products'] = $this->getProductListOutputFilter()
+                ->filter($presentedCart['products']);
+
             $this->ajaxDie(Tools::jsonEncode([
                 'success' => true,
                 'id_product' => $this->id_product,
                 'id_product_attribute' => $this->id_product_attribute,
                 'quantity' => $productQuantity,
-                'cart' => $cartPresenter->present($this->context->cart),
+                'cart' => $presentedCart,
                 'errors' => empty($this->updateOperationError) ? '' : reset($this->updateOperationError),
             ]));
         } else {

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -756,5 +756,10 @@
       <title>Display new elements in back office page with dashboard, on icons list</title>
       <description>This hook launches modules when the back office with dashboard is displayed</description>
     </hook>
+    <hook id="actionBuildFrontEndObject">
+      <name>actionBuildFrontEndObject</name>
+      <title>Manage elements added to the "prestashop" javascript object</title>
+      <description>This hook allows you to customize the "prestashop" javascript object that is included in all front office pages</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -761,5 +761,10 @@
       <title>Manage elements added to the "prestashop" javascript object</title>
       <description>This hook allows you to customize the "prestashop" javascript object that is included in all front office pages</description>
     </hook>
+    <hook id="actionFrontControllerAfterInit">
+      <name>actionFrontControllerAfterInit</name>
+      <title>Perform actions after front office controller initialization</title>
+      <description>This hook is launched after the initialization of all front office controllers</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/src/Core/Filter/CollectionFilter.php
+++ b/src/Core/Filter/CollectionFilter.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter;
+
+/**
+ * Iterates over a collection, filtering each element using a queue of filters
+ */
+class CollectionFilter implements FilterInterface
+{
+    /**
+     * @var FilterInterface[]
+     */
+    private $filters = [];
+
+    /**
+     * Sets process queue
+     *
+     * @param FilterInterface[] $filters
+     *
+     * @return $this
+     *
+     * @throws FilterException
+     */
+    public function queue(array $filters)
+    {
+        foreach ($filters as $filter) {
+            if (!$filter instanceof FilterInterface) {
+                throw new FilterException(
+                    sprintf("The provided filter is not valid filter: \"%s\"", print_r($filter, true))
+                );
+            }
+        }
+
+        $this->filters = $filters;
+
+        return $this;
+    }
+
+    /**
+     * Filters the provided subject
+     *
+     * @param array $subject Collection to filter
+     *
+     * @return array
+     *
+     * @throws FilterException
+     */
+    public function filter($subject)
+    {
+        if (!is_array($subject)) {
+            throw new FilterException(
+                sprintf("Invalid subject: %s", print_r($subject, true))
+            );
+        }
+
+        foreach ($subject as $k => $value) {
+            foreach ($this->filters as $filter) {
+                $value = $filter->filter($value);
+            }
+            $subject[$k] = $value;
+        }
+
+        return $subject;
+    }
+}

--- a/src/Core/Filter/CollectionFilter.php
+++ b/src/Core/Filter/CollectionFilter.php
@@ -62,6 +62,15 @@ class CollectionFilter implements FilterInterface
     }
 
     /**
+     * Returns the current queue
+     * @return FilterInterface[]
+     */
+    public function getQueue()
+    {
+        return $this->filters;
+    }
+
+    /**
      * Filters the provided subject
      *
      * @param array $subject Collection to filter

--- a/src/Core/Filter/FilterException.php
+++ b/src/Core/Filter/FilterException.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter;
+
+class FilterException extends \Exception
+{
+
+}

--- a/src/Core/Filter/FilterInterface.php
+++ b/src/Core/Filter/FilterInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter;
+
+interface FilterInterface
+{
+    public function filter($subject);
+}

--- a/src/Core/Filter/FilterInterface.php
+++ b/src/Core/Filter/FilterInterface.php
@@ -28,5 +28,12 @@ namespace PrestaShop\PrestaShop\Core\Filter;
 
 interface FilterInterface
 {
+    /**
+     * Performs a filter on the subject object.
+     *
+     * @param mixed $subject Subject to filter.
+     *
+     * @return mixed Filtered subject.
+     */
     public function filter($subject);
 }

--- a/src/Core/Filter/FrontEndObject/CartFilter.php
+++ b/src/Core/Filter/FrontEndObject/CartFilter.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter\FrontEndObject;
+
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
+
+/**
+ * Filters Cart objects that will be sent to the client
+ */
+class CartFilter extends HashMapWhitelistFilter
+{
+    public function __construct($productsFilter)
+    {
+        $whitelist = array(
+            'discounts',
+            'id_address_delivery',
+            'id_address_invoice',
+            'minimalPurchase',
+            'minimalPurchaseRequired',
+            'products' => $productsFilter,
+            'products_count',
+            'subtotals',
+            'summary_string',
+            'totals',
+            'vouchers',
+        );
+
+        $this->whitelist($whitelist);
+    }
+}

--- a/src/Core/Filter/FrontEndObject/CartFilter.php
+++ b/src/Core/Filter/FrontEndObject/CartFilter.php
@@ -38,8 +38,6 @@ class CartFilter extends HashMapWhitelistFilter
     {
         $whitelist = array(
             'discounts',
-            'id_address_delivery',
-            'id_address_invoice',
             'minimalPurchase',
             'minimalPurchaseRequired',
             'products' => $productsFilter,

--- a/src/Core/Filter/FrontEndObject/ConfigurationFilter.php
+++ b/src/Core/Filter/FrontEndObject/ConfigurationFilter.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter\FrontEndObject;
+
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
+
+/**
+ * Filters Configuration objects that will be sent to the client
+ */
+class ConfigurationFilter extends HashMapWhitelistFilter
+{
+    public function __construct()
+    {
+        $whitelist = array(
+            "display_taxes_label",
+            "is_catalog",
+            "opt_in",
+            "quantity_discount",
+            "return_enabled",
+            "show_prices",
+            "voucher_enabled",
+        );
+
+        $this->whitelist($whitelist);
+    }
+}

--- a/src/Core/Filter/FrontEndObject/CustomerFilter.php
+++ b/src/Core/Filter/FrontEndObject/CustomerFilter.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter\FrontEndObject;
+
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
+
+/**
+ * Filters Customer objects that will be sent to the client
+ */
+class CustomerFilter extends HashMapWhitelistFilter
+{
+    public function __construct()
+    {
+        $whitelist = array(
+            "addresses",
+            "ape",
+            "birthday",
+            "company",
+            "email",
+            "firstname",
+            "gender" => (new HashMapWhitelistFilter())
+                ->whitelist(array(
+                    "type",
+                    "name",
+                )),
+            "is_logged",
+            "lastname",
+            "newsletter",
+            "newsletter_date_add",
+            "optin",
+            "siret",
+            "website",
+        );
+
+        $this->whitelist($whitelist);
+    }
+}

--- a/src/Core/Filter/FrontEndObject/EmbeddedAttributesFilter.php
+++ b/src/Core/Filter/FrontEndObject/EmbeddedAttributesFilter.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter\FrontEndObject;
+
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
+
+/**
+ * Filters Product EmbeddedAttributes objects that will be sent to the client
+ */
+class EmbeddedAttributesFilter extends HashMapWhitelistFilter
+{
+
+    public function __construct()
+    {
+        $whitelist = [
+            "attributes",
+            "available_date",
+            "available_later",
+            "available_now",
+            "category",
+            "condition",
+            "customizable",
+            "description_short",
+            "ecotax",
+            "ecotax_rate",
+            "features",
+            "id_customization",
+            "id_image",
+            "id_manufacturer",
+            "id_product",
+            "id_product_attribute",
+            "is_virtual",
+            "link_rewrite",
+            "minimal_quantity",
+            "name",
+            "new",
+            "on_sale",
+            "online_only",
+            "out_of_stock",
+            "pack",
+            "price",
+            "price_amount",
+            "price_without_reduction",
+            "quantity",
+            "quantity_wanted",
+            "rate",
+            "reduction",
+            "reference",
+            "show_price",
+            "specific_prices",
+            "tax_name",
+            "unit_price_ratio",
+            "unity",
+        ];
+
+        $this->whitelist($whitelist);
+    }
+}

--- a/src/Core/Filter/FrontEndObject/EmbeddedAttributesFilter.php
+++ b/src/Core/Filter/FrontEndObject/EmbeddedAttributesFilter.php
@@ -59,7 +59,6 @@ class EmbeddedAttributesFilter extends HashMapWhitelistFilter
             "new",
             "on_sale",
             "online_only",
-            "out_of_stock",
             "pack",
             "price",
             "price_amount",

--- a/src/Core/Filter/FrontEndObject/EmbeddedAttributesFilter.php
+++ b/src/Core/Filter/FrontEndObject/EmbeddedAttributesFilter.php
@@ -39,7 +39,6 @@ class EmbeddedAttributesFilter extends HashMapWhitelistFilter
     {
         $whitelist = [
             "attributes",
-            "available_date",
             "available_later",
             "available_now",
             "category",
@@ -54,7 +53,6 @@ class EmbeddedAttributesFilter extends HashMapWhitelistFilter
             "id_manufacturer",
             "id_product",
             "id_product_attribute",
-            "is_virtual",
             "link_rewrite",
             "minimal_quantity",
             "name",
@@ -71,11 +69,8 @@ class EmbeddedAttributesFilter extends HashMapWhitelistFilter
             "rate",
             "reduction",
             "reference",
-            "show_price",
             "specific_prices",
             "tax_name",
-            "unit_price_ratio",
-            "unity",
         ];
 
         $this->whitelist($whitelist);

--- a/src/Core/Filter/FrontEndObject/MainFilter.php
+++ b/src/Core/Filter/FrontEndObject/MainFilter.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter\FrontEndObject;
+
+use PrestaShop\PrestaShop\Core\Filter\CollectionFilter;
+use PrestaShop\PrestaShop\Core\Filter\FilterInterface;
+
+/**
+ * Filters the main front end object ("prestashop" on your javascript console)
+ */
+class MainFilter implements FilterInterface
+{
+    /**
+     * @var FilterInterface[] filters, indexed by key to filter
+     */
+    private $filters;
+
+    /**
+     * @param array $filters FilterInterface[] filters, indexed by key to filter
+     */
+    public function __construct(array $filters) {
+        $this->filters = $filters;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array
+     */
+    public function filter($subject)
+    {
+        foreach ($this->filters as $key => $filter) {
+            if (isset($subject[$key]) && $filter instanceof FilterInterface) {
+
+                if ($filter instanceof CollectionFilter && !is_array($subject[$key])) {
+                    continue;
+                }
+
+                $subject[$key] = $filter->filter($subject[$key]);
+            }
+        }
+
+        return $subject;
+    }
+
+    /**
+     * @return FilterInterface[] filters, indexed by key to filter
+     */
+    public function getFilters()
+    {
+        return $this->filters;
+    }
+}

--- a/src/Core/Filter/FrontEndObject/ProductFilter.php
+++ b/src/Core/Filter/FrontEndObject/ProductFilter.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter\FrontEndObject;
+
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
+
+/**
+ * Filters Product objects that will be sent to the client
+ */
+class ProductFilter extends HashMapWhitelistFilter
+{
+    public function __construct()
+    {
+        $whitelist = array(
+            "add_to_cart_url",
+            "allow_oosp",
+            "attributes",
+            "attributes_small",
+            "availability",
+            "availability_date",
+            "availability_message",
+            "available_later",
+            "available_now",
+            "canonical_url",
+            "cart_quantity",
+            "category",
+            "condition",
+            "cover",
+            "customizable",
+            "description_short",
+            "discount_amount",
+            "discount_percentage",
+            "discount_percentage_absolute",
+            "discount_to_display",
+            "discount_type",
+            "down_quantity_url",
+            "ean13",
+            "ecotax",
+            "ecotax_attr",
+            "ecotax_rate",
+            "embedded_attributes" => new EmbeddedAttributesFilter(),
+            "flags",
+            "has_discount",
+            "id",
+            "id_customization",
+            "id_image",
+            "id_manufacturer",
+            "id_product",
+            "id_product_attribute",
+            "images",
+            "isbn",
+            "labels",
+            "legend",
+            "link_rewrite",
+            "main_variants",
+            "manufacturer_name",
+            "minimal_quantity",
+            "name",
+            "new",
+            "on_sale",
+            "online_only",
+            "pack",
+            "price",
+            "price_amount",
+            "price_attribute",
+            "price_with_reduction",
+            "price_with_reduction_without_tax",
+            "price_without_reduction",
+            "price_wt",
+            "quantity",
+            "quantity_discounts",
+            "quantity_wanted",
+            "rate",
+            "reduction",
+            "reference",
+            "reference_to_display",
+            "regular_price",
+            "regular_price_amount",
+            "remove_from_cart_url",
+            "show_availability",
+            "specific_prices",
+            "stock_quantity",
+            "tax_name",
+            "total",
+            "total_wt",
+            "unit_price",
+            "unit_price_full",
+            "up_quantity_url",
+            "upc",
+            "update_quantity_url",
+            "url",
+            "weight_unit",
+        );
+
+        $this->whitelist($whitelist);
+    }
+}

--- a/src/Core/Filter/FrontEndObject/ProductFilter.php
+++ b/src/Core/Filter/FrontEndObject/ProductFilter.php
@@ -103,6 +103,7 @@ class ProductFilter extends HashMapWhitelistFilter
             "regular_price_amount",
             "remove_from_cart_url",
             "show_availability",
+            "show_price",
             "specific_prices",
             "stock_quantity",
             "tax_name",

--- a/src/Core/Filter/FrontEndObject/SearchResultProductFilter.php
+++ b/src/Core/Filter/FrontEndObject/SearchResultProductFilter.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter\FrontEndObject;
+
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
+
+/**
+ * Filters Product objects for search results
+ */
+class SearchResultProductFilter extends HashMapWhitelistFilter
+{
+    public function __construct()
+    {
+        $whitelist = array(
+            'active',
+            'add_to_cart_url',
+            'canonical_url',
+            'cover',
+            'description_short',
+            'discount_amount',
+            'discount_percentage',
+            'discount_percentage_absolute',
+            'discount_to_display',
+            'discount_type',
+            'has_discount',
+            'id_product',
+            'labels',
+            'link',
+            'link_rewrite',
+            'main_variants',
+            'manufacturer_name',
+            'name',
+            'position',
+            'price',
+            'price_amount',
+            'rate',
+            'reference',
+            'regular_price',
+            'regular_price_amount',
+            'tax_name',
+            'unit_price',
+            'url',
+        );
+
+        $this->whitelist($whitelist);
+    }
+}

--- a/src/Core/Filter/FrontEndObject/ShopFilter.php
+++ b/src/Core/Filter/FrontEndObject/ShopFilter.php
@@ -34,13 +34,9 @@ class ShopFilter extends HashMapWhitelistFilter
     public function __construct()
     {
         $whitelist = array(
-            "address",
             "favicon",
-            "favicon_update_time",
-            "fax",
             "logo",
             "name",
-            "phone",
             "stores_icon",
         );
 

--- a/src/Core/Filter/FrontEndObject/ShopFilter.php
+++ b/src/Core/Filter/FrontEndObject/ShopFilter.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter\FrontEndObject;
+
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
+
+class ShopFilter extends HashMapWhitelistFilter
+{
+    public function __construct()
+    {
+        $whitelist = array(
+            "address",
+            "favicon",
+            "favicon_update_time",
+            "fax",
+            "logo",
+            "name",
+            "phone",
+            "stores_icon",
+        );
+
+        $this->whitelist($whitelist);
+    }
+}

--- a/src/Core/Filter/HashMapWhitelistFilter.php
+++ b/src/Core/Filter/HashMapWhitelistFilter.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Filter;
+
+/**
+ * This class filters associative arrays.
+ *
+ * Usage:
+ *
+ * ```php
+ * $map = [
+ *     'foo' => 'something',
+ *     'bar' => null,
+ *     'baz' => array(),
+ * ];
+ *
+ * $filter = (new HashMapFilter())
+ *     ->whitelist(
+ *         ['foo', 'baz']
+ *     );
+ *
+ * $filtered = $filter->filter();
+ * // returns [ 'foo' => something, 'baz' => [] ];
+ * ```
+ *
+ * You can also nest filters:
+ *
+ * ```php
+ * $map = [
+ *     'foo' => 'something',
+ *     'bar' => null,
+ *     'baz' => [true, false, 1, 0]
+ * ];
+ *
+ * $filter = (new HashMapFilter())
+ *     ->whitelist([
+ *         'foo',
+ *         'baz' => OnlyTruthyValuesInCollectionFilter()
+ *     ]);
+ *
+ * $filtered = $filter->filter();
+ * // returns [ 'foo' => something, 'baz' => [ true, 1 ] ];
+ * ```
+ */
+class HashMapWhitelistFilter implements FilterInterface
+{
+
+    /**
+     * Index of $keyToKeep => true
+     * @var true[]
+     */
+    protected $whitelistItems = [];
+
+    /**
+     * @var FilterInterface[]
+     */
+    protected $filters = [];
+
+    /**
+     * Adds keys to the whitelist.
+     *
+     * This method accepts either:
+     * - string[] an array of keys to keep
+     * - FilterInterface[] an array of filters, indexed by keys to keep
+     * - A mixture of the two
+     *
+     * @param string[]|FilterInterface[] $definition
+     *
+     * @return $this
+     */
+    public function whitelist($definition)
+    {
+        foreach ($definition as $k => $value) {
+            $this->addWhitelistItem($k, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Filters the subject
+     *
+     * @param array $subject
+     *
+     * @return array The filtered subject
+     */
+    public function filter($subject)
+    {
+        // keep whitelisted items
+        $subject = array_intersect_key($subject, $this->whitelistItems);
+
+        // run nested filters
+        foreach ($this->filters as $key => $filter) {
+            if (array_key_exists($key, $subject)) {
+                $subject[$key] = $filter->filter($subject[$key]);
+            }
+        }
+
+        return $subject;
+    }
+
+    /**
+     * Adds an element to the whitelist
+     *
+     * @param int|string $paramKey
+     * @param string|FilterInterface $paramValue
+     *
+     * @return $this
+     */
+    private function addWhitelistItem($paramKey, $paramValue)
+    {
+        $keyToWhitelist = $paramValue;
+        if ($paramValue instanceof FilterInterface) {
+            $this->filters[$paramKey] = $paramValue;
+
+            $keyToWhitelist = $paramKey;
+        }
+
+        // add as key to allow faster search
+        $this->whitelistItems[$keyToWhitelist] = true;
+
+        return $this;
+    }
+}

--- a/src/Core/Filter/HashMapWhitelistFilter.php
+++ b/src/Core/Filter/HashMapWhitelistFilter.php
@@ -137,7 +137,7 @@ class HashMapWhitelistFilter implements FilterInterface
     }
 
     /**
-     * Returns the ested filters, indexed by $keyToKeep
+     * Returns the nested filters, indexed by $keyToKeep
      *
      * @return FilterInterface[]
      */

--- a/src/Core/Filter/HashMapWhitelistFilter.php
+++ b/src/Core/Filter/HashMapWhitelistFilter.php
@@ -77,6 +77,7 @@ class HashMapWhitelistFilter implements FilterInterface
     protected $whitelistItems = [];
 
     /**
+     * Nested filters, indexed by $keyToKeep
      * @var FilterInterface[]
      */
     protected $filters = [];
@@ -100,6 +101,49 @@ class HashMapWhitelistFilter implements FilterInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Removes the provided key from the whitelist
+     *
+     * @param string|int $key
+     *
+     * @return $this
+     *
+     * @throws FilterException if $key is not scalar
+     */
+    public function removeFromWhitelist($key)
+    {
+        if (!is_scalar($key)) {
+            throw new FilterException(
+                sprintf( "Invalid parameter %s", print_r($key, true))
+            );
+        }
+
+        unset($this->whitelistItems[$key]);
+        unset($this->filters[$key]);
+
+        return $this;
+    }
+
+    /**
+     * Returns the white list
+     *
+     * @return true[]
+     */
+    public function getWhitelistItems()
+    {
+        return $this->whitelistItems;
+    }
+
+    /**
+     * Returns the ested filters, indexed by $keyToKeep
+     *
+     * @return FilterInterface[]
+     */
+    public function getFilters()
+    {
+        return $this->filters;
     }
 
     /**

--- a/tests/Unit/Core/Filter/CollectionFilterTest.php
+++ b/tests/Unit/Core/Filter/CollectionFilterTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Tests\Unit\Core\Filter;
+
+use PrestaShop\PrestaShop\Core\Filter\CollectionFilter;
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
+
+class CollectionFilterTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @param array $subject
+     * @param array $queue
+     * @param array $expectedResult
+     *
+     * @dataProvider provideTestCases
+     *
+     * @throws \PrestaShop\PrestaShop\Core\Filter\FilterException
+     */
+    public function testItProcessesAllItems($subject, $queue, $expectedResult)
+    {
+        $filter = new CollectionFilter();
+        $filter->queue($queue);
+
+        $result = $filter->filter($subject);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function provideTestCases()
+    {
+        $subject = [
+            [
+                'foo' => 'something',
+                'bar' => null,
+                'baz' => []
+            ],
+            [
+                'foo' => 'something',
+            ],
+            [
+                'bar' => null,
+                'baz' => [],
+            ],
+            []
+        ];
+
+        return [
+            [
+                'subject' => $subject,
+                'queue' => [
+                    (new HashMapWhitelistFilter())
+                        ->whitelist(['foo'])
+                ],
+                'expectedResult' => [
+                    [
+                        'foo' => 'something',
+                    ],
+                    [
+                        'foo' => 'something',
+                    ],
+                    [],
+                    [],
+                ]
+            ]
+        ];
+    }
+
+}

--- a/tests/Unit/Core/Filter/HashMapWhitelistFilterTest.php
+++ b/tests/Unit/Core/Filter/HashMapWhitelistFilterTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Tests\Unit\Core\Filter;
+
+use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
+
+class HashMapWhitelistFilterTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @param array $subject
+     * @param array $whitelist
+     * @param array $expectedResult
+     *
+     * @dataProvider provideTestCases
+     */
+    public function testItOnlyKeepsWhitelistedKeysWithoutLosingValues($subject, $whitelist, $expectedResult)
+    {
+        $filter = new HashMapWhitelistFilter();
+        $filter->whitelist($whitelist);
+
+        $result = $filter->filter($subject);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function provideTestCases()
+    {
+        $basicArray = [
+            'foo' => 'something',
+            'bar' => null,
+            'baz' => [],
+        ];
+
+        $nestedArray = [
+            'foo' => 'something',
+            'bar' => null,
+            'baz' => $basicArray,
+        ];
+
+        return [
+            'keep 1st'         => [
+                'subject'   => $basicArray,
+                'whitelist' => [
+                    'foo',
+                ],
+                'expected'  => [
+                    'foo' => 'something',
+                ],
+            ],
+            'keep 2nd'         => [
+                'subject'   => $basicArray,
+                'whitelist' => [
+                    'bar',
+                ],
+                'expected'  => [
+                    'bar' => null,
+                ],
+            ],
+            'keep 3rd'         => [
+                'subject'   => $basicArray,
+                'whitelist' => [
+                    'baz',
+                ],
+                'expected'  => [
+                    'baz' => array(),
+                ],
+            ],
+            'keep 1st and 2nd' => [
+                'subject'   => $basicArray,
+                'whitelist' => [
+                    'foo', 'bar',
+                ],
+                'expected'  => [
+                    'foo' => 'something',
+                    'bar' => null,
+                ],
+            ],
+            'keep all'         => [
+                'subject'   => $basicArray,
+                'whitelist' => [
+                    'foo', 'bar', 'baz',
+                ],
+                'expected'  => [
+                    'foo' => 'something',
+                    'bar' => null,
+                    'baz' => [],
+                ],
+            ],
+            'keep none'        => [
+                'subject'   => $basicArray,
+                'whitelist' => [],
+                'expected'  => [],
+            ],
+            'nested sanitizer' => [
+                'subject'   => $nestedArray,
+                'whitelist' => [
+                    'foo',
+                    'baz' => (new HashMapWhitelistFilter())->whitelist(['foo', 'baz'])
+                ],
+                'expected' => [
+                    'foo' => 'something',
+                    'baz' => [
+                        'foo' => 'something',
+                        'baz' => []
+                    ],
+                ]
+            ]
+        ];
+    }
+
+}

--- a/tests/Unit/Core/Filter/HashMapWhitelistFilterTest.php
+++ b/tests/Unit/Core/Filter/HashMapWhitelistFilterTest.php
@@ -48,6 +48,64 @@ class HashMapWhitelistFilterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedResult, $result);
     }
 
+    public function testKeysCanBeRemovedFromWhitelist()
+    {
+        $subject = [
+            'foo' => 'something',
+            'bar' => null,
+            'baz' => [],
+        ];
+
+        $filter = new HashMapWhitelistFilter();
+        $filter->whitelist([
+            'foo', 'bar'
+        ]);
+
+        $expected = [
+            'foo' => 'something',
+            'bar' => null,
+        ];
+
+        $this->assertSame($expected, $filter->filter($subject));
+
+        // remove 'foo' from whitelist and filter again
+        $filter->removeFromWhitelist('foo');
+        $expected = [
+            'bar' => null,
+        ];
+
+        $this->assertSame($expected, $filter->filter($subject));
+    }
+
+    public function testKeysCanBeAddedToWhitelist()
+    {
+        $subject = [
+            'foo' => 'something',
+            'bar' => null,
+            'baz' => [],
+        ];
+
+        $filter = new HashMapWhitelistFilter();
+        $filter->whitelist([
+            'foo'
+        ]);
+
+        $expected = [
+            'foo' => 'something',
+        ];
+
+        $this->assertSame($expected, $filter->filter($subject));
+
+        // add 'bar' to the whitelist and filter again
+        $filter->whitelist(['bar']);
+        $expected = [
+            'foo' => 'something',
+            'bar' => null,
+        ];
+
+        $this->assertSame($expected, $filter->filter($subject));
+    }
+
     public function provideTestCases()
     {
         $basicArray = [
@@ -116,7 +174,7 @@ class HashMapWhitelistFilterTest extends \PHPUnit_Framework_TestCase
                 'whitelist' => [],
                 'expected'  => [],
             ],
-            'nested sanitizer' => [
+            'nested filter' => [
                 'subject'   => $nestedArray,
                 'whitelist' => [
                     'foo',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | This PR introduces object filtering through property whitelisting. This filtering is now applied to:<br>1. Objects being sent to the front office through the "prestashop" object,<br>2. Objects being sent after adding a product to the cart,<br>3. Objects being sent in response to search.<br><br>It also introduces two hooks:<br>1. actionBuildFrontEndObject - Allows to add elements to the "prestashop" object included in javascript<br>2. actionFrontControllerAfterInit - Launched after the "init" method on all front controllers
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4509
| How to test?  | See ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8803)
<!-- Reviewable:end -->
