### PR TITLE
Fix empty text transformer to not treat zero as empty text

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -36,12 +37,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CachingType extends TranslatorAwareType
 {
-    private $extensionsList = array(
-        'CacheMemcache' => array('memcache'),
-        'CacheMemcached' => array('memcached'),
-        'CacheApc' => array('apc', 'apcu'),
-        'CacheXcache' => array('xcache'),
-    );
+    private $extensionsList = [
+        'CacheMemcache' => ['memcache'],
+        'CacheMemcached' => ['memcached'],
+        'CacheApc' => ['apc', 'apcu'],
+        'CacheXcache' => ['xcache'],
+    ];
 
     /**
      * {@inheritdoc}
@@ -50,13 +51,13 @@ class CachingType extends TranslatorAwareType
     {
         $builder
             ->add('use_cache', SwitchType::class)
-            ->add('caching_system', ChoiceType::class, array(
-                'choices'  => array(
+            ->add('caching_system', ChoiceType::class, [
+                'choices' => [
                     'Memcached via PHP::Memcache' => 'CacheMemcache',
                     'Memcached via PHP::Memcached' => 'CacheMemcached',
                     'APC' => 'CacheApc',
                     'Xcache' => 'CacheXcache',
-                ),
+                ],
                 'choice_label' => function ($value, $key, $index) {
                     $disabled = false;
                     foreach ($this->extensionsList[$index] as $extensionName) {
@@ -77,13 +78,12 @@ class CachingType extends TranslatorAwareType
                         $disabled = true;
                     }
 
-                    return $disabled === true ? array('disabled' => $disabled) : array();
+                    return $disabled === true ? ['disabled' => $disabled] : [];
                 },
                 'expanded' => true,
                 'required' => false,
                 'placeholder' => false
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -91,9 +91,9 @@ class CachingType extends TranslatorAwareType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
-        ));
+        ]);
     }
 
     /**
@@ -111,47 +111,47 @@ class CachingType extends TranslatorAwareType
      */
     private function getErrorsMessages()
     {
-        return array(
+        return [
             'CacheMemcache' => $this->trans('Memcached via PHP::Memcache', 'Admin.Advparameters.Feature')
                 . ' '
                 . $this->trans(
                     '(you must install the [a]Memcache PECL extension[/a])',
                     'Admin.Advparameters.Notification',
-                    array(
+                    [
                         '[a]' => '<a href="http://www.php.net/manual/en/memcache.installation.php" target="_blank">',
                         '[/a]' => '</a>',
-                    )
+                    ]
                 ),
             'CacheMemcached' => $this->trans('Memcached via PHP::Memcached', 'Admin.Advparameters.Feature')
                 . ' '
                 . $this->trans(
                     '(you must install the [a]Memcached PECL extension[/a])',
                     'Admin.Advparameters.Notification',
-                    array(
+                    [
                         '[a]' => '<a href="http://www.php.net/manual/en/memcached.installation.php" target="_blank">',
                         '[/a]' => '</a>',
-                    )
+                    ]
                 ),
             'CacheApc' => $this->trans('APC', 'Admin.Advparameters.Feature')
                 . ' '
                 . $this->trans(
                     '(you must install the [a]APC PECL extension[/a])',
                     'Admin.Advparameters.Notification',
-                    array(
+                    [
                         '[a]' => '<a href="http://www.php.net/manual/en/apc.installation.php" target="_blank">',
                         '[/a]' => '</a>',
-                    )
+                    ]
                 ),
             'CacheXcache' => $this->trans('Xcache', 'Admin.Advparameters.Feature')
                 . ' '
                 . $this->trans(
                     '(you must install the [a]Xcache extension[/a])',
                     'Admin.Advparameters.Notification',
-                    array(
+                    [
                         '[a]' => '<a href="http://xcache.lighttpd.net" target="_blank">',
                         '[/a]' => '</a>',
-                    )
+                    ]
                 ),
-        );
+        ];
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -41,16 +42,15 @@ class CombineCompressCacheType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('smart_cache_css', SwitchType::class, array(
+            ->add('smart_cache_css', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('smart_cache_js', SwitchType::class, array(
+            ])
+            ->add('smart_cache_js', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('apache_optimization', SwitchType::class, array(
+            ])
+            ->add('apache_optimization', SwitchType::class, [
                 'required' => true,
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -58,9 +58,9 @@ class CombineCompressCacheType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -41,16 +42,15 @@ class DebugModeType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('disable_non_native_modules', SwitchType::class, array(
+            ->add('disable_non_native_modules', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('disable_overrides', SwitchType::class, array(
+            ])
+            ->add('disable_overrides', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('debug_mode', SwitchType::class, array(
+            ])
+            ->add('debug_mode', SwitchType::class, [
                 'required' => true,
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -58,9 +58,9 @@ class DebugModeType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature'
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MediaServersType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MediaServersType.php
@@ -23,11 +23,13 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * This form class generates the "Media servers" form in Performance page
@@ -40,16 +42,18 @@ class MediaServersType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('media_server_one', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('media_server_one', TextType::class, [
                 'required' => false,
-            ))
-            ->add('media_server_two', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+                'empty_data' => '',
+            ])
+            ->add('media_server_two', TextType::class, [
                 'required' => false,
-            ))
-            ->add('media_server_three', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+                'empty_data' => '',
+            ])
+            ->add('media_server_three', TextType::class, [
                 'required' => false,
-            ))
-        ;
+                'empty_data' => '',
+            ]);
     }
 
     /**
@@ -57,9 +61,9 @@ class MediaServersType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature'
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MemcacheServerType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MemcacheServerType.php
@@ -23,11 +23,13 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * This form class generates the "Memcache server" form in Performance page
@@ -40,16 +42,18 @@ class MemcacheServerType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('memcache_ip', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('memcache_ip', TextType::class, [
                 'required' => false,
-            ))
-            ->add('memcache_port', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+                'empty_data' => '',
+            ])
+            ->add('memcache_port', TextType::class, [
                 'required' => false,
-            ))
-            ->add('memcache_weight', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+                'empty_data' => '',
+            ])
+            ->add('memcache_weight', TextType::class, [
                 'required' => false,
-            ))
-        ;
+                'empty_data' => '',
+            ]);
     }
 
     /**
@@ -57,9 +61,9 @@ class MemcacheServerType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature'
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -54,16 +55,15 @@ class OptionalFeaturesType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('combinations', SwitchType::class, array(
+            ->add('combinations', SwitchType::class, [
                 'disabled' => $this->isCombinationsUsed,
-            ))
-            ->add('features', SwitchType::class, array(
+            ])
+            ->add('features', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('customer_groups', SwitchType::class, array(
+            ])
+            ->add('customer_groups', SwitchType::class, [
                 'translation_domain' => 'Admin.Advparameters.features',
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -71,9 +71,9 @@ class OptionalFeaturesType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Global',
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormDataProvider.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShop\PrestaShop\Adapter\OptionalFeatures\OptionalFeaturesConfiguration;
@@ -76,8 +77,7 @@ final class PerformanceFormDataProvider implements FormDataProviderInterface
         CombineCompressCacheConfiguration $combineCompressCacheConfiguration,
         MediaServerConfiguration $mediaServerConfiguration,
         CachingConfiguration $cachingConfiguration
-    )
-    {
+    ) {
         $this->smartyCacheConfiguration = $smartyCacheConfiguration;
         $this->debugModeConfiguration = $debugModeConfiguration;
         $this->optionalFeaturesConfiguration = $optionalFeaturesConfiguration;
@@ -91,14 +91,14 @@ final class PerformanceFormDataProvider implements FormDataProviderInterface
      */
     public function getData()
     {
-        return array(
+        return [
             'smarty' => $this->smartyCacheConfiguration->getConfiguration(),
             'debug_mode' => $this->debugModeConfiguration->getConfiguration(),
             'optional_features' => $this->optionalFeaturesConfiguration->getConfiguration(),
             'ccc' => $this->combineCompressCacheConfiguration->getConfiguration(),
             'media_servers' => $this->mediaServerConfiguration->getConfiguration(),
             'caching' => $this->cachingConfiguration->getConfiguration(),
-        );
+        ];
     }
 
     /**
@@ -111,7 +111,6 @@ final class PerformanceFormDataProvider implements FormDataProviderInterface
             $this->optionalFeaturesConfiguration->updateConfiguration($data['optional_features']) +
             $this->combineCompressCacheConfiguration->updateConfiguration($data['ccc']) +
             $this->mediaServerConfiguration->updateConfiguration($data['media_servers']) +
-            $this->cachingConfiguration->updateConfiguration($data['caching'])
-        ;
+            $this->cachingConfiguration->updateConfiguration($data['caching']);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormHandler.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
@@ -69,15 +70,14 @@ final class PerformanceFormHandler extends AbstractFormHandler
         $formBuilder = $this->formFactory->createBuilder()
             ->add('smarty', SmartyType::class)
             ->add('debug_mode', DebugModeType::class)
-            ->add('optional_features', OptionalFeaturesType::class, array(
+            ->add('optional_features', OptionalFeaturesType::class, [
                 'are_combinations_used' => $this->combinationFeature->isUsed()
-            ))
+            ])
             ->add('ccc', CombineCompressCacheType::class)
             ->add('media_servers', MediaServersType::class)
             ->add('caching', CachingType::class)
             ->add('add_memcache_server', MemcacheServerType::class)
-            ->setData($this->formDataProvider->getData())
-        ;
+            ->setData($this->formDataProvider->getData());
 
         $this->hookDispatcher->dispatchForParameters('displayPerformancePageForm', ['form_builder' => &$formBuilder]);
 

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -42,35 +43,34 @@ class SmartyType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('template_compilation', ChoiceType::class, array(
-                'choices'  => array(
+            ->add('template_compilation', ChoiceType::class, [
+                'choices' => [
                     'Never recompile template files' => 0,
                     'Recompile templates if the files have been updated' => 1,
                     'Force compilation' => 2,
-                ),
+                ],
                 'required' => true,
-            ))
-            ->add('cache', SwitchType::class, array(
+            ])
+            ->add('cache', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('multi_front_optimization', SwitchType::class, array(
+            ])
+            ->add('multi_front_optimization', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('caching_type', ChoiceType::class, array(
-                'choices'  => array(
+            ])
+            ->add('caching_type', ChoiceType::class, [
+                'choices' => [
                     'File System' => 'filesystem',
                     'MySQL' => 'mysql',
-                ),
+                ],
                 'required' => true,
-            ))
-            ->add('clear_cache', ChoiceType::class, array(
-                'choices'  => array(
-                     'Never clear cache files' => 'never',
+            ])
+            ->add('clear_cache', ChoiceType::class, [
+                'choices' => [
+                    'Never clear cache files' => 'never',
                     'Clear cache everytime something has been modified' => 'everytime',
-                ),
+                ],
                 'required' => true,
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -78,9 +78,9 @@ class SmartyType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature'
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
+++ b/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
@@ -23,12 +23,14 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Category;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Form\Extension\Core\Type as FormType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -75,27 +77,27 @@ class SimpleCategory extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+        $builder->add('name', TextType::class, [
             'label' => $this->translator->trans('Name', [], 'Admin.Global'),
             'required' => false,
             'attr' => [
                 'placeholder' => $this->translator->trans('Category name', [], 'Admin.Catalog.Feature'),
                 'class' => 'ajax'
             ],
-            'constraints' => $options['ajax'] ? [] : array(
+            'constraints' => $options['ajax'] ? [] : [
                 new Assert\NotBlank(),
-                new Assert\Length(array('min' => 1, 'max' => 128))
-            )
-        ))
-        ->add('id_parent', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices' => $this->categories,
-            'required' => true,
-            'attr' => array(
-                'data-toggle' => 'select2',
-                'data-minimumResultsForSearch' => '7',
-            ),
-            'label' => $this->translator->trans('Parent of the category', [], 'Admin.Catalog.Feature')
-        ));
+                new Assert\Length(['min' => 1, 'max' => 128])
+            ]
+        ])
+            ->add('id_parent', ChoiceType::class, [
+                'choices' => $this->categories,
+                'required' => true,
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
+                'label' => $this->translator->trans('Parent of the category', [], 'Admin.Catalog.Feature')
+            ]);
     }
 
     /**
@@ -103,9 +105,9 @@ class SimpleCategory extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'ajax' => false,
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/FormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/FormDataProvider.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
 use PrestaShop\PrestaShop\Adapter\Admin\NotificationsConfiguration;
@@ -56,8 +57,7 @@ final class FormDataProvider implements FormDataProviderInterface
         GeneralConfiguration $generalConfiguration,
         UploadQuotaConfiguration $uploadConfiguration,
         NotificationsConfiguration $notificationsConfiguration
-    )
-    {
+    ) {
         $this->generalConfiguration = $generalConfiguration;
         $this->uploadConfiguration = $uploadConfiguration;
         $this->notificationsConfiguration = $notificationsConfiguration;
@@ -68,11 +68,11 @@ final class FormDataProvider implements FormDataProviderInterface
      */
     public function getData()
     {
-        return array(
+        return [
             'general' => $this->generalConfiguration->getConfiguration(),
             'upload_quota' => $this->uploadConfiguration->getConfiguration(),
             'notifications' => $this->notificationsConfiguration->getConfiguration(),
-        );
+        ];
     }
 
     /**
@@ -82,7 +82,6 @@ final class FormDataProvider implements FormDataProviderInterface
     {
         return $this->generalConfiguration->updateConfiguration($data['general']) +
             $this->uploadConfiguration->updateConfiguration($data['upload_quota']) +
-            $this->notificationsConfiguration->updateConfiguration($data['notifications'])
-        ;
+            $this->notificationsConfiguration->updateConfiguration($data['notifications']);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -39,19 +40,18 @@ class GeneralType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('check_modules_update', SwitchType::class, array(
+            ->add('check_modules_update', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('check_ip_address', SwitchType::class, array(
+            ])
+            ->add('check_ip_address', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('front_cookie_lifetime', TextType::class, array(
+            ])
+            ->add('front_cookie_lifetime', TextType::class, [
                 'required' => true,
-            ))
-            ->add('back_cookie_lifetime', TextType::class, array(
+            ])
+            ->add('back_cookie_lifetime', TextType::class, [
                 'required' => true,
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -59,9 +59,9 @@ class GeneralType extends TranslatorAwareType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -38,16 +39,15 @@ class NotificationsType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('show_notifs_new_orders', SwitchType::class, array(
+            ->add('show_notifs_new_orders', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('show_notifs_new_customers', SwitchType::class, array(
+            ])
+            ->add('show_notifs_new_customers', SwitchType::class, [
                 'required' => true,
-            ))
-            ->add('show_notifs_new_messages', SwitchType::class, array(
+            ])
+            ->add('show_notifs_new_messages', SwitchType::class, [
                 'required' => true,
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -55,9 +55,9 @@ class NotificationsType extends TranslatorAwareType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -61,8 +62,7 @@ class UploadQuotaType extends TranslatorAwareType
                     'required' => true,
                     'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),
                 ]
-            )
-        ;
+            );
     }
 
     /**
@@ -70,9 +70,9 @@ class UploadQuotaType extends TranslatorAwareType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -82,8 +82,7 @@ class ImportType extends TranslatorAwareType
             ])
             ->add('sendemail', SwitchType::class, [
                 'data' => true,
-            ])
-        ;
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/FilterLogsByAttributeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/FilterLogsByAttributeType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -42,24 +43,23 @@ final class FilterLogsByAttributeType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('id_log', TextType::class, array('required' => false))
-            ->add('employee', TextType::class, array('required' => false))
-            ->add('severity', TextType::class, array('required' => false))
-            ->add('message', TextType::class, array('required' => false))
-            ->add('object_type', TextType::class, array('required' => false))
-            ->add('object_id', TextType::class, array('required' => false))
-            ->add('error_code', TextType::class, array('required' => false))
-            ->add('date_from', DatePickerType::class, array(
+            ->add('id_log', TextType::class, ['required' => false])
+            ->add('employee', TextType::class, ['required' => false])
+            ->add('severity', TextType::class, ['required' => false])
+            ->add('message', TextType::class, ['required' => false])
+            ->add('object_type', TextType::class, ['required' => false])
+            ->add('object_id', TextType::class, ['required' => false])
+            ->add('error_code', TextType::class, ['required' => false])
+            ->add('date_from', DatePickerType::class, [
                 'required' => false,
-                'attr' => array('placeholder' => 'From'),
+                'attr' => ['placeholder' => 'From'],
                 'translation_domain' => 'Admin.Global',
-            ))
-            ->add('date_to', DatePickerType::class, array(
+            ])
+            ->add('date_to', DatePickerType::class, [
                 'required' => false,
-                'attr' => array('placeholder' => 'To'),
+                'attr' => ['placeholder' => 'To'],
                 'translation_domain' => 'Admin.Global',
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -67,9 +67,9 @@ final class FilterLogsByAttributeType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature'
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -41,10 +42,9 @@ final class LogsByEmailType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('logs_by_email', TextType::class, array(
+            ->add('logs_by_email', TextType::class, [
                 'required' => true,
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -52,9 +52,9 @@ final class LogsByEmailType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature'
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsFormDataProvider.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs;
 
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
@@ -49,7 +50,7 @@ final class LogsFormDataProvider implements FormDataProviderInterface
      */
     public function getData()
     {
-        return array('logs_by_email' => $this->logsConfiguration->getConfiguration());
+        return ['logs_by_email' => $this->logsConfiguration->getConfiguration()];
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesFormHandler.php
@@ -70,7 +70,7 @@ final class CustomerPreferencesFormHandler extends FormHandler
     {
         $b2bTabs = ['AdminOutstanding'];
         foreach ($b2bTabs as $tabName) {
-            $this->tabRepository->changeStatusByClassName($tabName, (bool) $b2bMode);
+            $this->tabRepository->changeStatusByClassName($tabName, (bool)$b2bMode);
         }
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -48,8 +48,7 @@ class GeneralType extends TranslatorAwareType
             ])
             ->add('enable_b2b_mode', SwitchType::class)
             ->add('ask_for_birthday', SwitchType::class)
-            ->add('enable_offers', SwitchType::class)
-        ;
+            ->add('enable_offers', SwitchType::class);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceFormDataProvider.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\General;
 
 use PrestaShop\PrestaShop\Adapter\Shop\MaintenanceConfiguration;
@@ -49,9 +50,9 @@ final class MaintenanceFormDataProvider implements FormDataProviderInterface
      */
     public function getData()
     {
-        return array(
+        return [
             'general' => $this->maintenanceConfiguration->getConfiguration(),
-        );
+        ];
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\General;
 
 use PrestaShopBundle\Form\Admin\Type\IpAddressType;
@@ -75,8 +76,7 @@ class MaintenanceType extends TranslatorAwareType
                     'hideTabs' => false,
                     'required' => true,
                 ]
-            )
-        ;
+            );
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesFormDataProvider.php
@@ -50,9 +50,9 @@ final class PreferencesFormDataProvider implements FormDataProviderInterface
      */
     public function getData()
     {
-        return array(
+        return [
             'general' => $this->preferencesConfiguration->getConfiguration(),
-        );
+        ];
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesFormHandler.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\General;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
@@ -54,8 +55,7 @@ final class PreferencesFormHandler implements FormHandlerInterface
         FormFactoryInterface $formFactory,
         PreferencesFormDataProvider $formDataProvider,
         Configuration $configuration
-    )
-    {
+    ) {
         $this->formFactory = $formFactory;
         $this->formDataProvider = $formDataProvider;
         $this->configuration = $configuration;
@@ -71,8 +71,7 @@ final class PreferencesFormHandler implements FormHandlerInterface
                 'is_ssl_enabled' => $this->configuration->getBoolean('PS_SSL_ENABLED'),
             ])
             ->setData($this->formDataProvider->getData())
-            ->getForm()
-        ;
+            ->getForm();
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -53,15 +53,15 @@ class PreferencesType extends TranslatorAwareType
         }
 
         $builder
-            ->add('enable_ssl_everywhere', SwitchType::class, array(
+            ->add('enable_ssl_everywhere', SwitchType::class, [
                 'disabled' => !$isSslEnabled,
-            ))
+            ])
             ->add('enable_token', SwitchType::class)
             ->add('allow_html_iframes', SwitchType::class)
             ->add('use_htmlpurifier', SwitchType::class)
-            ->add('price_round_mode', ChoiceType::class, array(
+            ->add('price_round_mode', ChoiceType::class, [
                 'choices_as_values' => true,
-                'choices'  => array(
+                'choices' => [
                     'Round up away from zero, when it is half way there (recommended)' =>
                         $configuration->get('PS_ROUND_HALF_UP'),
                     'Round down towards zero, when it is half way there' =>
@@ -74,29 +74,29 @@ class PreferencesType extends TranslatorAwareType
                         $configuration->get('PS_ROUND_UP'),
                     'Round down to the nearest value' =>
                         $configuration->get('PS_ROUND_DOWN'),
-                ),
-            ))
-            ->add('price_round_type', ChoiceType::class, array(
+                ],
+            ])
+            ->add('price_round_type', ChoiceType::class, [
                 'choices_as_values' => true,
-                'choices'  => array(
+                'choices' => [
                     'Round on each item' => Order::ROUND_ITEM,
                     'Round on each line' => Order::ROUND_LINE,
                     'Round on the total' => Order::ROUND_TOTAL,
-                ),
-            ))
-            ->add('price_display_precision', IntegerType::class, array(
+                ],
+            ])
+            ->add('price_display_precision', IntegerType::class, [
                 'attr' => [
                     'min' => 0,
                 ],
-            ))
+            ])
             ->add('display_suppliers', SwitchType::class)
             ->add('display_best_sellers', SwitchType::class)
             ->add('multishop_feature_active', SwitchType::class)
-            ->add('shop_activity', ChoiceType::class, array(
+            ->add('shop_activity', ChoiceType::class, [
                 'required' => false,
                 'choices_as_values' => true,
                 'placeholder' => $this->trans('-- Please choose your main activity --', 'Install'),
-                'choices'  => array(
+                'choices' => [
                     'Animals and Pets' => 2,
                     'Art and Culture' => 3,
                     'Babies' => 4,
@@ -117,10 +117,9 @@ class PreferencesType extends TranslatorAwareType
                     'Shoes and accessories' => 18,
                     'Sport and Entertainment' => 19,
                     'Travel' => 20,
-                ),
+                ],
                 'choice_translation_domain' => 'Install',
-            ))
-        ;
+            ]);
     }
 
     /**
@@ -128,9 +127,9 @@ class PreferencesType extends TranslatorAwareType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -82,8 +82,7 @@ class GeneralType extends TranslatorAwareType
                 'currency' => $defaultCurrency->iso_code,
                 'suffix' => $this->trans('(tax excl.)', 'Admin.Global'),
             ])
-            ->add('recalculate_shipping_cost', SwitchType::class)
-        ;
+            ->add('recalculate_shipping_cost', SwitchType::class);
 
         if ($isMultishippingEnabled) {
             $builder->add('allow_multishipping', SwitchType::class);
@@ -94,9 +93,8 @@ class GeneralType extends TranslatorAwareType
             ->add('enable_tos', SwitchType::class)
             ->add('tos_cms_id', ChoiceType::class, [
                 'placeholder' => $this->trans('None', 'Admin.Global'),
-                'choices'  => $this->tosCmsChoices,
-            ])
-        ;
+                'choices' => $this->tosCmsChoices,
+            ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -81,14 +81,13 @@ class GiftOptionsType extends TranslatorAwareType
                 'required' => false,
                 'currency' => $defaultCurrency->iso_code,
                 'suffix' => $this->trans('(tax excl.)', 'Admin.Global'),
-            ])
-        ;
+            ]);
 
         if (!$atcpShipWrap) {
             $builder->add('gift_wrapping_tax_rules_group', ChoiceType::class, [
                 'required' => false,
                 'placeholder' => $this->trans('None', 'Admin.Global'),
-                'choices'  => $this->taxChoices,
+                'choices' => $this->taxChoices,
             ]);
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -63,8 +63,7 @@ class GeneralType extends TranslatorAwareType
                 'required' => true,
             ])
             ->add('force_friendly_url', SwitchType::class)
-            ->add('default_status', SwitchType::class)
-        ;
+            ->add('default_status', SwitchType::class);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -51,14 +51,13 @@ class PageType extends AbstractType
             ->add('allow_add_variant_to_cart_from_listing', SwitchType::class)
             ->add('attribute_anchor_separator', ChoiceType::class, [
                 'choices' => [
-                   '-' => '-',
-                   ',' => ',',
+                    '-' => '-',
+                    ',' => ',',
                 ],
                 'required' => true,
                 'choice_translation_domain' => 'Admin.Global',
             ])
-            ->add('display_discount_price', SwitchType::class)
-        ;
+            ->add('display_discount_price', SwitchType::class);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -65,8 +65,7 @@ class PaginationType extends AbstractType
                 ],
                 'required' => true,
                 'choice_translation_domain' => 'Admin.Global',
-            ])
-        ;
+            ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/ProductPreferencesFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/ProductPreferencesFormDataProvider.php
@@ -103,8 +103,7 @@ class ProductPreferencesFormDataProvider implements FormDataProviderInterface
         return $this->generalConfiguration->updateConfiguration($data['general']) +
             $this->paginationConfiguration->updateConfiguration($data['pagination']) +
             $this->pageConfiguration->updateConfiguration($data['page']) +
-            $this->stockConfiguration->updateConfiguration($data['stock'])
-        ;
+            $this->stockConfiguration->updateConfiguration($data['stock']);
     }
 
     /**
@@ -146,7 +145,7 @@ class ProductPreferencesFormDataProvider implements FormDataProviderInterface
         }
 
         $productsPerPage = $data['pagination']['products_per_page'];
-        if (!is_numeric($productsPerPage) || 0 >  $productsPerPage) {
+        if (!is_numeric($productsPerPage) || 0 > $productsPerPage) {
             $invalidFields[] = $this->translator->trans('Products per page', [], 'Admin.Shopparameters.Feature');
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -64,12 +64,11 @@ class StockType extends TranslatorAwareType
             ])
             ->add('pack_stock_management', ChoiceType::class, [
                 'choices' => [
-                      'Decrement pack only.' => 0,
-                      'Decrement products in pack only.' => 1,
-                      'Decrement both.' => 2,
+                    'Decrement pack only.' => 0,
+                    'Decrement products in pack only.' => 1,
+                    'Decrement both.' => 2,
                 ],
-            ])
-        ;
+            ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
+++ b/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Feature;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -71,36 +72,36 @@ class ProductFeature extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('feature', FormType\ChoiceType::class, array(
-            'label' => $this->translator->trans('Feature', array(), 'Admin.Catalog.Feature'),
-            'choices' =>  $this->features,
-            'required' =>  false,
-            'attr' => array(
-                'data-action' => $this->router->generate('admin_feature_get_feature_values', array('idFeature' => 1)),
+        $builder->add('feature', FormType\ChoiceType::class, [
+            'label' => $this->translator->trans('Feature', [], 'Admin.Catalog.Feature'),
+            'choices' => $this->features,
+            'required' => false,
+            'attr' => [
+                'data-action' => $this->router->generate('admin_feature_get_feature_values', ['idFeature' => 1]),
                 'data-toggle' => 'select2',
                 'data-minimumResultsForSearch' => '7',
                 'class' => 'feature-selector',
-            ),
-            'placeholder' => $this->translator->trans('Choose a feature', array(), 'Admin.Catalog.Feature'),
-        ))
-        ->add('value', FormType\ChoiceType::class, array(
-            'label' => $this->translator->trans('Pre-defined value', array(), 'Admin.Catalog.Feature'),
-            'required' =>  false,
-            'attr' => array(
-                'class' => 'feature-value-selector',
-                'data-minimumResultsForSearch' => '7',
-            ),
-            'placeholder' => $this->translator->trans('Choose a value', array(), 'Admin.Catalog.Feature'),
-            'disabled' => true,
-        ))
-        ->add('custom_value', TranslateType::class, array(
-            'type' => FormType\TextType::class,
-            'options' => [],
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'required' =>  false,
-            'label' => $this->translator->trans('OR Customized value', array(), 'Admin.Catalog.Feature'),
-        ));
+            ],
+            'placeholder' => $this->translator->trans('Choose a feature', [], 'Admin.Catalog.Feature'),
+        ])
+            ->add('value', FormType\ChoiceType::class, [
+                'label' => $this->translator->trans('Pre-defined value', [], 'Admin.Catalog.Feature'),
+                'required' => false,
+                'attr' => [
+                    'class' => 'feature-value-selector',
+                    'data-minimumResultsForSearch' => '7',
+                ],
+                'placeholder' => $this->translator->trans('Choose a value', [], 'Admin.Catalog.Feature'),
+                'disabled' => true,
+            ])
+            ->add('custom_value', TranslateType::class, [
+                'type' => FormType\TextType::class,
+                'options' => [],
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'required' => false,
+                'label' => $this->translator->trans('OR Customized value', [], 'Admin.Catalog.Feature'),
+            ]);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             $form = $event->getForm();
@@ -139,17 +140,17 @@ class ProductFeature extends CommonAbstractType
 
     private function updateValueField(Form $form, $choices)
     {
-        $form->add('value', FormType\ChoiceType::class, array(
-            'label' => $this->translator->trans('Pre-defined value', array(), 'Admin.Catalog.Feature'),
-            'required' =>  false,
-            'attr' => array(
+        $form->add('value', FormType\ChoiceType::class, [
+            'label' => $this->translator->trans('Pre-defined value', [], 'Admin.Catalog.Feature'),
+            'required' => false,
+            'attr' => [
                 'class' => 'feature-value-selector',
                 'data-minimumResultsForSearch' => '7',
                 'data-toggle' => 'select2',
-            ),
+            ],
             'choices' => $choices,
-            'placeholder' => $this->translator->trans('Choose a value', array(), 'Admin.Catalog.Feature'),
-        ));
+            'placeholder' => $this->translator->trans('Choose a value', [], 'Admin.Catalog.Feature'),
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductAttachement.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductAttachement.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -30,7 +31,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\Extension\Core\Type as FormType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 
 /**
  * This form class is responsible to generate the product attachments
@@ -61,34 +64,35 @@ class ProductAttachement extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType', array(
+        $builder->add('file', FileType::class, [
             'required' => false,
             'label' => $this->translator->trans('File', [], 'Admin.Global'),
-            'constraints' => array(
-                new Assert\NotNull(array('message' => $this->translator->trans('Please select a file', [], 'Admin.Catalog.Feature'))),
-                new Assert\File(array('maxSize' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE').'M')),
-            )
-        ))
-        ->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'label' =>  $this->translator->trans('Filename', [], 'Admin.Global'),
-            'attr' =>  ['placeholder' => $this->translator->trans('Title', [], 'Admin.Global')],
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Length(array('min' => 2))
-            )
-        ))
-        ->add('description', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'label' =>  $this->translator->trans('Description', [], 'Admin.Global'),
-            'attr' =>  ['placeholder' => $this->translator->trans('Description', [], 'Admin.Global')],
-        ))
-        ->add('add', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
-            'label' =>  $this->translator->trans('Add', [], 'Admin.Actions'),
-            'attr' =>  ['class' => 'btn-outline-primary pull-right']
-        ))
-        ->add('cancel', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
-            'label' =>  $this->translator->trans('Cancel', [], 'Admin.Actions'),
-            'attr' =>  ['class' => 'btn-outline-secondary pull-right mr-2', 'data-toggle' => 'collapse', 'data-target' => '#collapsedForm']
-        ));
+            'constraints' => [
+                new Assert\NotNull(['message' => $this->translator->trans('Please select a file', [], 'Admin.Catalog.Feature')]),
+                new Assert\File(['maxSize' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') . 'M']),
+            ]
+        ])
+            ->add('name', TextType::class, [
+                'label' => $this->translator->trans('Filename', [], 'Admin.Global'),
+                'attr' => ['placeholder' => $this->translator->trans('Title', [], 'Admin.Global')],
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['min' => 2])
+                ]
+            ])
+            ->add('description', TextType::class, [
+                'label' => $this->translator->trans('Description', [], 'Admin.Global'),
+                'attr' => ['placeholder' => $this->translator->trans('Description', [], 'Admin.Global')],
+                'empty_data' => '',
+            ])
+            ->add('add', ButtonType::class, [
+                'label' => $this->translator->trans('Add', [], 'Admin.Actions'),
+                'attr' => ['class' => 'btn-outline-primary pull-right']
+            ])
+            ->add('cancel', ButtonType::class, [
+                'label' => $this->translator->trans('Cancel', [], 'Admin.Actions'),
+                'attr' => ['class' => 'btn-outline-secondary pull-right mr-2', 'data-toggle' => 'collapse', 'data-target' => '#collapsedForm']
+            ]);
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $form = $event->getForm();
@@ -96,8 +100,8 @@ class ProductAttachement extends CommonAbstractType
             //if this partial form is submit from a parent form, disable it
             if ($form->getParent()) {
                 $event->setData([]);
-                $form->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType', array('mapped' => false));
-                $form->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('mapped' => false));
+                $form->add('file', FileType::class, ['mapped' => false]);
+                $form->add('name', TextType::class, ['mapped' => false]);
             }
         });
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -23,15 +23,21 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\Extension\Core\Type as FormType;
-use PrestaShopBundle\Form\Admin\Type as PsFormType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 
 /**
  * This form class is responsible to generate the product combination form
@@ -65,137 +71,141 @@ class ProductCombination extends CommonAbstractType
     {
         $is_stock_management = $this->configuration->get('PS_STOCK_MANAGEMENT');
 
-        $builder->add('id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\HiddenType', array(
+        $builder->add('id_product_attribute', HiddenType::class, [
             'required' => false,
-        ))
-        ->add('attribute_reference', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Reference', array(), 'Admin.Global')
-        ))
-        ->add('attribute_ean13', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'required' => false,
-            'error_bubbling' => true,
-            'label' => $this->translator->trans('EAN-13 or JAN barcode', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\Regex("/^[0-9]{0,13}$/"),
-            )
-        ))
-        ->add('attribute_isbn', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'required' => false,
-            'label' => $this->translator->trans('ISBN code', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\Regex("/^[0-9-]{0,32}$/"),
-            ),
-        ))
-        ->add('attribute_upc', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'required' => false,
-            'label' => $this->translator->trans('UPC barcode', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\Regex("/^[0-9]{0,12}$/"),
-            )
-        ))
-        ->add('attribute_wholesale_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Cost price', array(), 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-            'attr' => ['class' => 'attribute_wholesale_price']
-        ))
-        ->add('attribute_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Impact on price (tax excl.)', array(), 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-            'attr' => ['class' => 'attribute_priceTE']
-        ))
-        ->add('attribute_priceTI', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'mapped' => false,
-            'label' => $this->translator->trans('Impact on price (tax incl.)', array(), 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-            'attr' => ['class' => 'attribute_priceTI']
-        ))
-        ->add('attribute_ecotax', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Ecotax', array(), 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
-            )
-        ))
-        ->add('attribute_weight', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Impact on weight', array(), 'Admin.Catalog.Feature')
-        ))
-        ->add('attribute_unity', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Impact on price per unit (tax excl.)', array(), 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-            'attr' => ['class' => 'attribute_unity'],
-        ))
-        ->add('attribute_minimal_quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Min. quantity for sale', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'numeric')),
-            )
-        ))
-        ->add('attribute_low_stock_threshold', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'label' => $this->translator->trans('Low stock level', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\Type(array('type' => 'numeric')),
-            ),
-            'attr' => array(
-                'placeholder' => $this->translator->trans(
-                    'Leave empty to disable',
-                    array(),
-                    'Admin.Catalog.Help'
-                ),
-            ),
-        ))
-        ->add('attribute_low_stock_alert', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-            'label' => $this->translator->trans('Send me an email when the quantity is below or equals this level', array(), 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\Type(array('type' => 'bool')),
-            ),
-        ))
-        ->add('available_date_attribute', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Availability date', array(), 'Admin.Catalog.Feature'),
-            'attr' => ['class' => 'date', 'placeholder' => 'YYYY-MM-DD']
-        ))
-        ->add('attribute_default', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-            'label'    => $this->translator->trans('Set as default combination', array(), 'Admin.Catalog.Feature'),
-            'required' => false,
-            'attr' => array('class' => 'attribute_default_checkbox'),
-        ));
+        ])
+            ->add('attribute_reference', TextType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Reference', [], 'Admin.Global'),
+                'empty_data' => '',
+            ])
+            ->add('attribute_ean13', TextType::class, [
+                'required' => false,
+                'error_bubbling' => true,
+                'label' => $this->translator->trans('EAN-13 or JAN barcode', [], 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Assert\Regex("/^[0-9]{0,13}$/"),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('attribute_isbn', TextType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('ISBN code', [], 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Assert\Regex("/^[0-9-]{0,32}$/"),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('attribute_upc', TextType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('UPC barcode', [], 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Assert\Regex("/^[0-9]{0,12}$/"),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('attribute_wholesale_price', MoneyType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Cost price', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+                'attr' => ['class' => 'attribute_wholesale_price']
+            ])
+            ->add('attribute_price', MoneyType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Impact on price (tax excl.)', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+                'attr' => ['class' => 'attribute_priceTE']
+            ])
+            ->add('attribute_priceTI', MoneyType::class, [
+                'required' => false,
+                'mapped' => false,
+                'label' => $this->translator->trans('Impact on price (tax incl.)', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+                'attr' => ['class' => 'attribute_priceTI']
+            ])
+            ->add('attribute_ecotax', MoneyType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Ecotax', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Type(['type' => 'float'])
+                ]
+            ])
+            ->add('attribute_weight', NumberType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Impact on weight', [], 'Admin.Catalog.Feature')
+            ])
+            ->add('attribute_unity', MoneyType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Impact on price per unit (tax excl.)', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+                'attr' => ['class' => 'attribute_unity'],
+            ])
+            ->add('attribute_minimal_quantity', NumberType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Min. quantity for sale', [], 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Type(['type' => 'numeric']),
+                ]
+            ])
+            ->add('attribute_low_stock_threshold', NumberType::class, [
+                'label' => $this->translator->trans('Low stock level', [], 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Assert\Type(['type' => 'numeric']),
+                ],
+                'attr' => [
+                    'placeholder' => $this->translator->trans(
+                        'Leave empty to disable',
+                        [],
+                        'Admin.Catalog.Help'
+                    ),
+                ],
+            ])
+            ->add('attribute_low_stock_alert', CheckboxType::class, [
+                'label' => $this->translator->trans('Send me an email when the quantity is below or equals this level', [], 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Assert\Type(['type' => 'bool']),
+                ],
+            ])
+            ->add('available_date_attribute', DatePickerType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Availability date', [], 'Admin.Catalog.Feature'),
+                'attr' => ['class' => 'date', 'placeholder' => 'YYYY-MM-DD']
+            ])
+            ->add('attribute_default', CheckboxType::class, [
+                'label' => $this->translator->trans('Set as default combination', [], 'Admin.Catalog.Feature'),
+                'required' => false,
+                'attr' => ['class' => 'attribute_default_checkbox'],
+            ]);
         if ($is_stock_management) {
             $builder->add(
                 'attribute_quantity',
-                'Symfony\Component\Form\Extension\Core\Type\NumberType',
-                array(
-                    'required'    => true,
-                    'label'       => $this->translator->trans('Quantity', array(), 'Admin.Catalog.Feature'),
-                    'constraints' => array(
+                NumberType::class,
+                [
+                    'required' => true,
+                    'label' => $this->translator->trans('Quantity', [], 'Admin.Catalog.Feature'),
+                    'constraints' => [
                         new Assert\NotBlank(),
-                        new Assert\Type(array('type' => 'numeric')),
-                    )
-                )
+                        new Assert\Type(['type' => 'numeric']),
+                    ]
+                ]
             );
         }
-        $builder->add('id_image_attr', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'choices'  => array(),
+        $builder->add('id_image_attr', ChoiceType::class, [
+            'choices' => [],
             'required' => false,
             'expanded' => true,
             'multiple' => true,
-            'label' => $this->translator->trans('Select images of this combination:', array(), 'Admin.Catalog.Feature'),
-            'attr' => array('class' => 'images'),
-        ))
-        ->add('final_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Final price', array(), 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-        ));
+            'label' => $this->translator->trans('Select images of this combination:', [], 'Admin.Catalog.Feature'),
+            'attr' => ['class' => 'images'],
+        ])
+            ->add('final_price', MoneyType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Final price', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+            ]);
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $form = $event->getForm();
@@ -208,12 +218,12 @@ class ProductCombination extends CommonAbstractType
                 }
             }
 
-            $form->add('id_image_attr', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+            $form->add('id_image_attr', ChoiceType::class, [
                 'choices' => $choices,
                 'required' => false,
                 'expanded' => true,
                 'multiple' => true,
-            ));
+            ]);
         });
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -30,6 +31,11 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 /**
  * This form class is responsible to generate the form for bulk combination feature
@@ -55,64 +61,64 @@ class ProductCombinationBulk extends CommonAbstractType
         $this->priceDisplayPrecision = $options['price_display_precision'];
 
         if ($is_stock_management) {
-            $builder->add('quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
+            $builder->add('quantity', NumberType::class, [
                 'required' => true,
-                'label' => $this->translator->trans('Quantity', array(), 'Admin.Catalog.Feature'),
-            ));
+                'label' => $this->translator->trans('Quantity', [], 'Admin.Catalog.Feature'),
+            ]);
         }
 
-        $builder->add('cost_price', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
+        $builder->add('cost_price', MoneyType::class, [
             'required' => false,
-            'label' => $this->translator->trans('Cost Price', array(), 'Admin.Catalog.Feature'),
-            'attr' => array('data-display-price-precision' => self::PRESTASHOP_DECIMALS),
+            'label' => $this->translator->trans('Cost Price', [], 'Admin.Catalog.Feature'),
+            'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
             'currency' => $this->isoCode,
-        ))
-        ->add('impact_on_weight', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Impact on weight', array(), 'Admin.Catalog.Feature'),
-        ))
-        ->add('impact_on_price_te', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Impact on price (tax excl.)', array(), 'Admin.Catalog.Feature'),
-            'currency' => $this->isoCode,
-        ))
-        ->add('impact_on_price_ti', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', array(
-            'required' => false,
-            'mapped' => false,
-            'label' => $this->translator->trans('Impact on price (tax incl.)', array(), 'Admin.Catalog.Feature'),
-            'currency' => $this->isoCode,
-        ))
-        ->add('date_availability', 'PrestaShopBundle\Form\Admin\Type\DatePickerType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Availability date', array(), 'Admin.Catalog.Feature'),
-            'attr' => array('class' => 'date', 'placeholder' => 'YYYY-MM-DD'),
-        ))
-        ->add('reference', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Reference', array(), 'Admin.Catalog.Feature'),
-        ))
-        ->add('minimal_quantity', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Minimum quantity', array(), 'Admin.Catalog.Feature'),
-        ))
-        ->add('low_stock_threshold', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Low stock level', array(), 'Admin.Catalog.Feature'),
-        ))
-        ->add('low_stock_alert', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Send me an email when the quantity is below or equals this level', array(), 'Admin.Catalog.Feature'),
-        ));
-
+        ])
+            ->add('impact_on_weight', NumberType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Impact on weight', [], 'Admin.Catalog.Feature'),
+            ])
+            ->add('impact_on_price_te', MoneyType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Impact on price (tax excl.)', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->isoCode,
+            ])
+            ->add('impact_on_price_ti', MoneyType::class, [
+                'required' => false,
+                'mapped' => false,
+                'label' => $this->translator->trans('Impact on price (tax incl.)', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->isoCode,
+            ])
+            ->add('date_availability', DatePickerType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Availability date', [], 'Admin.Catalog.Feature'),
+                'attr' => ['class' => 'date', 'placeholder' => 'YYYY-MM-DD'],
+            ])
+            ->add('reference', TextType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Reference', [], 'Admin.Catalog.Feature'),
+                'empty_data' => '',
+            ])
+            ->add('minimal_quantity', NumberType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Minimum quantity', [], 'Admin.Catalog.Feature'),
+            ])
+            ->add('low_stock_threshold', NumberType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Low stock level', [], 'Admin.Catalog.Feature'),
+            ])
+            ->add('low_stock_alert', CheckboxType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Send me an email when the quantity is below or equals this level', [], 'Admin.Catalog.Feature'),
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'validation_groups' => false,
             'iso_code' => '',
             'price_display_precision' => '',
-        ));
+        ]);
     }
 
     public function getBlockPrefix()

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -61,35 +62,35 @@ class ProductCustomField extends CommonAbstractType
         $builder->add(
             'id_customization_field',
             FormType\HiddenType::class,
-            array(
+            [
                 'required' => false,
-            )
+            ]
         )
-        ->add('label', TranslateType::class, array(
-            'type' => FormType\TextType::class,
-            'options' => [ 'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Length(array('min' => 2))
-            )],
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'label' => $this->translator->trans('Label', [], 'Admin.Global')
-        ))
-        ->add('type', FormType\ChoiceType::class, array(
-            'label' => $this->translator->trans('Type', [], 'Admin.Catalog.Feature'),
-            'choices'  => array(
-                $this->translator->trans('Text', [], 'Admin.Global') => 1,
-                $this->translator->trans('File', [], 'Admin.Global') => 0,
-            ),
-            'attr' => array(
-                'class' => 'c-select',
-            ),
-            'required' =>  true
-        ))
-        ->add('require', FormType\CheckboxType::class, array(
-            'label'    => $this->translator->trans('Required', [], 'Admin.Global'),
-            'required' => false,
-        ));
+            ->add('label', TranslateType::class, [
+                'type' => FormType\TextType::class,
+                'options' => ['constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['min' => 2])
+                ]],
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'label' => $this->translator->trans('Label', [], 'Admin.Global')
+            ])
+            ->add('type', FormType\ChoiceType::class, [
+                'label' => $this->translator->trans('Type', [], 'Admin.Catalog.Feature'),
+                'choices' => [
+                    $this->translator->trans('Text', [], 'Admin.Global') => 1,
+                    $this->translator->trans('File', [], 'Admin.Global') => 0,
+                ],
+                'attr' => [
+                    'class' => 'c-select',
+                ],
+                'required' => true
+            ])
+            ->add('require', FormType\CheckboxType::class, [
+                'label' => $this->translator->trans('Required', [], 'Admin.Global'),
+                'required' => false,
+            ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Category\SimpleCategory;
@@ -129,163 +130,161 @@ class ProductInformation extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $is_stock_management = $this->configuration->get('PS_STOCK_MANAGEMENT');
-        $builder->add('type_product', FormType\ChoiceType::class, array(
-            'choices'  => array(
+        $builder->add('type_product', FormType\ChoiceType::class, [
+            'choices' => [
                 $this->translator->trans('Standard product', [], 'Admin.Catalog.Feature') => 0,
                 $this->translator->trans('Pack of products', [], 'Admin.Catalog.Feature') => 1,
                 $this->translator->trans('Virtual product', [], 'Admin.Catalog.Feature') => 2,
-            ),
-            'attr' => array(
+            ],
+            'attr' => [
                 'class' => 'custom-select',
-            ),
-            'label' =>  $this->translator->trans('Type', [], 'Admin.Catalog.Feature'),
+            ],
+            'label' => $this->translator->trans('Type', [], 'Admin.Catalog.Feature'),
             'required' => true,
-        ))
-        ->add('inputPackItems', TypeaheadProductPackCollectionType::class, array(
-            'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&excludeVirtuals=1&limit=20&q=%QUERY',
-            'mapping_value' => 'id',
-            'mapping_name' => 'name',
-            'placeholder' => $this->translator->trans('Search for a product', [], 'Admin.Catalog.Help'),
-            'template_collection' => '
+        ])
+            ->add('inputPackItems', TypeaheadProductPackCollectionType::class, [
+                'remote_url' => $this->context->getAdminLink('', false) . 'ajax_products_list.php?forceJson=1&excludeVirtuals=1&limit=20&q=%QUERY',
+                'mapping_value' => 'id',
+                'mapping_name' => 'name',
+                'placeholder' => $this->translator->trans('Search for a product', [], 'Admin.Catalog.Help'),
+                'template_collection' => '
               <h4>%s</h4>
               <div class="ref">REF: %s</div>
               <div class="quantity text-md-right">x%s</div>
               <button type="button" class="btn btn-danger btn-sm delete"><i class="material-icons">delete</i></button>
             ',
-            'required' => false,
-            'label' => $this->translator->trans('Add products to your pack', [], 'Admin.Catalog.Feature'),
-        ))
-        ->add('name', TranslateType::class, array(
-            'type' => FormType\TextType::class,
-            'options' => [
-                'constraints' => array(
-                    new Assert\Regex(array(
-                        'pattern' => '/[<>;=#{}]/',
-                        'match'   => false,
-                    )),
-                    new Assert\NotBlank(),
-                    new Assert\Length(array('min' => 3, 'max' => 128))
-                ),
-                'attr' => [
-                    'placeholder' => $this->translator->trans('Enter your product name', [], 'Admin.Catalog.Help'),
-                    'class' => 'edit js-edit'
-                ]
-            ],
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'label' => $this->translator->trans('Name', [], 'Admin.Global')
-        ))
-        ->add('description', TranslateType::class, array(
-            'type' => FormattedTextareaType::class,
-            'options' => array(
                 'required' => false,
-            ),
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'label' =>  $this->translator->trans('Description', [], 'Admin.Global'),
-            'required' => false
-        ))
-        ->add('description_short', TranslateType::class, array(
-            'type' => FormType\TextareaType::class, // https://github.com/symfony/symfony/issues/5906
-            'options' => [
-                'attr' => array(
-                    'class' => 'autoload_rte',
-                    'placeholder' => $this->translator->trans('The summary is a short sentence describing your product.<br />It will appears at the top of your shop\'s product page, in product lists, and in search engines\' results page (so it\'s important for SEO). To give more details about your product, use the "Description" tab.', [], 'Admin.Catalog.Help'),
-                    'counter' => (int)$this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT') <= 0 ? 800 : (int)$this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT'),
-                ),
-                'constraints' => array(
-                    new TinyMceMaxLength(array(
-                        'max' => (int)$this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT') <= 0 ? 800 : (int)$this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT')
-                    ))
-                ),
+                'label' => $this->translator->trans('Add products to your pack', [], 'Admin.Catalog.Feature'),
+            ])
+            ->add('name', TranslateType::class, [
+                'type' => FormType\TextType::class,
+                'options' => [
+                    'constraints' => [
+                        new Assert\Regex([
+                            'pattern' => '/[<>;=#{}]/',
+                            'match' => false,
+                        ]),
+                        new Assert\NotBlank(),
+                        new Assert\Length(['min' => 3, 'max' => 128])
+                    ],
+                    'attr' => [
+                        'placeholder' => $this->translator->trans('Enter your product name', [], 'Admin.Catalog.Help'),
+                        'class' => 'edit js-edit'
+                    ]
+                ],
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'label' => $this->translator->trans('Name', [], 'Admin.Global')
+            ])
+            ->add('description', TranslateType::class, [
+                'type' => FormattedTextareaType::class,
+                'options' => [
+                    'required' => false,
+                ],
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'label' => $this->translator->trans('Description', [], 'Admin.Global'),
                 'required' => false
-            ],
-            'locales' => $this->locales,
-            'hideTabs' => true,
-            'label' =>  $this->translator->trans('Short description', [], 'Admin.Catalog.Feature'),
-            'required' => false
-        ))
-
-        //FEATURES & ATTRIBUTES
-        ->add('features', FormType\CollectionType::class, array(
-            'entry_type' =>'PrestaShopBundle\Form\Admin\Feature\ProductFeature',
-            'prototype' => true,
-            'allow_add' => true,
-            'allow_delete' => true
-        ))
-        ->add('id_manufacturer', FormType\ChoiceType::class, array(
-            'choices' => $this->manufacturers,
-            'required' => false,
-            'attr' => array(
-                'data-toggle' => 'select2',
-                'data-minimumResultsForSearch' => '7',
-            ),
-            'label' => $this->translator->trans('Brand', [], 'Admin.Catalog.Feature')
-        ))
-
-        //RIGHT COL
-        ->add('active', FormType\CheckboxType::class, array(
-            'label' => $this->translator->trans('Enabled', [], 'Admin.Global'),
-            'required' => false,
-        ))
-        ->add('price_shortcut', FormType\MoneyType::class, array(
-            'required' => false,
-            'label' => $this->translator->trans('Pre-tax retail price', [], 'Admin.Catalog.Feature'),
-            'currency' => $this->currency->iso_code,
-            'constraints' => array(
-                new Assert\NotBlank(),
-                new Assert\Type(array('type' => 'float'))
-            ),
-            'attr' => []
-        ))
-        ->add('price_ttc_shortcut', FormType\MoneyType::class, array(
-            'required' => false,
-            'label' => $this->translator->trans('Retail price with tax', [], 'Admin.Catalog.Feature'),
-            'mapped' => false,
-            'currency' => $this->currency->iso_code,
-        ));
+            ])
+            ->add('description_short', TranslateType::class, [
+                'type' => FormType\TextareaType::class, // https://github.com/symfony/symfony/issues/5906
+                'options' => [
+                    'attr' => [
+                        'class' => 'autoload_rte',
+                        'placeholder' => $this->translator->trans('The summary is a short sentence describing your product.<br />It will appears at the top of your shop\'s product page, in product lists, and in search engines\' results page (so it\'s important for SEO). To give more details about your product, use the "Description" tab.', [], 'Admin.Catalog.Help'),
+                        'counter' => (int)$this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT') <= 0 ? 800 : (int)$this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT'),
+                    ],
+                    'constraints' => [
+                        new TinyMceMaxLength([
+                            'max' => (int)$this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT') <= 0 ? 800 : (int)$this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT')
+                        ])
+                    ],
+                    'required' => false
+                ],
+                'locales' => $this->locales,
+                'hideTabs' => true,
+                'label' => $this->translator->trans('Short description', [], 'Admin.Catalog.Feature'),
+                'required' => false
+            ])
+            //FEATURES & ATTRIBUTES
+            ->add('features', FormType\CollectionType::class, [
+                'entry_type' => 'PrestaShopBundle\Form\Admin\Feature\ProductFeature',
+                'prototype' => true,
+                'allow_add' => true,
+                'allow_delete' => true
+            ])
+            ->add('id_manufacturer', FormType\ChoiceType::class, [
+                'choices' => $this->manufacturers,
+                'required' => false,
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
+                'label' => $this->translator->trans('Brand', [], 'Admin.Catalog.Feature')
+            ])
+            //RIGHT COL
+            ->add('active', FormType\CheckboxType::class, [
+                'label' => $this->translator->trans('Enabled', [], 'Admin.Global'),
+                'required' => false,
+            ])
+            ->add('price_shortcut', FormType\MoneyType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Pre-tax retail price', [], 'Admin.Catalog.Feature'),
+                'currency' => $this->currency->iso_code,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Type(['type' => 'float'])
+                ],
+                'attr' => []
+            ])
+            ->add('price_ttc_shortcut', FormType\MoneyType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Retail price with tax', [], 'Admin.Catalog.Feature'),
+                'mapped' => false,
+                'currency' => $this->currency->iso_code,
+            ]);
         if ($is_stock_management) {
-            $builder->add('qty_0_shortcut', FormType\NumberType::class, array(
+            $builder->add('qty_0_shortcut', FormType\NumberType::class, [
                 'required' => false,
                 'label' => $this->translator->trans('Quantity', [], 'Admin.Catalog.Feature'),
-                'constraints' => array(
+                'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Type(array('type' => 'numeric'))
-                )
-            ));
+                    new Assert\Type(['type' => 'numeric'])
+                ]
+            ]);
         }
-        $builder->add('categories', ChoiceCategoriesTreeType::class, array(
+        $builder->add('categories', ChoiceCategoriesTreeType::class, [
             'label' => $this->translator->trans('Associated categories', [], 'Admin.Catalog.Feature'),
             'list' => $this->nested_categories,
             'valid_list' => $this->categories,
             'multiple' => true,
-        ))
-        ->add('id_category_default', FormType\ChoiceType::class, array(
-            'choices' =>  $this->categories,
-            'expanded' => true,
-            'multiple' => false,
-            'required' =>  true,
-            'label' => $this->translator->trans('Default category', [], 'Admin.Catalog.Feature')
-        ))
-        ->add('new_category', SimpleCategory::class, array(
-            'ajax' => true,
-            'required' => false,
-            'mapped' => false,
-            'constraints' => [],
-            'label' => $this->translator->trans('Add a new category', [], 'Admin.Catalog.Feature'),
-        ))
-        ->add('ignore', null, [
-            'mapped' => false
         ])
-        ->add('related_products', TypeaheadProductCollectionType::class, array(
-            'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
-            'mapping_value' => 'id',
-            'mapping_name' => 'name',
-            'placeholder' => $this->translator->trans('Search and add a related product', [], 'Admin.Catalog.Help'),
-            'template_collection' => '<span class="label">%s</span><i class="material-icons delete">clear</i>',
-            'required' => false,
-            'label' =>  $this->translator->trans('Accessories', [], 'Admin.Catalog.Feature')
-        ));
+            ->add('id_category_default', FormType\ChoiceType::class, [
+                'choices' => $this->categories,
+                'expanded' => true,
+                'multiple' => false,
+                'required' => true,
+                'label' => $this->translator->trans('Default category', [], 'Admin.Catalog.Feature')
+            ])
+            ->add('new_category', SimpleCategory::class, [
+                'ajax' => true,
+                'required' => false,
+                'mapped' => false,
+                'constraints' => [],
+                'label' => $this->translator->trans('Add a new category', [], 'Admin.Catalog.Feature'),
+            ])
+            ->add('ignore', null, [
+                'mapped' => false
+            ])
+            ->add('related_products', TypeaheadProductCollectionType::class, [
+                'remote_url' => $this->context->getAdminLink('', false) . 'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
+                'mapping_value' => 'id',
+                'mapping_name' => 'name',
+                'placeholder' => $this->translator->trans('Search and add a related product', [], 'Admin.Catalog.Help'),
+                'template_collection' => '<span class="label">%s</span><i class="material-icons delete">clear</i>',
+                'required' => false,
+                'label' => $this->translator->trans('Accessories', [], 'Admin.Catalog.Feature')
+            ]);
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
@@ -101,130 +101,134 @@ class ProductOptions extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('visibility', FormType\ChoiceType::class, array(
-            'choices'  => array(
+        $builder->add('visibility', FormType\ChoiceType::class, [
+            'choices' => [
                 $this->translator->trans('Everywhere', [], 'Admin.Catalog.Feature') => 'both',
                 $this->translator->trans('Catalog only', [], 'Admin.Catalog.Feature') => 'catalog',
                 $this->translator->trans('Search only', [], 'Admin.Catalog.Feature') => 'search',
                 $this->translator->trans('Nowhere', [], 'Admin.Catalog.Feature') => 'none',
-            ),
-            'attr' => array(
+            ],
+            'attr' => [
                 'class' => 'custom-select',
-            ),
+            ],
             'required' => true,
             'label' => $this->translator->trans('Visibility', [], 'Admin.Catalog.Feature'),
-        ))
-        ->add('tags', TranslateType::class, array(
-            'type' => FormType\TextType::class,
-            'options' => [
+        ])
+            ->add('tags', TranslateType::class, [
+                'type' => FormType\TextType::class,
+                'options' => [
+                    'attr' => [
+                        'class' => 'tokenfield',
+                        'placeholder' => $this->translator->trans('Use a comma to create separate tags. E.g.: dress, cotton, party dresses.', [], 'Admin.Catalog.Help')
+                    ]
+                ],
+                'locales' => $this->locales,
+                'label' => $this->translator->trans('Tags', [], 'Admin.Catalog.Feature')
+            ])
+            ->add(
+                $builder->create(
+                    'display_options',
+                    FormType\FormType::class,
+                    [
+                        'required' => false,
+                        'label' => $this->translator->trans('Display options', [], 'Admin.Catalog.Feature')
+                    ]
+                )
+                    ->add(
+                        'available_for_order',
+                        FormType\CheckboxType::class,
+                        [
+                            'label' => $this->translator->trans('Available for order', [], 'Admin.Catalog.Feature'),
+                            'required' => false,
+                        ]
+                    )
+                    ->add(
+                        'show_price',
+                        FormType\CheckboxType::class,
+                        [
+                            'label' => $this->translator->trans('Show price', [], 'Admin.Catalog.Feature'),
+                            'required' => false,
+                        ]
+                    )
+                    ->add(
+                        'online_only',
+                        FormType\CheckboxType::class,
+                        [
+                            'label' => $this->translator->trans(
+                                'Web only (not sold in your retail store)',
+                                [],
+                                'Admin.Catalog.Feature'
+                            ),
+                            'required' => false,
+                        ]
+                    )
+            )
+            ->add('upc', FormType\TextType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('UPC barcode', [], 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Assert\Regex("/^[0-9]{0,12}$/"),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('ean13', FormType\TextType::class, [
+                'required' => false,
+                'error_bubbling' => true,
+                'label' => $this->translator->trans('EAN-13 or JAN barcode', [], 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Assert\Regex("/^[0-9]{0,13}$/"),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('isbn', FormType\TextType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('ISBN', [], 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Assert\Regex("/^[0-9-]{0,32}$/"),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('reference', FormType\TextType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Reference', [], 'Admin.Global'),
+                'empty_data' => '',
+            ])
+            ->add('show_condition', FormType\CheckboxType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Display condition on product page', [], 'Admin.Catalog.Feature'),
+            ])
+            ->add('condition', FormType\ChoiceType::class, [
+                'choices' => [
+                    $this->translator->trans('New', [], 'Shop.Theme.Catalog') => 'new',
+                    $this->translator->trans('Used', [], 'Shop.Theme.Catalog') => 'used',
+                    $this->translator->trans('Refurbished', [], 'Shop.Theme.Catalog') => 'refurbished'
+                ],
                 'attr' => [
-                    'class' => 'tokenfield',
-                    'placeholder' => $this->translator->trans('Use a comma to create separate tags. E.g.: dress, cotton, party dresses.', [], 'Admin.Catalog.Help')
-                ]
-            ],
-            'locales' => $this->locales,
-            'label' => $this->translator->trans('Tags', [], 'Admin.Catalog.Feature')
-        ))
-        ->add(
-            $builder->create(
-                'display_options',
-                FormType\FormType::class,
-                [
-                    'required' => false,
-                    'label' => $this->translator->trans('Display options', [], 'Admin.Catalog.Feature')
-                ]
-            )
-            ->add(
-                'available_for_order',
-                FormType\CheckboxType::class,
-                array(
-                    'label'    => $this->translator->trans('Available for order', [], 'Admin.Catalog.Feature'),
-                    'required' => false,
-                )
-            )
-            ->add(
-                'show_price',
-                FormType\CheckboxType::class,
-                array(
-                    'label'    => $this->translator->trans('Show price', [], 'Admin.Catalog.Feature'),
-                    'required' => false,
-                )
-            )
-            ->add(
-                'online_only',
-                FormType\CheckboxType::class,
-                array(
-                    'label'    => $this->translator->trans(
-                        'Web only (not sold in your retail store)',
-                        [],
-                        'Admin.Catalog.Feature'
-                    ),
-                    'required' => false,
-                )
-            )
-        )
-        ->add('upc', FormType\TextType::class, array(
-            'required' => false,
-            'label' => $this->translator->trans('UPC barcode', [], 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\Regex("/^[0-9]{0,12}$/"),
-            )
-        ))
-        ->add('ean13', FormType\TextType::class, array(
-            'required' => false,
-            'error_bubbling' => true,
-            'label' => $this->translator->trans('EAN-13 or JAN barcode', [], 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\Regex("/^[0-9]{0,13}$/"),
-            )
-        ))
-        ->add('isbn', FormType\TextType::class, array(
-            'required' => false,
-            'label' => $this->translator->trans('ISBN', [], 'Admin.Catalog.Feature'),
-            'constraints' => array(
-                new Assert\Regex("/^[0-9-]{0,32}$/"),
-            ),
-        ))
-        ->add('reference', FormType\TextType::class, array(
-            'required' => false,
-            'label' => $this->translator->trans('Reference', [], 'Admin.Global')
-        ))
-        ->add('show_condition', FormType\CheckboxType::class, array(
-            'required' => false,
-            'label' => $this->translator->trans('Display condition on product page', [], 'Admin.Catalog.Feature'),
-        ))
-        ->add('condition', FormType\ChoiceType::class, array(
-            'choices'  => array(
-                 $this->translator->trans('New', [], 'Shop.Theme.Catalog') => 'new',
-                 $this->translator->trans('Used', [], 'Shop.Theme.Catalog') => 'used',
-                 $this->translator->trans('Refurbished', [], 'Shop.Theme.Catalog') => 'refurbished'
-            ),
-            'attr' => array(
-                'class' => 'custom-select',
-            ),
-            'required' => true,
-            'label' => $this->translator->trans('Condition', [], 'Admin.Catalog.Feature')
-        ))
-        ->add('suppliers', FormType\ChoiceType::class, array(
-            'choices' =>  $this->suppliers,
-            'expanded' =>  true,
-            'multiple' =>  true,
-            'required' =>  false,
-            'attr' => array(
-                'class' => 'custom-select',
-            ),
-            'label' => $this->translator->trans('Suppliers', [], 'Admin.Global')
-        ))
-        ->add('default_supplier', FormType\ChoiceType::class, array(
-            'choices' =>  $this->suppliers,
-            'expanded' =>  true,
-            'multiple' =>  false,
-            'required' =>  true,
-            'attr' => array(
-                'class' => 'custom-select',
-            ),
-            'label' => $this->translator->trans('Default suppliers', [], 'Admin.Catalog.Feature')
-        ));
+                    'class' => 'custom-select',
+                ],
+                'required' => true,
+                'label' => $this->translator->trans('Condition', [], 'Admin.Catalog.Feature')
+            ])
+            ->add('suppliers', FormType\ChoiceType::class, [
+                'choices' => $this->suppliers,
+                'expanded' => true,
+                'multiple' => true,
+                'required' => false,
+                'attr' => [
+                    'class' => 'custom-select',
+                ],
+                'label' => $this->translator->trans('Suppliers', [], 'Admin.Global')
+            ])
+            ->add('default_supplier', FormType\ChoiceType::class, [
+                'choices' => $this->suppliers,
+                'expanded' => true,
+                'multiple' => false,
+                'required' => true,
+                'attr' => [
+                    'class' => 'custom-select',
+                ],
+                'label' => $this->translator->trans('Default suppliers', [], 'Admin.Catalog.Feature')
+            ]);
 
         foreach ($this->suppliers as $supplier => $id) {
             $builder->add(
@@ -232,9 +236,9 @@ class ProductOptions extends CommonAbstractType
                 FormType\CollectionType::class,
                 [
                     'entry_type' => ProductSupplierCombination::class,
-                    'entry_options'  => array(
+                    'entry_options' => [
                         'id_supplier' => $id,
-                    ),
+                    ],
                     'prototype' => true,
                     'allow_add' => true,
                     'required' => false,
@@ -243,37 +247,37 @@ class ProductOptions extends CommonAbstractType
             );
         }
 
-        $builder->add('custom_fields', FormType\CollectionType::class, array(
+        $builder->add('custom_fields', FormType\CollectionType::class, [
             'entry_type' => ProductCustomField::class,
             'label' => $this->translator->trans('Customization', [], 'Admin.Catalog.Feature'),
             'prototype' => true,
             'allow_add' => true,
             'allow_delete' => true
-        ));
+        ]);
 
         //Add product attachment form
-        $builder->add('attachment_product', ProductAttachement::class, array(
+        $builder->add('attachment_product', ProductAttachement::class, [
             'required' => false,
             'label' => $this->translator->trans('Attachment', [], 'Admin.Catalog.Feature'),
-            'attr' => ['data-action' => $this->router->generate('admin_product_attachement_add_action', array('idProduct' => 1))]
-        ));
+            'attr' => ['data-action' => $this->router->generate('admin_product_attachement_add_action', ['idProduct' => 1])]
+        ]);
 
         //Add attachment selectors
-        $builder->add('attachments', FormType\ChoiceType::class, array(
-            'expanded'  => true,
-            'multiple'  => true,
-            'choices'  => $this->attachmentList,
+        $builder->add('attachments', FormType\ChoiceType::class, [
+            'expanded' => true,
+            'multiple' => true,
+            'choices' => $this->attachmentList,
             'choice_label' => function ($choice, $key, $value) {
                 $attachmentKey = array_search($key, array_column($this->fullAttachmentList, 'file'));
                 return $this->fullAttachmentList[$attachmentKey]['name'];
             },
             'required' => false,
-            'attr' => array(
+            'attr' => [
                 'class' => 'custom-select',
                 'data' => $this->fullAttachmentList
-            ),
+            ],
             'label' => $this->translator->trans('Attachments for this product:', [], 'Admin.Catalog.Feature')
-        ));
+        ]);
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
@@ -282,7 +286,7 @@ class ProductOptions extends CommonAbstractType
             if (!isset($data['suppliers']) || count($data['suppliers']) == 0) {
                 $form = $event->getForm();
                 foreach ($this->suppliers as $supplier => $id) {
-                    $form->remove('supplier_combination_'.$id);
+                    $form->remove('supplier_combination_' . $id);
                 }
             }
         });

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -82,130 +83,131 @@ class ProductPrice extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $this->tax_rules = array_merge(
-            array($this->translator->trans('No tax', [], 'Admin.Catalog.Feature') => 0),
+            [$this->translator->trans('No tax', [], 'Admin.Catalog.Feature') => 0],
             $this->tax_rules
         );
         $builder->add(
             'price',
             FormType\MoneyType::class,
-            array(
+            [
                 'required' => false,
                 'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
                 'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
                 'currency' => $this->currency->iso_code,
-                'constraints' => array(
+                'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Type(array('type' => 'float'))
-                )
-            )
+                    new Assert\Type(['type' => 'float'])
+                ]
+            ]
         )
-        ->add(
-            'price_ttc',
-            FormType\MoneyType::class,
-            array(
-                'required' => false,
-                'mapped' => false,
-                'label' => $this->translator->trans('Price (tax incl.)', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
+            ->add(
+                'price_ttc',
+                FormType\MoneyType::class,
+                [
+                    'required' => false,
+                    'mapped' => false,
+                    'label' => $this->translator->trans('Price (tax incl.)', [], 'Admin.Catalog.Feature'),
+                    'currency' => $this->currency->iso_code,
+                ]
             )
-        )
-        ->add(
-            'ecotax',
-            FormType\MoneyType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Ecotax (tax incl.)', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
-                'constraints' => array(
-                    new Assert\NotBlank(),
-                    new Assert\Type(array('type' => 'float'))
-                ),
-                'attr' => ['data-eco-tax-rate' => $this->eco_tax_rate],
+            ->add(
+                'ecotax',
+                FormType\MoneyType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Ecotax (tax incl.)', [], 'Admin.Catalog.Feature'),
+                    'currency' => $this->currency->iso_code,
+                    'constraints' => [
+                        new Assert\NotBlank(),
+                        new Assert\Type(['type' => 'float'])
+                    ],
+                    'attr' => ['data-eco-tax-rate' => $this->eco_tax_rate],
+                ]
             )
-        )
-        ->add(
-            'id_tax_rules_group',
-            FormType\ChoiceType::class,
-            array(
-                'choices' =>  $this->tax_rules,
-                'required' => true,
-                'choice_attr' => function ($val) {
-                    return [
-                        'data-rates' => implode(',', $this->tax_rules_rates[$val]['rates']),
-                        'data-computation-method' => $this->tax_rules_rates[$val]['computation_method'],
-                    ];
-                },
-                'attr' => array(
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ),
-                'label' => $this->translator->trans('Tax rule', [], 'Admin.Catalog.Feature'),
+            ->add(
+                'id_tax_rules_group',
+                FormType\ChoiceType::class,
+                [
+                    'choices' => $this->tax_rules,
+                    'required' => true,
+                    'choice_attr' => function ($val) {
+                        return [
+                            'data-rates' => implode(',', $this->tax_rules_rates[$val]['rates']),
+                            'data-computation-method' => $this->tax_rules_rates[$val]['computation_method'],
+                        ];
+                    },
+                    'attr' => [
+                        'data-toggle' => 'select2',
+                        'data-minimumResultsForSearch' => '7',
+                    ],
+                    'label' => $this->translator->trans('Tax rule', [], 'Admin.Catalog.Feature'),
+                ]
             )
-        )
-        ->add(
-            'on_sale',
-            FormType\CheckboxType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans(
-                    'Display the "On sale!" flag on the product page, and on product listings.',
-                    [],
-                    'Admin.Catalog.Feature'
-                ),
+            ->add(
+                'on_sale',
+                FormType\CheckboxType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans(
+                        'Display the "On sale!" flag on the product page, and on product listings.',
+                        [],
+                        'Admin.Catalog.Feature'
+                    ),
+                ]
             )
-        )
-        ->add(
-            'wholesale_price',
-            FormType\MoneyType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
+            ->add(
+                'wholesale_price',
+                FormType\MoneyType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
+                    'currency' => $this->currency->iso_code,
+                ]
             )
-        )
-        ->add(
-            'unit_price',
-            FormType\MoneyType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Price per unit (tax excl.)', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
+            ->add(
+                'unit_price',
+                FormType\MoneyType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Price per unit (tax excl.)', [], 'Admin.Catalog.Feature'),
+                    'currency' => $this->currency->iso_code,
+                ]
             )
-        )
-        ->add(
-            'unity',
-            FormType\TextType::class,
-            array(
-                'required' => false,
-                'attr' => ['placeholder' => $this->translator->trans('Per kilo, per litre', [], 'Admin.Catalog.Help')]
+            ->add(
+                'unity',
+                FormType\TextType::class,
+                [
+                    'required' => false,
+                    'attr' => ['placeholder' => $this->translator->trans('Per kilo, per litre', [], 'Admin.Catalog.Help')]
+                ]
             )
-        )
-        ->add('specific_price', ProductSpecificPrice::class)
-        ->add(
-            'specificPricePriorityToAll',
-            FormType\CheckboxType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Apply to all products', [], 'Admin.Catalog.Feature'),
-            )
-        );
+            ->add('specific_price', ProductSpecificPrice::class)
+            ->add(
+                'specificPricePriorityToAll',
+                FormType\CheckboxType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Apply to all products', [], 'Admin.Catalog.Feature'),
+                ]
+            );
 
         //generates fields for price priority
         $specificPricePriorityChoices = [
-             $this->translator->trans('Shop', [], 'Admin.Global') => 'id_shop',
-             $this->translator->trans('Currency', [], 'Admin.Global') => 'id_currency',
-             $this->translator->trans('Country', [], 'Admin.Global') => 'id_country',
-             $this->translator->trans('Group', [], 'Admin.Global') => 'id_group',
+            $this->translator->trans('Shop', [], 'Admin.Global') => 'id_shop',
+            $this->translator->trans('Currency', [], 'Admin.Global') => 'id_currency',
+            $this->translator->trans('Country', [], 'Admin.Global') => 'id_country',
+            $this->translator->trans('Group', [], 'Admin.Global') => 'id_group',
         ];
+
 
         for ($i=0, $iMax = count($specificPricePriorityChoices); $i < $iMax; $i++) {
             $builder->add(
-                'specificPricePriority_'.$i,
+                'specificPricePriority_' . $i,
                 FormType\ChoiceType::class,
-                array(
+                [
                     'choices' => $specificPricePriorityChoices,
                     'required' => true
-                )
+                ]
             );
         }
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -75,32 +75,33 @@ class ProductQuantity extends CommonAbstractType
             ->add(
                 'attributes',
                 FormType\TextType::class,
-                array(
-                    'attr'  => array(
-                        'class'          => 'tokenfield',
+                [
+                    'attr' => [
+                        'class' => 'tokenfield',
                         'data-minLength' => 1,
-                        'placeholder'    => $this->translator->trans(
+                        'placeholder' => $this->translator->trans(
                             'Combine several attributes, e.g.: "Size: all", "Color: red".',
                             [],
                             'Admin.Catalog.Help'
                         ),
-                        'data-prefetch'  => $this->router->generate('admin_attribute_get_all'),
-                        'data-action'    => $this->router->generate('admin_attribute_generator'),
-                    ),
+                        'data-prefetch' => $this->router->generate('admin_attribute_get_all'),
+                        'data-action' => $this->router->generate('admin_attribute_generator'),
+                    ],
                     'label' => $this->translator->trans('Create combinations', [], 'Admin.Catalog.Feature'),
-                )
+                    'empty_data' => '',
+                ]
             )
             ->add(
                 'advanced_stock_management',
                 FormType\CheckboxType::class,
-                array(
+                [
                     'required' => false,
-                    'label'    => $this->translator->trans(
+                    'label' => $this->translator->trans(
                         'I want to use the advanced stock management system for this product.',
                         [],
                         'Admin.Catalog.Feature'
                     ),
-                )
+                ]
             )
             ->add(
                 'pack_stock_type',
@@ -109,8 +110,8 @@ class ProductQuantity extends CommonAbstractType
             ->add(
                 'depends_on_stock',
                 FormType\ChoiceType::class,
-                array(
-                    'choices' => array(
+                [
+                    'choices' => [
                         $this->translator->trans(
                             'The available quantities for the current product and its combinations are based on the stock in your warehouse (using the advanced stock management system). ',
                             [],
@@ -121,25 +122,25 @@ class ProductQuantity extends CommonAbstractType
                             [],
                             'Admin.Catalog.Feature'
                         ) => 0,
-                    ),
+                    ],
                     'expanded' => true,
                     'required' => true,
                     'multiple' => false,
-                )
+                ]
             );
 
         if ($is_stock_management) {
             $builder->add(
                 'qty_0',
                 FormType\NumberType::class,
-                array(
+                [
                     'required' => true,
                     'label' => $this->translator->trans('Quantity', [], 'Admin.Catalog.Feature'),
-                    'constraints' => array(
+                    'constraints' => [
                         new Assert\NotBlank(),
-                        new Assert\Type(array('type' => 'numeric')),
-                    ),
-                )
+                        new Assert\Type(['type' => 'numeric']),
+                    ],
+                ]
             );
         }
         $builder
@@ -150,57 +151,57 @@ class ProductQuantity extends CommonAbstractType
             ->add(
                 'minimal_quantity',
                 FormType\NumberType::class,
-                array(
+                [
                     'required' => true,
                     'label' => $this->translator->trans('Minimum quantity for sale', [], 'Admin.Catalog.Feature'),
-                    'constraints' => array(
+                    'constraints' => [
                         new Assert\NotBlank(),
-                        new Assert\Type(array('type' => 'numeric')),
-                    ),
-                )
+                        new Assert\Type(['type' => 'numeric']),
+                    ],
+                ]
             )
             ->add(
                 'low_stock_threshold',
                 FormType\NumberType::class,
-                array(
+                [
                     'label' => $this->translator->trans('Low stock level', [], 'Admin.Catalog.Feature'),
-                    'attr' => array(
+                    'attr' => [
                         'placeholder' => $this->translator->trans('Leave empty to disable', [], 'Admin.Catalog.Help'),
-                    ),
-                    'constraints' => array(
-                        new Assert\Type(array('type' => 'numeric')),
-                    ),
-                )
+                    ],
+                    'constraints' => [
+                        new Assert\Type(['type' => 'numeric']),
+                    ],
+                ]
             )
             ->add(
                 'low_stock_alert',
                 FormType\CheckboxType::class,
-                array(
+                [
                     'label' => $this->translator->trans(
                         'Send me an email when the quantity is below or equals this level',
                         [],
                         'Admin.Catalog.Feature'
                     ),
-                    'constraints' => array(
-                        new Assert\Type(array('type' => 'bool')),
-                    ),
-                )
+                    'constraints' => [
+                        new Assert\Type(['type' => 'bool']),
+                    ],
+                ]
             )
             ->add(
                 'available_now',
                 TranslateType::class,
-                array(
+                [
                     'type' => FormType\TextType::class,
                     'options' => [],
                     'locales' => $this->locales,
                     'hideTabs' => true,
                     'label' => $this->translator->trans('Label when in stock', [], 'Admin.Catalog.Feature'),
-                )
+                ]
             )
             ->add(
                 'available_later',
                 TranslateType::class,
-                array(
+                [
                     'type' => FormType\TextType::class,
                     'options' => [],
                     'locales' => $this->locales,
@@ -210,28 +211,28 @@ class ProductQuantity extends CommonAbstractType
                         [],
                         'Admin.Catalog.Feature'
                     ),
-                )
+                ]
             )
             ->add(
                 'available_date',
                 DatePickerType::class,
-                array(
+                [
                     'required' => false,
                     'label' => $this->translator->trans('Availability date', [], 'Admin.Catalog.Feature'),
-                    'attr' => array('placeholder' => 'YYYY-MM-DD'),
-                )
+                    'attr' => ['placeholder' => 'YYYY-MM-DD'],
+                ]
             )
             ->add(
                 'virtual_product',
                 ProductVirtual::class,
-                array(
+                [
                     'required' => false,
                     'label' => $this->translator->trans(
                         'Does this product have an associated file?',
                         [],
                         'Admin.Catalog.Feature'
                     ),
-                )
+                ]
             );
 
         $builder->addEventListener(
@@ -253,22 +254,22 @@ class ProductQuantity extends CommonAbstractType
                 $form->add(
                     'out_of_stock',
                     FormType\ChoiceType::class,
-                    array(
-                        'choices' => array(
-                            $this->translator->trans('Deny orders', [], 'Admin.Catalog.Feature')  => '0',
+                    [
+                        'choices' => [
+                            $this->translator->trans('Deny orders', [], 'Admin.Catalog.Feature') => '0',
                             $this->translator->trans('Allow orders', [], 'Admin.Catalog.Feature') => '1',
                             $defaultChoiceLabel => '2',
-                        ),
+                        ],
                         'expanded' => true,
                         'required' => false,
-                        'placeholder'=> false,
+                        'placeholder' => false,
                         'label' => $this->translator->trans('When out of stock', [], 'Admin.Catalog.Feature'),
-                    )
+                    ]
                 );
 
                 //Manage out_of_stock field with contextual values/label
                 $pack_stock_type = $this->configuration->get('PS_PACK_STOCK_TYPE');
-                $defaultChoiceLabel = $this->translator->trans('Default', [], 'Admin.Global').': ';
+                $defaultChoiceLabel = $this->translator->trans('Default', [], 'Admin.Global') . ': ';
                 if ($pack_stock_type == Pack::STOCK_TYPE_PACK_ONLY) {
                     $defaultChoiceLabel .= $this->translator->trans(
                         'Decrement pack only.',
@@ -288,18 +289,18 @@ class ProductQuantity extends CommonAbstractType
                 $form->add(
                     'pack_stock_type',
                     FormType\ChoiceType::class,
-                    array(
-                        'choices' => array(
+                    [
+                        'choices' => [
                             $this->translator->trans('Decrement pack only.', [], 'Admin.Catalog.Feature') => 0,
                             $this->translator->trans('Decrement products in pack only.', [], 'Admin.Catalog.Feature') => 1,
-                            $this->translator->trans('Decrement both.', [], 'Admin.Catalog.Feature')  => 2,
+                            $this->translator->trans('Decrement both.', [], 'Admin.Catalog.Feature') => 2,
                             $defaultChoiceLabel => 3,
-                        ),
+                        ],
                         'expanded' => false,
                         'required' => true,
                         'placeholder' => false,
                         'label' => $this->translator->trans('Pack quantities', [], 'Admin.Catalog.Feature'),
-                    )
+                    ]
                 );
             }
         );
@@ -313,9 +314,9 @@ class ProductQuantity extends CommonAbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
-            array(
+            [
                 'allow_extra_fields' => true,
-            )
+            ]
         );
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType;
@@ -62,17 +63,17 @@ class ProductSeo extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $remoteUrls = array(
-            '301-product' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
-            '302-product' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
-            '301-category' => $this->router->generate('admin_get_ajax_categories').'&query=%QUERY',
-            '302-category' => $this->router->generate('admin_get_ajax_categories').'&query=%QUERY',
-        );
+        $remoteUrls = [
+            '301-product' => $this->context->getAdminLink('', false) . 'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
+            '302-product' => $this->context->getAdminLink('', false) . 'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
+            '301-category' => $this->router->generate('admin_get_ajax_categories') . '&query=%QUERY',
+            '302-category' => $this->router->generate('admin_get_ajax_categories') . '&query=%QUERY',
+        ];
 
         $builder->add(
             'meta_title',
             TranslateType::class,
-            array(
+            [
                 'type' => FormType\TextType::class,
                 'options' => [
                     'attr' => [
@@ -91,84 +92,84 @@ class ProductSeo extends CommonAbstractType
                     'class' => 'px-0',
                 ],
                 'required' => false
-            )
+            ]
         )
-        ->add(
-            'meta_description',
-            TranslateType::class,
-            array(
-                'type' => FormType\TextareaType::class,
-                'options' => [
-                    'attr' => [
-                        'placeholder' => $this->translator->trans('To have a different description than your product summary in search results pages, write it here.', [], 'Admin.Catalog.Help'),
-                        'counter' => 160,
-                        'counter_type' => 'recommended',
+            ->add(
+                'meta_description',
+                TranslateType::class,
+                [
+                    'type' => FormType\TextareaType::class,
+                    'options' => [
+                        'attr' => [
+                            'placeholder' => $this->translator->trans('To have a different description than your product summary in search results pages, write it here.', [], 'Admin.Catalog.Help'),
+                            'counter' => 160,
+                            'counter_type' => 'recommended',
+                        ],
+                        'required' => false
+                    ],
+                    'locales' => $this->locales,
+                    'hideTabs' => true,
+                    'label' => $this->translator->trans('Meta description', [], 'Admin.Catalog.Feature'),
+                    'label_attr' => [
+                        'popover' => $this->translator->trans('This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)', [], 'Admin.Catalog.Help'),
+                        'popover_placement' => 'right',
+                        'class' => 'px-0',
                     ],
                     'required' => false
-                ],
-                'locales' => $this->locales,
-                'hideTabs' => true,
-                'label' => $this->translator->trans('Meta description', [], 'Admin.Catalog.Feature'),
-                'label_attr' => [
-                    'popover' => $this->translator->trans('This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)', [], 'Admin.Catalog.Help'),
-                    'popover_placement' => 'right',
-                    'class' => 'px-0',
-                ],
-                'required' => false
+                ]
             )
-        )
-        ->add(
-            'link_rewrite',
-            TranslateType::class,
-            array(
-                'type' => FormType\TextType::class,
-                'options' => [],
-                'locales' => $this->locales,
-                'hideTabs' => true,
-                'label' => $this->translator->trans('Friendly URL', [], 'Admin.Catalog.Feature'),
+            ->add(
+                'link_rewrite',
+                TranslateType::class,
+                [
+                    'type' => FormType\TextType::class,
+                    'options' => [],
+                    'locales' => $this->locales,
+                    'hideTabs' => true,
+                    'label' => $this->translator->trans('Friendly URL', [], 'Admin.Catalog.Feature'),
+                ]
             )
-        )
-        ->add(
-            'redirect_type',
-            FormType\ChoiceType::class,
-            array(
-                'choices'  => array(
-                    $this->translator->trans('No redirection (404)', [], 'Admin.Catalog.Feature') => '404',
-                    $this->translator->trans('Permanent redirection to a product (301)', [], 'Admin.Catalog.Feature') => '301-product',
-                    $this->translator->trans('Temporary redirection to a product (302)', [], 'Admin.Catalog.Feature') => '302-product',
-                    $this->translator->trans('Permanent redirection to a category (301)', [], 'Admin.Catalog.Feature') => '301-category',
-                    $this->translator->trans('Temporary redirection to a category (302)', [], 'Admin.Catalog.Feature') => '302-category',
-                ),
-                'choice_attr' => function ($val, $key, $index) use ($remoteUrls) {
-                    if (array_key_exists($index, $remoteUrls)) {
-                        return ['data-remoteurl' => $remoteUrls[$index]];
-                    }
-                    return [];
-                },
-                'required' => true,
-                'label' => $this->translator->trans('Redirection when offline', [], 'Admin.Catalog.Feature'),
-                'attr' => array(
-                    'data-labelproduct' => $this->translator->trans('Target product', [], 'Admin.Catalog.Feature'),
-                    'data-placeholderproduct' => $this->translator->trans('To which product the page should redirect?', [], 'Admin.Catalog.Help'),
-                    'data-labelcategory' => $this->translator->trans('Target category', [], 'Admin.Catalog.Feature'),
-                    'data-placeholdercategory' => $this->translator->trans('To which category the page should redirect?', [], 'Admin.Catalog.Help'),
-                ),
+            ->add(
+                'redirect_type',
+                FormType\ChoiceType::class,
+                [
+                    'choices' => [
+                        $this->translator->trans('No redirection (404)', [], 'Admin.Catalog.Feature') => '404',
+                        $this->translator->trans('Permanent redirection to a product (301)', [], 'Admin.Catalog.Feature') => '301-product',
+                        $this->translator->trans('Temporary redirection to a product (302)', [], 'Admin.Catalog.Feature') => '302-product',
+                        $this->translator->trans('Permanent redirection to a category (301)', [], 'Admin.Catalog.Feature') => '301-category',
+                        $this->translator->trans('Temporary redirection to a category (302)', [], 'Admin.Catalog.Feature') => '302-category',
+                    ],
+                    'choice_attr' => function ($val, $key, $index) use ($remoteUrls) {
+                        if (array_key_exists($index, $remoteUrls)) {
+                            return ['data-remoteurl' => $remoteUrls[$index]];
+                        }
+                        return [];
+                    },
+                    'required' => true,
+                    'label' => $this->translator->trans('Redirection when offline', [], 'Admin.Catalog.Feature'),
+                    'attr' => [
+                        'data-labelproduct' => $this->translator->trans('Target product', [], 'Admin.Catalog.Feature'),
+                        'data-placeholderproduct' => $this->translator->trans('To which product the page should redirect?', [], 'Admin.Catalog.Help'),
+                        'data-labelcategory' => $this->translator->trans('Target category', [], 'Admin.Catalog.Feature'),
+                        'data-placeholdercategory' => $this->translator->trans('To which category the page should redirect?', [], 'Admin.Catalog.Help'),
+                    ],
+                ]
             )
-        )
-        ->add(
-            'id_type_redirected',
-            TypeaheadProductCollectionType::class,
-            array(
-                'remote_url' => $this->context->getAdminLink('', false).'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
-                'mapping_value' => 'id',
-                'mapping_name' => 'name',
-                'mapping_type' => $options['mapping_type'],
-                'template_collection' => '<span class="label">%s</span><i class="material-icons delete">clear</i>',
-                'limit' => 1,
-                'required' => false,
-                'label' => $this->translator->trans('Target', [], 'Admin.Catalog.Feature'),
-            )
-        );
+            ->add(
+                'id_type_redirected',
+                TypeaheadProductCollectionType::class,
+                [
+                    'remote_url' => $this->context->getAdminLink('', false) . 'ajax_products_list.php?forceJson=1&disableCombination=1&exclude_packs=0&excludeVirtuals=0&limit=20&q=%QUERY',
+                    'mapping_value' => 'id',
+                    'mapping_name' => 'name',
+                    'mapping_type' => $options['mapping_type'],
+                    'template_collection' => '<span class="label">%s</span><i class="material-icons delete">clear</i>',
+                    'limit' => 1,
+                    'required' => false,
+                    'label' => $this->translator->trans('Target', [], 'Admin.Catalog.Feature'),
+                ]
+            );
     }
 
     /**
@@ -186,8 +187,8 @@ class ProductSeo extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'mapping_type' => 'product',
-        ));
+        ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -67,7 +68,7 @@ class ProductShipping extends CommonAbstractType
         );
         $this->carriersChoices = [];
         foreach ($carriers as $carrier) {
-            $this->carriersChoices[$carrier['name'].' ('.$carrier['delay'].')'] = $carrier['id_reference'];
+            $this->carriersChoices[$carrier['name'] . ' (' . $carrier['delay'] . ')'] = $carrier['id_reference'];
         }
     }
 
@@ -81,136 +82,136 @@ class ProductShipping extends CommonAbstractType
         $builder->add(
             'width',
             FormType\NumberType::class,
-            array(
+            [
                 'required' => false,
                 'label' => $this->translator->trans('Width', [], 'Admin.Catalog.Feature'),
-                'constraints' => array(
+                'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Type(array('type' => 'numeric'))
-                )
-            )
+                    new Assert\Type(['type' => 'numeric'])
+                ]
+            ]
         )
-        ->add(
-            'height',
-            FormType\NumberType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Height', [], 'Admin.Catalog.Feature'),
-                'constraints' => array(
-                    new Assert\NotBlank(),
-                    new Assert\Type(array('type' => 'numeric'))
-                )
+            ->add(
+                'height',
+                FormType\NumberType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Height', [], 'Admin.Catalog.Feature'),
+                    'constraints' => [
+                        new Assert\NotBlank(),
+                        new Assert\Type(['type' => 'numeric'])
+                    ]
+                ]
             )
-        )
-        ->add(
-            'depth',
-            FormType\NumberType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Depth', [], 'Admin.Catalog.Feature'),
-                'constraints' => array(
-                    new Assert\NotBlank(),
-                    new Assert\Type(array('type' => 'numeric'))
-                )
+            ->add(
+                'depth',
+                FormType\NumberType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Depth', [], 'Admin.Catalog.Feature'),
+                    'constraints' => [
+                        new Assert\NotBlank(),
+                        new Assert\Type(['type' => 'numeric'])
+                    ]
+                ]
             )
-        )
-        ->add(
-            'weight',
-            FormType\NumberType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Weight', [], 'Admin.Catalog.Feature'),
-                'constraints' => array(
-                    new Assert\NotBlank(),
-                    new Assert\Type(array('type' => 'numeric'))
-                )
+            ->add(
+                'weight',
+                FormType\NumberType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Weight', [], 'Admin.Catalog.Feature'),
+                    'constraints' => [
+                        new Assert\NotBlank(),
+                        new Assert\Type(['type' => 'numeric'])
+                    ]
+                ]
             )
-        )
-        ->add(
-            'additional_shipping_cost',
-            FormType\MoneyType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Shipping fees', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
-                'constraints' => array(
-                    new Assert\NotBlank(),
-                    new Assert\Type(array('type' => 'float'))
-                )
+            ->add(
+                'additional_shipping_cost',
+                FormType\MoneyType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Shipping fees', [], 'Admin.Catalog.Feature'),
+                    'currency' => $this->currency->iso_code,
+                    'constraints' => [
+                        new Assert\NotBlank(),
+                        new Assert\Type(['type' => 'float'])
+                    ]
+                ]
             )
-        )
-        ->add(
-            'selectedCarriers',
-            FormType\ChoiceType::class,
-            array(
-                'choices' =>  $this->carriersChoices,
-                'expanded' =>  true,
-                'multiple' =>  true,
-                'required' =>  false,
-                'label' => $this->translator->trans('Available carriers', [], 'Admin.Catalog.Feature')
+            ->add(
+                'selectedCarriers',
+                FormType\ChoiceType::class,
+                [
+                    'choices' => $this->carriersChoices,
+                    'expanded' => true,
+                    'multiple' => true,
+                    'required' => false,
+                    'label' => $this->translator->trans('Available carriers', [], 'Admin.Catalog.Feature')
+                ]
             )
-        )
-        ->add(
-            'additional_delivery_times',
-            FormType\ChoiceType::class,
-            array(
-                'choices' =>  array(
-                    $this->translator->trans('None', [], 'Admin.Catalog.Feature') => 0,
-                    $this->translator->trans('Default delivery time', [], 'Admin.Catalog.Feature') => 1,
-                    $this->translator->trans('Specific delivery time to this product', [], 'Admin.Catalog.Feature') => 2,
-                ),
-                'expanded' =>  true,
-                'multiple' =>  false,
-                'required' =>  false,
-                'placeholder' => null,
-                'preferred_choices' => array('default'),
-                'label' => $this->translator->trans('Delivery Time', [], 'Admin.Catalog.Feature'),
+            ->add(
+                'additional_delivery_times',
+                FormType\ChoiceType::class,
+                [
+                    'choices' => [
+                        $this->translator->trans('None', [], 'Admin.Catalog.Feature') => 0,
+                        $this->translator->trans('Default delivery time', [], 'Admin.Catalog.Feature') => 1,
+                        $this->translator->trans('Specific delivery time to this product', [], 'Admin.Catalog.Feature') => 2,
+                    ],
+                    'expanded' => true,
+                    'multiple' => false,
+                    'required' => false,
+                    'placeholder' => null,
+                    'preferred_choices' => ['default'],
+                    'label' => $this->translator->trans('Delivery Time', [], 'Admin.Catalog.Feature'),
+                ]
             )
-        )
-        ->add(
-            'delivery_out_stock',
-            TranslateType::class,
-            array(
-                'type' => FormType\TextType::class,
-                'options' => array(
-                    'attr' => array(
-                        'placeholder' => $this->translator->trans('Delivered within 5-7 days', [], 'Admin.Catalog.Feature'),
-                    )
-                ),
-                'locales' => $this->locales,
-                'hideTabs' => true,
-                'required' => false,
-                'label' => $this->translator->trans(
-                    'Delivery time of out-of-stock products with allowed orders:',
-                    [],
-                    'Admin.Catalog.Feature'
-                ),
+            ->add(
+                'delivery_out_stock',
+                TranslateType::class,
+                [
+                    'type' => FormType\TextType::class,
+                    'options' => [
+                        'attr' => [
+                            'placeholder' => $this->translator->trans('Delivered within 5-7 days', [], 'Admin.Catalog.Feature'),
+                        ]
+                    ],
+                    'locales' => $this->locales,
+                    'hideTabs' => true,
+                    'required' => false,
+                    'label' => $this->translator->trans(
+                        'Delivery time of out-of-stock products with allowed orders:',
+                        [],
+                        'Admin.Catalog.Feature'
+                    ),
+                ]
             )
-        )
-        ->add(
-            'delivery_in_stock',
-            TranslateType::class,
-            array(
-                'type' => FormType\TextType::class,
-                'options' => array(
-                    'attr' => array(
-                        'placeholder' => $this->translator->trans('Delivered within 3-4 days', [], 'Admin.Catalog.Feature'),
-                    )
-                ),
-                'locales' => $this->locales,
-                'hideTabs' => true,
-                'required' => false,
-                'label' => $this->translator->trans('Delivery time of in-stock products:', [], 'Admin.Catalog.Feature'),
-            )
-        );
+            ->add(
+                'delivery_in_stock',
+                TranslateType::class,
+                [
+                    'type' => FormType\TextType::class,
+                    'options' => [
+                        'attr' => [
+                            'placeholder' => $this->translator->trans('Delivered within 3-4 days', [], 'Admin.Catalog.Feature'),
+                        ]
+                    ],
+                    'locales' => $this->locales,
+                    'hideTabs' => true,
+                    'required' => false,
+                    'label' => $this->translator->trans('Delivery time of in-stock products:', [], 'Admin.Catalog.Feature'),
+                ]
+            );
 
 
         foreach ($this->warehouses as $warehouse) {
             $builder->add(
-                'warehouse_combination_'.$warehouse['id_warehouse'],
+                'warehouse_combination_' . $warehouse['id_warehouse'],
                 CollectionType::class,
                 [
-                    'entry_type' =>'PrestaShopBundle\Form\Admin\Product\ProductWarehouseCombination',
+                    'entry_type' => 'PrestaShopBundle\Form\Admin\Product\ProductWarehouseCombination',
                     'entry_options' => [
                         'id_warehouse' => $warehouse['id_warehouse'],
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -99,187 +100,187 @@ class ProductSpecificPrice extends CommonAbstractType
             $builder->add(
                 'sp_id_shop',
                 FormType\HiddenType::class,
-                array(
+                [
                     'required' => false,
-                )
+                ]
             );
         } else {
             $builder->add(
                 'sp_id_shop',
                 FormType\ChoiceType::class,
-                array(
+                [
                     'choices' => $this->shops,
                     'required' => false,
                     'label' => false,
-                    'placeholder' => $this->translator->trans('All shops', array(), 'Admin.Global'),
-                )
+                    'placeholder' => $this->translator->trans('All shops', [], 'Admin.Global'),
+                ]
             );
         }
 
         $builder->add(
             'sp_id_currency',
             FormType\ChoiceType::class,
-            array(
+            [
                 'choices' => $this->currencies,
                 'required' => false,
                 'label' => false,
-                'attr' => array(
+                'attr' => [
                     'data-toggle' => 'select2',
                     'data-minimumResultsForSearch' => '7',
-                ),
-                'placeholder' => $this->translator->trans('All currencies', array(), 'Admin.Global'),
-            )
+                ],
+                'placeholder' => $this->translator->trans('All currencies', [], 'Admin.Global'),
+            ]
         )
-        ->add(
-            'sp_id_country',
-            FormType\ChoiceType::class,
-            array(
-                'choices' => $this->countries,
-                'required' => false,
-                'label' => false,
-                'attr' => array(
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ),
-                'placeholder' => $this->translator->trans('All countries', array(), 'Admin.Global'),
+            ->add(
+                'sp_id_country',
+                FormType\ChoiceType::class,
+                [
+                    'choices' => $this->countries,
+                    'required' => false,
+                    'label' => false,
+                    'attr' => [
+                        'data-toggle' => 'select2',
+                        'data-minimumResultsForSearch' => '7',
+                    ],
+                    'placeholder' => $this->translator->trans('All countries', [], 'Admin.Global'),
+                ]
             )
-        )
-        ->add(
-            'sp_id_group',
-            FormType\ChoiceType::class,
-            array(
-                'choices' => $this->groups,
-                'required' => false,
-                'label' => false,
-                'attr' => array(
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ),
-                'placeholder' => $this->translator->trans('All groups', array(), 'Admin.Global'),
+            ->add(
+                'sp_id_group',
+                FormType\ChoiceType::class,
+                [
+                    'choices' => $this->groups,
+                    'required' => false,
+                    'label' => false,
+                    'attr' => [
+                        'data-toggle' => 'select2',
+                        'data-minimumResultsForSearch' => '7',
+                    ],
+                    'placeholder' => $this->translator->trans('All groups', [], 'Admin.Global'),
+                ]
             )
-        )
-        ->add(
-            'sp_id_customer',
-            TypeaheadCustomerCollectionType::class,
-            array(
-                'remote_url' => $this->context->getAdminLink('AdminCustomers', true).'&sf2=1&ajax=1&tab=AdminCustomers&action=searchCustomers&customer_search=%QUERY',
-                'mapping_value' => 'id_customer',
-                'mapping_name' => 'fullname_and_email',
-                'placeholder' => $this->translator->trans('All customers', array(), 'Admin.Global'),
-                'template_collection' => '<div class="media-body"><div class="label">%s</div><i class="material-icons delete">clear</i></div>',
-                'limit' => 1,
-                'required' => false,
-                'label' => $this->translator->trans('Add customer', array(), 'Admin.Catalog.Feature'),
+            ->add(
+                'sp_id_customer',
+                TypeaheadCustomerCollectionType::class,
+                [
+                    'remote_url' => $this->context->getAdminLink('AdminCustomers', true) . '&sf2=1&ajax=1&tab=AdminCustomers&action=searchCustomers&customer_search=%QUERY',
+                    'mapping_value' => 'id_customer',
+                    'mapping_name' => 'fullname_and_email',
+                    'placeholder' => $this->translator->trans('All customers', [], 'Admin.Global'),
+                    'template_collection' => '<div class="media-body"><div class="label">%s</div><i class="material-icons delete">clear</i></div>',
+                    'limit' => 1,
+                    'required' => false,
+                    'label' => $this->translator->trans('Add customer', [], 'Admin.Catalog.Feature'),
+                ]
             )
-        )
-        ->add(
-            'sp_id_product_attribute',
-            FormType\ChoiceType::class,
-            array(
-                'choices' => array(),
-                'required' => false,
-                'placeholder' => $this->translator->trans('Apply to all combinations', array(), 'Admin.Catalog.Feature'),
-                'label' => $this->translator->trans('Combinations', array(), 'Admin.Catalog.Feature'),
-                'attr' => array('data-action' => $this->router->generate('admin_get_product_combinations', ['idProduct' => 1])),
+            ->add(
+                'sp_id_product_attribute',
+                FormType\ChoiceType::class,
+                [
+                    'choices' => [],
+                    'required' => false,
+                    'placeholder' => $this->translator->trans('Apply to all combinations', [], 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Combinations', [], 'Admin.Catalog.Feature'),
+                    'attr' => ['data-action' => $this->router->generate('admin_get_product_combinations', ['idProduct' => 1])],
+                ]
             )
-        )
-        ->add(
-            'sp_from',
-            DatePickerType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Available from', array(), 'Admin.Catalog.Feature'),
-                'attr' => array('placeholder' => 'YYYY-MM-DD'),
+            ->add(
+                'sp_from',
+                DatePickerType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Available from', [], 'Admin.Catalog.Feature'),
+                    'attr' => ['placeholder' => 'YYYY-MM-DD'],
+                ]
             )
-        )
-        ->add(
-            'sp_to',
-            DatePickerType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('to', array(), 'Admin.Global'),
-                'attr' => array('placeholder' => 'YYYY-MM-DD'),
+            ->add(
+                'sp_to',
+                DatePickerType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('to', [], 'Admin.Global'),
+                    'attr' => ['placeholder' => 'YYYY-MM-DD'],
+                ]
             )
-        )
-        ->add(
-            'sp_from_quantity',
-            FormType\NumberType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Starting at', array(), 'Admin.Catalog.Feature'),
-                'constraints' => array(
-                    new Assert\Type(array('type' => 'numeric')),
-                ),
+            ->add(
+                'sp_from_quantity',
+                FormType\NumberType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Starting at', [], 'Admin.Catalog.Feature'),
+                    'constraints' => [
+                        new Assert\Type(['type' => 'numeric']),
+                    ],
+                ]
             )
-        )
-        ->add(
-            'sp_price',
-            FormType\MoneyType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('Product price (tax excl.)', array(), 'Admin.Catalog.Feature'),
-                'attr' => array('class' => 'price'),
-                'currency' => $this->currency->iso_code,
-                'disabled' => true,
+            ->add(
+                'sp_price',
+                FormType\MoneyType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Product price (tax excl.)', [], 'Admin.Catalog.Feature'),
+                    'attr' => ['class' => 'price'],
+                    'currency' => $this->currency->iso_code,
+                    'disabled' => true,
+                ]
             )
-        )
-        ->add(
-            'leave_bprice',
-            FormType\CheckboxType::class,
-            array(
-                'label' => $this->translator->trans('Leave initial price', array(), 'Admin.Catalog.Feature'),
-                'required' => false,
+            ->add(
+                'leave_bprice',
+                FormType\CheckboxType::class,
+                [
+                    'label' => $this->translator->trans('Leave initial price', [], 'Admin.Catalog.Feature'),
+                    'required' => false,
+                ]
             )
-        )
-        ->add(
-            'sp_reduction',
-            FormType\MoneyType::class,
-            array(
-                'label' => $this->translator->trans('Reduction', array(), 'Admin.Catalog.Feature'),
-                'required' => false,
-                'currency' => $this->currency->iso_code,
+            ->add(
+                'sp_reduction',
+                FormType\MoneyType::class,
+                [
+                    'label' => $this->translator->trans('Reduction', [], 'Admin.Catalog.Feature'),
+                    'required' => false,
+                    'currency' => $this->currency->iso_code,
+                ]
             )
-        )
-        ->add(
-            'sp_reduction_type',
-            FormType\ChoiceType::class,
-            array(
-                'label' => $this->translator->trans('Reduction type', array(), 'Admin.Catalog.Feature'),
-                'choices' => array(
-                    '€' => 'amount',
-                    $this->translator->trans('%', array(), 'Admin.Global') => 'percentage',
-                ),
-                'required' => true,
+            ->add(
+                'sp_reduction_type',
+                FormType\ChoiceType::class,
+                [
+                    'label' => $this->translator->trans('Reduction type', [], 'Admin.Catalog.Feature'),
+                    'choices' => [
+                        '€' => 'amount',
+                        $this->translator->trans('%', [], 'Admin.Global') => 'percentage',
+                    ],
+                    'required' => true,
+                ]
             )
-        )
-        ->add(
-            'sp_reduction_tax',
-            FormType\ChoiceType::class,
-            array(
-                'label' => $this->translator->trans('Reduction tax', array(), 'Admin.Catalog.Feature'),
-                'choices' => array(
-                    $this->translator->trans('Tax excluded', array(), 'Admin.Catalog.Feature') => '0',
-                    $this->translator->trans('Tax included', array(), 'Admin.Catalog.Feature') => '1',
-                ),
-                'required' => true,
+            ->add(
+                'sp_reduction_tax',
+                FormType\ChoiceType::class,
+                [
+                    'label' => $this->translator->trans('Reduction tax', [], 'Admin.Catalog.Feature'),
+                    'choices' => [
+                        $this->translator->trans('Tax excluded', [], 'Admin.Catalog.Feature') => '0',
+                        $this->translator->trans('Tax included', [], 'Admin.Catalog.Feature') => '1',
+                    ],
+                    'required' => true,
+                ]
             )
-        )
-        ->add(
-            'save',
-            FormType\ButtonType::class,
-            array(
-                'label' => $this->translator->trans('Apply', array(), 'Admin.Actions'),
-                'attr' => array('class' => 'btn-outline-primary js-save'),
+            ->add(
+                'save',
+                FormType\ButtonType::class,
+                [
+                    'label' => $this->translator->trans('Apply', [], 'Admin.Actions'),
+                    'attr' => ['class' => 'btn-outline-primary js-save'],
+                ]
             )
-        )
-        ->add(
-            'cancel',
-            FormType\ButtonType::class,
-            array(
-                'label' => $this->translator->trans('Cancel', array(), 'Admin.Actions'),
-                'attr' => array('class' => 'btn-outline-secondary js-cancel'),
-            )
-        );
+            ->add(
+                'cancel',
+                FormType\ButtonType::class,
+                [
+                    'label' => $this->translator->trans('Cancel', [], 'Admin.Actions'),
+                    'attr' => ['class' => 'btn-outline-secondary js-cancel'],
+                ]
+            );
         //
         // ResetType can't be used because the product page is wrapped
         // inside a big form: reset a specific price form the "right" way
@@ -299,10 +300,10 @@ class ProductSpecificPrice extends CommonAbstractType
             $form->add(
                 'sp_id_product_attribute',
                 FormType\ChoiceType::class,
-                array(
-                    'choices' => array($data['sp_id_product_attribute'] => ''),
+                [
+                    'choices' => [$data['sp_id_product_attribute'] => ''],
                     'required' => false,
-                )
+                ]
             );
         });
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -64,36 +65,37 @@ class ProductSupplierCombination extends CommonAbstractType
         $builder->add(
             'supplier_reference',
             FormType\TextType::class,
-            array(
+            [
                 'required' => false,
-                'label' => null
-            )
+                'label' => null,
+                'empty_data' => '',
+            ]
         )
-        ->add(
-            'product_price',
-            FormType\MoneyType::class,
-            array(
-                'required' => false,
-                'constraints' => array(
-                    new Assert\NotBlank(),
-                    new Assert\Type(array('type' => 'float'))
-                )
+            ->add(
+                'product_price',
+                FormType\MoneyType::class,
+                [
+                    'required' => false,
+                    'constraints' => [
+                        new Assert\NotBlank(),
+                        new Assert\Type(['type' => 'float'])
+                    ]
+                ]
             )
-        )
-        ->add(
-            'product_price_currency',
-            FormType\ChoiceType::class,
-            array(
-                'choices'  => $this->formatDataChoicesList($this->currencyAdapter->getCurrencies(), 'id_currency'),
-                'required' => true,
-                'attr' => array(
-                    'class' => 'custom-select',
-                ),
+            ->add(
+                'product_price_currency',
+                FormType\ChoiceType::class,
+                [
+                    'choices' => $this->formatDataChoicesList($this->currencyAdapter->getCurrencies(), 'id_currency'),
+                    'required' => true,
+                    'attr' => [
+                        'class' => 'custom-select',
+                    ],
+                ]
             )
-        )
-        ->add('id_product_attribute', FormType\HiddenType::class)
-        ->add('product_id', FormType\HiddenType::class)
-        ->add('supplier_id', FormType\HiddenType::class);
+            ->add('id_product_attribute', FormType\HiddenType::class)
+            ->add('product_id', FormType\HiddenType::class)
+            ->add('supplier_id', FormType\HiddenType::class);
 
         //set default minimal values for collection prototype
         $builder->setData([
@@ -102,14 +104,15 @@ class ProductSupplierCombination extends CommonAbstractType
             'product_price_currency' => $this->contextLegacy->currency->id,
         ]);
     }
+
     /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'id_supplier' => null,
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -32,7 +33,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
-use PrestaShopBundle\Form\Admin\Type as PsFormType;
 
 /**
  * This form class is responsible to generate the virtual product
@@ -66,76 +66,76 @@ class ProductVirtual extends CommonAbstractType
         $builder->add(
             'is_virtual_file',
             FormType\ChoiceType::class,
-            array(
-                'choices'  => array(
+            [
+                'choices' => [
                     $this->translator->trans('Yes', [], 'Admin.Global') => 1,
                     $this->translator->trans('No', [], 'Admin.Global') => 0,
-                ),
+                ],
                 'expanded' => true,
                 'required' => true,
                 'multiple' => false,
-            )
+            ]
         )
-        ->add(
-            'file',
-            FormType\FileType::class,
-            array(
-                'required' => false,
-                'label' => $this->translator->trans('File', [], 'Admin.Global'),
-                'constraints' => array(
-                    new Assert\File(array('maxSize' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE').'M')),
-                )
+            ->add(
+                'file',
+                FormType\FileType::class,
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('File', [], 'Admin.Global'),
+                    'constraints' => [
+                        new Assert\File(['maxSize' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') . 'M']),
+                    ]
+                ]
             )
-        )
-        ->add(
-            'name',
-            FormType\TextType::class,
-            array(
-                'label'    => $this->translator->trans('Filename', [], 'Admin.Global'),
-                'constraints' => array(
-                    new Assert\NotBlank(),
-                ),
+            ->add(
+                'name',
+                FormType\TextType::class,
+                [
+                    'label' => $this->translator->trans('Filename', [], 'Admin.Global'),
+                    'constraints' => [
+                        new Assert\NotBlank(),
+                    ],
+                ]
             )
-        )
-        ->add(
-            'nb_downloadable',
-            FormType\NumberType::class,
-            array(
-                'label'    => $this->translator->trans('Number of allowed downloads', [], 'Admin.Catalog.Feature'),
-                'required' => false,
-                'constraints' => array(
-                    new Assert\Type(array('type' => 'numeric')),
-                ),
+            ->add(
+                'nb_downloadable',
+                FormType\NumberType::class,
+                [
+                    'label' => $this->translator->trans('Number of allowed downloads', [], 'Admin.Catalog.Feature'),
+                    'required' => false,
+                    'constraints' => [
+                        new Assert\Type(['type' => 'numeric']),
+                    ],
+                ]
             )
-        )
-        ->add(
-            'expiration_date',
-            DatePickerType::class,
-            array(
-                'label'    => $this->translator->trans('Expiration date', [], 'Admin.Catalog.Feature'),
-                'required' => false,
-                'attr' => ['placeholder' => 'YYYY-MM-DD']
+            ->add(
+                'expiration_date',
+                DatePickerType::class,
+                [
+                    'label' => $this->translator->trans('Expiration date', [], 'Admin.Catalog.Feature'),
+                    'required' => false,
+                    'attr' => ['placeholder' => 'YYYY-MM-DD']
+                ]
             )
-        )
-        ->add(
-            'nb_days',
-            FormType\NumberType::class,
-            array(
-                'label'    => $this->translator->trans('Number of days', [], 'Admin.Catalog.Feature'),
-                'required' => false,
-                'constraints' => array(
-                    new Assert\Type(array('type' => 'numeric')),
-                )
+            ->add(
+                'nb_days',
+                FormType\NumberType::class,
+                [
+                    'label' => $this->translator->trans('Number of days', [], 'Admin.Catalog.Feature'),
+                    'required' => false,
+                    'constraints' => [
+                        new Assert\Type(['type' => 'numeric']),
+                    ]
+                ]
             )
-        )
-        ->add(
-            'save',
-            FormType\ButtonType::class,
-            array(
-                'label' => $this->translator->trans('Save', [], 'Admin.Actions'),
-                'attr' => ['class' => 'btn-primary pull-right']
-            )
-        );
+            ->add(
+                'save',
+                FormType\ButtonType::class,
+                [
+                    'label' => $this->translator->trans('Save', [], 'Admin.Actions'),
+                    'attr' => ['class' => 'btn-primary pull-right']
+                ]
+            );
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $form = $event->getForm();
@@ -144,10 +144,10 @@ class ProductVirtual extends CommonAbstractType
             //if this partial form is submit from a parent form, disable it
             if ($form->getParent()) {
                 $event->setData([]);
-                $form->add('name', FormType\TextType::class, array('mapped' => false));
+                $form->add('name', FormType\TextType::class, ['mapped' => false]);
             } elseif ($data['is_virtual_file'] == 0) {
                 //disable name mapping when is virtual not defined to yes
-                $form->add('name', FormType\TextType::class, array('mapped' => false));
+                $form->add('name', FormType\TextType::class, ['mapped' => false]);
             }
         });
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php
@@ -23,13 +23,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 /**
  * This form class is responsible to generate the basic product Warehouse combinations form
@@ -58,17 +60,18 @@ class ProductWarehouseCombination extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('activated', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+        $builder->add('activated', CheckboxType::class, [
             'required' => false,
             'label' => $this->translator->trans('Stored', [], 'Admin.Catalog.Feature')
-        ))
-        ->add('id_product_attribute', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
-        ->add('product_id', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
-        ->add('warehouse_id', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
-        ->add('location', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'required' => false,
-            'label' => $this->translator->trans('Location (optional)', [], 'Admin.Catalog.Feature')
-        ));
+        ])
+            ->add('id_product_attribute', HiddenType::class)
+            ->add('product_id', HiddenType::class)
+            ->add('warehouse_id', HiddenType::class)
+            ->add('location', TextType::class, [
+                'required' => false,
+                'label' => $this->translator->trans('Location (optional)', [], 'Admin.Catalog.Feature'),
+                'empty_data' => '',
+            ]);
 
         //set default minimal values for collection prototype
         $builder->setData([
@@ -82,9 +85,9 @@ class ProductWarehouseCombination extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'id_warehouse' => null,
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Sell\Order\Delivery;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Sell\Order\Delivery;
 
 use DateTime;

--- a/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
@@ -31,6 +32,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 /**
  * This form class is responsible to create a category selector using Nested sets
@@ -60,14 +62,14 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('tree', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        $builder->add('tree', ChoiceType::class, [
             'label' => false,
             'choices' => $options['valid_list'],
             'required' => false,
-            'multiple'  => true,
-            'expanded'  => true,
-            'error_bubbling'  => true
-        ));
+            'multiple' => true,
+            'expanded' => true,
+            'error_bubbling' => true
+        ]);
     }
 
     /**
@@ -75,12 +77,12 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'label' => '',
             'list' => [],
             'valid_list' => [],
             'multiple' => true,
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\AbstractType;
@@ -55,7 +56,7 @@ abstract class CommonAbstractType extends AbstractType
      */
     protected function formatDataChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
     {
-        $new_list = array();
+        $new_list = [];
         foreach ($list as $item) {
             if (array_key_exists($item[$mapping_name], $new_list)) {
                 return $this->formatDataDuplicateChoicesList($list, $mapping_value, $mapping_name);
@@ -76,9 +77,9 @@ abstract class CommonAbstractType extends AbstractType
      */
     protected function formatDataDuplicateChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
     {
-        $new_list = array();
+        $new_list = [];
         foreach ($list as $item) {
-            $new_list[$item[$mapping_value].' - '.$item[$mapping_name]] = $item[$mapping_value];
+            $new_list[$item[$mapping_value] . ' - ' . $item[$mapping_name]] = $item[$mapping_value];
         }
         return $new_list;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\AbstractTypeExtension;
@@ -42,14 +43,14 @@ class CustomMoneyType extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'precision' => null,
             'scale' => self::PRESTASHOP_DECIMALS,
             'grouping' => false,
             'divisor' => 1,
             'currency' => 'EUR',
             'compound' => false,
-        ));
+        ]);
 
         $resolver->setAllowedTypes('scale', 'int');
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -47,9 +48,9 @@ class DatePickerType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'widget' => 'single_text'
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
@@ -43,10 +43,10 @@ class FormattedTextareaType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'autoload' => true, // Start automatically TinyMCE
             'limit' => 21844, // size max of UTF-8 content in MySQL text column
-        ));
+        ]);
         $resolver->setAllowedTypes('limit', 'int');
         $resolver->setAllowedTypes('autoload', 'bool');
     }
