### PR TITLE
Remove addition of . folder in release archives

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -673,7 +673,7 @@ class ReleaseCreator
             $zip->addGlob(
                 "{$this->projectPath}/tools/build/doc/*",
                 0,
-                array('add_path' => './', 'remove_all_path' => true)
+                array('remove_all_path' => true)
             );
 
             $zip->close();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | We found the file `Install_PrestaShop.html` in releases was stored in a folder `.`. This PR fixes the issue
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Generate an archive and check 3 files are stored in it

### Expected archive
![capture du 2018-04-16 14-57-40](https://user-images.githubusercontent.com/6768917/38813341-9864259a-4186-11e8-9853-980ac33962f5.png)


### Wrong archive detected

* root
![capture du 2018-04-16 14-44-35](https://user-images.githubusercontent.com/6768917/38813223-4eb85664-4186-11e8-94ad-9618db25e5e9.png)
* . subfolder
![capture du 2018-04-16 14-45-06](https://user-images.githubusercontent.com/6768917/38813248-5acbc9a4-4186-11e8-90d7-7bf2c51e0e78.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8949)
<!-- Reviewable:end -->
