### PR TITLE
Use getBoolean() instead of get() when configuration is bool in Product Settings page

### DIFF
--- a/src/Adapter/Product/GeneralConfiguration.php
+++ b/src/Adapter/Product/GeneralConfiguration.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -36,11 +36,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class GeneralConfiguration implements DataConfigurationInterface
 {
     /**
-     * @var ConfigurationInterface
+     * @var Configuration
      */
     private $configuration;
 
-    public function __construct(ConfigurationInterface $configuration)
+    public function __construct(Configuration $configuration)
     {
         $this->configuration = $configuration;
     }
@@ -51,12 +51,12 @@ class GeneralConfiguration implements DataConfigurationInterface
     public function getConfiguration()
     {
         return [
-            'catalog_mode' => $this->configuration->get('PS_CATALOG_MODE'),
+            'catalog_mode' => $this->configuration->getBoolean('PS_CATALOG_MODE'),
             'new_days_number' => $this->configuration->get('PS_NB_DAYS_NEW_PRODUCT'),
             'short_description_limit' => $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT'),
             'quantity_discount' => $this->configuration->get('PS_QTY_DISCOUNT_ON_COMBINATION'),
-            'force_friendly_url' => $this->configuration->get('PS_FORCE_FRIENDLY_PRODUCT'),
-            'default_status' => $this->configuration->get('PS_PRODUCT_ACTIVATION_DEFAULT'),
+            'force_friendly_url' => $this->configuration->getBoolean('PS_FORCE_FRIENDLY_PRODUCT'),
+            'default_status' => $this->configuration->getBoolean('PS_PRODUCT_ACTIVATION_DEFAULT'),
         ];
     }
 

--- a/src/Adapter/Product/PageConfiguration.php
+++ b/src/Adapter/Product/PageConfiguration.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -36,11 +36,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PageConfiguration implements DataConfigurationInterface
 {
     /**
-     * @var ConfigurationInterface
+     * @var Configuration
      */
     private $configuration;
 
-    public function __construct(ConfigurationInterface $configuration)
+    public function __construct(Configuration $configuration)
     {
         $this->configuration = $configuration;
     }
@@ -51,12 +51,12 @@ class PageConfiguration implements DataConfigurationInterface
     public function getConfiguration()
     {
         return [
-            'display_quantities' => $this->configuration->get('PS_DISPLAY_QTIES'),
+            'display_quantities' => $this->configuration->getBoolean('PS_DISPLAY_QTIES'),
             'display_last_quantities' => $this->configuration->get('PS_LAST_QTIES'),
-            'display_unavailable_attributes' => $this->configuration->get('PS_DISP_UNAVAILABLE_ATTR'),
-            'allow_add_variant_to_cart_from_listing' => $this->configuration->get('PS_ATTRIBUTE_CATEGORY_DISPLAY'),
+            'display_unavailable_attributes' => $this->configuration->getBoolean('PS_DISP_UNAVAILABLE_ATTR'),
+            'allow_add_variant_to_cart_from_listing' => $this->configuration->getBoolean('PS_ATTRIBUTE_CATEGORY_DISPLAY'),
             'attribute_anchor_separator' => $this->configuration->get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'),
-            'display_discount_price' => $this->configuration->get('PS_DISPLAY_DISCOUNT_PRICE'),
+            'display_discount_price' => $this->configuration->getBoolean('PS_DISPLAY_DISCOUNT_PRICE'),
         ];
     }
 

--- a/src/Adapter/Product/StockConfiguration.php
+++ b/src/Adapter/Product/StockConfiguration.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -36,11 +36,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class StockConfiguration implements DataConfigurationInterface
 {
     /**
-     * @var ConfigurationInterface
+     * @var Configuration
      */
     private $configuration;
 
-    public function __construct(ConfigurationInterface $configuration)
+    public function __construct(Configuration $configuration)
     {
         $this->configuration = $configuration;
     }
@@ -51,8 +51,8 @@ class StockConfiguration implements DataConfigurationInterface
     public function getConfiguration()
     {
         return [
-            'allow_ordering_oos' => $this->configuration->get('PS_ORDER_OUT_OF_STOCK'),
-            'stock_management' => $this->configuration->get('PS_STOCK_MANAGEMENT'),
+            'allow_ordering_oos' => $this->configuration->getBoolean('PS_ORDER_OUT_OF_STOCK'),
+            'stock_management' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
             'in_stock_label' => $this->configuration->get('PS_LABEL_IN_STOCK_PRODUCTS'),
             'oos_allowed_backorders' => $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOA'),
             'oos_denied_backorders' => $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD'),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Small fix to use more appropriate way to get configuration values.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Should work exactly the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9008)
<!-- Reviewable:end -->
