### PR TITLE
State filter in catalog page doesn't work

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -65,7 +65,7 @@
           {% endif %}
 
           <th scope="col" class="text-center">
-            {{ ps.sortable_column_header("Status"|trans({}, 'Admin.Global'), 'active') }}
+            {{ ps.sortable_column_header("Status"|trans({}, 'Admin.Global'), 'active', orderBy, sortOrder) }}
           </th>
           {% if has_category_filter == true %}
             <th scope="col">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | On the catalog page in BO, I try to filter by state to display first the products enabled or disabled but it doesn't work and keep always the same order.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5652
| How to test?  | Try to change order state

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9157)
<!-- Reviewable:end -->
