### PR TITLE
Disable 'add to cart' on insufficient stock

### DIFF
--- a/src/Core/Product/ProductPresenter.php
+++ b/src/Core/Product/ProductPresenter.php
@@ -242,7 +242,8 @@ class ProductPresenter
 
         if ($settings->stock_management_enabled
             && !$product['allow_oosp']
-            && $product['quantity'] <= 0
+            && ($product['quantity'] <= 0
+            || $product['quantity'] - $this->getQuantityWanted() < 0)
         ) {
             $shouldEnable = false;
         }
@@ -279,6 +280,14 @@ class ProductPresenter
             false,
             true
         );
+    }
+
+    /**
+     * @return int Quantity of product requested by the customer
+     */
+    private function getQuantityWanted()
+    {
+        return (int) Tools::getValue('quantity_wanted', 1);
     }
 
     private function addMainVariantsInformation(
@@ -441,7 +450,7 @@ class ProductPresenter
         $show_price = $this->shouldShowPrice($settings, $product);
         $show_availability = $show_price && $settings->stock_management_enabled;
         $presentedProduct['show_availability'] = $show_availability;
-        $product['quantity_wanted'] = (int) Tools::getValue('quantity_wanted', 1);
+        $product['quantity_wanted'] = $this->getQuantityWanted();
 
         if (isset($product['available_date']) && '0000-00-00' == $product['available_date']) {
             $product['available_date'] = null;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When the chosen quantity is higher then the available one, the "add to cart" was not disabled.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5309
| How to test?  | On a product page, modify the quantity to get a message "insufficient stock".The button should be disabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9019)
<!-- Reviewable:end -->
