### PR TITLE
Passing language ID for Store object instance

### DIFF
--- a/classes/Store.php
+++ b/classes/Store.php
@@ -129,7 +129,7 @@ class StoreCore extends ObjectModel
      */
     public function __construct($idStore = null, $idLang = null)
     {
-        parent::__construct($idStore);
+        parent::__construct($idStore, $idLang);
         $this->id_image = ($this->id && file_exists(_PS_STORE_IMG_DIR_.(int) $this->id.'.jpg')) ? (int) $this->id : false;
         $this->image_dir = _PS_STORE_IMG_DIR_;
     }


### PR DESCRIPTION
In due to Store came to be a multilingual entity it would be much convenient to pass a language ID when an object instance creating

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | In due to Store came to be a multilingual entity it would be much convenient to pass a language ID when an object instance creating.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create any instance of Store object with multilingual availability(1.7.3+)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8859)
<!-- Reviewable:end -->
