### PR TITLE
Add ean13 to link_rewrite if available for product combinations in Front Office

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -53,9 +53,14 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function canonicalRedirection($canonical_url = '')
     {
         if (Validate::isLoadedObject($this->product)) {
+            $url = $this->product->link_rewrite;
+            if ($this->product->ean13) {
+                $url = $this->product->link_rewrite.'-'.$this->product->ean13;
+            }
+
             if (!$this->product->hasCombinations()) {
                 unset($_GET['id_product_attribute']);
-            } else if (!Tools::getValue('id_product_attribute') || Tools::getValue('rewrite') !== $this->product->link_rewrite) {
+            } else if (!Tools::getValue('id_product_attribute') || Tools::getValue('rewrite') !== $url) {
                 $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
             }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -54,7 +54,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     {
         if (Validate::isLoadedObject($this->product)) {
             $url = $this->product->link_rewrite;
-            if ($this->product->ean13) {
+            if (!empty($this->product->ean13)) {
                 $url = $this->product->link_rewrite.'-'.$this->product->ean13;
             }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If we define ean13 for product, it is added to url so change combination with select for example, query to product with attribute redirect to default attribute because compare rewrite and link_rewrite from product. But we need to merge link_rewrite + ean13 in case of.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Just add a product with EAN13 and combination and try to change combination, not work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9015)
<!-- Reviewable:end -->
