### PR TITLE
Fix products pagination without URL rewriting

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1746,8 +1746,6 @@ class FrontControllerCore extends Controller
             }
         }
 
-        ksort($params);
-
         if (null !== $extraParams) {
             foreach ($params as $key => $param) {
                 if (null === $param || '' === $param) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On the front-office of a shop without URL rewriting, switching to another page of the same category does not work because of canonical URL issues.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4847
| How to test?  | Using the pagination without URL rewriting must work .

![capture du 2018-06-25 15-19-29](https://user-images.githubusercontent.com/6768917/41852582-de7a2c5a-788b-11e8-8cdd-d4990b8e3bff.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9214)
<!-- Reviewable:end -->
