### PR TITLE
Avoid infinite redirects if unhandled exception during BO authentication

### DIFF
--- a/src/Adapter/Security/Admin.php
+++ b/src/Adapter/Security/Admin.php
@@ -26,10 +26,10 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Security;
 
-use Access;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -60,7 +60,7 @@ class Admin
 
     /**
      * Check if employee is logged in
-     * If not loggedin in, redirect to admin home page
+     * If not logged in, redirect to admin home page
      *
      * @param GetResponseEvent $event
      *
@@ -74,6 +74,13 @@ class Admin
             $token = new UsernamePasswordToken($user, null, 'admin', $user->getRoles());
             $this->securityTokenStorage->setToken($token);
 
+            return true;
+        }
+
+        // in case of exception handler sub request, avoid infinite redirection
+        if ($event->getRequestType() === HttpKernelInterface::SUB_REQUEST
+            && isset($event->getRequest()->attributes['exception'])
+        ) {
             return true;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If an unhandled exception is thrown during the authentication process on the BO, the user is caught in an infinite redirection loop.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Edit `ControllerCore.php`, add `throw new Exception()` on the first line of `public function run()`. Open up the BO in an incognito window (you have to be logged out).<br>**Without this PR:** you are caught in an infinite redirection loop.<br>**With this PR:** You get an error screen with a stack trace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9023)
<!-- Reviewable:end -->
