### PR TITLE
Fixed undefined variables when an url is called in ajax

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -36,15 +36,6 @@ class OrderDetailControllerCore extends FrontController
     protected $order_to_display;
 
     /**
-     * Initialize order detail controller
-     * @see FrontController::init()
-     */
-    public function init()
-    {
-        parent::init();
-    }
-
-    /**
      * Start forms process
      * @see FrontController::postProcess()
      */

--- a/controllers/front/listing/BestSalesController.php
+++ b/controllers/front/listing/BestSalesController.php
@@ -42,10 +42,19 @@ class BestSalesControllerCore extends ProductListingFrontController
     {
         if (Configuration::get('PS_DISPLAY_BEST_SELLERS')) {
             parent::init();
-            $this->doProductSearch('catalog/listing/best-sales');
         } else {
             Tools::redirect('index.php?controller=404');
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function initContent()
+    {
+        parent::initContent();
+
+        $this->doProductSearch('catalog/listing/best-sales');
     }
 
     protected function getProductSearchQuery()

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -36,6 +36,9 @@ class CategoryControllerCore extends ProductListingFrontController
     /** @var bool If set to false, customer cannot view the current category. */
     public $customer_access = true;
 
+    /**
+     * @var Category
+     */
     protected $category;
 
     public function canonicalRedirection($canonicalURL = '')
@@ -84,7 +87,7 @@ class CategoryControllerCore extends ProductListingFrontController
 
         $categoryVar = $this->getTemplateVarCategory();
 
-        $filteredCategory= Hook::exec(
+        $filteredCategory = Hook::exec(
             'filterCategoryContent',
             array('object' => $categoryVar),
             $id_module = null,
@@ -102,8 +105,22 @@ class CategoryControllerCore extends ProductListingFrontController
             'category' => $categoryVar,
             'subcategories' => $this->getTemplateVarSubCategories(),
         ));
+    }
 
-        $this->doProductSearch('catalog/listing/category', array('entity' => 'category', 'id' => $id_category));
+    /**
+     * @inheritdoc
+     */
+    public function initContent()
+    {
+        parent::initContent();
+
+        $this->doProductSearch(
+            'catalog/listing/category',
+            array(
+                'entity' => 'category',
+                'id' => $this->category->id
+            )
+        );
     }
 
     protected function getProductSearchQuery()

--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -72,6 +72,8 @@ class ManufacturerControllerCore extends ProductListingFrontController
     public function initContent()
     {
         if (Configuration::get('PS_DISPLAY_SUPPLIERS')) {
+            parent::initContent();
+
             if (Validate::isLoadedObject($this->manufacturer) && $this->manufacturer->active && $this->manufacturer->isAssociatedToShop()) {
                 $this->assignManufacturer();
                 $this->label = $this->trans(
@@ -91,7 +93,6 @@ class ManufacturerControllerCore extends ProductListingFrontController
                 );
                 $this->setTemplate('catalog/manufacturers', array('entity' => 'manufacturers'));
             }
-            parent::initContent();
         } else {
             $this->redirect_after = '404';
             $this->redirect();

--- a/controllers/front/listing/NewProductsController.php
+++ b/controllers/front/listing/NewProductsController.php
@@ -32,15 +32,11 @@ class NewProductsControllerCore extends ProductListingFrontController
     public $php_self = 'new-products';
 
     /**
-     * Initializes controller.
-     *
-     * @see FrontController::init()
-     *
-     * @throws PrestaShopException
+     * @inheritdoc
      */
-    public function init()
+    public function initContent()
     {
-        parent::init();
+        parent::initContent();
 
         $this->doProductSearch('catalog/listing/new-products');
     }

--- a/controllers/front/listing/PricesDropController.php
+++ b/controllers/front/listing/PricesDropController.php
@@ -32,15 +32,12 @@ class PricesDropControllerCore extends ProductListingFrontController
     public $php_self = 'prices-drop';
 
     /**
-     * Initializes controller.
-     *
-     * @see FrontController::init()
-     *
-     * @throws PrestaShopException
+     * @inheritdoc
      */
-    public function init()
+    public function initContent()
     {
-        parent::init();
+        parent::initContent();
+
         $this->doProductSearch('catalog/listing/prices-drop');
     }
 

--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -60,6 +60,9 @@ class SearchControllerCore extends ProductListingFrontController
         );
     }
 
+    /**
+     * Performs the search
+     */
     public function initContent()
     {
         parent::initContent();

--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -58,9 +58,15 @@ class SearchControllerCore extends ProductListingFrontController
                 'search_tag'    => $this->search_tag,
             )
         );
+    }
+
+    public function initContent()
+    {
+        parent::initContent();
 
         $this->doProductSearch('catalog/listing/search', array('entity' => 'search'));
     }
+
 
     protected function getProductSearchQuery()
     {

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -73,6 +73,8 @@ class SupplierControllerCore extends ProductListingFrontController
     public function initContent()
     {
         if (Configuration::get('PS_DISPLAY_SUPPLIERS')) {
+            parent::initContent();
+
             if (Validate::isLoadedObject($this->supplier) && $this->supplier->active && $this->supplier->isAssociatedToShop()) {
                 $this->assignSupplier();
                 $this->label = $this->trans(
@@ -93,7 +95,6 @@ class SupplierControllerCore extends ProductListingFrontController
                 );
                 $this->setTemplate('catalog/suppliers', array('entity' => 'suppliers'));
             }
-            parent::initContent();
         } else {
             $this->redirect_after = '404';
             $this->redirect();


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | In product listing page, the action called in Ajax doesn't have access to general purpose variables in Smarty templates.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1223
| How to test?  | Put  `{$urls.pages.cart}` in `themes\classic\templates\catalog\_partials\miniatures\product.tpl` and reach page 2 of product list (In home page, access "all products" link).

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8856)
<!-- Reviewable:end -->
