### PR TITLE
Fixed access to Front Office container from modules

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3185,7 +3185,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function isSymfonyContext()
     {
-        return !defined('ADMIN_LEGACY_CONTEXT') && defined('_PS_ADMIN_DIR_');
+        return !$this->isAdminLegacyContext() && defined('_PS_ADMIN_DIR_');
     }
 
     /**

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3185,7 +3185,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function isSymfonyContext()
     {
-        return !defined('ADMIN_LEGACY_CONTEXT') && $this->context->controller instanceof AdminLegacyLayoutControllerCore;
+        return !defined('ADMIN_LEGACY_CONTEXT') && defined('_PS_ADMIN_DIR_');
     }
 
     /**


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Accessing to Symfony services from modules hooks can be broken.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Please see below


- use must test whith module provided on https://github.com/PrestaShop/PrestaShop/pull/8922 by Mickael
and adding some case where there is no controller like :
```
 public function hookActionProductUpdate($params)
{
  [...]
  $request = $this->get('request');
  [...]
}
```

- please see discussion on https://github.com/PrestaShop/PrestaShop/pull/8922
- note , that as indicades on the php comments " To be removed - because useless - when the migration will be done. "
- extra note : sorry use case are so various that i does not know how to test alls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9226)
<!-- Reviewable:end -->
