### PR TITLE
Follow-up to: display GDPR consent checkbox in contactform

### DIFF
--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -109,6 +109,14 @@
           </div>
         </div>
 
+        {if isset($id_module)}
+          <div class="form-group row">
+            <div class="offset-md-3">
+              {hook h='displayGDPRConsent' id_module=$id_module}
+            </div>
+          </div>
+        {/if}
+
       </section>
 
       <footer class="form-footer text-sm-right">


### PR DESCRIPTION
This is a follow-up to adjust the classic theme to the change suggested in https://github.com/PrestaShop/contactform/pull/21

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.3.x
| Description?  | Display a GDPR consent checkbox in the contactform module. This is a follow-up to adapt the classic theme to a suggested change in the contactform module https://github.com/PrestaShop/contactform/pull/21 
| Type?         | new feature
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Install module psgdpr and update contactform module so that it contains the changes in https://github.com/PrestaShop/contactform/pull/21. Upon activating the GDPR consent checkbox for contactform on the configuration page of psgdpr module, the contactform should display a (required) consent checkbox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9099)
<!-- Reviewable:end -->
