### PR TITLE
Fix display of image form in product page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
@@ -25,12 +25,12 @@
  */
 namespace PrestaShopBundle\Controller\Admin;
 
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Validator\Constraints as Assert;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-
 /**
  * Admin controller for product images
  */
@@ -128,7 +128,7 @@ class ProductImageController extends FrameworkBundleAdminController
 
         $image = $productAdapter->getImage((int)$idImage);
 
-        $form = $this->container->get('form.factory')->createNamedBuilder('form_image', 'form', $image, array('csrf_protection' => false))
+        $form = $this->container->get('form.factory')->createNamedBuilder('form_image', FormType::class, $image, array('csrf_protection' => false))
             ->add('legend', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
                 'type' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType',
                 'options' => array(),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix the image form on the BO Product page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Try to set an image as cover, the form must be shown.

![capture du 2018-03-28 10-55-14](https://user-images.githubusercontent.com/6768917/38022162-ae10ffae-3276-11e8-822f-39b94643f239.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8890)
<!-- Reviewable:end -->
