### PR TITLE
Bad link in breadcrumbs in symfony pages

### DIFF
--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -3,21 +3,17 @@
 <div class="header-toolbar">
 
   {block name=pageBreadcrumb}
-    <nav class="breadcrumb">
-
+    <ol class="breadcrumb">
       {if $breadcrumbs2.container.name != ''}
-        {if $breadcrumbs2.container.href != ''}
-          <a class="breadcrumb-item" href="{$breadcrumbs2.container.href|escape}">{$breadcrumbs2.container.name|escape}</a>
-        {/if}
+        <li class="breadcrumb-item">{$breadcrumbs2.container.name|escape}</li>
       {/if}
 
-      {if $breadcrumbs2.tab.name != '' && $breadcrumbs2.container.name != $breadcrumbs2.tab.name}
-        {if $breadcrumbs2.tab.href != ''}
-          <a class="breadcrumb-item active" href="{$breadcrumbs2.tab.href|escape}">{$breadcrumbs2.tab.name|escape}</a>
-        {/if}
+      {if $breadcrumbs2.tab.name != '' && $breadcrumbs2.container.name != $breadcrumbs2.tab.name && $breadcrumbs2.tab.href != ''}
+        <li class="breadcrumb-item active">
+          <a href="{$breadcrumbs2.tab.href|escape}">{$breadcrumbs2.tab.name|escape}</a>
+        </li>
       {/if}
-
-    </nav>
+    </ol>
   {/block}
 
   {block name=pageTitle}

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -3,17 +3,19 @@
 <div class="header-toolbar">
 
   {block name=pageBreadcrumb}
-    <ol class="breadcrumb">
-      {if $breadcrumbs2.container.name != ''}
-        <li class="breadcrumb-item">{$breadcrumbs2.container.name|escape}</li>
-      {/if}
+    <nav>
+      <ol class="breadcrumb">
+        {if $breadcrumbs2.container.name != ''}
+          <li class="breadcrumb-item">{$breadcrumbs2.container.name|escape}</li>
+        {/if}
 
-      {if $breadcrumbs2.tab.name != '' && $breadcrumbs2.container.name != $breadcrumbs2.tab.name && $breadcrumbs2.tab.href != ''}
-        <li class="breadcrumb-item active">
-          <a href="{$breadcrumbs2.tab.href|escape}">{$breadcrumbs2.tab.name|escape}</a>
-        </li>
-      {/if}
-    </ol>
+        {if $breadcrumbs2.tab.name != '' && $breadcrumbs2.container.name != $breadcrumbs2.tab.name && $breadcrumbs2.tab.href != ''}
+          <li class="breadcrumb-item active">
+            <a href="{$breadcrumbs2.tab.href|escape}">{$breadcrumbs2.tab.name|escape}</a>
+          </li>
+        {/if}
+      </ol>
+    </nav>
   {/block}
 
   {block name=pageTitle}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Some pages migrated on symfony, have parent breadcrumbs who are returning 404
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5504
| How to test?  | Go to symfony pages and navigate with breadcrumb..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9051)
<!-- Reviewable:end -->
