### PR TITLE
Fixed broken search after #8741

### DIFF
--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -58,9 +58,15 @@ class SearchControllerCore extends ProductListingFrontController
                 'search_tag'    => $this->search_tag,
             )
         );
+    }
+
+    public function initContent()
+    {
+        parent::initContent();
 
         $this->doProductSearch('catalog/listing/search', array('entity' => 'search'));
     }
+
 
     protected function getProductSearchQuery()
     {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | General purpose variables like `$page` weren't available in SearchController because of the search being performed during the `init()` controller phase instead of during `initContent()`. After #8741 search was broken. This PR makes it work again 🙂 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Use the search

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8823)
<!-- Reviewable:end -->
