### PR TITLE
QUERY_STRING is not set on all environments

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1711,7 +1711,10 @@ class FrontControllerCore extends Controller
         $uriWithoutParams = explode('?', $_SERVER['REQUEST_URI'])[0];
         $url = Tools::getCurrentUrlProtocolPrefix().$_SERVER['HTTP_HOST'].$uriWithoutParams;
         $params = array();
-        $paramsFromUri = explode('?', $_SERVER['REQUEST_URI'])[1];
+        $paramsFromUri = '';
+        if (strpos($_SERVER['REQUEST_URI'], '?') !== false) {
+            $paramsFromUri = explode('?', $_SERVER['REQUEST_URI'])[1];
+        }
         parse_str($paramsFromUri, $params);
 
         if (null !== $extraParams) {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1711,7 +1711,8 @@ class FrontControllerCore extends Controller
         $uriWithoutParams = explode('?', $_SERVER['REQUEST_URI'])[0];
         $url = Tools::getCurrentUrlProtocolPrefix().$_SERVER['HTTP_HOST'].$uriWithoutParams;
         $params = array();
-        parse_str($_SERVER['QUERY_STRING'], $params);
+        $paramsFromUri = explode('?', $_SERVER['REQUEST_URI'])[1];
+        parse_str($paramsFromUri, $params);
 
         if (null !== $extraParams) {
             foreach ($extraParams as $key => $value) {


### PR DESCRIPTION
$_SERVER['QUERY_STRING'] is not set on all environments, so we can't count on it.
https://imgur.com/a/pa3r3

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | $_SERVER['QUERY_STRING'] is not set on all environments, we can't count on it.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | There are some server configuration which don't have QUERY_STRING set, I couldn't figure out which of them. http://php.net/manual/ro/reserved.variables.server.php#120980 https://imgur.com/a/pa3r3

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8884)
<!-- Reviewable:end -->
