### PR TITLE
Discount / Wrong variable use in loop for mobile

### DIFF
--- a/themes/classic/templates/customer/discount.tpl
+++ b/themes/classic/templates/customer/discount.tpl
@@ -57,7 +57,7 @@
       </tbody>
     </table>
     <div class="cart-rules hidden-md-up">
-      {foreach from=$cart_rules item=slip}
+      {foreach from=$cart_rules item=cart_rule}
         <div class="cart-rule">
           <ul>
             <li>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When customer have more than 1 discount. Switch to mobile view, the last discount is repeat many times.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | No
| Deprecations? | No
| How to test?  | **1)** Create 2 discount associate to 1 customer **2)** Login with this customer **3)** Go to mydiscount page **4)** Switch to mobile view **5)** Same discount is display many times

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8972)
<!-- Reviewable:end -->
