### PR TITLE
Fix bug on saving store hours

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -302,13 +302,13 @@ class AdminStoresControllerCore extends AdminController
 
         $hours_temp = ($this->getFieldValue($obj, 'hours'));
         if (is_array($hours_temp) && !empty($hours_temp)) {
-            $Langs = Language::getLanguages(true);
+            $langs = Language::getLanguages(false);
             $hours_temp = array_map('json_decode', $hours_temp);
             $hours = array_map(
                 array($this, 'adaptHoursFormat'),
                 $hours_temp
             );
-            $hours = (count($Langs) > 1) ? $hours : $hours[reset($Langs)['id_lang']];
+            $hours = (count($langs) > 1) ? $hours : $hours[reset($langs)['id_lang']];
         }
 
         $this->fields_value = array(
@@ -324,7 +324,7 @@ class AdminStoresControllerCore extends AdminController
     public function postProcess()
     {
         if (isset($_POST['submitAdd'.$this->table])) {
-            $langs = Language::getLanguages();
+            $langs = Language::getLanguages(false);
             /* Cleaning fields */
             foreach ($_POST as $kp => $vp) {
                 if (!in_array($kp, array('checkBoxShopGroupAsso_store', 'checkBoxShopAsso_store', 'hours'))) {


### PR DESCRIPTION
There is an error on saving store hours when there are two languages available on the shop with only one is activated.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There is an error on saving store hours when there are two languages available on the shop with only one is activated. In BO, you can fill the two languages but in processing and display only the activated language is used/processed.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | To reproduce this bug, you have to have 2 languages installed including one disabled. In my case : french enabled and english disabled. 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8933)
<!-- Reviewable:end -->
