### PR TITLE
Dispatcher: Get request URI from Symfony's Request

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -248,7 +248,7 @@ class DispatcherCore
     }
 
     /**
-     * Either sets a given request or creates one.
+     * Either sets a given request or a new one.
      *
      * @param SymfonyRequest|null $request
      */

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -397,11 +397,11 @@ class DispatcherCore
                                 include_once(_PS_OVERRIDE_DIR_ . "modules/{$tab->module}/controllers/admin/$controller_name.php");
                                 $controller_class = $controller_name . (
                                     strpos($controller_name,'Controller') ? 'Override' : 'ControllerOverride'
-                                    );
+                                );
                             } else {
                                 $controller_class = $controller_name . (
                                     strpos($controller_name, 'Controller') ? '' : 'Controller'
-                                    );
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Refactored method and mainly: get request URI from Symfony's request object. It's more reliable and future proof.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | -

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9065)
<!-- Reviewable:end -->
