### PR TITLE
Out of stock message display only if customer can order the product

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -102,7 +102,8 @@
       {elseif $product.additional_delivery_times == 2}
         {if $product.quantity > 0}
           <span class="delivery-information">{$product.delivery_in_stock}</span>
-        {else}
+        {* Out of stock message should not be displayed if customer can't order the product. *}
+        {elseif $product.quantity == 0 && $product.add_to_cart_url}
           <span class="delivery-information">{$product.delivery_out_stock}</span>
         {/if}
       {/if}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Out of stock message should be displayed only if customer can order the product
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4841
| How to test?  | See Jira issue for reproducible test

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8931)
<!-- Reviewable:end -->
