### PR TITLE
Able to pass hook as a parameter

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -79,7 +79,7 @@ function withWidget($params, callable $cb)
 function smartyWidget($params, &$smarty)
 {
     return withWidget($params, function ($widget, $params) {
-        return $widget->renderWidget(null, $params);
+        return $widget->renderWidget(isset($params['hook']) ? $params['hook'] : null, $params);
     });
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Arcoding to this documentation (https://developers.prestashop.com/themes/smarty/helpers.html?highlight=widget) is it should be possible to pass Hookname as a param in widgets tag. Now is possible like this {widget name="ps_{moduleName}" hook="displayHome"}.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | create a widget tag and pass hook as a param

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8959)
<!-- Reviewable:end -->
