### PR TITLE
Catch module theme installation error, add error message for invalid module

### DIFF
--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -276,8 +276,10 @@ class ModuleManager implements AddonManagerInterface
         if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
-                    'You are not allowed to uninstall this module.',
-                    array(),
+                    'You are not allowed to uninstall the module %module%.',
+                    array(
+                        '%module%' => $name
+                    ),
                     'Admin.Modules.Notification'));
         }
 
@@ -310,8 +312,10 @@ class ModuleManager implements AddonManagerInterface
         if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
-                    'You are not allowed to upgrade this module.',
-                    array(),
+                    'You are not allowed to upgrade the module %module%.',
+                    array(
+                        '%module%' => $name,
+                    ),
                     'Admin.Modules.Notification'));
         }
 
@@ -348,8 +352,10 @@ class ModuleManager implements AddonManagerInterface
         if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
-                    'You are not allowed to disable this module.',
-                    array(),
+                    'You are not allowed to disable the module %module%.',
+                    array(
+                        '%module%' => $name,
+                    ),
                     'Admin.Modules.Notification'));
         }
 
@@ -385,8 +391,10 @@ class ModuleManager implements AddonManagerInterface
         if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
-                    'You are not allowed to enable this module.',
-                    array(),
+                    'You are not allowed to enable the module %module%.',
+                    array(
+                        '%module%' => $name,
+                    ),
                     'Admin.Modules.Notification'));
         }
 
@@ -434,8 +442,10 @@ class ModuleManager implements AddonManagerInterface
         if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
-                    'You are not allowed to disable this module on mobile.',
-                    array(),
+                    'You are not allowed to disable the module %module% on mobile.',
+                    array(
+                        '%module%' => $name,
+                    ),
                     'Admin.Modules.Notification'));
         }
 
@@ -482,8 +492,10 @@ class ModuleManager implements AddonManagerInterface
         if (!$this->adminModuleProvider->isAllowedAccess(__FUNCTION__, $name)) {
             throw new Exception(
                 $this->translator->trans(
-                    'You are not allowed to enable this module on mobile.',
-                    array(),
+                    'You are not allowed to enable the module %module% on mobile.',
+                    array(
+                        '%module%' => $name,
+                    ),
                     'Admin.Modules.Notification'));
         }
 
@@ -514,8 +526,10 @@ class ModuleManager implements AddonManagerInterface
         if (!$this->adminModuleProvider->isAllowedAccess('install') || !$this->adminModuleProvider->isAllowedAccess('uninstall', $name)) {
             throw new Exception(
                 $this->translator->trans(
-                    'You are not allowed to reset this module.',
-                    array(),
+                    'You are not allowed to reset the module %module%.',
+                    array(
+                        '%module%' => $name,
+                    ),
                     'Admin.Modules.Notification'));
         }
 

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -606,9 +606,11 @@ class ModuleManager implements AddonManagerInterface
             $message = array_pop($errors);
         } else {
             // Invalid instance: Missing or with syntax error
-            $message = $this->translator->trans('The module is invalid and cannot be loaded.',
+            $message = $this->translator->trans(
+                'The module is invalid and cannot be loaded.',
                 array(),
-                'Admin.Modules.Notification');
+                'Admin.Modules.Notification'
+            );
         }
 
         if (empty($message)) {

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -590,6 +590,11 @@ class ModuleManager implements AddonManagerInterface
         if ($module->hasValidInstance()) {
             $errors = $module->getInstance()->getErrors();
             $message = array_pop($errors);
+        } else {
+            // Invalid instance: Missing or with syntax error
+            $message = $this->translator->trans('The module is invalid and cannot be loaded.',
+                array(),
+                'Admin.Modules.Notification');
         }
 
         if (empty($message)) {

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -285,15 +285,17 @@ class ThemeManager implements AddonManagerInterface
 
         foreach ($modules as $key => $moduleName) {
             if (!$moduleManager->isInstalled($moduleName)
-                && !$moduleManager->install($moduleName)) {
+                && !$moduleManager->install($moduleName)
+            ) {
                 throw new PrestaShopException(
-                    $this->translator->trans('Cannot %action% module %module%. %error_details%',
-                    array(
-                        '%action%' => 'install',
-                        '%module%' => $moduleName,
-                        '%error_details%' => $moduleManager->getError($moduleName),
-                    ),
-                    'Admin.Modules.Notification')
+                    $this->translator->trans(
+                        'Cannot %action% module %module%. %error_details%',
+                        array(
+                            '%action%' => 'install',
+                            '%module%' => $moduleName,
+                            '%error_details%' => $moduleManager->getError($moduleName),
+                        ),
+                        'Admin.Modules.Notification')
                 );
             }
             if (!$moduleManager->isEnabled($moduleName)) {

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -284,8 +284,17 @@ class ThemeManager implements AddonManagerInterface
         $moduleManager = $moduleManagerBuilder->build()->setActionParams(['confirmPrestaTrust' => true]);
 
         foreach ($modules as $key => $moduleName) {
-            if (!$moduleManager->isInstalled($moduleName)) {
-                $moduleManager->install($moduleName);
+            if (!$moduleManager->isInstalled($moduleName)
+                && !$moduleManager->install($moduleName)) {
+                throw new PrestaShopException(
+                    $this->translator->trans('Cannot %action% module %module%. %error_details%',
+                    array(
+                        '%action%' => 'install',
+                        '%module%' => $moduleName,
+                        '%error_details%' => $moduleManager->getError($moduleName),
+                    ),
+                    'Admin.Modules.Notification')
+                );
             }
             if (!$moduleManager->isEnabled($moduleName)) {
                 $moduleManager->enable($moduleName);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | <ul><li>If a module requested by a theme could not be installed, no error was thrown and the execution was going on. Enabling the same uninstalled module was failing and the message wasn't explicit enough.</li><li>A new error message has finally been added for invalid modules (missing or with a syntax error). Merchants will now get a specific error instead of the current "no more details provided" :raised_hands: )</li></ul>
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5480
| How to test?  | Install the theme provided in the forge issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9089)
<!-- Reviewable:end -->
