### PR TITLE
Added a service to manage PrestaShop versions (may deprecate _PS_VERSION_)

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -32,6 +32,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class AppKernel extends Kernel
 {
+    const VERSION = '1.7.4.0';
+    const MAJOR_VERSION_STRING = '1.7';
+    const MAJOR_VERSION = 17;
+    const MINOR_VERSION = 4;
+    const RELEASE_VERSION = 0;
+
     /**
      * @{inheritdoc}
      */

--- a/config/autoload.php
+++ b/config/autoload.php
@@ -23,11 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+require_once __DIR__.'/../vendor/autoload.php';
 
-define('_PS_VERSION_', '1.7.4.0');
+define('_PS_VERSION_', AppKernel::VERSION);
 
-require_once(_PS_CONFIG_DIR_.'alias.php');
-require_once(_PS_CLASS_DIR_.'PrestaShopAutoload.php');
+require_once _PS_CONFIG_DIR_.'alias.php';
+require_once _PS_CLASS_DIR_.'PrestaShopAutoload.php';
 spl_autoload_register(array(PrestaShopAutoload::getInstance(), 'load'));
-
-require_once(__DIR__.'/../vendor/autoload.php');

--- a/src/Adapter/Admin/PagePreference.php
+++ b/src/Adapter/Admin/PagePreference.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Admin;
 use PrestaShopBundle\Service\TransitionalBehavior\AdminPagePreferenceInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage;
+use AppKernel;
 use Db;
 
 /**
@@ -96,7 +97,7 @@ class PagePreference implements AdminPagePreferenceInterface
             return false;
         }
         $installVersion = explode('.', $version);
-        $currentVersion = explode('.', _PS_VERSION_);
+        $currentVersion = explode('.', AppKernel::VERSION);
 
         // Prod mode, depends on the page
         switch ($page) {

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Adapter\ImageManager;
 use PrestaShop\PrestaShop\Adapter\Validate;
 use PrestaShopBundle\Entity\AdminFilter;
 use PrestaShopBundle\Service\DataProvider\Admin\ProductInterface;
+use AppKernel;
 use Db;
 use Context;
 use Hook;
@@ -297,7 +298,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
 
         // exec legacy hook but with different parameters (retro-compat < 1.7 is broken here)
         Hook::exec('actionAdminProductsListingFieldsModifier', array(
-            '_ps_version' => _PS_VERSION_,
+            '_ps_version' => AppKernel::VERSION,
             'sql_select' => &$sqlSelect,
             'sql_table' => &$sqlTable,
             'sql_where' => &$sqlWhere,
@@ -328,7 +329,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
 
         // exec legacy hook but with different parameters (retro-compat < 1.7 is broken here)
         Hook::exec('actionAdminProductsListingFieldsModifier', array(
-            '_ps_version' => _PS_VERSION_,
+            '_ps_version' => AppKernel::VERSION,
             'sql_select' => &$sqlSelect,
             'sql_table' => &$sqlTable,
             'sql_where' => &$sqlWhere,
@@ -360,7 +361,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         // post treatment by hooks
         // exec legacy hook but with different parameters (retro-compat < 1.7 is broken here)
         Hook::exec('actionAdminProductsListingResultsModifier', array(
-            '_ps_version' => _PS_VERSION_,
+            '_ps_version' => AppKernel::VERSION,
             'products' => &$products,
             'total' => $total,
         ));

--- a/src/Adapter/Requirement/CheckMissingOrUpdatedFiles.php
+++ b/src/Adapter/Requirement/CheckMissingOrUpdatedFiles.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Requirement;
 
+use AppKernel;
+
 /**
  * Part of requirements for a PrestaShop website
  * Check if all required files exists.
@@ -43,7 +45,7 @@ class CheckMissingOrUpdatedFiles
         );
         
         if (is_null($dir)) {
-            $xml = @simplexml_load_file(_PS_API_URL_.'/xml/md5/'._PS_VERSION_.'.xml');
+            $xml = @simplexml_load_file(_PS_API_URL_.'/xml/md5/'.AppKernel::VERSION.'.xml');
             if (!$xml) {
                 return $fileList;
             }

--- a/src/Adapter/Shop/ShopInformation.php
+++ b/src/Adapter/Shop/ShopInformation.php
@@ -55,7 +55,7 @@ class ShopInformation
     public function getShopInformation()
     {
         return array(
-            'version' => _PS_VERSION_,
+            'version' => AppKernel::VERSION,
             'url' => $this->context->shop->getBaseURL(),
             'theme' => $this->context->shop->theme->getName(),
         );

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -160,7 +160,8 @@ class ModuleManagerBuilder
             self::$translator->getLocale(),
             $this->getCountryIso(),
             new Tools(),
-            (new Configuration())->get('_PS_BASE_URL_')
+            (new Configuration())->get('_PS_BASE_URL_'),
+            \AppKernel::VERSION
         );
 
         $marketPlaceClient->setSslVerification(_PS_CACHE_CA_CERT_FILE_);

--- a/src/Core/Foundation/PrestaShopVersion/Exception/InvalidVersionException.php
+++ b/src/Core/Foundation/PrestaShopVersion/Exception/InvalidVersionException.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShop\PrestaShop\Core\Foundation\PrestaShopVersion\Exception;
+
+use Exception;
+
+class InvalidVersionException extends Exception
+{
+}

--- a/src/Core/Foundation/PrestaShopVersion/PrestaShopVersion.php
+++ b/src/Core/Foundation/PrestaShopVersion/PrestaShopVersion.php
@@ -34,6 +34,27 @@ class PrestaShopVersion
     const STRING = 0;
     const INTEGER = 1;
 
+    private $version;
+    private $majorVersionString;
+    private $majorVersion;
+    private $minorVersion;
+    private $releaseVersion;
+
+    public function __construct(
+        $version = AppKernel::VERSION,
+        $majorVersionString = AppKernel::MAJOR_VERSION_STRING,
+        $majorVersion = AppKernel::MAJOR_VERSION,
+        $minorVersion = AppKernel::MINOR_VERSION,
+        $releaseVersion = AppKernel::RELEASE_VERSION
+    )
+    {
+        $this->version = $version;
+        $this->majorVersionString = $majorVersionString;
+        $this->majorVersion = $majorVersion;
+        $this->minorVersion = $minorVersion;
+        $this->releaseVersion = $releaseVersion;
+    }
+
     /**
      * Returns the current PrestaShop version which is hardcoded in \AppKernel::VERSION
      *
@@ -41,7 +62,7 @@ class PrestaShopVersion
      */
     public function getVersion()
     {
-        return AppKernel::VERSION;
+        return $this->version;
     }
 
     /**
@@ -54,11 +75,11 @@ class PrestaShopVersion
     public function getMajorVersion($type = self::STRING)
     {
         if (self::STRING === $type) {
-            return AppKernel::MAJOR_VERSION_STRING;
+            return $this->majorVersionString;
         }
 
         if (self::INTEGER === $type) {
-            return AppKernel::MAJOR_VERSION;
+            return $this->majorVersion;
         }
 
         throw new InvalidArgumentException('The major version can only be retrieved via \AppKernel::STRING or \AppKernel::INTEGER.');
@@ -71,7 +92,7 @@ class PrestaShopVersion
      */
     public function getMinorVersion()
     {
-        return AppKernel::MINOR_VERSION;
+        return $this->minorVersion;
     }
 
     /**
@@ -81,7 +102,7 @@ class PrestaShopVersion
      */
     public function getReleaseVersion()
     {
-        return AppKernel::RELEASE_VERSION;
+        return $this->releaseVersion;
     }
 
     /**
@@ -186,7 +207,7 @@ class PrestaShopVersion
             throw new InvalidArgumentException($e->getMessage());
         }
 
-        return version_compare(AppKernel::VERSION, $version, $operator);
+        return version_compare($this->version, $version, $operator);
     }
 
     /**

--- a/src/Core/Foundation/PrestaShopVersion/PrestaShopVersion.php
+++ b/src/Core/Foundation/PrestaShopVersion/PrestaShopVersion.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShop\PrestaShop\Core\Foundation\PrestaShopVersion;
+
+use AppKernel;
+use PrestaShop\PrestaShop\Core\Foundation\PrestaShopVersion\Exception\InvalidVersionException;
+use InvalidArgumentException;
+
+class PrestaShopVersion
+{
+    const STRING = 0;
+    const INTEGER = 1;
+
+    /**
+     * Returns the current PrestaShop version which is hardcoded in \AppKernel::VERSION
+     *
+     * @return string For example "1.7.4.0"
+     */
+    public function getVersion()
+    {
+        return AppKernel::VERSION;
+    }
+
+    /**
+     * Returns the current PrestaShop major version as string or integer
+     *
+     * @param int $type Defines the datatype of the returned major version (\AppKernel::STRING or \AppKernel::INTEGER)
+     *
+     * @return int|string For example "1.7" or 17
+     */
+    public function getMajorVersion($type = self::STRING)
+    {
+        if (self::STRING === $type) {
+            return AppKernel::MAJOR_VERSION_STRING;
+        }
+
+        if (self::INTEGER === $type) {
+            return AppKernel::MAJOR_VERSION;
+        }
+
+        throw new InvalidArgumentException('The major version can only be retrieved via \AppKernel::STRING or \AppKernel::INTEGER.');
+    }
+
+    /**
+     * Returns the current PrestaShop minor version
+     *
+     * @return int
+     */
+    public function getMinorVersion()
+    {
+        return AppKernel::MINOR_VERSION;
+    }
+
+    /**
+     * Returns the current PrestaShop release version
+     *
+     * @return int
+     */
+    public function getReleaseVersion()
+    {
+        return AppKernel::RELEASE_VERSION;
+    }
+
+    /**
+     * Returns if the current PrestaShop version is greater than the provided version
+     *
+     * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException If the provided version is invalid
+     */
+    public function isGreaterThan($version)
+    {
+        return $this->versionCompare($version, '>');
+    }
+
+    /**
+     * Returns if the current PrestaShop version is greater than or equal to the provided version
+     *
+     * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException If the provided version is invalid
+     */
+    public function isGreaterThanOrEqualTo($version)
+    {
+        return $this->versionCompare($version, '>=');
+    }
+
+    /**
+     * Returns if the current PrestaShop version is less than the provided version
+     *
+     * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException If the provided version is invalid
+     */
+    public function isLessThan($version)
+    {
+        return $this->versionCompare($version, '<');
+    }
+
+    /**
+     * Returns if the current PrestaShop version is less than or equal to the provided version
+     *
+     * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException If the provided version is invalid
+     */
+    public function isLessThanOrEqualTo($version)
+    {
+        return $this->versionCompare($version, '<=');
+    }
+
+    /**
+     * Returns if the current PrestaShop version is equal to the provided version
+     *
+     * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException If the provided version is invalid
+     */
+    public function isEqualTo($version)
+    {
+        return $this->versionCompare($version, '=');
+    }
+
+    /**
+     * Returns if the current PrestaShop version is not equal to the provided version
+     *
+     * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException If the provided version is invalid
+     */
+    public function isNotEqualTo($version)
+    {
+        return $this->versionCompare($version, '!=');
+    }
+
+    /**
+     * Compares the current PrestaShop version with the provided version depending on the provided operator
+     *
+     * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
+     * @param $operator Operator for version_compare(), allowed values are: <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
+     *
+     * @return boolean Result of the comparison
+     *
+     * @throws InvalidArgumentException If the provided version is invalid
+     */
+    private function versionCompare($version, $operator)
+    {
+        try {
+            $this->checkVersion($version);
+        } catch(InvalidVersionException $e) {
+            throw new InvalidArgumentException($e->getMessage());
+        }
+
+        return version_compare(AppKernel::VERSION, $version, $operator);
+    }
+
+    /**
+     * @param $version
+     * @throws InvalidVersionException If the provided version is invalid
+     */
+    private function checkVersion($version)
+    {
+        if (!is_string($version)) {
+            throw new InvalidVersionException('A valid version must be a string.');
+        }
+
+        $versionParts = explode('.', $version);
+
+        if (4 !== count($versionParts)) {
+            throw new InvalidVersionException('A valid version string must contain three times the "." character, for example "1.7.4.0".');
+        }
+
+        foreach ($versionParts as $versionPart) {
+            if (!is_numeric($versionPart)) {
+                throw new InvalidVersionException('A valid version string must contain four numeric characters divided by three "." characters, for example "1.7.4.0".');
+            }
+        }
+    }
+}

