### PR TITLE
Fixed CCC settings

### DIFF
--- a/src/Adapter/Cache/CombineCompressCacheConfiguration.php
+++ b/src/Adapter/Cache/CombineCompressCacheConfiguration.php
@@ -97,11 +97,10 @@ class CombineCompressCacheConfiguration implements DataConfigurationInterface
         $errors = array();
 
         if ($this->validateConfiguration($configuration)) {
+            $this->updateCachesVersionsIfNeeded($configuration);
             if ($configuration['smart_cache_css'] || $configuration['smart_cache_js']) {
                 // Manage JS & CSS Smart cache
-                if ($this->createThemeCacheFolder()) {
-                    $this->updateCachesVersionsIfNeeded($configuration);
-                } else {
+                if (!$this->createThemeCacheFolder()) {
                     $errors[] = array(
                         'key' => 'To use Smarty Cache, the directory %directorypath% must be writable.',
                         'domain' => 'Admin.Advparameters.Notification',


### PR DESCRIPTION
In Prestashop 1.7.3, CCC settings from Advanced Parameters -> Performance were not saved if at least one of smart_cache_css or smart_cache_js were not set to "On".

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In Prestashop 1.7.3, CCC settings from Advanced Parameters -> Performance were not saved if at least one of smart_cache_css or smart_cache_js were not set to "Yes".
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Go to Advanced Parameters -> Performance, set one of "Smart cache for CSS" or "Smart cache for JavaScript" to "Yes", then try to set both of them to "No". Settings will not be saved, because the "save" algorithm runs only if one of them is set to "Yes".

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8865)
<!-- Reviewable:end -->
