### PR TITLE
Removed almost all deprecations on Product page

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -66,9 +66,9 @@ class AppKernel extends Kernel
          * @see https://symfony.com/doc/2.8/configuration/external_parameters.html#environment-variables
          */
         if (extension_loaded('apc')) {
-            $_SERVER['SYMFONY__CACHE__DRIVER'] = 'apc';
+            $_SERVER['CACHE_DRIVER'] = 'apc';
         } else {
-            $_SERVER['SYMFONY__CACHE__DRIVER'] = 'array';
+            $_SERVER['CACHE_DRIVER'] = 'array';
         }
 
         return $bundles;

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -28,5 +28,5 @@ monolog:
 
 doctrine:
     orm:
-        metadata_cache_driver: "%cache.driver%"
-        query_cache_driver:    "%cache.driver%"
+        metadata_cache_driver: "%env(CACHE_DRIVER)%"
+        query_cache_driver:    "%env(CACHE_DRIVER)%"

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -17,3 +17,4 @@ security:
 
         main:
             anonymous: ~
+            logout_on_user_change: true

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/RouterPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/RouterPass.php
@@ -42,6 +42,6 @@ class RouterPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $container->setAlias('router', 'prestashop.router');
+        $container->setAlias('router', 'prestashop.router')->setPublic(true);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
+++ b/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
@@ -86,7 +86,6 @@ class SimpleCategory extends CommonAbstractType
         ))
         ->add('id_parent', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' => $this->categories,
-            'choices_as_values' => true,
             'required' => true,
             'attr' => array(
                 'data-toggle' => 'select2',

--- a/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
+++ b/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
@@ -73,7 +73,6 @@ class ProductFeature extends CommonAbstractType
         $builder->add('feature', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label' => $this->translator->trans('Feature', array(), 'Admin.Catalog.Feature'),
             'choices' =>  $this->features,
-            'choices_as_values' => true,
             'required' =>  false,
             'attr' => array(
                 'data-action' => $this->router->generate('admin_feature_get_feature_values', array('idFeature' => 1)),
@@ -86,7 +85,6 @@ class ProductFeature extends CommonAbstractType
         ->add('value', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label' => $this->translator->trans('Pre-defined value', array(), 'Admin.Catalog.Feature'),
             'required' =>  false,
-            'choices_as_values' => true,
             'attr' => array(
                 'class' => 'feature-value-selector',
                 'data-minimumResultsForSearch' => '7',
@@ -149,7 +147,6 @@ class ProductFeature extends CommonAbstractType
                 'data-toggle' => 'select2',
             ),
             'choices' => $choices,
-            'choices_as_values' => true,
             'placeholder' => $this->translator->trans('Choose a value', array(), 'Admin.Catalog.Feature'),
         ));
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -185,7 +185,6 @@ class ProductCombination extends CommonAbstractType
         }
         $builder->add('id_image_attr', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices'  => array(),
-            'choices_as_values' => true,
             'required' => false,
             'expanded' => true,
             'multiple' => true,
@@ -214,7 +213,6 @@ class ProductCombination extends CommonAbstractType
                 'required' => false,
                 'expanded' => true,
                 'multiple' => true,
-                'choices_as_values' => true,
             ));
         });
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
@@ -83,7 +83,6 @@ class ProductCustomField extends CommonAbstractType
             'attr' => array(
                 'class' => 'c-select',
             ),
-            'choices_as_values' => true,
             'required' =>  true
         ))->add('require', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
             'label'    => $this->translator->trans('Required', [], 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -123,7 +123,6 @@ class ProductInformation extends CommonAbstractType
             'attr' => array(
                 'class' => 'custom-select',
             ),
-            'choices_as_values' => true,
             'label' =>  $this->translator->trans('Type', [], 'Admin.Catalog.Feature'),
             'required' => true,
         ))
@@ -197,7 +196,6 @@ class ProductInformation extends CommonAbstractType
         ))
         ->add('id_manufacturer', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' => $this->manufacturers,
-            'choices_as_values' => true,
             'required' => false,
             'attr' => array(
                 'data-toggle' => 'select2',
@@ -245,7 +243,6 @@ class ProductInformation extends CommonAbstractType
         ))
         ->add('id_category_default', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->categories,
-            'choices_as_values' => true,
             'expanded' => true,
             'multiple' => false,
             'required' =>  true,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
@@ -98,7 +98,6 @@ class ProductOptions extends CommonAbstractType
             'attr' => array(
                 'class' => 'custom-select',
             ),
-            'choices_as_values' => true,
             'required' => true,
             'label' => $this->translator->trans('Visibility', [], 'Admin.Catalog.Feature'),
         ))
