### PR TITLE
Make the dezipper great again

### DIFF
--- a/tools/build/Library/InstallUnpacker/compile.php
+++ b/tools/build/Library/InstallUnpacker/compile.php
@@ -29,15 +29,20 @@ $template = file_get_contents(__DIR__.'/index_template.php');
 if ($handle = opendir(__DIR__.'/content')) {
   while (false !== ($entry = readdir($handle))) {
     $filePath = __DIR__.'/content/'.$entry;
+
     if (is_file($filePath)) {
       echo "File found: $entry\n";
+
       if (strpos($template, $entry)) {
         echo "\033[0;32mReplace entry: $entry\033[0m\n";
+
+        $content = base64_encode(file_get_contents($filePath));
         $template = str_replace(
-          "'$entry'",
-          '<<<EOF'.PHP_EOL.base64_encode(file_get_contents($filePath)).PHP_EOL.'EOF'.PHP_EOL,
+          "getFileContent('$entry', true)",
+          "getFileContent('$content', false)",
           $template
         );
+
       } else {
         echo "\033[0;31mFile not present on the template\033[0m\n";
       }

--- a/tools/build/Library/InstallUnpacker/index_template.php
+++ b/tools/build/Library/InstallUnpacker/index_template.php
@@ -139,7 +139,6 @@ if (isset($_POST['extract'])) {
         unlink(getcwd().'/index.php');
         unlink(getcwd().'/prestashop.zip');
         rename(getcwd().'/index.php.temp', getcwd().'/index.php');
-        sleep(2); // we need to wait the rename creation as the ajax call is asynchronous
     }
 
     die(json_encode([

--- a/tools/build/Library/InstallUnpacker/index_template.php
+++ b/tools/build/Library/InstallUnpacker/index_template.php
@@ -232,7 +232,7 @@ if (isset($_GET['element'])) {
       } else {
         if (msg.lastId > msg.numFiles) {
           // end
-          location.reload();
+          window.location.reload(true);
         } else {
           $("#progressContainer")
             .find(".current")

--- a/tools/build/Library/InstallUnpacker/index_template.php
+++ b/tools/build/Library/InstallUnpacker/index_template.php
@@ -33,6 +33,9 @@ define('ZIP_NAME', 'prestashop.zip');
 define('TARGET_FOLDER', __DIR__.'/');
 define('BATCH_SIZE', 500);
 
+// bust cache, or else it won't load the installer after the extraction is done
+header("Cache-Control: no-cache, no-store, must-revalidate");
+
 if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_) {
     die('You need at least PHP '._PS_INSTALL_MINIMUM_PHP_VERSION_.' to install PrestaShop. Your current PHP version is '.PHP_VERSION);
 }

--- a/tools/build/Library/InstallUnpacker/index_template.php
+++ b/tools/build/Library/InstallUnpacker/index_template.php
@@ -26,52 +26,102 @@
 
 set_time_limit(0);
 
+define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 50400);
+define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '5.4');
+
 define('ZIP_NAME', 'prestashop.zip');
 define('TARGET_FOLDER', __DIR__.'/');
 define('BATCH_SIZE', 500);
 
-$startId = 0;
-if (isset($_POST['startId'])) {
-  $startId = (int)$_POST['startId'];
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_) {
+    die('You need at least PHP '._PS_INSTALL_MINIMUM_PHP_VERSION_.' to install PrestaShop. Your current PHP version is '.PHP_VERSION);
 }
 
-if (isset($_POST['extract'])) {
-  if (!extension_loaded('zip')) {
-    die(json_encode([
-      'error' => true,
-      'message' => 'You must install PHP zip extension first',
-    ]));
-  }
+function getFileContent($fileOrContent, $debug) {
+    if ($debug) {
+        return file_get_contents('content/'.$fileOrContent);
+    }
+    return base64_decode($fileOrContent);
+}
 
-  $zip = new ZipArchive();
-  if ($zip->open(__DIR__.'/'.ZIP_NAME) === true) {
+function getZipErrorMessage($errorCode) {
+    $errors = [
+        ZipArchive::ER_EXISTS => "File already exists.",
+        ZipArchive::ER_INCONS => "Zip archive inconsistent or corrupted. Double check your uploaded files.",
+        ZipArchive::ER_INVAL => "Invalid argument.",
+        ZipArchive::ER_MEMORY => "Allocation error. Out of memory?",
+        ZipArchive::ER_NOENT => "Unable to find the release zip file. Make sure that the prestashop.zip file has been uploaded and is located in the same directory as this dezipper.",
+        ZipArchive::ER_NOZIP => "The release file is not a zip file or it is corrupted. Double check your uploaded files.",
+        ZipArchive::ER_OPEN => "Can't open file. Make sure PHP has read access to the prestashop.zip file.",
+        ZipArchive::ER_READ => "Read error.",
+        ZipArchive::ER_SEEK => "Seek error.",
+    ];
+
+    if (isset($errors[$errorCode])) {
+        return "Unzipping error - " . $errors[$errorCode];
+    }
+
+    return "An unknown error was found while reading the zip file";
+}
+
+$selfUri = basename(__FILE__);
+
+$startId = (isset($_POST['startId'])) ? (int) $_POST['startId'] : 0;
+
+if (isset($_POST['extract'])) {
+    if (!extension_loaded('zip')) {
+        die(json_encode([
+            'error'   => true,
+            'message' => 'You must install PHP zip extension first',
+        ]));
+    }
+
+    $zip = new ZipArchive();
+    if (true !== $error = $zip->open(__DIR__.'/'.ZIP_NAME)) {
+        die(json_encode([
+            'error'   => true,
+            'message' => getZipErrorMessage($error),
+        ]));
+    }
+
+    if (!is_writable(TARGET_FOLDER)) {
+        die(json_encode([
+            'error'   => true,
+            'message' => "You need to grant write permissions for PHP on the following directory: "
+                . realpath(TARGET_FOLDER),
+        ]));
+    }
 
     $numFiles = $zip->numFiles;
     $lastId = $startId + BATCH_SIZE;
 
     $fileList = array();
     for ($id = $startId; $id < min($numFiles, $lastId); $id++) {
-      $currentFile = $zip->getNameIndex($id);
-      if (in_array($currentFile, ['/index.php', 'index.php'])) {
-        $indexContent = $zip->getFromIndex($id);
-        file_put_contents(getcwd().'/index.php.temp', $indexContent);
-      } else {
-        $fileList[] = $currentFile;
-      }
+        $currentFile = $zip->getNameIndex($id);
+        if (in_array($currentFile, ['/index.php', 'index.php'])) {
+            $indexContent = $zip->getFromIndex($id);
+            if (!file_put_contents(getcwd().'/index.php.temp', $indexContent)) {
+                die(json_encode([
+                    'error' => true,
+                    'message' => "Unable to write to file " . getcwd() . '/index.php.temp'
+                ]));
+            }
+        } else {
+            $fileList[] = $currentFile;
+        }
     }
 
     foreach ($fileList as $currentFile) {
-      if ($zip->extractTo(TARGET_FOLDER, $currentFile) === false) {
-        die(json_encode([
-          'error' => true,
-          'message' => 'An error occured during the extraction',
-          'file' => $currentFile,
-          'status' => $zip->getStatusString(),
-          'numFiles' => $numFiles,
-          'lastId' => $lastId,
-          'files' => $fileList,
-        ]));
-      }
+        if ($zip->extractTo(TARGET_FOLDER, $currentFile) === false) {
+            die(json_encode([
+                'error'    => true,
+                'message'  => 'Extraction error - '.$zip->getStatusString(),
+                'file'     => $currentFile,
+                'numFiles' => $numFiles,
+                'lastId'   => $lastId,
+                'files'    => $fileList,
+            ]));
+        }
     }
 
     @chmod('install/index.php', 0644);
@@ -83,40 +133,39 @@ if (isset($_POST['extract'])) {
     $zip->close();
 
     if ($lastId >= $numFiles) {
-      unlink(getcwd().'/index.php');
-      unlink(getcwd().'/prestashop.zip');
-      rename(getcwd().'/index.php.temp', getcwd().'/index.php');
-      sleep(2); // we need to wait the rename creation as the ajax call is asynchronous
+        unlink(getcwd().'/index.php');
+        unlink(getcwd().'/prestashop.zip');
+        rename(getcwd().'/index.php.temp', getcwd().'/index.php');
+        sleep(2); // we need to wait the rename creation as the ajax call is asynchronous
     }
 
     die(json_encode([
-      'error' => false,
-      'numFiles' => $numFiles,
-      'lastId' => $lastId,
+        'error'    => false,
+        'numFiles' => $numFiles,
+        'lastId'   => $lastId,
     ]));
-  }
 }
 
 if (isset($_GET['element'])) {
-  switch ($_GET['element']) {
-    case 'font':
-      header('Content-Type: application/font-sfnt');
-      echo base64_decode('OpenSans-Regular.ttf');
-      break;
-    case 'css':
-      header('Content-Type: text/css');
-      echo base64_decode('style.css');
-      break;
-    case 'jquery':
-      header('Content-Type: text/javascript');
-      echo base64_decode('jquery-2.2.3.min.js');
-      break;
-    case 'gif':
-      header('Content-Type: image/gif');
-      echo base64_decode('installer.gif');
-    break;
-  }
-  exit;
+    switch ($_GET['element']) {
+        case 'font':
+            header('Content-Type: application/font-sfnt');
+            echo getFileContent('OpenSans-Regular.ttf', true);
+            break;
+        case 'css':
+            header('Content-Type: text/css');
+            echo getFileContent('style.css', true);
+            break;
+        case 'jquery':
+            header('Content-Type: text/javascript');
+            echo getFileContent('jquery-2.2.3.min.js', true);
+            break;
+        case 'gif':
+            header('Content-Type: image/gif');
+            echo getFileContent('installer.gif', true);
+            break;
+    }
+    exit;
 }
 
 ?>
@@ -125,83 +174,87 @@ if (isset($_GET['element'])) {
 <head>
   <meta charset="UTF-8">
   <title>PrestaShop installation</title>
-  <link rel="stylesheet" type="text/css" href="index.php?element=css">
+  <link rel="stylesheet" type="text/css" href="<?= $selfUri ?>?element=css">
 </head>
 <body>
-  <div id="content">
-    <div>
-      <img src="index.php?element=gif" />
-      <div id="progressContainer">
-        <div class="progressNumber">0 %</div>
-        <div class="progress">
-          <div class="current">
-          </div>
+<div id="content">
+  <div>
+    <img id="spinner" src="<?= $selfUri ?>?element=gif"/>
+    <div id="progressContainer">
+      <div class="progressNumber">0 %</div>
+      <div class="progress">
+        <div class="current">
         </div>
       </div>
-      <div id="error"></div>
     </div>
+    <div id="error"></div>
   </div>
-  <script type="text/javascript" src="index.php?element=jquery"></script>
-  <script type="text/javascript">
+</div>
+<script type="text/javascript" src="<?= $selfUri ?>?element=jquery"></script>
+<script type="text/javascript">
 
-    function extractFiles(startId) {
+  function extractFiles(startId) {
 
-      if (typeof startId == 'undefined') {
-        startId = 0;
-      }
-
-      var request = $.ajax({
-        method: "POST",
-        url: "index.php",
-        data: {
-          extract: true,
-          startId: startId,
-        }
-      });
-
-      request.done(function(msg) {
-        try {
-          msg = JSON.parse(msg);
-        }catch(e){
-          msg = {
-            message: msg
-          };
-        }
-
-        if (
-          msg.fail
-          || typeof msg.lastId == 'undefined'
-          || typeof msg.numFiles == 'undefined'
-        ) {
-          $('#error').html('An error has occured : <br />'+ msg.message);
-          $('.spinner').remove();
-        } else {
-          if (msg.lastId > msg.numFiles) {
-            location.reload();
-          } else {
-            $("#progressContainer")
-              .find(".current")
-              .width((msg.lastId / msg.numFiles * 100)+'%');
-
-            $("#progressContainer")
-              .find(".progressNumber")
-              .css({left: Math.round((msg.lastId / msg.numFiles * 100))+'%'})
-              .html(Math.round((msg.lastId / msg.numFiles * 100))+'%');
-
-            extractFiles(msg.lastId);
-          }
-        }
-      });
-
-      request.fail(function(jqXHR, textStatus, errorThrown) {
-        $('#error').html('An error has occured' + textStatus);
-        $('.spinner').remove();
-      });
+    if (typeof startId === 'undefined') {
+      startId = 0;
     }
 
-    $(function() {
-      extractFiles();
+    var request = $.ajax({
+      method: "POST",
+      url: "<?= $selfUri ?>",
+      data: {
+        extract: true,
+        startId: startId,
+      }
     });
-  </script>
+
+    request.done(function(msg) {
+      try {
+        msg = JSON.parse(msg);
+      } catch (e) {
+        if (String(msg).match("<tittle>PrestaShop")) {
+          msg = "Invalid server response";
+        }
+        msg = {
+          message: msg
+        };
+      }
+
+      if (
+        msg.error
+        || typeof msg.lastId === 'undefined'
+        || typeof msg.numFiles === 'undefined'
+      ) {
+        $('#error').html('An error has occured: <br />' + msg.message);
+        $('#spinner').remove();
+      } else {
+        if (msg.lastId > msg.numFiles) {
+          // end
+          location.reload();
+        } else {
+          $("#progressContainer")
+            .find(".current")
+            .width((msg.lastId / msg.numFiles * 100)+'%');
+
+          $("#progressContainer")
+            .find(".progressNumber")
+            .css({left: Math.round((msg.lastId / msg.numFiles * 100))+'%'})
+            .html(Math.round((msg.lastId / msg.numFiles * 100))+'%');
+
+          extractFiles(msg.lastId);
+        }
+      }
+    });
+
+    request.fail(function(jqXHR, textStatus, errorThrown) {
+      $('#error').html('An error has occurred' + textStatus);
+      $('#spinner').remove();
+    });
+  }
+
+  $(function() {
+    extractFiles();
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
The dezipper now:
- Can be debugged
- Checks for minimum PHP version
- Actually display errors, most of them informative
- Avoids infinite loops on failure 👍 

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Improves the dezipper
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4881
| How to test?  | Create a build and test things like launching the dezipping on an old version of PHP, or without zip extension, or without the zip file, or without granting Apache write rights on the folder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8860)
<!-- Reviewable:end -->