@@ -60,11 +60,11 @@ class FormattedTextareaType extends AbstractType
             $view->vars['attr']['class'] = 'autoload_rte';
         }
         $view->vars['attr']['counter'] = $options['limit'];
-        $view->vars['constraints'] = array(
-            new TinyMceMaxLength(array(
+        $view->vars['constraints'] = [
+            new TinyMceMaxLength([
                 'max' => $options['limit'],
-            ))
-        );
+            ])
+        ];
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\AbstractType;

--- a/src/PrestaShopBundle/Form/Admin/Type/MoneyWithSuffixType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/MoneyWithSuffixType.php
@@ -77,7 +77,7 @@ class MoneyWithSuffixType extends MoneyType
     private function applySuffix(&$value, $key, $suffix)
     {
         if (strlen($value) > 0) {
-            $value = rtrim($value).' '.$suffix;
+            $value = rtrim($value) . ' ' . $suffix;
         }
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
@@ -38,21 +38,22 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class SwitchType extends AbstractType
 {
     const TRANS_DOMAIN = 'Admin.Global';
+
     /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'choices' => array(
+        $resolver->setDefaults([
+            'choices' => [
                 'No' => false,
                 'Yes' => true,
-            ),
+            ],
             'multiple' => false,
             'expanded' => false,
             'disabled' => false,
             'choice_translation_domain' => self::TRANS_DOMAIN,
-        ));
+        ]);
         $resolver->setAllowedTypes('disabled', 'bool');
     }
 