--- a/src/Core/Foundation/Version/Exception/InvalidVersionException.php
+++ b/src/Core/Foundation/Version/Exception/InvalidVersionException.php
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-namespace PrestaShop\PrestaShop\Core\Foundation\PrestaShopVersion\Exception;
+namespace PrestaShop\PrestaShop\Core\Foundation\Version\Exception;
 
 use Exception;
 

--- a/src/Core/Foundation/Version/Exception/InvalidVersionException.php
+++ b/src/Core/Foundation/Version/Exception/InvalidVersionException.php
@@ -27,6 +27,34 @@ namespace PrestaShop\PrestaShop\Core\Foundation\Version\Exception;
 
 use Exception;
 
+/**
+ * This exception will be thrown if an invalid Shop version name is used
+ * in the application.
+ */
 class InvalidVersionException extends Exception
 {
+    /**
+     * Creates an exception for the invalid type.
+     *
+     * @return static The created exception.
+     */
+    public static function mustBeAString()
+    {
+        return new static('A valid version must be a string.');
+    }
+
+    /**
+     * Creates an exception for the invalid version name.
+     *
+     * @param string  $versionName  The version name.
+     *
+     * @return static The created exception.
+     */
+    public static function mustBeValidName($versionName)
+    {
+        return new static(sprintf(
+            'You provided an invalid version string ("%s"). A valid version string must contain four numeric characters divided by three "." characters, for example "1.7.4.0".',
+            $versionName
+        ));
+    }
 }

