### PR TITLE
Hooks for recommended modules & themes

### DIFF
--- a/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
@@ -116,3 +116,12 @@
 	{$smarty.block.parent}
 
 {/block}
+
+
+{block name="after"}
+	<script type="text/javascript">
+		// These variable will move the form to another location
+		var formToMove = "appearance";
+		var formDestination = "js_theme_form_container";
+	</script>
+{/block}

--- a/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
@@ -116,32 +116,3 @@
 	{$smarty.block.parent}
 
 {/block}
-
-
-{block name="after"}
-	<div class="panel clearfix" id="prestastore-content"></div>
-	<script type="text/javascript">
-		$.ajax({
-			type: 'POST',
-			headers: { "cache-control": "no-cache" },
-			url: 'ajax-tab.php?rand=' + new Date().getTime(),
-			async: true,
-			cache: false,
-			dataType : "html",
-			data: {
-				tab: 'AdminThemes',
-				token: '{$token|escape:'html':'UTF-8'}',
-				ajax: '1',
-				action:'getAddonsThemes',
-				page:'themes'
-			},
-			success: function(htmlData) {
-				$("#prestastore-content").html("<h3><i class='icon-picture-o'></i> {l s='Live from PrestaShop Addons!'}</h3>"+htmlData);
-			}
-		});
-
-		// These variable will move the form to another location
-		var formToMove = "appearance";
-		var formDestination = "js_theme_form_container";
-	</script>
-{/block}

--- a/admin-dev/themes/default/template/footer.tpl
+++ b/admin-dev/themes/default/template/footer.tpl
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-
+         {hook h='displayAdminEndContent'}
 	</div>
 </div>
 {if $display_footer}

--- a/admin-dev/themes/default/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/default/template/page_header_toolbar.tpl
@@ -79,6 +79,7 @@
             <div>{l s='Menu' d='Admin.Navigation.Menu'}</div>
           </a>
           <ul id="toolbar-nav" class="nav nav-pills pull-right collapse navbar-collapse">
+            {hook h='displayDashboardToolbarTopMenu'}
             {foreach from=$toolbar_btn item=btn key=k}
               {if $k != 'back' && $k != 'modules-list'}
                 <li>

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -104,6 +104,7 @@
       <div class="row ">
         <div class="col-sm-12">
           {$page}
+          {hook h='displayAdminEndContent'}
         </div>
       </div>
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2329,56 +2329,16 @@ class AdminControllerCore extends Controller
     }
 
     /**
+     * Was used to display a list of recommended modules
+     * 
      * @param string|bool $tracking_source Source information for URL used by "Install" button
-     * @return string
+     * @return string Empty
+     *
+     * @deprecated since 1.7.4.0
      */
     public function renderModulesList($tracking_source = false)
     {
-        // Load cache file modules list (natives and partners modules)
-        $xml_modules = false;
-        if (file_exists(_PS_ROOT_DIR_.Module::CACHE_FILE_MODULES_LIST)) {
-            $xml_modules = @simplexml_load_file(_PS_ROOT_DIR_.Module::CACHE_FILE_MODULES_LIST);
-        }
-        if ($xml_modules) {
-            foreach ($xml_modules->children() as $xml_module) {
-                /** @var SimpleXMLElement $xml_module */
-                foreach ($xml_module->children() as $module) {
-                    /** @var SimpleXMLElement $module */
-                    foreach ($module->attributes() as $key => $value) {
-                        if ($xml_module->attributes() == 'native' && $key == 'name') {
-                            $this->list_natives_modules[] = (string)$value;
-                        }
-                        if ($xml_module->attributes() == 'partner' && $key == 'name') {
-                            $this->list_partners_modules[] = (string)$value;
-                        }
-                    }
-                }
-            }
-        }
-
-        if ($this->getModulesList($this->filter_modules_list, $tracking_source)) {
-            $tmp = array();
-            foreach ($this->modules_list as $key => $module) {
-                if ($module->active) {
-                    $tmp[] = $module;
-                    unset($this->modules_list[$key]);
-                }
-            }
-
-            $this->modules_list = array_merge($tmp, $this->modules_list);
-
-            foreach ($this->modules_list as $key => $module) {
-                if (in_array($module->name, $this->list_partners_modules)) {
-                    $this->modules_list[$key]->type = 'addonsPartner';
-                }
-                if (isset($module->description_full) && trim($module->description_full) != '') {
-                    $module->show_quick_view = true;
-                    $module->optionsHtml = array($module->optionsHtml[0]);
-                }
-            }
-            $helper = new Helper();
-            return $helper->renderModulesList($this->modules_list);
-        }
+        return '';
     }
 
     /**

--- a/controllers/admin/AdminPaymentController.php
+++ b/controllers/admin/AdminPaymentController.php
@@ -92,7 +92,6 @@ class AdminPaymentControllerCore extends AdminController
     {
         if ($this->getModulesList($this->filter_modules_list, $tracking_source)) {
             $active_list = array();
-            $unactive_list = array();
             foreach ($this->modules_list as $key => $module) {
                 if (in_array($module->name, $this->list_partners_modules)) {
                     $this->modules_list[$key]->type = 'addonsPartner';
@@ -116,8 +115,6 @@ class AdminPaymentControllerCore extends AdminController
 
                 if ($module->active) {
                     $active_list[] = $module;
-                } else {
-                    $unactive_list[] = $module;
                 }
             }
 
@@ -134,7 +131,7 @@ class AdminPaymentControllerCore extends AdminController
                 'panel_id' => 'recommended-payment-gateways-panel',
                 'view_all' => true
             ));
-            $fetch .= $helper->renderModulesList($unactive_list);
+            $fetch .= parent::renderModulesList();
             return $fetch;
         }
     }

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -209,6 +209,24 @@ class AdminThemesControllerCore extends AdminController
         }
     }
 
+    /**
+     * Ajax request handler for displaying theme catalog from the marketplace.
+     * Not used anymore.
+     *
+     * @deprecated since 1.7.4.0
+     */
+    public function ajaxProcessGetAddonsThemes()
+    {
+        $parent_domain = Tools::getHttpHost(true).substr($_SERVER['REQUEST_URI'], 0, -1 * strlen(basename($_SERVER['REQUEST_URI'])));
+        $iso_lang = $this->context->language->iso_code;
+        $iso_currency = $this->context->currency->iso_code;
+        $iso_country = $this->context->country->iso_code;
+        $activity = Configuration::get('PS_SHOP_ACTIVITY');
+        $addons_url = Tools::getCurrentUrlProtocolPrefix().'addons.prestashop.com/iframe/search-1.7.php?psVersion='._PS_VERSION_.'&onlyThemes=1&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain;
+
+        die(Tools::file_get_contents($addons_url));
+    }
+
     public function renderView()
     {
         $this->tpl_view_vars = array(

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -209,18 +209,6 @@ class AdminThemesControllerCore extends AdminController
         }
     }
 
