### PR TITLE
PHP 7.2 Compat - fix `Warning count(): Parameter must be an array or an object that im…

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -548,7 +548,7 @@ class AdminControllerCore extends Controller
      */
     public function initBreadcrumbs($tab_id = null, $tabs = null)
     {
-        if (is_array($tabs) || count($tabs)) {
+        if (is_array($tabs)) {
             $tabs = array();
         }
 


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | 1.6.1.x
| Description  | fix `Warning count(): Parameter must be an array or an object that implements Countable`
| Type         | bug fix 
| Category     | BO
| BC breaks    | no
| Deprecations | no
| Fixed ticket? | 
| How to test  | run a fresh prestashop install, go to admin page. php 7.2.6

This is already fixed in 1.7 branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9186)
<!-- Reviewable:end -->
