### PR TITLE
Use CustomerPreferencesFormHandler to handle specific tabs toggling for B2B mode

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesFormHandler.php
@@ -45,11 +45,13 @@ final class CustomerPreferencesFormHandler extends FormHandler
      */
     public function save(array $data)
     {
-        if (empty($this->dataProvider->setData($data))) {
+        $errors = parent::save($data);
+
+        if (empty($errors)) {
             $this->handleB2bUpdate($data['general']['enable_b2b_mode']);
         }
 
-        return parent::save($data);
+        return $errors;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/form/form_handler.yml
@@ -41,7 +41,7 @@ services:
             - 'AdministrationPage'
 
     prestashop.admin.customer_preferences.form_handler:
-        class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'
+        class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\CustomerPreferences\CustomerPreferencesFormHandler'
         arguments:
             - '@=service("form.factory").createBuilder()'
             - '@prestashop.hook.dispatcher'
@@ -49,6 +49,10 @@ services:
             -
               'general': 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\CustomerPreferences\GeneralType'
             - 'CustomerPreferencesPage'
+        calls:
+            - method: setTabRepository
+              arguments:
+                  - '@prestashop.core.admin.tab.repository'
 
     prestashop.admin.product_preferences.form_handler:
         class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences\ProductPreferencesFormHandler'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x |
| Description?  | The Customer Preferences form allows to switch on and off the B2B Mode. When on, it requires the tab "Outstanding" to show. This requires an extra step that standard class FormHandler cannot do, so I extend it to add this extra processing step using former CustomerPreferencesFormHandler.
| Type?         | bug fix |
| Category?     | BO |
| BC breaks?    | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5700 |
| How to test?  | Do not use B2B mode: "Outstanding" menu link is hidden. Switch it on, the menu link must appears. |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9181)
<!-- Reviewable:end -->
