### PR TITLE
Fix infinite loop on multiple vouchers

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1113,7 +1113,7 @@ class CartRuleCore extends ObjectModel
             if ($this->reduction_percent && $this->reduction_product == 0) {
                 // Do not give a reduction on free products!
                 $order_total = $order_package_products_total;
-                foreach ($context->cart->getCartRules(CartRule::FILTER_ACTION_GIFT) as $cart_rule) {
+                foreach ($context->cart->getCartRules(CartRule::FILTER_ACTION_GIFT, false) as $cart_rule) {
                     $order_total -= Tools::ps_round($cart_rule['obj']->getContextualValue($use_tax, $context, CartRule::FILTER_ACTION_GIFT, $package), _PS_PRICE_COMPUTE_PRECISION_);
                 }
 

--- a/tests/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests/Unit/Core/Cart/AbstractCartTest.php
@@ -104,8 +104,8 @@ abstract class AbstractCartTest extends IntegrationTestCase
         $this->cart->add(); // required, else we cannot get the content when calculation total
         Context::getContext()->cart = $this->cart;
         $this->resetCart();
-        $this->insertProducts();
-        $this->insertCartRules();
+        $this->insertProductsFromFixtures();
+        $this->insertCartRulesFromFixtures();
     }
 
     public function tearDown()
@@ -150,7 +150,7 @@ abstract class AbstractCartTest extends IntegrationTestCase
         }
     }
 
