### PR TITLE
Saved confirmation message isn't displayed anymore in translation page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -62,7 +62,7 @@ class TranslationsController extends FrameworkBundleAdminController
         foreach ($request->request->all() as $k => $p) {
             if (strstr($k, 'selected')) {
                 $k = 'selected';
-            } else if ('locale' === $k) {
+            } elseif ('locale' === $k) {
                 $translationService = $this->get('prestashop.service.translation');
                 $p = $translationService->langToLocale($p);
             }
@@ -86,17 +86,15 @@ class TranslationsController extends FrameworkBundleAdminController
             return $this->redirect('./admin-dev/index.php?controller=AdminTranslations');
         }
 
-        if (
-            !in_array(
-                $this->authorizationLevel($this::CONTROLLER_NAME),
-                array(
-                    PageVoter::LEVEL_READ,
-                    PageVoter::LEVEL_UPDATE,
-                    PageVoter::LEVEL_CREATE,
-                    PageVoter::LEVEL_DELETE,
-                )
+        if (!in_array(
+            $this->authorizationLevel(self::CONTROLLER_NAME),
+            array(
+                PageVoter::LEVEL_READ,
+                PageVoter::LEVEL_UPDATE,
+                PageVoter::LEVEL_CREATE,
+                PageVoter::LEVEL_DELETE,
             )
-        ) {
+        )) {
             return $this->redirect('admin_dashboard');
         }
 

--- a/src/PrestaShopBundle/Controller/Api/ApiController.php
+++ b/src/PrestaShopBundle/Controller/Api/ApiController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Api;
 
+use Exception;
 use PrestaShopBundle\Api\QueryParamsCollection;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -93,7 +94,7 @@ abstract class ApiController
         try {
             $cacheRefresh->addCacheClear();
             $cacheRefresh->execute();
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->container->get('logger')->error($exception->getMessage());
         }
     }
@@ -106,8 +107,11 @@ abstract class ApiController
      * @param array $headers
      * @return array
      */
-    protected function addAdditionalInfo(Request $request, QueryParamsCollection $queryParams = null, $headers = array())
-    {
+    protected function addAdditionalInfo(
+        Request $request,
+        QueryParamsCollection $queryParams = null,
+        $headers = array()
+    ) {
         $router = $this->container->get('router');
 
         $queryParamsArray = array();
@@ -115,12 +119,19 @@ abstract class ApiController
             $queryParamsArray = $queryParams->getQueryParams();
         }
 
-        $allParams = $allParamsWithoutPagination = array_merge($request->attributes->get('_route_params'), $queryParamsArray, $request->query->all());
+        $allParams = $allParamsWithoutPagination = array_merge(
+            $request->attributes->get('_route_params'),
+            $queryParamsArray,
+            $request->query->all()
+        );
         unset($allParamsWithoutPagination['page_index'], $allParamsWithoutPagination['page_size']);
 
         $info = array(
             'current_url' => $router->generate($request->attributes->get('_route'), $allParams),
-            'current_url_without_pagination' => $router->generate($request->attributes->get('_route'), $allParamsWithoutPagination)
+            'current_url_without_pagination' => $router->generate(
+                $request->attributes->get('_route'),
+                $allParamsWithoutPagination
+            )
         );
 
         if (array_key_exists('page_index', $allParams) && $allParams['page_index'] > 1) {
@@ -141,8 +152,7 @@ abstract class ApiController
             $info['next_url'] = $router->generate($request->attributes->get('_route'), $nextParams);
         }
 
-
-        if(array_key_exists('Total-Pages', $headers)) {
+        if (array_key_exists('Total-Pages', $headers)) {
             $info['total_page'] = $headers['Total-Pages'];
         }
 

--- a/src/PrestaShopBundle/Controller/Api/I18nController.php
+++ b/src/PrestaShopBundle/Controller/Api/I18nController.php
@@ -46,8 +46,7 @@ class I18nController extends ApiController
 
             try {
                 $translationClass = $this->container->get('prestashop.translation.api.'.$page);
-            }
-            catch (Exception $exception) {
+            } catch (Exception $exception) {
                 throw new BadRequestHttpException($exception->getMessage());
             }
         } catch (BadRequestHttpException $exception) {

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -71,7 +71,8 @@ class TranslationController extends ApiController
                 'Total-Pages' => ceil(count($catalog['data']) / $queryParams['page_size'])
             );
 
-            $catalog['info'] = array_merge($catalog['info'],
+            $catalog['info'] = array_merge(
+                $catalog['info'],
                 array(
                     'locale' => $locale,
                     'domain' => $domain,
@@ -94,7 +95,6 @@ class TranslationController extends ApiController
             );
 
             return $this->jsonResponse($catalog, $request, $queryParamsCollection, 200, $info);
-
         } catch (Exception $exception) {
             return $this->handleException(new BadRequestHttpException($exception->getMessage(), $exception));
         }
@@ -131,7 +131,6 @@ class TranslationController extends ApiController
             }
 
             return $this->jsonResponse($tree, $request);
-
         } catch (Exception $exception) {
             return $this->handleException(new BadRequestHttpException($exception->getMessage(), $exception));
         }
@@ -141,6 +140,7 @@ class TranslationController extends ApiController
      * Route to edit translation
      *
      * @param Request $request
+     *
      * @return JsonResponse
      */
     public function translationEditAction(Request $request)
@@ -152,8 +152,7 @@ class TranslationController extends ApiController
             $this->guardAgainstInvalidTranslationEditRequest($translations);
 
             $translationService = $this->container->get('prestashop.service.translation');
-            $response = array();
-
+            $response = [];
             foreach ($translations as $translation) {
                 if (!array_key_exists('theme', $translation)) {
                     $translation['theme'] = null;
@@ -198,7 +197,7 @@ class TranslationController extends ApiController
             $this->guardAgainstInvalidTranslationResetRequest($translations);
 
             $translationService = $this->container->get('prestashop.service.translation');
-            $response = array();
+            $response = [];
 
             foreach ($translations as $translation) {
                 if (!array_key_exists('theme', $translation)) {
@@ -238,7 +237,10 @@ class TranslationController extends ApiController
 
         $decodedContent = $this->guardAgainstInvalidJsonBody($content);
 
-        if (empty($decodedContent) || !array_key_exists('translations', $decodedContent) || !is_array($decodedContent['translations'])) {
+        if (empty($decodedContent) ||
+            !array_key_exists('translations', $decodedContent) ||
+            !is_array($decodedContent['translations'])
+        ) {
             $message = 'The request body should contain a JSON-encoded array of translations';
             throw new BadRequestHttpException(sprintf('Invalid JSON content (%s)', $message));
         }
@@ -269,7 +271,7 @@ class TranslationController extends ApiController
     /**
      * @param $content
      */
-    function guardAgainstInvalidTranslationResetRequest($content)
+    protected function guardAgainstInvalidTranslationResetRequest($content)
     {
         $message = 'Each item of JSON-encoded array in the request body should contain ' .
             'a "locale", a "domain" and a "default" values. '.

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -34,7 +34,7 @@ services:
     prestashop.cache.refresh:
         class: PrestaShopBundle\Service\Cache\Refresh
         arguments:
-            - "%kernel.environment%"
+            - "@kernel"
         calls:
             - [addCacheClear, []]
 

--- a/src/PrestaShopBundle/Service/Command/AbstractCommand.php
+++ b/src/PrestaShopBundle/Service/Command/AbstractCommand.php
@@ -42,10 +42,15 @@ abstract class AbstractCommand
      *
      * Construct the symfony environment.
      *
-     * @param string $env Environment to set.
+     * @param AppKernel $kernel Symfony Kernel
      */
-    public function __construct(AppKernel $kernel)
+    public function __construct(AppKernel $kernel = null)
     {
+        if (null === $kernel) {
+            require_once _PS_ROOT_DIR_.'/app/AppKernel.php';
+            $kernel = new AppKernel(_PS_MODE_DEV_ ? 'dev' : 'prod', false);
+        }
+
         $this->kernel = $kernel;
         $this->application = new Application($this->kernel);
         $this->application->setAutoExit(false);

--- a/src/PrestaShopBundle/Service/Command/AbstractCommand.php
+++ b/src/PrestaShopBundle/Service/Command/AbstractCommand.php
@@ -25,15 +25,17 @@
  */
 namespace PrestaShopBundle\Service\Command;
 
+use AppKernel;
+use Exception;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Input\ArrayInput;
 
 abstract class AbstractCommand
 {
-    private $env;
+    protected $kernel;
     protected $application;
-    protected $commands;
+    protected $commands = [];
 
     /**
      * Constructor.
@@ -42,30 +44,17 @@ abstract class AbstractCommand
      *
      * @param string $env Environment to set.
      */
-    public function __construct($env = null)
+    public function __construct(AppKernel $kernel)
     {
-        umask(0000);
-        set_time_limit(0);
-
-        if (null === $env) {
-            $this->env = _PS_MODE_DEV_ ? 'dev' : 'prod';
-        } else {
-            $this->env = $env;
-        }
-
-        $this->commands = array();
-
-        require_once _PS_ROOT_DIR_.'/app/AppKernel.php';
-
-        $kernel = new \AppKernel($this->env, false);
-        $this->application = new Application($kernel);
+        $this->kernel = $kernel;
+        $this->application = new Application($this->kernel);
         $this->application->setAutoExit(false);
     }
 
     /**
      * Execute all defined commands.
      *
-     * @throws \Exception if no command defined
+     * @throws Exception if no command defined
      */
     public function execute()
     {
@@ -73,7 +62,7 @@ abstract class AbstractCommand
         $commandOutput = array();
 
         if (empty($this->commands)) {
-            throw new \Exception('Error, you need to define at least one command');
+            throw new Exception('Error, you need to define at least one command');
         }
 
         foreach ($this->commands as $command) {

--- a/src/PrestaShopBundle/Service/Command/AbstractCommand.php
+++ b/src/PrestaShopBundle/Service/Command/AbstractCommand.php
@@ -46,6 +46,9 @@ abstract class AbstractCommand
      */
     public function __construct(AppKernel $kernel = null)
     {
+        umask(0000);
+        set_time_limit(0);
+
         if (null === $kernel) {
             require_once _PS_ROOT_DIR_.'/app/AppKernel.php';
             $kernel = new AppKernel(_PS_MODE_DEV_ ? 'dev' : 'prod', false);

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -26,13 +26,14 @@
 
 namespace PrestaShopBundle\Service;
 
+use Exception;
 use PrestaShopBundle\Entity\Translation;
 use PrestaShopBundle\Translation\Constraints\PassVsprintf;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Validator\Validation;
 
-class TranslationService {
-
+class TranslationService
+{
     /**
      * @var Container
      */
@@ -52,7 +53,7 @@ class TranslationService {
     /**
      * @param $locale
      * @return mixed
-     * @throws \Exception
+     * @throws Exception
      */
     public function findLanguageByLocale($locale)
     {
@@ -61,7 +62,7 @@ class TranslationService {
         $lang = $doctrine->getManager()->getRepository('PrestaShopBundle:Lang')->findOneByLocale($locale);
 
         if (!$lang) {
-            throw new \Exception('The language for this locale is not available');
+            throw new Exception('The language for this locale is not available');
         }
 
         return $lang;
@@ -69,7 +70,7 @@ class TranslationService {
 
     /**
      * @return mixed
-     * @throws \Exception
+     * @throws Exception
      */
     private function getLangToLocalesMapping()
     {
@@ -80,7 +81,7 @@ class TranslationService {
 
         $jsonLastErrorCode = json_last_error();
         if (JSON_ERROR_NONE !== $jsonLastErrorCode) {
-            throw new \Exception('The legacy to standard locales JSON could not be decoded', $jsonLastErrorCode);
+            throw new Exception('The legacy to standard locales JSON could not be decoded', $jsonLastErrorCode);
         }
 
         return $legacyToStandardLocales;
@@ -143,7 +144,8 @@ class TranslationService {
      * @param null $search
      * @return array
      */
-    public function listDomainTranslation($locale, $domain, $theme = null, $search = null){
+    public function listDomainTranslation($locale, $domain, $theme = null, $search = null)
+    {
         if (!empty($theme) && 'classic' !== $theme) {
             $translationProvider = $this->container->get('prestashop.translation.theme_provider');
             $translationProvider->setThemeName($theme);
@@ -151,7 +153,7 @@ class TranslationService {
             $translationProvider = $this->container->get('prestashop.translation.search_provider');
         }
 
-        if ('Messages' === $domain){
+        if ('Messages' === $domain) {
             $domain = 'messages';
         }
 
@@ -209,7 +211,8 @@ class TranslationService {
      * @param $data
      * @return bool
      */
-    private function dataContainsSearchWord($search, $data) {
+    private function dataContainsSearchWord($search, $data)
+    {
         if (is_string($search)) {
             $search = strtolower($search);
             return false !== strpos(strtolower($data['default']), $search) ||
@@ -293,7 +296,7 @@ class TranslationService {
             $entityManager->flush();
 
             $updatedTranslationSuccessfully = true;
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $logger->error($exception->getMessage());
         }
 
@@ -335,7 +338,7 @@ class TranslationService {
             $entityManager->flush();
 
             $resetTranslationSuccessfully = true;
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->container->get('logger')->error($exception->getMessage());
         }
 

--- a/tests/Integration/PrestaShopBundle/Controller/Api/ApiTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/ApiTestCase.php
@@ -74,7 +74,6 @@ abstract class ApiTestCase extends WebTestCase
         self::$container = null;
         self::$kernel = null;
         self::$client = null;
-
     }
 
     /**
@@ -227,7 +226,7 @@ abstract class ApiTestCase extends WebTestCase
      * @param $route
      * @param $params
      */
-    protected function assetOkRequest($route, $params)
+    protected function assertOkRequest($route, $params)
     {
         $route = $this->router->generate($route, $params);
         self::$client->request('GET', $route);

--- a/tests/Integration/PrestaShopBundle/Controller/Api/I18nControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/I18nControllerTest.php
@@ -51,7 +51,7 @@ class I18nControllerTest extends ApiTestCase
      */
     public function it_should_return_ok_response_when_requesting_list_of_translations($params)
     {
-        $this->assetOkRequest('api_i18n_translations_list', $params);
+        $this->assertOkRequest('api_i18n_translations_list', $params);
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
@@ -182,8 +182,7 @@ class StockManagementControllerTest extends ApiTestCase
         $routeName,
         $parameters = array(),
         $expectedTotalPages = null
-    )
-    {
+    ) {
         $route = $this->router->generate($routeName, $parameters);
         self::$client->request('GET', $route);
 

--- a/tests/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
@@ -68,7 +68,7 @@ class TranslationControllerTest extends ApiTestCase
      */
     public function it_should_return_ok_response_when_requesting_domain($params)
     {
-        $this->assetOkRequest('api_translation_domain_catalog', $params);
+        $this->assertOkRequest('api_translation_domain_catalog', $params);
     }
 
     /**
@@ -120,7 +120,7 @@ class TranslationControllerTest extends ApiTestCase
      */
     public function it_should_return_ok_response_when_requesting_domain_catalog($params)
     {
-        $this->assetOkRequest('api_translation_domains_tree', $params);
+        $this->assertOkRequest('api_translation_domains_tree', $params);
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
@@ -38,7 +38,9 @@ class TranslationControllerTest extends ApiTestCase
     {
         parent::setUp();
 
-        $cacheMock = $this->getMockBuilder('PrestaShopBundle\Service\Cache\Refresh')->getMock();
+        $cacheMock = $this->getMockBuilder('PrestaShopBundle\Service\Cache\Refresh')
+                   ->disableOriginalConstructor()
+                   ->getMock();
 
         $cacheMock
             ->method('execute')


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | When saving translations an error 500 is raised.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5539
| How to test?  | Save translations and watch http request in network tab (firebug / chrome)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9084)
<!-- Reviewable:end -->