-    public function ajaxProcessGetAddonsThemes()
-    {
-        $parent_domain = Tools::getHttpHost(true).substr($_SERVER['REQUEST_URI'], 0, -1 * strlen(basename($_SERVER['REQUEST_URI'])));
-        $iso_lang = $this->context->language->iso_code;
-        $iso_currency = $this->context->currency->iso_code;
-        $iso_country = $this->context->country->iso_code;
-        $activity = Configuration::get('PS_SHOP_ACTIVITY');
-        $addons_url = Tools::getCurrentUrlProtocolPrefix().'addons.prestashop.com/iframe/search-1.7.php?psVersion='._PS_VERSION_.'&onlyThemes=1&isoLang='.$iso_lang.'&isoCurrency='.$iso_currency.'&isoCountry='.$iso_country.'&activity='.(int)$activity.'&parentUrl='.$parent_domain;
-
-        die(Tools::file_get_contents($addons_url));
-    }
-
     public function renderView()
     {
         $this->tpl_view_vars = array(

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -336,6 +336,11 @@
       <title>Administration panel hover the tabs</title>
       <description>This hook is displayed on the roll hover of the tabs within the admin panel</description>
     </hook>
+    <hook id="displayAdminEndContent">
+      <name>displayAdminEndContent</name>
+      <title>Administration end of content</title>
+      <description>This hook is displayed at the end of the main content, before the footer</description>
+    </hook>
     <hook id="displayBackOfficeFooter">
       <name>displayBackOfficeFooter</name>
       <title>Administration panel footer</title>

--- a/install-dev/upgrade/sql/1.7.4.0.sql
+++ b/install-dev/upgrade/sql/1.7.4.0.sql
@@ -22,4 +22,5 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionPerformancePageForm', 'Manage Performance Page form fields', 'This hook adds, update or remove fields of the Performance Page form', '1'),
   (NULL, 'actionPerformancePageFormSave', 'Processing Performance page form', 'This hook is called when the Performance Page form is processed', '1'),
   (NULL, 'actionMaintenancePageForm', 'Manage Maintenance Page form fields', 'This hook adds, update or remove fields of the Maintenance Page form', '1'),
-  (NULL, 'actionMaintenancePageFormSave', 'Processing Maintenance page form', 'This hook is called when the Maintenance Page form is processed', '1');
+  (NULL, 'actionMaintenancePageFormSave', 'Processing Maintenance page form', 'This hook is called when the Maintenance Page form is processed', '1'),
+  (NULL, 'displayAdminEndContent', 'Administration end of content', 'This hook is displayed at the end of the main content, before the footer', '1');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Brings new hook to the back office. One for the top nav bar on legacy pages, one for the end of content on all BO page.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Yes
| Fixed ticket? | http://forge.prestashop.com/browse/FF-167
| How to test?  | Some content has been removed: Recommended modules on payment & carrier  pages, "Live from the marketplace" on the theme page.

## New hooks
* **displayDashboardToolbarTopMenu**: Already exists on new pages, backported on legacy controllers
* **displayAdminEndContent**: Display HTML at the end of the `content` part (= before the footer) on new & legacy pages

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8947)
<!-- Reviewable:end -->