-    protected function insertProducts()
+    protected function insertProductsFromFixtures()
     {
         foreach (static::PRODUCT_FIXTURES as $k => $productFixture) {
             $product           = new Product;
@@ -191,25 +191,30 @@ abstract class AbstractCartTest extends IntegrationTestCase
         Pack::resetStaticCache();
     }
 
-    protected function addProductsToCart($productData)
+    protected function addProductsToCart($productsData)
     {
-        foreach ($productData as $id => $quantity) {
-            $product = $this->getProductFromFixtureId($id);
-            if ($product !== null) {
-                $this->cart->updateQty($quantity, $product->id);
-            }
+        foreach ($productsData as $productFixtureId => $quantity) {
+            $this->addProductToCart($productFixtureId, $quantity);
+        }
+    }
+
+    protected function addProductToCart($productFixtureId, $quantity)
+    {
+        $product = $this->getProductFromFixtureId($productFixtureId);
+        if ($product !== null) {
+            $this->cart->updateQty($quantity, $product->id);
         }
     }
 
     /**
-     * @param int $id fixture product id
+     * @param int $productFixtureId fixture product id
      *
      * @return Product|null
      */
-    protected function getProductFromFixtureId($id)
+    protected function getProductFromFixtureId($productFixtureId)
     {
-        if (isset($this->products[$id])) {
-            return $this->products[$id];
+        if (isset($this->products[$productFixtureId])) {
+            return $this->products[$productFixtureId];
         }
 
         return null;
@@ -229,59 +234,73 @@ abstract class AbstractCartTest extends IntegrationTestCase
         return null;
     }
 
-    protected function insertCartRules()
+    protected function insertCartRulesFromFixtures()
     {
         foreach (static::CART_RULES_FIXTURES as $k => $cartRuleData) {
-            $cartRule                    = new CartRule;
-            $cartRule->reduction_percent = $cartRuleData['percent'];
-            $cartRule->reduction_amount  = $cartRuleData['amount'];
-            $cartRule->name              = array(Configuration::get('PS_LANG_DEFAULT') => 'foo');
-            if (!empty($cartRuleData['code'])) {
-                $cartRule->code = $cartRuleData['code'];
-            }
-            $cartRule->priority          = $cartRuleData['priority'];
-            $cartRule->quantity          = 1000;
-            $cartRule->quantity_per_user = 1000;
-            if (!empty($cartRuleData['productRestrictionId'])) {
-                $product = $this->getProductFromFixtureId($cartRuleData['productRestrictionId']);
-                if ($product === null) {
-                    // if product does not exist, skip this rule
-                    continue;
-                }
-                $cartRule->product_restriction = true;
-                $cartRule->reduction_product   = $product->id;
-            }
-            if (!empty($cartRuleData['productGiftId'])) {
-                $product = $this->getProductFromFixtureId($cartRuleData['productGiftId']);
-                if ($product === null) {
-                    // if product does not exist, skip this rule
-                    continue;
-                }
-                $cartRule->gift_product = $product->id;
-            }
-            $now = new \DateTime();
-            // sub 1s to avoid bad comparisons with strictly greater than
-            $now->sub(new \DateInterval('PT1S'));
-            $cartRule->date_from = $now->format('Y-m-d H:i:s');
-            $now->add(new \DateInterval('P1Y'));
-            $cartRule->date_to = $now->format('Y-m-d H:i:s');
-            $cartRule->active  = 1;
-            if (!empty($cartRuleData['carrierRestrictionIds'])) {
-                $cartRule->carrier_restriction = 1;
-            }
-            $cartRule->add();
-            $this->cartRules[$k] = $cartRule;
+            $this->insertCartRule($k, $cartRuleData);
         }
     }
 
-    protected function addCartRulesToCart(array $cartRuleIds)
+    protected function insertCartRule($cartRuleFixtureId, $cartRuleData)
     {
-        foreach ($cartRuleIds as $cartRuleId) {
-            $cartRule = $this->getCartRuleFromFixtureId($cartRuleId);
+        $cartRule                    = new CartRule;
+        $cartRule->reduction_percent = $cartRuleData['percent'];
+        $cartRule->reduction_amount  = $cartRuleData['amount'];
+        $cartRule->name              = array(Configuration::get('PS_LANG_DEFAULT') => 'foo');
+        if (!empty($cartRuleData['code'])) {
+            $cartRule->code = $cartRuleData['code'];
+        }
+        $cartRule->priority          = $cartRuleData['priority'];
+        $cartRule->quantity          = 1000;
+        $cartRule->quantity_per_user = 1000;
+        if (!empty($cartRuleData['productRestrictionId'])) {
+            $product = $this->getProductFromFixtureId($cartRuleData['productRestrictionId']);
+            if ($product === null) {
+                // if product does not exist, skip this rule
+                return;
+            }
+            $cartRule->product_restriction = true;
+            $cartRule->reduction_product   = $product->id;
+        }
+        if (!empty($cartRuleData['productGiftId'])) {
+            $product = $this->getProductFromFixtureId($cartRuleData['productGiftId']);
+            if ($product === null) {
+                // if product does not exist, skip this rule
+                return;
+            }
+            $cartRule->gift_product = $product->id;
+        }
+        $now = new \DateTime();
+        // sub 1s to avoid bad comparisons with strictly greater than
+        $now->sub(new \DateInterval('PT1S'));
+        $cartRule->date_from = $now->format('Y-m-d H:i:s');
+        $now->add(new \DateInterval('P1Y'));
+        $cartRule->date_to = $now->format('Y-m-d H:i:s');
+        $cartRule->active  = 1;
+        if (!empty($cartRuleData['carrierRestrictionIds'])) {
+            $cartRule->carrier_restriction = 1;
+        }
+        $cartRule->add();
+        $this->cartRules[$cartRuleFixtureId] = $cartRule;
+    }
+
+    protected function addCartRulesToCart(array $cartRuleFixtureIds)
+    {
+        foreach ($cartRuleFixtureIds as $cartRuleFixtureId) {
+            $cartRule = $this->getCartRuleFromFixtureId($cartRuleFixtureId);
             if ($cartRule !== null) {
                 $this->cartRulesInCart[] = $cartRule;
                 $this->cart->addCartRule($cartRule->id);
             }
+        }
+    }
+
+    protected function addCartRuleToCart($cartRuleFixtureId)
+    {
+        $cartRule = $this->getCartRuleFromFixtureId($cartRuleFixtureId);
+        if ($cartRule !== null) {
+            $this->cartRulesInCart[] = $cartRule;
+            $this->cart->addCartRule($cartRule->id);
         }
     }
 

--- a/tests/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests/Unit/Core/Cart/AbstractCartTest.php
@@ -31,6 +31,8 @@ use Cart;
 use CartRule;
 use Configuration;
 use Context;
+use DateInterval;
+use DateTime;
 use Db;
 use Tests\TestCase\IntegrationTestCase;
 use Product;
@@ -270,11 +272,11 @@ abstract class AbstractCartTest extends IntegrationTestCase
             }
             $cartRule->gift_product = $product->id;
         }
-        $now = new \DateTime();
+        $now = new DateTime();
         // sub 1s to avoid bad comparisons with strictly greater than
-        $now->sub(new \DateInterval('PT1S'));
+        $now->sub(new DateInterval('PT1S'));
         $cartRule->date_from = $now->format('Y-m-d H:i:s');
-        $now->add(new \DateInterval('P1Y'));
+        $now->add(new DateInterval('P1Y'));
         $cartRule->date_to = $now->format('Y-m-d H:i:s');
         $cartRule->active  = 1;
         if (!empty($cartRuleData['carrierRestrictionIds'])) {

--- a/tests/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
+++ b/tests/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
@@ -79,52 +79,71 @@ class AddRuleTest extends AbstractCartTest
         $this->assertEquals($expectedProductCountAfterRules, Cart::getNbProducts($this->cart->id));
     }
 
+    /**
+     * test bugfix BOOM-5477
+     */
+    public function testMultipleCartRulesWithoutCode()
+    {
+        $this->addProductToCart(1,1);
+        // ad multiple fixtures without code
+        $cartRulesData = [
+            14 => ['priority' => 12, 'code' => '', 'percent' => 10, 'amount' => 0, 'productGiftId' => 3],
+            15 => ['priority' => 13, 'code' => '', 'percent' => 10, 'amount' => 0, 'productGiftId' => 4],
+        ];
+        foreach ($cartRulesData as $k => $cartRuleData) {
+            $this->insertCartRule($k, $cartRuleData);
+        }
+        $cartRule                = $this->getCartRuleFromFixtureId(1);
+        $result                  = $cartRule->checkValidity(\Context::getContext(), false, false);
+        $this->assertEquals(true, $result);
+    }
+
     public function cartRuleValidityProvider()
     {
-        return array(
-            'No product in cart should give a not valid cart rule insertion'                                               => array(
-                'products'                       => array(),
-                'cartRules'                      => array(1),
+        return [
+            'No product in cart should give a not valid cart rule insertion'                                               => [
+                'products'                       => [],
+                'cartRules'                      => [1],
                 'shouldRulesBeApplied'           => false,
                 'expectedProductCount'           => 0,
                 'expectedProductCountAfterRules' => 0,
-            ),
-            '1 product in cart, cart rule is inserted correctly'                                                           => array(
-                'products'                       => array(1 => 1),
-                'cartRules'                      => array(1),
+            ],
+            '1 product in cart, cart rule is inserted correctly'                                                           => [
+                'products'                       => [1 => 1],
+                'cartRules'                      => [1],
                 'shouldRulesBeApplied'           => true,
                 'expectedProductCount'           => 1,
                 'expectedProductCountAfterRules' => 1,
-            ),
-            '1 product in cart, cart rules are inserted correctly'                                                         => array(
-                'products'                       => array(1 => 1),
-                'cartRules'                      => array(1, 2),
+            ],
+            '1 product in cart, cart rules are inserted correctly'                                                         => [
+                'products'                       => [1 => 1],
+                'cartRules'                      => [1, 2],
                 'shouldRulesBeApplied'           => true,
                 'expectedProductCount'           => 1,
                 'expectedProductCountAfterRules' => 1,
-            ),
-            '1 product in cart, double cart rule not inserted'                                                             => array(
-                'products'                       => array(1 => 1),
-                'cartRules'                      => array(1, 1),
+            ],
+            '1 product in cart, double cart rule not inserted'                                                             => [
+                'products'                       => [1 => 1],
+                'cartRules'                      => [1, 1],
                 'shouldRulesBeApplied'           => false,
                 'expectedProductCount'           => 1,
                 'expectedProductCountAfterRules' => 1,
-            ),
-            '1 product in cart, cart rule giving gift, and global cart rule should be inserted without error'              => array(
-                'products'                       => array(1 => 1),
-                'cartRules'                      => array(12, 1),
+            ],
+            '1 product in cart, cart rule giving gift, and global cart rule should be inserted without error'              => [
+                'products'                       => [1 => 1],
+                'cartRules'                      => [12, 1],
                 'shouldRulesBeApplied'           => true,
                 'expectedProductCount'           => 1,
                 'expectedProductCountAfterRules' => 2,
-            ),
+            ],
             // test PR #8361
-            '1 product in cart, cart rule giving gift out of stock, and global cart rule should be inserted without error' => array(
-                'products'                       => array(1 => 1),
-                'cartRules'                      => array(13, 1),
+            '1 product in cart, cart rule giving gift out of stock, and global cart rule should be inserted without error' => [
+                'products'                       => [1 => 1],
+                'cartRules'                      => [13, 1],
                 'shouldRulesBeApplied'           => true,
                 'expectedProductCount'           => 1,
                 'expectedProductCountAfterRules' => 1,
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/tests/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
+++ b/tests/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
@@ -79,25 +79,6 @@ class AddRuleTest extends AbstractCartTest
         $this->assertEquals($expectedProductCountAfterRules, Cart::getNbProducts($this->cart->id));
     }
 
-    /**
-     * test bugfix BOOM-5477
-     */
-    public function testMultipleCartRulesWithoutCode()
-    {
-        $this->addProductToCart(1,1);
-        // ad multiple fixtures without code
-        $cartRulesData = [
-            14 => ['priority' => 12, 'code' => '', 'percent' => 10, 'amount' => 0, 'productGiftId' => 3],
-            15 => ['priority' => 13, 'code' => '', 'percent' => 10, 'amount' => 0, 'productGiftId' => 4],
-        ];
-        foreach ($cartRulesData as $k => $cartRuleData) {
-            $this->insertCartRule($k, $cartRuleData);
-        }
-        $cartRule                = $this->getCartRuleFromFixtureId(1);
-        $result                  = $cartRule->checkValidity(\Context::getContext(), false, false);
-        $this->assertEquals(true, $result);
-    }
-
     public function cartRuleValidityProvider()
     {
         return [

--- a/tests/Unit/Core/Cart/Calculation/CartRules/CartRulesWithoutCodeTest.php
+++ b/tests/Unit/Core/Cart/Calculation/CartRules/CartRulesWithoutCodeTest.php
@@ -43,9 +43,9 @@ class CartRulesWithoutCodeTest extends AbstractCartCalculationTest
      */
     public function testMultipleCartRulesWithoutCode()
     {
-        $this->addProductToCart(1,3);
-        $this->addProductToCart(2,2);
-        $this->addProductToCart(3,1);
+        $this->addProductToCart(1, 3);
+        $this->addProductToCart(2, 2);
+        $this->addProductToCart(3, 1);
         // ad multiple fixtures without code
         $cartRulesData = [
             14 => ['priority' => 12, 'code' => '', 'percent' => 10, 'amount' => 0],
@@ -54,17 +54,17 @@ class CartRulesWithoutCodeTest extends AbstractCartCalculationTest
         foreach ($cartRulesData as $k => $cartRuleData) {
             $this->insertCartRule($k, $cartRuleData);
         }
-        $cartRule                = $this->getCartRuleFromFixtureId(1);
-        $result                  = $cartRule->checkValidity(\Context::getContext(), false, false);
+        $cartRule = $this->getCartRuleFromFixtureId(1);
+        $result   = $cartRule->checkValidity(\Context::getContext(), false, false);
         $this->assertEquals(true, $result);
 
-        $expectedTotal= (1 - $cartRulesData[14]['percent'] / 100)
-                        * (1 - $cartRulesData[15]['percent'] / 100)
-                        * (3 * static::PRODUCT_FIXTURES[1]['price']
-                           + 2 * static::PRODUCT_FIXTURES[2]['price']
-                           + static::PRODUCT_FIXTURES[3]['price'])
-                        + static::DEFAULT_SHIPPING_FEE + static::DEFAULT_WRAPPING_FEE;
-        $this->compareCartTotalTaxIncl($expectedTotal,true);
+        $expectedTotal = (1 - $cartRulesData[14]['percent'] / 100)
+                         * (1 - $cartRulesData[15]['percent'] / 100)
+                         * (3 * static::PRODUCT_FIXTURES[1]['price']
+                            + 2 * static::PRODUCT_FIXTURES[2]['price']
+                            + static::PRODUCT_FIXTURES[3]['price'])
+                         + static::DEFAULT_SHIPPING_FEE + static::DEFAULT_WRAPPING_FEE;
+        $this->compareCartTotalTaxIncl($expectedTotal, true);
     }
 
 }

--- a/tests/Unit/Core/Cart/Calculation/CartRules/CartRulesWithoutCodeTest.php
+++ b/tests/Unit/Core/Cart/Calculation/CartRules/CartRulesWithoutCodeTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Cart\Calculation\CartRules;
+
+use Tests\Unit\Core\Cart\Calculation\AbstractCartCalculationTest;
+
+/**
+ * these tests aim to check the correct calculation of cart total when applying cart rules without code
+ *
+ * products are inserted as fixtures
+ * products are inserted in cart from data providers
+ * cart rules are inserted from data providers
+ */
+class CartRulesWithoutCodeTest extends AbstractCartCalculationTest
+{
+
+    /**
+     * test bugfix BOOM-5477
+     */
+    public function testMultipleCartRulesWithoutCode()
+    {
+        $this->addProductToCart(1,3);
+        $this->addProductToCart(2,2);
+        $this->addProductToCart(3,1);
+        // ad multiple fixtures without code
+        $cartRulesData = [
+            14 => ['priority' => 12, 'code' => '', 'percent' => 10, 'amount' => 0],
+            15 => ['priority' => 13, 'code' => '', 'percent' => 10, 'amount' => 0],
+        ];
+        foreach ($cartRulesData as $k => $cartRuleData) {
+            $this->insertCartRule($k, $cartRuleData);
+        }
+        $cartRule                = $this->getCartRuleFromFixtureId(1);
+        $result                  = $cartRule->checkValidity(\Context::getContext(), false, false);
+        $this->assertEquals(true, $result);
+
+        $expectedTotal= (1 - $cartRulesData[14]['percent'] / 100)
+                        * (1 - $cartRulesData[15]['percent'] / 100)
+                        * (3 * static::PRODUCT_FIXTURES[1]['price']
+                           + 2 * static::PRODUCT_FIXTURES[2]['price']
+                           + static::PRODUCT_FIXTURES[3]['price'])
+                        + static::DEFAULT_SHIPPING_FEE + static::DEFAULT_WRAPPING_FEE;
+        $this->compareCartTotalTaxIncl($expectedTotal,true);
+    }
+
+}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | fix for infinite loop when multiple vouchers without code are set simultaneously
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Boom 5477
| How to test?  | add 2 percent vouchers with empty code in BO, add a product in FO : cart must have the product and the both vouchers applied

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9036)
<!-- Reviewable:end -->
