### PR TITLE
Add unlimited timeout to dropzone configuration

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -518,6 +518,7 @@ var AdminModuleController = function() {
       addRemoveLinks: true,
       dictDefaultMessage: '',
       hiddenInputContainer: self.dropZoneImportZoneSelector,
+      timeout:0, // add unlimited timeout. Otherwise dropzone timeout is 30 seconds and if a module is long to install, it is not possible to install the module.
       addedfile: function() {
         self.animateStartUpload();
       },


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add unlimited timeout to prestashop because default timout of dropzone is 30 seconds. If the module is long to install that generate an infinite loop and the module can not to be installed
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5194
| How to test?  | Simply use dropzone to install a big module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8918)
<!-- Reviewable:end -->
