### PR TITLE
SSL field is only available is accessed using HTTPS protocol

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -41,6 +41,11 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 class PreferencesType extends TranslatorAwareType
 {
     /**
+     * @var bool
+     */
+    private $isSecure;
+
+    /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -48,8 +53,11 @@ class PreferencesType extends TranslatorAwareType
         $configuration = $this->getConfiguration();
         $isSslEnabled = $configuration->getBoolean('PS_SSL_ENABLED');
 
+        if ($this->isSecure) {
+            $builder->add('enable_ssl', SwitchType::class);
+        }
+
         $builder
-            ->add('enable_ssl', SwitchType::class)
             ->add('enable_ssl_everywhere', SwitchType::class, array(
                 'disabled' => !$isSslEnabled,
             ))
@@ -118,6 +126,15 @@ class PreferencesType extends TranslatorAwareType
                 'choice_translation_domain' => 'Install',
             ))
         ;
+    }
+
+    /**
+     * Enabled only if the form is accessed using HTTPS protocol.
+     * @var bool
+     */
+    public function setIsSecure($isSecure)
+    {
+        $this->isSecure = $isSecure;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/form/form_type.yml
@@ -279,6 +279,8 @@ services:
         class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\General\PreferencesType'
         parent: 'form.type.translatable.aware'
         public: true
+        calls:
+            - ['setIsSecure', ["@=service('request_stack').getCurrentRequest().isSecure()"]]
         tags:
             - { name: form.type }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | The SSL field was rendered even when we don't want to.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | ping @PierreRambaud :-)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9223)
<!-- Reviewable:end -->
