### PR TITLE
Fix deprecation message

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -300,7 +300,7 @@ class TabCore extends ObjectModel
 
     /**
      * Get tab id from name
-     * @deprecated since version 1.7.1.0, available now in PrestaShopBundle\Entity\Repository\TabRepository::getOneIdByClassName($className)
+     * @deprecated since version 1.7.1.0, available now in PrestaShopBundle\Entity\Repository\TabRepository::findOneIdByClassName($className)
      *
      * @param string $className
      *


### PR DESCRIPTION
replace getOneIdByClassName by the findOneIdByClassName in deprecation message

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develog
| Description?  | fix the method name on depreciation message
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8926)
<!-- Reviewable:end -->
