### PR TITLE
Optimize breadcrumb computation performances

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1514,11 +1514,13 @@ class CategoryCore extends ObjectModel
         $treeInfo = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow(
             'SELECT c.`nleft`, c.`nright`  '.$sqlAppend.' WHERE c.`id_category` = '.(int) $idCurrent
         );
-        $rootTreeInfo = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow(
-            'SELECT c.`nleft`, c.`nright` FROM `'._DB_PREFIX_.'category` c 
-            WHERE c.`id_category` = '.(int) $context->shop->id_category
-        );
+
         if (!empty($treeInfo)) {
+            $rootTreeInfo = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow(
+                'SELECT c.`nleft`, c.`nright` FROM `'._DB_PREFIX_.'category` c 
+            WHERE c.`id_category` = '.(int) $context->shop->id_category
+            );
+
             $categories = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 'SELECT c.*, cl.*  '.$sqlAppend.
                 ' WHERE c.`nleft` <= '.(int) $treeInfo['nleft'].

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -784,7 +784,7 @@ class CategoryCore extends ObjectModel
 		WHERE cl.`id_lang` = '.(int) $idLang.'
 		AND c.`id_category` != '.Configuration::get('PS_ROOT_CATEGORY').'
 		GROUP BY c.id_category
-		ORDER BY c.`id_category`, category_shop.`position`');
+		ORDER BY c.`id_category`, category_shop.`position`', true, false);
     }
 
     /**

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -768,11 +768,11 @@ class CategoryCore extends ObjectModel
     }
 
     /**
-     * Get a simple list of categories
+     * Get a simple list of categories with id_category and name for each Category
      *
      * @param int $idLang Language ID
      *
-     * @return array|false|mysqli_result|null|PDOStatement|resource Return array with `id_category` and `name` for every Category
+     * @return array|false|mysqli_result|null|PDOStatement|resource
      */
     public static function getSimpleCategories($idLang)
     {
@@ -788,11 +788,12 @@ class CategoryCore extends ObjectModel
     }
 
     /**
-     * Get a simple list of categories with parent infos
+     * Get a simple list of categories with id_category, name and id_parent infos
+     * It also takes into account the root category of the current shop
      *
      * @param int $idLang Language ID
      *
-     * @return array|false|mysqli_result|null|PDOStatement|resource Return array with `id_category` and `name` for every Category
+     * @return array|false|mysqli_result|null|PDOStatement|resource
      */
     public static function getSimpleCategoriesWithParentInfos($idLang)
     {

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -34,7 +34,7 @@ class CategoryCore extends ObjectModel
     /** @var int category ID */
     public $id_category;
 
-    /** @var string Name */
+    /** @var mixed string or array of Name */
     public $name;
 
     /** @var bool Status for display */
@@ -43,7 +43,7 @@ class CategoryCore extends ObjectModel
     /** @var  int category position */
     public $position;
 
-    /** @var string Description */
+    /** @var mixed string or array of Description */
     public $description;
 
     /** @var int Parent category ID */
@@ -61,16 +61,16 @@ class CategoryCore extends ObjectModel
     /** @var int Nested tree model "right" value */
     public $nright;
 
-    /** @var string string used in rewrited URL */
+    /** @var mixed string or array of string used in rewrited URL */
     public $link_rewrite;
 
-    /** @var string Meta title */
+    /** @var mixed string or array of Meta title */
     public $meta_title;
 
-    /** @var string Meta keywords */
+    /** @var mixed string or array of Meta keywords */
     public $meta_keywords;
 
-    /** @var string Meta description */
+    /** @var mixed string or array of Meta description */
     public $meta_description;
 
     /** @var string Object creation date */
@@ -449,7 +449,13 @@ class CategoryCore extends ObjectModel
 
         $parentCategory = new Category((int) $this->id_parent);
         if (!Validate::isLoadedObject($parentCategory)) {
-            throw new PrestaShopException('Parent category does not exist');
+            if (is_array($this->name)) {
+                $name = $this->name[Context::getContext()->language->id];
+            } else {
+                $name = $this->name;
+            }
+            throw new PrestaShopException('Parent category '.$this->id_parent.
+                ' does not exist. Current category: '.$name);
         }
 
         return (int) $parentCategory->level_depth + 1;

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -800,7 +800,7 @@ class CategoryCore extends ObjectModel
         $context = Context::getContext();
         if (count(Category::getCategoriesWithoutParent()) > 1
             && \Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE')
-            && count(Shop::getShops(true, null, true)) != 1) {
+            && count(Shop::getShops(true, null, true)) !== 1) {
             $idCategoryRoot = (int) \Configuration::get('PS_ROOT_CATEGORY');
         } elseif (!$context->shop->id) {
             $idCategoryRoot = (new Shop(\Configuration::get('PS_SHOP_DEFAULT')))->id_category;
@@ -1212,10 +1212,10 @@ class CategoryCore extends ObjectModel
 		LEFT JOIN `'._DB_PREFIX_.'category_shop` cs ON (c.`id_category` = cs.`id_category` AND cs.`id_shop` = '.(int) $idShop.')
 		WHERE `id_lang` = '.(int) $idLang.'
 		AND c.`id_parent` = '.(int) $idParent;
-        if (Shop::getContext() == Shop::CONTEXT_SHOP && $useShopContext) {
+        if (Shop::getContext() === Shop::CONTEXT_SHOP && $useShopContext) {
             $sql .= ' AND cs.`id_shop` = '.(int) $shop->id;
         }
-        if (!Shop::isFeatureActive() || Shop::getContext() == Shop::CONTEXT_SHOP && $useShopContext) {
+        if (!Shop::isFeatureActive() || Shop::getContext() === Shop::CONTEXT_SHOP && $useShopContext) {
             $sql .= ' ORDER BY cs.`position` ASC';
         }
 
@@ -1483,7 +1483,7 @@ class CategoryCore extends ObjectModel
         $idCurrent = $this->id;
         if (count(Category::getCategoriesWithoutParent()) > 1
             && Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE')
-            && count(Shop::getShops(true, null, true)) != 1) {
+            && count(Shop::getShops(true, null, true)) !== 1) {
             $context->shop->id_category = (int) Configuration::get('PS_ROOT_CATEGORY');
         } elseif (!$context->shop->id) {
             $context->shop = new Shop(Configuration::get('PS_SHOP_DEFAULT'));
@@ -1494,15 +1494,15 @@ class CategoryCore extends ObjectModel
 			LEFT JOIN `'._DB_PREFIX_.'category_lang` cl
 				ON (c.`id_category` = cl.`id_category`
                     AND `id_lang` = '.(int) $idLang.Shop::addSqlRestrictionOnLang('cl').')';
-        if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP) {
+        if (Shop::isFeatureActive() && Shop::getContext() === Shop::CONTEXT_SHOP) {
             $sqlAppend .= ' LEFT JOIN `'._DB_PREFIX_.'category_shop` cs '.
                 'ON (c.`id_category` = cs.`id_category` AND cs.`id_shop` = '.(int) $idShop.')';
         }
-        if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP) {
+        if (Shop::isFeatureActive() && Shop::getContext() === Shop::CONTEXT_SHOP) {
             $sqlAppend .= ' AND cs.`id_shop` = '.(int) $context->shop->id;
         }
         $rootCategory = Category::getRootCategory();
-        if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_SHOP
+        if (Shop::isFeatureActive() && Shop::getContext() === Shop::CONTEXT_SHOP
             && (!Tools::isSubmit('id_category')
                 || (int) Tools::getValue('id_category') == (int) $rootCategory->id
                 || (int) $rootCategory->id == (int) $context->shop->id_category)) {

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1435,7 +1435,7 @@ class AdminImportControllerCore extends AdminController
             $category->force_id = (bool)$force_ids;
             if (!$res && !$validateOnly) {
                 $res = $category->add();
-                if ($category->id != $info['id']) {
+                if (isset($info['id']) && $category->id != $info['id']) {
                     $cat_moved[$info['id']] = $category->id;
                 }
             }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1278,10 +1278,6 @@ class AdminImportControllerCore extends AdminController
             );
         }
 
-        if (!$validateOnly) {
-            /* Import has finished, we can regenerate the categories nested tree */
-            Category::regenerateEntireNtree();
-        }
         $this->closeCsvFile($handle);
 
         if ($crossStepsVariables !== false) {
@@ -1439,6 +1435,9 @@ class AdminImportControllerCore extends AdminController
             $category->force_id = (bool)$force_ids;
             if (!$res && !$validateOnly) {
                 $res = $category->add();
+                if ($category->id != $info['id']) {
+                    $cat_moved[$info['id']] = $category->id;
+                }
             }
         }
 
@@ -4426,10 +4425,15 @@ class AdminImportControllerCore extends AdminController
                 }
             }
             Db::getInstance()->disableCache();
+            $clearCache = false;
             switch ((int)Tools::getValue('entity')) {
                 case $this->entities[$import_type = $this->trans('Categories', array(), 'Admin.Global')]:
                     $doneCount += $this->categoryImport($offset, $limit, $crossStepsVariables, $validateOnly);
-                    $this->clearSmartyCache();
+                    if ($doneCount < $limit && !$validateOnly) {
+                        /* Import has finished, we can regenerate the categories nested tree */
+                        Category::regenerateEntireNtree();
+                    }
+                    $clearCache = true;
                     break;
                 case $this->entities[$import_type = $this->trans('Products', array(), 'Admin.Global')]:
                     if (!defined('PS_MASS_PRODUCT_CREATION')) {
@@ -4437,7 +4441,7 @@ class AdminImportControllerCore extends AdminController
                     }
                     $moreStepLabels = array($this->trans('Linking Accessories...', array(), 'Admin.Advparameters.Notification'));
                     $doneCount += $this->productImport($offset, $limit, $crossStepsVariables, $validateOnly, $moreStep);
-                    $this->clearSmartyCache();
+                    $clearCache = true;
                     break;
                 case $this->entities[$import_type = $this->trans('Customers', array(), 'Admin.Global')]:
                     $doneCount += $this->customerImport($offset, $limit, $validateOnly);
@@ -4447,22 +4451,22 @@ class AdminImportControllerCore extends AdminController
                     break;
                 case $this->entities[$import_type = $this->trans('Combinations', array(), 'Admin.Global')]:
                     $doneCount += $this->attributeImport($offset, $limit, $crossStepsVariables, $validateOnly);
-                    $this->clearSmartyCache();
+                    $clearCache = true;
                     break;
                 case $this->entities[$import_type = $this->trans('Brands', array(), 'Admin.Global')]:
                     $doneCount += $this->manufacturerImport($offset, $limit, $validateOnly);
-                    $this->clearSmartyCache();
+                    $clearCache = true;
                     break;
                 case $this->entities[$import_type = $this->trans('Suppliers', array(), 'Admin.Global')]:
                     $doneCount += $this->supplierImport($offset, $limit, $validateOnly);
-                    $this->clearSmartyCache();
+                    $clearCache = true;
                     break;
                 case $this->entities[$import_type = $this->trans('Alias', array(), 'Admin.Shopparameters.Feature')]:
                     $doneCount += $this->aliasImport($offset, $limit, $validateOnly);
                     break;
                 case $this->entities[$import_type = $this->trans('Store contacts', array(), 'Admin.Advparameters.Feature')]:
                     $doneCount += $this->storeContactImport($offset, $limit, $validateOnly);
-                    $this->clearSmartyCache();
+                    $clearCache = true;
                     break;
             }
 
@@ -4484,6 +4488,9 @@ class AdminImportControllerCore extends AdminController
 
             if ($results !== null) {
                 $results['isFinished'] = ($doneCount < $limit);
+                if ($results['isFinished'] && $clearCache && !$validateOnly) {
+                    $this->clearSmartyCache();
+                }
                 $results['doneCount'] = $offset + $doneCount;
                 if ($offset === 0) {
                     // compute total count only once, because it takes time

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -382,6 +382,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function formAction($id, Request $request)
     {
+        gc_disable();
         if (
             !$this->isGranted(PageVoter::READ, 'ADMINPRODUCTS_')
             && !$this->isGranted(PageVoter::UPDATE, 'ADMINPRODUCTS_')

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -50,6 +50,7 @@ use PrestaShop\PrestaShop\Adapter\Entity\Cookie;
 use PrestaShop\PrestaShop\Adapter\Entity\Currency;
 use PrestaShop\PrestaShop\Adapter\Entity\Validate;
 use PrestaShop\PrestaShop\Adapter\Entity\Cart;
+use PrestaShop\PrestaShop\Adapter\Entity\Category;
 use InstallSession;
 use Language as LanguageLegacy;
 use PrestaShop\PrestaShop\Core\Cldr\Update;
@@ -1095,6 +1096,10 @@ class Install extends AbstractInstall
         // IDS from xmlLoader are stored in order to use them for fixtures
         $this->xml_loader_ids = $xml_loader->getIds();
         unset($xml_loader);
+
+        if ($entity === 'category') {
+            Category::regenerateEntireNtree();
+        }
 
         if ($entity === null) {
             Search::indexation(true);

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -280,6 +280,7 @@ class XmlLoader
 
 
         // Load all row for current entity and prepare data to be populated
+        $i = 0;
         foreach ($xml->entities->$entity as $node) {
             $data = array();
             $identifier = (string)$node['id'];
@@ -337,6 +338,12 @@ class XmlLoader
                 } else {
                     $this->copyImages($entity, $identifier, (string)$xml->fields['image'], $data);
                 }
+            }
+            $i++;
+
+            if ($i >= 100) {
+                $this->flushDelayedInserts();
+                $i = 0;
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Greatly improve performances with a lot of categories
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3666
| How to test?  | load a product page in BO with a lot of categories in the database

It actually improves both frontoffice & backoffice performances when a lot of categories are used

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8896)
<!-- Reviewable:end -->
