### PR TITLE
Unsupported type hinting for PHP lower than PHP 7

### DIFF
--- a/src/Adapter/CombinationDataProvider.php
+++ b/src/Adapter/CombinationDataProvider.php
@@ -78,7 +78,7 @@ class CombinationDataProvider
      * @throws \PrestaShopDatabaseException
      * @throws \PrestaShopException
      */
-    public function getFormCombinations(array $combinationIds, int $languageId)
+    public function getFormCombinations(array $combinationIds, $languageId)
     {
         $productId = (new Combination($combinationIds[0]))->id_product;
         $product = new Product($productId);


### PR DESCRIPTION
Scalar type hinting is unsupported for PHP versions lower than PHP 7. But the requirements says that PHP 5.6 and higher is enough for Pretashop 1.7+

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Scalar type hinting is unsupported for PHP versions lower than PHP 7. But the requirements says that PHP 5.6 and higher is enough for Pretashop 1.7+
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Products combinations don't appear in a admin panel if server has PHP version lower that PHP 7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8963)
<!-- Reviewable:end -->
