### PR TITLE
Fix wrong test in left join condition

### DIFF
--- a/classes/ProductAssembler.php
+++ b/classes/ProductAssembler.php
@@ -83,10 +83,10 @@ class ProductAssemblerCore
                     ON pl.id_product = p.id_product
                     AND pl.id_shop = $idShop
                     AND pl.id_lang = $idLang
-                    AND p.id_product = $idProduct
                 LEFT JOIN {$prefix}stock_available sa
 			        ON sa.id_product = p.id_product 
-			        AND sa.id_shop = $idShop";
+			        AND sa.id_shop = $idShop
+			    WHERE p.id_product = $idProduct";
 
         $rows = Db::getInstance()->executeS($sql);
         if ($rows === false) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |1.7.4.x
| Description?  | If a translation is missing, the query will return all the product instead of the one corresponding to the wanted id_product
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create two product without any corresponding entry in product_lang and try to display it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9188)
<!-- Reviewable:end -->
