### PR TITLE
Deprecate polyfill function array_replace()

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -779,6 +779,36 @@ class ToolsCore
 
         return $price;
     }
+    
+    /**
+     * Implement array_replace for PHP <= 5.2
+     *
+     * @return array|mixed|null
+     *
+     * @deprecated since version 1.7.4.0, to be removed.
+     */
+    public static function array_replace()
+    {
+        Tools::displayAsDeprecated('Use PHP\'s array_replace() instead');
+        if (!function_exists('array_replace')) {
+            $args     = func_get_args();
+            $num_args = func_num_args();
+            $res      = array();
+            for ($i = 0; $i < $num_args; $i++) {
+                if (is_array($args[$i])) {
+                    foreach ($args[$i] as $key => $val) {
+                        $res[$key] = $val;
+                    }
+                } else {
+                    trigger_error(__FUNCTION__.'(): Argument #'.($i + 1).' is not an array', E_USER_WARNING);
+                    return null;
+                }
+            }
+            return $res;
+        } else {
+            return call_user_func_array('array_replace', func_get_args());
+        }
+    }
 
     /**
      *

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -781,33 +781,6 @@ class ToolsCore
     }
 
     /**
-     * Implement array_replace for PHP <= 5.2
-     *
-     * @return array|mixed|null
-     */
-    public static function array_replace()
-    {
-        if (!function_exists('array_replace')) {
-            $args     = func_get_args();
-            $num_args = func_num_args();
-            $res      = array();
-            for ($i = 0; $i < $num_args; $i++) {
-                if (is_array($args[$i])) {
-                    foreach ($args[$i] as $key => $val) {
-                        $res[$key] = $val;
-                    }
-                } else {
-                    trigger_error(__FUNCTION__.'(): Argument #'.($i + 1).' is not an array', E_USER_WARNING);
-                    return null;
-                }
-            }
-            return $res;
-        } else {
-            return call_user_func_array('array_replace', func_get_args());
-        }
-    }
-
-    /**
      *
      * Convert amount from a currency to an other currency automatically
      * @param float $amount

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -779,7 +779,7 @@ class ToolsCore
 
         return $price;
     }
-    
+
     /**
      * Implement array_replace for PHP <= 5.2
      *


### PR DESCRIPTION
Remove polyfill function Tools::array_replace() for PHP versions <= 5.2 since PHP 5.2 is no longer supported (according to https://www.prestashop.com/en/system-requirements)

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove polyfill function Tools::array_replace() for PHP versions <= 5.2 since PHP 5.2 is no longer supported (according to https://www.prestashop.com/en/system-requirements)
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no (but will log a message for every call of Tools::array_replace() function in production)
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | no additional tests needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9056)
<!-- Reviewable:end -->
