### PR TITLE
FO : Fix add to cart url in product listing appear or not

### DIFF
--- a/src/Core/Product/ProductListingPresenter.php
+++ b/src/Core/Product/ProductListingPresenter.php
@@ -34,4 +34,42 @@ namespace PrestaShop\PrestaShop\Core\Product;
  */
 class ProductListingPresenter extends \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter
 {
+    public function present(
+        ProductPresentationSettings $settings,
+        array $product,
+        \Language $language
+    ) {
+        $presentedProduct = parent::present(
+            $settings,
+            $product,
+            $language
+        );
+
+        if ($product['id_product_attribute'] != 0 && !$settings->allow_add_variant_to_cart_from_listing) {
+            $presentedProduct['add_to_cart_url'] = null;
+        }
+
+        if ($product['customizable'] == 2 || !empty($product['customization_required'])) {
+            $presentedProduct['add_to_cart_url'] = null;
+        }
+
+        if (!$this->shouldEnableAddToCartButton($product, $settings)) {
+            $presentedProduct['add_to_cart_url'] = null;
+        }
+
+        return $presentedProduct;
+    }
+
+    protected function shouldEnableAddToCartButton(array $product, ProductPresentationSettings $settings)
+    {
+        if ($settings->stock_management_enabled && !$product['allow_oosp'] && $product['quantity'] <= 0) {
+            return false;
+        }
+
+        if (isset($product['attributes']) && count($product['attributes']) > 0 && !$settings->allow_add_variant_to_cart_from_listing) {
+            return false;
+        }
+
+        return parent::shouldEnableAddToCartButton($product, $settings);
+    }
 }


### PR DESCRIPTION
There is an attribut add_to_cart_url who correctly work on product page but not on category page. add_to_cart_url always return url but must return null if product cannot be ordered. In productrpresenter, "quantity_wanted" attribute is used but is not used in category page. I fix it with edit override and add the same logic without check "quantity_wanted". I think on category page use case generic, we cannot choose a quantity.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix a bug with add_to_cart_url who always return string on listing product. Can return null if product cannot be ordered.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Enable or not OUT_OF_STOCK option and go to category see if product button can disappear with use of $product.add_to_cart_url

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9014)
<!-- Reviewable:end -->
