### PR TITLE
Allowed robots access to assets requierd to be mobile-friendly

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2557,6 +2557,9 @@ FileETag none
             '*/modules/*.js',
             '*/modules/*.png',
             '*/modules/*.jpg',
+            '*/themes/*/assets/cache/*.js',
+            '*/themes/*/assets/cache/*.css',
+            '*/themes/*/assets/css/*',
         );
 
         // Directories


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Google said site was not mobile-friendly since it could not load the cached css/js. And in addition I added access to assets/css to stop google from saying there where some loading issues.
| Branch?     | develop
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | No
| How to test?  | Use googles test https://search.google.com/test/mobile-friendly on a PrestaShop 1.7 site

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8954)
<!-- Reviewable:end -->
