### PR TITLE
fix autoremove voucher when changing carrier

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3029,6 +3029,10 @@ class CartCore extends ObjectModel
         }
 
         $this->delivery_option = json_encode($delivery_option);
+
+        // update auto cart rules
+        CartRule::autoRemoveFromCart();
+        CartRule::autoAddToCart();
     }
 
     /**

--- a/tests/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests/Unit/Core/Cart/AbstractCartTest.php
@@ -378,6 +378,14 @@ abstract class AbstractCartTest extends IntegrationTestCase
         $this->cartRules[$cartRuleFixtureId] = $cartRule;
     }
 
+    /**
+     * Silently add the cart rules from data
+     * if a cart rule does not exist or if it is already in cart, do nothing
+     *
+     * @param array $cartRuleFixtureIds
+     *
+     * @return bool
+     */
     protected function addCartRulesToCart(array $cartRuleFixtureIds)
     {
         $allAdded = true;

--- a/tests/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests/Unit/Core/Cart/AbstractCartTest.php
@@ -380,22 +380,30 @@ abstract class AbstractCartTest extends IntegrationTestCase
 
     protected function addCartRulesToCart(array $cartRuleFixtureIds)
     {
+        $allAdded = true;
         foreach ($cartRuleFixtureIds as $cartRuleFixtureId) {
             $cartRule = $this->getCartRuleFromFixtureId($cartRuleFixtureId);
-            if ($cartRule !== null) {
+            if ($cartRule === null) {
+                $allAdded = false;
+            } else {
                 $this->cartRulesInCart[] = $cartRule;
-                $this->cart->addCartRule($cartRule->id);
+                if (!$this->cart->addCartRule($cartRule->id)) {
+                    $allAdded = false;
+                }
             }
         }
+
+        return $allAdded;
     }
 
     protected function addCartRuleToCart($cartRuleFixtureId)
     {
         $cartRule = $this->getCartRuleFromFixtureId($cartRuleFixtureId);
-        if ($cartRule !== null) {
-            $this->cartRulesInCart[] = $cartRule;
-            $this->cart->addCartRule($cartRule->id);
+        if ($cartRule === null) {
+            return false;
         }
-    }
+        $this->cartRulesInCart[] = $cartRule;
 
+        return $this->cart->addCartRule($cartRule->id);
+    }
 }

--- a/tests/Unit/Core/Cart/Calculation/Carrier/CarrierTest.php
+++ b/tests/Unit/Core/Cart/Calculation/Carrier/CarrierTest.php
@@ -46,7 +46,7 @@ class CarrierTest extends AbstractCarrierTest
         // specific setUp
         $this->addProductsToCart($productData);
         $this->addCartRulesToCart($cartRuleData);
-        $this->setCartCarrier($carrierId);
+        $this->setCartCarrierFromFixtureId($carrierId);
         $this->setCartAddress($addressId);
 
         // assertions
@@ -69,7 +69,7 @@ class CarrierTest extends AbstractCarrierTest
         // specific setUp
         $this->addProductsToCart($productData);
         $this->addCartRulesToCart($cartRuleData);
-        $this->setCartCarrier($carrierId);
+        $this->setCartCarrierFromFixtureId($carrierId);
         $this->setCartAddress($addressId);
 
         // assertions

--- a/tests/Unit/Core/Cart/Calculation/Carrier/CartRulesCarrierSpecificTest.php
+++ b/tests/Unit/Core/Cart/Calculation/Carrier/CartRulesCarrierSpecificTest.php
@@ -56,9 +56,10 @@ class CartRulesCarrierSpecificTest extends AbstractCarrierTest
     ) {
         // specific setUp
         $this->addProductsToCart($productData);
-        $this->addCartRulesToCart($cartRuleData);
-        $this->setCartCarrier($carrierId);
+        $this->setCartCarrierFromFixtureId($carrierId);
         $this->setCartAddress($addressId);
+        $result = $this->addCartRulesToCart($cartRuleData);
+        $this->assertTrue($result);
 
         // assertions
         $this->compareCartTotalTaxIncl($expectedTotal);
@@ -99,8 +100,7 @@ class CartRulesCarrierSpecificTest extends AbstractCarrierTest
                 'addressId'            => 1,
                 'carrierId'            => 2,
             ],
-            /*
-            // following is testing te bug http://forge.prestashop.com/browse/BOOM-3307
+            // following is testing the bug http://forge.prestashop.com/browse/BOOM-3307
             ' carrier #2 (voucher specific): one product in cart, quantity 1'        => [
                 'products'             => [1 => 1,],
                 'expectedTotal'        => (1 - static::CART_RULES_FIXTURES[1]['percent'] / 100)
@@ -114,7 +114,6 @@ class CartRulesCarrierSpecificTest extends AbstractCarrierTest
                 'addressId'            => 1,
                 'carrierId'            => 2,
             ],
-            */
         ];
     }
 }

--- a/tests/Unit/Core/Cart/Calculation/Carrier/RuleWhenChangingCarrierTest.php
+++ b/tests/Unit/Core/Cart/Calculation/Carrier/RuleWhenChangingCarrierTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2017 PrestaShop
+ * 2007-2018 PrestaShop
  *
  * NOTICE OF LICENSE
  *

