### PR TITLE
Fix contactform module issues

### DIFF
--- a/mails/en/contact_form.html
+++ b/mails/en/contact_form.html
@@ -86,7 +86,6 @@
 					<font size="2" face="Open-sans, sans-serif" color="#555454">
 						<span style="color:#777">
 							Your message has been sent successfully.<br /><br />
-							<span style="color:#333"><strong>Message:</strong></span> {message}<br /><br />
 							<span style="color:#333"><strong>Order ID:</strong></span> {order_name}<br />
 							<span style="color:#333"><strong>Product:</strong></span> {product_name}<br />
 							<span style="color:#333"><strong>Attached file:</strong></span> {attached_file}

--- a/mails/en/contact_form.txt
+++ b/mails/en/contact_form.txt
@@ -5,8 +5,6 @@ Your message to {shop_name} Customer Service
 
 Your message has been sent successfully.
 
-MESSAGE: {message}
-
 ORDER ID: {order_name}
 
 PRODUCT: {product_name}

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -844,6 +844,7 @@ class Install extends AbstractInstall
             }
         } else {
             $modules = array(
+                'contactform',
                 'dashactivity',
                 'dashtrends',
                 'dashgoals',

--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -112,6 +112,13 @@
       </section>
 
       <footer class="form-footer text-sm-right">
+        <style>
+          input[name=url] {
+            display: none !important;
+          }
+        </style>
+        <input type="text" name="url" value=""/>
+        <input type="hidden" name="token" value="{$token}" />
         <input class="btn btn-primary" type="submit" name="submitMessage" value="{l s='Send' d='Shop.Theme.Actions'}">
       </footer>
     {/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Fix module contactform not installed, remove user message from contact_form email templates, add spam protections.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [BOOM-4288](http://forge.prestashop.com/browse/BOOM-4288).
| How to test?  | Install a new PrestaShop, module contactform should be installed. open contact us page, wait 11 minutes token should be expired. set a value to the input[name=url] an error should occure. Customer email confirmation do not have the message anymore.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8873)
<!-- Reviewable:end -->
