### PR TITLE
Add customization ID to cart ajax response and updateCart event data

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -132,6 +132,7 @@ class CartControllerCore extends FrontController
                 'success' => true,
                 'id_product' => $this->id_product,
                 'id_product_attribute' => $this->id_product_attribute,
+                'id_customization' => $this->customization_id,
                 'quantity' => $productQuantity,
                 'cart' => $cartPresenter->present($this->context->cart),
                 'errors' => empty($this->updateOperationError) ? '' : reset($this->updateOperationError),

--- a/themes/_core/js/cart.js
+++ b/themes/_core/js/cart.js
@@ -105,6 +105,7 @@ $(document).ready(() => {
             reason: {
               idProduct: resp.id_product,
               idProductAttribute: resp.id_product_attribute,
+              idCustomization: resp.id_customization,
               linkAction: 'add-to-cart',
               cart: resp.cart
             },


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This adds the customization ID to be used by the ps_shopping_cart module. It will allow to improve this PR https://github.com/PrestaShop/ps_shoppingcart/pull/20 so instead of reading the customization ID from the DOM, it will be able to read it from the event data. Line: https://github.com/PrestaShop/ps_shoppingcart/pull/20/commits/58cf94861f49cd6015db9748dd7cd8592c9cf577#diff-e9db747301f30dfe08b54bf4e7cfe35bR41
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8956)
<!-- Reviewable:end -->
