### PR TITLE
Preserve position in category when adding a new Product using Web services

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5651,10 +5651,10 @@ class ProductCore extends ObjectModel
         $positions_lookup = array();
         $max_position_lookup = array();
 
-        foreach($positions as $row) {
+        foreach ($positions as $row) {
             $positions_lookup[(int)$row['id_category']] = (int)$row['position'];
         }
-        foreach($max_positions as $row) {
+        foreach ($max_positions as $row) {
             $max_position_lookup[(int)$row['id_category']] = (int)$row['maximum'];
         }
 
@@ -5663,9 +5663,9 @@ class ProductCore extends ObjectModel
             $sql_values = array();
             foreach ($ids as $id) {
                 $pos = 0;
-                if(array_key_exists((int)$id, $positions_lookup)) {
+                if (array_key_exists((int)$id, $positions_lookup)) {
                     $pos = (int)$positions_lookup[(int) $id] + 1;
-                } elseif(array_key_exists((int)$id, $max_position_lookup)) {
+                } elseif (array_key_exists((int)$id, $max_position_lookup)) {
                     $pos = (int)$max_position_lookup[(int) $id] + 1;
                 }
 				


### PR DESCRIPTION
concerning bug
http://forge.prestashop.com/browse/PSCSX-4218

keeps the previous position of a product in a category or adds it to the end of category if a new category was assigned

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | if a product is saved via webservice, its position in a category was lost. This improvement preserved the position. If a new category was added, the product will be added to the end of the cateogry
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-4218
| How to test?  | 1. add a product to a shop via webservice. 2. Change position of product in category 3. add/update the product again via webservice and look at the positions in a category

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9202)
<!-- Reviewable:end -->
