### PR TITLE
Check if key exists before checking the value

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1650,7 +1650,7 @@ class CartCore extends ObjectModel
         }
 
         $preservedGifts = $this->getProductsGifts($id_product, $id_product_attribute);
-        if ($preservedGifts[$id_product.'-'.$id_product_attribute] > 0) {
+        if (isset($preservedGifts[$id_product.'-'.$id_product_attribute]) && $preservedGifts[$id_product.'-'.$id_product_attribute] > 0) {
             return Db::getInstance()->execute(
                 'UPDATE `'._DB_PREFIX_.'cart_product`
                 SET `quantity` = '.(int)$preservedGifts[$id_product.'-'.$id_product_attribute].'
@@ -3819,7 +3819,7 @@ class CartCore extends ObjectModel
                     $delivery
                 );
             }
-            
+
             if (
                 ! $product['active'] ||
                 ! $product['available_for_order'] ||
@@ -3827,7 +3827,7 @@ class CartCore extends ObjectModel
             ) {
                 return $returnProductOnFailure ? $product : false;
             }
-            
+
             if (! $product['allow_oosp']) {
                 $productQuantity = Product::getQuantity(
                     $product['id_product'],

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1650,10 +1650,10 @@ class CartCore extends ObjectModel
         }
 
         $preservedGifts = $this->getProductsGifts($id_product, $id_product_attribute);
-        if (isset($preservedGifts[$id_product.'-'.$id_product_attribute]) && $preservedGifts[$id_product.'-'.$id_product_attribute] > 0) {
+        if ($preservedGifts[(int)$id_product.'-'.(int)$id_product_attribute] > 0) {
             return Db::getInstance()->execute(
                 'UPDATE `'._DB_PREFIX_.'cart_product`
-                SET `quantity` = '.(int)$preservedGifts[$id_product.'-'.$id_product_attribute].'
+                SET `quantity` = '.(int)$preservedGifts[(int)$id_product.'-'.(int)$id_product_attribute].'
                 WHERE `id_cart` = '.(int)$this->id.'
                 AND `id_product` = '.(int)$id_product.
                 ($id_product_attribute != null ? ' AND `id_product_attribute` = '.(int)$id_product_attribute : '')


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | Our plugin uses a virtual product to add a fee to the order. Before calculating the fee, i make sure the fee product is removed from the cart (and added afterwards). FYI [this](https://github.com/paynl/prestashop1.7-plugin/blob/master/paynlpaymentmethods/paynlpaymentmethods.php#L458) is the code in my plugin that handles this. When developer mode is active, we get a notice on the line i just edited, halting the checkout process. Notice: Undefined index: 31- in Cart.php line 1653
| Type?         | bug fix
| Category?     |  CO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | N.A.
| How to test?  | I think the fix is quite obvious

Got some complaints from our customers about this.
Our plugin manages a 'fee'  product, but when we try to delete the product, a notice is shown.
It seems like you should check if the value is set before checking what the value is.

type: bug fix
CO: Check if key exists before checking the value when removing preservedGifts from cart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9105)
<!-- Reviewable:end -->
