### PR TITLE
Fix phone fieldtype

### DIFF
--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -96,8 +96,7 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                     if ($this->country->need_zip_code) {
                         $formField->setRequired(true);
                     }
-                }
-                if ($field === 'phone') {
+                } elseif ($field === 'phone') {
                     $formField->setType('tel');
                 }
             } elseif (count($fieldParts) === 2) {

--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -97,6 +97,9 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                         $formField->setRequired(true);
                     }
                 }
+                if ($field === 'phone') {
+                    $formField->setType('tel');
+                }
             } elseif (count($fieldParts) === 2) {
                 list($entity, $entityField) = $fieldParts;
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the customer address form, the phone field should have the type set to 'tel'. This way, when completing the field on a smartphone, a specific phone keyboard will be used, making the input of the phone easier.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5577
| How to test?  |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9097)
<!-- Reviewable:end -->
