### PR TITLE
FO: fix uniform incoherence with global.js

### DIFF
--- a/themes/default-bootstrap/js/autoload/15-jquery.uniform-modified.js
+++ b/themes/default-bootstrap/js/autoload/15-jquery.uniform-modified.js
@@ -1073,7 +1073,7 @@ Enjoy!
 if (typeof isMobile != 'undefined' && !isMobile){
 
     $(window).load(function () {
-    	$("select.form-control,input[type='checkbox']:not(.comparator), input[type='radio'],input#id_carrier2, input[type='file']").uniform();
+    	$("select.form-control,input[type='checkbox']:not(.comparator), input[type='radio'],input#id_carrier2, input[type='file']").not(".not_uniform").uniform();
     });
 
     // refresh uniform selects on document width change


### PR DESCRIPTION
Exclude form elements containing .not_uniform class

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Exclude form elements containing .not_uniform class
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8953)
<!-- Reviewable:end -->
