### PR TITLE
Fix override handling when PS_DISABLE_OVERRIDES is used

### DIFF
--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -166,7 +166,7 @@ class PrestaShopAutoload
      */
     public function generateIndex()
     {
-        if (defined('_PS_CREATION_DATE_')) {
+        if (class_exists('Configuration') && defined('_PS_CREATION_DATE_')) {
             $creationDate = _PS_CREATION_DATE_;
             if (!empty($creationDate) && Configuration::get('PS_DISABLE_OVERRIDES')) {
                 $this->_include_override_path = false;

--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -166,6 +166,15 @@ class PrestaShopAutoload
      */
     public function generateIndex()
     {
+        if (defined('_PS_CREATION_DATE_')) {
+            $creationDate = _PS_CREATION_DATE_;
+            if (!empty($creationDate) && Configuration::get('PS_DISABLE_OVERRIDES')) {
+                $this->_include_override_path = false;
+            } else {
+                $this->_include_override_path = true;
+            }
+        }
+
         $coreClasses = $this->getClassesFromDir('classes/');
 
         $classes = array_merge(

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2669,12 +2669,6 @@ FileETag none
 
     public static function generateIndex()
     {
-        if (defined('_PS_CREATION_DATE_')) {
-            $creationDate = _PS_CREATION_DATE_;
-            if (!empty($creationDate) && Configuration::get('PS_DISABLE_OVERRIDES')) {
-                PrestaShopAutoload::getInstance()->_include_override_path = false;
-            }
-        }
         PrestaShopAutoload::getInstance()->generateIndex();
     }
 

--- a/robots.txt
+++ b/robots.txt
@@ -12,6 +12,9 @@ Allow: */modules/*.css
 Allow: */modules/*.js
 Allow: */modules/*.png
 Allow: */modules/*.jpg
+Allow: */themes/*/assets/cache/*.js
+Allow: */themes/*/assets/cache/*.css
+Allow: */themes/*/assets/css/*
 # Private pages
 Disallow: /*?order=
 Disallow: /*?tag=
@@ -75,19 +78,3 @@ Disallow: */upload/
 Disallow: */vendor/
 Disallow: */web/
 Disallow: */webservice/
-# Files
-Disallow: /password-recovery
-Disallow: /address
-Disallow: /addresses
-Disallow: /login
-Disallow: /cart
-Disallow: /discount
-Disallow: /order-history
-Disallow: /identity
-Disallow: /my-account
-Disallow: /order-follow
-Disallow: /credit-slip
-Disallow: /order
-Disallow: /search
-Disallow: /guest-tracking
-Disallow: /order-confirmation

--- a/robots.txt
+++ b/robots.txt
@@ -12,9 +12,6 @@ Allow: */modules/*.css
 Allow: */modules/*.js
 Allow: */modules/*.png
 Allow: */modules/*.jpg
-Allow: */themes/*/assets/cache/*.js
-Allow: */themes/*/assets/cache/*.css
-Allow: */themes/*/assets/css/*
 # Private pages
 Disallow: /*?order=
 Disallow: /*?tag=
@@ -78,3 +75,19 @@ Disallow: */upload/
 Disallow: */vendor/
 Disallow: */web/
 Disallow: */webservice/
+# Files
+Disallow: /password-recovery
+Disallow: /address
+Disallow: /addresses
+Disallow: /login
+Disallow: /cart
+Disallow: /discount
+Disallow: /order-history
+Disallow: /identity
+Disallow: /my-account
+Disallow: /order-follow
+Disallow: /credit-slip
+Disallow: /order
+Disallow: /search
+Disallow: /guest-tracking
+Disallow: /order-confirmation


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | PS_DISABLE_OVERRIDES is not properly taken into account when index_cache file is automatically regenerated
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Unittest added

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9234)
<!-- Reviewable:end -->
