### PR TITLE
Add compliance to GDPR law for blocknewsletter, contact form and mail alerts

### DIFF
--- a/themes/default-bootstrap/contact-form.tpl
+++ b/themes/default-bootstrap/contact-form.tpl
@@ -143,7 +143,7 @@
 						<label for="message">{l s='Message'}</label>
 						<textarea class="form-control" id="message" name="message">{if isset($message)}{$message|escape:'html':'UTF-8'|stripslashes}{/if}</textarea>
 					</div>
-					{hook h='displayGDPRConsent' contactForm='contactForm'}
+					{hook h='displayGDPRConsent' moduleName='contactform'}
 				</div>
 			</div>
 			<div class="submit">

--- a/themes/default-bootstrap/contact-form.tpl
+++ b/themes/default-bootstrap/contact-form.tpl
@@ -143,6 +143,7 @@
 						<label for="message">{l s='Message'}</label>
 						<textarea class="form-control" id="message" name="message">{if isset($message)}{$message|escape:'html':'UTF-8'|stripslashes}{/if}</textarea>
 					</div>
+					{hook h='displayGDPRConsent' contactForm='contactForm'}
 				</div>
 			</div>
 			<div class="submit">

--- a/themes/default-bootstrap/css/modules/blocknewsletter/blocknewsletter.css
+++ b/themes/default-bootstrap/css/modules/blocknewsletter/blocknewsletter.css
@@ -87,5 +87,7 @@
         clear: none; } }
   #footer #newsletter_block_left .newsletter-input {
     max-width: 300px !important; }
+  #footer #newsletter_block_left #gdpr_consent {
+    margin-top: 20px; }
 
 /*# sourceMappingURL=blocknewsletter.css.map */

--- a/themes/default-bootstrap/js/modules/mailalerts/mailalerts.js
+++ b/themes/default-bootstrap/js/modules/mailalerts/mailalerts.js
@@ -97,11 +97,13 @@ function oosHookJsCodeMailAlert()
 			{
 				$('#mailalert_link').show();
 				$('#oos_customer_email').show();
+				$('#oosHook').find('#gdpr_consent').show();
 			}
 			else
 			{
 				$('#mailalert_link').hide();
 				$('#oos_customer_email').hide();
+				$('#oosHook').find('#gdpr_consent').hide();
 			}
 		}
 	});
