### PR TITLE
Fixed missing call of ObjectModel hooks in CMSCategory::delete()

### DIFF
--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -251,7 +251,7 @@ class CMSCategoryCore extends ObjectModel
      *
      * @return bool Deletion result
      */
-    public function deleteLite()
+    private function deleteLite()
     {
         return parent::delete();
     }
@@ -264,12 +264,13 @@ class CMSCategoryCore extends ObjectModel
 
         $this->clearCache();
 
-        $objects = $this->getAllChildren();
-        $objects[] = $this;
-        foreach ($objects as $object) {
-            $object->deleteCMS();
-            $object->deleteLite();
-            CMSCategory::cleanPositions($object->id_parent);
+        $cmsCategories = $this->getAllChildren();
+        $cmsCategories[] = $this;
+        foreach ($cmsCategories as $cmsCategory) {
+            /** @var CMSCategory */
+            $cmsCategory->deleteCMS();
+            $cmsCategory->deleteLite();
+            CMSCategory::cleanPositions($cmsCategory->id_parent);
         }
 
         return true;
@@ -280,7 +281,7 @@ class CMSCategoryCore extends ObjectModel
      *
      * @return bool Deletion result
      */
-    public function deleteCMS()
+    private function deleteCMS()
     {
         $result = true;
         $cms = new PrestaShopCollection('CMS');
@@ -444,7 +445,7 @@ class CMSCategoryCore extends ObjectModel
      *
      * @return PrestaShopCollection Collection of CMSCategory
      */
-    public function getAllChildren()
+    private function getAllChildren()
     {
         // Get children
         $toDelete = array((int)$this->id);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In CMSCategory class, the delete method doesn't call to parent ObjectModel delete method so any hook is called.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5847
| How to test?  | Create a module and try to retrieve ID of CMSCategory deleted, you can't because there are any hook for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9231)
<!-- Reviewable:end -->
