### PR TITLE
Fix Drop-down Facets being Cleared by other Drop-down Facets [BOOM-5484]

### DIFF
--- a/themes/classic/templates/catalog/_partials/facets.tpl
+++ b/themes/classic/templates/catalog/_partials/facets.tpl
@@ -112,48 +112,57 @@
 
           {else}
 
-            {block name='facet_item_dropdown'}
-              <ul id="facet_{$_expand_id}" class="collapse{if !$_collapse} in{/if}">
-                <li>
-                  <div class="col-sm-12 col-xs-12 col-md-12 facet-dropdown dropdown">
-                    <a class="select-title" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                      {$active_found = false}
-                      <span>
-                        {foreach from=$facet.filters item="filter"}
-                          {if $filter.active}
-                            {$filter.label}
-                            {if $filter.magnitude}
-                              ({$filter.magnitude})
+            {$active_found = false}
+            {foreach from=$facet.filters item="filter"}
+                {if $filter.active}
+                    {$active_found = true}
+                    {break}
+                {/if}
+            {/foreach}
+            {if !$active_found}
+              {block name='facet_item_dropdown'}
+                <ul id="facet_{$_expand_id}" class="collapse{if !$_collapse} in{/if}">
+                  <li>
+                    <div class="col-sm-12 col-xs-12 col-md-12 facet-dropdown dropdown">
+                      <a class="select-title" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        {$active_found = false}
+                        <span>
+                          {foreach from=$facet.filters item="filter"}
+                            {if $filter.active}
+                              {$filter.label}
+                              {if $filter.magnitude}
+                                ({$filter.magnitude})
+                              {/if}
+                              {$active_found = true}
                             {/if}
-                            {$active_found = true}
+                          {/foreach}
+                          {if !$active_found}
+                            {l s='(no filter)' d='Shop.Theme.Global'}
+                          {/if}
+                        </span>
+                        <i class="material-icons float-xs-right">&#xE5C5;</i>
+                      </a>
+                      <div class="dropdown-menu">
+                        {foreach from=$facet.filters item="filter"}
+                          {if !$filter.active}
+                            <a
+                              rel="nofollow"
+                              href="{$filter.nextEncodedFacetsURL}"
+                              class="select-list"
+                            >
+                              {$filter.label}
+                              {if $filter.magnitude}
+                                ({$filter.magnitude})
+                              {/if}
+                            </a>
                           {/if}
                         {/foreach}
-                        {if !$active_found}
-                          {l s='(no filter)' d='Shop.Theme.Global'}
-                        {/if}
-                      </span>
-                      <i class="material-icons float-xs-right">&#xE5C5;</i>
-                    </a>
-                    <div class="dropdown-menu">
-                      {foreach from=$facet.filters item="filter"}
-                        {if !$filter.active}
-                          <a
-                            rel="nofollow"
-                            href="{$filter.nextEncodedFacetsURL}"
-                            class="select-list"
-                          >
-                            {$filter.label}
-                            {if $filter.magnitude}
-                              ({$filter.magnitude})
-                            {/if}
-                          </a>
-                        {/if}
-                      {/foreach}
+                      </div>
                     </div>
-                  </div>
-                </li>
-              </ul>
-            {/block}
+                  </li>
+                </ul>
+              {/block}
+            {/if}
 
           {/if}
         </section>


### PR DESCRIPTION
Workaround: Set MultipleSelectionAllowed to 'true' for drop down in 'ps_facetedsearch/src/Ps_FacetedsearchFiltersConverter.php' and  disable actual end-user Multi-Select on drop downs in 'themes/classic/templates/catalog/_partials/facet.tpl'
 
Fix Requires Pulls from Prestahop AND ps_facetedsearch development repos 

This is my first Pull Request (suggested in [BOOM-5484]) and I was not able to combine the 2 PRs into 1 PR (if it is possible from 2 different repos).

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?      | develop
| Description?  | Fix Drop-down Facets being Cleared by other Drop-down Facets [BOOM-5484] 
| Type?     | bug fix
| Category?    | FO
| BC breaks?   | No
| Deprecations?  | No
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | see [Boom-5484]
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9049)
<!-- Reviewable:end -->