@@ -167,13 +166,11 @@ class ProductOptions extends CommonAbstractType
             'attr' => array(
                 'class' => 'custom-select',
             ),
-            'choices_as_values' => true,
             'required' => true,
             'label' => $this->translator->trans('Condition', [], 'Admin.Catalog.Feature')
         ))
         ->add('suppliers', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->suppliers,
-            'choices_as_values' => true,
             'expanded' =>  true,
             'multiple' =>  true,
             'required' =>  false,
@@ -184,7 +181,6 @@ class ProductOptions extends CommonAbstractType
         ))
         ->add('default_supplier', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->suppliers,
-            'choices_as_values' => true,
             'expanded' =>  true,
             'multiple' =>  false,
             'required' =>  true,
@@ -227,7 +223,6 @@ class ProductOptions extends CommonAbstractType
             'expanded'  => true,
             'multiple'  => true,
             'choices'  => $this->attachmentList,
-            'choices_as_values' => true,
             'choice_label' => function ($choice, $key, $value) {
                 $attachmentKey = array_search($key, array_column($this->fullAttachmentList, 'file'));
                 return $this->fullAttachmentList[$attachmentKey]['name'];

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -113,7 +113,6 @@ class ProductPrice extends CommonAbstractType
         ->add('id_tax_rules_group', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->tax_rules,
             'required' => true,
-            'choices_as_values' => true,
             'choice_attr' => function ($val) {
                 return [
                     'data-rates' => implode(',', $this->tax_rules_rates[$val]['rates']),
@@ -161,7 +160,6 @@ class ProductPrice extends CommonAbstractType
         for ($i=0; $i < count($specificPricePriorityChoices); $i++) {
             $builder->add('specificPricePriority_'.$i, 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices' => $specificPricePriorityChoices,
-                'choices_as_values' => true,
                 'required' => true
             ));
         }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -99,8 +99,7 @@ class ProductQuantity extends CommonAbstractType
             )
             ->add(
                 'pack_stock_type',
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-                array('choices_as_values' => true)
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
             )//see eventListener for details
             ->add(
                 'depends_on_stock',
@@ -118,7 +117,6 @@ class ProductQuantity extends CommonAbstractType
                             'Admin.Catalog.Feature'
                         ) => 0,
                     ),
-                    'choices_as_values' => true,
                     'expanded' => true,
                     'required' => true,
                     'multiple' => false,
@@ -142,10 +140,7 @@ class ProductQuantity extends CommonAbstractType
         $builder
             ->add(
                 'out_of_stock',
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-                array(
-                    'choices_as_values' => true,
-                )
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
             )
             ->add(
                 'minimal_quantity',
@@ -243,7 +238,6 @@ class ProductQuantity extends CommonAbstractType
                             $this->translator->trans('Allow orders', array(), 'Admin.Catalog.Feature') => '1',
                             $defaultChoiceLabel => '2',
                         ),
-                        'choices_as_values' => true,
                         'expanded' => true,
                         'required' => false,
                         'placeholder'=> false,
@@ -272,7 +266,6 @@ class ProductQuantity extends CommonAbstractType
                             $this->translator->trans('Decrement both.', array(), 'Admin.Catalog.Feature')  => '2',
                             $defaultChoiceLabel => '3',
                         ),
-                        'choices_as_values' => true,
                         'expanded' => false,
                         'required' => true,
                         'placeholder' => false,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
@@ -128,7 +128,6 @@ class ProductSeo extends CommonAbstractType
                 }
                 return [];
             },
