### PR TITLE
1.7.3.x FO: Fix wrong "InStock" microdata for out of stock products

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4690,7 +4690,13 @@ class CartCore extends ObjectModel
             }
             $idProductAttribute = !empty($product['id_product_attribute']) ? $product['id_product_attribute'] : null;
             $availableOutOfStock = Product::isAvailableWhenOutOfStock($product['out_of_stock']);
-            $productQuantity = Product::getQuantity($product['id_product'], $idProductAttribute, null, $this);
+            $productQuantity = Product::getQuantity(
+                $product['id_product'],
+                $idProductAttribute,
+                null,
+                $this,
+                $product['id_customization']
+            );
 
             if (!$exclusive
                 && ($productQuantity < 0 && !$availableOutOfStock)

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1136,16 +1136,17 @@ class CartCore extends ObjectModel
     /**
      * Check if the Cart contains the given Product (Attribute)
      *
-     * @param int $id_product Product ID
-     * @param int $id_product_attribute ProductAttribute ID
-     * @param int $id_customization Customization ID
-     * @param int $id_address_delivery Delivery Address ID
+     * @param int $idProduct Product ID
+     * @param int $idProductAttribute ProductAttribute ID
+     * @param int $idCustomization Customization ID
+     * @param int $idAddressDelivery Delivery Address ID
      *
      * @return array quantity index     : number of product in cart without counting those of pack in cart
      *               deep_quantity index: number of product in cart counting those of pack in cart
      */
-    public function getProductQuantity($id_product, $id_product_attribute = 0, $id_customization = 0, $id_address_delivery = 0)
+    public function getProductQuantity($idProduct, $idProductAttribute = 0, $idCustomization = 0, $idAddressDelivery = 0)
     {
+        $productIsPack = Pack::isPack($idProduct);
         $defaultPackStockType = Configuration::get('PS_PACK_STOCK_TYPE');
         $packStockTypesAllowed = array(
             Pack::STOCK_TYPE_PRODUCTS_ONLY,
@@ -1159,7 +1160,7 @@ class CartCore extends ObjectModel
             ' JOIN `'._DB_PREFIX_.'pack` p ON cp.`id_product` = p.`id_product_pack`' .
             ' JOIN `'._DB_PREFIX_.'product` pr ON p.`id_product_pack` = pr.`id_product`';
 
-        if ($id_customization) {
+        if ($idCustomization) {
             $customizationJoin = '
                 LEFT JOIN `'._DB_PREFIX_.'customization` c ON (
                     c.`id_product` = cp.`id_product`
@@ -1169,25 +1170,28 @@ class CartCore extends ObjectModel
             $secondUnionSql .= $customizationJoin;
         }
         $commonWhere = '
-            WHERE cp.`id_product_attribute` = '.(int)$id_product_attribute.'
-            AND cp.`id_customization` = '.(int)$id_customization.'
+            WHERE cp.`id_product_attribute` = '.(int)$idProductAttribute.'
+            AND cp.`id_customization` = '.(int)$idCustomization.'
             AND cp.`id_cart` = '.(int)$this->id;
 
         if (Configuration::get('PS_ALLOW_MULTISHIPPING') && $this->isMultiAddressDelivery()) {
-            $commonWhere .= ' AND cp.`id_address_delivery` = '.(int)$id_address_delivery;
+            $commonWhere .= ' AND cp.`id_address_delivery` = '.(int)$idAddressDelivery;
         }
 
-        if ($id_customization) {
-            $commonWhere .= ' AND c.`id_customization` = '.(int)$id_customization;
+        if ($idCustomization) {
+            $commonWhere .= ' AND c.`id_customization` = '.(int)$idCustomization;
         }
         $firstUnionSql .=  $commonWhere;
-        $firstUnionSql .= ' AND cp.`id_product` = ' . (int) $id_product;
+        $firstUnionSql .= ' AND cp.`id_product` = ' . (int) $idProduct;
         $secondUnionSql .= $commonWhere;
-        $secondUnionSql .= ' AND p.`id_product_item` = ' . (int) $id_product;
-        $secondUnionSql .= ' AND (pr.`pack_stock_type` IN (' . implode(',', $packStockTypesAllowed) . ') OR (
+        $secondUnionSql .= ' AND p.`id_product_item` = ' . (int) $idProduct;
+
+        if ($productIsPack) {
+            $secondUnionSql .= ' AND (pr.`pack_stock_type` IN (' . implode(',', $packStockTypesAllowed) . ') OR (
                 pr.`pack_stock_type` = ' . Pack::STOCK_TYPE_DEFAULT . '
                 AND ' . $packStockTypesDefaultSupported . ' = 1
             ))';
+        }
         $parentSql = 'SELECT 
             COALESCE(SUM(first_level_quantity) + SUM(pack_quantity), 0) as deep_quantity,
             COALESCE(SUM(first_level_quantity), 0) as quantity 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4690,10 +4690,10 @@ class CartCore extends ObjectModel
             }
             $idProductAttribute = !empty($product['id_product_attribute']) ? $product['id_product_attribute'] : null;
             $availableOutOfStock = Product::isAvailableWhenOutOfStock($product['out_of_stock']);
-            $productQuantity = Product::getQuantity($product['id_product'], $idProductAttribute, null, $this) - (int) $product['cart_quantity'];
+            $productQuantity = Product::getQuantity($product['id_product'], $idProductAttribute, null, $this);
 
             if (!$exclusive
-                && ($productQuantity <= 0 && !$availableOutOfStock)
+                && ($productQuantity < 0 && !$availableOutOfStock)
             ) {
                 return false;
             } else if ($exclusive) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1185,13 +1185,10 @@ class CartCore extends ObjectModel
         $firstUnionSql .= ' AND cp.`id_product` = ' . (int) $idProduct;
         $secondUnionSql .= $commonWhere;
         $secondUnionSql .= ' AND p.`id_product_item` = ' . (int) $idProduct;
-
-        if ($productIsPack) {
-            $secondUnionSql .= ' AND (pr.`pack_stock_type` IN (' . implode(',', $packStockTypesAllowed) . ') OR (
-                pr.`pack_stock_type` = ' . Pack::STOCK_TYPE_DEFAULT . '
-                AND ' . $packStockTypesDefaultSupported . ' = 1
-            ))';
-        }
+        $secondUnionSql .= ' AND (pr.`pack_stock_type` IN (' . implode(',', $packStockTypesAllowed) . ') OR (
+            pr.`pack_stock_type` = ' . Pack::STOCK_TYPE_DEFAULT . '
+            AND ' . $packStockTypesDefaultSupported . ' = 1
+        ))';
         $parentSql = 'SELECT 
             COALESCE(SUM(first_level_quantity) + SUM(pack_quantity), 0) as deep_quantity,
             COALESCE(SUM(first_level_quantity), 0) as quantity 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4677,6 +4677,7 @@ class CartCore extends ObjectModel
     {
         $product_out_of_stock = 0;
         $product_in_stock = 0;
+
         foreach ($this->getProducts() as $product) {
             if (!$exclusive) {
                 if (((int)$product['quantity_available'] - (int)$product['cart_quantity']) < 0
@@ -4688,6 +4689,7 @@ class CartCore extends ObjectModel
                     && (!$ignore_virtual || !$product['is_virtual'])) {
                     $product_out_of_stock++;
                 }
+
                 if ((int)$product['quantity_available'] > 0
                     && (!$ignore_virtual || !$product['is_virtual'])) {
                     $product_in_stock++;
@@ -4698,6 +4700,7 @@ class CartCore extends ObjectModel
                 }
             }
         }
+
         return true;
     }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3839,6 +3839,16 @@ class CartCore extends ObjectModel
                 || (!$product['allow_oosp'] && $product['stock_quantity'] < $product['cart_quantity'])) {
                 return $return_product ? $product : false;
             }
