### PR TITLE
Module tab new subtree

### DIFF
--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -40,7 +40,7 @@ use TabCore as Tab;
 
 class ModuleTabRegister
 {
-    const suffix = '_MTR';
+    const SUFFIX = '_MTR';
 
     private $defaultParent = 'DEFAULT';
     /**
@@ -279,7 +279,7 @@ class ModuleTabRegister
         $parentClassName = $data->get('parent_class_name', $data->get('ParentClassName'));
         if (!empty($parentClassName)) {
             // Could be a previously duicated tab
-            $idParent = (int)$this->tabRepository->findOneIdByClassName($parentClassName.self::suffix);
+            $idParent = (int)$this->tabRepository->findOneIdByClassName($parentClassName.self::SUFFIX);
             if (!$idParent) {
                 $idParent = (int)$this->tabRepository->findOneIdByClassName($parentClassName);
             }
@@ -307,7 +307,7 @@ class ModuleTabRegister
         $newTab = clone($currentTab);
         $newTab->id = 0;
         $newTab->id_parent = $currentTab->id_parent;
-        $newTab->class_name = $currentTab->class_name.self::suffix;
+        $newTab->class_name = $currentTab->class_name.self::SUFFIX;
         $newTab->save();
 
         // Second save in order to get the proper position (add() resets it)

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -239,24 +239,24 @@ class ModuleTabRegister
      * Install a tab according to its defined structure
      *
      * @param Module $module
-     * @param ParameterBag $data The structure of the tab.
+     * @param ParameterBag $tabDetails The structure of the tab.
      *
      * @throws Exception in case of error from validation or save
      */
-    protected function registerTab(Module $module, ParameterBag $data)
+    protected function registerTab(Module $module, ParameterBag $tabDetails)
     {
-        $this->checkIsValid($module->get('name'), $data);
+        $this->checkIsValid($module->get('name'), $tabDetails);
 
         // Legacy Tab, to be replaced with Doctrine entity when right management
         // won't be directly linked to the tab creation
         // @ToDo
         $tab = new Tab();
-        $tab->active = $data->getBoolean('visible', true);
-        $tab->class_name = $data->get('class_name');
+        $tab->active = $tabDetails->getBoolean('visible', true);
+        $tab->class_name = $tabDetails->get('class_name');
         $tab->module = $module->get('name');
-        $tab->name = $this->getTabNames($data->get('name', $tab->class_name));
-        $tab->icon = $data->get('icon');
-        $tab->id_parent = $this->findParentId($data);
+        $tab->name = $this->getTabNames($tabDetails->get('name', $tab->class_name));
+        $tab->icon = $tabDetails->get('icon');
+        $tab->id_parent = $this->findParentId($tabDetails);
 
         if (!$tab->save()) {
             throw new Exception(
@@ -270,23 +270,23 @@ class ModuleTabRegister
     /**
      * Find the parent ID from the given tab context
      *
-     * @param ParameterBag $data The structure of the tab.
+     * @param ParameterBag $tabDetails The structure of the tab.
      * @return int ID of the parent, 0 if none
      */
-    protected function findParentId(ParameterBag $data)
+    protected function findParentId(ParameterBag $tabDetails)
     {
         $idParent = 0;
-        $parentClassName = $data->get('parent_class_name', $data->get('ParentClassName'));
+        $parentClassName = $tabDetails->get('parent_class_name', $tabDetails->get('ParentClassName'));
         if (!empty($parentClassName)) {
-            // Could be a previously duicated tab
-            $idParent = (int)$this->tabRepository->findOneIdByClassName($parentClassName.self::SUFFIX);
+            // Could be a previously duplicated tab
+            $idParent = $this->tabRepository->findOneIdByClassName($parentClassName.self::SUFFIX);
             if (!$idParent) {
-                $idParent = (int)$this->tabRepository->findOneIdByClassName($parentClassName);
+                $idParent = $this->tabRepository->findOneIdByClassName($parentClassName);
             }
-        } elseif (true === $data->getBoolean('visible', true)) {
-            $idParent = (int)$this->tabRepository->findOneIdByClassName($this->defaultParent);
+        } elseif (true === $tabDetails->getBoolean('visible', true)) {
+            $idParent = $this->tabRepository->findOneIdByClassName($this->defaultParent);
         }
-        return $this->duplicateParentIfAlone($idParent);
+        return $this->duplicateParentIfAlone((int) $idParent);
     }
 
     /**

--- a/src/Adapter/Module/Tab/ModuleTabUnregister.php
+++ b/src/Adapter/Module/Tab/ModuleTabUnregister.php
@@ -122,7 +122,7 @@ class ModuleTabUnregister
         $child = end($remainingChildren);
 
         // We know we have a tab to delete if the parent name is the remaining child name+_MTR
-        if ($parent->getClassName() === $child->getClassName().ModuleTabRegister::suffix) {
+        if ($parent->getClassName() === $child->getClassName().ModuleTabRegister::SUFFIX) {
             $legacyTabParent = new TabClass($parent->getId());
             // Setting a wrong id_parent will prevent the children to move
             $legacyTabParent->id_parent = -1;

--- a/src/PrestaShopBundle/Entity/Repository/TabRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/TabRepository.php
@@ -39,6 +39,15 @@ class TabRepository extends EntityRepository
     {
         return $this->findBy(['module' => $moduleName]);
     }
+
+    /**
+     * @param $idParent
+     * @return array
+     */
+    public function findByParentId($idParent)
+    {
+        return $this->findBy(['idParent' => $idParent]);
+    }
     
     /**
      * @param $className


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | This PRs improves #5922, allowing module contributors to add new entries in the menu. It fixes an issue when he wants to add a new level of submenus (for instance, to display tabs in the header of the BO on an existing page from the core).
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4912
| How to test?  | Install the following module: https://github.com/Quetzacoalt91/moduletab, you must discover new tabs on the Theme page.

![capture du 2018-02-28 15-13-37](https://user-images.githubusercontent.com/6768917/36841324-e194b01a-1d3f-11e8-963f-7f2a745183b9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8814)
<!-- Reviewable:end -->