@@ -66,7 +67,7 @@ class SwitchType extends AbstractType
         }
         $view->vars['attr']['class'] = 'ps-switch';
         if (isset($options['attr']['class'])) {
-            $view->vars['attr']['class'] .= ' '.$options['attr']['class'];
+            $view->vars['attr']['class'] .= ' ' . $options['attr']['class'];
         }
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Type/TextEmptyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextEmptyType.php
@@ -29,6 +29,9 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 
+/**
+ * @deprecated 1.7.5, to be removed in 1.8
+ */
 class TextEmptyType extends AbstractTypeExtension implements DataTransformerInterface
 {
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/src/PrestaShopBundle/Form/Admin/Type/TextEmptyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextEmptyType.php
@@ -51,6 +51,6 @@ class TextEmptyType extends AbstractTypeExtension implements DataTransformerInte
 
     public function reverseTransform($data)
     {
-        return null === $data ? '' : $data;
+        return empty($data) ? '' : $data;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/TextEmptyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextEmptyType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\AbstractTypeExtension;

--- a/src/PrestaShopBundle/Form/Admin/Type/TextEmptyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextEmptyType.php
@@ -48,6 +48,6 @@ class TextEmptyType extends AbstractTypeExtension implements DataTransformerInte
 
     public function reverseTransform($data)
     {
-        return empty($data) ? '' : $data;
+        return null === $data ? '' : $data;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/TextWithUnitType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextWithUnitType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\FormView;
@@ -46,10 +47,10 @@ class TextWithUnitType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'widget' => 'single_text',
             'unit' => 'unit'
-        ));
+        ]);
     }
 
     /**
@@ -59,9 +60,9 @@ class TextWithUnitType extends AbstractType
     {
         parent::buildView($view, $form, $options);
 
-        $view->vars = array_merge($view->vars, array(
+        $view->vars = array_merge($view->vars, [
             'unit' => $options['unit']
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/TextareaEmptyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextareaEmptyType.php
@@ -30,6 +30,9 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 
+/**
+ * @deprecated 1.7.5, to be removed in 1.8
+ */
 class TextareaEmptyType extends AbstractTypeExtension implements DataTransformerInterface
 {
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
@@ -23,9 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
@@ -43,14 +43,16 @@ class TranslateType extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $i=0;
+        $i = 0;
         foreach ($options['locales'] as $locale) {
+            $options['options']['empty_data'] = '';
             $locale_options = $options['options'];
             $locale_options['label'] = $locale['iso_code'];
-            if ($i>0) {
+            if ($i > 0) {
                 $locale_options['required'] = false;
                 unset($locale_options['constraints']);
             }
+
             $builder->add($locale['id_lang'], $options['type'], $locale_options);
             $i++;
         }
@@ -73,12 +75,12 @@ class TranslateType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'type' => null,
             'options' => [],
             'locales' => [],
             'hideTabs' => true,
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Translation\TranslatorInterface;
@@ -58,7 +59,7 @@ abstract class TranslatorAwareType extends CommonAbstractType
      *
      * @returns string
      */
-    protected function trans($key, $domain, $parameters = array())
+    protected function trans($key, $domain, $parameters = [])
     {
         return $this->translator->trans($key, $parameters, $domain);
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\FormBuilderInterface;
@@ -64,7 +65,7 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
 
         //if form is submitted, inject datas to display collection
         if (!empty($view->vars['value']) && !empty($view->vars['value']['data'])) {
-            $collection = array();
+            $collection = [];
 
             $i = 0;
             foreach ($view->vars['value']['data'] as $id) {
@@ -72,10 +73,10 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
                     continue;
                 }
                 $customer = $this->customerAdapter->getCustomer($id);
-                $collection[] = array(
+                $collection[] = [
                     'id' => $id,
-                    'name' => $customer->firstname.' '.$customer->lastname.' - '.$customer->email,
-                );
+                    'name' => $customer->firstname . ' ' . $customer->lastname . ' - ' . $customer->email,
+                ];
                 $i++;
 
                 //if collection length is up to limit, break
@@ -94,14 +95,14 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('data', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
-            'entry_type' =>'Symfony\Component\Form\Extension\Core\Type\HiddenType',
+        $builder->add('data', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', [
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\HiddenType',
             'allow_add' => true,
             'allow_delete' => true,
             'label' => false,
             'required' => false,
             'prototype' => true,
-        ));
+        ]);
     }
 
     /**
@@ -109,14 +110,14 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'remote_url' => '',
             'mapping_value' => 'id',
             'mapping_name' => 'name',
             'placeholder' => '',
             'template_collection' => '',
             'limit' => 0,
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -23,12 +23,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
 /**
  * This form class is responsible to create a product, with or without attribute field
@@ -67,7 +70,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
 
         //if form is submitted, inject datas to display collection
         if (!empty($view->vars['value']) && !empty($view->vars['value']['data'])) {
-            $collection = array();
+            $collection = [];
 
             $i = 0;
             foreach ($view->vars['value']['data'] as $id) {
@@ -78,20 +81,20 @@ class TypeaheadProductCollectionType extends CommonAbstractType
                 switch ($view->vars['mapping_type']) {
                     case 'category':
                         $category = $this->categoryAdapter->getCategory($id);
-                        $collection[] = array(
+                        $collection[] = [
                             'id' => $id,
                             'name' => $this->categoryAdapter->getBreadCrumb($category->id),
                             'image' => $category->image,
-                        );
+                        ];
                         break;
 
                     default:
                         $product = $this->productAdapter->getProduct($id);
-                        $collection[] = array(
+                        $collection[] = [
                             'id' => $id,
-                            'name' => reset($product->name).' (ref:'.$product->reference.')',
+                            'name' => reset($product->name) . ' (ref:' . $product->reference . ')',
                             'image' => $product->image,
-                        );
+                        ];
                         break;
                 }
                 $i++;
@@ -112,14 +115,14 @@ class TypeaheadProductCollectionType extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('data', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
-            'entry_type' =>'Symfony\Component\Form\Extension\Core\Type\HiddenType',
+        $builder->add('data', CollectionType::class, [
+            'entry_type' => HiddenType::class,
             'allow_add' => true,
             'allow_delete' => true,
             'label' => false,
             'required' => false,
             'prototype' => true,
-        ));
+        ]);
     }
 
     /**
@@ -127,7 +130,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'remote_url' => '',
             'mapping_value' => 'id',
             'mapping_name' => 'name',
@@ -135,7 +138,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
             'placeholder' => '',
             'template_collection' => '',
             'limit' => 0,
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductPackCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductPackCollectionType.php
@@ -23,12 +23,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
 /**
  * This form class is responsible to create a product, with or without attribute field
@@ -74,14 +77,14 @@ class TypeaheadProductPackCollectionType extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('data', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
-            'entry_type' =>'Symfony\Component\Form\Extension\Core\Type\HiddenType',
+        $builder->add('data', CollectionType::class, [
+            'entry_type' => HiddenType::class,
             'allow_add' => true,
             'allow_delete' => true,
             'label' => false,
             'required' => false,
             'prototype' => true,
-        ));
+        ]);
     }
 
     /**
@@ -89,13 +92,13 @@ class TypeaheadProductPackCollectionType extends CommonAbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'remote_url' => '',
             'mapping_value' => 'id',
             'mapping_name' => 'name',
             'placeholder' => '',
             'template_collection' => '',
-        ));
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLength.php
+++ b/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLength.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
@@ -35,15 +36,15 @@ class TinyMceMaxLength extends Constraint
     public function __construct($options = null)
     {
         if (null !== $options && !is_array($options)) {
-            $options = array(
+            $options = [
                 'max' => $options,
-            );
+            ];
         }
 
-         parent::__construct($options);
+        parent::__construct($options);
 
         if (null === $this->max) {
-            throw new MissingOptionsException(sprintf('Option "max" must be given for constraint %s', __CLASS__), array('max'));
+            throw new MissingOptionsException(sprintf('Option "max" must be given for constraint %s', __CLASS__), ['max']);
         }
     }
 }

--- a/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
+++ b/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Validator\Constraints;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
@@ -33,17 +34,17 @@ class TinyMceMaxLengthValidator extends ConstraintValidator
 {
     public function validate($value, Constraint $constraint)
     {
-        $replaceArray = array(
+        $replaceArray = [
             "\n",
             "\r",
             "\n\r",
-        );
-        $str = str_replace($replaceArray, array(''), strip_tags($value));
+        ];
+        $str = str_replace($replaceArray, [''], strip_tags($value));
 
         if (iconv_strlen($str) > $constraint->max) {
             $this->context->addViolation(
                 (new LegacyContext())->getContext()->getTranslator()->trans('This value is too long. It should have %limit% characters or less.', [], 'Admin.Catalog.Notification'),
-                array('%limit%' => $constraint->max)
+                ['%limit%' => $constraint->max]
             );
         }
     }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -2,16 +2,6 @@ services:
     _defaults:
         public: true
 
-    form.type.extension.textarea:
-        class: 'PrestaShopBundle\Form\Admin\Type\TextareaEmptyType'
-        tags:
-            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\TextareaType }
-
-    form.type.extension.text:
-        class: 'PrestaShopBundle\Form\Admin\Type\TextEmptyType'
-        tags:
-            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\TextType }
-
     form.type.extension.money:
         class: 'PrestaShopBundle\Form\Admin\Type\CustomMoneyType'
         tags:


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | You cannot save "0" as a value in TextType form fields. It's transformed into an empty string, because 0 is considered an empty value. This PR makes text fields to allow saving 0.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Go to BO and edit a product. In "Prices" tab, set unit field to 0, hit save. Reload the page. It should show 0 in the unit field. (unit field: https://prnt.sc/jm2ya9). Before it would show empty value after entering 0 and saving. This applies to all the text fields in migrated pages, that allow entering 0 as a value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9120)
<!-- Reviewable:end -->
