### PR TITLE
Change pushState to replaceState on variant change

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -141,7 +141,7 @@ $(document).ready(function () {
       }
 
       if (event.refreshUrl) {
-        window.history.pushState({id_product_attribute: resp.id_product_attribute}, undefined, resp.product_url);
+        window.history.replaceState({id_product_attribute: resp.id_product_attribute}, undefined, resp.product_url);
       }
 
       prestashop.emit('updatedProduct', resp);


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Currently when you change product combination on product page trigger url change in address bar. When you change variant few times returing back to product list maybe hard since you need to roll back each combination change becouse they are added to browser history. With replace state url is still changed but you visitor can return to product list with one click on back button
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | change products variant on product page and click on back button

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8822)
<!-- Reviewable:end -->