--- a/tests/Unit/Core/Cart/Calculation/Carrier/RuleWhenChangingCarrierTest.php
+++ b/tests/Unit/Core/Cart/Calculation/Carrier/RuleWhenChangingCarrierTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Cart\Calculation\Carrier;
+
+use Configuration;
+
+/**
+ * these tests aim to check the correct calculation of cart total when applying cart rules
+ *
+ * products are inserted as fixtures
+ * products are inserted in cart from data providers
+ * cart rules are inserted from data providers
+ */
+class RuleWhenChangingCarrierTest extends AbstractCarrierTest
+{
+
+    const CART_RULES_FIXTURES = [
+        1 => ['code' => 'foo', 'priority' => 1, 'percent' => 55, 'amount' => 0, 'carrierRestrictionIds' => [2]],
+        2 => ['code' => 'bar', 'priority' => 1, 'percent' => 55, 'amount' => 0, 'carrierRestrictionIds' => [1]],
+        3 => ['code' => '', 'priority' => 1, 'percent' => 55, 'amount' => 0, 'carrierRestrictionIds' => [3]],
+    ];
+
+    const CARRIER_FIXTURES = [
+        1 => [
+            'name'   => 'carrier 1',
+            'isFree' => false,
+            'ranges' => [
+                1 => [
+                    'from'           => 0,
+                    'to'             => 10000,
+                    'shippingPrices' => [
+                        1 => 3.1, // zoneId => price
+                        2 => 4.3, // zoneId => price
+                    ],
+                ],
+            ],
+        ],
+        2 => [
+            'name'   => 'carrier 2',
+            'isFree' => false,
+            'ranges' => [
+                1 => [
+                    'from'           => 0,
+                    'to'             => 10000,
+                    'shippingPrices' => [
+                        1 => 5.7, // zoneId => price
+                        2 => 6.2, // zoneId => price
+                    ],
+                ],
+            ],
+        ],
+        3 => [
+            'name'   => 'carrier 3',
+            'isFree' => false,
+            'ranges' => [
+                1 => [
+                    'from'           => 0,
+                    'to'             => 10000,
+                    'shippingPrices' => [
+                        1 => 5.7, // zoneId => price
+                        2 => 6.2, // zoneId => price
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    public function testCarrierSpecificCartRuleCorresponding()
+    {
+        // specific setUp
+        $this->setCartCarrierFromFixtureId(2);
+        $this->setCartAddress(1);
+        $this->addProductToCart(1, 1);
+
+        // tests
+        $cartRule = $this->getCartRuleFromFixtureId(2);
+        $result   = $cartRule->checkValidity(\Context::getContext(), false, false);
+        $this->assertFalse($result);
+
+        $cartRule = $this->getCartRuleFromFixtureId(1);
+        $result   = $cartRule->checkValidity(\Context::getContext(), false, false);
+        $this->assertTrue($result);
+        $this->cartRulesInCart[] = $cartRule;
+        $result                  = $this->cart->addCartRule($cartRule->id);
+        $this->assertTrue($result);
+        $cartRules = $this->cart->getCartRules();
+        $this->assertCount(1, $cartRules);
+
+        $result = $cartRule->checkValidity(\Context::getContext(), false, false);
+        $this->assertFalse($result);
+        $this->cartRulesInCart[] = $cartRule;
+        $result                  = $this->cart->addCartRule($cartRule->id);
+        $this->assertFalse($result);
+        $cartRules = $this->cart->getCartRules();
+        $this->assertCount(1, $cartRules);
+    }
+
+    public function testCarrierSpecificCartRuleNotCorresponding()
+    {
+        // specific setUp
+        $this->setCartCarrierFromFixtureId(2);
+        $this->setCartAddress(1);
+        $this->addProductToCart(1, 1);
+
+        // tests
+        $cartRule = $this->getCartRuleFromFixtureId(2);
+        $result   = $cartRule->checkValidity(\Context::getContext(), false, false);
+        $this->assertFalse($result);
+    }
+
+    public function testCarrierSpecificCartRuleRemovedWhenChangingCarrier()
+    {
+        // specific setUp
+        $this->setCartCarrierFromFixtureId(2);
+        $this->setCartAddress(1);
+        $this->addProductToCart(1, 1);
+
+        // tests
+        $cartRule                = $this->getCartRuleFromFixtureId(1);
+        $this->cartRulesInCart[] = $cartRule;
+        $result                  = $this->cart->addCartRule($cartRule->id);
+        $this->assertTrue($result);
+        $cartRules = $this->cart->getCartRules();
+        $this->assertCount(1, $cartRules);
+
+        $this->setCartCarrierFromFixtureId(1);
+
+        $cartRules = $this->cart->getCartRules();
+        $this->assertCount(0, $cartRules);
+    }
+
+    public function testCarrierSpecificCartRuleWithoutCodeSetAndUnset()
+    {
+        // specific setUp
+        $this->setCartAddress(1);
+        $this->addProductToCart(1, 1);
+
+        // tests
+        $this->setCartCarrierFromFixtureId(2);
+        $cartRules = $this->cart->getCartRules();
+        $this->assertCount(0, $cartRules);
+        $this->setCartCarrierFromFixtureId(3);
+        $cartRules = $this->cart->getCartRules();
+        $this->assertCount(1, $cartRules);
+        $this->setCartCarrierFromFixtureId(2);
+        $cartRules = $this->cart->getCartRules();
+        $this->assertCount(0, $cartRules);
+    }
+
+}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix auto-remove carrier-specific voucher when changing carrier
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-3307 http://forge.prestashop.com/browse/BOOM-5218 http://forge.prestashop.com/browse/BOOM-5219
| How to test?  | Add a carrier-specific voucher. Check voucher is automatically removed when changing carrier. Test the same behaviour with empty-code voucher

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9142)
<!-- Reviewable:end -->
