### PR TITLE
Remove deprecated message for DataCollectorInterface

### DIFF
--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -91,6 +91,14 @@ final class HookDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
+    public function reset()
+    {
+        $this->data = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'ps.hooks_collector';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When running tests: composer phpunit-admin `20x: Implementing  "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface"  without the "reset()" method is deprecated since Symfony 3.4 and  will be unsupported in 4.0 for class  "PrestaShopBundle\DataCollector\HookDataCollector".` 
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Run command: composer phpunit-admin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8980)
<!-- Reviewable:end -->
