### PR TITLE
Fix wrong parameter verification, allowing redirection to arbitrary URL

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -416,17 +416,31 @@ class ToolsCore
     }
 
     /**
-    * Secure an URL referrer
-    *
-    * @param string $referrer URL referrer
-    * @return string secured referrer
-    */
+     * Returns a safe URL referrer
+     *
+     * @param string $referrer URL referrer
+     * @return string secured referrer
+     */
     public static function secureReferrer($referrer)
     {
-        if (preg_match('/^http[s]?:\/\/'.Tools::getServerName().'(:'._PS_SSL_PORT_.')?\/.*$/Ui', $referrer)) {
+        if (static::urlBelongsToShop($referrer)) {
             return $referrer;
         }
         return __PS_BASE_URI__;
+    }
+
+    /**
+     * Indicates if the provided URL belongs to this shop (relative urls count as belonging to the shop)
+     *
+     * @param string $url
+     *
+     * @return bool
+     */
+    public static function urlBelongsToShop($url)
+    {
+        $urlHost = parse_url($url, PHP_URL_HOST);
+
+        return (empty($urlHost) || $urlHost === Tools::getServerName());
     }
 
     /**

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -92,7 +92,7 @@ class AddressControllerCore extends FrontController
     public function initContent()
     {
         if (!$this->ajax && $this->should_redirect) {
-            if (($back = Tools::getValue('back')) && Tools::secureReferrer($back)) {
+            if (($back = Tools::getValue('back')) && Tools::urlBelongsToShop($back)) {
                 $mod = Tools::getValue('mod');
                 $this->redirectWithNotifications('index.php?controller='.$back.($mod ? '&back='.$mod : ''));
             } else {

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -91,23 +91,21 @@ class AuthControllerCore extends FrontController
         if ($should_redirect && !$this->ajax) {
             $back = urldecode(Tools::getValue('back'));
 
-            if (Tools::secureReferrer($back)) {
+            if (Tools::urlBelongsToShop($back)) {
                 // Checks to see if "back" is a fully qualified
                 // URL that is on OUR domain, with the right protocol
-                $this->redirectWithNotifications($back);
-            } else {
-                // Well we're not redirecting to a URL,
-                // so...
-                if ($this->authRedirection) {
-                    // We may need to go there if defined
-                    $back = $this->authRedirection;
-                } elseif (!preg_match('/^[\w\-]+$/', $back)) {
-                    // Otherwise, check that "back" matches a controller name
-                    // and set a default if not.
-                    $back = 'my-account';
-                }
-                $this->redirectWithNotifications('index.php?controller='.urlencode($back));
+                return $this->redirectWithNotifications($back);
             }
+
+            // Well we're not redirecting to a URL,
+            // so...
+            if ($this->authRedirection) {
+                // We may need to go there if defined
+                return $this->redirectWithNotifications($this->authRedirection);
+            }
+
+            // go home
+            return $this->redirectWithNotifications(__PS_BASE_URI__);
         }
     }
 }

--- a/tests/Unit/Classes/ToolsCoreTest.php
+++ b/tests/Unit/Classes/ToolsCoreTest.php
@@ -339,6 +339,48 @@ class ToolsCoreTest extends TestCase
         $this->assertEquals($expected, Tools::StrReplaceFirst($search, $replace, $subject, $cur));
     }
 
+    /**
+     * @param string $url
+     * @param string $expectedDomain
+     *
+     * @dataProvider domainProvider
+     */
+    public function testExtractUrlDomain($url, $expectedDomain)
+    {
+        $this->assertSame($expectedDomain, Tools::extractHost($url));
+    }
+
+    public function domainProvider()
+    {
+        return [
+            ['http://example.com:80#@google.com/', 'example.com'],
+            ['http://example.com:80?@google.com/', 'example.com'],
+            ['http://example.com#@google.com/', 'example.com'],
+            ['http://example.com?@google.com/', 'example.com'],
+            ['https://example.com:80#@google.com/', 'example.com'],
+            ['https://example.com:80?@google.com/', 'example.com'],
+            ['http://example.com:80/', 'example.com'],
+            ['http://example.com/', 'example.com'],
+            ['https://example.com/', 'example.com'],
+            ['http://foo@bar.com:yolo@example.com:80/foo', 'example.com'],
+            ['https://example.com/', 'example.com'],
+            ['ttp://example.com:80#@google.com/', 'example.com'],
+            ['example.com:80#@google.com/', ''],
+            ['example.com:80?@google.com/', ''],
+            ['example.com#@google.com/', ''],
+            ['example.com?@google.com/', ''],
+            ['example.com:80#@google.com/', ''],
+            ['example.com:80?@google.com/', ''],
+            ['example.com:80/', ''],
+            ['example.com/', ''],
+            ['example.com/', ''],
+            ['foo@bar.com:yolo@example.com:80/foo', ''],
+            ['example.com/', ''],
+            ['/blah/bleh', ''],
+            ['/plop.html', ''],
+        ];
+    }
+
     public function testStrReplaceFirstProvider() {
         return [
             ['s', 'f', 'seed', 0, 'feed'],


### PR DESCRIPTION
Kudos to @123monsite-regis for pointing this one up

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | A wrongly verified parameter allowed redirection to an external URL after some actions like log in
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | **Before**: Open your shop, click on my account, change the "back" parameter to an external URL, log in, you get redirected to that URL.<br>**After**: You get redirected to the home unless the URL belongs to your shop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9017)
<!-- Reviewable:end -->