-            'choices_as_values' => true,
             'required' => true,
             'label' => $this->translator->trans('Redirection when offline', [], 'Admin.Catalog.Feature'),
             'attr' => array(

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -112,7 +112,6 @@ class ProductShipping extends CommonAbstractType
         ))
         ->add('selectedCarriers', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' =>  $this->carriersChoices,
-            'choices_as_values' => true,
             'expanded' =>  true,
             'multiple' =>  true,
             'required' =>  false,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -85,7 +85,6 @@ class ProductSpecificPrice extends CommonAbstractType
         } else {
             $builder->add('sp_id_shop', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices' => $this->shops,
-                'choices_as_values' => true,
                 'required' => false,
                 'label' => false,
                 'placeholder' => $this->translator->trans('All shops', array(), 'Admin.Global'),
@@ -94,7 +93,6 @@ class ProductSpecificPrice extends CommonAbstractType
 
         $builder->add('sp_id_currency', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' => $this->currencies,
-            'choices_as_values' => true,
             'required' => false,
             'label' => false,
             'attr' => array(
@@ -105,7 +103,6 @@ class ProductSpecificPrice extends CommonAbstractType
         ))
         ->add('sp_id_country', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' => $this->countries,
-            'choices_as_values' => true,
             'required' => false,
             'label' => false,
             'attr' => array(
@@ -116,7 +113,6 @@ class ProductSpecificPrice extends CommonAbstractType
         ))
         ->add('sp_id_group', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' => $this->groups,
-            'choices_as_values' => true,
             'required' => false,
             'label' => false,
             'attr' => array(
@@ -137,7 +133,6 @@ class ProductSpecificPrice extends CommonAbstractType
         ))
         ->add('sp_id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices' => array(),
-            'choices_as_values' => true,
             'required' => false,
             'placeholder' => $this->translator->trans('Apply to all combinations', array(), 'Admin.Catalog.Feature'),
             'label' => $this->translator->trans('Combinations', array(), 'Admin.Catalog.Feature'),
@@ -182,7 +177,6 @@ class ProductSpecificPrice extends CommonAbstractType
                 '€' => 'amount',
                  $this->translator->trans('%', array(), 'Admin.Global') => 'percentage',
             ),
-            'choices_as_values' => true,
             'required' => true,
         ))
         ->add('sp_reduction_tax', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
@@ -191,7 +185,6 @@ class ProductSpecificPrice extends CommonAbstractType
                 $this->translator->trans('Tax excluded', array(), 'Admin.Catalog.Feature') => '0',
                 $this->translator->trans('Tax included', array(), 'Admin.Catalog.Feature') => '1',
             ),
-            'choices_as_values' => true,
             'required' => true,
         ))
         ->add('save', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
@@ -220,7 +213,6 @@ class ProductSpecificPrice extends CommonAbstractType
             //bypass SF validation, define submitted value in choice list
             $form->add('sp_id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices' => array($data['sp_id_product_attribute'] => ''),
-                'choices_as_values' => true,
                 'required' => false,
             ));
         });

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
@@ -74,7 +74,6 @@ class ProductSupplierCombination extends CommonAbstractType
         ))
         ->add('product_price_currency', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'choices'  => $this->formatDataChoicesList($this->currencyAdapter->getCurrencies(), 'id_currency'),
-            'choices_as_values' => true,
             'required' => true,
             'attr' => array(
                 'class' => 'custom-select',

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
@@ -67,7 +67,6 @@ class ProductVirtual extends CommonAbstractType
                 $this->translator->trans('Yes', [], 'Admin.Global') => 1,
                 $this->translator->trans('No', [], 'Admin.Global') => 0,
             ),
-            'choices_as_values' => true,
             'expanded' => true,
             'required' => true,
             'multiple' => false,

--- a/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
@@ -63,7 +63,6 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
         $builder->add('tree', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label' => false,
             'choices' => $options['valid_list'],
-            'choices_as_values' => true,
             'required' => false,
             'multiple'  => true,
             'expanded'  => true,

--- a/src/PrestaShopBundle/Resources/config/services/alias.yml
+++ b/src/PrestaShopBundle/Resources/config/services/alias.yml
@@ -2,12 +2,9 @@ services:
     # Service aliases for backward campatibility
     prestashop.core.api.stockMovement.repository:
         alias: prestashop.core.api.stock_movement.repository
-        deprecated: 'The "%service_id%" service is deprecated. Use "prestashop.core.api.stock_movement.repository" instead'
 
     prestashop.core.api.stockMovement.controller:
         alias: prestashop.core.api.stock_movement.controller
-        deprecated: 'The "%service_id%" service is deprecated. Use "prestashop.core.api.stock_movement.controller" instead'
 
     prestashop.twig.extension.dataFormatter:
         alias: prestashop.twig.extension.data_formatter
-        deprecated: 'The "%service_id%" service is deprecated. Use "prestashop.twig.extension.data_formatter" instead'


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The logger is full of deprecations messages (almost 250 on product page).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | In dev mode, the number of deprecations should be under 5 (mainly only the deprecated calls to the logger should remain, as it's already fixed in another [pull request](https://github.com/PrestaShop/PrestaShop/pull/8710)) 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8864)
<!-- Reviewable:end -->
