### PR TITLE
Adapted module URLs for new routing

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -176,7 +176,7 @@ var AdminModuleController = function() {
 
   this.ajaxLoadPage = function() {
     var token = window.location.search;
-    var urlToCall = this.baseAdminDir+'module/catalog/refresh' + token;
+    var urlToCall = this.baseAdminDir+'improve/modules/catalog/refresh' + token;
     var self = this;
 
     $.ajax({
@@ -668,7 +668,7 @@ var AdminModuleController = function() {
         return;
     }
     var token = window.location.search;
-    var urlToCall = this.baseAdminDir+'module/notifications/count' + token;
+    var urlToCall = this.baseAdminDir+'improve/modules/notifications/count' + token;
 
     $.getJSON(urlToCall, function(badge) {
         // TODO: This HTML code comes from an already specific template.

--- a/admin-dev/themes/default/js/bundle/module/module.js
+++ b/admin-dev/themes/default/js/bundle/module/module.js
@@ -19,7 +19,6 @@ var AdminModuleController = function() {
   this.pstaggerInput = null;
   this.lastBulkAction = null;
   this.isUploadStarted = false;
-  this.baseAdminDir = '';
 
   /**
    * Loaded modules list.
@@ -175,13 +174,11 @@ var AdminModuleController = function() {
   };
 
   this.ajaxLoadPage = function() {
-    var token = window.location.search;
-    var urlToCall = this.baseAdminDir+'improve/modules/catalog/refresh' + token;
     var self = this;
 
     $.ajax({
       method: 'GET',
-      url: urlToCall
+      url: moduleURLs.catalogRefresh
     }).done(function (response) {
       if (response.status === true) {
         if (typeof response.domElements === 'undefined') response.domElements = null;
@@ -512,7 +509,7 @@ var AdminModuleController = function() {
 
     // @see: dropzone.js
     var dropzoneOptions = {
-      url: 'import' + window.location.search,
+      url: moduleURLs.moduleImport,
       acceptedFiles: '.zip, .tar',
       // The name that will be used to transfer the file
       paramName: 'file_uploaded',
@@ -567,7 +564,7 @@ var AdminModuleController = function() {
         self.animateEndUpload(function() {
             if (result.status === true) {
               if (result.is_configurable === true) {
-                var configureLink = self.baseAdminDir + 'module/manage/action/configure/' + result.module_name + window.location.search;
+                var configureLink = moduleURLs.configurationPage.replace('1', result.module_name);
                 $(self.moduleImportSuccessConfigureBtnSelector).attr('href', configureLink);
                 $(self.moduleImportSuccessConfigureBtnSelector).show();
               }
@@ -643,13 +640,6 @@ var AdminModuleController = function() {
 
   this.loadVariables = function () {
     this.initCurrentDisplay();
-
-    // If index.php found in the current URL, we need it also in the baseAdminDir
-    //noinspection JSUnresolvedVariable
-    this.baseAdminDir = baseAdminDir;
-    if (window.location.href.indexOf('index.php') != -1) {
-      this.baseAdminDir += 'index.php/';
-    }
   };
 
   this.getModuleItemSelector = function () {
@@ -668,7 +658,7 @@ var AdminModuleController = function() {
         return;
     }
     var token = window.location.search;
-    var urlToCall = this.baseAdminDir+'improve/modules/notifications/count' + token;
+    var urlToCall = moduleURLs.notificationsCount;
 
     $.getJSON(urlToCall, function(badge) {
         // TODO: This HTML code comes from an already specific template.
@@ -759,9 +749,6 @@ var AdminModuleController = function() {
       'bulk-reset': 'reset'
     };
 
-    // char is used only to be easy to replace by the end of this function
-    var baseActionUrl = this.baseAdminDir + 'module/manage/action/@/';
-
     // Note no grid selector used yet since we do not needed it at dev time
     // Maybe useful to implement this kind of things later if intended to
     // use this functionality elsewhere but "manage my module" section
@@ -788,7 +775,6 @@ var AdminModuleController = function() {
         var moduleTechName = data.techName;
 
         var urlActionSegment = bulkActionToUrl[requestedBulkAction];
-        baseActionUrl.replace('@', urlActionSegment);
 
         if (typeof module_card_controller !== 'undefined') {
           // We use jQuery to get the specific link for this action. If found, we send it.

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/catalog.html.twig
@@ -22,14 +22,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% extends '@PrestaShop/Admin/Module/common.html.twig' %}
 
 {% block javascripts %}
     {{ parent() }}
-    <script src="{{ asset('themes/default/js/bundle/plugins/jquery.pstagger.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/module/loader.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/module/module_card.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/module/module.js') }}"></script>
     {% if app.request.get('filterCategoryTab') %}
       <script>
         $('body').on('moduleCatalogLoaded', function() {

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -28,10 +28,10 @@
     {{ parent() }}
     <script>
         var moduleURLs = {
-            'catalogRefresh': '{{ url('admin_module_catalog_refresh')|e('js') }}',
-            'configurationPage': '{{ url('admin_module_configure_action', {'module_name': '1'})|e('js') }}',
-            'moduleImport': '{{ url('admin_module_import')|e('js') }}',
-            'notificationsCount': '{{ url('admin_module_notification_count')|e('js') }}',
+            'catalogRefresh': '{{ path('admin_module_catalog_refresh')|e('js') }}',
+            'configurationPage': '{{ path('admin_module_configure_action', {'module_name': '1'})|e('js') }}',
+            'moduleImport': '{{ path('admin_module_import')|e('js') }}',
+            'notificationsCount': '{{ path('admin_module_notification_count')|e('js') }}',
         };
     </script>
     <script src="{{ asset('themes/default/js/bundle/plugins/jquery.pstagger.js') }}"></script>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -1,0 +1,41 @@
+{#**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script>
+        var moduleURLs = {
+            'catalogRefresh': '{{ url('admin_module_catalog_refresh')|e('js') }}',
+            'configurationPage': '{{ url('admin_module_configure_action', {'module_name': '1'})|e('js') }}',
+            'moduleImport': '{{ url('admin_module_import')|e('js') }}',
+            'notificationsCount': '{{ url('admin_module_notification_count')|e('js') }}',
+        };
+    </script>
+    <script src="{{ asset('themes/default/js/bundle/plugins/jquery.pstagger.js') }}"></script>
+    <script src="{{ asset('themes/default/js/bundle/module/loader.js') }}"></script>
+    <script src="{{ asset('themes/default/js/bundle/module/module_card.js') }}"></script>
+    <script src="{{ asset('themes/default/js/bundle/module/module.js') }}"></script>    
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -22,15 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
-
-{% block javascripts %}
-    {{ parent() }}
-    <script src="{{ asset('themes/default/js/bundle/plugins/jquery.pstagger.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/module/loader.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/module/module_card.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/module/module.js') }}"></script>
-{% endblock %}
+{% extends '@PrestaShop/Admin/Module/common.html.twig' %}
 
 {% block content %}
     <div class="row justify-content-center">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/notifications.html.twig
@@ -22,15 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
-
-{% block javascripts %}
-    {{ parent() }}
-    <script src="{{ asset('themes/default/js/bundle/plugins/jquery.pstagger.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/module/loader.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/module/module_card.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/module/module.js') }}"></script>
-{% endblock %}
+{% extends '@PrestaShop/Admin/Module/common.html.twig' %}
 
 {% block content %}
     {# Addons connect modal #}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | @marionf reported the module page wasn't working anymore after the new routing. The PRs updates the URLs remaining on the old address.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Reach the module page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9215)
<!-- Reviewable:end -->
