### PR TITLE
Fixed list of activated modules

### DIFF
--- a/src/PrestaShopBundle/Kernel/ModuleRepository.php
+++ b/src/PrestaShopBundle/Kernel/ModuleRepository.php
@@ -69,7 +69,7 @@ final class ModuleRepository
     {
         $paths = array();
         $modulesFiles = Finder::create()->directories()->in(__DIR__.'/../../../modules')->depth(0);
-        $activeModules = array_keys($this->getActiveModules());
+        $activeModules = $this->getActiveModules();
 
         foreach ($modulesFiles as $moduleFile) {
             if (in_array($moduleFile->getFilename(), $activeModules)) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | The list of active modules was wrong, this could make the override of templates enabled even on the modules not installed: annoying :)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Use [this module](https://github.com/PrestaShop/PrestaShop/files/1997910/module_inheritance.zip) and put it in `modules` folder **without** enable/install it. In develop branch, Product Catalog page is altered by this module... and in this patch it is not. This is the right behavior.


<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9064)
<!-- Reviewable:end -->
