### PR TITLE
Fix missing security event listeners registration

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -32,3 +32,23 @@ services:
             - "@=service('kernel').getRootDir()"
         tags:
             - { name: kernel.event_listener, event: console.command, method: onConsoleCommand }
+
+    prestashop.access_denied.listener:
+        class: PrestaShopBundle\EventListener\AccessDeniedListener
+        arguments:
+            - "@router"
+            - "@translator"
+            - "@session"
+        tags:
+            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
+
+    prestashop.demo_mode_enabled.listener:
+        class: PrestaShopBundle\EventListener\DemoModeEnabledListener
+        arguments:
+            - "@router"
+            - "@translator"
+            - "@session"
+            - "@annotation_reader"
+            - "@=service('prestashop.adapter.legacy.configuration').getBoolean('_PS_MODE_DEMO_')"
+        tags:
+            - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | 1.7.4 were merged into develop but security event listeners registration are missing now in develop, this PR fixes it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Access control & demo mode should be working in Symfony controllers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9156)
<!-- Reviewable:end -->
