### PR TITLE
Fix notice on brands page

### DIFF
--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -236,13 +236,11 @@ class ManufacturerCore extends ObjectModel
                 $counts[(int) $result['id_manufacturer']] = (int) $result['nb_products'];
             }
 
-            if (count($counts)) {
-                foreach ($manufacturers as $key => $manufacturer) {
-                    if (array_key_exists((int) $manufacturer['id_manufacturer'], $counts)) {
-                        $manufacturers[$key]['nb_products'] = $counts[(int) $manufacturer['id_manufacturer']];
-                    } else {
-                        $manufacturers[$key]['nb_products'] = 0;
-                    }
+            foreach ($manufacturers as $key => $manufacturer) {
+                if (array_key_exists((int) $manufacturer['id_manufacturer'], $counts)) {
+                    $manufacturers[$key]['nb_products'] = $counts[(int) $manufacturer['id_manufacturer']];
+                } else {
+                    $manufacturers[$key]['nb_products'] = 0;
                 }
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Fix notice `Undefined index: nb_products` on brands page if there is no products linked to any manufacturer
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | BOOM-2663
| How to test?  |visit brands page with at least a brand but without any products linked to a brand

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9138)
<!-- Reviewable:end -->