+            $productQuantity = Product::getQuantity(
+                $product['id_product'],
+                $product['id_product_attribute'],
+                null,
+                $this,
+                $product['id_customization']
+            );
+            if ($productQuantity < 0) {
+                return $return_product ? $product : false;
+            }
         }
 
         return true;

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -222,31 +222,33 @@ class PackCore extends Product
      *
      * @param int $id_product Product id
      * @param int $id_product_attribute Product attribute id (optional)
-     * @param bool|null $cache_is_pack
+     * @param bool|null $cacheIsPack
      * @param Cart $cart
+     * @param int $idCustomization Product customization id (optional)
      * @return int
      * @throws PrestaShopException
      */
     public static function getQuantity(
-        $id_product,
-        $id_product_attribute = null,
-        $cache_is_pack = null,
-        Cart $cart = null
+        $idProduct,
+        $idProductAttribute = null,
+        $cacheIsPack = null,
+        Cart $cart = null,
+        $idCustomization = null
     ) {
-        $id_product = (int) $id_product;
-        $id_product_attribute = (int) $id_product_attribute;
-        $cache_is_pack = (bool) $cache_is_pack;
+        $idProduct = (int) $idProduct;
+        $idProductAttribute = (int) $idProductAttribute;
+        $cacheIsPack = (bool) $cacheIsPack;
 
-        if (!self::isPack($id_product)) {
-            throw new PrestaShopException("Product with id $id_product is not a pack");
+        if (!self::isPack($idProduct)) {
+            throw new PrestaShopException("Product with id $idProduct is not a pack");
         }
 
         // Initialize
-        $product = new Product($id_product, false);
+        $product = new Product($idProduct, false);
         $packQuantity = 0;
         $packQuantityInStock = StockAvailable::getQuantityAvailableByProduct(
-            $id_product,
-            $id_product_attribute
+            $idProduct,
+            $idProductAttribute
         );
         $packStockType = $product->pack_stock_type;
         $allPackStockType = array(
@@ -275,10 +277,10 @@ class PackCore extends Product
         // Set pack quantity to the minimum quantity of pack, or
         // product pack
         if (in_array($packStockType, array(self::STOCK_TYPE_PACK_BOTH, self::STOCK_TYPE_PRODUCTS_ONLY))) {
-            $items = array_values(Pack::getItems($id_product, Configuration::get('PS_LANG_DEFAULT')));
+            $items = array_values(Pack::getItems($idProduct, Configuration::get('PS_LANG_DEFAULT')));
 
             foreach ($items as $index => $item) {
-                $itemQuantity = Product::getQuantity($item->id, null, null, $cart);
+                $itemQuantity = Product::getQuantity($item->id, null, null, $cart, $idCustomization);
                 $nbPackAvailableForItem = (int) ($itemQuantity / $item->pack_quantity);
 
                 // Initialize packQuantity with the first product quantity
@@ -296,7 +298,7 @@ class PackCore extends Product
                 }
             }
         } else if (!empty($cart)) {
-            $cartProduct = $cart->getProductQuantity($id_product);
+            $cartProduct = $cart->getProductQuantity($idProduct, $idProductAttribute, $idCustomization);
 
             if (!empty($cartProduct['deep_quantity'])) {
                 $packQuantity -= $cartProduct['deep_quantity'];

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -281,7 +281,7 @@ class PackCore extends Product
 
             foreach ($items as $index => $item) {
                 $itemQuantity = Product::getQuantity($item->id, null, null, $cart, $idCustomization);
-                $nbPackAvailableForItem = (int) ($itemQuantity / $item->pack_quantity);
+                $nbPackAvailableForItem = floor($itemQuantity / $item->pack_quantity);
 
                 // Initialize packQuantity with the first product quantity
                 // if pack decrement stock type is products only

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3585,7 +3585,7 @@ class ProductCore extends ObjectModel
     }
 
     /**
-    * Get available product quantities
+    * Get available product quantities (this method already have decreased products in cart)
     *
     * @param int $idProduct Product id
     * @param int $idProductAttribute Product attribute id (optional)

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3587,26 +3587,28 @@ class ProductCore extends ObjectModel
     /**
     * Get available product quantities
     *
-    * @param int $id_product Product id
-    * @param int $id_product_attribute Product attribute id (optional)
-    * @param bool|null $cache_is_pack
+    * @param int $idProduct Product id
+    * @param int $idProductAttribute Product attribute id (optional)
+    * @param bool|null $cacheIsPack
     * @param Cart|null $cart
+    * @param int $idCustomization Product customization id (optional)
     * @return int Available quantities
     */
     public static function getQuantity(
-        $id_product,
-        $id_product_attribute = null,
-        $cache_is_pack = null,
-        Cart $cart = null
+        $idProduct,
+        $idProductAttribute = null,
+        $cacheIsPack = null,
+        Cart $cart = null,
+        $idCustomization = null
     ) {
-        if (Pack::isPack((int)$id_product)) {
-            return Pack::getQuantity($id_product, $id_product_attribute, $cache_is_pack, $cart);
+        if (Pack::isPack((int)$idProduct)) {
+            return Pack::getQuantity($idProduct, $idProductAttribute, $cacheIsPack, $cart, $idCustomization);
         }
-        $availableQuantity = StockAvailable::getQuantityAvailableByProduct($id_product, $id_product_attribute);
+        $availableQuantity = StockAvailable::getQuantityAvailableByProduct($idProduct, $idProductAttribute);
         $nbProductInCart = 0;
 
         if (!empty($cart)) {
-            $cartProduct = $cart->getProductQuantity($id_product, $id_product_attribute);
+            $cartProduct = $cart->getProductQuantity($idProduct, $idProductAttribute, $idCustomization);
 
             if (!empty($cartProduct['deep_quantity'])) {
                 $nbProductInCart = $cartProduct['deep_quantity'];

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -47,7 +47,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
     {
         $allProductsInStock = $this->getCheckoutSession()->getCart()->isAllProductsInStock();
 
-        if ($allProductsInStock != true) {
+        if ($allProductsInStock !== true) {
             $cartShowUrl = $this->context->link->getPageLink(
                 'cart',
                 null,

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -45,6 +45,23 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
 
     public function handleRequest(array $requestParams = array())
     {
+        $allProductsInStock = $this->getCheckoutSession()->getCart()->isAllProductsInStock();
+
+        if ($allProductsInStock != true) {
+            $cartShowUrl = $this->context->link->getPageLink(
+                'cart',
+                null,
+                $this->context->language->id,
+                array(
+                    'action' => 'show'
+                ),
+                false,
+                null,
+                false
+            );
+            Tools::redirect($cartShowUrl);
+        }
+
         if (isset($requestParams['select_payment_option'])) {
             $this->selected_payment_option = $requestParams['select_payment_option'];
         }
@@ -58,15 +75,18 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
         );
     }
 
+    /**
+     * @param array $extraParams
+     * @return string
+     */
     public function render(array $extraParams = array())
     {
         $isFree = 0 == (float) $this->getCheckoutSession()->getCart()->getOrderTotal(true, Cart::BOTH);
         $paymentOptions = $this->paymentOptionsFinder->present($isFree);
-
         $conditionsToApprove = $this->conditionsToApproveFinder->getConditionsToApproveForTemplate();
-
         $deliveryOptions = $this->getCheckoutSession()->getDeliveryOptions();
         $deliveryOptionKey = $this->getCheckoutSession()->getSelectedDeliveryOption();
+
         if (isset($deliveryOptions[$deliveryOptionKey])) {
             $selectedDeliveryOption = $deliveryOptions[$deliveryOptionKey];
         } else {
@@ -81,7 +101,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
             'selected_payment_option' => $this->selected_payment_option,
             'selected_delivery_option' => $selectedDeliveryOption,
             'show_final_summary' => Configuration::get('PS_FINAL_SUMMARY_ENABLED'),
-            );
+        );
 
         return $this->renderTemplate($this->getTemplate(), $extraParams, $assignedVars);
     }

--- a/localization/ir.xml
+++ b/localization/ir.xml
@@ -40,9 +40,9 @@
 		<language iso_code="fa" is_rtl="1" name="پارسی (Persian)" />
 	</languages>
 	<taxes>
-		<tax id="1" name="8% مالیات بر ارزش افزوده" rate="8" />
+		<tax id="1" name="9% مالیات بر ارزش افزوده" rate="9" />
 		
-		<taxRulesGroup name="IR VAT(8%)">
+		<taxRulesGroup name="IR VAT(9%)">
 			<taxRule iso_code_country="ir" id_tax="1" />
 		</taxRulesGroup>
 	</taxes>

--- a/tests/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests/Unit/Core/Cart/AbstractCartTest.php
@@ -33,6 +33,7 @@ use Configuration;
 use Context;
 use PrestaShop\PrestaShop\Tests\TestCase\IntegrationTestCase;
 use Product;
+use Pack;
 use StockAvailable;
 
 /**
@@ -162,7 +163,7 @@ abstract class AbstractCartTest extends IntegrationTestCase
                 && $productFixture['is_pack'] === true
             ) {
                 foreach ($productFixture['pack_items'] as $packItem) {
-                    \Pack::addItem(
+                    Pack::addItem(
                         $product->id,
                         $this->products[$packItem['id_product_fixture']]->id,
                         $packItem['quantity']
@@ -179,7 +180,7 @@ abstract class AbstractCartTest extends IntegrationTestCase
         }
 
         // Fix issue pack cache is set when adding products.
-        \Pack::resetStaticCache();
+        Pack::resetStaticCache();
     }
 
     protected function addProductsToCart($productData)

--- a/tests/Unit/Core/Cart/Adding/Product/AddPackTest.php
+++ b/tests/Unit/Core/Cart/Adding/Product/AddPackTest.php
@@ -26,6 +26,10 @@
 
 namespace PrestaShop\PrestaShop\Tests\Unit\Core\Cart\Adding\CartRule;
 
+use Configuration;
+use Product;
+use Pack;
+use StockAvailable;
 use PrestaShop\PrestaShop\Tests\Unit\Core\Cart\AbstractCartTest;
 
 class AddPackTest extends AbstractCartTest
@@ -63,23 +67,23 @@ class AddPackTest extends AbstractCartTest
     public function testProductStockNumberMatch()
     {
         // Pack type decrement pack only
-        \Configuration::set('PS_PACK_STOCK_TYPE', \Pack::STOCK_TYPE_PACK_ONLY);
-        $nbPack = \Product::getQuantity($this->pack->id);
-        $nbProduct = \Product::getQuantity($this->productInPack->id);
+        Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PACK_ONLY);
+        $nbPack = Product::getQuantity($this->pack->id);
+        $nbProduct = Product::getQuantity($this->productInPack->id);
         $this->assertEquals(10, $nbPack);
         $this->assertEquals(50, $nbProduct);
 
         // Pack type decrement products only
-        \Configuration::set('PS_PACK_STOCK_TYPE', \Pack::STOCK_TYPE_PRODUCTS_ONLY);
-        $nbPack = \Product::getQuantity($this->pack->id);
-        $nbProduct = \Product::getQuantity($this->productInPack->id);
+        Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PRODUCTS_ONLY);
+        $nbPack = Product::getQuantity($this->pack->id);
+        $nbProduct = Product::getQuantity($this->productInPack->id);
         $this->assertEquals(5, $nbPack);
         $this->assertEquals(50, $nbProduct);
 
         // Pack type decrement pack and products
-        \Configuration::set('PS_PACK_STOCK_TYPE', \Pack::STOCK_TYPE_PACK_BOTH);
-        $nbPack = \Product::getQuantity($this->pack->id);
-        $nbProduct = \Product::getQuantity($this->productInPack->id);
+        Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PACK_BOTH);
+        $nbPack = Product::getQuantity($this->pack->id);
+        $nbProduct = Product::getQuantity($this->productInPack->id);
         $this->assertEquals(5, $nbPack);
         $this->assertEquals(50, $nbProduct);
     }
@@ -87,40 +91,40 @@ class AddPackTest extends AbstractCartTest
     public function testPackIsInStock()
     {
         // Pack type decrement pack only
-        \Configuration::set('PS_PACK_STOCK_TYPE', \Pack::STOCK_TYPE_PACK_ONLY);
-        $this->assertTrue(\Pack::isInStock($this->pack->id, 10));
-        $this->assertFalse(\Pack::isInStock($this->pack->id, 11));
+        Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PACK_ONLY);
+        $this->assertTrue(Pack::isInStock($this->pack->id, 10));
+        $this->assertFalse(Pack::isInStock($this->pack->id, 11));
 
         // Pack type decrement products only
-        \Configuration::set('PS_PACK_STOCK_TYPE', \Pack::STOCK_TYPE_PRODUCTS_ONLY);
-        $this->assertTrue(\Pack::isInStock($this->pack->id, 5));
-        $this->assertFalse(\Pack::isInStock($this->pack->id, 6));
+        Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PRODUCTS_ONLY);
+        $this->assertTrue(Pack::isInStock($this->pack->id, 5));
+        $this->assertFalse(Pack::isInStock($this->pack->id, 6));
 
         // Pack type decrement pack and products
-        \Configuration::set('PS_PACK_STOCK_TYPE', \Pack::STOCK_TYPE_PACK_BOTH);
-        $this->assertTrue(\Pack::isInStock($this->pack->id, 5));
-        $this->assertFalse(\Pack::isInStock($this->pack->id, 6));
+        Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PACK_BOTH);
+        $this->assertTrue(Pack::isInStock($this->pack->id, 5));
+        $this->assertFalse(Pack::isInStock($this->pack->id, 6));
     }
 
     public function testPackIsPack()
     {
-        $this->assertTrue(\Pack::isPack($this->pack->id));
+        $this->assertTrue(Pack::isPack($this->pack->id));
     }
 
     public function testProductsQuantitiesInCart()
     {
         // Pack type decrement pack only
-        $this->pack->pack_stock_type = \Pack::STOCK_TYPE_PACK_ONLY;
+        $this->pack->pack_stock_type = Pack::STOCK_TYPE_PACK_ONLY;
         $this->pack->update();
         $this->calculProductsQuantitiesinCart(2, 2, 30, 30, 8, 20);
 
         // Pack type decrement product only
-        $this->pack->pack_stock_type = \Pack::STOCK_TYPE_PRODUCTS_ONLY;
+        $this->pack->pack_stock_type = Pack::STOCK_TYPE_PRODUCTS_ONLY;
         $this->pack->update();
         $this->calculProductsQuantitiesinCart(2, 2, 30, 50, 0, 0);
 
         // Pack type decrement pack and product
-        $this->pack->pack_stock_type = \Pack::STOCK_TYPE_PACK_BOTH;
+        $this->pack->pack_stock_type = Pack::STOCK_TYPE_PACK_BOTH;
         $this->pack->update();
         $this->calculProductsQuantitiesinCart(2, 2, 30, 50, 0, 0);
     }
@@ -160,9 +164,9 @@ class AddPackTest extends AbstractCartTest
             $this->assertContains($cartProduct['id_product'], array($this->pack->id, $this->productInPack->id));
 
             if ($cartProduct['id_product'] == $this->pack->id) {
-                $this->assertEquals($packLeftExpected, \Product::getQuantity($cartProduct['id_product'], null, null, $this->cart));
+                $this->assertEquals($packLeftExpected, Product::getQuantity($cartProduct['id_product'], null, null, $this->cart));
             } else {
-                $this->assertEquals($productLeftExpected, \Product::getQuantity($cartProduct['id_product'], null, null, $this->cart));
+                $this->assertEquals($productLeftExpected, Product::getQuantity($cartProduct['id_product'], null, null, $this->cart));
             }
         }
         $this->resetCart();
@@ -173,56 +177,56 @@ class AddPackTest extends AbstractCartTest
     public function testAddProductsOutOfStockInCart()
     {
         // Test pack out of stock disabled
-        \StockAvailable::setProductOutOfStock($this->pack->id, false);
+        StockAvailable::setProductOutOfStock($this->pack->id, false);
         $this->assertFalse($this->cart->updateQty(11, $this->pack->id));
-        $outOfStock = \StockAvailable::outOfStock($this->pack->id);
+        $outOfStock = StockAvailable::outOfStock($this->pack->id);
         $this->assertEquals(0, $this->pack->isAvailableWhenOutOfStock($outOfStock));
 
         // Test pack out of stock enabled
-        \StockAvailable::setProductOutOfStock($this->pack->id, true);
+        StockAvailable::setProductOutOfStock($this->pack->id, true);
         $this->assertTrue($this->cart->updateQty(11, $this->pack->id));
-        $outOfStock = \StockAvailable::outOfStock($this->pack->id);
+        $outOfStock = StockAvailable::outOfStock($this->pack->id);
         $this->assertEquals(1, $this->pack->isAvailableWhenOutOfStock($outOfStock));
 
         // Test pack out of stock disabled
-        \StockAvailable::setProductOutOfStock($this->productInPack->id, false);
+        StockAvailable::setProductOutOfStock($this->productInPack->id, false);
         $this->assertFalse($this->cart->updateQty(51, $this->productInPack->id));
-        $outOfStock = \StockAvailable::outOfStock($this->productInPack->id);
+        $outOfStock = StockAvailable::outOfStock($this->productInPack->id);
         $this->assertEquals(0, $this->pack->isAvailableWhenOutOfStock($outOfStock));
 
         // Test pack out of stock enabled
-        \StockAvailable::setProductOutOfStock($this->productInPack->id, true);
+        StockAvailable::setProductOutOfStock($this->productInPack->id, true);
         $this->assertTrue($this->cart->updateQty(51, $this->productInPack->id));
-        $outOfStock = \StockAvailable::outOfStock($this->productInPack->id);
+        $outOfStock = StockAvailable::outOfStock($this->productInPack->id);
         $this->assertEquals(1, $this->pack->isAvailableWhenOutOfStock($outOfStock));
     }
 
     public function testUnableToAddPackOutOfStock()
     {
         // Pack type decrement pack only
-        $this->pack->pack_stock_type = \Pack::STOCK_TYPE_PACK_ONLY;
+        $this->pack->pack_stock_type = Pack::STOCK_TYPE_PACK_ONLY;
         $this->pack->update();
-        \StockAvailable::setProductOutOfStock($this->pack->id, false);
+        StockAvailable::setProductOutOfStock($this->pack->id, false);
         $this->assertTrue($this->cart->updateQty(9, $this->pack->id));
-        $this->assertFalse(\Pack::isInStock($this->pack->id, 2, $this->cart));
-        $this->assertTrue(\Pack::isInStock($this->pack->id, 1, $this->cart));
+        $this->assertFalse(Pack::isInStock($this->pack->id, 2, $this->cart));
+        $this->assertTrue(Pack::isInStock($this->pack->id, 1, $this->cart));
         $this->resetCart();
 
         // Pack type decrement product only
-        $this->pack->pack_stock_type = \Pack::STOCK_TYPE_PRODUCTS_ONLY;
+        $this->pack->pack_stock_type = Pack::STOCK_TYPE_PRODUCTS_ONLY;
         $this->pack->update();
-        \StockAvailable::setProductOutOfStock($this->pack->id, false);
+        StockAvailable::setProductOutOfStock($this->pack->id, false);
         $this->assertTrue($this->cart->updateQty(40, $this->productInPack->id));
-        $this->assertFalse(\Pack::isInStock($this->pack->id, 2, $this->cart));
-        $this->assertTrue(\Pack::isInStock($this->pack->id, 1, $this->cart));
+        $this->assertFalse(Pack::isInStock($this->pack->id, 2, $this->cart));
+        $this->assertTrue(Pack::isInStock($this->pack->id, 1, $this->cart));
         $this->resetCart();
 
         // Pack type decrement pack and product
-        $this->pack->pack_stock_type = \Pack::STOCK_TYPE_PACK_BOTH;
+        $this->pack->pack_stock_type = Pack::STOCK_TYPE_PACK_BOTH;
         $this->pack->update();
-        \StockAvailable::setProductOutOfStock($this->pack->id, false);
+        StockAvailable::setProductOutOfStock($this->pack->id, false);
         $this->assertTrue($this->cart->updateQty(40, $this->productInPack->id));
-        $this->assertFalse(\Pack::isInStock($this->pack->id, 2, $this->cart));
-        $this->assertTrue(\Pack::isInStock($this->pack->id, 1, $this->cart));
+        $this->assertFalse(Pack::isInStock($this->pack->id, 2, $this->cart));
+        $this->assertTrue(Pack::isInStock($this->pack->id, 1, $this->cart));
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In Classic, there is a wrong schema of "InStock" for all products, regardless if the product is in or out of stock. If the product is out of stock, the right schema shoul be "OutofStock". I made a PR on my fork, I really don't know how to use git properly. Here is the PR: https://github.com/rdy4ever/PrestaShop/pull/1
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Go to the Google structured data testing tool and try it with both in stock and out of stock products. Currently, out of stock products report as "In stock".
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9011)
<!-- Reviewable:end -->
