### PR TITLE
FIX invoice taxes details when using discounts

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2259,6 +2259,7 @@ class OrderCore extends ObjectModel
 
         // compute products discount
         $order_discount_tax_excl = $this->total_discounts_tax_excl;
+        $order_discount_tax_incl = $this->total_discounts_tax_incl;
 
         $free_shipping_tax = 0;
         $product_specific_discounts = array();
@@ -2269,6 +2270,7 @@ class OrderCore extends ObjectModel
             if ($order_cart_rule['free_shipping'] && $free_shipping_tax === 0) {
                 $free_shipping_tax = $this->total_shipping_tax_incl - $this->total_shipping_tax_excl;
                 $order_discount_tax_excl -= $this->total_shipping_tax_excl;
+                $order_discount_tax_incl -= $this->total_shipping_tax_incl;
                 $expected_total_base += $this->total_shipping_tax_excl;
             }
 
@@ -2280,10 +2282,11 @@ class OrderCore extends ObjectModel
 
                 $product_specific_discounts[$cart_rule->reduction_product] += $order_cart_rule['value_tax_excl'];
                 $order_discount_tax_excl -= $order_cart_rule['value_tax_excl'];
+                $order_discount_tax_incl -= $order_cart_rule['value_tax_incl'];
             }
         }
         
-        $expected_total_tax = $this->total_products_wt - $this->total_products;
+        $expected_total_tax = ($this->total_products_wt - $order_discount_tax_incl) - ($this->total_products - $order_discount_tax_excl);
         $actual_total_tax = 0;
         $actual_total_base = 0;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Taxes breakdown is wrong in order invoices including a discount 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-9578
| How to test?  | Create an order including a discount, and generate the invoice. The taxes breakdown calculation is wrong (it doesn't account for discounts in the $expected_total_tax calcultation)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8839)
<!-- Reviewable:end -->
