### PR TITLE
Corrects a bug when importing store contacts

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -482,10 +482,10 @@ class AdminImportControllerCore extends AdminController
                 );
                 break;
             case $this->entities[$this->trans('Store contacts', array(), 'Admin.Advparameters.Feature')]:
-                unset(self::$validators['name']);
-                self::$validators = array(
-                    'hours' => array('AdminImportController', 'split')
-                );
+                self::$validators['hours'] = array('AdminImportController', 'split');
+                self::$validators['address1'] = array('AdminImportController', 'createMultiLangField');
+                self::$validators['address2'] = array('AdminImportController', 'createMultiLangField');
+                
                 $this->required_fields = array(
                     'address1',
                     'city',
@@ -3849,7 +3849,8 @@ class AdminImportControllerCore extends AdminController
                 );
             }
         } else {
-            $this->errors[] = $this->trans('Store is invalid', array(), 'Admin.Advparameters.Notification').' ('.$store->name.')';
+            $id_lang = Language::getIdByIso(Tools::getValue('iso_lang'));
+            $this->errors[] = $this->trans('Store is invalid', array(), 'Admin.Advparameters.Notification').' ('.$store->name[$id_lang].')';
             $this->errors[] = ($field_error !== true ? $field_error : '').(isset($lang_field_error) && $lang_field_error !== true ? $lang_field_error : '');
         }
     }


### PR DESCRIPTION
The fields name, address1 and address2 are multilingual, so the importer has to take this into account.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Corrects a bug when importing store contacts
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Just import data

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9235)
<!-- Reviewable:end -->
