### PR TITLE
FO: Correct email subscription form input type

### DIFF
--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -46,7 +46,7 @@
               <input
                 name="email"
                 type="email"
-                value="{if $customer.is_logged && !$customer.newsletter}{$customer.email}{/if}"
+                value="{$value}"
                 placeholder="{l s='Your email address' d='Shop.Forms.Labels'}"
                 aria-labelledby="block-newsletter-label"
               >

--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -45,8 +45,8 @@
             <div class="input-wrapper">
               <input
                 name="email"
-                type="text"
-                value="{$value}"
+                type="email"
+                value="{if $customer.is_logged && !$customer.newsletter}{$customer.email}{/if}"
                 placeholder="{l s='Your email address' d='Shop.Forms.Labels'}"
                 aria-labelledby="block-newsletter-label"
               >


### PR DESCRIPTION
In ps_emailsubscription input type should be "email" instead of "text", allowing browser validation.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In ps_emailsubscription input type should be "email" instead of "text", allowing browser validation. (The input type="email" is used for input fields that should contain an e-mail address. Depending on browser support, the e-mail address can be automatically validated when submitted. Some smartphones recognize the email type, and adds ".com" to the keyboard to match email input.)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | -

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9013)
<!-- Reviewable:end -->
