### PR TITLE
Fix gift wrapping fees

### DIFF
--- a/src/Core/Cart/Fees.php
+++ b/src/Core/Cart/Fees.php
@@ -27,6 +27,8 @@
 namespace PrestaShop\PrestaShop\Core\Cart;
 
 use Cart;
+use Currency;
+use Tools;
 
 class Fees
 {
@@ -102,19 +104,19 @@ class Fees
         // wrapping fees
         if ($cart->gift) {
             $this->wrappingFees      = new AmountImmutable(
-                \Tools::convertPrice(
-                    \Tools::ps_round(
+                Tools::convertPrice(
+                    Tools::ps_round(
                         $cart->getGiftWrappingPrice(true),
                         $computePrecision
                     ),
-                    \Currency::getCurrencyInstance((int) $cart->id_currency)
+                    Currency::getCurrencyInstance((int) $cart->id_currency)
                 ),
-                \Tools::convertPrice(
-                    \Tools::ps_round(
+                Tools::convertPrice(
+                    Tools::ps_round(
                         $cart->getGiftWrappingPrice(false),
                         $computePrecision
                     ),
-                    \Currency::getCurrencyInstance((int) $cart->id_currency)
+                    Currency::getCurrencyInstance((int) $cart->id_currency)
                 )
             );
         } else {

--- a/src/Core/Cart/Fees.php
+++ b/src/Core/Cart/Fees.php
@@ -100,24 +100,27 @@ class Fees
         $this->finalShippingFees = clone($this->shippingFees);
 
         // wrapping fees
-        $this->wrappingFees      = new AmountImmutable(
-            \Tools::convertPrice(
-                \Tools::ps_round(
-                    $cart->getGiftWrappingPrice(true),
-                    $computePrecision
+        if ($cart->gift) {
+            $this->wrappingFees      = new AmountImmutable(
+                \Tools::convertPrice(
+                    \Tools::ps_round(
+                        $cart->getGiftWrappingPrice(true),
+                        $computePrecision
+                    ),
+                    \Currency::getCurrencyInstance((int) $cart->id_currency)
                 ),
-                \Currency::getCurrencyInstance((int) $cart->id_currency)
-            ),
-            \Tools::convertPrice(
-                \Tools::ps_round(
-                    $cart->getGiftWrappingPrice(false),
-                    $computePrecision
-                ),
-                \Currency::getCurrencyInstance((int) $cart->id_currency)
-            )
-        );
+                \Tools::convertPrice(
+                    \Tools::ps_round(
+                        $cart->getGiftWrappingPrice(false),
+                        $computePrecision
+                    ),
+                    \Currency::getCurrencyInstance((int) $cart->id_currency)
+                )
+            );
+        } else {
+            $this->wrappingFees      = new AmountImmutable();
+        }
         $this->finalWrappingFees = clone($this->wrappingFees);
-
         $this->isProcessed = true;
     }
 

--- a/tests/Unit/Core/Cart/Calculation/Products/CartGiftWrappingTest.php
+++ b/tests/Unit/Core/Cart/Calculation/Products/CartGiftWrappingTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Cart\Calculation\Products;
+
+use Tests\Unit\Core\Cart\Calculation\AbstractCartCalculationTest;
+use Configuration;
+
+class CartGiftWrappingTest extends AbstractCartCalculationTest
+{
+
+    const GIFT_WRAPPING_PRICE = 5.3;
+    protected $previousGiftWrapping;
+    protected $previousGiftWrappingPrice;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->previousGiftWrapping      = Configuration::get('PS_GIFT_WRAPPING');
+        $this->previousGiftWrappingPrice = Configuration::get('PS_GIFT_WRAPPING_PRICE');
+        Configuration::set('PS_GIFT_WRAPPING', true);
+        Configuration::set('PS_GIFT_WRAPPING_PRICE', static::GIFT_WRAPPING_PRICE);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        Configuration::set('PS_GIFT_WRAPPING', $this->previousGiftWrapping);
+        Configuration::set('PS_GIFT_WRAPPING_PRICE', $this->previousGiftWrappingPrice);
+    }
+
+    /**
+     * @dataProvider cartWithoutCartRulesProvider
+     */
+    public function testCartWithGiftWrapping($productData, $expectedTotal, $expectedTotalWithGiftWrapping)
+    {
+        $this->resetCart();
+        $this->addProductsToCart($productData);
+        $this->compareCartTotalTaxIncl($expectedTotal);
+        $this->cart->gift = true;
+        $this->compareCartTotalTaxIncl($expectedTotalWithGiftWrapping);
+    }
+
+    public function cartWithoutCartRulesProvider()
+    {
+        return [
+            'empty cart'                             => [
+                'products'      => [],
+                'expectedTotal' => 0,
+                'cartRules'     => [],
+            ],
+            'one product in cart, quantity 1'        => [
+                'products'                      => [1 => 1,],
+                'expectedTotal'                 => static::PRODUCT_FIXTURES[1]['price']
+                                                   + static::DEFAULT_SHIPPING_FEE + static::DEFAULT_WRAPPING_FEE,
+                'expectedTotalWithGiftWrapping' => static::PRODUCT_FIXTURES[1]['price']
+                                                   + static::DEFAULT_SHIPPING_FEE
+                                                   + static::DEFAULT_WRAPPING_FEE
+                                                   + static::GIFT_WRAPPING_PRICE,
+            ],
+            'one product in cart, quantity 3'        => [
+                'products'                      => [1 => 3,],
+                'expectedTotal'                 => 3 * static::PRODUCT_FIXTURES[1]['price']
+                                                   + static::DEFAULT_SHIPPING_FEE + static::DEFAULT_WRAPPING_FEE,
+                'expectedTotalWithGiftWrapping' => 3 * static::PRODUCT_FIXTURES[1]['price']
+                                                   + static::DEFAULT_SHIPPING_FEE
+                                                   + static::DEFAULT_WRAPPING_FEE
+                                                   + static::GIFT_WRAPPING_PRICE,
+            ],
+            '3 products in cart, several quantities' => [
+                'products'                      => [
+                    2 => 2,
+                    1 => 3,
+                    3 => 1,
+                ],
+                'expectedTotal'                 => 3 * static::PRODUCT_FIXTURES[1]['price']
+                                                   + 2 * static::PRODUCT_FIXTURES[2]['price']
+                                                   + static::PRODUCT_FIXTURES[3]['price']
+                                                   + static::DEFAULT_SHIPPING_FEE + static::DEFAULT_WRAPPING_FEE,
+                'expectedTotalWithGiftWrapping' => 3 * static::PRODUCT_FIXTURES[1]['price']
+                                                   + 2 * static::PRODUCT_FIXTURES[2]['price']
+                                                   + static::PRODUCT_FIXTURES[3]['price']
+                                                   + static::DEFAULT_SHIPPING_FEE
+                                                   + static::DEFAULT_WRAPPING_FEE
+                                                   + static::GIFT_WRAPPING_PRICE,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | fix gift wrapping fees added even if not checked
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5328
| How to test?  | Activate gift wrapping fees on BO. Check fees are not added on cart total when adding a product. Check gift wrapping fees are correctly added when checking the corresponding checkbox at the end of the cart process

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9069)
<!-- Reviewable:end -->
