### PR TITLE
Add hook for extra fields on customer address form

### DIFF
--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -146,6 +146,21 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
             $format[$formField->getName()] = $formField;
         }
 
+        //To add the extra fields in address form
+        $additionalAddressFormFields = Hook::exec('additionalCustomerAddressFields', array(), null, true);
+        if (is_array($additionalAddressFormFields)) {
+            foreach ($additionalAddressFormFields as $moduleName => $additionnalFormFields) {
+                if (!is_array($additionnalFormFields)) {
+                    continue;
+                }
+
+                foreach ($additionnalFormFields as $formField) {
+                    $formField->moduleName = $moduleName;
+                    $format[$moduleName.'_'.$formField->getName()] = $formField;
+                }
+            }
+        }
+
         return $this->addConstraints(
                 $this->addMaxLength(
                     $format


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Please add a hook on customer address form to add a custom field through a module like as customer registration form and also manage the validation code for the corresponding fields because the existing hook ('actionValidateCustomerAddressForm') cannot be used as the form function is private.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to add a custom field in address form through a module.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9132)
<!-- Reviewable:end -->
