### PR TITLE
Correcting rights for AdminPerformances

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
@@ -66,6 +66,19 @@ class PerformanceController extends FrameworkBundleAdminController
             'servers' => $this->get('prestashop.adapter.memcache_server.manager')->getServers(),
         );
 
+        if (!in_array(
+            $this->authorizationLevel($this::CONTROLLER_NAME),
+            array(
+                PageVoter::LEVEL_READ,
+                PageVoter::LEVEL_UPDATE,
+                PageVoter::LEVEL_CREATE,
+                PageVoter::LEVEL_DELETE,
+            )
+        )) {
+            $this->addFlash('error', $this->trans('Access denied.', 'Admin.Notifications.Error'));
+            return $this->redirect('admin_dashboard');
+        }
+
         return $this->render('@AdvancedParameters/performance.html.twig', $twigValues);
     }
 
@@ -120,8 +133,18 @@ class PerformanceController extends FrameworkBundleAdminController
      */
     public function clearCacheAction()
     {
-        $this->get('prestashop.adapter.cache_clearer')->clearAllCaches();
-        $this->addFlash('success', $this->trans('All caches cleared successfully', 'Admin.Advparameters.Notification'));
+        if (!in_array(
+            $this->authorizationLevel($this::CONTROLLER_NAME),
+            array(
+                PageVoter::LEVEL_DELETE,
+            )
+        )) {
+            $this->addFlash('error', $this->trans('You do not have permission to update this.', 'Admin.Notifications.Error'));
+            return $this->redirectToRoute('admin_performance');
+        } else {
+            $this->get('prestashop.adapter.cache_clearer')->clearAllCaches();
+            $this->addFlash('success', $this->trans('All caches cleared successfully', 'Admin.Advparameters.Notification'));
+        }
 
         return $this->redirectToRoute('admin_performance');
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Adding rights control for the route AdminPerfomances. Everybody with a BO access could access to the page and flush the cache.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no.
| How to test?  | Create a profile without rights. Create an employee and access to "https://shop_url/bo_folder/index.php/configure/advanced/performance" try to flush the cache or access the page.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9025)
<!-- Reviewable:end -->
