### PR TITLE
Automatically use HTTPS when enabled

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1976,7 +1976,7 @@ class AdminControllerCore extends Controller
             'full_language_code' => $this->context->language->language_code,
             'link' => $this->context->link,
             'shop_name' => Configuration::get('PS_SHOP_NAME'),
-            'base_url' => $this->context->shop->getBaseURL(),
+            'base_url' => $this->context->shop->getBaseURL(true),
             'tab' => isset($tab) ? $tab : null, // Deprecated, this tab is declared in the foreach, so it's the last tab in the foreach
             'current_parent_id' => (int)Tab::getCurrentParentId(),
             'tabs' => $tabs,
@@ -2258,7 +2258,7 @@ class AdminControllerCore extends Controller
                 .'email='.urlencode($this->context->employee->email)
                 .'&firstname='.urlencode($this->context->employee->firstname)
                 .'&lastname='.urlencode($this->context->employee->lastname)
-                .'&website='.urlencode($this->context->shop->getBaseURL())
+                .'&website='.urlencode($this->context->shop->getBaseURL(true))
                 .'&utm_source=back-office&utm_medium=connect-to-addons'
                 .'&utm_campaign=back-office-'.Tools::strtoupper($this->context->language->iso_code)
                 .'&utm_content='.(defined('_PS_HOST_MODE_') ? 'cloud' : 'download').'#createnow',

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -253,7 +253,7 @@ class HelperFormCore extends Helper
             'required_fields' => $this->getFieldsRequired(),
             'vat_number' => Module::isInstalled('vatnumber') && file_exists(_PS_MODULE_DIR_.'vatnumber/ajax.php'),
             'module_dir' => _MODULE_DIR_,
-            'base_url' => $this->context->shop->getBaseURL(),
+            'base_url' => $this->context->shop->getBaseURL(true),
             'contains_states' => (isset($this->fields_value['id_country']) && isset($this->fields_value['id_state'])) ? Country::containsStates($this->fields_value['id_country']) : null,
             'show_cancel_button' => $this->show_cancel_button,
             'back_url' => $this->back_url

--- a/controllers/admin/AdminInformationController.php
+++ b/controllers/admin/AdminInformationController.php
@@ -80,7 +80,7 @@ class AdminInformationControllerCore extends AdminController
         $shop_vars = array(
             'shop' => array(
                 'ps' => _PS_VERSION_,
-                'url' => $this->context->shop->getBaseURL(),
+                'url' => $this->context->shop->getBaseURL(true),
                 'theme' => $this->context->shop->theme_name,
             ),
             'mail' => Configuration::get('PS_MAIL_METHOD') == 1,

--- a/controllers/admin/AdminModulesPositionsController.php
+++ b/controllers/admin/AdminModulesPositionsController.php
@@ -345,7 +345,7 @@ class AdminModulesPositionsControllerCore extends AdminController
 
         // Shop::initialize() in config.php may empty $this->context->shop->virtual_uri so using a new shop instance for getBaseUrl()
         $this->context->shop = new Shop((int)$this->context->shop->id);
-        $url = $this->context->shop->getBaseURL().$lang.Dispatcher::getInstance()->createUrl('index', (int)$this->context->language->id, $live_edit_params);
+        $url = $this->context->shop->getBaseURL(true).$lang.Dispatcher::getInstance()->createUrl('index', (int)$this->context->language->id, $live_edit_params);
 
         return $url;
     }

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -3382,7 +3382,7 @@ class AdminProductsControllerCore extends AdminController
             'languages' => $this->_languages,
             'id_lang' => $this->context->language->id,
             'ps_ssl_enabled' => Configuration::get('PS_SSL_ENABLED'),
-            'curent_shop_url' => $this->context->shop->getBaseURL(),
+            'curent_shop_url' => $this->context->shop->getBaseURL(true),
             'default_form_language' => $this->default_form_language,
             'rewritten_links' => $rewritten_links
         ));

--- a/tests/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
+++ b/tests/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
@@ -3095,7 +3095,7 @@ class AdminProductsController extends AdminProductsControllerCore
             'languages' => $this->_languages,
             'id_lang' => $this->context->language->id,
             'ps_ssl_enabled' => Configuration::get('PS_SSL_ENABLED'),
-            'curent_shop_url' => $this->context->shop->getBaseURL(),
+            'curent_shop_url' => $this->context->shop->getBaseURL(true),
             'default_form_language' => $this->default_form_language,
             'rewritten_links' => $rewritten_links
         ));

--- a/tests/resources/module/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/resources/module/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -2995,7 +2995,7 @@ class AdminProductsController extends AdminProductsControllerCore
             'languages' => $this->_languages,
             'id_lang' => $this->context->language->id,
             'ps_ssl_enabled' => Configuration::get('PS_SSL_ENABLED'),
-            'curent_shop_url' => $this->context->shop->getBaseURL(),
+            'curent_shop_url' => $this->context->shop->getBaseURL(true),
             'default_form_language' => $this->default_form_language,
             'rewritten_links' => $rewritten_links
         ));


### PR DESCRIPTION
- In "My shop" link in BO header
- When generating forms
- In "Configuration Information" page
- "Live Edit" link in Module Positions page
- Unused variable in form SEO and relative tests

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | In some place of the backoffice http links were generated. https links can be generated automatically when the feature is active.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Check that the links generated in the sections indicated above are HTTPS when generated.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9114)
<!-- Reviewable:end -->
