### PR TITLE
Add a product removal confirmation

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
@@ -27,7 +27,7 @@
     <div class="col-lg-5">
       <a
         href="{{ path('admin_product_unit_action', {action: 'delete', id: productId}) }}"
-        class="tooltip-link btn btn-lg"
+        class="tooltip-link btn btn-lg delete"
         data-toggle="pstooltip"
         id="product_form_delete_btn"
         title="{{ 'Permanently delete this product.'|trans({}, 'Admin.Catalog.Help') }}"


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | On the product page, the modal to confirm the deletion when clicking the button to delete a product which is right next to the "preview" button, doesn't exist.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4950
| How to test?  | On the product page, delete a product by clicking the button to delete a product which is right next to the "preview" button, a modal to confirm the deletion will be displayed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9106)
<!-- Reviewable:end -->
