### PR TITLE
Replace Noto Sans font with Vazir font for Farsi in Classic theme

### DIFF
--- a/themes/classic/assets/css/theme.rtlfix
+++ b/themes/classic/assets/css/theme.rtlfix
@@ -1,3 +1,86 @@
+/*
+Vazir Font Copyright
+Changes by Saber Rastikerdar are in public domain.
+Glyphs and data from Roboto font are licensed under the Apache License, Version 2.0.
+
+Fonts are (c) Bitstream (see below). DejaVu changes are in public domain. 
+
+Bitstream Vera Fonts Copyright
+------------------------------
+
+Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is
+a trademark of Bitstream, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the fonts accompanying this license ("Fonts") and associated
+documentation files (the "Font Software"), to reproduce and distribute the
+Font Software, including without limitation the rights to use, copy, merge,
+publish, distribute, and/or sell copies of the Font Software, and to permit
+persons to whom the Font Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright and trademark notices and this permission notice shall
+be included in all copies of one or more of the Font Software typefaces.
+
+The Font Software may be modified, altered, or added to, and in particular
+the designs of glyphs or characters in the Fonts may be modified and
+additional glyphs or characters may be added to the Fonts, only if the fonts
+are renamed to names not containing either the words "Bitstream" or the word
+"Vera".
+
+This License becomes null and void to the extent applicable to Fonts or Font
+Software that has been modified and is distributed under the "Bitstream
+Vera" names.
+
+The Font Software may be sold as part of a larger software package but no
+copy of one or more of the Font Software typefaces may be sold by itself.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT,
+TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME
+FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING
+ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE
+FONT SOFTWARE.
+
+Except as contained in this notice, the names of Gnome, the Gnome
+Foundation, and Bitstream Inc., shall not be used in advertising or
+otherwise to promote the sale, use or other dealings in this Font Software
+without prior written authorization from the Gnome Foundation or Bitstream
+Inc., respectively. For further information, contact: fonts at gnome dot
+org.
+*/
+@font-face {
+  font-family: Vazir;
+  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir.eot');
+  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir.eot?#iefix') format('embedded-opentype'),
+       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir.woff') format('woff'),
+       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir.ttf') format('truetype');
+  font-weight: normal;
+}
+      
+@font-face {
+  font-family: Vazir;
+  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Bold.eot');
+  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Bold.eot?#iefix') format('embedded-opentype'),
+       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Bold.woff') format('woff'),
+       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Bold.ttf') format('truetype');
+  font-weight: bold;
+}
+
+@font-face {
+  font-family: Vazir;
+  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Light.eot');
+  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Light.eot?#iefix') format('embedded-opentype'),
+       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Light.woff') format('woff'),
+       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Light.ttf') format('truetype');
+  font-weight: 300;
+}
+body.lang-fa{
+	font-family: "Vazir",sans-serif;
+}
 .rtl-flip:not(.rtl-no-flip), .material-icons:not(.rtl-no-flip) {
 	-moz-transform: scaleX(-1);
 	-o-transform: scaleX(-1);

--- a/themes/classic/assets/css/theme.rtlfix
+++ b/themes/classic/assets/css/theme.rtlfix
@@ -1,81 +1,27 @@
-/*
-Vazir Font Copyright
-Changes by Saber Rastikerdar are in public domain.
-Glyphs and data from Roboto font are licensed under the Apache License, Version 2.0.
-
-Fonts are (c) Bitstream (see below). DejaVu changes are in public domain. 
-
-Bitstream Vera Fonts Copyright
-------------------------------
-
-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is
-a trademark of Bitstream, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of the fonts accompanying this license ("Fonts") and associated
-documentation files (the "Font Software"), to reproduce and distribute the
-Font Software, including without limitation the rights to use, copy, merge,
-publish, distribute, and/or sell copies of the Font Software, and to permit
-persons to whom the Font Software is furnished to do so, subject to the
-following conditions:
-
-The above copyright and trademark notices and this permission notice shall
-be included in all copies of one or more of the Font Software typefaces.
-
-The Font Software may be modified, altered, or added to, and in particular
-the designs of glyphs or characters in the Fonts may be modified and
-additional glyphs or characters may be added to the Fonts, only if the fonts
-are renamed to names not containing either the words "Bitstream" or the word
-"Vera".
-
-This License becomes null and void to the extent applicable to Fonts or Font
-Software that has been modified and is distributed under the "Bitstream
-Vera" names.
-
-The Font Software may be sold as part of a larger software package but no
-copy of one or more of the Font Software typefaces may be sold by itself.
-
-THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT,
-TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME
-FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING
-ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
-THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE
-FONT SOFTWARE.
-
-Except as contained in this notice, the names of Gnome, the Gnome
-Foundation, and Bitstream Inc., shall not be used in advertising or
-otherwise to promote the sale, use or other dealings in this Font Software
-without prior written authorization from the Gnome Foundation or Bitstream
-Inc., respectively. For further information, contact: fonts at gnome dot
-org.
-*/
 @font-face {
   font-family: Vazir;
-  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir.eot');
-  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir.eot?#iefix') format('embedded-opentype'),
-       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir.woff') format('woff'),
-       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir.ttf') format('truetype');
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.eot');
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.eot?#iefix') format('embedded-opentype'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.woff') format('woff'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir.ttf') format('truetype');
   font-weight: normal;
 }
       
 @font-face {
   font-family: Vazir;
-  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Bold.eot');
-  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Bold.eot?#iefix') format('embedded-opentype'),
-       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Bold.woff') format('woff'),
-       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Bold.ttf') format('truetype');
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045523/vazir_v18.0.0/Vazir-Bold.eot');
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045523/vazir_v18.0.0/Vazir-Bold.eot?#iefix') format('embedded-opentype'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.woff') format('woff'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522045523/vazir_v18.0.0/Vazir-Bold.ttf') format('truetype');
   font-weight: bold;
 }
 
 @font-face {
   font-family: Vazir;
-  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Light.eot');
-  src: url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Light.eot?#iefix') format('embedded-opentype'),
-       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Light.woff') format('woff'),
-       url('https://cdn.rawgit.com/rastikerdar/vazir-font/61a73a5c/dist/Vazir-Light.ttf') format('truetype');
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.eot');
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.eot?#iefix') format('embedded-opentype'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.woff') format('woff'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.ttf') format('truetype');
   font-weight: 300;
 }
 body.lang-fa{


### PR DESCRIPTION
Replace the Noto Sans font with Vazir font (v18.0.0) which is a better choice for Farsi typeface + copyright (Apache v2)

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Replace the Noto Sans font with Vazir font (v18.0.0) which is a better choice for Farsi typeface + copyright (Apache v2)
| Type?         | improvement
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | https://trello.com/c/FI0ri5Ev/1-fonts
| How to test?  | Generate RTL stylesheet from Design -> Theme & Logo menu. Please remove "theme_rtl.css" file from "themes/classic/assets/css" path if existing before generating new RTL stylesheet.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8835)
<!-- Reviewable:end -->
