### PR TITLE
Make commands from PrestaShop modules available in PrestaShop application

### DIFF
--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -53,7 +53,7 @@ class PrestaShopBundle extends Bundle
     {
         $container->addCompilerPass(new DynamicRolePass());
         $container->addCompilerPass(new PopulateTranslationProvidersPass());
-        $container->addCompilerPass(new LoadServicesFromModulesPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new LoadServicesFromModulesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         $container->addCompilerPass(new RemoveXmlCompiledContainerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RouterPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new OverrideTranslatorServiceCompilerPass());


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | A Symfony command registered as a service in a module should be available in Symfony Console. This is a feature not really introduced in 1.7.3 that I have forgotten to finish in 1.7.4. We can imagine new business in addons, as this feature is NOT available in 1.6 :) Discussing with @eternoendless about it, it will be available in 1.7.5
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Install the following [module](https://github.com/PrestaShop/PrestaShop/files/2036163/ps_test.zip) (and enable it). Then clear the cache. Then in a terminal, try the command "php bin/console app:test". I you see "APP TEST!%" displayed, it proves it works :)

### Docs

https://symfony.com/doc/3.4/console.html#creating-a-command

and 

```yaml
# in modules/your-module/config/services.yml
    name_of_your_command:
        class: Foo\Command\TestCommand
        tags:
            - { name: 'console.command' }
```


<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9121)
<!-- Reviewable:end -->
