### PR TITLE
Fix notices thrown during SQL upgrade from 1.7.3.x

### DIFF
--- a/install-dev/upgrade/php/ps_1740_copy_data_from_currency_to_currency_lang.php
+++ b/install-dev/upgrade/php/ps_1740_copy_data_from_currency_to_currency_lang.php
@@ -26,11 +26,12 @@
 
 function ps_1740_copy_data_from_currency_to_currency_lang()
 {
+    $idLang = Context::getContext()->language->id;
     $currencies = Currency::getCurrencies();
     foreach ($currencies as $currency) {
         Db::getInstance()->execute(
             "INSERT INTO `" . _DB_PREFIX_ . "currency_lang` (`id_currency`, `id_lang`, `name`)
-            SELECT `id_currency`, " . $currency['id_lang'] . " as id_lang , `name`
+            SELECT `id_currency`, " . $idLang . " as id_lang , `name`
             FROM `" . _DB_PREFIX_ . "currency`"
         );
     }

--- a/install-dev/upgrade/sql/1.7.4.0.sql
+++ b/install-dev/upgrade/sql/1.7.4.0.sql
@@ -10,9 +10,9 @@ CREATE TABLE `PREFIX_currency_lang` (
   `id_currency` int(10) unsigned NOT NULL,
   `id_lang` int(10) unsigned NOT NULL,
   `name` varchar(255) NOT NULL,
-  `symbol` varchar(255) NOT NULL
+  `symbol` varchar(255) NOT NULL,
   PRIMARY KEY (`id_currency`,`id_lang`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
 /* PHP:ps_1740_copy_data_from_currency_to_currency_lang(); */;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes a syntax error on CREATE TABLE and undefined variable notice
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5289
| How to test?  | Make a SQL upgrade from 1.7.3.x to 1.7.4.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8978)
<!-- Reviewable:end -->
