### PR TITLE
Navigate between pages in catalog page

### DIFF
--- a/tests/E2E/test/campaigns/full/02_product/15_navigate_between_catalog_pages.js
+++ b/tests/E2E/test/campaigns/full/02_product/15_navigate_between_catalog_pages.js
@@ -1,0 +1,39 @@
+const {AccessPageBO} = require('../../../selectors/BO/access_page');
+const {Menu} = require('../../../selectors/BO/menu.js');
+const {ProductList} = require('../../../selectors/BO/add_product_page');
+const {AddProductPage} = require('../../../selectors/BO/add_product_page');
+const commonProduct = require('../../common_scenarios/product');
+let promise = Promise.resolve();
+let productData = {
+  name: 'Product test',
+  quantity: "50",
+  price: '500',
+  image_name: 'image_test.jpg',
+  reference: 'ref123'
+};
+
+scenario('Navigate between the catalog pages in the back office', () => {
+  scenario('Login in the Back Office', client => {
+    test('should open the browser', () => client.open());
+    test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
+  }, 'common_client');
+
+  scenario('Create products to have more than 20 product in the catalog', client => {
+    test('should go to "Catalog" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
+    test('should create products if there\'s less than 20 product in the list', () => {
+      return promise
+        .then(() => client.getProductPageNumber('product_catalog_list'))
+        .then(() => {
+          let productNumber = 20 - global.productsPageNumber;
+          if (productNumber !== 0) {
+            for (let i = 0; i < productNumber + 1; i++) {
+              commonProduct.createProduct(AddProductPage, productData);
+            }
+          }
+        })
+        .then(() => commonProduct.checkPaginationBO('Next', '1', 20, false, true))
+        .then(() => commonProduct.checkPaginationBO('Next', '1', 50))
+        .then(() => commonProduct.checkPaginationBO('Next', '1', 100, true));
+    });
+  }, 'product/product');
+}, 'common_client');

--- a/tests/E2E/test/campaigns/high/02_product/7_check_all_products.js
+++ b/tests/E2E/test/campaigns/high/02_product/7_check_all_products.js
@@ -25,7 +25,7 @@ scenario('Check that all products are well displayed in the Back Office', client
   test('should check the existence of pagination', () => {
     return promise
       .then(() => client.isVisible(productPage.pagination_next))
-      .then(() => client.clickPageNextOrPrevious(productPage.pagination_next));
+      .then(() => client.clickNextOrPrevious(productPage.pagination_next));
   });
   test('should go to the first product page', () => client.waitForExistAndClick(productPage.first_product_all));
 }, 'product/product', true);

--- a/tests/E2E/test/clients/product/product.js
+++ b/tests/E2E/test/clients/product/product.js
@@ -133,7 +133,7 @@ class Product extends CommonClient {
       .selectByVisibleText(addProductPage.feature_value_select, value);
   }
 
-  clickPageNextOrPrevious(selector) {
+  clickNextOrPrevious(selector) {
     if (global.isVisible) {
       return this.client
         .click(selector)

--- a/tests/E2E/test/selectors/BO/add_product_page.js
+++ b/tests/E2E/test/selectors/BO/add_product_page.js
@@ -158,14 +158,30 @@ module.exports = {
     options_file_add_button: '//*[@id="form_step6_attachment_product_add"]',
     options_file_checkbox: '//*[@id="form_step6_attachments_0"]',
     catalog_product_table: '#product_catalog_list table.product',
-    get catalog_product_name() { return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(4) > a'; },
-    get catalog_product_reference() { return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(5)'; },
-    get catalog_product_category() { return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(6)'; },
-    get catalog_product_price() { return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(7)'; },
-    get catalog_product_quantity() { return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(8)'; },
-    get catalog_product_online() { return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(9) > a > i'; },
-    get catalog_reset_filter() { return this.catalog_product_table + ' .column-filters button[name="products_filter_reset"]'; },
-    get catalog_submit_filter() { return this.catalog_product_table + '.column-filters button[name="products_filter_submit"]'; },
+    get catalog_product_name() {
+      return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(4) > a';
+    },
+    get catalog_product_reference() {
+      return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(5)';
+    },
+    get catalog_product_category() {
+      return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(6)';
+    },
+    get catalog_product_price() {
+      return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(7)';
+    },
+    get catalog_product_quantity() {
+      return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(8)';
+    },
+    get catalog_product_online() {
+      return this.catalog_product_table + ' > tbody tr:first-child > td:nth-child(9) > a > i';
+    },
+    get catalog_reset_filter() {
+      return this.catalog_product_table + ' .column-filters button[name="products_filter_reset"]';
+    },
+    get catalog_submit_filter() {
+      return this.catalog_product_table + '.column-filters button[name="products_filter_submit"]';
+    },
     catalog_home: '//*[@id="form_step1_categories"]/ul/li/div/label',
     catalog_first_element_radio: '//*[@id="form_step1_categories"]/ul/li/ul/li[1]/div',
     catalog_second_element_radio: '//*[@id="form_step1_categories"]/ul/li/ul/li[2]/div',
@@ -202,6 +218,10 @@ module.exports = {
     action_duplicate_button: '(//*[@id="product_catalog_list"]//tbody//div[@class="btn-group-action"]//a[contains(@onclick,"duplicate")])[%POS]',
     action_delete_button: '(//*[@id="product_catalog_list"]//tbody//div[@class="btn-group-action"]//a[contains(@onclick,"delete")])[%POS]',
     delete_now_modal_button: '//*[@id="catalog_deletion_modal"]//button[contains(text(), "Delete now")]',
-    search_no_results: '//*[@id="product_catalog_list"]//tbody/tr[1]/td'
+    search_no_results: '//*[@id="product_catalog_list"]//tbody/tr[1]/td',
+    pagination_next: '//*[@id="pagination_next_url"]',
+    pagination_previous: '//*[@id="product_catalog_list"]//li[@class="page-item previous "]//a',
+    page_active_number: '//*[@id="product_catalog_list"]//li[@class="page-item active"]//input',
+    item_per_page: '//*[@id="paginator_select_page_limit"]'
   }
 };


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This script is testing whether the pagination and the item per page option is working well on the catalog page
| Type?         | new feature
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | /
| How to test?  | Run this command:  path=full/02_product/15_navigate_between_catalog_pages npm run specific-test -- --URL=URLFrontOffice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9147)
<!-- Reviewable:end -->
