### PR TITLE
Stop sending a copy of the contact message to the "author" (avoid spam)

### DIFF
--- a/controllers/front/ContactController.php
+++ b/controllers/front/ContactController.php
@@ -187,13 +187,10 @@ class ContactControllerCore extends FrontController
                         }
                     }
 
-                    if (empty($contact->email)) {
-                        Mail::Send($this->context->language->id, 'contact_form', ((isset($ct) && Validate::isLoadedObject($ct)) ? sprintf(Mail::l('Your message has been correctly sent #ct%1$s #tc%2$s'), $ct->id, $ct->token) : Mail::l('Your message has been correctly sent')), $var_list, $from, null, null, null, $file_attachment);
-                    } else {
+                    if (!empty($contact->email)) {
                         if (!Mail::Send($this->context->language->id, 'contact', Mail::l('Message from contact form').' [no_sync]',
                             $var_list, $contact->email, $contact->name, null, null,
-                                    $file_attachment, null,    _PS_MAIL_DIR_, false, null, null, $from) ||
-                                !Mail::Send($this->context->language->id, 'contact_form', ((isset($ct) && Validate::isLoadedObject($ct)) ? sprintf(Mail::l('Your message has been correctly sent #ct%1$s #tc%2$s'), $ct->id, $ct->token) : Mail::l('Your message has been correctly sent')), $var_list, $from, null, null, null, $file_attachment, null, _PS_MAIL_DIR_, false, null, null, $contact->email)) {
+                                    $file_attachment, null,    _PS_MAIL_DIR_, false, null, null, $from)) {
                             $this->errors[] = Tools::displayError('An error occurred while sending the message.');
                         }
                     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | The contact form is being exploited by spammers. This PR stops the "author" from receiving a copy of the message, which mitigates the problem.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (partially) http://forge.prestashop.com/browse/BOOM-4288
| How to test?  | Use the contact form, you shouldn't receive a copy of the message anymore

Kudos to @rGaillard for the patch!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8828)
<!-- Reviewable:end -->
