### PR TITLE
Fix wrong update of shipping cost when order is updated in BO

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1191,7 +1191,8 @@ class CartCore extends ObjectModel
         $id_address_delivery = 0,
         Shop $shop = null,
         $auto_add_cart_rule = true,
-        $skipAvailabilityCheckOutOfStock = false
+        $skipAvailabilityCheckOutOfStock = false,
+        $bo_changes = null //if null - usual behavoir.
     ) {
         if (!$shop) {
             $shop = Context::getContext()->shop;
@@ -1326,9 +1327,15 @@ class CartCore extends ObjectModel
                 }
 
                 if (!Product::isAvailableWhenOutOfStock((int)$result2['out_of_stock'])) {
-                    if ((int)$quantity > $result2['quantity']) {
-                        return false;
-                    }
+                    if (isset($bo_changes)){//changes have been made in BO
+   			if ($result2['quantity'] < 0){
+     				return false;
+   			}
+  		    }else{//old fashion for cart routins probably
+   			if ( (int)$quantity > $result2['quantity']) {
+      				return false;
+   			}
+  		    }
                 }
 
                 if ((int)$quantity < $minimal_quantity) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1328,14 +1328,14 @@ class CartCore extends ObjectModel
 
                 if (!Product::isAvailableWhenOutOfStock((int)$result2['out_of_stock'])) {
                     if (isset($bo_changes)){//changes have been made in BO
-   			if ($result2['quantity'] < 0){
-     				return false;
-   			}
-  		    }else{//old fashion for cart routins probably
-   			if ( (int)$quantity > $result2['quantity']) {
-      				return false;
-   			}
-  		    }
+                        if ($result2['quantity'] < 0){
+                            return false;
+                        }
+                    }else{//old fashion for cart routins probably
+                        if ( (int)$quantity > $result2['quantity']) {
+                            return false;
+                        }
+                    }
                 }
 
                 if ((int)$quantity < $minimal_quantity) {

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2545,7 +2545,15 @@ class OrderCore extends ObjectModel
 
         // add real order products
         foreach ($this->getProducts() as $product) {
-            $new_cart->updateQty($product['product_quantity'], (int) $product['product_id']);
+            $new_cart->updateQty($product['product_quantity'], (int) $product['product_id'],
+            null, //pass default values
+            false, 
+            'up', 
+            0, 
+            null, 
+            true,
+            false,
+            'yes' ); //marker we made changes in BO
         }
 
         // get new shipping cost


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If the order is beeing changed from BO the shipping cost become free (zero) if the qty of the product is more than availble for order. It happens when editing qty, adding new product to the order, deleting one product from the order, changing the qty of the product, address is beeing changed. As I see that's because method refreshShippingCost (Order.php) use updateQty (Cart.php). This method works perfect (as I know) for front office, but it should be rewritten for the BO routins. It can return false but this value is not handled by refreshShippingCost. When refreshShippingCost gets false from updateQty - shipping costs becomes free. I made simple change to the code. Those changes work but I believe new method in Cart.php should be written. Now updateQty still can return false if one add qty more than availble.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5163
| How to test?  | I'm not sure I made all correct. Create order with one or more goods with qty 1 each. Change qty first of them in BO, so new qty would be more than qty availble. Shipping costs would be calculated correct. Without changes the shipping costs get free.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8905)
<!-- Reviewable:end -->
