### PR TITLE
Fixed order gets wrong status when ordered all qty of the product.

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -738,7 +738,9 @@ abstract class PaymentModuleCore extends Module
                     $new_history->addWithemail(true, $extra_vars);
 
                     // Switch to back order if needed
-                    if (Configuration::get('PS_STOCK_MANAGEMENT') && ($order_detail->getStockState() || $order_detail->product_quantity_in_stock <= 0)) {
+                    if (Configuration::get('PS_STOCK_MANAGEMENT') && 
+                            ($order_detail->getStockState() || 
+                            $order_detail->product_quantity_in_stock < 0)) {
                         $history = new OrderHistory();
                         $history->id_order = (int)$order->id;
                         $history->changeIdOrderState(Configuration::get($order->valid ? 'PS_OS_OUTOFSTOCK_PAID' : 'PS_OS_OUTOFSTOCK_UNPAID'), $order, true);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | After upgrade from 1.7.3.0 to 1.7.3.1 the order gets wrong status On backorder (not paid) if the all available quantity of the product has been ordered. Product should be simple.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5391
| How to test?  | Create a new sipmple product or use one of the preinstalled products from the fresh install of 1.7.3.1. Put all available qty of the product into the cart. Complete the order. After that the order has status On backorder (not paid) in BO and FO.

I changed last comparision so now that status could be set only when the order contains more qty than was availble for order, but I don't understand why it worked correct before 1.7.3.1

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8985)
<!-- Reviewable:end -->
