### PR TITLE
Better handling of invalid modules from Addons API

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -26,8 +26,8 @@
 namespace PrestaShop\PrestaShop\Adapter\Module;
 
 use Doctrine\Common\Cache\CacheProvider;
-use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterOrigin;
+use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShopBundle\Service\DataProvider\Admin\AddonsInterface;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
 use PrestaShopBundle\Service\DataProvider\Admin\ModuleInterface;
@@ -172,9 +172,10 @@ class AdminModuleDataProvider implements ModuleInterface
         return ($this->employee->can('edit', 'AdminModulessf') && $this->moduleProvider->can('configure', $name));
     }
 
-    public function generateAddonsUrls(array $addons, $specific_action = null)
+    public function generateAddonsUrls(AddonsCollection $addons, $specific_action = null)
     {
-        foreach ($addons as &$addon) {
+        $addons = $addons->toArray();
+        foreach ($addons as $key => &$addon) {
             $urls = array();
             foreach ($this->moduleActions as $action) {
                 $urls[$action] = $this->router->generate('admin_module_manage_action', array(
@@ -186,14 +187,14 @@ class AdminModuleDataProvider implements ModuleInterface
                 'module_name' => $addon->attributes->get('name'),
             ));
 
-            if ($addon->database->has('installed') && $addon->database->get('installed') == 1) {
-                if ($addon->database->get('active') == 0) {
+            if ($addon->database->has('installed') && $addon->database->getBoolean('installed')) {
+                if (!$addon->database->getBoolean('active')) {
                     $url_active = 'enable';
                     unset(
                         $urls['install'],
                         $urls['disable']
                     );
-                } elseif ($addon->attributes->get('is_configurable') == 1) {
+                } elseif ($addon->attributes->getBoolean('is_configurable')) {
                     $url_active = 'configure';
                     unset(
                         $urls['enable'],
@@ -208,7 +209,7 @@ class AdminModuleDataProvider implements ModuleInterface
                     );
                 }
 
-                if ($addon->attributes->get('is_configurable') == 0) {
+                if (!$addon->attributes->getBoolean('is_configurable')) {
                     unset($urls['configure']);
                 }
 
@@ -219,7 +220,7 @@ class AdminModuleDataProvider implements ModuleInterface
                         $urls['upgrade']
                     );
                 }
-                if ($addon->database->get('active_on_mobile') == 0) {
+                if (!$addon->database->getBoolean('active_on_mobile')) {
                     unset($urls['disable_mobile']);
                 } else {
                     unset($urls['enable_mobile']);
@@ -231,7 +232,7 @@ class AdminModuleDataProvider implements ModuleInterface
                 }
             } elseif (
                 !$addon->attributes->has('origin') ||
-                $addon->disk->get('is_present') == true ||
+                $addon->disk->getBoolean('is_present') ||
                 in_array($addon->attributes->get('origin'), array('native', 'native_all', 'partner', 'customer'))
             ) {
                 $url_active = 'install';
@@ -347,6 +348,12 @@ class AdminModuleDataProvider implements ModuleInterface
 
                     $addons = $this->addonsDataProvider->request($action, $params);
                     foreach ($addons as $addonsType => $addon) {
+                        if (empty($addon->name)) {
+                            $this->logger->error(sprintf("The addon with id %s does not have name.", $addon->id));
+
+                            continue;
+                        }
+
                         $addon->origin = $action;
                         $addon->origin_filter_value = $action_filter_value;
                         $addon->categoryParent = $this->categoriesProvider

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -175,7 +175,7 @@ class AdminModuleDataProvider implements ModuleInterface
     public function generateAddonsUrls(AddonsCollection $addons, $specific_action = null)
     {
         $addons = $addons->toArray();
-        foreach ($addons as $key => &$addon) {
+        foreach ($addons as &$addon) {
             $urls = array();
             foreach ($this->moduleActions as $action) {
                 $urls[$action] = $this->router->generate('admin_module_manage_action', array(
@@ -233,7 +233,7 @@ class AdminModuleDataProvider implements ModuleInterface
             } elseif (
                 !$addon->attributes->has('origin') ||
                 $addon->disk->getBoolean('is_present') ||
-                in_array($addon->attributes->get('origin'), array('native', 'native_all', 'partner', 'customer'))
+                in_array($addon->attributes->get('origin'), array('native', 'native_all', 'partner', 'customer'), true)
             ) {
                 $url_active = 'install';
                 unset(

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -184,21 +184,24 @@ class Module implements ModuleInterface
      */
     public function hasValidInstance()
     {
-        if (($this->disk->has('is_present') && $this->disk->get('is_present') == false)
-            || ($this->disk->has('is_valid') && $this->disk->get('is_valid') == false)) {
+        if (($this->disk->has('is_present') && $this->disk->getBoolean('is_present') === false)
+            || ($this->disk->has('is_valid') && $this->disk->getBoolean('is_valid') === false)) {
+
             return false;
         }
 
         if ($this->instance === null) {
-            // We try to instanciate the legacy class if not done yet
+            // We try to instantiate the legacy class if not done yet
             try {
                 $this->instanciateLegacyModule($this->attributes->get('name'));
             } catch (\Exception $e) {
                 $this->disk->set('is_valid', false);
-                throw $e;
+
+                return false;
             }
         }
-        $this->disk->set('is_valid', ($this->instance instanceof LegacyModule));
+
+        $this->disk->set('is_valid', $this->instance instanceof LegacyModule);
 
         return $this->disk->get('is_valid');
     }

--- a/src/Core/Addon/AddonsCollection.php
+++ b/src/Core/Addon/AddonsCollection.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Addon;
+
+use PrestaShop\PrestaShop\Adapter\Module\Module as Addon;
+use ArrayAccess;
+use Countable;
+use IteratorAggregate;
+
+/**
+ * An ArrayCollection is a Collection implementation that wraps a regular PHP array.
+ */
+class AddonsCollection implements ArrayAccess, Countable, IteratorAggregate
+{
+    /**
+     * An array containing the addons of this collection.
+     *
+     * @var array
+     */
+    private $addons;
+
+    /**
+     * Initializes a new AddonsCollection.
+     *
+     * @param array $addons
+     */
+    public function __construct(array $addons = [])
+    {
+        $this->addons = $addons;
+    }
+
+    /**
+     * Creates a new instance from the specified elements.
+     *
+     * This method is provided for derived classes to specify how a new
+     * instance should be created when constructor semantics have changed.
+     *
+     * @param array $addons Elements.
+     *
+     * @return static
+     */
+    public static function createFrom(array $addons)
+    {
+        return new static($addons);
+    }
+
+    /**
+     * Gets a native PHP array representation of the collection.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->addons;
+    }
+
+    /**
+     * @return ArrayIterator|\Traversable
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->addons);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return $this->containsKey($offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * Required by ArrayAccess interface.
+     *
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $addon)
+    {
+        if (!isset($offset)) {
+            $this->add($addon);
+            return;
+        }
+
+        $this->set($offset, $addon);
+    }
+
+    /**
+     * Required by interface ArrayAccess.
+     *
+     * {@inheritDoc}
+     */
+    public function offsetUnset($offset)
+    {
+        $this->remove($offset);
+    }
+
+    /**
+     * Returns true if the key is found in the collection.
+     *
+     * @param mixed $key the key, can be integer or string
+     * @return bool
+     */
+    public function containsKey($key)
+    {
+        return isset($this->addons[$key]) || array_key_exists($key, $this->addons);
+    }
+
+    /**
+     * Returns true if the addon is found in the collection.
+     *
+     * @param Addon $addon the addon
+     * @return bool
+     */
+    public function contains(Addon $addon)
+    {
+        return in_array($addon, $this->addons, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function indexOf(Addon $addon)
+    {
+        return array_search($addon, $this->addons, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($key)
+    {
+        return $this->addons[$key] ? $this->addons[$key] : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getKeys()
+    {
+        return array_keys($this->addons);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValues()
+    {
+        return array_values($this->addons);
+    }
+
+    /**
+     * Add an Addon with a specified key in the collection.
+     *
+     * @param mixed $key the key
+     * @param Addon $addon the specified addon
+     */
+    public function set($key, Addon $addon)
+    {
+        $this->addons[$key] = $addon;
+    }
+
+    /**
+     * Add an Addon in the collection.
+     *
+     * @param Addon $addon the specified addon
+     * @return bool
+     */
+    public function add(Addon $addon)
+    {
+        $this->addons[] = $addon;
+
+        return true;
+    }
+
+    /**
+     * Remove an addon from the collection by key.
+     *
+     * @param mixed the key (can be int or string).
+     * @return bool true if the addon has been found and removed.
+     */
+    public function removeByKey($key)
+    {
+        if (! isset($this->addons[$key]) && ! array_key_exists($key, $this->addons)) {
+            return null;
+        }
+
+        $removed = $this->addons[$key];
+        unset($this->addons[$key]);
+
+        return $removed;
+    }
+
+    /**
+     * Remove an addon from the collection by key.
+     *
+     * @param Addon $addon the addon to be removed.
+     * @return bool true if the addon has been found and removed.
+     */
+    public function remove(Addon $addon)
+    {
+        $key = array_search($addon, $this->addons, true);
+
+        if ($key === false) {
+            return false;
+        }
+
+        unset($this->addons[$key]);
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEmpty()
+    {
+        return empty($this->addons);
+    }
+
+    /**
+     * Gets the sum of addons of the collection.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->addons);
+    }
+}

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
+use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShop\PrestaShop\Core\Addon\Module\Exception\UnconfirmedModuleActionException;
 use PrestaShopBundle\Event\ModuleManagementEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -147,7 +148,8 @@ class ModuleManager implements AddonManagerInterface
 
         $modulesProvider = $this->adminModuleProvider;
         foreach ($modules as $moduleLabel => $modulesPart) {
-            $modules->{$moduleLabel} = $modulesProvider->generateAddonsUrls($modulesPart, str_replace("to_", "", $moduleLabel));
+            $collection = AddonsCollection::createFrom($modulesPart);
+            $modules->{$moduleLabel} = $modulesProvider->generateAddonsUrls($collection, str_replace("to_", "", $moduleLabel));
             $modules->{$moduleLabel} = $modulesPresenter($modulesPart);
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -25,6 +25,7 @@
  */
 namespace PrestaShopBundle\Controller\Admin;
 
+use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -157,11 +158,11 @@ class CommonController extends FrameworkBundleAdminController
      */
     public function recommendedModulesAction($domain, $limit = 0, $randomize = 0)
     {
-        $recommendedModules = $this->container->get('prestashop.data_provider.modules.recommended');
+        $recommendedModules = $this->get('prestashop.data_provider.modules.recommended');
         /* @var $recommendedModules RecommendedModules */
         $moduleIdList = $recommendedModules->getRecommendedModuleIdList($domain, ($randomize == 1));
 
-        $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
+        $modulesProvider = $this->get('prestashop.core.admin.data_provider.module_interface');
         /* @var $modulesProvider AdminModuleDataProvider */
         $modulesRepository = ModuleManagerBuilder::getInstance()->buildRepository();
 
@@ -180,7 +181,8 @@ class CommonController extends FrameworkBundleAdminController
         }
 
         $modules = $recommendedModules->filterInstalledAndBadModules($modules);
-        $modules = $modulesProvider->generateAddonsUrls($modules);
+        $collection = AddonsCollection::createFrom($modules);
+        $modules = $modulesProvider->generateAddonsUrls($collection);
 
         return array(
             'domain' => $domain,


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In some edge cases, modules list from Addons API can be invalid: we need to ignore invalid modules or this break the Module Catalog page and every page with "Recommended modules" action.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Add an invalid module or ask Addons team to add an invalid module in their api lulz

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8831)
<!-- Reviewable:end -->
