### PR TITLE
Display the "No Image" image for Products with no image

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -26,6 +26,7 @@
 use PrestaShop\PrestaShop\Adapter\Cart\CartPresenter;
 use PrestaShop\PrestaShop\Adapter\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Configuration as ConfigurationAdapter;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -1496,7 +1497,10 @@ class FrontControllerCore extends Controller
         $urls['actions'] = array(
             'logout' => $this->context->link->getPageLink('index', true, null, 'mylogout'),
         );
-
+        
+        $imageRetriever = new ImageRetriever($this->context->link);
+        $urls['no_picture_image'] =  $imageRetriever->getNoPictureImage($this->context->language);
+        
         return $urls;
     }
 

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -211,4 +211,44 @@ class ImageRetriever
             'legend' => ''
         ];
     }
+
+    public function getNoPictureImage(Language $language)
+    {
+        $urls  = [];
+        $type = 'products';
+        $image_types = ImageType::getImagesTypes($type, true);
+        
+        foreach ($image_types as $image_type) {
+            
+            $url = $this->link->getImageLink(
+                '',
+                $language->iso_code.'-default',
+                $image_type['name']
+            );
+
+            $urls[$image_type['name']] = [
+                'url'      => $url,
+                'width'     => (int)$image_type['width'],
+                'height'    => (int)$image_type['height'],
+            ];
+        }
+        
+        uasort($urls, function (array $a, array $b) {
+            return $a['width'] * $a['height'] > $b['width'] * $b['height'] ? 1 : -1;
+        });
+
+        $keys = array_keys($urls);
+
+        $small  = $urls[$keys[0]];
+        $large  = end($urls);
+        $medium = $urls[$keys[ceil((count($keys) - 1) / 2)]];
+        
+        return array(
+            'bySize' => $urls,
+            'small'  => $small,
+            'medium' => $medium,
+            'large'  => $large,
+            'legend' => ''
+        );
+    }
 }

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -26,13 +26,21 @@
   <article class="product-miniature js-product-miniature" data-id-product="{$product.id_product}" data-id-product-attribute="{$product.id_product_attribute}" itemscope itemtype="http://schema.org/Product">
     <div class="thumbnail-container">
       {block name='product_thumbnail'}
-        <a href="{$product.url}" class="thumbnail product-thumbnail">
-          <img
-            src = "{$product.cover.bySize.home_default.url}"
-            alt = "{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
-            data-full-size-image-url = "{$product.cover.large.url}"
-          >
-        </a>
+        {if $product.cover}
+          <a href="{$product.url}" class="thumbnail product-thumbnail">
+            <img
+              src = "{$product.cover.bySize.home_default.url}"
+              alt = "{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
+              data-full-size-image-url = "{$product.cover.large.url}"
+            >
+          </a>
+        {else}
+          <a href="{$product.url}" class="thumbnail product-thumbnail">
+            <img
+              src = "{$urls.no_picture_image.bySize.home_default.url}"
+            >
+          </a>
+        {/if}
       {/block}
 
       <div class="product-description">

--- a/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -25,10 +25,14 @@
 <div class="images-container">
   {block name='product_cover'}
     <div class="product-cover">
-      <img class="js-qv-product-cover" src="{$product.cover.bySize.large_default.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" style="width:100%;" itemprop="image">
-      <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
-        <i class="material-icons zoom-in">&#xE8FF;</i>
-      </div>
+      {if $product.cover}
+        <img class="js-qv-product-cover" src="{$product.cover.bySize.large_default.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" style="width:100%;" itemprop="image">
+        <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
+          <i class="material-icons zoom-in">&#xE8FF;</i>
+        </div>
+      {else}
+        <img src="{$urls.no_picture_image.bySize.large_default.url}" style="width:100%;">
+      {/if}
     </div>
   {/block}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | You can add a "No-picture" image , Langage , it was not anymore displayed on 1.7 when a product have no image.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | See below please

------------
How to test ?
- First upload a "No-picture" image fraom admin > your langage ( no one is delivered on default ps instal) 
- Créate a product whithout any pictures,
- go on your front Office and see the result

------------
Before this commit, whe add :
![correctif_images_before_1](https://user-images.githubusercontent.com/3170104/35032556-8c98223a-fb67-11e7-82ed-d2d1c21cad26.png)
![correctif_images_before_2](https://user-images.githubusercontent.com/3170104/35032557-8caf3312-fb67-11e7-93fe-14748b397bca.png)


------------
After this commit, we have  Preston as "No-picture" image:
![correction_no_image_after_1](https://user-images.githubusercontent.com/3170104/35032576-9914d274-fb67-11e7-9bb0-ef177d766a74.png)
![correction_no_image_after_2](https://user-images.githubusercontent.com/3170104/35032577-992f45c8-fb67-11e7-861f-ea094a846d2f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8678)
<!-- Reviewable:end -->
