### PR TITLE
We should be able to activate SSL

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -48,11 +48,8 @@ class PreferencesType extends TranslatorAwareType
         $configuration = $this->getConfiguration();
         $isSslEnabled = $configuration->getBoolean('PS_SSL_ENABLED');
 
-        if ($isSslEnabled) {
-            $builder->add('enable_ssl', SwitchType::class);
-        }
-
         $builder
+            ->add('enable_ssl', SwitchType::class)
             ->add('enable_ssl_everywhere', SwitchType::class, array(
                 'disabled' => !$isSslEnabled,
             ))

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
@@ -43,7 +43,7 @@
                             <div class="card-text">
                                 <div class="form-group">
                                     {{ ps.label_with_help(('Enable SSL'|trans), ('If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-                                    {% if isSslEnabled %}
+                                    {% if app.request.isSecure() %}
                                         {{ form_errors(generalForm.enable_ssl) }}
                                         {{ form_widget(generalForm.enable_ssl) }}
                                         <small class="form-text">{{ 'If you own an SSL certificate for your shop\'s domain name, you can activate SSL encryption (https://) for customer account identification and order processing.'|trans({}, 'Admin.Shopparameters.Help') }}</small>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | If SSL is not enabled, the switch option to enable it is not rendered, annoying :)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5833
| How to test?  | Play with SSL options in Configure > Shop Parameters > General page of BO

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9221)
<!-- Reviewable:end -->
