### PR TITLE
Fix unknown key route error in customer settings page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
@@ -65,7 +65,7 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
 
     /**
      * Process the Customer Preferences configuration form.
-     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to update this.", route="admin_customer_preferences")
+     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to update this.", redirectRoute="admin_customer_preferences")
      * @DemoRestricted(redirectRoute="admin_customer_preferences")
      *
      * @param Request $request


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | When you save the customer settings page, there is the error Unknown key route for annotation @PrestaShopBundle\Security\Annotation\AdminSecurity
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5640
| How to test?  | Go in BO > Shop parameters > Customer settings change a parameter and click on Save

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9143)
<!-- Reviewable:end -->
