### PR TITLE
Disable Symfony tokenization in routing

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -682,7 +682,7 @@ class LinkCore
             return '';
         }
 
-        if ($withToken && !TokenInUrls::isEnabled()) {
+        if ($withToken && !TokenInUrls::isDisabled()) {
             $params['token'] = Tools::getAdminTokenLite($controller);
         }
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -27,6 +27,7 @@
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 
 class LinkCore
 {
@@ -681,7 +682,7 @@ class LinkCore
             return '';
         }
 
-        if ($withToken && getenv('_TOKEN_OFF_') !== "enabled") {
+        if ($withToken && !TokenInUrls::isEnabled()) {
             $params['token'] = Tools::getAdminTokenLite($controller);
         }
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -681,7 +681,7 @@ class LinkCore
             return '';
         }
 
-        if ($withToken) {
+        if ($withToken && getenv('_TOKEN_OFF_') !== "enabled") {
             $params['token'] = Tools::getAdminTokenLite($controller);
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Core\Cldr;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
+use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 
 class AdminControllerCore extends Controller
 {
@@ -764,7 +765,7 @@ class AdminControllerCore extends Controller
      */
     public function checkToken()
     {
-        if (getenv('_TOKEN_OFF_') === "enabled") {
+        if (TokenInUrls::isEnabled()) {
             return true;
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -765,7 +765,7 @@ class AdminControllerCore extends Controller
      */
     public function checkToken()
     {
-        if (TokenInUrls::isEnabled()) {
+        if (TokenInUrls::isDisabled()) {
             return true;
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -764,6 +764,10 @@ class AdminControllerCore extends Controller
      */
     public function checkToken()
     {
+        if (getenv('_TOKEN_OFF_') === "enabled") {
+            return true;
+        }
+
         $token = Tools::getValue('token');
         if (!empty($token) && $token === $this->token) {
             return true;

--- a/src/Core/Feature/TokenInUrls.php
+++ b/src/Core/Feature/TokenInUrls.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+
+namespace PrestaShop\PrestaShop\Core\Feature;
+
+/**
+ * Defines if token is urls are enabled.
+ */
+final class TokenInUrls
+{
+    const ENABLED = 'enabled';
+    const ENV_VAR = '_TOKEN_OFF_';
+
+    /**
+     * @return bool
+     */
+    public static function isEnabled()
+    {
+        return getenv(self::ENV_VAR) === self::ENABLED;
+    }
+}

--- a/src/Core/Feature/TokenInUrls.php
+++ b/src/Core/Feature/TokenInUrls.php
@@ -28,18 +28,18 @@
 namespace PrestaShop\PrestaShop\Core\Feature;
 
 /**
- * Defines if token is urls are enabled.
+ * Defines if token in urls are disabled.
  */
 final class TokenInUrls
 {
-    const ENABLED = 'enabled';
-    const ENV_VAR = '_TOKEN_OFF_';
+    const DISABLED = 'disabled';
+    const ENV_VAR = '_TOKEN_';
 
     /**
      * @return bool
      */
-    public static function isEnabled()
+    public static function isDisabled()
     {
-        return getenv(self::ENV_VAR) === self::ENABLED;
+        return getenv(self::ENV_VAR) === self::DISABLED;
     }
 }

--- a/src/PrestaShopBundle/EventListener/TokenizedUrlsListener.php
+++ b/src/PrestaShopBundle/EventListener/TokenizedUrlsListener.php
@@ -71,7 +71,7 @@ class TokenizedUrlsListener
     {
         $request = $event->getRequest();
 
-        if (TokenInUrls::isEnabled()) {
+        if (TokenInUrls::isDisabled()) {
             return;
         }
 

--- a/src/PrestaShopBundle/EventListener/TokenizedUrlsListener.php
+++ b/src/PrestaShopBundle/EventListener/TokenizedUrlsListener.php
@@ -31,8 +31,10 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Csrf\CsrfToken;
+use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 
 use Employee;
+use Symfony\CS\Tokenizer\Token;
 use Tools;
 
 /**
@@ -68,6 +70,10 @@ class TokenizedUrlsListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
+
+        if (TokenInUrls::isEnabled()) {
+            return;
+        }
 
         if (!$event->isMasterRequest()) {
             return;

--- a/src/PrestaShopBundle/Service/Routing/Router.php
+++ b/src/PrestaShopBundle/Service/Routing/Router.php
@@ -63,7 +63,7 @@ class Router extends BaseRouter
 
     public static function generateTokenizedUrl($url, $token)
     {
-        if (TokenInUrls::isEnabled()) {
+        if (TokenInUrls::isDisabled()) {
             return $url;
         }
         $components = parse_url($url);

--- a/src/PrestaShopBundle/Service/Routing/Router.php
+++ b/src/PrestaShopBundle/Service/Routing/Router.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Service\Routing;
 use Symfony\Bundle\FrameworkBundle\Routing\Router as BaseRouter;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use PrestaShopBundle\Service\DataProvider\UserProvider;
+use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 
 /**
  * We extends Symfony Router in order to add a token to each url.
@@ -62,6 +63,9 @@ class Router extends BaseRouter
 
     public static function generateTokenizedUrl($url, $token)
     {
+        if (TokenInUrls::isEnabled()) {
+            return $url;
+        }
         $components = parse_url($url);
         $baseUrl = (isset($components['path']) ? $components['path'] : '');
         $queryParams = array();


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Setup **environnement** `_TOKEN_` variable to `"disabled"` allows you to disable token in urls for Symfony pages and in legacy pages.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOGOSS-85
| How to test?  | Someone from QA team needs to setup environment variable (`SetEnv _TOKEN_ disabled` in apache vhost configuration file) and check that Symfony pages (Product, Module, ...) urls doesn't contains `_token`  anymore and legacy pages shouldn't contains `token` parameter.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8876)
<!-- Reviewable:end -->
