### PR TITLE
Wrong product attribute weight with multishop

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -557,7 +557,7 @@ class CartCore extends ObjectModel
             $sql->select('
 				product_attribute_shop.`price` AS price_attribute, product_attribute_shop.`ecotax` AS ecotax_attr,
 				IF (IFNULL(pa.`reference`, \'\') = \'\', p.`reference`, pa.`reference`) AS reference,
-				(p.`weight`+ pa.`weight`) weight_attribute,
+				(p.`weight`+ product_attribute_shop.`weight`) weight_attribute,
 				IF (IFNULL(pa.`ean13`, \'\') = \'\', p.`ean13`, pa.`ean13`) AS ean13,
 				IF (IFNULL(pa.`upc`, \'\') = \'\', p.`upc`, pa.`upc`) AS upc,
 				IFNULL(product_attribute_shop.`minimal_quantity`, product_shop.`minimal_quantity`) as minimal_quantity,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Having different weight for the same product in a multishop environment can lead to wrong attribute weight returned by the `Cart::getProducts` method
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Activate multishop, configure the weight of an attribute with different values in different shops, add the product to cart in FO. The total weight of the cart can sometimes be wrong (visible with delivery ranges by weight for example)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8861)
<!-- Reviewable:end -->