@@ -117,10 +119,11 @@ function  addNotification()
 		url: mailalerts_url_add,
 		data: 'id_product=' + id_product + '&id_product_attribute='+$('#idCombination').val()+'&customer_email='+$('#oos_customer_email').val()+'',
 		success: function (msg) {
-			if (msg == '1') 
+			if (msg == '1')
 			{
 				$('#mailalert_link').hide();
 				$('#oos_customer_email').hide();
+				$('#oosHook').find('#gdpr_consent').hide();
 				$('#oos_customer_email_result').html(mailalerts_registered);
 				$('#oos_customer_email_result').css('color', 'green').show();
 			}
@@ -128,7 +131,7 @@ function  addNotification()
 			{
 				$('#oos_customer_email_result').html(mailalerts_already);
 				$('#oos_customer_email_result').css('color', 'red').show();
-			} 
+			}
 			else
 			{
 				$('#oos_customer_email_result').html(mailalerts_invalid);

--- a/themes/default-bootstrap/modules/blocknewsletter/blocknewsletter.tpl
+++ b/themes/default-bootstrap/modules/blocknewsletter/blocknewsletter.tpl
@@ -34,7 +34,9 @@
                 </button>
 				<input type="hidden" name="action" value="0" />
 			</div>
+            {if isset($id_module)}
             {hook h='displayGDPRConsent' id_module=$id_module}
+            {/if}
 		</form>
 	</div>
     {hook h="displayBlockNewsletterBottom" from='blocknewsletter'}

--- a/themes/default-bootstrap/modules/blocknewsletter/blocknewsletter.tpl
+++ b/themes/default-bootstrap/modules/blocknewsletter/blocknewsletter.tpl
@@ -29,17 +29,17 @@
 		<form action="{$link->getPageLink('index', null, null, null, false, null, true)|escape:'html':'UTF-8'}" method="post">
 			<div class="form-group{if isset($msg) && $msg } {if $nw_error}form-error{else}form-ok{/if}{/if}" >
 				<input class="inputNew form-control grey newsletter-input" id="newsletter-input" type="text" name="email" size="18" value="{if isset($msg) && $msg}{$msg}{elseif isset($value) && $value}{$value}{else}{l s='Enter your e-mail' mod='blocknewsletter'}{/if}" />
-                <button type="submit" name="submitNewsletter" class="btn btn-default button button-small">
-                    <span>{l s='Ok' mod='blocknewsletter'}</span>
-                </button>
+				<button type="submit" name="submitNewsletter" class="btn btn-default button button-small">
+					<span>{l s='Ok' mod='blocknewsletter'}</span>
+				</button>
 				<input type="hidden" name="action" value="0" />
 			</div>
-            {if isset($id_module)}
-            {hook h='displayGDPRConsent' id_module=$id_module}
-            {/if}
+			{if isset($id_module)}
+				{hook h='displayGDPRConsent' id_module=$id_module}
+			{/if}
 		</form>
 	</div>
-    {hook h="displayBlockNewsletterBottom" from='blocknewsletter'}
+	{hook h="displayBlockNewsletterBottom" from='blocknewsletter'}
 </div>
 <!-- /Block Newsletter module-->
 {strip}

--- a/themes/default-bootstrap/modules/blocknewsletter/blocknewsletter.tpl
+++ b/themes/default-bootstrap/modules/blocknewsletter/blocknewsletter.tpl
@@ -34,6 +34,7 @@
                 </button>
 				<input type="hidden" name="action" value="0" />
 			</div>
+            {hook h='displayGDPRConsent' id_module=$id_module}
 		</form>
 	</div>
     {hook h="displayBlockNewsletterBottom" from='blocknewsletter'}

--- a/themes/default-bootstrap/modules/mailalerts/views/templates/hook/product.tpl
+++ b/themes/default-bootstrap/modules/mailalerts/views/templates/hook/product.tpl
@@ -24,13 +24,18 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <!-- MODULE MailAlerts -->
-	{if isset($email) AND $email}
-		<p class="form-group">
-			<input type="text" id="oos_customer_email" name="customer_email" size="20" value="{l s='your@email.com' mod='mailalerts'}" class="mailalerts_oos_email form-control" />
-    	</p>
-    {/if}
-	<a href="#" title="{l s='Notify me when available' mod='mailalerts'}" id="mailalert_link" rel="nofollow">{l s='Notify me when available' mod='mailalerts'}</a>
-	<span id="oos_customer_email_result" style="display:none; display: block;"></span>
+	<form>
+		{if isset($email) AND $email}
+			<p class="form-group">
+				<input type="text" id="oos_customer_email" name="customer_email" size="20" value="{l s='your@email.com' mod='mailalerts'}" class="mailalerts_oos_email form-control" />
+			</p>
+		{/if}
+		{if isset($id_module)}
+			{hook h='displayGDPRConsent' id_module=$id_module}
+		{/if}
+		<button type="submit" title="{l s='Notify me when available' mod='mailalerts'}" id="mailalert_link" rel="nofollow">{l s='Notify me when available' mod='mailalerts'}</button>
+		<span id="oos_customer_email_result" style="display:none; display: block;"></span>
+	</form>
 {strip}
 {addJsDef oosHookJsCodeFunctions=array('oosHookJsCodeMailAlert')}
 {addJsDef mailalerts_url_check=$link->getModuleLink('mailalerts', 'actions', ['process' => 'check'])}

--- a/themes/default-bootstrap/modules/mailalerts/views/templates/hook/product.tpl
+++ b/themes/default-bootstrap/modules/mailalerts/views/templates/hook/product.tpl
@@ -33,7 +33,7 @@
 		{if isset($id_module)}
 			{hook h='displayGDPRConsent' id_module=$id_module}
 		{/if}
-		<button type="submit" title="{l s='Notify me when available' mod='mailalerts'}" id="mailalert_link" rel="nofollow">{l s='Notify me when available' mod='mailalerts'}</button>
+		<button type="submit" class="btn btn-default" title="{l s='Notify me when available' mod='mailalerts'}" id="mailalert_link" rel="nofollow">{l s='Notify me when available' mod='mailalerts'}</button>
 		<span id="oos_customer_email_result" style="display:none; display: block;"></span>
 	</form>
 {strip}

--- a/themes/default-bootstrap/sass/modules/blocknewsletter/blocknewsletter.scss
+++ b/themes/default-bootstrap/sass/modules/blocknewsletter/blocknewsletter.scss
@@ -107,5 +107,8 @@
 		.newsletter-input {
   			max-width: 300px !important;
   		}
+  		#gdpr-consent {
+  			margin-top: 20px;
+  		}
 	}
 }

--- a/themes/default-bootstrap/sass/modules/blocknewsletter/blocknewsletter.scss
+++ b/themes/default-bootstrap/sass/modules/blocknewsletter/blocknewsletter.scss
@@ -107,7 +107,7 @@
 		.newsletter-input {
   			max-width: 300px !important;
   		}
-  		#gdpr-consent {
+  		#gdpr_consent {
   			margin-top: 20px;
   		}
 	}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Add displayGDPRConsent hook (from official GDPR module by PrestaShop) in order to display a consent checkbox in the contact form and blocknewsletter module
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? |
| Fixed ticket? |
| How to test?  | You need to install the last version of the psgdpr module in order to display checkboxes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9103)
<!-- Reviewable:end -->
