### PR TITLE
Updated page parameter name in Link and Meta classes

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1082,7 +1082,7 @@ class LinkCore
 
         $vars = array();
         $varsNb = array('n');
-        $varsSort = array('orderby', 'orderway');
+        $varsSort = array('order');
         $varsPagination = array('page');
 
         foreach ($_GET as $k => $value) {

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1083,7 +1083,7 @@ class LinkCore
         $vars = array();
         $varsNb = array('n');
         $varsSort = array('orderby', 'orderway');
-        $varsPagination = array('p');
+        $varsPagination = array('page');
 
         foreach ($_GET as $k => $value) {
             if ($k != 'id_'.$type && $k != 'controller') {

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -373,7 +373,7 @@ class MetaCore extends ObjectModel
         if (!empty($title)) {
             $title = ' - '.$title;
         }
-        $pageNumber = (int)Tools::getValue('p');
+        $pageNumber = (int)Tools::getValue('page');
         $category = new Category($idCategory, $idLang);
 
         $cacheId = 'Meta::getCategoryMetas'.(int) $idCategory.'-'.(int) $idLang;
@@ -421,7 +421,7 @@ class MetaCore extends ObjectModel
      */
     public static function getManufacturerMetas($idManufacturer, $idLang, $pageName)
     {
-        $pageNumber = (int)Tools::getValue('p');
+        $pageNumber = (int)Tools::getValue('page');
         $manufacturer = new Manufacturer($idManufacturer, $idLang);
         if (Validate::isLoadedObject($manufacturer)) {
             $row = Meta::getPresentedObject($manufacturer);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | in 1.7 URL parameter for page name was updated from 'p' to 'page'. Methods affected in this commit were using outdated 'p' name, so they didn't work as expected. 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | --
| How to test?  | Meta:php -> try to open "your_category_url?p=2" and "your_category_url?page=2". And check for page name in parentheses in meta title <br><br> Link.php -> Try $context->link->getPaginationLink(false, false, false, false, 1) if current URL is this one: "your_category_url?p=2", and then this: "your_category_url?page=2" (and try to do the same in PS 1.6)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9211)
<!-- Reviewable:end -->
