### PR TITLE
Hide disabled level 3 tabs in the BO

### DIFF
--- a/admin-dev/themes/default/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/default/template/page_header_toolbar.tpl
@@ -152,9 +152,11 @@
             {foreach $level_2.sub_tabs as $level_3}
               {if $level_3.current}
                 {foreach $level_3.sub_tabs as $level_4}
-                  <li>
-                    <a href="{$level_4.href}" id="subtab-{$level_4.class_name}" {if $level_4.current}class="current"{/if} data-submenu="{$level_4.id_tab}">{$level_4.name}</a>
-                  </li>
+                  {if $level_4.active}
+                    <li>
+                      <a href="{$level_4.href}" id="subtab-{$level_4.class_name}" {if $level_4.current}class="current"{/if} data-submenu="{$level_4.id_tab}">{$level_4.name}</a>
+                    </li>
+                  {/if}
                 {/foreach}
               {/if}
             {/foreach}

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -101,9 +101,11 @@
           {foreach $level_2.sub_tabs as $level_3}
             {if $level_3.current}
               {foreach $level_3.sub_tabs as $level_4}
-                <li class="nav-item">
-                  <a href="{$level_4.href}" id="subtab-{$level_4.class_name}" class="nav-link tab {if $level_4.current}active current{/if}" data-submenu="{$level_4.id_tab}">{$level_4.name}</a>
-                </li>
+                {if $level_4.active}
+                  <li class="nav-item">
+                    <a href="{$level_4.href}" id="subtab-{$level_4.class_name}" class="nav-link tab {if $level_4.current}active current{/if}" data-submenu="{$level_4.id_tab}">{$level_4.name}</a>
+                  </li>
+                {/if}
               {/foreach}
             {/if}
           {/foreach}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | As we can hide a link from the side menu, we expected us to be able to hide a lvl 3 entry, in the BO header. Unfortunately, it appeared we could not hide them. This PR fixes the issue.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Disable a tab from the database (for instance one of the module tabs), and check it properly disappears

![capture du 2018-06-15 10-32-44](https://user-images.githubusercontent.com/6768917/41461413-8b751378-7087-11e8-94fc-020e0d77f988.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9189)
<!-- Reviewable:end -->
