### PR TITLE
Add compliance to GDPR law for ps_emailsubscription module

### DIFF
--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -63,6 +63,7 @@
                   {$msg}
                 </p>
               {/if}
+                {hook h='displayGDPRConsent' id_module=$id_module}
           </div>
         </div>
       </form>

--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -63,7 +63,9 @@
                   {$msg}
                 </p>
               {/if}
-                {hook h='displayGDPRConsent' id_module=$id_module}
+              {if isset($id_module)}
+              {hook h='displayGDPRConsent' id_module=$id_module}
+              {/if}
           </div>
         </div>
       </form>

--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -64,7 +64,7 @@
                 </p>
               {/if}
               {if isset($id_module)}
-              {hook h='displayGDPRConsent' id_module=$id_module}
+                {hook h='displayGDPRConsent' id_module=$id_module}
               {/if}
           </div>
         </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.3.x
| Description?  | Add displayGDPRConsent hook (from official GDPR module by PrestaShop) in order to display a consent checkbox in ps_emailsubscription
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | You need to install the last version of the psgdpr module in order to display checkboxes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9104)
<!-- Reviewable:end -->
