### PR TITLE
Added $result (from facet) in hook filterProductSearch

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -374,6 +374,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
         }
 
         $searchVariables = array(
+            'result' => $result,
             'label' => $this->getListingLabel(),
             'products' => $products,
             'sort_orders' => $sort_orders,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | $result from facet has some interesting informations and this commit allows to use it in modules via a hook. Now for me, it's useful to display current Manufacturer present on the category page. And it's possible to display on the category page, present features or attributes and adding a nice presentation with icons, etc...
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Just use the hook `filterProductSearch` or `actionProductSearchAfter` and use the variable available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9079)
<!-- Reviewable:end -->
