### PR TITLE
Replace array_push calls behaving as $array[] since it works faster than invoking functions in PHP

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -405,7 +405,7 @@ class ConfigurationTestCore
         foreach (ConfigurationTest::$test_files as $file) {
             if (!file_exists(rtrim(_PS_ROOT_DIR_, DIRECTORY_SEPARATOR).str_replace('/', DIRECTORY_SEPARATOR, $file))) {
                 if ($full) {
-                    array_push($return, $file);
+                    $return[] = $file;
                 } else {
                     return false;
                 }

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -815,7 +815,7 @@ class MediaCore
                                 if ($version != _PS_JQUERY_VERSION_) {
                                     Context::getContext()->controller->addJquery($version, null, $minifier);
                                 }
-                                array_push(Media::$inline_script_src, $src);
+                                Media::$inline_script_src[] = $src;
                             }
                         }
                     }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3749,7 +3749,7 @@ class AdminImportControllerCore extends AdminController
         if (isset($store->hours) && is_array($store->hours)) {
             $newHours = array();
             foreach ($store->hours as $hour) {
-                array_push($newHours, array($hour));
+                $newHours[] = array($hour);
             }
             $store->hours = json_encode($newHours);
         }

--- a/controllers/admin/AdminModulesPositionsController.php
+++ b/controllers/admin/AdminModulesPositionsController.php
@@ -525,7 +525,7 @@ class AdminModulesPositionsControllerCore extends AdminController
                         $hookableList[$hook_name] = array();
                     }
                     if ($moduleInstance->isHookableOn($hook_name)) {
-                        array_push($hookableList[$hook_name], str_replace('_', '-', $module));
+                        $hookableList[$hook_name][] = str_replace('_', '-', $module);
                     }
                 }
             }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2842,7 +2842,7 @@ class AdminTranslationsControllerCore extends AdminController
                     $stack = array();
                     $folder = dirname($file['to']);
                     while (!is_dir($folder)) {
-                        array_push($stack, $folder);
+                        $stack[] = $folder;
                         $folder = dirname($folder);
                     }
                     while ($folder = array_pop($stack)) {

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -370,34 +370,25 @@ class CartControllerCore extends FrontController
         }
 
         if ($this->qty == 0) {
-            array_push(
-                $this->{$ErrorKey},
-                $this->trans(
-                    'Null quantity.',
-                    array(),
-                    'Shop.Notifications.Error'
-                )
+            $this->{$ErrorKey}[] = $this->trans(
+                'Null quantity.',
+                array(),
+                'Shop.Notifications.Error'
             );
         } elseif (!$this->id_product) {
-            array_push(
-                $this->{$ErrorKey},
-                $this->trans(
-                    'Product not found',
-                    array(),
-                    'Shop.Notifications.Error'
-                )
+            $this->{$ErrorKey}[] = $this->trans(
+                'Product not found',
+                array(),
+                'Shop.Notifications.Error'
             );
         }
 
         $product = new Product($this->id_product, true, $this->context->language->id);
         if (!$product->id || !$product->active || !$product->checkAccess($this->context->cart->id_customer)) {
-            array_push(
-                $this->{$ErrorKey},
-                $this->trans(
-                    'This product (%product%) is no longer available.',
-                    array('%product%' => $product->name),
-                    'Shop.Notifications.Error'
-                )
+            $this->{$ErrorKey}[] = $this->trans(
+                'This product (%product%) is no longer available.',
+                array('%product%' => $product->name),
+                'Shop.Notifications.Error'
             );
             return;
         }
@@ -434,13 +425,10 @@ class CartControllerCore extends FrontController
 
         // Check product quantity availability
         if ('update' !== $mode && $this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
-            array_push(
-                $this->{$ErrorKey},
-                $this->trans(
-                    'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
-                    array('%product%' => $product->name),
-                    'Shop.Notifications.Error'
-                )
+            $this->{$ErrorKey}[] = $this->trans(
+                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
+                array('%product%' => $product->name),
+                'Shop.Notifications.Error'
             );
         }
 
@@ -461,13 +449,10 @@ class CartControllerCore extends FrontController
             // Check customizable fields
 
             if (!$product->hasAllRequiredCustomizableFields() && !$this->customization_id) {
-                array_push(
-                    $this->{$ErrorKey},
-                    $this->trans(
-                        'Please fill in all of the required fields, and then save your customizations.',
-                        array(),
-                        'Shop.Notifications.Error'
-                    )
+                $this->{$ErrorKey}[] = $this->trans(
+                    'Please fill in all of the required fields, and then save your customizations.',
+                    array(),
+                    'Shop.Notifications.Error'
                 );
             }
 
@@ -499,32 +484,23 @@ class CartControllerCore extends FrontController
                     $minimal_quantity = ($this->id_product_attribute)
                         ? Attribute::getAttributeMinimalQty($this->id_product_attribute)
                         : $product->minimal_quantity;
-                    array_push(
-                        $this->{$ErrorKey},
-                        $this->trans(
-                            'You must add %quantity% minimum quantity',
-                            array('%quantity%' => $minimal_quantity),
-                            'Shop.Notifications.Error'
-                        )
+                    $this->{$ErrorKey}[] = $this->trans(
+                        'You must add %quantity% minimum quantity',
+                        array('%quantity%' => $minimal_quantity),
+                        'Shop.Notifications.Error'
                     );
                 } elseif (!$update_quantity) {
-                    array_push(
-                        $this->errors,
-                        $this->trans(
-                            'You already have the maximum quantity available for this product.',
-                            array(),
-                            'Shop.Notifications.Error'
-                        )
+                    $this->errors[] = $this->trans(
+                        'You already have the maximum quantity available for this product.',
+                        array(),
+                        'Shop.Notifications.Error'
                     );
                 } elseif ($this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
                     // check quantity after cart quantity update
-                    array_push(
-                        $this->{$ErrorKey},
-                        $this->trans(
-                            'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
-                            array('%product%' => $product->name),
-                            'Shop.Notifications.Error'
-                        )
+                    $this->{$ErrorKey}[] = $this->trans(
+                        'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
+                        array('%product%' => $product->name),
+                        'Shop.Notifications.Error'
                     );
                 }
 

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -196,7 +196,7 @@ class TranslationService
                 if (empty($data['xliff']) && empty($data['database'])) {
                     array_unshift($domains['data'], $data);
                 } else {
-                    array_push($domains['data'], $data);
+                    $domains['data'][] = $data;
                 }
             }
         }

--- a/tools/htmlpurifier/HTMLPurifier.standalone.php
+++ b/tools/htmlpurifier/HTMLPurifier.standalone.php
@@ -8119,7 +8119,7 @@ class HTMLPurifier_Queue {
      * Pushes an element onto the front of the queue.
      */
     public function push($x) {
-        array_push($this->input, $x);
+        $this->input[] = $x;
     }
 
     /**
@@ -9940,7 +9940,7 @@ class HTMLPurifier_Zipper
      * @return Original contents of new hole.
      */
     public function next($t) {
-        if ($t !== null) array_push($this->front, $t);
+        if ($t !== null) $this->front[] = $t;
         return empty($this->back) ? null : array_pop($this->back);
     }
 
@@ -9963,7 +9963,7 @@ class HTMLPurifier_Zipper
      * @return Original contents of new hole.
      */
     public function prev($t) {
-        if ($t !== null) array_push($this->back, $t);
+        if ($t !== null) $this->back[] = $t;
         return empty($this->front) ? null : array_pop($this->front);
     }
 
@@ -9989,7 +9989,7 @@ class HTMLPurifier_Zipper
      * @param Element to insert
      */
     public function insertBefore($t) {
-        if ($t !== null) array_push($this->front, $t);
+        if ($t !== null) $this->front[] = $t;
     }
 
     /**
@@ -9997,7 +9997,7 @@ class HTMLPurifier_Zipper
      * @param Element to insert
      */
     public function insertAfter($t) {
-        if ($t !== null) array_push($this->back, $t);
+        if ($t !== null) $this->back[] = $t;
     }
 
     /**
@@ -13178,7 +13178,7 @@ class HTMLPurifier_AttrDef_URI_IPv6 extends HTMLPurifier_AttrDef_URI_IPv4
             }
 
             while (count($first) < 8) {
-                array_push($first, '0');
+                $first[] = '0';
             }
 
             array_splice($first, 8 - count($second), 8, $second);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | http://php.net/manual/en/function.array-push.php > Note: If you use array_push() to add one element to the array, it's better to use $array[] = because in that way there is no overhead of calling a function. 
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Run the store

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9207)
<!-- Reviewable:end -->
