### PR TITLE
Fix template on attachment delete

### DIFF
--- a/admin-dev/themes/default/template/controllers/attachments/helpers/list/list_action_delete.tpl
+++ b/admin-dev/themes/default/template/controllers/attachments/helpers/list/list_action_delete.tpl
@@ -22,6 +22,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-<a href="{$href|escape:'html':'UTF-8'}"{if isset($confirm)} onclick="{if isset($product_attachements[$id_attachment|escape:'html':'UTF-8'])}if (attachments.confirmProductAttached('{$product_list[$id_attachment|escape:'html':'UTF-8']}')){ldelim}return true;{rdelim}else{ldelim}event.stopPropagation(); event.preventDefault();{rdelim};{else}return confirm('{$confirm}'){/if}"{/if} title="{$action|escape:'html':'UTF-8'}" class="delete">
+<a href="{$href|escape:'html':'UTF-8'}"{if isset($confirm)} onclick="{if isset($product_attachements[$id_attachment])}if (attachments.confirmProductAttached('{$product_attachements[$id_attachment|escape:'html':'UTF-8']}')){ldelim}return true;{rdelim}else{ldelim}event.stopPropagation(); event.preventDefault();{rdelim};{else}return confirm('{$confirm}'){/if}"{/if} title="{$action|escape:'html':'UTF-8'}" class="delete">
 	<i class="icon-trash"></i> {$action|escape:'html':'UTF-8'}
 </a>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | fix undefined index notice on attachment page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5543
| How to test?  | On BO : go to catalog > attachments. Add an attachment. The list page should not trigger error. You should be able to delete an attachment
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9086)
<!-- Reviewable:end -->
