### PR TITLE
Fix delivery time labels not displayed

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -57,7 +57,7 @@ class CachingType extends TranslatorAwareType
                     'APC' => 'CacheApc',
                     'Xcache' => 'CacheXcache',
                 ),
-                'choice_label' => function($value, $key, $index) {
+                'choice_label' => function ($value, $key, $index) {
                     $disabled = false;
                     foreach ($this->extensionsList[$index] as $extensionName) {
                         if (extension_loaded($extensionName)) {
@@ -68,7 +68,7 @@ class CachingType extends TranslatorAwareType
 
                     return $disabled === true ? $this->getErrorsMessages()[$index] : $value;
                 },
-                'choice_attr' => function($value, $key, $index) {
+                'choice_attr' => function ($value, $key, $index) {
                     $disabled = false;
                     foreach ($this->extensionsList[$index] as $extensionName) {
                         if (extension_loaded($extensionName)) {

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormHandler.php
@@ -55,8 +55,7 @@ final class PerformanceFormHandler extends AbstractFormHandler
         FormFactoryInterface $formFactory,
         FormDataProviderInterface $formDataProvider,
         CombinationFeature $combinationFeature
-    )
-    {
+    ) {
         $this->formFactory = $formFactory;
         $this->combinationFeature = $combinationFeature;
         $this->formDataProvider = $formDataProvider;
@@ -91,8 +90,10 @@ final class PerformanceFormHandler extends AbstractFormHandler
     public function save(array $data)
     {
         $errors = $this->formDataProvider->setData($data);
-
-        $this->hookDispatcher->dispatchForParameters('actionPerformancePageFormSave', ['errors' => &$errors, 'form_data' => &$data]);
+        $this->hookDispatcher->dispatchForParameters(
+            'actionPerformancePageFormSave',
+            ['errors' => &$errors, 'form_data' => &$data]
+        );
 
         return $errors;
     }

--- a/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
+++ b/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
@@ -78,7 +78,10 @@ class SimpleCategory extends CommonAbstractType
         $builder->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'label' => $this->translator->trans('Name', [], 'Admin.Global'),
             'required' => false,
-            'attr' => ['placeholder' => $this->translator->trans('Category name', [], 'Admin.Catalog.Feature'), 'class' => 'ajax'],
+            'attr' => [
+                'placeholder' => $this->translator->trans('Category name', [], 'Admin.Catalog.Feature'),
+                'class' => 'ajax'
+            ],
             'constraints' => $options['ajax'] ? [] : array(
                 new Assert\NotBlank(),
                 new Assert\Length(array('min' => 1, 'max' => 128))

--- a/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
+++ b/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
@@ -26,6 +26,7 @@
 namespace PrestaShopBundle\Form\Admin\Feature;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormEvents;
@@ -70,7 +71,7 @@ class ProductFeature extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('feature', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        $builder->add('feature', FormType\ChoiceType::class, array(
             'label' => $this->translator->trans('Feature', array(), 'Admin.Catalog.Feature'),
             'choices' =>  $this->features,
             'required' =>  false,
@@ -82,7 +83,7 @@ class ProductFeature extends CommonAbstractType
             ),
             'placeholder' => $this->translator->trans('Choose a feature', array(), 'Admin.Catalog.Feature'),
         ))
-        ->add('value', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        ->add('value', FormType\ChoiceType::class, array(
             'label' => $this->translator->trans('Pre-defined value', array(), 'Admin.Catalog.Feature'),
             'required' =>  false,
             'attr' => array(
@@ -92,8 +93,8 @@ class ProductFeature extends CommonAbstractType
             'placeholder' => $this->translator->trans('Choose a value', array(), 'Admin.Catalog.Feature'),
             'disabled' => true,
         ))
-        ->add('custom_value', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+        ->add('custom_value', TranslateType::class, array(
+            'type' => FormType\TextType::class,
             'options' => [],
             'locales' => $this->locales,
             'hideTabs' => true,
@@ -138,7 +139,7 @@ class ProductFeature extends CommonAbstractType
 
     private function updateValueField(Form $form, $choices)
     {
-        $form->add('value', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        $form->add('value', FormType\ChoiceType::class, array(
             'label' => $this->translator->trans('Pre-defined value', array(), 'Admin.Catalog.Feature'),
             'required' =>  false,
             'attr' => array(

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
@@ -26,6 +26,7 @@
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
@@ -59,13 +60,13 @@ class ProductCustomField extends CommonAbstractType
     {
         $builder->add(
             'id_customization_field',
-            'Symfony\Component\Form\Extension\Core\Type\HiddenType',
+            FormType\HiddenType::class,
             array(
                 'required' => false,
             )
         )
-        ->add('label', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+        ->add('label', TranslateType::class, array(
+            'type' => FormType\TextType::class,
             'options' => [ 'constraints' => array(
                 new Assert\NotBlank(),
                 new Assert\Length(array('min' => 2))
@@ -74,7 +75,7 @@ class ProductCustomField extends CommonAbstractType
             'hideTabs' => true,
             'label' => $this->translator->trans('Label', [], 'Admin.Global')
         ))
-        ->add('type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        ->add('type', FormType\ChoiceType::class, array(
             'label' => $this->translator->trans('Type', [], 'Admin.Catalog.Feature'),
             'choices'  => array(
                 $this->translator->trans('Text', [], 'Admin.Global') => 1,
@@ -84,7 +85,8 @@ class ProductCustomField extends CommonAbstractType
                 'class' => 'c-select',
             ),
             'required' =>  true
-        ))->add('require', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+        ))
+        ->add('require', FormType\CheckboxType::class, array(
             'label'    => $this->translator->trans('Required', [], 'Admin.Global'),
             'required' => false,
         ));

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -25,15 +25,21 @@
  */
 namespace PrestaShopBundle\Form\Admin\Product;
 
+use PrestaShopBundle\Form\Admin\Category\SimpleCategory;
+use PrestaShopBundle\Form\Admin\Type\ChoiceCategoriesTreeType;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
-use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShopBundle\Form\Admin\Type\TranslateType;
+use PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType;
+use PrestaShopBundle\Form\Admin\Type\TypeaheadProductPackCollectionType;
 use PrestaShopBundle\Form\Validator\Constraints\TinyMceMaxLength;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * This form class is responsible to generate the basic product information form
@@ -63,8 +69,15 @@ class ProductInformation extends CommonAbstractType
      * @param object $featureDataProvider
      * @param object $manufacturerDataProvider
      */
-    public function __construct($translator, $legacyContext, $router, $categoryDataProvider, $productDataProvider, $featureDataProvider, $manufacturerDataProvider)
-    {
+    public function __construct(
+        $translator,
+        $legacyContext,
+        $router,
+        $categoryDataProvider,
+        $productDataProvider,
+        $featureDataProvider,
+        $manufacturerDataProvider
+    ) {
         $this->context = $legacyContext;
         $this->translator = $translator;
         $this->router = $router;
@@ -83,7 +96,8 @@ class ProductInformation extends CommonAbstractType
                 $root_category = null,
                 $id_lang = false,
                 $active = false
-            ), 'id_category'
+            ),
+            'id_category'
         );
 
         $this->nested_categories = $this->categoryDataProvider->getNestedCategories(
@@ -101,7 +115,8 @@ class ProductInformation extends CommonAbstractType
                 $n = false,
                 $all_group = false,
                 $group_by = true
-            ), 'id_manufacturer'
+            ),
+            'id_manufacturer'
         );
     }
 
@@ -114,7 +129,7 @@ class ProductInformation extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $is_stock_management = $this->configuration->get('PS_STOCK_MANAGEMENT');
-        $builder->add('type_product', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        $builder->add('type_product', FormType\ChoiceType::class, array(
             'choices'  => array(
                 $this->translator->trans('Standard product', [], 'Admin.Catalog.Feature') => 0,
                 $this->translator->trans('Pack of products', [], 'Admin.Catalog.Feature') => 1,
@@ -126,7 +141,7 @@ class ProductInformation extends CommonAbstractType
             'label' =>  $this->translator->trans('Type', [], 'Admin.Catalog.Feature'),
             'required' => true,
         ))
-        ->add('inputPackItems', 'PrestaShopBundle\Form\Admin\Type\TypeaheadProductPackCollectionType', array(
+        ->add('inputPackItems', TypeaheadProductPackCollectionType::class, array(
             'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&excludeVirtuals=1&limit=20&q=%QUERY',
             'mapping_value' => 'id',
             'mapping_name' => 'name',
@@ -140,8 +155,8 @@ class ProductInformation extends CommonAbstractType
             'required' => false,
             'label' => $this->translator->trans('Add products to your pack', [], 'Admin.Catalog.Feature'),
         ))
-        ->add('name', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+        ->add('name', TranslateType::class, array(
+            'type' => FormType\TextType::class,
             'options' => [
                 'constraints' => array(
                     new Assert\Regex(array(
@@ -150,13 +165,17 @@ class ProductInformation extends CommonAbstractType
                     )),
                     new Assert\NotBlank(),
                     new Assert\Length(array('min' => 3, 'max' => 128))
-                ), 'attr' => ['placeholder' => $this->translator->trans('Enter your product name', [], 'Admin.Catalog.Help'), 'class' => 'edit js-edit']
+                ),
+                'attr' => [
+                    'placeholder' => $this->translator->trans('Enter your product name', [], 'Admin.Catalog.Help'),
+                    'class' => 'edit js-edit'
+                ]
             ],
             'locales' => $this->locales,
             'hideTabs' => true,
             'label' => $this->translator->trans('Name', [], 'Admin.Global')
         ))
-        ->add('description', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+        ->add('description', TranslateType::class, array(
             'type' => FormattedTextareaType::class,
             'options' => array(
                 'required' => false,
@@ -166,8 +185,8 @@ class ProductInformation extends CommonAbstractType
             'label' =>  $this->translator->trans('Description', [], 'Admin.Global'),
             'required' => false
         ))
-        ->add('description_short', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType', // https://github.com/symfony/symfony/issues/5906
+        ->add('description_short', TranslateType::class, array(
+            'type' => FormType\TextareaType::class, // https://github.com/symfony/symfony/issues/5906
             'options' => [
                 'attr' => array(
                     'class' => 'autoload_rte',
@@ -188,13 +207,13 @@ class ProductInformation extends CommonAbstractType
         ))
 
         //FEATURES & ATTRIBUTES
-        ->add('features', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+        ->add('features', FormType\CollectionType::class, array(
             'entry_type' =>'PrestaShopBundle\Form\Admin\Feature\ProductFeature',
             'prototype' => true,
             'allow_add' => true,
             'allow_delete' => true
         ))
-        ->add('id_manufacturer', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        ->add('id_manufacturer', FormType\ChoiceType::class, array(
             'choices' => $this->manufacturers,
             'required' => false,
             'attr' => array(
@@ -205,11 +224,11 @@ class ProductInformation extends CommonAbstractType
         ))
 
         //RIGHT COL
-        ->add('active', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+        ->add('active', FormType\CheckboxType::class, array(
             'label' => $this->translator->trans('Enabled', [], 'Admin.Global'),
             'required' => false,
         ))
-        ->add('price_shortcut', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
+        ->add('price_shortcut', FormType\MoneyType::class, array(
             'required' => false,
             'label' => $this->translator->trans('Pre-tax retail price', [], 'Admin.Catalog.Feature'),
             'currency' => $this->currency->iso_code,
@@ -219,14 +238,14 @@ class ProductInformation extends CommonAbstractType
             ),
             'attr' => []
         ))
-        ->add('price_ttc_shortcut', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
+        ->add('price_ttc_shortcut', FormType\MoneyType::class, array(
             'required' => false,
             'label' => $this->translator->trans('Retail price with tax', [], 'Admin.Catalog.Feature'),
             'mapped' => false,
             'currency' => $this->currency->iso_code,
         ));
         if ($is_stock_management) {
-            $builder->add('qty_0_shortcut', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
+            $builder->add('qty_0_shortcut', FormType\NumberType::class, array(
                 'required' => false,
                 'label' => $this->translator->trans('Quantity', [], 'Admin.Catalog.Feature'),
                 'constraints' => array(
@@ -235,20 +254,20 @@ class ProductInformation extends CommonAbstractType
                 )
             ));
         }
-        $builder->add('categories', 'PrestaShopBundle\Form\Admin\Type\ChoiceCategoriesTreeType', array(
+        $builder->add('categories', ChoiceCategoriesTreeType::class, array(
             'label' => $this->translator->trans('Associated categories', [], 'Admin.Catalog.Feature'),
             'list' => $this->nested_categories,
             'valid_list' => $this->categories,
             'multiple' => true,
         ))
-        ->add('id_category_default', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        ->add('id_category_default', FormType\ChoiceType::class, array(
             'choices' =>  $this->categories,
             'expanded' => true,
             'multiple' => false,
             'required' =>  true,
             'label' => $this->translator->trans('Default category', [], 'Admin.Catalog.Feature')
         ))
-        ->add('new_category', 'PrestaShopBundle\Form\Admin\Category\SimpleCategory', array(
+        ->add('new_category', SimpleCategory::class, array(
             'ajax' => true,
             'required' => false,
             'mapped' => false,
@@ -258,7 +277,7 @@ class ProductInformation extends CommonAbstractType
         ->add('ignore', null, [
             'mapped' => false
         ])
-        ->add('related_products', 'PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType', array(
+        ->add('related_products', TypeaheadProductCollectionType::class, array(
             'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
             'mapping_value' => 'id',
             'mapping_name' => 'name',
@@ -280,7 +299,11 @@ class ProductInformation extends CommonAbstractType
             if ($data['type_product'] == 1) {
                 if (!isset($data['inputPackItems']) || empty($data['inputPackItems']['data'])) {
                     $form = $event->getForm();
-                    $error = $this->translator->trans('This pack is empty. You must add at least one product item.', [], 'Admin.Catalog.Notification');
+                    $error = $this->translator->trans(
+                        'This pack is empty. You must add at least one product item.',
+                        [],
+                        'Admin.Catalog.Notification'
+                    );
                     $form->get('inputPackItems')->addError(new FormError($error));
                 }
             }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
@@ -26,12 +26,16 @@
 
 namespace PrestaShopBundle\Form\Admin\Product;
 
+use PrestaShopBundle\Form\Admin\Product\ProductAttachement;
+use PrestaShopBundle\Form\Admin\Product\ProductCustomField;
+use PrestaShopBundle\Form\Admin\Product\ProductSupplierCombination;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Validator\Constraints as Assert;
+use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * This form class is responsible to generate the product options form
@@ -59,8 +63,15 @@ class ProductOptions extends CommonAbstractType
      * @param object $attachmentDataprovider
      * @param object $router
      */
-    public function __construct($translator, $legacyContext, $productDataProvider, $supplierDataProvider, $currencyDataprovider, $attachmentDataprovider, $router)
-    {
+    public function __construct(
+        $translator,
+        $legacyContext,
+        $productDataProvider,
+        $supplierDataProvider,
+        $currencyDataprovider,
+        $attachmentDataprovider,
+        $router
+    ) {
         $this->context = $legacyContext;
         $this->translator = $translator;
         $this->productAdapter = $productDataProvider;
@@ -73,7 +84,9 @@ class ProductOptions extends CommonAbstractType
             'id_supplier'
         );
 
-        $this->fullAttachmentList = $attachmentDataprovider->getAllAttachments($this->context->getLanguages()[0]['id_lang']);
+        $this->fullAttachmentList = $attachmentDataprovider->getAllAttachments(
+            $this->context->getLanguages()[0]['id_lang']
+        );
         $this->attachmentList = $this->formatDataChoicesList(
             $this->fullAttachmentList,
             'id_attachment',
@@ -88,7 +101,7 @@ class ProductOptions extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('visibility', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        $builder->add('visibility', FormType\ChoiceType::class, array(
             'choices'  => array(
                 $this->translator->trans('Everywhere', [], 'Admin.Catalog.Feature') => 'both',
                 $this->translator->trans('Catalog only', [], 'Admin.Catalog.Feature') => 'catalog',
@@ -101,8 +114,8 @@ class ProductOptions extends CommonAbstractType
             'required' => true,
             'label' => $this->translator->trans('Visibility', [], 'Admin.Catalog.Feature'),
         ))
-        ->add('tags', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+        ->add('tags', TranslateType::class, array(
+            'type' => FormType\TextType::class,
             'options' => [
                 'attr' => [
                     'class' => 'tokenfield',
@@ -113,28 +126,51 @@ class ProductOptions extends CommonAbstractType
             'label' => $this->translator->trans('Tags', [], 'Admin.Catalog.Feature')
         ))
         ->add(
-            $builder->create('display_options', 'Symfony\Component\Form\Extension\Core\Type\FormType', array('required' => false, 'label' => $this->translator->trans('Display options', [], 'Admin.Catalog.Feature')))
-                ->add('available_for_order', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+            $builder->create(
+                'display_options',
+                FormType\FormType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Display options', [], 'Admin.Catalog.Feature')
+                ]
+            )
+            ->add(
+                'available_for_order',
+                FormType\CheckboxType::class,
+                array(
                     'label'    => $this->translator->trans('Available for order', [], 'Admin.Catalog.Feature'),
                     'required' => false,
-                ))
-                ->add('show_price', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+                )
+            )
+            ->add(
+                'show_price',
+                FormType\CheckboxType::class,
+                array(
                     'label'    => $this->translator->trans('Show price', [], 'Admin.Catalog.Feature'),
                     'required' => false,
-                ))
-                ->add('online_only', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-                    'label'    => $this->translator->trans('Web only (not sold in your retail store)', [], 'Admin.Catalog.Feature'),
+                )
+            )
+            ->add(
+                'online_only',
+                FormType\CheckboxType::class,
+                array(
+                    'label'    => $this->translator->trans(
+                        'Web only (not sold in your retail store)',
+                        [],
+                        'Admin.Catalog.Feature'
+                    ),
                     'required' => false,
-                ))
+                )
+            )
         )
-        ->add('upc', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+        ->add('upc', FormType\TextType::class, array(
             'required' => false,
             'label' => $this->translator->trans('UPC barcode', [], 'Admin.Catalog.Feature'),
             'constraints' => array(
                 new Assert\Regex("/^[0-9]{0,12}$/"),
             )
         ))
-        ->add('ean13', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+        ->add('ean13', FormType\TextType::class, array(
             'required' => false,
             'error_bubbling' => true,
             'label' => $this->translator->trans('EAN-13 or JAN barcode', [], 'Admin.Catalog.Feature'),
@@ -142,22 +178,22 @@ class ProductOptions extends CommonAbstractType
                 new Assert\Regex("/^[0-9]{0,13}$/"),
             )
         ))
-        ->add('isbn', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+        ->add('isbn', FormType\TextType::class, array(
             'required' => false,
             'label' => $this->translator->trans('ISBN', [], 'Admin.Catalog.Feature'),
             'constraints' => array(
                 new Assert\Regex("/^[0-9-]{0,32}$/"),
             ),
         ))
-        ->add('reference', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+        ->add('reference', FormType\TextType::class, array(
             'required' => false,
             'label' => $this->translator->trans('Reference', [], 'Admin.Global')
         ))
-        ->add('show_condition', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+        ->add('show_condition', FormType\CheckboxType::class, array(
             'required' => false,
             'label' => $this->translator->trans('Display condition on product page', [], 'Admin.Catalog.Feature'),
         ))
-        ->add('condition', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        ->add('condition', FormType\ChoiceType::class, array(
             'choices'  => array(
                  $this->translator->trans('New', [], 'Shop.Theme.Catalog') => 'new',
                  $this->translator->trans('Used', [], 'Shop.Theme.Catalog') => 'used',
@@ -169,7 +205,7 @@ class ProductOptions extends CommonAbstractType
             'required' => true,
             'label' => $this->translator->trans('Condition', [], 'Admin.Catalog.Feature')
         ))
-        ->add('suppliers', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        ->add('suppliers', FormType\ChoiceType::class, array(
             'choices' =>  $this->suppliers,
             'expanded' =>  true,
             'multiple' =>  true,
@@ -179,7 +215,7 @@ class ProductOptions extends CommonAbstractType
             ),
             'label' => $this->translator->trans('Suppliers', [], 'Admin.Global')
         ))
-        ->add('default_supplier', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        ->add('default_supplier', FormType\ChoiceType::class, array(
             'choices' =>  $this->suppliers,
             'expanded' =>  true,
             'multiple' =>  false,
@@ -191,20 +227,24 @@ class ProductOptions extends CommonAbstractType
         ));
 
         foreach ($this->suppliers as $supplier => $id) {
-            $builder->add('supplier_combination_'.$id, 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
-                'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductSupplierCombination',
-                'entry_options'  => array(
-                    'id_supplier' => $id,
-                ),
-                'prototype' => true,
-                'allow_add' => true,
-                'required' => false,
-                'label' => $supplier,
-            ));
+            $builder->add(
+                'supplier_combination_' . $id,
+                FormType\CollectionType::class,
+                [
+                    'entry_type' => ProductSupplierCombination::class,
+                    'entry_options'  => array(
+                        'id_supplier' => $id,
+                    ),
+                    'prototype' => true,
+                    'allow_add' => true,
+                    'required' => false,
+                    'label' => $supplier,
+                ]
+            );
         }
 
-        $builder->add('custom_fields', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
-            'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductCustomField',
+        $builder->add('custom_fields', FormType\CollectionType::class, array(
+            'entry_type' => ProductCustomField::class,
             'label' => $this->translator->trans('Customization', [], 'Admin.Catalog.Feature'),
             'prototype' => true,
             'allow_add' => true,
@@ -212,14 +252,14 @@ class ProductOptions extends CommonAbstractType
         ));
 
         //Add product attachment form
-        $builder->add('attachment_product', 'PrestaShopBundle\Form\Admin\Product\ProductAttachement', array(
+        $builder->add('attachment_product', ProductAttachement::class, array(
             'required' => false,
             'label' => $this->translator->trans('Attachment', [], 'Admin.Catalog.Feature'),
             'attr' => ['data-action' => $this->router->generate('admin_product_attachement_add_action', array('idProduct' => 1))]
         ));
 
         //Add attachment selectors
-        $builder->add('attachments', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        $builder->add('attachments', FormType\ChoiceType::class, array(
             'expanded'  => true,
             'multiple'  => true,
             'choices'  => $this->attachmentList,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -26,6 +26,7 @@
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\Admin\Product\ProductSpecificPrice;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
@@ -84,70 +85,110 @@ class ProductPrice extends CommonAbstractType
             array($this->translator->trans('No tax', [], 'Admin.Catalog.Feature') => 0),
             $this->tax_rules
         );
-        $builder->add('price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
-            'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
-            'currency' => $this->currency->iso_code,
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
+        $builder->add(
+            'price',
+            FormType\MoneyType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
+                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'currency' => $this->currency->iso_code,
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                    new Assert\Type(array('type' => 'float'))
+                )
             )
-        ))
-        ->add('price_ttc', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'mapped' => false,
-            'label' => $this->translator->trans('Price (tax incl.)', [], 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-        ))
-        ->add('ecotax', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Ecotax (tax incl.)', [], 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
-            ),
-            'attr' => ['data-eco-tax-rate' => $this->eco_tax_rate],
-        ))
-        ->add('id_tax_rules_group', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices' =>  $this->tax_rules,
-            'required' => true,
-            'choice_attr' => function ($val) {
-                return [
-                    'data-rates' => implode(',', $this->tax_rules_rates[$val]['rates']),
-                    'data-computation-method' => $this->tax_rules_rates[$val]['computation_method'],
-                ];
-            },
-            'attr' => array(
-                'data-toggle' => 'select2',
-                'data-minimumResultsForSearch' => '7',
-            ),
-            'label' => $this->translator->trans('Tax rule', [], 'Admin.Catalog.Feature'),
-        ))
-        ->add('on_sale', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Display the "On sale!" flag on the product page, and on product listings.', [], 'Admin.Catalog.Feature'),
-        ))
-        ->add('wholesale_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-        ))
-        ->add('unit_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Price per unit (tax excl.)', [], 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-        ))
-        ->add('unity', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'required' => false,
-            'attr' => ['placeholder' => $this->translator->trans('Per kilo, per litre', [], 'Admin.Catalog.Help')]
-        ))
-        ->add('specific_price', 'PrestaShopBundle\Form\Admin\Product\ProductSpecificPrice')
-        ->add('specificPricePriorityToAll', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Apply to all products', [], 'Admin.Catalog.Feature'),
-        ));
+        )
+        ->add(
+            'price_ttc',
+            FormType\MoneyType::class,
+            array(
+                'required' => false,
+                'mapped' => false,
+                'label' => $this->translator->trans('Price (tax incl.)', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+            )
+        )
+        ->add(
+            'ecotax',
+            FormType\MoneyType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Ecotax (tax incl.)', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                    new Assert\Type(array('type' => 'float'))
+                ),
+                'attr' => ['data-eco-tax-rate' => $this->eco_tax_rate],
+            )
+        )
+        ->add(
+            'id_tax_rules_group',
+            FormType\ChoiceType::class,
+            array(
+                'choices' =>  $this->tax_rules,
+                'required' => true,
+                'choice_attr' => function ($val) {
+                    return [
+                        'data-rates' => implode(',', $this->tax_rules_rates[$val]['rates']),
+                        'data-computation-method' => $this->tax_rules_rates[$val]['computation_method'],
+                    ];
+                },
+                'attr' => array(
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ),
+                'label' => $this->translator->trans('Tax rule', [], 'Admin.Catalog.Feature'),
+            )
+        )
+        ->add(
+            'on_sale',
+            FormType\CheckboxType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans(
+                    'Display the "On sale!" flag on the product page, and on product listings.',
+                    [],
+                    'Admin.Catalog.Feature'
+                ),
+            )
+        )
+        ->add(
+            'wholesale_price',
+            FormType\MoneyType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+            )
+        )
+        ->add(
+            'unit_price',
+            FormType\MoneyType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Price per unit (tax excl.)', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+            )
+        )
+        ->add(
+            'unity',
+            FormType\TextType::class,
+            array(
+                'required' => false,
+                'attr' => ['placeholder' => $this->translator->trans('Per kilo, per litre', [], 'Admin.Catalog.Help')]
+            )
+        )
+        ->add('specific_price', ProductSpecificPrice::class)
+        ->add(
+            'specificPricePriorityToAll',
+            FormType\CheckboxType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Apply to all products', [], 'Admin.Catalog.Feature'),
+            )
+        );
 
         //generates fields for price priority
         $specificPricePriorityChoices = [
@@ -158,10 +199,14 @@ class ProductPrice extends CommonAbstractType
         ];
 
         for ($i=0; $i < count($specificPricePriorityChoices); $i++) {
-            $builder->add('specificPricePriority_'.$i, 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-                'choices' => $specificPricePriorityChoices,
-                'required' => true
-            ));
+            $builder->add(
+                'specificPricePriority_'.$i,
+                FormType\ChoiceType::class,
+                array(
+                    'choices' => $specificPricePriorityChoices,
+                    'required' => true
+                )
+            );
         }
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -26,13 +26,17 @@
 
 namespace PrestaShopBundle\Form\Admin\Product;
 
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Pack;
+use PrestaShopBundle\Form\Admin\Product\ProductVirtual;
+use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use PrestaShopBundle\Form\Admin\Type\TranslateType;
+use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use Symfony\Component\Form\Extension\Core\Type as FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * This form class is responsible to generate the product quantity form.
@@ -70,51 +74,51 @@ class ProductQuantity extends CommonAbstractType
         $builder
             ->add(
                 'attributes',
-                'Symfony\Component\Form\Extension\Core\Type\TextType',
+                FormType\TextType::class,
                 array(
                     'attr'  => array(
                         'class'          => 'tokenfield',
                         'data-minLength' => 1,
                         'placeholder'    => $this->translator->trans(
                             'Combine several attributes, e.g.: "Size: all", "Color: red".',
-                            array(),
+                            [],
                             'Admin.Catalog.Help'
                         ),
                         'data-prefetch'  => $this->router->generate('admin_attribute_get_all'),
                         'data-action'    => $this->router->generate('admin_attribute_generator'),
                     ),
-                    'label' => $this->translator->trans('Create combinations', array(), 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Create combinations', [], 'Admin.Catalog.Feature'),
                 )
             )
             ->add(
                 'advanced_stock_management',
-                'Symfony\Component\Form\Extension\Core\Type\CheckboxType',
+                FormType\CheckboxType::class,
                 array(
                     'required' => false,
                     'label'    => $this->translator->trans(
                         'I want to use the advanced stock management system for this product.',
-                        array(),
+                        [],
                         'Admin.Catalog.Feature'
                     ),
                 )
             )
             ->add(
                 'pack_stock_type',
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                FormType\ChoiceType::class
             )//see eventListener for details
             ->add(
                 'depends_on_stock',
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+                FormType\ChoiceType::class,
                 array(
-                    'choices'           => array(
+                    'choices' => array(
                         $this->translator->trans(
                             'The available quantities for the current product and its combinations are based on the stock in your warehouse (using the advanced stock management system). ',
-                            array(),
+                            [],
                             'Admin.Catalog.Feature'
                         ) => 1,
                         $this->translator->trans(
                             'I want to specify available quantities manually.',
-                            array(),
+                            [],
                             'Admin.Catalog.Feature'
                         ) => 0,
                     ),
@@ -127,10 +131,10 @@ class ProductQuantity extends CommonAbstractType
         if ($is_stock_management) {
             $builder->add(
                 'qty_0',
-                'Symfony\Component\Form\Extension\Core\Type\NumberType',
+                FormType\NumberType::class,
                 array(
                     'required' => true,
-                    'label' => $this->translator->trans('Quantity', array(), 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Quantity', [], 'Admin.Catalog.Feature'),
                     'constraints' => array(
                         new Assert\NotBlank(),
                         new Assert\Type(array('type' => 'numeric')),
@@ -141,14 +145,14 @@ class ProductQuantity extends CommonAbstractType
         $builder
             ->add(
                 'out_of_stock',
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                FormType\ChoiceType::class
             )
             ->add(
                 'minimal_quantity',
-                'Symfony\Component\Form\Extension\Core\Type\NumberType',
+                FormType\NumberType::class,
                 array(
                     'required' => true,
-                    'label' => $this->translator->trans('Minimum quantity for sale', array(), 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Minimum quantity for sale', [], 'Admin.Catalog.Feature'),
                     'constraints' => array(
                         new Assert\NotBlank(),
                         new Assert\Type(array('type' => 'numeric')),
@@ -157,11 +161,11 @@ class ProductQuantity extends CommonAbstractType
             )
             ->add(
                 'low_stock_threshold',
-                'Symfony\Component\Form\Extension\Core\Type\NumberType',
+                FormType\NumberType::class,
                 array(
-                    'label' => $this->translator->trans('Low stock level', array(), 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Low stock level', [], 'Admin.Catalog.Feature'),
                     'attr' => array(
-                        'placeholder' => $this->translator->trans('Leave empty to disable', array(), 'Admin.Catalog.Help'),
+                        'placeholder' => $this->translator->trans('Leave empty to disable', [], 'Admin.Catalog.Help'),
                     ),
                     'constraints' => array(
                         new Assert\Type(array('type' => 'numeric')),
@@ -170,9 +174,13 @@ class ProductQuantity extends CommonAbstractType
             )
             ->add(
                 'low_stock_alert',
-                'Symfony\Component\Form\Extension\Core\Type\CheckboxType',
+                FormType\CheckboxType::class,
                 array(
-                    'label' => $this->translator->trans('Send me an email when the quantity is below or equals this level', array(), 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans(
+                        'Send me an email when the quantity is below or equals this level',
+                        [],
+                        'Admin.Catalog.Feature'
+                    ),
                     'constraints' => array(
                         new Assert\Type(array('type' => 'bool')),
                     ),
@@ -180,41 +188,49 @@ class ProductQuantity extends CommonAbstractType
             )
             ->add(
                 'available_now',
-                'PrestaShopBundle\Form\Admin\Type\TranslateType',
+                TranslateType::class,
                 array(
-                    'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-                    'options' => array(),
+                    'type' => FormType\TextType::class,
+                    'options' => [],
                     'locales' => $this->locales,
                     'hideTabs' => true,
-                    'label' => $this->translator->trans('Label when in stock', array(), 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Label when in stock', [], 'Admin.Catalog.Feature'),
                 )
             )
             ->add(
                 'available_later',
-                'PrestaShopBundle\Form\Admin\Type\TranslateType',
+                TranslateType::class,
                 array(
-                    'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-                    'options' => array(),
+                    'type' => FormType\TextType::class,
+                    'options' => [],
                     'locales' => $this->locales,
                     'hideTabs' => true,
-                    'label' => $this->translator->trans('Label when out of stock (and back order allowed)', array(), 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans(
+                        'Label when out of stock (and back order allowed)',
+                        [],
+                        'Admin.Catalog.Feature'
+                    ),
                 )
             )
             ->add(
                 'available_date',
-                'PrestaShopBundle\Form\Admin\Type\DatePickerType',
+                DatePickerType::class,
                 array(
                     'required' => false,
-                    'label' => $this->translator->trans('Availability date', array(), 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Availability date', [], 'Admin.Catalog.Feature'),
                     'attr' => array('placeholder' => 'YYYY-MM-DD'),
                 )
             )
             ->add(
                 'virtual_product',
-                'PrestaShopBundle\Form\Admin\Product\ProductVirtual',
+                ProductVirtual::class,
                 array(
                     'required' => false,
-                    'label' => $this->translator->trans('Does this product have an associated file?', array(), 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans(
+                        'Does this product have an associated file?',
+                        [],
+                        'Admin.Catalog.Feature'
+                    ),
                 )
             );
 
@@ -224,53 +240,65 @@ class ProductQuantity extends CommonAbstractType
                 $form = $event->getForm();
 
                 //Manage out_of_stock field with contextual values/label
-                $defaultChoiceLabel = $this->translator->trans('Use default behavior', array(), 'Admin.Catalog.Feature').' (';
+                $defaultChoiceLabel = $this->translator->trans(
+                    'Use default behavior',
+                    [],
+                    'Admin.Catalog.Feature'
+                ) . ' (';
                 $defaultChoiceLabel .= $this->configuration->get('PS_ORDER_OUT_OF_STOCK') == 1 ?
-                    $this->translator->trans('Allow orders', array(), 'Admin.Catalog.Feature') :
-                    $this->translator->trans('Deny orders', array(), 'Admin.Catalog.Feature');
+                    $this->translator->trans('Allow orders', [], 'Admin.Catalog.Feature') :
+                    $this->translator->trans('Deny orders', [], 'Admin.Catalog.Feature');
                 $defaultChoiceLabel .= ')';
 
                 $form->add(
                     'out_of_stock',
-                    'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+                    FormType\ChoiceType::class,
                     array(
                         'choices' => array(
-                            $this->translator->trans('Deny orders', array(), 'Admin.Catalog.Feature')  => '0',
-                            $this->translator->trans('Allow orders', array(), 'Admin.Catalog.Feature') => '1',
+                            $this->translator->trans('Deny orders', [], 'Admin.Catalog.Feature')  => '0',
+                            $this->translator->trans('Allow orders', [], 'Admin.Catalog.Feature') => '1',
                             $defaultChoiceLabel => '2',
                         ),
                         'expanded' => true,
                         'required' => false,
                         'placeholder'=> false,
-                        'label' => $this->translator->trans('When out of stock', array(), 'Admin.Catalog.Feature'),
+                        'label' => $this->translator->trans('When out of stock', [], 'Admin.Catalog.Feature'),
                     )
                 );
 
                 //Manage out_of_stock field with contextual values/label
                 $pack_stock_type = $this->configuration->get('PS_PACK_STOCK_TYPE');
-                $defaultChoiceLabel = $this->translator->trans('Default', array(), 'Admin.Global').': ';
+                $defaultChoiceLabel = $this->translator->trans('Default', [], 'Admin.Global').': ';
                 if ($pack_stock_type == Pack::STOCK_TYPE_PACK_ONLY) {
-                    $defaultChoiceLabel .= $this->translator->trans('Decrement pack only.', array(), 'Admin.Catalog.Feature');
+                    $defaultChoiceLabel .= $this->translator->trans(
+                        'Decrement pack only.',
+                        [],
+                        'Admin.Catalog.Feature'
+                    );
                 } elseif ($pack_stock_type == Pack::STOCK_TYPE_PRODUCTS_ONLY) {
-                    $defaultChoiceLabel .= $this->translator->trans('Decrement products in pack only.', array(), 'Admin.Catalog.Feature');
+                    $defaultChoiceLabel .= $this->translator->trans(
+                        'Decrement products in pack only.',
+                        [],
+                        'Admin.Catalog.Feature'
+                    );
                 } else {
-                    $defaultChoiceLabel .= $this->translator->trans('Decrement both.', array(), 'Admin.Catalog.Feature');
+                    $defaultChoiceLabel .= $this->translator->trans('Decrement both.', [], 'Admin.Catalog.Feature');
                 }
 
                 $form->add(
                     'pack_stock_type',
-                    'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+                    FormType\ChoiceType::class,
                     array(
                         'choices' => array(
-                            $this->translator->trans('Decrement pack only.', array(), 'Admin.Catalog.Feature') => '0',
-                            $this->translator->trans('Decrement products in pack only.', array(), 'Admin.Catalog.Feature') => '1',
-                            $this->translator->trans('Decrement both.', array(), 'Admin.Catalog.Feature')  => '2',
-                            $defaultChoiceLabel => '3',
+                            $this->translator->trans('Decrement pack only.', [], 'Admin.Catalog.Feature') => 0,
+                            $this->translator->trans('Decrement products in pack only.', [], 'Admin.Catalog.Feature') => 1,
+                            $this->translator->trans('Decrement both.', [], 'Admin.Catalog.Feature')  => 2,
+                            $defaultChoiceLabel => 3,
                         ),
                         'expanded' => false,
                         'required' => true,
                         'placeholder' => false,
-                        'label' => $this->translator->trans('Pack quantities', array(), 'Admin.Catalog.Feature'),
+                        'label' => $this->translator->trans('Pack quantities', [], 'Admin.Catalog.Feature'),
                     )
                 );
             }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
@@ -25,6 +25,8 @@
  */
 namespace PrestaShopBundle\Form\Admin\Product;
 
+use PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType;
+use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
@@ -67,86 +69,106 @@ class ProductSeo extends CommonAbstractType
             '302-category' => $this->router->generate('admin_get_ajax_categories').'&query=%QUERY',
         );
 
-        $builder->add('meta_title', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-            'options' => [
-                'attr' => [
-                    'placeholder' => $this->translator->trans('To have a different title from the product name, enter it here.', [], 'Admin.Catalog.Help'),
-                    'counter' => 70,
-                    'counter_type' => 'recommended',
+        $builder->add(
+            'meta_title',
+            PrestaShopBundle\Form\Admin\Type\TranslateType::class,
+            array(
+                'type' => FormType\TextType::class,
+                'options' => [
+                    'attr' => [
+                        'placeholder' => $this->translator->trans('To have a different title from the product name, enter it here.', [], 'Admin.Catalog.Help'),
+                        'counter' => 70,
+                        'counter_type' => 'recommended',
+                    ],
+                    'required' => false
+                ],
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'label' => $this->translator->trans('Meta title', [], 'Admin.Catalog.Feature'),
+                'label_attr' => [
+                    'popover' => $this->translator->trans('Public title for the product\'s page, and for search engines. Leave blank to use the product name. The number of remaining characters is displayed to the left of the field.', [], 'Admin.Catalog.Help'),
+                    'popover_placement' => 'right',
+                    'class' => 'px-0',
                 ],
                 'required' => false
-            ],
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'label' => $this->translator->trans('Meta title', [], 'Admin.Catalog.Feature'),
-            'label_attr' => [
-                'popover' => $this->translator->trans('Public title for the product\'s page, and for search engines. Leave blank to use the product name. The number of remaining characters is displayed to the left of the field.', [], 'Admin.Catalog.Help'),
-                'popover_placement' => 'right',
-                'class' => 'px-0',
-            ],
-            'required' => false
-        ))
-        ->add('meta_description', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType',
-            'options' => [
-                'attr' => [
-                    'placeholder' => $this->translator->trans('To have a different description than your product summary in search results pages, write it here.', [], 'Admin.Catalog.Help'),
-                    'counter' => 160,
-                    'counter_type' => 'recommended',
+            )
+        )
+        ->add(
+            'meta_description',
+            PrestaShopBundle\Form\Admin\Type\TranslateType::class,
+            array(
+                'type' => FormType\TextareaType::class,
+                'options' => [
+                    'attr' => [
+                        'placeholder' => $this->translator->trans('To have a different description than your product summary in search results pages, write it here.', [], 'Admin.Catalog.Help'),
+                        'counter' => 160,
+                        'counter_type' => 'recommended',
+                    ],
+                    'required' => false
+                ],
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'label' => $this->translator->trans('Meta description', [], 'Admin.Catalog.Feature'),
+                'label_attr' => [
+                    'popover' => $this->translator->trans('This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)', [], 'Admin.Catalog.Help'),
+                    'popover_placement' => 'right',
+                    'class' => 'px-0',
                 ],
                 'required' => false
-            ],
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'label' => $this->translator->trans('Meta description', [], 'Admin.Catalog.Feature'),
-            'label_attr' => [
-                'popover' => $this->translator->trans('This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)', [], 'Admin.Catalog.Help'),
-                'popover_placement' => 'right',
-                'class' => 'px-0',
-            ],
-            'required' => false
-        ))
-        ->add('link_rewrite', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-            'options' => [],
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'label' => $this->translator->trans('Friendly URL', [], 'Admin.Catalog.Feature'),
-        ))
-        ->add('redirect_type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices'  => array(
-                $this->translator->trans('No redirection (404)', [], 'Admin.Catalog.Feature') => '404',
-                $this->translator->trans('Permanent redirection to a product (301)', [], 'Admin.Catalog.Feature') => '301-product',
-                $this->translator->trans('Temporary redirection to a product (302)', [], 'Admin.Catalog.Feature') => '302-product',
-                $this->translator->trans('Permanent redirection to a category (301)', [], 'Admin.Catalog.Feature') => '301-category',
-                $this->translator->trans('Temporary redirection to a category (302)', [], 'Admin.Catalog.Feature') => '302-category',
-            ),
-            'choice_attr' => function ($val, $key, $index) use ($remoteUrls) {
-                if (array_key_exists($index, $remoteUrls)) {
-                    return ['data-remoteurl' => $remoteUrls[$index]];
-                }
-                return [];
-            },
-            'required' => true,
-            'label' => $this->translator->trans('Redirection when offline', [], 'Admin.Catalog.Feature'),
-            'attr' => array(
-                'data-labelproduct' => $this->translator->trans('Target product', [], 'Admin.Catalog.Feature'),
-                'data-placeholderproduct' => $this->translator->trans('To which product the page should redirect?', [], 'Admin.Catalog.Help'),
-                'data-labelcategory' => $this->translator->trans('Target category', [], 'Admin.Catalog.Feature'),
-                'data-placeholdercategory' => $this->translator->trans('To which category the page should redirect?', [], 'Admin.Catalog.Help'),
-            ),
-        ))
-        ->add('id_type_redirected', 'PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType', array(
-            'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
-            'mapping_value' => 'id',
-            'mapping_name' => 'name',
-            'mapping_type' => $options['mapping_type'],
-            'template_collection' => '<span class="label">%s</span><i class="material-icons delete">clear</i>',
-            'limit' => 1,
-            'required' => false,
-            'label' => $this->translator->trans('Target', [], 'Admin.Catalog.Feature'),
-        ));
+            )
+        )
+        ->add(
+            'link_rewrite',
+            PrestaShopBundle\Form\Admin\Type\TranslateType::class,
+            array(
+                'type' => FormType\TextType::class,
+                'options' => [],
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'label' => $this->translator->trans('Friendly URL', [], 'Admin.Catalog.Feature'),
+            )
+        )
+        ->add(
+            'redirect_type',
+            FormType\ChoiceType::class,
+            array(
+                'choices'  => array(
+                    $this->translator->trans('No redirection (404)', [], 'Admin.Catalog.Feature') => '404',
+                    $this->translator->trans('Permanent redirection to a product (301)', [], 'Admin.Catalog.Feature') => '301-product',
+                    $this->translator->trans('Temporary redirection to a product (302)', [], 'Admin.Catalog.Feature') => '302-product',
+                    $this->translator->trans('Permanent redirection to a category (301)', [], 'Admin.Catalog.Feature') => '301-category',
+                    $this->translator->trans('Temporary redirection to a category (302)', [], 'Admin.Catalog.Feature') => '302-category',
+                ),
+                'choice_attr' => function ($val, $key, $index) use ($remoteUrls) {
+                    if (array_key_exists($index, $remoteUrls)) {
+                        return ['data-remoteurl' => $remoteUrls[$index]];
+                    }
+                    return [];
+                },
+                'required' => true,
+                'label' => $this->translator->trans('Redirection when offline', [], 'Admin.Catalog.Feature'),
+                'attr' => array(
+                    'data-labelproduct' => $this->translator->trans('Target product', [], 'Admin.Catalog.Feature'),
+                    'data-placeholderproduct' => $this->translator->trans('To which product the page should redirect?', [], 'Admin.Catalog.Help'),
+                    'data-labelcategory' => $this->translator->trans('Target category', [], 'Admin.Catalog.Feature'),
+                    'data-placeholdercategory' => $this->translator->trans('To which category the page should redirect?', [], 'Admin.Catalog.Help'),
+                ),
+            )
+        )
+        ->add(
+            'id_type_redirected',
+            TypeaheadProductCollectionType::class,
+            array(
+                'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
+                'mapping_value' => 'id',
+                'mapping_name' => 'name',
+                'mapping_type' => $options['mapping_type'],
+                'template_collection' => '<span class="label">%s</span><i class="material-icons delete">clear</i>',
+                'limit' => 1,
+                'required' => false,
+                'label' => $this->translator->trans('Target', [], 'Admin.Catalog.Feature'),
+            )
+        );
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
@@ -71,7 +71,7 @@ class ProductSeo extends CommonAbstractType
 
         $builder->add(
             'meta_title',
-            PrestaShopBundle\Form\Admin\Type\TranslateType::class,
+            TranslateType::class,
             array(
                 'type' => FormType\TextType::class,
                 'options' => [
@@ -95,7 +95,7 @@ class ProductSeo extends CommonAbstractType
         )
         ->add(
             'meta_description',
-            PrestaShopBundle\Form\Admin\Type\TranslateType::class,
+            TranslateType::class,
             array(
                 'type' => FormType\TextareaType::class,
                 'options' => [
@@ -119,7 +119,7 @@ class ProductSeo extends CommonAbstractType
         )
         ->add(
             'link_rewrite',
-            PrestaShopBundle\Form\Admin\Type\TranslateType::class,
+            TranslateType::class,
             array(
                 'type' => FormType\TextType::class,
                 'options' => [],

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -26,7 +26,9 @@
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 
@@ -55,8 +57,15 @@ class ProductShipping extends CommonAbstractType
         $this->locales = $this->legacyContext->getLanguages();
         $this->warehouses = $warehouseDataProvider->getWarehouses();
 
-        $carriers = $carrierDataProvider->getCarriers($this->locales[0]['id_lang'], false, false, false, null, $carrierDataProvider->getAllCarriersConstant());
-        $this->carriersChoices = array();
+        $carriers = $carrierDataProvider->getCarriers(
+            $this->locales[0]['id_lang'],
+            false,
+            false,
+            false,
+            null,
+            $carrierDataProvider->getAllCarriersConstant()
+        );
+        $this->carriersChoices = [];
         foreach ($carriers as $carrier) {
             $this->carriersChoices[$carrier['name'].' ('.$carrier['delay'].')'] = $carrier['id_reference'];
         }
@@ -69,107 +78,148 @@ class ProductShipping extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('width', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Width', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'numeric'))
-            )
-        ))
-        ->add('height', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Height', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'numeric'))
-            )
-        ))
-        ->add('depth', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Depth', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'numeric'))
-            )
-        ))
-        ->add('weight', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Weight', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'numeric'))
-            )
-        ))
-        ->add('additional_shipping_cost', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Shipping fees', array(), 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
-            )
-        ))
-        ->add('selectedCarriers', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices' =>  $this->carriersChoices,
-            'expanded' =>  true,
-            'multiple' =>  true,
-            'required' =>  false,
-            'label' => $this->translator->trans('Available carriers', array(), 'Admin.Catalog.Feature')
-        ))
-        ->add('additional_delivery_times', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices' =>  array(
-                '0' => $this->translator->trans('None', array(), 'Admin.Catalog.Feature'),
-                '1'   => $this->translator->trans('Default delivery time', array(), 'Admin.Catalog.Feature'),
-                '2'   => $this->translator->trans('Specific delivery time to this product', array(), 'Admin.Catalog.Feature'),
-            ),
-            'expanded' =>  true,
-            'multiple' =>  false,
-            'required' =>  false,
-            'preferred_choices' => array('default'),
-            'label' => $this->translator->trans('Delivery Time', array(), 'Admin.Catalog.Feature')
-        ))
-        ->add('delivery_out_stock', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-            'options' => array(
-                'attr' => array(
-                    'placeholder' => $this->translator->trans('Delivered within 5-7 days', array(), 'Admin.Catalog.Feature'),
+        $builder->add(
+            'width',
+            FormType\NumberType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Width', [], 'Admin.Catalog.Feature'),
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                    new Assert\Type(array('type' => 'numeric'))
                 )
-            ),
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'required' => false,
-            'label' => $this->translator->trans(
-                'Delivery time of out-of-stock products with allowed orders:',
-                array(),
-                'Admin.Catalog.Feature'
-            ),
-        ))
-        ->add('delivery_in_stock', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-            'options' => array(
-                'attr' => array(
-                    'placeholder' => $this->translator->trans('Delivered within 3-4 days', array(), 'Admin.Catalog.Feature'),
-                 )
-            ),
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'required' => false,
-            'label' => $this->translator->trans('Delivery time of in-stock products:', array(), 'Admin.Catalog.Feature'),
-        ));
+            )
+        )
+        ->add(
+            'height',
+            FormType\NumberType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Height', [], 'Admin.Catalog.Feature'),
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                    new Assert\Type(array('type' => 'numeric'))
+                )
+            )
+        )
+        ->add(
+            'depth',
+            FormType\NumberType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Depth', [], 'Admin.Catalog.Feature'),
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                    new Assert\Type(array('type' => 'numeric'))
+                )
+            )
+        )
+        ->add(
+            'weight',
+            FormType\NumberType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Weight', [], 'Admin.Catalog.Feature'),
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                    new Assert\Type(array('type' => 'numeric'))
+                )
+            )
+        )
+        ->add(
+            'additional_shipping_cost',
+            FormType\MoneyType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Shipping fees', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                    new Assert\Type(array('type' => 'float'))
+                )
+            )
+        )
+        ->add(
+            'selectedCarriers',
+            FormType\ChoiceType::class,
+            array(
+                'choices' =>  $this->carriersChoices,
+                'expanded' =>  true,
+                'multiple' =>  true,
+                'required' =>  false,
+                'label' => $this->translator->trans('Available carriers', [], 'Admin.Catalog.Feature')
+            )
+        )
+        ->add(
+            'additional_delivery_times',
+            FormType\ChoiceType::class,
+            array(
+                'choices' =>  array(
+                    $this->translator->trans('None', [], 'Admin.Catalog.Feature') => 0,
+                    $this->translator->trans('Default delivery time', [], 'Admin.Catalog.Feature') => 1,
+                    $this->translator->trans('Specific delivery time to this product', [], 'Admin.Catalog.Feature') => 2,
+                ),
+                'expanded' =>  true,
+                'multiple' =>  false,
+                'required' =>  false,
+                'placeholder' => null,
+                'preferred_choices' => array('default'),
+                'label' => $this->translator->trans('Delivery Time', [], 'Admin.Catalog.Feature'),
+            )
+        )
+        ->add(
+            'delivery_out_stock',
+            TranslateType::class,
+            array(
+                'type' => FormType\TextType::class,
+                'options' => array(
+                    'attr' => array(
+                        'placeholder' => $this->translator->trans('Delivered within 5-7 days', [], 'Admin.Catalog.Feature'),
+                    )
+                ),
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'required' => false,
+                'label' => $this->translator->trans(
+                    'Delivery time of out-of-stock products with allowed orders:',
+                    [],
+                    'Admin.Catalog.Feature'
+                ),
+            )
+        )
+        ->add(
+            'delivery_in_stock',
+            TranslateType::class,
+            array(
+                'type' => FormType\TextType::class,
+                'options' => array(
+                    'attr' => array(
+                        'placeholder' => $this->translator->trans('Delivered within 3-4 days', [], 'Admin.Catalog.Feature'),
+                    )
+                ),
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'required' => false,
+                'label' => $this->translator->trans('Delivery time of in-stock products:', [], 'Admin.Catalog.Feature'),
+            )
+        );
 
 
         foreach ($this->warehouses as $warehouse) {
-            $builder->add('warehouse_combination_'.$warehouse['id_warehouse'], 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
-                'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductWarehouseCombination',
-                'entry_options' => array(
-                    'id_warehouse' => $warehouse['id_warehouse'],
-                ),
-                'prototype' => true,
-                'allow_add' => true,
-                'required' => false,
-                'label' => $warehouse['name'],
-            ));
+            $builder->add(
+                'warehouse_combination_'.$warehouse['id_warehouse'],
+                CollectionType::class,
+                [
+                    'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductWarehouseCombination',
+                    'entry_options' => [
+                        'id_warehouse' => $warehouse['id_warehouse'],
+                    ],
+                    'prototype' => true,
+                    'allow_add' => true,
+                    'required' => false,
+                    'label' => $warehouse['name'],
+                ]
+            );
         }
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -26,10 +26,13 @@
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use PrestaShopBundle\Form\Admin\Type\TypeaheadCustomerCollectionType;
+use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * This form class is responsible to generate the basic product specific prices form.
@@ -55,16 +58,30 @@ class ProductSpecificPrice extends CommonAbstractType
      * @param object $groupDataprovider
      * @param object $legacyContext
      */
-    public function __construct($router, $translator, $shopContextAdapter, $countryDataprovider, $currencyDataprovider, $groupDataprovider, $legacyContext, $customerDataprovider)
-    {
+    public function __construct(
+        $router,
+        $translator,
+        $shopContextAdapter,
+        $countryDataprovider,
+        $currencyDataprovider,
+        $groupDataprovider,
+        $legacyContext,
+        $customerDataprovider
+    ) {
         $this->router = $router;
         $this->translator = $translator;
         $this->context = $legacyContext;
         $this->locales = $legacyContext->getLanguages();
         $this->shops = $this->formatDataChoicesList($shopContextAdapter->getShops(), 'id_shop');
-        $this->countries = $this->formatDataChoicesList($countryDataprovider->getCountries($this->locales[0]['id_lang']), 'id_country');
+        $this->countries = $this->formatDataChoicesList(
+            $countryDataprovider->getCountries($this->locales[0]['id_lang']),
+            'id_country'
+        );
         $this->currencies = $this->formatDataChoicesList($currencyDataprovider->getCurrencies(), 'id_currency');
-        $this->groups = $this->formatDataChoicesList($groupDataprovider->getGroups($this->locales[0]['id_lang']), 'id_group');
+        $this->groups = $this->formatDataChoicesList(
+            $groupDataprovider->getGroups($this->locales[0]['id_lang']),
+            'id_group'
+        );
         $this->currency = $legacyContext->getContext()->currency;
         $this->customerDataprovider = $customerDataprovider;
     }
@@ -79,122 +96,190 @@ class ProductSpecificPrice extends CommonAbstractType
         //If context multi-shop, hide shop selector
         //Else show selector
         if (count($this->shops) == 1) {
-            $builder->add('sp_id_shop', 'Symfony\Component\Form\Extension\Core\Type\HiddenType', array(
-                'required' => false,
-            ));
+            $builder->add(
+                'sp_id_shop',
+                FormType\HiddenType::class,
+                array(
+                    'required' => false,
+                )
+            );
         } else {
-            $builder->add('sp_id_shop', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-                'choices' => $this->shops,
-                'required' => false,
-                'label' => false,
-                'placeholder' => $this->translator->trans('All shops', array(), 'Admin.Global'),
-            ));
+            $builder->add(
+                'sp_id_shop',
+                FormType\ChoiceType::class,
+                array(
+                    'choices' => $this->shops,
+                    'required' => false,
+                    'label' => false,
+                    'placeholder' => $this->translator->trans('All shops', array(), 'Admin.Global'),
+                )
+            );
         }
 
-        $builder->add('sp_id_currency', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices' => $this->currencies,
-            'required' => false,
-            'label' => false,
-            'attr' => array(
-                'data-toggle' => 'select2',
-                'data-minimumResultsForSearch' => '7',
-            ),
-            'placeholder' => $this->translator->trans('All currencies', array(), 'Admin.Global'),
-        ))
-        ->add('sp_id_country', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices' => $this->countries,
-            'required' => false,
-            'label' => false,
-            'attr' => array(
-                'data-toggle' => 'select2',
-                'data-minimumResultsForSearch' => '7',
-            ),
-            'placeholder' => $this->translator->trans('All countries', array(), 'Admin.Global'),
-        ))
-        ->add('sp_id_group', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices' => $this->groups,
-            'required' => false,
-            'label' => false,
-            'attr' => array(
-                'data-toggle' => 'select2',
-                'data-minimumResultsForSearch' => '7',
-            ),
-            'placeholder' => $this->translator->trans('All groups', array(), 'Admin.Global'),
-        ))
-        ->add('sp_id_customer', 'PrestaShopBundle\Form\Admin\Type\TypeaheadCustomerCollectionType', array(
-            'remote_url' => $this->context->getAdminLink('AdminCustomers', true).'&sf2=1&ajax=1&tab=AdminCustomers&action=searchCustomers&customer_search=%QUERY',
-            'mapping_value' => 'id_customer',
-            'mapping_name' => 'fullname_and_email',
-            'placeholder' => $this->translator->trans('All customers', array(), 'Admin.Global'),
-            'template_collection' => '<div class="media-body"><div class="label">%s</div><i class="material-icons delete">clear</i></div>',
-            'limit' => 1,
-            'required' => false,
-            'label' => $this->translator->trans('Add customer', array(), 'Admin.Catalog.Feature'),
-        ))
-        ->add('sp_id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices' => array(),
-            'required' => false,
-            'placeholder' => $this->translator->trans('Apply to all combinations', array(), 'Admin.Catalog.Feature'),
-            'label' => $this->translator->trans('Combinations', array(), 'Admin.Catalog.Feature'),
-            'attr' => array('data-action' => $this->router->generate('admin_get_product_combinations', ['idProduct' => 1])),
-        ))
-        ->add('sp_from', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Available from', array(), 'Admin.Catalog.Feature'),
-            'attr' => array('placeholder' => 'YYYY-MM-DD'),
-        ))
-        ->add('sp_to', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
-            'required' => false,
-            'label' => $this->translator->trans('to', array(), 'Admin.Global'),
-            'attr' => array('placeholder' => 'YYYY-MM-DD'),
-        ))
-        ->add('sp_from_quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Starting at', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\Type(array('type' => 'numeric')),
-            ),
-        ))
-        ->add('sp_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Product price (tax excl.)', array(), 'Admin.Catalog.Feature'),
-            'attr' => array('class' => 'price'),
-            'currency' => $this->currency->iso_code,
-            'disabled' => true,
-        ))
-        ->add('leave_bprice', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-            'label' => $this->translator->trans('Leave initial price', array(), 'Admin.Catalog.Feature'),
-            'required' => false,
-        ))
-        ->add('sp_reduction', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'label' => $this->translator->trans('Reduction', array(), 'Admin.Catalog.Feature'),
-            'required' => false,
-            'currency' => $this->currency->iso_code,
-        ))
-        ->add('sp_reduction_type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'label' => $this->translator->trans('Reduction type', array(), 'Admin.Catalog.Feature'),
-            'choices' => array(
-                '€' => 'amount',
-                 $this->translator->trans('%', array(), 'Admin.Global') => 'percentage',
-            ),
-            'required' => true,
-        ))
-        ->add('sp_reduction_tax', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'label' => $this->translator->trans('Reduction tax', array(), 'Admin.Catalog.Feature'),
-            'choices' => array(
-                $this->translator->trans('Tax excluded', array(), 'Admin.Catalog.Feature') => '0',
-                $this->translator->trans('Tax included', array(), 'Admin.Catalog.Feature') => '1',
-            ),
-            'required' => true,
-        ))
-        ->add('save', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
-            'label' => $this->translator->trans('Apply', array(), 'Admin.Actions'),
-            'attr' => array('class' => 'btn-outline-primary js-save'),
-        ))
-        ->add('cancel', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
-            'label' => $this->translator->trans('Cancel', array(), 'Admin.Actions'),
-            'attr' => array('class' => 'btn-outline-secondary js-cancel'),
-        ));
+        $builder->add(
+            'sp_id_currency',
+            FormType\ChoiceType::class,
+            array(
+                'choices' => $this->currencies,
+                'required' => false,
+                'label' => false,
+                'attr' => array(
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ),
+                'placeholder' => $this->translator->trans('All currencies', array(), 'Admin.Global'),
+            )
+        )
+        ->add(
+            'sp_id_country',
+            FormType\ChoiceType::class,
+            array(
+                'choices' => $this->countries,
+                'required' => false,
+                'label' => false,
+                'attr' => array(
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ),
+                'placeholder' => $this->translator->trans('All countries', array(), 'Admin.Global'),
+            )
+        )
+        ->add(
+            'sp_id_group',
+            FormType\ChoiceType::class,
+            array(
+                'choices' => $this->groups,
+                'required' => false,
+                'label' => false,
+                'attr' => array(
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ),
+                'placeholder' => $this->translator->trans('All groups', array(), 'Admin.Global'),
+            )
+        )
+        ->add(
+            'sp_id_customer',
+            TypeaheadCustomerCollectionType::class,
+            array(
+                'remote_url' => $this->context->getAdminLink('AdminCustomers', true).'&sf2=1&ajax=1&tab=AdminCustomers&action=searchCustomers&customer_search=%QUERY',
+                'mapping_value' => 'id_customer',
+                'mapping_name' => 'fullname_and_email',
+                'placeholder' => $this->translator->trans('All customers', array(), 'Admin.Global'),
+                'template_collection' => '<div class="media-body"><div class="label">%s</div><i class="material-icons delete">clear</i></div>',
+                'limit' => 1,
+                'required' => false,
+                'label' => $this->translator->trans('Add customer', array(), 'Admin.Catalog.Feature'),
+            )
+        )
+        ->add(
+            'sp_id_product_attribute',
+            FormType\ChoiceType::class,
+            array(
+                'choices' => array(),
+                'required' => false,
+                'placeholder' => $this->translator->trans('Apply to all combinations', array(), 'Admin.Catalog.Feature'),
+                'label' => $this->translator->trans('Combinations', array(), 'Admin.Catalog.Feature'),
+                'attr' => array('data-action' => $this->router->generate('admin_get_product_combinations', ['idProduct' => 1])),
+            )
+        )
+        ->add(
+            'sp_from',
+            DatePickerType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Available from', array(), 'Admin.Catalog.Feature'),
+                'attr' => array('placeholder' => 'YYYY-MM-DD'),
+            )
+        )
+        ->add(
+            'sp_to',
+            DatePickerType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('to', array(), 'Admin.Global'),
+                'attr' => array('placeholder' => 'YYYY-MM-DD'),
+            )
+        )
+        ->add(
+            'sp_from_quantity',
+            FormType\NumberType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Starting at', array(), 'Admin.Catalog.Feature'),
+                'constraints' => array(
+                    new Assert\Type(array('type' => 'numeric')),
+                ),
+            )
+        )
+        ->add(
+            'sp_price',
+            FormType\MoneyType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('Product price (tax excl.)', array(), 'Admin.Catalog.Feature'),
+                'attr' => array('class' => 'price'),
+                'currency' => $this->currency->iso_code,
+                'disabled' => true,
+            )
+        )
+        ->add(
+            'leave_bprice',
+            FormType\CheckboxType::class,
+            array(
+                'label' => $this->translator->trans('Leave initial price', array(), 'Admin.Catalog.Feature'),
+                'required' => false,
+            )
+        )
+        ->add(
+            'sp_reduction',
+            FormType\MoneyType::class,
+            array(
+                'label' => $this->translator->trans('Reduction', array(), 'Admin.Catalog.Feature'),
+                'required' => false,
+                'currency' => $this->currency->iso_code,
+            )
+        )
+        ->add(
+            'sp_reduction_type',
+            FormType\ChoiceType::class,
+            array(
+                'label' => $this->translator->trans('Reduction type', array(), 'Admin.Catalog.Feature'),
+                'choices' => array(
+                    '€' => 'amount',
+                    $this->translator->trans('%', array(), 'Admin.Global') => 'percentage',
+                ),
+                'required' => true,
+            )
+        )
+        ->add(
+            'sp_reduction_tax',
+            FormType\ChoiceType::class,
+            array(
+                'label' => $this->translator->trans('Reduction tax', array(), 'Admin.Catalog.Feature'),
+                'choices' => array(
+                    $this->translator->trans('Tax excluded', array(), 'Admin.Catalog.Feature') => '0',
+                    $this->translator->trans('Tax included', array(), 'Admin.Catalog.Feature') => '1',
+                ),
+                'required' => true,
+            )
+        )
+        ->add(
+            'save',
+            FormType\ButtonType::class,
+            array(
+                'label' => $this->translator->trans('Apply', array(), 'Admin.Actions'),
+                'attr' => array('class' => 'btn-outline-primary js-save'),
+            )
+        )
+        ->add(
+            'cancel',
+            FormType\ButtonType::class,
+            array(
+                'label' => $this->translator->trans('Cancel', array(), 'Admin.Actions'),
+                'attr' => array('class' => 'btn-outline-secondary js-cancel'),
+            )
+        );
         //
         // ResetType can't be used because the product page is wrapped
         // inside a big form: reset a specific price form the "right" way
@@ -211,10 +296,14 @@ class ProductSpecificPrice extends CommonAbstractType
             $form = $event->getForm();
 
             //bypass SF validation, define submitted value in choice list
-            $form->add('sp_id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-                'choices' => array($data['sp_id_product_attribute'] => ''),
-                'required' => false,
-            ));
+            $form->add(
+                'sp_id_product_attribute',
+                FormType\ChoiceType::class,
+                array(
+                    'choices' => array($data['sp_id_product_attribute'] => ''),
+                    'required' => false,
+                )
+            );
         });
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
@@ -61,27 +61,39 @@ class ProductSupplierCombination extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('supplier_reference', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'required' => false,
-            'label' => null
-        ))
-        ->add('product_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
+        $builder->add(
+            'supplier_reference',
+            FormType\TextType::class,
+            array(
+                'required' => false,
+                'label' => null
             )
-        ))
-        ->add('product_price_currency', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices'  => $this->formatDataChoicesList($this->currencyAdapter->getCurrencies(), 'id_currency'),
-            'required' => true,
-            'attr' => array(
-                'class' => 'custom-select',
-            ),
-        ))
-        ->add('id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
-        ->add('product_id', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
-        ->add('supplier_id', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
+        )
+        ->add(
+            'product_price',
+            FormType\MoneyType::class,
+            array(
+                'required' => false,
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                    new Assert\Type(array('type' => 'float'))
+                )
+            )
+        )
+        ->add(
+            'product_price_currency',
+            FormType\ChoiceType::class,
+            array(
+                'choices'  => $this->formatDataChoicesList($this->currencyAdapter->getCurrencies(), 'id_currency'),
+                'required' => true,
+                'attr' => array(
+                    'class' => 'custom-select',
+                ),
+            )
+        )
+        ->add('id_product_attribute', FormType\HiddenType::class)
+        ->add('product_id', FormType\HiddenType::class)
+        ->add('supplier_id', FormType\HiddenType::class);
 
         //set default minimal values for collection prototype
         $builder->setData([

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
@@ -26,6 +26,7 @@
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Form\FormEvents;
@@ -62,51 +63,79 @@ class ProductVirtual extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('is_virtual_file', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices'  => array(
-                $this->translator->trans('Yes', [], 'Admin.Global') => 1,
-                $this->translator->trans('No', [], 'Admin.Global') => 0,
-            ),
-            'expanded' => true,
-            'required' => true,
-            'multiple' => false,
-        ))
-        ->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType', array(
-            'required' => false,
-            'label' => $this->translator->trans('File', [], 'Admin.Global'),
-            'constraints' => array(
-                new Assert\File(array('maxSize' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE').'M')),
+        $builder->add(
+            'is_virtual_file',
+            FormType\ChoiceType::class,
+            array(
+                'choices'  => array(
+                    $this->translator->trans('Yes', [], 'Admin.Global') => 1,
+                    $this->translator->trans('No', [], 'Admin.Global') => 0,
+                ),
+                'expanded' => true,
+                'required' => true,
+                'multiple' => false,
             )
-        ))
-        ->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'label'    => $this->translator->trans('Filename', [], 'Admin.Global'),
-            'constraints' => array(
-                new Assert\NotBlank(),
-            ),
-        ))
-        ->add('nb_downloadable', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'label'    => $this->translator->trans('Number of allowed downloads', [], 'Admin.Catalog.Feature'),
-            'required' => false,
-            'constraints' => array(
-                new Assert\Type(array('type' => 'numeric')),
-            ),
-        ))
-        ->add('expiration_date', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
-            'label'    => $this->translator->trans('Expiration date', [], 'Admin.Catalog.Feature'),
-            'required' => false,
-            'attr' => ['placeholder' => 'YYYY-MM-DD']
-        ))
-        ->add('nb_days', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'label'    => $this->translator->trans('Number of days', [], 'Admin.Catalog.Feature'),
-            'required' => false,
-            'constraints' => array(
-                new Assert\Type(array('type' => 'numeric')),
+        )
+        ->add(
+            'file',
+            FormType\FileType::class,
+            array(
+                'required' => false,
+                'label' => $this->translator->trans('File', [], 'Admin.Global'),
+                'constraints' => array(
+                    new Assert\File(array('maxSize' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE').'M')),
+                )
             )
-        ))
-        ->add('save', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
-            'label' => $this->translator->trans('Save', [], 'Admin.Actions'),
-            'attr' => ['class' => 'btn-primary pull-right']
-        ));
+        )
+        ->add(
+            'name',
+            FormType\TextType::class,
+            array(
+                'label'    => $this->translator->trans('Filename', [], 'Admin.Global'),
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                ),
+            )
+        )
+        ->add(
+            'nb_downloadable',
+            FormType\NumberType::class,
+            array(
+                'label'    => $this->translator->trans('Number of allowed downloads', [], 'Admin.Catalog.Feature'),
+                'required' => false,
+                'constraints' => array(
+                    new Assert\Type(array('type' => 'numeric')),
+                ),
+            )
+        )
+        ->add(
+            'expiration_date',
+            DatePickerType::class,
+            array(
+                'label'    => $this->translator->trans('Expiration date', [], 'Admin.Catalog.Feature'),
+                'required' => false,
+                'attr' => ['placeholder' => 'YYYY-MM-DD']
+            )
+        )
+        ->add(
+            'nb_days',
+            FormType\NumberType::class,
+            array(
+                'label'    => $this->translator->trans('Number of days', [], 'Admin.Catalog.Feature'),
+                'required' => false,
+                'constraints' => array(
+                    new Assert\Type(array('type' => 'numeric')),
+                )
+            )
+        )
+        ->add(
+            'save',
+            FormType\ButtonType::class,
+            array(
+                'label' => $this->translator->trans('Save', [], 'Admin.Actions'),
+                'attr' => ['class' => 'btn-primary pull-right']
+            )
+        );
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $form = $event->getForm();
@@ -115,10 +144,10 @@ class ProductVirtual extends CommonAbstractType
             //if this partial form is submit from a parent form, disable it
             if ($form->getParent()) {
                 $event->setData([]);
-                $form->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('mapped' => false));
+                $form->add('name', FormType\TextType::class, array('mapped' => false));
             } elseif ($data['is_virtual_file'] == 0) {
                 //disable name mapping when is virtual not defined to yes
-                $form->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('mapped' => false));
+                $form->add('name', FormType\TextType::class, array('mapped' => false));
             }
         });
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
@@ -32,7 +32,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-
 /**
  * Displays a switch (ON / OFF by default)
  */

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
@@ -83,7 +83,7 @@
             {% if child.vars.value == 1 %}
               <div class="widget-radio-inline">
                 {{ form_widget(child) }}
-                <a href="{{ getAdminLink("AdminPPreferences") }}" class="btn sensitive px-0" target=_blank><i class="material-icons">open_in_new</i> {{ "edit"|trans({}, 'Admin.Catalog.Help') }}</a>
+                <a href="{{ path('admin_product_preferences') }}" class="btn sensitive px-0" target=_blank><i class="material-icons">open_in_new</i> {{ "edit"|trans({}, 'Admin.Catalog.Help') }}</a>
               </div>
             {% else %}
               {{ form_widget(child) }}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Fix error with label and placeholder in product page + code refactoring in forms.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5479
| How to test?  | In the product page in BO (shipping tab) check the delivery time's labels .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9044)
<!-- Reviewable:end -->
