### PR TITLE
Fixed birthday input from 'text' to 'date'

### DIFF
--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -180,9 +180,7 @@ class CustomerFormatterCore implements FormFormatterInterface
         if ($this->ask_for_birthdate) {
             $format['birthday'] = (new FormField)
                 ->setName('birthday')
-                ->setType('date')
-                ->setRequired(true)
-                ->setLabel(
+                ->setType('date')                ->setLabel(
                     $this->translator->trans(
                         'Birthdate', [], 'Shop.Forms.Labels'
                     )

--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -180,7 +180,8 @@ class CustomerFormatterCore implements FormFormatterInterface
         if ($this->ask_for_birthdate) {
             $format['birthday'] = (new FormField)
                 ->setName('birthday')
-                ->setType('text')
+                ->setType('date')
+                ->setRequired(true)
                 ->setLabel(
                     $this->translator->trans(
                         'Birthdate', [], 'Shop.Forms.Labels'
@@ -215,7 +216,7 @@ class CustomerFormatterCore implements FormFormatterInterface
                 if (!is_array($additionnalFormFields)) {
                     continue;
                 }
-                
+
                 foreach ($additionnalFormFields as $formField) {
                     $formField->moduleName = $moduleName;
                     $format[$moduleName.'_'.$formField->getName()] = $formField;

--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -180,7 +180,9 @@ class CustomerFormatterCore implements FormFormatterInterface
         if ($this->ask_for_birthdate) {
             $format['birthday'] = (new FormField)
                 ->setName('birthday')
-                ->setType('date')                ->setLabel(
+                ->setType('date')
+
+                -setLabel(
                     $this->translator->trans(
                         'Birthdate', [], 'Shop.Forms.Labels'
                     )


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | CO changed the input type from text to date as it isn't user friendly on a birthday field
| Type?         |  improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8991)
<!-- Reviewable:end -->
