### PR TITLE
Fix broken "you must first create a new language" link in BO Translations

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/main.tpl
@@ -363,7 +363,7 @@
 			<p class="alert alert-info">
 				{l s='Copies data from one language to another.' d='Admin.International.Help'}<br />
 				{l s='Warning: This will replace all of the existing data inside the destination language.' d='Admin.International.Help'}<br />
-        {l s='If necessary [1][2] you must first create a new language[/1].' sprintf=['[1]' => "<a href=\"-{$url_create_language}-\" class=\"btn btn-link\">", '[/1]' => '</a>', '[2]' => '<i class="icon-external-link-sign"></i>'] d='Admin.International.Help'}
+        {l s='If necessary [1][2] you must first create a new language[/1].' sprintf=['[1]' => "<a href=\"{$url_create_language}\" class=\"btn btn-link\">", '[/1]' => '</a>', '[2]' => '<i class="icon-external-link-sign"></i>'] d='Admin.International.Help'}
 			</p>
 			<div class="form-group">
 				<label class="control-label col-lg-3 required" for="fromLang"> {l s='From' d='Admin.Global'}</label>


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Fixed broken link because of invalid dashes ("-") before and after the link. This is what happens when product managers contribute code 😛 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4963
| How to test?  | Explained in the ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8975)
<!-- Reviewable:end -->
