### PR TITLE
Include docs when creating zip build

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -668,6 +668,14 @@ class ReleaseCreator
             $zip->open("{$this->tempProjectPath}/{$this->zipFileName}", ZipArchive::CREATE | ZipArchive::OVERWRITE);
             $zip->addFile("{$this->tempProjectPath}/{$installerZipFilename}", $installerZipFilename);
             $zip->addFile("{$this->projectPath}/tools/build/Library/InstallUnpacker/index.php", 'index.php');
+
+            // add docs at the root
+            $zip->addGlob(
+                "{$this->projectPath}/tools/build/doc/*",
+                0,
+                array('add_path' => './', 'remove_all_path' => true)
+            );
+
             $zip->close();
             exec("rm {$argProjectPath}/tools/build/Library/InstallUnpacker/index.php");
         } else {

--- a/tools/build/doc/Install_PrestaShop.html
+++ b/tools/build/doc/Install_PrestaShop.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Install PrestaShop</title>
+</head>
+<body>
+<a href="http://doc.prestashop.com/display/PS17/Installing+PrestaShop?utm_source=html_installer">You will be redirected to the getting started guide</a>
+<script type="text/javascript">document.location.href = 'http://doc.prestashop.com/display/PS17/Installing+PrestaShop?utm_source=html_installer';</script>
+</body>
+</html>
+


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | When we migrated the build tool into the core, we forgot to include an HTML file with a link to the docs that was present in previous releases. This PR fixes that.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Launch a build and check that there's a file named "Install_PrestaShop.html" in the zip package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8858)
<!-- Reviewable:end -->
