### PR TITLE
Fix delivery time not shown

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -103,7 +103,7 @@
         {if $product.quantity > 0}
           <span class="delivery-information">{$product.delivery_in_stock}</span>
         {* Out of stock message should not be displayed if customer can't order the product. *}
-        {elseif $product.quantity == 0 && $product.add_to_cart_url}
+        {elseif $product.quantity <= 0 && $product.add_to_cart_url}
           <span class="delivery-information">{$product.delivery_out_stock}</span>
         {/if}
       {/if}


### PR DESCRIPTION
To solve http://forge.prestashop.com/browse/BOOM-5829

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If we have a product backordered, stock -1 or less the text with the transport delivery time does not show.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5829
| How to test?  | see that a product with stock -1 does not appear the delivery time

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9219)
<!-- Reviewable:end -->
