### PR TITLE
Fix HookConfigurator: Filter certain non-arrays from theme.yml

### DIFF
--- a/src/Core/Module/HookConfigurator.php
+++ b/src/Core/Module/HookConfigurator.php
@@ -59,6 +59,7 @@ class HookConfigurator
      */
     public function getThemeHooksConfiguration(array $hooks)
     {
+        $hooks = array_filter($hooks, "is_array");
         $uniqueModuleList = $this->getUniqueModuleToHookList($hooks);
         $currentHooks = $this->hookRepository->getDisplayHooksWithModules();
 

--- a/src/Core/Module/HookConfigurator.php
+++ b/src/Core/Module/HookConfigurator.php
@@ -59,7 +59,7 @@ class HookConfigurator
      */
     public function getThemeHooksConfiguration(array $hooks)
     {
-        $hooks = array_filter($hooks, "is_array");
+        $hooks = array_filter($hooks, 'is_array');
         $uniqueModuleList = $this->getUniqueModuleToHookList($hooks);
         $currentHooks = $this->hookRepository->getDisplayHooksWithModules();
 


### PR DESCRIPTION
Themes created with PrestaBuilder can lead to the following errors:

```
PHP Warning:  array_merge(): Argument #1 is not an array in /var/www/html/src/Core/Module/HookConfigurator.php on line 115
PHP Warning:  in_array() expects parameter 2 to be array, null given in /var/www/html/src/Core/Module/HookConfigurator.php on line 67
PHP Warning:  Invalid argument supplied for foreach() in /var/www/html/src/Core/Module/HookConfigurator.php on line 80
```

This is caused by certain empty properties in the related ``theme.yml``, which might look like this:

```
  hooks:
    modules_to_hook:
      ...
      displayFooterBefore:
        - ps_emailsubscription
        - ps_socialfollow
      displayAfterBodyOpeningTag:
      displayBeforeBodyClosingTag:
      displayFooter:
        - ps_linklist
      ...
```

This pull request fixes the issue by filtering the offending items from ``modules_to_hook``. 

Possibly related forum post: https://www.prestashop.com/forums/topic/667167-template-install-error/.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PrestaShop 1.7.3.1, PrestaBuilder Theme
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9050)
<!-- Reviewable:end -->
