### PR TITLE
Fix not visible category display

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -76,16 +76,12 @@ class CategoryControllerCore extends ProductListingFrontController
 
         parent::init();
 
-        //*
         if (!$this->category->checkAccess($this->context->customer->id)) {
             header('HTTP/1.1 403 Forbidden');
             header('Status: 403 Forbidden');
-            //$this->errors[] = $this->trans('You do not have access to this category.', array(), 'Shop.Notifications.Error');
-            //$this->setTemplate('errors/forbidden');
 
             return;
         }
-        //*/
 
         $categoryVar = $this->getTemplateVarCategory();
 

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -76,14 +76,16 @@ class CategoryControllerCore extends ProductListingFrontController
 
         parent::init();
 
+        //*
         if (!$this->category->checkAccess($this->context->customer->id)) {
             header('HTTP/1.1 403 Forbidden');
             header('Status: 403 Forbidden');
-            $this->errors[] = $this->trans('You do not have access to this category.', array(), 'Shop.Notifications.Error');
-            $this->setTemplate('errors/forbidden');
+            //$this->errors[] = $this->trans('You do not have access to this category.', array(), 'Shop.Notifications.Error');
+            //$this->setTemplate('errors/forbidden');
 
             return;
         }
+        //*/
 
         $categoryVar = $this->getTemplateVarCategory();
 
@@ -114,13 +116,31 @@ class CategoryControllerCore extends ProductListingFrontController
     {
         parent::initContent();
 
-        $this->doProductSearch(
-            'catalog/listing/category',
-            array(
-                'entity' => 'category',
-                'id' => $this->category->id
-            )
+        $templateName = 'catalog/listing/category';
+        $templateParams = array(
+            'entity' => 'category',
+            'id' => $this->category->id
         );
+        if ($this->category->checkAccess($this->context->customer->id)) {
+            $this->doProductSearch(
+                $templateName,
+                $templateParams
+            );
+        } else {
+            $this->setTemplate($templateName, $templateParams);
+            $this->context->smarty->assign(['listing' => ['products'=>[]]]);
+            $this->context->smarty->assign('categoryErrorMessage', $this->trans('You do not have access to this category.', array(), 'Shop.Notifications.Error'));
+        }
+    }
+
+    public function getLayout()
+    {
+
+        if (!$this->category->checkAccess($this->context->customer->id)) {
+            return 'layouts/layout-full-width.tpl';
+        }
+
+        return parent::getLayout();
     }
 
     protected function getProductSearchQuery()

--- a/themes/classic/templates/catalog/listing/category.tpl
+++ b/themes/classic/templates/catalog/listing/category.tpl
@@ -25,18 +25,22 @@
 {extends file='catalog/listing/product-list.tpl'}
 
 {block name='product_list_header'}
-    <div class="block-category card card-block hidden-sm-down">
-      <h1 class="h1">{$category.name}</h1>
-      {if $category.description}
-        <div id="category-description" class="text-muted">{$category.description nofilter}</div>
-      {/if}
-      {if $category.image.large.url}
-        <div class="category-cover">
-          <img src="{$category.image.large.url}" alt="{$category.image.legend}">
+    {if isset($category) }
+        <div class="block-category card card-block hidden-sm-down">
+          <h1 class="h1">{$category.name}</h1>
+          {if $category.description}
+            <div id="category-description" class="text-muted">{$category.description nofilter}</div>
+          {/if}
+          {if $category.image.large.url}
+            <div class="category-cover">
+              <img src="{$category.image.large.url}" alt="{$category.image.legend}">
+            </div>
+          {/if}
         </div>
-      {/if}
-    </div>
-    <div class="text-sm-center hidden-md-up">
-      <h1 class="h1">{$category.name}</h1>
-    </div>
+        <div class="text-sm-center hidden-md-up">
+          <h1 class="h1">{$category.name}</h1>
+        </div>
+    {else}
+        <p class="alert alert-danger js-address-error">{$categoryErrorMessage}</p>
+    {/if}
 {/block}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | fix exception thrown when visiting a not visible category page, fix error message position
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5678 http://forge.prestashop.com/browse/BOOM-3633 (only message position)
| How to test?  | restrict category access to authenticated users only, visit the page with a not-authenticated account
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9191)
<!-- Reviewable:end -->
