### PR TITLE
Removed call to Tools::array_replace()

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2312,7 +2312,7 @@ class CartCore extends ObjectModel
             $id_warehouse = 0;
             foreach ($warehouse_count_by_address[$product['id_address_delivery']] as $id_war => $val) {
                 if (array_key_exists((int)$id_war, $product['warehouse_list'])) {
-                    $product['carrier_list'] = Tools::array_replace($product['carrier_list'], Carrier::getAvailableCarrierList(new Product($product['id_product']), $id_war, $product['id_address_delivery'], null, $this));
+                    $product['carrier_list'] = array_replace($product['carrier_list'], Carrier::getAvailableCarrierList(new Product($product['id_product']), $id_war, $product['id_address_delivery'], null, $this));
                     if (!$id_warehouse) {
                         $id_warehouse = (int)$id_war;
                     }


### PR DESCRIPTION
Remove call to  polyfill Tools::array_replace()  (meant for PHP versions <= 5.2 )

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Removed call to  polyfill Tools::array_replace() (meant for PHP versions <= 5.2) 
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | no additional tests needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9056)
<!-- Reviewable:end -->