### PR TITLE
Fix uninitialized $moreStepLabels in AdminImportController

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -4421,6 +4421,7 @@ class AdminImportControllerCore extends AdminController
             }
             $import_type = false;
             $doneCount = 0;
+            $moreStepLabels = array();
             // Sometime, import will use registers to memorize data across all elements to import (for trees, or else).
             // Since import is splitted in multiple ajax calls, we must keep these data across all steps of the full import.
             $crossStepsVariables = array();


### PR DESCRIPTION
Was PHP Notice:  Undefined variable: moreStepLabels

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Type?         | bug fix
| Branch?     | develop
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Description | Fixed notice, several times variable was undefined

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8830)
<!-- Reviewable:end -->
