### PR TITLE
Fix dezipper redirect

### DIFF
--- a/tools/build/Library/InstallUnpacker/index_template.php
+++ b/tools/build/Library/InstallUnpacker/index_template.php
@@ -232,7 +232,7 @@ if (isset($_GET['element'])) {
       } else {
         if (msg.lastId > msg.numFiles) {
           // end
-          window.location.reload(true);
+          window.location.href = 'install/';
         } else {
           $("#progressContainer")
             .find(".current")


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Sometimes the dezipper will want to stay in cache after the dezipping process, resulting in an error. This fix makes the dezipper explicitly redirect to the installer after it's done instead of reloading to avoid those issues.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5196
| How to test?  | Create a build and test the unzipping process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8891)
<!-- Reviewable:end -->
