### PR TITLE
Collect all hooks for the debugger

### DIFF
--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -249,11 +249,11 @@ class LegacyHookSubscriber implements EventSubscriberInterface
                         $functionName = 'call_' . $id . '_' . $moduleId;
                         $moduleListeners[] = array($functionName, 2000 - $order);
                     }
-
-                    if (count($moduleListeners)) {
-                        $listeners[$name] = $moduleListeners;
-                    }
+                } else {
+                    $moduleListeners[] = array('call_' . $id . '_0', 2000);
                 }
+
+                $listeners[$name] = $moduleListeners;
             }
         }
         return $listeners;
@@ -278,18 +278,17 @@ class LegacyHookSubscriber implements EventSubscriberInterface
         $ids = explode('_', $name);
         array_shift($ids); // remove 'call'
 
-        if (count($ids) != 2) {
+        if (count($ids) !== 2) {
             throw new \BadMethodCallException('The call to \''.$name.'\' is not recognized.');
         }
 
-        $moduleId = $ids[1];
+        $moduleId = (int) $ids[1];
+        list($event, $hookName) = $args;
 
-        $hookName = $args[1];
-        $event = $args[0];
         /* @var $event HookEvent */
         $content = Hook::exec($hookName, $event->getHookParameters(), $moduleId, ($event instanceof RenderingHookEvent));
 
-        if ($event instanceof RenderingHookEvent) {
+        if ($event instanceof RenderingHookEvent && 0 !== $moduleId) {
             $event->setContent(array_values($content)[0], array_keys($content)[0]);
         }
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Hooks dispatched using `HookDispatcher` service are not collected by the debugger because the class `LegacyHookSubscriber` doesn't call them. Now they are dispatched, you can see the difference on Administration, Maintenance or Performance page when looking at "not called hooks" in Hooks section of the debugger toolbar.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Re-install your shop if you didn't do it since the addition of these [hooks](https://github.com/PrestaShop/PrestaShop/pull/8368). Now they are dispatched, you should see one more Hook dispatched in "not called hooks" section of Hooks section of the debugger toolbar for Administration, Maintenance or Performance pages.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8910)
<!-- Reviewable:end -->
