### PR TITLE
Fixed finding the default lang when translating e-mail templates

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2240,10 +2240,9 @@ class AdminTranslationsControllerCore extends AdminController
     public function getMailFiles($dir, $group_name = 'mail')
     {
         $arr_return = array();
-        if (Language::getIdByIso('en')) {
+        $default_language = Language::getIsoById((int)Configuration::get('PS_LANG_DEFAULT'));
+        if (!$default_language && Language::getIdByIso('en')) {
             $default_language = 'en';
-        } else {
-            $default_language = Language::getIsoById((int)Configuration::get('PS_LANG_DEFAULT'));
         }
         if (!$default_language || !Validate::isLanguageIsoCode($default_language)) {
             return false;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | 1.6.1.x
| Description  | When AdminTranslationsController tries to get the mail files list in the getMailFiles() function, it checks first for the 'en' ISO code in the database, regardless if US English is the default or even enabled language. 'en_US' should be only the fall-back, which is what this pull request aims to do.
| Type         | bug fix
| Category     |BO
| BC breaks    | no
| Deprecations | no
| Fixed ticket | http://forge.prestashop.com/browse/PSCSX-9893
| How to test  | See the ticket above.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8992)
<!-- Reviewable:end -->
