### PR TITLE
Fix error populating tables when installing in Greek

### DIFF
--- a/install-dev/langs/el/data/cms.xml
+++ b/install-dev/langs/el/data/cms.xml
@@ -8,7 +8,7 @@
     <link_rewrite>delivery</link_rewrite>
   </cms>
   <cms id="Legal_Notice">
-    <meta_title>Ανακοίνωση νομικού περιεχομένου/meta_title>
+    <meta_title>Ανακοίνωση νομικού περιεχομένου</meta_title>
     <meta_description>Ανακοίνωση νομικού περιεχομένου</meta_description>
     <meta_keywords>notice, legal, credits</meta_keywords>
     <content>&lt;h2&gt;Legal&lt;/h2&gt;&lt;h3&gt;Credits&lt;/h3&gt;&lt;p&gt;Concept and production:&lt;/p&gt;&lt;p&gt;This Online store was created using &lt;a href="http://www.prestashop.com"&gt;Prestashop Shopping Cart Software&lt;/a&gt;,check out PrestaShop's &lt;a href="http://www.prestashop.com/blog/en/"&gt;ecommerce blog&lt;/a&gt; for news and advices about selling online and running your ecommerce website.&lt;/p&gt;</content>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Error populating tables during installation.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4340
| How to test?  | Install in greek, should be block at 36% or 39%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9052)
<!-- Reviewable:end -->
