### PR TITLE
PHP 7.2 Compat - BO : bug fix : count(): Parameter must be an array or an object that …

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3271,7 +3271,7 @@ class AdminControllerCore extends Controller
             $filter_modules_list = array($filter_modules_list);
         }
 
-        if (!count($filter_modules_list)) {
+        if (is_null($filter_modules_list) || !count($filter_modules_list)) {
             return false;
         } //if there is no modules to display just return false;
 


### PR DESCRIPTION
…implements Countable

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | 1.6.1.x
| Description  | fix `Warning count(): Parameter must be an array or an object that implements Countable`
| Type         | bug fix 
| Category     | BO
| BC breaks    | no
| Deprecations | no
| Fixed ticket? | 
| How to test  | run a fresh prestashop install, go to admin page. php 7.2.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9187)
<!-- Reviewable:end -->
