### PR TITLE
Add alt tag for images categories

### DIFF
--- a/themes/classic/templates/catalog/listing/category.tpl
+++ b/themes/classic/templates/catalog/listing/category.tpl
@@ -32,7 +32,7 @@
       {/if}
       {if $category.image.large.url}
         <div class="category-cover">
-          <img src="{$category.image.large.url}" alt="{$category.name}">
+          <img src="{$category.image.large.url}" alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}">
         </div>
       {/if}
     </div>

--- a/themes/classic/templates/catalog/listing/category.tpl
+++ b/themes/classic/templates/catalog/listing/category.tpl
@@ -32,7 +32,7 @@
       {/if}
       {if $category.image.large.url}
         <div class="category-cover">
-          <img src="{$category.image.large.url}" alt="{$category.image.legend}">
+          <img src="{$category.image.large.url}" alt="{$category.name}">
         </div>
       {/if}
     </div>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Add the alt tag for the image categories
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4413
| How to test?  | Look if the images of categories contain a alt tag

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9227)
<!-- Reviewable:end -->
