### PR TITLE
CO: fixes validation of a hook name when it contains forward slashes

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -167,7 +167,7 @@ class ValidateCore
      */
     public static function isHookName($hook)
     {
-        return preg_match('/^[a-zA-Z0-9_-]+$/', $hook);
+        return preg_match('/^[a-z0-9_\-\\\\]+$/i', $hook);
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | When saving an Object Model, the `actionObject_[className]_BeforeSave` hook is triggered. For Object Model classes defined within a namespace, the name is the fully qualified namespace including forwards slashes and breaking the hook name validator regex. The proposed fix allows for forward slashes to be part of hook names.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9178)
<!-- Reviewable:end -->
