### PR TITLE
Make checkbox labels clickable on the classic theme

### DIFF
--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -88,9 +88,11 @@
 
         {block name='form_field_item_checkbox'}
           <span class="custom-checkbox">
-            <input name="{$field.name}" type="checkbox" value="1" {if $field.value}checked="checked"{/if} {if $field.required}required{/if}>
-            <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
-            <label>{$field.label nofilter}</label >
+            <label>
+              <input name="{$field.name}" type="checkbox" value="1" {if $field.value}checked="checked"{/if} {if $field.required}required{/if}>
+              <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
+              {$field.label nofilter}
+            </label>
           </span>
         {/block}
 


### PR DESCRIPTION
On the Identity page (and some other places), the checkbox labels are not clickable and the user needs to click only on the box itself in order to check it. This PR makes the label text also clickable, improving usability.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On the Identity page (and some other places), the checkbox labels are not clickable and the user needs to click only on the box itself in order to check it. This PR makes the label text also clickable, improving usability.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5589
| How to test?  |
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9110)
<!-- Reviewable:end -->
