### PR TITLE
Fix Smarty.class.php class not found

### DIFF
--- a/classes/Smarty/SmartyCacheResourceMysql.php
+++ b/classes/Smarty/SmartyCacheResourceMysql.php
@@ -24,8 +24,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-require_once(_PS_VENDOR_DIR_.'/prestashop/smarty/Smarty.class.php');
-
 class Smarty_CacheResource_Mysql extends Smarty_CacheResource_Custom
 {
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Prevent error while changing cache mode to MySQL.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Change cache mode to MySQL and reload page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9040)
<!-- Reviewable:end -->
