### PR TITLE
Set explicit version of MySQL in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Then reach your shop with the URL http://localhost:8001
 It will bind your ports 8001 to the web server. If you want to use other ports, open and modify the file `docker-compose.yml`.
 MySQL credentials can also be found and modified in this file if needed.
 
+**Note:**  Before auto-installing PrestaShop, this container checks the file *config/settings.inc.php* does not exist on startup.
+If you expect the container to (re)install your shop, remove this file if it exists.
+
 User documentation
 --------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 
 services:
     mysql:
-        image: mysql
+        image: mysql:5
         ports:
             - "3306"
         volumes:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The next major version of MySQL seems to have to issue to run on Docker. Let's stick to the version 5.x which is known to work with PrestaShop.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5396
| How to test?  | Running a docker-compose.yml can be done with `docker-composer up`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8981)
<!-- Reviewable:end -->
