### PR TITLE
FO: Fix tax label display on product page

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -362,7 +362,7 @@ class ProductControllerCore extends FrontController
             'group_reduction' => $group_reduction,
             'no_tax' => Tax::excludeTaxeOption() || !$this->product->getTaxesRate($address),
             'ecotax' => (!count($this->errors) && $this->product->ecotax > 0 ? Tools::convertPrice((float)$this->product->ecotax) : 0),
-            'tax_enabled' => Configuration::get('PS_TAX') && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'),
+            'tax_enabled' => Configuration::get('PS_TAX') && !(Module::isEnabled('advancedeucompliance') && Configuration::get('AEUC_LABEL_TAX_INC_EXC')),
             'customer_group_without_tax' => Group::getPriceDisplayMethod($this->context->customer->id_default_group),
         ));
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When the Advanced EU Compliance module is installed, but disabled, it still affects tax label display on front-end. We should check if the module is enabled when taking one of its parameters into account in conditionals.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | `tax_enabled` template parameter for `assignPriceAndTax()` function in `ProductController` class should not be affected by Advanced EU Compliance module settings when this module is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9166)
<!-- Reviewable:end -->
