### PR TITLE
Fixed mixed up display in some cases at partial refunds

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
@@ -161,7 +161,7 @@
 		0/{$productQuantity}
 	{/if}
 	</td>
-	<td class="partial_refund_fields current-edit" colspan="2" style="display:none; width: 250px;">
+	<td class="partial_refund_fields current-edit" colspan="2" style="display:none; width: 250px; min-width: 250px;">
 		{if $product['quantity_refundable'] > 0}
 		{if ($order->getTaxCalculationMethod() == $smarty.const.PS_TAX_EXC)}
 			{assign var='amount_refundable' value=$product['amount_refundable']}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes a bug in display at the orders-view when creating a partial refund
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9195)
<!-- Reviewable:end -->
