### PR TITLE
Added missing use statment in AddonsCollection class

### DIFF
--- a/src/Core/Addon/AddonsCollection.php
+++ b/src/Core/Addon/AddonsCollection.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Addon;
 
 use PrestaShop\PrestaShop\Adapter\Module\Module as Addon;
 use ArrayAccess;
+use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 


### PR DESCRIPTION
I'm working on making new console commands and i faced the folowing error when i try to use an AddonCollection
![image](https://user-images.githubusercontent.com/7163132/39919589-627e4a7c-5514-11e8-99a5-ec60c049b2b8.png)

Adding the use statement fix this issue.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Add missing use for class PrestaShop\PrestaShop\Core\Addon\AddonsCollection
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9054)
<!-- Reviewable:end -->
