### PR TITLE
CO: Fixed cache_id in Categories

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -522,7 +522,7 @@ class CategoryCore extends ObjectModel
         }
 
         $cache_id = 'Category::getAllCategoriesName_'.md5((int)$root_category.(int)$id_lang.(int)$active.(int)$use_shop_restriction
-            .(isset($groups) && Group::isFeatureActive() ? implode('', $groups) : ''));
+            .(isset($groups) && Group::isFeatureActive() ? implode('', $groups) : '').$sql_filter.$sql_sort.$sql_limit);
 
         if (!Cache::isStored($cache_id)) {
             $result = Db::getInstance()->executeS('
@@ -565,7 +565,7 @@ class CategoryCore extends ObjectModel
         }
 
         $cache_id = 'Category::getNestedCategories_'.md5((int)$root_category.(int)$id_lang.(int)$active.(int)$use_shop_restriction
-            .(isset($groups) && Group::isFeatureActive() ? implode('', $groups) : ''));
+            .(isset($groups) && Group::isFeatureActive() ? implode('', $groups) : '').$sql_filter.$sql_sort.$sql_limit);
 
         if (!Cache::isStored($cache_id)) {
             $result = Db::getInstance()->executeS('


### PR DESCRIPTION
Fixed cache_id in getAllCategoriesName
Fixed cache_id in getNestedCategories

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fixed cache_id in 2 methods. Otherwise, methods could retrieve wrong results from cache.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Use Category::getAllCategoriesName() and Category::getNestedCategories() with the same parameters except changing the $sql_filter parameter each time.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8855)
<!-- Reviewable:end -->
