### PR TITLE
Check the addons catalog page

### DIFF
--- a/tests/E2E/test/campaigns/full/10_module/5_check_addons_catalog_page.js
+++ b/tests/E2E/test/campaigns/full/10_module/5_check_addons_catalog_page.js
@@ -1,0 +1,56 @@
+const {AccessPageBO} = require('../../../selectors/BO/access_page');
+const {Menu} = require('../../../selectors/BO/menu');
+const {ModulesCatalogPage} = require('../../../selectors/BO/addons_catalog_page');
+let promise = Promise.resolve();
+
+scenario('Check the addons catalog page in the Back Office', () => {
+  scenario('Login in the Back Office', client => {
+    test('should open the browser', () => client.open());
+    test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
+  }, 'common_client');
+  scenario('Check the addons catalog page', client => {
+    test('should go to "Modules" page', () => client.goToSubtabMenuPage(Menu.Improve.Modules.modules_menu, Menu.Improve.Modules.modules_catalog_submenu));
+    test('should click on "View all the Traffic modules" link', () => client.waitForExistAndClick(ModulesCatalogPage.view_all_traffic_modules_link));
+    test('should check that the page is well opened', () => {
+      return promise
+        .then(() => client.switchWindow(1))
+        .then(() => client.checkTextValue(ModulesCatalogPage.category_name_text, "Traffic", 'contain'))
+        .then(() => client.switchWindow(0))
+    });
+    test('should click on "Discover" button of the "SEO Expert" module', () => client.waitForExistAndClick(ModulesCatalogPage.discover_button));
+    test('should check that the page is well opened', () => {
+      return promise
+        .then(() => client.switchWindow(2))
+        .then(() => client.checkTextValue(ModulesCatalogPage.module_name, "SEO Expert", 'contain'))
+        .then(() => client.switchWindow(0))
+    });
+    test('should click on "Discover the payment modules" link', () => client.waitForExistAndClick(ModulesCatalogPage.discover_payment_modules_link));
+    test('should check that the page is well opened', () => {
+      return promise
+        .then(() => client.switchWindow(3))
+        .then(() => client.checkTextValue(ModulesCatalogPage.category_name_text, "Payment", 'contain'))
+        .then(() => client.switchWindow(0))
+    });
+    test('should click on "View all modules" link', () => client.waitForExistAndClick(ModulesCatalogPage.view_all_modules_button));
+    test('should check that the page is well opened', () => {
+      return promise
+        .then(() => client.switchWindow(4))
+        .then(() => client.isExisting(ModulesCatalogPage.prestashop_addons_logo))
+        .then(() => client.switchWindow(0))
+    });
+    test('should search for the modules on the prestashop addons', () => {
+      return promise
+        .then(() => client.waitAndSetValue(ModulesCatalogPage.search_addons_input, 'chart'))
+        .then(() => client.keys('Enter'))
+    });
+    test('should check that the page is well opened', () => {
+      return promise
+        .then(() => client.switchWindow(5))
+        .then(() => client.checkTextValue(ModulesCatalogPage.search_name, "chart"))
+        .then(() => client.switchWindow(0))
+    });
+  }, 'common_client');
+  scenario('Logout from the Back Office', client => {
+    test('should logout successfully from the Back Office', () => client.signOutBO());
+  }, 'common_client');
+}, 'common_client', true);

--- a/tests/E2E/test/selectors/BO/addons_catalog_page.js
+++ b/tests/E2E/test/selectors/BO/addons_catalog_page.js
@@ -1,0 +1,13 @@
+module.exports = {
+  ModulesCatalogPage: {
+    view_all_traffic_modules_link: '//*[@id="main-div"]//div[contains(@class, "addons-module-traffic-block")]//a[contains(text(), "View all the Traffic modules")]',
+    category_name_text: '//*[@id="category_name"]',
+    discover_button: '//*[@id="main-div"]//div[contains(@class, "addons-module-traffic-block")]//a[@title="SEO Expert"]',
+    module_name: '//*[@id="product_content"]//h1',
+    discover_payment_modules_link: '//*[@id="main-div"]//div[contains(@class, "addons-module-selection-ps")]//a[contains(text(), "Discover the payment modules")]',
+    view_all_modules_button: '//*[@id="main-div"]//div[contains(@class, "addons-all-modules")]//a[contains(text(), "View all modules")]',
+    prestashop_addons_logo: '//*[@id="logo"]',
+    search_addons_input: '//*[@id="addons-search-box"]',
+    search_name: '//*[@id="search_name"]/b'
+  }
+};


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR allows to : click on "View all the Traffic modules" link then check that the addons page is well opened. Click on "Discover" button of the module then check that the addons page is well opened. Click on "View all modules" link then check that the addons page is well opened. Test the module search action then check that the addons page is well opened.
| Type?         | new feature
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | /
| How to test?  | Run the script path=full/10_module/5_check_addons_catalog_page.js npm run specific-test -- --URL=BackOfficeURL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8875)
<!-- Reviewable:end -->
