### PR TITLE
Ability to use widget block from specific hook

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -124,7 +124,7 @@ function smartyWidgetBlock($params, $content, &$smarty)
         withWidget($params, function ($widget, $params) use (&$smarty, &$backedUpVariablesStack) {
             // Assign widget variables and backup all the variables they override
             $currentVariables = $smarty->getTemplateVars();
-            $scopedVariables = $widget->getWidgetVariables(null, $params);
+            $scopedVariables = $widget->getWidgetVariables(isset($params['hook']) ? $params['hook'] : null, $params);
             $backedUpVariables = array();
             foreach ($scopedVariables as $key => $value) {
                 if (array_key_exists($key, $currentVariables)) {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | see below the table
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | probably
| How to test?  | see code below
| Sponsor company  | impSolutions
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

try to use this code, before and after, assuming that you have some links in linklist and displayTop
```
{widget_block name='ps_linklist' hook='displayTop'}
{$linkBlocks|@print_r}
{/widget_block}
```

I really hope that you can push it to 1.7.4, this is killer feature for widgets...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9220)
<!-- Reviewable:end -->
