### PR TITLE
Check if template_vars if an array before merge in OrderHistory::sendEmail() 

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -488,7 +488,7 @@ class OrderHistoryCore extends ObjectModel
                 }
             }
 
-            if ($template_vars) {
+            if (is_array($template_vars)) {
                 $data = array_merge($data, $template_vars);
             }
 


### PR DESCRIPTION
Some payment modules send "PaymentModule validateOrder method's extra_vars" variable string or else and then warning given array_merge.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Some payment modules send "PaymentModule validateOrder method's extra_vars" variable string or else and then warning given array_merge.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Send PaymentModule's validateOrder method's extra_vars string order history sendMail method give warning about array_merge

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9010)
<!-- Reviewable:end -->
