### PR TITLE
FO: Fix wrong "InStock" microdata for out of stock products

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -40,7 +40,7 @@
         itemscope
         itemtype="https://schema.org/Offer"
       >
-        <link itemprop="availability" href="{if $product.quantity > 0}https://schema.org/InStock{else}http://schema.org/OutOfStock{/if}"/>
+        <link itemprop="availability" href="https://schema.org/{if $product.quantity > 0}InStock{else if $product.quantity <=0 && $product.allow_oosp}PreOrder{else}OutOfStock{/if}"/>
         <meta itemprop="priceCurrency" content="{$currency.iso_code}">
 
         <div class="current-price">

--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -40,7 +40,7 @@
         itemscope
         itemtype="https://schema.org/Offer"
       >
-        <link itemprop="availability" href="https://schema.org/InStock"/>
+        <link itemprop="availability" href="{if $product.quantity > 0}https://schema.org/InStock{else}http://schema.org/OutOfStock{/if}"/>
         <meta itemprop="priceCurrency" content="{$currency.iso_code}">
 
         <div class="current-price">


### PR DESCRIPTION
In Classic, there is a wrong schema of "InStock" for all products, regardless if the product is actually out of stock. If the product is out of stock, the right schema should be "OutofStock". If the product is Out of stock but orders are alowed, the schema should be "PreOrder".

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In Classic, there is a wrong schema of "InStock" for all products, regardless if the product is actually out of stock.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5447
| How to test?  | Go to the Google structured data testing tool and try it with both in stock and out of stock products. Currently, out of stock products report as "In stock".

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9012)
<!-- Reviewable:end -->
