### PR TITLE
Fixed access to Front Office container from modules

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3185,7 +3185,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function isSymfonyContext()
     {
-        return !defined('ADMIN_LEGACY_CONTEXT');
+        return !defined('ADMIN_LEGACY_CONTEXT') && $this->context->controller instanceof AdminLegacyLayoutControllerCore;
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | We can't rely on `ADMIN_LEGACY_CONTEXT` constant to ensure we are in Front Office.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Use this [module](https://github.com/PrestaShop/PrestaShop/files/1882211/ps_test.zip) after a re-installation in `1.7.3.x` branch and on this one, accessing the Front Office.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8922)
<!-- Reviewable:end -->
