### PR TITLE
Fix Version service namespace usage

### DIFF
--- a/src/Core/Localization/Pack/Factory/LocalizationPackFactoryInterface.php
+++ b/src/Core/Localization/Pack/Factory/LocalizationPackFactoryInterface.php
@@ -34,7 +34,7 @@ use PrestaShop\PrestaShop\Adapter\Entity\LocalizationPack;
 interface LocalizationPackFactoryInterface
 {
     /**
-     * Creates new localizatio pack
+     * Creates new localization pack
      *
      * @return LocalizationPack
      */

--- a/src/Core/Localization/Pack/Loader/RemoteLocalizationPackLoader.php
+++ b/src/Core/Localization/Pack/Loader/RemoteLocalizationPackLoader.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Localization\Pack\Loader;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Foundation\Version\Version;
+use PrestaShop\PrestaShop\Core\Foundation\Version;
 
 /**
  * Class RemoteLocalizationPackLoader is responsible for loading localization pack data from prestashop.com


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | `Version` service namespace was updated in #9201 but `RemoteLocalizationPackLoader` was still using old namespace, this makes Localization page to crash. This PR fixes that.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Localization page should not crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9241)
<!-- Reviewable:end -->
