### PR TITLE
Allow autoloading in modules for services use in BO

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -72,6 +72,13 @@ class AppKernel extends Kernel
             $_SERVER['CACHE_DRIVER'] = 'array';
         }
 
+        /* Will not work until PrestaShop is installed */
+        if ($this->parametersFileExists()) {
+            try {
+                $this->enableComposerAutoloaderOnModules($this->getActiveModules());
+            } catch (\Exception $e) {}
+        }
+
         return $bundles;
     }
 
@@ -203,5 +210,22 @@ class AppKernel extends Kernel
             'charset' => 'utf8',
             'driver' => 'pdo_mysql',
         ));
+    }
+
+    /**
+     * Enable auto loading of module Composer autoloader if needed.
+     * Need to be done as earlier as possible in application lifecycle.
+     *
+     * @param array $modules the list of modules
+     */
+    private function enableComposerAutoloaderOnModules($modules)
+    {
+        foreach ($modules as $module) {
+            $autoloader = __DIR__.'/../modules/'.$module.'/vendor/autoload.php';
+
+            if (file_exists($autoloader)) {
+                include_once $autoloader;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If you declare services in modules and if your module is using Composer as autoloader, the service container breaks during compilation because PrestaShop is unaware of classes inside the module (the module may not be instantiated when the service container is built).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Declare a service in one of your modules and try to access a "modern" Back Office page.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8909)
<!-- Reviewable:end -->
