### PR TITLE
CO : Bug when using checkAccessStatic with logged in customer

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5378,6 +5378,13 @@ class ProductCore extends ObjectModel
             return true;
         }
 
+        if (!$id_customer) {
+            $customer = Context::getContext()->customer;
+            if (Validate::isLoadedObject($customer)) {
+                $id_customer = (int)$customer->id;
+            }
+        }
+
         $cache_id = 'Product::checkAccess_'.(int)$id_product.'-'.(int)$id_customer.(!$id_customer ? '-'.(int)Group::getCurrent()->id : '');
         if (!Cache::isStored($cache_id)) {
             if (!$id_customer) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a customer was logged in, and you where using checkAccessStatic without specifying the customer's ID, only the customer's default group was tested, which is inconsistant with the behaviour when a customer's ID was specified.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8919)
<!-- Reviewable:end -->
