### PR TITLE
Fixed url redirection on Administration page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/AdvancedParameters/AdministrationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AdvancedParameters/AdministrationController.php
@@ -50,7 +50,7 @@ class AdministrationController extends FrameworkBundleAdminController
 
         $twigValues = array(
             'layoutHeaderToolbarBtn' => array(),
-            'layoutTitle' => $this->get('translator')->trans('Administration', array(), 'Admin.Navigation.Menu'),
+            'layoutTitle' => $this->trans('Administration','Admin.Navigation.Menu'),
             'requireAddonsSearch' => true,
             'requireBulkActions' => false,
             'showContentHeader' => true,

--- a/src/PrestaShopBundle/Controller/Admin/AdvancedParameters/AdministrationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AdvancedParameters/AdministrationController.php
@@ -71,7 +71,7 @@ class AdministrationController extends FrameworkBundleAdminController
         if ($this->isDemoModeEnabled()) {
             $this->addFlash('error', $this->getDemoModeErrorMessage());
 
-            return $this->redirectToRoute('admin_performance');
+            return $this->redirectToRoute('admin_administration');
         }
 
         $this->dispatchHook('actionAdminAdminPreferencesControllerPostProcessBefore', array('controller' => $this));


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In Demo mode, the redirection in Configure > Advanced Parameters > Administration page was wrong.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | In Demonstration mode, try to access Configure > Advanced Parameters > Administration page: before, you were redirected to Performance page.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8923)
<!-- Reviewable:end -->
