### PR TITLE
Fix cannot order oos product even if it's allowed

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3839,15 +3839,17 @@ class CartCore extends ObjectModel
                 || (!$product['allow_oosp'] && $product['stock_quantity'] < $product['cart_quantity'])) {
                 return $return_product ? $product : false;
             }
-            $productQuantity = Product::getQuantity(
-                $product['id_product'],
-                $product['id_product_attribute'],
-                null,
-                $this,
-                $product['id_customization']
-            );
-            if ($productQuantity < 0) {
-                return $return_product ? $product : false;
+            if (!$product['allow_oosp']) {
+                $productQuantity = Product::getQuantity(
+                    $product['id_product'],
+                    $product['id_product_attribute'],
+                    null,
+                    $this,
+                    $product['id_customization']
+                );
+                if ($productQuantity < 0) {
+                    return $return_product ? $product : false;
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | fix checkout button disabled on cart load even if checkout is enabled for out of stock product
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5439
| How to test?  | add product in your cart with quantity > available stock. If product is allowed for order when out of stock, you should be able to checkout on initial cart page load

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9005)
<!-- Reviewable:end -->
