### PR TITLE
Add safety returns after ajaxRender calls

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -527,6 +527,8 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
             ob_end_clean();
             header('Content-Type: application/json');
             $this->ajaxRender(json_encode($this->getAjaxProductSearchVariables()));
+
+            return;
         } else {
             $variables = $this->getProductSearchVariables();
             $this->context->smarty->assign(array(

--- a/controllers/admin/AdminQuickAccessesController.php
+++ b/controllers/admin/AdminQuickAccessesController.php
@@ -198,6 +198,7 @@ class AdminQuickAccessesControllerCore extends AdminController
         if (!empty($this->errors)) {
             $this->errors['has_errors'] = true;
             $this->ajaxRender(json_encode($this->errors));
+
             return false;
         }
         return $this->getQuickAccessesList();

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -138,5 +138,7 @@ class AddressControllerCore extends FrontController
                 $addressForm->getTemplateVariables()
             ),
         )));
+
+        return;
     }
 }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -144,12 +144,16 @@ class CartControllerCore extends FrontController
                 'cart' => $presentedCart,
                 'errors' => empty($this->updateOperationError) ? '' : reset($this->updateOperationError),
             ]));
+
+            return;
         } else {
             $this->ajaxRender(Tools::jsonEncode([
                 'hasError' => true,
                 'errors' => $this->errors,
                 'quantity' => $productQuantity,
             ]));
+
+            return;
         }
     }
 
@@ -170,6 +174,8 @@ class CartControllerCore extends FrontController
             'cart_detailed_actions' => $this->render('checkout/_partials/cart-detailed-actions'),
             'cart_voucher' => $this->render('checkout/_partials/cart-voucher'),
         ]));
+
+        return;
     }
 
     /**
@@ -214,6 +220,8 @@ class CartControllerCore extends FrontController
             'success' => true,
             'productUrl' => $url
         ]));
+
+        return;
     }
 
     public function postProcess()

--- a/controllers/front/ChangeCurrencyController.php
+++ b/controllers/front/ChangeCurrencyController.php
@@ -36,7 +36,11 @@ class ChangeCurrencyControllerCore extends FrontController
         if (Validate::isLoadedObject($currency) && !$currency->deleted) {
             $this->context->cookie->id_currency = (int)$currency->id;
             $this->ajaxRender('1');
+
+            return;
         }
         $this->ajaxRender('0');
+
+        return;
     }
 }

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -249,6 +249,8 @@ class OrderControllerCore extends FrontController
                 'static_token' => Tools::getToken(false),
             ))
         )));
+
+        return;
     }
 
     public function initContent()
@@ -335,5 +337,7 @@ class OrderControllerCore extends FrontController
                 $templateParams
             ),
         )));
+
+        return;
     }
 }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -383,6 +383,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'quickview_html' => $this->render('catalog/_partials/quickview', $product_for_template),
             'product' => $product_for_template,
         )));
+
+        return;
     }
 
     public function displayAjaxRefresh()
@@ -425,6 +427,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
         )));
+
+        return;
     }
 
     /**

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -152,6 +152,8 @@ class StoresControllerCore extends FrontController
         header('Content-type: text/xml');
 
         $this->ajaxRender($parnode->asXML());
+
+        return;
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add safety returns after call to ajaxRender()
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Test pages with ajax

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9122)
<!-- Reviewable:end -->
