### PR TITLE
Fix duplicate wording

### DIFF
--- a/app/Resources/translations/default/AdminNotificationsError.xlf
+++ b/app/Resources/translations/default/AdminNotificationsError.xlf
@@ -1320,16 +1320,6 @@ File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/Memcach
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5a6013a735465600cb2b695361009999">
-        <source>You do not have permission to edit this</source>
-        <target>You do not have permission to edit this</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php:100</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="5d1994bf28899a87795983875a98c2e1">

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
@@ -97,7 +97,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
                 PageVoter::LEVEL_DELETE,
             ]
         )) {
-            $this->addFlash('error', $this->trans('You do not have permission to edit this', 'Admin.Notifications.Error'));
+            $this->addFlash('error', $this->trans('You do not have permission to edit this.', 'Admin.Notifications.Error'));
 
             return $this->redirectToRoute('admin_product_preferences');
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Fixed use of duplicate wording (missing `.` at the end of the string)
| Type?         | bug fix
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9197)
<!-- Reviewable:end -->
