### PR TITLE
FIX PHP 7.1 compat in WebserviceOutputBuilder

### DIFF
--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -709,7 +709,7 @@ class WebserviceOutputBuilderCore
 
     public function getSynopsisDetails($field)
     {
-        $arr_details = '';
+        $arr_details = array();
         if (array_key_exists('required', $field) && $field['required']) {
             $arr_details['required'] = 'true';
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | PHP 7.1 does not auto convert string to array and throws a Fatal error: http://php.net/manual/fr/migration71.incompatible.php#migration71.incompatible.empty-string-index-operator
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Use WS to display schema or synopsys of objects: `/api/products?schema=blank` or `/api/products?schema=synopsis`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8821)
<!-- Reviewable:end -->
