### PR TITLE
Check the change of the default combination from the edition page

### DIFF
--- a/tests/E2E/test/campaigns/high/02_product/3_create_product_with_combination.js
+++ b/tests/E2E/test/campaigns/high/02_product/3_create_product_with_combination.js
@@ -99,7 +99,13 @@ scenario('Create product with combination in the Back Office', client => {
         .then(() => client.goToEditCombination());
     });
     test('should edit second combination', () => client.editCombination(2));
+    /**
+     * This scenario is based on the bug described in this ticket
+     * http://forge.prestashop.com/browse/BOOM-4827
+     **/
+    test('should click on "Set as default combination" button', () => client.scrollWaitForExistAndClick(AddProductPage.default_combination.replace('%NUMBER', combinationId)));
     test('should go back to combination list', () => client.backToProduct());
+    test('should check that the second combination is the default combination', () => client.isSelected(AddProductPage.combination_default_button.replace('%NUMBER', combinationId)));
     test('should check that combination\'s quantity is equal to "10"', () => client.checkAttributeValue(AddProductPage.combination_attribute_quantity.replace('%NUMBER', combinationId), 'value', "10"));
     test('should check that combination\'s picture is well updated', () => client.checkAttributeValue(AddProductPage.combination_attribute_image.replace('%NUMBER', combinationId), 'src', title_image, 'contain'));
     test('should check that the "Impact on price (tax incl.) is equal to "20"', () => {
@@ -193,7 +199,6 @@ scenario('Check the product creation in the Back Office', client => {
   test('should reset filter', () => client.waitForExistAndClick(AddProductPage.catalog_reset_filter));
 }, 'product/check_product', true);
 
-
 scenario('Check the product with combination in the Front Office', () => {
   scenario('Login in the Front Office', client => {
     test('should open the browser', () => client.open());
@@ -224,4 +229,3 @@ scenario('Check the product with combination in the Front Office', () => {
     });
   }, 'product/product');
 }, 'product/product', true);
-

--- a/tests/E2E/test/clients/common_client.js
+++ b/tests/E2E/test/clients/common_client.js
@@ -278,8 +278,15 @@ class CommonClient {
   isExisting(selector, pause = 0) {
     return this.client
       .pause(pause)
-      .scrollTo(selector)
       .isExisting(selector)
+      .then((isExisting) => expect(isExisting).to.be.true)
+  }
+
+  isSelected(selector, pause = 0) {
+    return this.client
+      .pause(pause)
+      .scrollTo(selector)
+      .isSelected(selector)
       .then((isExisting) => expect(isExisting).to.be.true)
   }
 

--- a/tests/E2E/test/selectors/BO/add_product_page.js
+++ b/tests/E2E/test/selectors/BO/add_product_page.js
@@ -112,6 +112,8 @@ module.exports = {
     combination_attribute_quantity: '//*[@id="attribute_%NUMBER"]/td[6]/div/input',
     combination_image: '//*[@id="combination_%NUMBER_id_image_attr"]/div[2]/img',
     combination_edit: '//*[@id="attribute_%NUMBER"]/td[7]/div[1]/a',
+    combination_default_button: '//input[@class="attribute-default" and @data-id="%NUMBER"]',
+    default_combination: '//*[@id="combination_%NUMBER_attribute_default"]',
     back_to_product: '//*[@id="combination_form_%NUMBER"]/div[2]/div[1]/button',
     product_pricing_tab: '//*[@id="tab_step2"]/a',
     unit_price: '#form_step2_unit_price',


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Check the change of the default combination from the edition page
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4827
| How to test?  | path=full/02_product/3_create_product_with_combination.js npm run specific-test -- --URL=BackOfficeURL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8854)
<!-- Reviewable:end -->