--- a/src/Core/Foundation/Version/Version.php
+++ b/src/Core/Foundation/Version/Version.php
@@ -211,7 +211,10 @@ class Version
     }
 
     /**
+     * Checks if a given version is a valid version string
+     *
      * @param $version
+     *
      * @throws InvalidVersionException If the provided version is invalid
      */
     private function checkVersion($version)
@@ -220,16 +223,8 @@ class Version
             throw new InvalidVersionException('A valid version must be a string.');
         }
 
-        $versionParts = explode('.', $version);
-
-        if (4 !== count($versionParts)) {
-            throw new InvalidVersionException('A valid version string must contain three times the "." character, for example "1.7.4.0".');
-        }
-
-        foreach ($versionParts as $versionPart) {
-            if (!is_numeric($versionPart)) {
-                throw new InvalidVersionException('A valid version string must contain four numeric characters divided by three "." characters, for example "1.7.4.0".');
-            }
+        if (!preg_match('/^[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*$/', $version)) {
+            throw new InvalidVersionException(sprintf('You provided an invalid version string ("%s"). A valid version string must contain four numeric characters divided by three "." characters, for example "1.7.4.0".', $version));
         }
     }
 }

--- a/src/Core/Foundation/Version/Version.php
+++ b/src/Core/Foundation/Version/Version.php
@@ -23,13 +23,13 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-namespace PrestaShop\PrestaShop\Core\Foundation\PrestaShopVersion;
+namespace PrestaShop\PrestaShop\Core\Foundation\Version;
 
 use AppKernel;
