### PR TITLE
Fix tinymce RTL text direction

### DIFF
--- a/js/admin/tinymce.inc.js
+++ b/js/admin/tinymce.inc.js
@@ -45,9 +45,6 @@ function tinySetup(config) {
     config.selector = '.' + config.editor_selector;
   }
 
-  if (typeof lang_is_rtl === 'undefined') {
-    var lang_is_rtl = '0';
-  }
 
   var default_config = {
     selector: ".rte",


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix text direction bug in tinymce editor for RTL languages
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Editor text direction is LTR now. You can see admin product add/edit page in both RTL and LTR languages.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8838)
<!-- Reviewable:end -->
