### PR TITLE
Handle 1.7 method in update function 'add_new_tab'

### DIFF
--- a/install-dev/upgrade/php/add_new_tab.php
+++ b/install-dev/upgrade/php/add_new_tab.php
@@ -24,6 +24,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+use PrestaShopBundle\Security\Voter\PageVoter;
+
 function add_new_tab($className, $name, $id_parent, $returnId = false, $parentTab = null, $module = '')
 {
     if (!is_null($parentTab) && !empty($parentTab) && strtolower(trim($parentTab)) !== 'null') {
@@ -71,16 +73,16 @@ function add_new_tab($className, $name, $id_parent, $returnId = false, $parentTa
             ');
         }
 
-        foreach (array('CREATE', 'READ', 'UPDATE', 'DELETE') as $role) {
+        foreach (array(PageVoter::CREATE, PageVoter::READ, PageVoter::UPDATE, PageVoter::DELETE) as $role) {
             // 1- Add role
-            $roleToAdd = 'ROLE_MOD_TAB_'.strtoupper($className).'_'.$role;
+            $roleToAdd = strtoupper('ROLE_MOD_TAB_'.$className.'_'.$role);
             Db::getInstance()->execute('INSERT IGNORE INTO `'._DB_PREFIX_.'authorization_role` (`slug`)
 		VALUES ("'.$roleToAdd.'")');
             $newID = Db::getInstance()->Insert_ID();
 
             // 2- Copy access from the parent
             if (!empty($parentClassName) && !empty($newID)) {
-                $parentRole = 'ROLE_MOD_TAB_'.strtoupper(pSQL($parentClassName)).'_'.$role;
+                $parentRole = strtoupper('ROLE_MOD_TAB_'.pSQL($parentClassName).'_'.$role);
                 Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'access` (`id_profile`, `id_authorization_role`) 
                     SELECT a.`id_profile`, '. (int)$newID .' as `id_authorization_role`
                     FROM `'._DB_PREFIX_.'access` a join `'._DB_PREFIX_.'authorization_role` ar on a.`id_authorization_role` = ar.`id_authorization_role`

--- a/install-dev/upgrade/php/ps_1740_update_module_tabs.php
+++ b/install-dev/upgrade/php/ps_1740_update_module_tabs.php
@@ -38,7 +38,7 @@ function ps_1740_update_module_tabs()
 
     include_once('add_new_tab.php');
     foreach ($moduleTabsToBeAdded as $className => $translations) {
-        add_new_tab($className, $translations, 0, false, 'AdminModulesSf');
+        add_new_tab_17($className, $translations, 0, false, 'AdminModulesSf');
     }
 
     Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.'tab` SET `active`=1 WHERE `class_name` IN ("AdminModulesManage", "AdminModulesCatalog", "AdminModulesNotifications")');

--- a/install-dev/upgrade/php/ps_1740_update_module_tabs.php
+++ b/install-dev/upgrade/php/ps_1740_update_module_tabs.php
@@ -40,4 +40,7 @@ function ps_1740_update_module_tabs()
     foreach ($moduleTabsToBeAdded as $className => $translations) {
         add_new_tab($className, $translations, 0, false, 'AdminModulesSf');
     }
+
+    Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.'tab` SET `active`=1 WHERE `class_name` IN ("AdminModulesManage", "AdminModulesCatalog", "AdminModulesNotifications")');
+
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | While running a specific upgrade script, it appeared the access system was not adapted for 1.7 versions. The upgrade method has been updated to prevent merchants to loose access to the module pages with the new tabs.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | From PrestaShop 1.7.3.3, start an upgrade to 1.7.4.0 or launch the following code on a database from version older than 1.7.4.0.

You can use the following code, for instance in `index.php` after `require(dirname(__FILE__).'/config/config.inc.php');`
```php
require_once(__DIR__.'/install-dev/upgrade/php/ps_1740_update_module_tabs.php');
ps_1740_update_module_tabs();
die('ok');
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9194)
<!-- Reviewable:end -->
