### PR TITLE
BO AdminStores state select fill

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -247,7 +247,7 @@ class AdminStoresControllerCore extends AdminController
                     'options' => array(
                         'id' => 'id_state',
                         'name' => 'name',
-                        'query' => null
+                        'query' => State::getStates($this->context->language->id)
                     )
                 ),
                 array(


### PR DESCRIPTION
Fill states options at AdminStores.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | The states option is empty, and I can't fill forms with this field.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Using other country (like Argentina), try to add a new Store in BO. "States" selector is empty.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8877)
<!-- Reviewable:end -->
