### PR TITLE
BO: Change dnd.js to show error messages on drag and drop re-ordering failure

### DIFF
--- a/js/admin/dnd.js
+++ b/js/admin/dnd.js
@@ -189,7 +189,11 @@ function initTableDnD(table)
 							nodrag_lines.children('td.dragHandle:first').find('a:even').attr('disabled',true);
 							nodrag_lines.children('td.dragHandle:last').find('a:odd').attr('disabled',true);
 						}
-						showSuccessMessage(update_success_msg);
+						if (typeof (data.hasError) != 'undefined' && data.hasError == true) {
+							showErrorMessage(data.errors)
+						} else {
+							showSuccessMessage(update_success_msg);
+						}
 					}
 				});
 			}


### PR DESCRIPTION


<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  "1.6.1.x" 
| Description?  | Currently the drag and drop in the Backoffice shows a success message no matter what, even if a re-ordering operation has failed and a json object is returned with a hasError property set to true and an error string under the property errors. This checks to see if the response has an error, and shows an error message if it does.
| Type?         | fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | no
| How to test?  | Fake the return data response to simulate the error response created  in controllers/admin/AdminProductsController.php  on or around line 5111, i.e. echo '{"hasError" : true, "errors" : "Can not update product '.(int)$id_product.' to position '.(int)$position.' "}';

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8964)
<!-- Reviewable:end -->
