### PR TITLE
Minor install improvements

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -27,6 +27,7 @@ use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShop\PrestaShop\Core\Cldr\Repository as cldrRepository;
 use PrestaShop\PrestaShop\Core\Localization\RTL\Processor as RtlStylesheetProcessor;
 use PrestaShopBundle\Translation\Translator;
+use Symfony\Component\Filesystem\Filesystem;
 
 class LanguageCore extends ObjectModel
 {
@@ -1073,25 +1074,24 @@ class LanguageCore extends ObjectModel
     {
         $file = _PS_TRANSLATIONS_DIR_.$type.'-'.$locale.'.zip';
         $url = ('emails' === $type) ? self::EMAILS_LANGUAGE_PACK_URL : self::SF_LANGUAGE_PACK_URL;
-        $content = Tools::file_get_contents(
-            str_replace(
-                array(
-                    '%version%',
-                    '%locale%',
-                ),
-                array(
-                    _PS_VERSION_,
-                    $locale,
-                ),
-                $url
-            )
+        $url = str_replace(
+            array(
+                '%version%',
+                '%locale%',
+            ),
+            array(
+                _PS_VERSION_,
+                $locale,
+            ),
+            $url
         );
 
         if (!is_writable(dirname($file))) {
             // @todo Throw exception
             $errors[] = Context::getContext()->getTranslator()->trans('Server does not have permissions for writing.', array(), 'Admin.International.Notification').' ('.$file.')';
         } else {
-            @file_put_contents($file, $content);
+            $fs = new Filesystem();
+            $fs->copy($url, $file);
         }
     }
 
@@ -1111,7 +1111,7 @@ class LanguageCore extends ObjectModel
     public static function installEmailsLanguagePack($lang_pack, &$errors = array())
     {
         $folder = _PS_TRANSLATIONS_DIR_.'emails-'.$lang_pack['locale'];
-        $fileSystem = new \Symfony\Component\Filesystem\Filesystem();
+        $fileSystem = new Filesystem();
         $finder = new \Symfony\Component\Finder\Finder();
 
         if (!file_exists($folder.'.zip')) {

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1097,12 +1097,13 @@ class LanguageCore extends ObjectModel
 
     public static function installSfLanguagePack($locale, &$errors = array())
     {
-        if (!file_exists(_PS_TRANSLATIONS_DIR_.'sf-'.$locale.'.zip')) {
+        $zipFilePath = _PS_TRANSLATIONS_DIR_.'sf-'.$locale.'.zip';
+        if (!file_exists($zipFilePath)) {
             // @todo Throw exception
             $errors[] = Context::getContext()->getTranslator()->trans('Language pack unavailable.', array(), 'Admin.International.Notification');
         } else {
             $zipArchive = new ZipArchive();
-            $zipArchive->open(_PS_TRANSLATIONS_DIR_.'sf-'.$locale.'.zip');
+            $zipArchive->open($zipFilePath);
             $zipArchive->extractTo(_PS_ROOT_DIR_.'/app/Resources/translations');
             $zipArchive->close();
         }

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1091,7 +1091,7 @@ class LanguageCore extends ObjectModel
             $errors[] = Context::getContext()->getTranslator()->trans('Server does not have permissions for writing.', array(), 'Admin.International.Notification').' ('.$file.')';
         } else {
             $fs = new Filesystem();
-            $fs->copy($url, $file);
+            $fs->copy($url, $file, true);
         }
     }
 

--- a/install-dev/index.php
+++ b/install-dev/index.php
@@ -24,8 +24,17 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+require_once 'install_version.php';
 
-if (!extension_loaded('SimpleXML') || !extension_loaded('zip') || PHP_VERSION_ID < 50400 || !is_writable(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'cache')) {
+if (
+    !defined('PHP_VERSION_ID') // PHP_VERSION_ID is available since 5.2.7
+    || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_
+    || !extension_loaded('SimpleXML')
+    || !extension_loaded('zip')
+    || !is_writable(
+        __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'cache'
+    )
+) {
     require_once dirname(__FILE__).'/missing_requirement.php';
     exit();
 }

--- a/install-dev/index_cli.php
+++ b/install-dev/index_cli.php
@@ -26,6 +26,13 @@
 
 use PrestaShop\PrestaShop\Core\Cldr\Composer\Hook;
 
+require_once 'install_version.php';
+
+// Check PHP version
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_) {
+    die('You need at least PHP '._PS_INSTALL_MINIMUM_PHP_VERSION_.' to install PrestaShop. Your current PHP version is '.PHP_VERSION);
+}
+
 /* Redefine REQUEST_URI */
 $_SERVER['REQUEST_URI'] = '/install/index_cli.php';
 require_once dirname(__FILE__).'/init.php';

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -25,6 +25,8 @@
  */
 ob_start();
 
+require_once 'install_version.php';
+
 // Set execution time and time_limit to infinite if available
 @set_time_limit(0);
 @ini_set('max_execution_time', '0');

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -52,11 +52,6 @@ if ($tmp = strpos($_SERVER['REQUEST_URI'], '?')) {
 }
 $_SERVER['REQUEST_URI'] = str_replace('//', '/', $_SERVER['REQUEST_URI']);
 
-// Check PHP version
-if (version_compare(preg_replace('/[^0-9.]/', '', PHP_VERSION), '5.4', '<')) {
-    die('You need at least PHP 5.4 to run PrestaShop. Your current PHP version is '.PHP_VERSION);
-}
-
 // we check if theses constants are defined
 // in order to use init.php in upgrade.php script
 if (!defined('__PS_BASE_URI__')) {
@@ -96,8 +91,6 @@ define('_PS_INSTALL_CONTROLLERS_PATH_', _PS_INSTALL_PATH_.'controllers/');
 define('_PS_INSTALL_MODELS_PATH_', _PS_INSTALL_PATH_.'models/');
 define('_PS_INSTALL_LANGS_PATH_', _PS_INSTALL_PATH_.'langs/');
 define('_PS_INSTALL_FIXTURES_PATH_', _PS_INSTALL_PATH_.'fixtures/');
-
-require_once _PS_INSTALL_PATH_.'install_version.php';
 
 // PrestaShop autoload is used to load some helpfull classes like Tools.
 // Add classes used by installer bellow.

--- a/install-dev/install_version.php
+++ b/install-dev/install_version.php
@@ -25,3 +25,6 @@
  */
 
 define('_PS_INSTALL_VERSION_', '1.7.3.1');
+
+define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 50400);
+define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '5.4');

--- a/install-dev/missing_requirement.php
+++ b/install-dev/missing_requirement.php
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta name="description" content="This store is powered by PrestaShop" />
+  <title>PrestaShop Installation</title>
   <style>
     ::-moz-selection {
       background: #b3d4fc;
@@ -97,18 +97,18 @@
   <ol>
     <?php if (!extension_loaded('SimpleXML')): ?>
     <li>
-        PrestaShop installation requires at least the <b>SimpleXML extension</b> to be enabled.
+        PrestaShop installation requires the <b>SimpleXML extension</b> to be enabled.
     </li>
     <?php endif; ?>
     <?php if (!extension_loaded('zip')): ?>
       <li>
-          PrestaShop installation requires at least the <b>zip extension</b> to be enabled.
+          PrestaShop installation requires the <b>zip extension</b> to be enabled.
       </li>
     <?php endif; ?>
-    <?php if (PHP_VERSION_ID < 50400): ?>
+    <?php if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_): ?>
       <li>
-          PrestaShop requires at least PHP 5.4 or newer versions.
-          <i>You can install PrestaShop 1.6 if you can't update your version of PHP.</i>
+          PrestaShop requires at least PHP <?= _PS_INSTALL_MINIMUM_PHP_VERSION_ ?> or newer versions.
+          <i>To install PrestaShop <?= _PS_INSTALL_VERSION_ ?> you need to update your version of PHP.</i>
       </li>
     <?php endif; ?>
         <?php if (!is_writable(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'cache')): ?>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | This PR brings two minor improvements during the install:<br>1. The minimum supported PHP version is now a constant, which means that error messages will use that constant. Also, version check has been standardized and done at the very start.<br>2. Localization packs were being copied by reading the files into memory and then saving their contents elsewhere. This has been replaced by a simple copy using the Symfony Filesystem library.
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Perform an install in the language of your choice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8843)
<!-- Reviewable:end -->
