### PR TITLE
Rely on the right legacy container if available on modules

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3191,9 +3191,10 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Access the Symfony Container if we are in Symfony Context.
      * Note: in this case, we must get a container from SymfonyContainer class.
+     * Note: if not in Symfony context, fallback to legacy Container for FO/BO.
      * @param string $serviceName
      *
-     * @return Object|false if Symfony is not booted, it returns false.
+     * @return Object|false if a container is not available, it returns false.
      */
     public function get($serviceName)
     {
@@ -3203,6 +3204,10 @@ abstract class ModuleCore implements ModuleInterface
             }
 
             return $this->container->get($serviceName);
+        }
+
+        if ($this->context->controller instanceof Controller) {
+            return $this->context->controller->get($serviceName);
         }
 
         return false;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | In modules, we should be able to access legacy containers if available.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Hooks dispatched from FO should have access to front office legacy container, hooks dispatched from legacy BO should have access to back office legacy container and in Symfony context we should have access to the current BO container.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8867)
<!-- Reviewable:end -->