-use PrestaShop\PrestaShop\Core\Foundation\PrestaShopVersion\Exception\InvalidVersionException;
+use PrestaShop\PrestaShop\Core\Foundation\Version\Exception\InvalidVersionException;
 use InvalidArgumentException;
 
-class PrestaShopVersion
+class Version
 {
     const STRING = 0;
     const INTEGER = 1;

--- a/src/Core/Foundation/Version/Version.php
+++ b/src/Core/Foundation/Version/Version.php
@@ -25,7 +25,6 @@
  */
 namespace PrestaShop\PrestaShop\Core\Foundation\Version;
 
-use AppKernel;
 use PrestaShop\PrestaShop\Core\Foundation\Version\Exception\InvalidVersionException;
 use InvalidArgumentException;
 
@@ -40,13 +39,7 @@ class Version
     private $minorVersion;
     private $releaseVersion;
 
-    public function __construct(
-        $version = AppKernel::VERSION,
-        $majorVersionString = AppKernel::MAJOR_VERSION_STRING,
-        $majorVersion = AppKernel::MAJOR_VERSION,
-        $minorVersion = AppKernel::MINOR_VERSION,
-        $releaseVersion = AppKernel::RELEASE_VERSION
-    )
+    public function __construct($version, $majorVersionString, $majorVersion, $minorVersion, $releaseVersion)
     {
         $this->version = $version;
         $this->majorVersionString = $majorVersionString;

--- a/src/Core/Foundation/Version/Version.php
+++ b/src/Core/Foundation/Version/Version.php
@@ -26,18 +26,51 @@
 namespace PrestaShop\PrestaShop\Core\Foundation\Version;
 
 use PrestaShop\PrestaShop\Core\Foundation\Version\Exception\InvalidVersionException;
-use InvalidArgumentException;
 
+/**
+ * Class responsible of managing the right version of Shop
+ * for every internal/external services.
+ */
 class Version
 {
     const STRING = 0;
     const INTEGER = 1;
 
-    private $version;
+    /**
+     * Full version name.
+     *
+     * @var string
+     */
+    private $fullVersion;
+
+    /**
+     * Major version name.
+     *
+     * @var string
+     */
     private $majorVersionString;
+
+    /**
+     * Major version.
+     *
+     * @var int
+     */
     private $majorVersion;
+
+    /**
+     * Minor version.
+     *
+     * @var int
+     */
     private $minorVersion;
+
+    /**
+     * Release version.
+     *
+     * @var int
+     */
     private $releaseVersion;
+
 
     public function __construct($version, $majorVersionString, $majorVersion, $minorVersion, $releaseVersion)
     {
@@ -49,37 +82,37 @@ class Version
     }
 
     /**
-     * Returns the current PrestaShop version which is hardcoded in \AppKernel::VERSION
+     * Returns the current PrestaShop version which is hardcoded in \AppKernel::VERSION.
      *
      * @return string For example "1.7.4.0"
      */
-    public function getVersion()
+    public function getFullVersion()
     {
-        return $this->version;
+        return $this->fullVersion;
     }
 
     /**
-     * Returns the current PrestaShop major version as string or integer
+     * Returns the current PrestaShop major version as a string.
      *
-     * @param int $type Defines the datatype of the returned major version (\AppKernel::STRING or \AppKernel::INTEGER)
-     *
-     * @return int|string For example "1.7" or 17
+     * @return string For example "1.7"
      */
-    public function getMajorVersion($type = self::STRING)
+    public function getStringMajorVersion()
     {
-        if (self::STRING === $type) {
-            return $this->majorVersionString;
-        }
-
-        if (self::INTEGER === $type) {
-            return $this->majorVersion;
-        }
-
-        throw new InvalidArgumentException('The major version can only be retrieved via \AppKernel::STRING or \AppKernel::INTEGER.');
+        return $this->majorVersionString;
     }
 
     /**
-     * Returns the current PrestaShop minor version
+     * Returns the current PrestaShop major version as an integer.
+     *
+     * @return int For example 17
+     */
+    public function getMajorVersion()
+    {
+        return $this->majorVersion;
+    }
+
+    /**
+     * Returns the current PrestaShop minor version.
      *
      * @return int
      */
@@ -99,7 +132,7 @@ class Version
     }
 
     /**
-     * Returns if the current PrestaShop version is greater than the provided version
+     * Returns if the current PrestaShop version is greater than the provided version.
      *
      * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
      *
@@ -113,7 +146,7 @@ class Version
     }
 
     /**
-     * Returns if the current PrestaShop version is greater than or equal to the provided version
+     * Returns if the current PrestaShop version is greater than or equal to the provided version.
      *
      * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
      *
@@ -127,7 +160,7 @@ class Version
     }
 
     /**
-     * Returns if the current PrestaShop version is less than the provided version
+     * Returns if the current PrestaShop version is less than the provided version.
      *
      * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
      *
@@ -141,7 +174,7 @@ class Version
     }
 
     /**
-     * Returns if the current PrestaShop version is less than or equal to the provided version
+     * Returns if the current PrestaShop version is less than or equal to the provided version.
      *
      * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
      *
@@ -155,7 +188,7 @@ class Version
     }
 
     /**
-     * Returns if the current PrestaShop version is equal to the provided version
+     * Returns if the current PrestaShop version is equal to the provided version.
      *
      * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
      *
@@ -169,7 +202,7 @@ class Version
     }
 
     /**
-     * Returns if the current PrestaShop version is not equal to the provided version
+     * Returns if the current PrestaShop version is not equal to the provided version.
      *
      * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
      *
@@ -183,24 +216,20 @@ class Version
     }
 
     /**
-     * Compares the current PrestaShop version with the provided version depending on the provided operator
+     * Compares the current PrestaShop version with the provided version depending on the provided operator.
      *
      * @param $version Must be a valid PrestaShop version string, for example "1.7.4.0"
      * @param $operator Operator for version_compare(), allowed values are: <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
      *
-     * @return boolean Result of the comparison
+     * @return boolean Result of the comparison.
      *
-     * @throws InvalidArgumentException If the provided version is invalid
+     * @throws InvalidVersionException If the provided version is invalid.
      */
     private function versionCompare($version, $operator)
     {
-        try {
-            $this->checkVersion($version);
-        } catch(InvalidVersionException $e) {
-            throw new InvalidArgumentException($e->getMessage());
+        if ($this->checkVersion($version)) {
+            return version_compare($this->version, $version, $operator);
         }
-
-        return version_compare($this->version, $version, $operator);
     }
 
     /**
@@ -208,16 +237,19 @@ class Version
      *
      * @param $version
      *
+     * @return bool true only if version is valid, else throw an exception.
      * @throws InvalidVersionException If the provided version is invalid
      */
     private function checkVersion($version)
     {
         if (!is_string($version)) {
-            throw new InvalidVersionException('A valid version must be a string.');
+            throw InvalidVersionException::mustBeAString();
         }
 
         if (!preg_match('/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/', $version)) {
-            throw new InvalidVersionException(sprintf('You provided an invalid version string ("%s"). A valid version string must contain four numeric characters divided by three "." characters, for example "1.7.4.0".', $version));
+            throw InvalidVersionException::mustBeValidName();
         }
+
+        return true;
     }
 }

--- a/src/Core/Foundation/Version/Version.php
+++ b/src/Core/Foundation/Version/Version.php
@@ -223,7 +223,7 @@ class Version
             throw new InvalidVersionException('A valid version must be a string.');
         }
 
-        if (!preg_match('/^[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*$/', $version)) {
+        if (!preg_match('/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/', $version)) {
             throw new InvalidVersionException(sprintf('You provided an invalid version string ("%s"). A valid version string must contain four numeric characters divided by three "." characters, for example "1.7.4.0".', $version));
         }
     }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -156,6 +156,7 @@ class FrameworkBundleAdminController extends Controller
      */
     protected function generateSidebarLink($section, $title = false)
     {
+        $fullVersion = $this->get('prestashop.core.foundation.version')->getFullVersion();
         $legacyContext = $this->get('prestashop.adapter.legacy.context');
 
         if (empty($title)) {
@@ -163,7 +164,7 @@ class FrameworkBundleAdminController extends Controller
         }
 
         $docLink = urlencode('https://help.prestashop.com/'.$legacyContext->getEmployeeLanguageIso().'/doc/'
-            .$section.'?version='._PS_VERSION_.'&country='.$legacyContext->getEmployeeLanguageIso());
+            .$section.'?version='.$fullVersion.'&country='.$legacyContext->getEmployeeLanguageIso());
 
         return $this->generateUrl('admin_common_sidebar', [
             'url' => $docLink,

--- a/src/PrestaShopBundle/Controller/Admin/Improve/AddonsStoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/AddonsStoreController.php
@@ -66,7 +66,7 @@ class AddonsStoreController extends FrameworkBundleAdminController
      */
     private function getAddonsUrl(Request $request)
     {
-        $psVersion = $this->get('prestashop.adapter.legacy.configuration')->get('_PS_VERSION_');
+        $psVersion = $this->get('prestashop.core.foundation.version')->getFullVersion();
         $parent_domain = $request->getSchemeAndHttpHost();
         $context = $this->getContext();
         $currencyCode = $context->currency->iso_code;

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 
+use PrestaShop\PrestaShop\Core\Foundation\PrestaShopVersion\PrestaShopVersion;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -43,14 +44,15 @@ class ThemeCatalogController extends FrameworkBundleAdminController
      */
     public function indexAction(Request $request)
     {
-        $context = $this->getContext();
         $configuration = $this->get('prestashop.adapter.legacy.configuration');
+        $prestaShopVersion = new PrestaShopVersion();
 
-        $pageContent = file_get_contents('https://addons.prestashop.com/iframe/search-' . $this->getMajorVersion($configuration->get('_PS_VERSION_')) . '.php?'
+        $pageContent = file_get_contents(
+            'https://addons.prestashop.com/iframe/search-' . $prestaShopVersion->getMajorVersion() . '.php?'
             . http_build_query([
-                'psVersion' => $configuration->get('_PS_VERSION_'),
-                'isoLang' => $context->language->iso_code,
-                'isoCurrency' => $context->currency->iso_code,
+                'psVersion' => $prestaShopVersion->getVersion(),
+                'isoLang' => $this->getContext->language->iso_code,
+                'isoCurrency' => $this->getContext->currency->iso_code,
                 'isoCountry' => $this->getContext()->country->iso_code,
                 'activity' => $configuration->getInt('PS_SHOP_ACTIVITY'),
                 'parentUrl' => $request->getSchemeAndHttpHost(),

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
@@ -46,7 +46,7 @@ class ThemeCatalogController extends FrameworkBundleAdminController
     {
         $configuration = $this->get('prestashop.adapter.legacy.configuration');
         $version = new Version();
-
+        
         $pageContent = file_get_contents(
             'https://addons.prestashop.com/iframe/search-' . $version->getMajorVersion() . '.php?'
             . http_build_query([

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 
-use PrestaShop\PrestaShop\Core\Foundation\PrestaShopVersion\PrestaShopVersion;
+use PrestaShop\PrestaShop\Core\Foundation\Version\Version;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -45,12 +45,12 @@ class ThemeCatalogController extends FrameworkBundleAdminController
     public function indexAction(Request $request)
     {
         $configuration = $this->get('prestashop.adapter.legacy.configuration');
-        $prestaShopVersion = new PrestaShopVersion();
+        $version = new Version();
 
         $pageContent = file_get_contents(
-            'https://addons.prestashop.com/iframe/search-' . $prestaShopVersion->getMajorVersion() . '.php?'
+            'https://addons.prestashop.com/iframe/search-' . $version->getMajorVersion() . '.php?'
             . http_build_query([
-                'psVersion' => $prestaShopVersion->getVersion(),
+                'psVersion' => $version->getVersion(),
                 'isoLang' => $this->getContext()->language->iso_code,
                 'isoCurrency' => $this->getContext()->currency->iso_code,
                 'isoCountry' => $this->getContext()->country->iso_code,

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
@@ -45,8 +45,8 @@ class ThemeCatalogController extends FrameworkBundleAdminController
     public function indexAction(Request $request)
     {
         $configuration = $this->get('prestashop.adapter.legacy.configuration');
-        $version = new Version();
-        
+        $version = $this->get('prestashop.core.foundation.version');
+
         $pageContent = file_get_contents(
             'https://addons.prestashop.com/iframe/search-' . $version->getMajorVersion() . '.php?'
             . http_build_query([

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
@@ -45,12 +45,12 @@ class ThemeCatalogController extends FrameworkBundleAdminController
     public function indexAction(Request $request)
     {
         $configuration = $this->get('prestashop.adapter.legacy.configuration');
-        $version = $this->get('prestashop.core.foundation.version');
+        $versionHelper = $this->get('prestashop.core.foundation.version');
 
         $pageContent = file_get_contents(
-            'https://addons.prestashop.com/iframe/search-' . $version->getMajorVersion() . '.php?'
+            'https://addons.prestashop.com/iframe/search-' . $versionHelper->getMajorVersion() . '.php?'
             . http_build_query([
-                'psVersion' => $version->getVersion(),
+                'psVersion' => $versionHelper->getFullVersion(),
                 'isoLang' => $this->getContext()->language->iso_code,
                 'isoCurrency' => $this->getContext()->currency->iso_code,
                 'isoCountry' => $this->getContext()->country->iso_code,

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
@@ -51,8 +51,8 @@ class ThemeCatalogController extends FrameworkBundleAdminController
             'https://addons.prestashop.com/iframe/search-' . $prestaShopVersion->getMajorVersion() . '.php?'
             . http_build_query([
                 'psVersion' => $prestaShopVersion->getVersion(),
-                'isoLang' => $this->getContext->language->iso_code,
-                'isoCurrency' => $this->getContext->currency->iso_code,
+                'isoLang' => $this->getContext()->language->iso_code,
+                'isoCurrency' => $this->getContext()->currency->iso_code,
                 'isoCountry' => $this->getContext()->country->iso_code,
                 'activity' => $configuration->getInt('PS_SHOP_ACTIVITY'),
                 'parentUrl' => $request->getSchemeAndHttpHost(),

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
@@ -72,22 +72,4 @@ class ThemeCatalogController extends FrameworkBundleAdminController
             'requireFilterStatus' => false,
         ]);
     }
-
-    /**
-     * Extracts the major version part of a PrestaShop version string
-     *
-     * For "1.7.4.0" the method returns "1.7", etc.
-     *
-     * @param string $version
-     *
-     * @return bool|string
-     */
-    private function getMajorVersion($version)
-    {
-        return substr(
-            $version,
-            0,
-            strpos($version, '.', strpos($version, '.') + 1)
-        );
-    }
 }

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -51,6 +51,7 @@ use PrestaShop\PrestaShop\Adapter\Entity\Currency;
 use PrestaShop\PrestaShop\Adapter\Entity\Validate;
 use PrestaShop\PrestaShop\Adapter\Entity\Cart;
 use PrestaShop\PrestaShop\Adapter\Entity\Category;
+use AppKernel;
 use InstallSession;
 use Language as LanguageLegacy;
 use PrestaShop\PrestaShop\Core\Cldr\Update;
@@ -430,7 +431,7 @@ class Install extends AbstractInstall
             if (!$all_languages) {
                 $iso_codes_to_install = array($this->language->getLanguageIso());
                 if ($iso_country) {
-                    $version = str_replace('.', '', _PS_VERSION_);
+                    $version = str_replace('.', '', AppKernel::VERSION);
                     $version = substr($version, 0, 2);
                     $localization_file_content = $this->getLocalizationPackContent($version, $iso_country);
 
@@ -789,7 +790,7 @@ class Install extends AbstractInstall
         Db::getInstance()->execute('UPDATE '._DB_PREFIX_.'country SET active = 0 WHERE id_country != '.(int)$id_country);
 
         // Set localization configuration
-        $version = str_replace('.', '', _PS_VERSION_);
+        $version = str_replace('.', '', AppKernel::VERSION);
         $version = substr($version, 0, 2);
         $localization_file_content = $this->getLocalizationPackContent($version, $data['shop_country']);
 

--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -58,6 +58,7 @@ namespace PrestaShopBundle\Install {
     use Symfony\Component\Yaml\Yaml;
     use Symfony\Component\Filesystem\Filesystem;
     use Symfony\Component\Filesystem\Exception\IOException;
+    use AppKernel;
     use Context;
     use Cache;
     use Shop;
@@ -319,18 +320,14 @@ namespace PrestaShopBundle\Install {
             require_once _PS_ROOT_DIR_.'/config/smarty.config.inc.php';
 
             Context::getContext()->smarty = $smarty;
-            if(version_compare(_PS_VERSION_, '1.5.0.0', '<=')) {
-                Language::loadLanguagesLegacy();
-            } else {
-                Language::loadLanguages();
-            }
+            Language::loadLanguages();
 
             $this->translator = Context::getContext()->getTranslator();
         }
 
         private function getConfValue($name)
         {
-            $full = version_compare('1.5.0.10', _PS_VERSION_) < 0;
+            $full = version_compare('1.5.0.10', AppKernel::VERSION) < 0;
 
             $sql = 'SELECT IF(cl.`id_lang` IS NULL, c.`value`, cl.`value`) AS value
 			FROM `'._DB_PREFIX_.'configuration` c
@@ -702,37 +699,6 @@ namespace PrestaShopBundle\Install {
 
         private function cleanupOldDirectories()
         {
-            if (version_compare(_PS_VERSION_, '1.5.0.0', '<=')) {
-                $dir = _PS_ROOT_DIR_ . '/controllers/';
-                if (file_exists($dir)) {
-                    foreach (scandir($dir) as $file) {
-                        if (!is_dir($file) && $file[0] != '.' && $file != 'index.php' && $file != '.htaccess') {
-                            if (file_exists($dir . basename(str_replace('.php', '', $file) . '.php'))) {
-                                unlink($dir . basename($file));
-                            }
-                        }
-                    }
-                }
-
-                $dir = _PS_ROOT_DIR_ . '/classes/';
-                foreach (self::$classes14 as $class) {
-                    if (file_exists($dir . basename($class) . '.php')) {
-                        unlink($dir . basename($class) . '.php');
-                    }
-                }
-
-                $dir = _PS_ADMIN_DIR_ . '/tabs/';
-                if (file_exists($dir)) {
-                    foreach (scandir($dir) as $file) {
-                        if (!is_dir($file) && $file[0] != '.' && $file != 'index.php' && $file != '.htaccess') {
-                            if (file_exists($dir . basename(str_replace('.php', '', $file) . '.php'))) {
-                                unlink($dir . basename($file));
-                            }
-                        }
-                    }
-                }
-            }
-
             if ($this->adminDir) {
                 $path = $this->adminDir . DIRECTORY_SEPARATOR . 'themes' . DIRECTORY_SEPARATOR . 'default' . DIRECTORY_SEPARATOR
                     . 'template' . DIRECTORY_SEPARATOR . 'controllers' . DIRECTORY_SEPARATOR . 'modules'
@@ -754,18 +720,14 @@ namespace PrestaShopBundle\Install {
                     if (Validate::isLangIsoCode($isoCode)) {
                         $errorsLanguage = array();
 
-                        Language::downloadLanguagePack($isoCode, _PS_VERSION_, $errorsLanguage);
+                        Language::downloadLanguagePack($isoCode, AppKernel::VERSION, $errorsLanguage);
 
                         $lang_pack = Language::getLangDetails($isoCode);
                         Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
                         Language::installEmailsLanguagePack($lang_pack, $errorsLanguage);
 
                         if (empty($errorsLanguage)) {
-                            if(version_compare(_PS_VERSION_, '1.5.0.0', '<=')) {
-                                Language::loadLanguagesLegacy();
-                            } else {
-                                Language::loadLanguages();
-                            }
+                            Language::loadLanguages();
 
                             $cldrUpdate = new Update(_PS_TRANSLATIONS_DIR_);
                             $cldrUpdate->fetchLocale(Language::getLocaleByIso($isoCode));

--- a/src/PrestaShopBundle/Resources/config/services/bundle/data_collector.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/data_collector.yml
@@ -15,7 +15,7 @@ services:
     # Web Profiler Bundle
     data_collector.config:
         class: Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector
-        arguments: ["PrestaShop", "@=service('prestashop.adapter.legacy.configuration').get('_PS_VERSION_')"]
+        arguments: ["PrestaShop", "@=service('prestashop.core.foundation.version').getFullVersion()"]
         public: false
         calls:
           - ["setKernel", ["@kernel"]]

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -97,5 +97,6 @@ services:
             - "@=service('prestashop.adapter.data_provider.country').getIsoCodebyId()"
             - "@prestashop.adapter.tools"
             - "@=service('prestashop.adapter.legacy.configuration').get('_PS_BASE_URL_')"
+            - "@=service('prestashop.core.foundation.version').getFullVersion()"
         calls:
             - [ "setSslVerification", ["%prestashop.addons.api_client.verify_ssl%"]]

--- a/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
@@ -1,0 +1,9 @@
+services:
+    prestashop.core.foundation.version:
+        class: PrestaShop\PrestaShop\Core\Foundation\Version\Version
+        arguments:
+            - !php/const:AppKernel::VERSION
+            - !php/const:AppKernel::MAJOR_VERSION_STRING
+            - !php/const:AppKernel::MAJOR_VERSION
+            - !php/const:AppKernel::MINOR_VERSION
+            - !php/const:AppKernel::RELEASE_VERSION

--- a/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
@@ -2,8 +2,8 @@ services:
     prestashop.core.foundation.version:
         class: PrestaShop\PrestaShop\Core\Foundation\Version\Version
         arguments:
-            - !php/const:AppKernel::VERSION
-            - !php/const:AppKernel::MAJOR_VERSION_STRING
-            - !php/const:AppKernel::MAJOR_VERSION
-            - !php/const:AppKernel::MINOR_VERSION
-            - !php/const:AppKernel::RELEASE_VERSION
+            - !php/const AppKernel::VERSION
+            - !php/const AppKernel::MAJOR_VERSION_STRING
+            - !php/const AppKernel::MAJOR_VERSION
+            - !php/const AppKernel::MINOR_VERSION
+            - !php/const AppKernel::RELEASE_VERSION

--- a/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
@@ -1,4 +1,7 @@
 services:
+    _defaults:
+        public: true
+
     prestashop.core.foundation.version:
         class: PrestaShop\PrestaShop\Core\Foundation\Version\Version
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core_services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core_services.yml
@@ -3,3 +3,4 @@ imports:
     - { resource: core/configuration.yml }
     - { resource: core/search.yml }
     - { resource: core/addon.yml }
+    - { resource: core/foundation.yml }

--- a/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
@@ -46,7 +46,8 @@ class ApiClient
         $locale,
         $isoCode,
         $toolsAdapter,
-        $domain
+        $domain,
+        $shopVersion
     ) {
         $this->addonsApiClient = $addonsApiClient;
         $this->toolsAdapter = $toolsAdapter;
@@ -55,7 +56,7 @@ class ApiClient
 
         $this->setIsoLang($isoLang)
             ->setIsoCode($isoCode)
-            ->setVersion(_PS_VERSION_)
+            ->setVersion($shopVersion)
             ->setShopUrl($domain)
         ;
         $this->defaultQueryParameters = $this->queryParameters;

--- a/src/PrestaShopBundle/Service/Hook/HookEvent.php
+++ b/src/PrestaShopBundle/Service/Hook/HookEvent.php
@@ -25,6 +25,7 @@
  */
 namespace PrestaShopBundle\Service\Hook;
 
+use AppKernel;
 use Symfony\Component\EventDispatcher\Event;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
@@ -60,7 +61,7 @@ class HookEvent extends Event
      */
     public function getHookParameters()
     {
-        $globalParameters = array('_ps_version' => _PS_VERSION_);
+        $globalParameters = array('_ps_version' => AppKernel::VERSION);
 
         $sfContainer = SymfonyContainer::getInstance();
         if (!is_null($sfContainer) && !is_null($sfContainer->get('request_stack')->getCurrentRequest())) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adds functionality to retrieve the current PS version and to compare a given version to the current PS version. In this PR the PS version is hardcoded in AppKernel (which replaces _PS_VERSION_) - In Symfony the version is hardcoded in Kernel::VERSION. A Version object can be retrieved from the service container.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | If the PR is ok I will provide unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9174)
<!-- Reviewable:end -->
