### PR TITLE
add casting operation because of scalar / array casting error

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3945,7 +3945,7 @@ exit;
                 $adjustment_factor += $sign * 1 / $unit;
             }
 
-            $row[$column] += $adjustment_factor;
+            $row[$column] = (float)$row[$column] + $adjustment_factor;
 
             ++$position;
         }


### PR DESCRIPTION
We got an error with current PS Version 1.7.3.3:
"Cannot use a scalar value as an array" in line 3948 of the Tools.php
the values were

array('amount' => '2.2204460492503E-16', 
	'precision' => '2', 
	'rows' => array('0.95'), 
	'column' => 'id_tax', 
	'sort_function' => 'lambda_1', 
	'unit' => '100', 
	'int_amount' => '0', 
	'remainder' => '0', 
	'amount_to_spread' => '0', 
	'sign' => '1', 
	'position' => '0', 
	'row' => '0.95', 
	'adjustment_factor' => '0')

with this float cast, the error was gone.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Trying to place an order with bankwire module, an error "Cannot use a scalar value as an array." occured pointing to this line in the Tools.php class. Customers couldn't finish the order.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no tickets found only similar entry: https://www.prestashop.com/forums/topic/635593-contexterrorexception%C2%A0in%C2%A0toolsphp-line-3780/
| How to test?  | Place an order with above values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9217)
<!-- Reviewable:end -->
