### PR TITLE
Fix undefined index on supplier page in FO

### DIFF
--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -171,13 +171,11 @@ class SupplierCore extends ObjectModel
                 $counts[(int) $result['id_supplier']] = (int) $result['nb_products'];
             }
 
-            if (count($counts) && is_array($suppliers)) {
-                foreach ($suppliers as $key => $supplier) {
-                    if (isset($counts[(int) $supplier['id_supplier']])) {
-                        $suppliers[$key]['nb_products'] = $counts[(int) $supplier['id_supplier']];
-                    } else {
-                        $suppliers[$key]['nb_products'] = 0;
-                    }
+            foreach ($suppliers as $key => $supplier) {
+                if (array_key_exists((int) $supplier['id_supplier'], $counts)) {
+                    $suppliers[$key]['nb_products'] = $counts[(int) $supplier['id_supplier']];
+                } else {
+                    $suppliers[$key]['nb_products'] = 0;
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | If you have a supplier without any products and try to see the supplier page in FO you will have an Undefined index: nb_products in SupplierController.php
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5626
| How to test?  | Create a supplier, open the supplier page in FO & check if there isn't error

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9134)
<!-- Reviewable:end -->
