### PR TITLE
BO: check the array coming from the DB since initial value is null

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -517,8 +517,8 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         if (Shop::isTableAssociated($this->def['table'])) {
             $id_shop_list = Shop::getContextListShopID();
-            if (count($this->id_shop_list) > 0) {
-                $id_shop_list = $this->id_shop_list;
+            if (count($id_shop_list) > 0) {
+                $this->id_shop_list = $id_shop_list;
             }
         }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -683,8 +683,8 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         }
 
         $id_shop_list = Shop::getContextListShopID();
-        if (count($this->id_shop_list) > 0) {
-            $id_shop_list = $this->id_shop_list;
+        if (count($id_shop_list) > 0) {
+            $this->id_shop_list = $id_shop_list;
         }
 
         if (Shop::checkIdShopDefault($this->def['table']) && !$this->id_shop_default) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | theres a bug occurring in the install process, when its trying to count $this->id_shop_list while its null
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | when installing a new store on "Store installation" step it will give out an error trying to count $this->id_shop_list which is a null

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8808)
<!-- Reviewable:end -->
