### PR TITLE
PHP 7.2 Compat - fix fatal error - method signature

### DIFF
--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -148,9 +148,10 @@ class AdminLoginControllerCore extends AdminController
     /**
      * All BO users can access the login page
      *
+     * @param  bool $disable
      * @return bool
      */
-    public function viewAccess()
+    public function viewAccess($disable = false)
     {
         return true;
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | 1.6.1.x
| Description  | fix `Fatal error: Declaration of AdminLoginControllerCore::viewAccess() must be compatible with AdminControllerCore::viewAccess($disable = false)`
| Type         | bug fix 
| Category     | BO
| BC breaks    | no
| Deprecations | no
| Fixed ticket? | 
| How to test  | run a fresh prestashop install, go to admin page. php 7.2.6


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9185)
<!-- Reviewable:end -->
