### PR TITLE
Error with quota fields

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -38,18 +38,30 @@ class UploadQuotaType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('max_size_attached_files', TextWithUnitType::class, array(
-                'required' => true,
-                'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),
-            ))
-            ->add('max_size_downloadable_product', TextWithUnitType::class, array(
-                'required' => true,
-                'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),
-            ))
-            ->add('max_size_product_image', TextWithUnitType::class, array(
-                'required' => true,
-                'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),
-            ))
+            ->add(
+                'max_size_attached_files',
+                TextWithUnitType::class,
+                [
+                    'required' => true,
+                    'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),
+                ]
+            )
+            ->add(
+                'max_size_downloadable_product',
+                TextWithUnitType::class,
+                [
+                    'required' => true,
+                    'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),
+                ]
+            )
+            ->add(
+                'max_size_product_image',
+                TextWithUnitType::class,
+                [
+                    'required' => true,
+                    'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),
+                ]
+            )
         ;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | We mustn't be able to set a empty value. More only check for array_key_exists instead of array_keys([], true) which remove keys with empty value and there is a difference between file and post data.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5631
| How to test?  | Try to set "0" in upload quota fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9149)
<!-- Reviewable:end -->
