### PR TITLE
Introducing reusable way to display KPIs blocks in Back Office modern pages

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -1,6 +1,11 @@
 .kpi-container {
   position: relative;
   text-decoration: none;
+  background: $gray-soft;
+  padding-top: .9375rem;
+  padding-bottom: .9375rem;
+  text-align: center;
+  display: block;
 
   &:hover {
     text-decoration: none;
@@ -15,6 +20,8 @@
 
 .kpi-content {
   position: relative;
+  text-align: left;
+  padding-left: 40px;
 
   > .material-icons {
     position: absolute;
@@ -24,20 +31,40 @@
     color: $primary;
   }
 
+  &.-color2 {
+    > .value,
+    > .material-icons {
+      color: $danger;
+    }
+  }
+
+  &.-color3 {
+    > .value,
+    > .material-icons {
+      color: $success;
+    }
+  }
+
   > .title,
   > .subtitle,
   > .value {
     font-size: 0.75rem;
-    padding-left: 3.125rem;
-    display: block;
+    padding-left: .125rem;
     color: $gray-dark;
   }
+  
+  > .title {
+    display: inline-block;
+  }
+  
   > .subtitle {
     text-transform: uppercase;
     color: $gray-medium;
+    display: block;
   }
   > .value {
     font-size: 1.25rem;
     color: $primary;
+    display: block;
   }
 }

--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -14,6 +14,7 @@
 
 .kpi-refresh {
   position: absolute;
+  z-index: 1;
   top: 0;
   right: 0;
 }

--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -68,3 +68,10 @@
     display: block;
   }
 }
+
+.container-fluid {
+  > .kpi-container {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -935,6 +935,10 @@ $(document).ready(function()
     if ($('.kpi-container').length) {
         refresh_kpis();
     }
+
+    $('.kpi-refresh').on('click', '.refresh-kpis', function () {
+        refresh_kpis(true);
+    });
 });
 
 function bindSwapSave(context)

--- a/src/Adapter/Configuration/KpiConfiguration.php
+++ b/src/Adapter/Configuration/KpiConfiguration.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Configuration;
+
+use ConfigurationKPI;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+
+/**
+ * Class KpiConfiguration provides access to legacy ConfigurationKpi methods
+ */
+class KpiConfiguration extends Configuration
+{
+    /**
+     * Changes configuration definition before calling it's methods
+     *
+     * @param $name
+     * @param $arguments
+     *
+     * @return mixed
+     */
+    public function __call($name, $arguments)
+    {
+        if (is_callable([$this, $name])) {
+            ConfigurationKPI::setKpiDefinition();
+            $result = call_user_func([$this, $name], $arguments);
+            ConfigurationKPI::unsetKpiDefinition();
+
+            return $result;
+        }
+    }
+}

--- a/src/Adapter/Kpi/EnabledLanguagesKpi.php
+++ b/src/Adapter/Kpi/EnabledLanguagesKpi.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Kpi;
+
+use HelperKpi;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Class EnabledLanguagesKpi is an implementation for enabled languages KPI
+ */
+final class EnabledLanguagesKpi implements KpiInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @var LegacyContext
+     */
+    private $legacyContext;
+
+    /**
+     * @param LegacyContext $legacyContext
+     * @param TranslatorInterface $translator
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(
+        LegacyContext $legacyContext,
+        TranslatorInterface $translator,
+        ConfigurationInterface $configuration
+    ) {
+        $this->translator = $translator;
+        $this->configuration = $configuration;
+        $this->legacyContext = $legacyContext;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render()
+    {
+        $enabledLanguages = $this->configuration->get('ENABLED_LANGUAGES');
+
+        $kpi = new HelperKpi();
+        $kpi->context->smarty->setTemplateDir(_PS_BO_ALL_THEMES_DIR_.'new-theme/template/');
+        $kpi->id = 'box-languages';
+        $kpi->icon = 'mic';
+        $kpi->color = 'color1';
+        $kpi->href = $this->legacyContext->getAdminLink('AdminLanguages');
+        $kpi->title = $this->translator->trans('Enabled Languages', [], 'Admin.International.Feature');
+
+        if (false !== $enabledLanguages) {
+            $kpi->value = $enabledLanguages;
+        }
+
+        $params = [
+            'ajax' => 1,
+            'action' => 'getKpi',
+            'kpi' => 'enabled_languages',
+        ];
+        $kpi->source = $this->legacyContext->getAdminLink('AdminStats', true, $params);
+        $kpi->refresh = $this->configuration->get('ENABLED_LANGUAGES_EXPIRE') < time();
+
+        return $kpi->generate();
+    }
+}

--- a/src/Adapter/Kpi/EnabledLanguagesKpi.php
+++ b/src/Adapter/Kpi/EnabledLanguagesKpi.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Kpi;
 
 use HelperKpi;
-use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -48,23 +47,31 @@ final class EnabledLanguagesKpi implements KpiInterface
     private $configuration;
 
     /**
-     * @var LegacyContext
+     * @var string
      */
-    private $legacyContext;
+    private $clickLink;
 
     /**
-     * @param LegacyContext $legacyContext
+     * @var string
+     */
+    private $sourceLink;
+
+    /**
      * @param TranslatorInterface $translator
      * @param ConfigurationInterface $configuration
+     * @param string $clickLink a link for clicking on the KPI
+     * @param string $sourceLink a link to refresh KPI
      */
     public function __construct(
-        LegacyContext $legacyContext,
         TranslatorInterface $translator,
-        ConfigurationInterface $configuration
+        ConfigurationInterface $configuration,
+        $clickLink,
+        $sourceLink
     ) {
         $this->translator = $translator;
         $this->configuration = $configuration;
-        $this->legacyContext = $legacyContext;
+        $this->clickLink = $clickLink;
+        $this->sourceLink = $sourceLink;
     }
 
     /**
@@ -79,19 +86,14 @@ final class EnabledLanguagesKpi implements KpiInterface
         $kpi->id = 'box-languages';
         $kpi->icon = 'mic';
         $kpi->color = 'color1';
-        $kpi->href = $this->legacyContext->getAdminLink('AdminLanguages');
+        $kpi->href = $this->clickLink;
         $kpi->title = $this->translator->trans('Enabled Languages', [], 'Admin.International.Feature');
 
         if (false !== $enabledLanguages) {
             $kpi->value = $enabledLanguages;
         }
 
-        $params = [
-            'ajax' => 1,
-            'action' => 'getKpi',
-            'kpi' => 'enabled_languages',
-        ];
-        $kpi->source = $this->legacyContext->getAdminLink('AdminStats', true, $params);
+        $kpi->source = $this->sourceLink;
         $kpi->refresh = $this->configuration->get('ENABLED_LANGUAGES_EXPIRE') < time();
 
         return $kpi->generate();

--- a/src/Adapter/Kpi/MainCountryKpi.php
+++ b/src/Adapter/Kpi/MainCountryKpi.php
@@ -75,6 +75,7 @@ final class MainCountryKpi implements KpiInterface
         $mainCountry = $this->configuration->get('MAIN_COUNTRY');
 
         $kpi = new HelperKpi();
+        $kpi->context->smarty->setTemplateDir(_PS_BO_ALL_THEMES_DIR_.'new-theme/template/');
         $kpi->id = 'box-country';
         $kpi->icon = 'home';
         $kpi->color = 'color2';

--- a/src/Adapter/Kpi/MainCountryKpi.php
+++ b/src/Adapter/Kpi/MainCountryKpi.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Kpi;
 
 use HelperKpi;
-use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -48,23 +47,23 @@ final class MainCountryKpi implements KpiInterface
     private $configuration;
 
     /**
-     * @var LegacyContext
+     * @var string
      */
-    private $legacyContext;
+    private $sourceLink;
 
     /**
-     * @param LegacyContext $legacyContext
      * @param TranslatorInterface $translator
      * @param ConfigurationInterface $configuration
+     * @param string $sourceLink a link to refresh KPI
      */
     public function __construct(
-        LegacyContext $legacyContext,
         TranslatorInterface $translator,
-        ConfigurationInterface $configuration
+        ConfigurationInterface $configuration,
+        $sourceLink
     ) {
         $this->translator = $translator;
         $this->configuration = $configuration;
-        $this->legacyContext = $legacyContext;
+        $this->sourceLink = $sourceLink;
     }
 
     /**
@@ -86,12 +85,7 @@ final class MainCountryKpi implements KpiInterface
             $kpi->value = $mainCountry;
         }
 
-        $params = [
-            'ajax' => 1,
-            'action' => 'getKpi',
-            'kpi' => 'main_country',
-        ];
-        $kpi->source = $this->legacyContext->getAdminLink('AdminStats', true, $params);
+        $kpi->source = $this->sourceLink;
         $kpi->refresh = $this->configuration->get('MAIN_COUNTRY_EXPIRE') < time();
 
         return $kpi->generate();

--- a/src/Adapter/Kpi/MainCountryKpi.php
+++ b/src/Adapter/Kpi/MainCountryKpi.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Kpi;
+
+use HelperKpi;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Class MainCountryKpi is an implementation for main countries KPI
+ */
+final class MainCountryKpi implements KpiInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @var LegacyContext
+     */
+    private $legacyContext;
+
+    /**
+     * @param LegacyContext $legacyContext
+     * @param TranslatorInterface $translator
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(
+        LegacyContext $legacyContext,
+        TranslatorInterface $translator,
+        ConfigurationInterface $configuration
+    ) {
+        $this->translator = $translator;
+        $this->configuration = $configuration;
+        $this->legacyContext = $legacyContext;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render()
+    {
+        $mainCountry = $this->configuration->get('MAIN_COUNTRY');
+
+        $kpi = new HelperKpi();
+        $kpi->id = 'box-country';
+        $kpi->icon = 'home';
+        $kpi->color = 'color2';
+        $kpi->title = $this->translator->trans('Main Country', [], 'Admin.International.Feature');
+        $kpi->subtitle = $this->translator->trans('30 Days', [], 'Admin.Global');
+
+        if (false !== $mainCountry) {
+            $kpi->value = $mainCountry;
+        }
+
+        $params = [
+            'ajax' => 1,
+            'action' => 'getKpi',
+            'kpi' => 'main_country',
+        ];
+        $kpi->source = $this->legacyContext->getAdminLink('AdminStats', true, $params);
+        $kpi->refresh = $this->configuration->get('MAIN_COUNTRY_EXPIRE') < time();
+
+        return $kpi->generate();
+    }
+}

--- a/src/Adapter/Kpi/TranslationsKpi.php
+++ b/src/Adapter/Kpi/TranslationsKpi.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Kpi;
+
+use HelperKpi;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Class TranslationsKpi is an implementation for translations KPI
+ */
+final class TranslationsKpi implements KpiInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @var LegacyContext
+     */
+    private $legacyContext;
+
+    /**
+     * @param LegacyContext $legacyContext
+     * @param TranslatorInterface $translator
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(
+        LegacyContext $legacyContext,
+        TranslatorInterface $translator,
+        ConfigurationInterface $configuration
+    ) {
+        $this->translator = $translator;
+        $this->configuration = $configuration;
+        $this->legacyContext = $legacyContext;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render()
+    {
+        $frontOfficeTranslations = $this->configuration->get('FRONTOFFICE_TRANSLATIONS');
+
+        $kpi = new HelperKpi();
+        $kpi->id = 'box-translations';
+        $kpi->icon = 'list';
+        $kpi->color = 'color3';
+        $kpi->title = $this->translator->trans('Front office Translations', [], 'Admin.International.Feature');
+
+        if (false !== $frontOfficeTranslations) {
+            $kpi->value = $frontOfficeTranslations;
+        }
+
+        $params = [
+            'ajax' => 1,
+            'action' => 'getKpi',
+            'kpi' => 'frontoffice_translations',
+        ];
+        $kpi->source = $this->legacyContext->getAdminLink('AdminStats', true, $params);
+        $kpi->refresh = $this->configuration->get('FRONTOFFICE_TRANSLATIONS_EXPIRE') < time();
+
+        return $kpi->generate();
+    }
+}

--- a/src/Adapter/Kpi/TranslationsKpi.php
+++ b/src/Adapter/Kpi/TranslationsKpi.php
@@ -75,6 +75,7 @@ final class TranslationsKpi implements KpiInterface
         $frontOfficeTranslations = $this->configuration->get('FRONTOFFICE_TRANSLATIONS');
 
         $kpi = new HelperKpi();
+        $kpi->context->smarty->setTemplateDir(_PS_BO_ALL_THEMES_DIR_.'new-theme/template/');
         $kpi->id = 'box-translations';
         $kpi->icon = 'list';
         $kpi->color = 'color3';

--- a/src/Adapter/Kpi/TranslationsKpi.php
+++ b/src/Adapter/Kpi/TranslationsKpi.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Kpi;
 
 use HelperKpi;
-use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -48,23 +47,23 @@ final class TranslationsKpi implements KpiInterface
     private $configuration;
 
     /**
-     * @var LegacyContext
+     * @var string
      */
-    private $legacyContext;
+    private $sourceLink;
 
     /**
-     * @param LegacyContext $legacyContext
      * @param TranslatorInterface $translator
      * @param ConfigurationInterface $configuration
+     * @param string $sourceLink a link to refresh KPI
      */
     public function __construct(
-        LegacyContext $legacyContext,
         TranslatorInterface $translator,
-        ConfigurationInterface $configuration
+        ConfigurationInterface $configuration,
+        $sourceLink
     ) {
         $this->translator = $translator;
         $this->configuration = $configuration;
-        $this->legacyContext = $legacyContext;
+        $this->sourceLink = $sourceLink;
     }
 
     /**
@@ -85,12 +84,7 @@ final class TranslationsKpi implements KpiInterface
             $kpi->value = $frontOfficeTranslations;
         }
 
-        $params = [
-            'ajax' => 1,
-            'action' => 'getKpi',
-            'kpi' => 'frontoffice_translations',
-        ];
-        $kpi->source = $this->legacyContext->getAdminLink('AdminStats', true, $params);
+        $kpi->source = $this->sourceLink;
         $kpi->refresh = $this->configuration->get('FRONTOFFICE_TRANSLATIONS_EXPIRE') < time();
 
         return $kpi->generate();

--- a/src/Core/Kpi/KpiInterface.php
+++ b/src/Core/Kpi/KpiInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi;
+
+/**
+ * Interface KpiInterface describes a KPI
+ */
+interface KpiInterface extends RenderableKpi
+{
+}

--- a/src/Core/Kpi/RenderableKpi.php
+++ b/src/Core/Kpi/RenderableKpi.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi;
+
+/**
+ * Interface RenderableKpi describes a renderable KPI
+ */
+interface RenderableKpi
+{
+    /**
+     * Renders the KPI's view
+     *
+     * @return string
+     */
+    public function render();
+}

--- a/src/Core/Kpi/Row/KpiRow.php
+++ b/src/Core/Kpi/Row/KpiRow.php
@@ -34,6 +34,11 @@ use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
 final class KpiRow implements KpiRowInterface
 {
     /**
+     * @var bool
+     */
+    private $allowRefresh = true;
+
+    /**
      * @var array[KpiInterface]
      */
     private $kpis = [];
@@ -52,5 +57,21 @@ final class KpiRow implements KpiRowInterface
     public function getKpis()
     {
         return $this->kpis;
+    }
+
+    /**
+     * @param bool $allowRefresh
+     */
+    public function setAllowRefresh($allowRefresh)
+    {
+        $this->allowRefresh = $allowRefresh;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAllowRefresh()
+    {
+        return $this->allowRefresh;
     }
 }

--- a/src/Core/Kpi/Row/KpiRow.php
+++ b/src/Core/Kpi/Row/KpiRow.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi\Row;
+
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+
+/**
+ * Class KpiRow defines a row of KPIs
+ */
+final class KpiRow implements KpiRowInterface
+{
+    /**
+     * @var array[KpiInterface]
+     */
+    private $kpis = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addKpi(KpiInterface $kpi)
+    {
+        $this->kpis[] = $kpi;
+    }
+
+    /**
+     * @return array[KpiInterface]
+     */
+    public function getKpis()
+    {
+        return $this->kpis;
+    }
+}

--- a/src/Core/Kpi/Row/KpiRow.php
+++ b/src/Core/Kpi/Row/KpiRow.php
@@ -70,7 +70,7 @@ final class KpiRow implements KpiRowInterface
     /**
      * @return bool
      */
-    public function getAllowRefresh()
+    public function isRefreshAllowed()
     {
         return $this->allowRefresh;
     }

--- a/src/Core/Kpi/Row/KpiRowFactory.php
+++ b/src/Core/Kpi/Row/KpiRowFactory.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi\Row;
+
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+
+/**
+ * Class KpiRowFactory builds a KPI row
+ */
+final class KpiRowFactory implements KpiRowFactoryInterface
+{
+    /**
+     * @var KpiInterface[]
+     */
+    private $kpis;
+
+    /**
+     * @param KpiInterface ...$kpis
+     */
+    public function __construct(KpiInterface ...$kpis)
+    {
+        $this->kpis = $kpis;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build()
+    {
+        $kpiRow = new KpiRow();
+
+        foreach ($this->kpis as $kpi) {
+            $kpiRow->addKpi($kpi);
+        }
+
+        return $kpiRow;
+    }
+}

--- a/src/Core/Kpi/Row/KpiRowFactoryInterface.php
+++ b/src/Core/Kpi/Row/KpiRowFactoryInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi\Row;
+
+/**
+ * Interface KpiRowFactoryInterface describes a KPI row factory
+ */
+interface KpiRowFactoryInterface
+{
+    /**
+     * Builds a KPI row
+     *
+     * @return KpiRowInterface
+     */
+    public function build();
+}

--- a/src/Core/Kpi/Row/KpiRowInterface.php
+++ b/src/Core/Kpi/Row/KpiRowInterface.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi\Row;
+
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+
+/**
+ * Interface KpiRowInterface describes a KPI row
+ */
+interface KpiRowInterface
+{
+    /**
+     * Add a KPI to this row
+     *
+     * @param KpiInterface $kpi
+     */
+    public function addKpi(KpiInterface $kpi);
+
+    /**
+     * @return array[KpiInterface]
+     */
+    public function getKpis();
+}

--- a/src/Core/Kpi/Row/KpiRowInterface.php
+++ b/src/Core/Kpi/Row/KpiRowInterface.php
@@ -44,4 +44,14 @@ interface KpiRowInterface
      * @return array[KpiInterface]
      */
     public function getKpis();
+
+    /**
+     * @param bool $allowRefresh
+     */
+    public function setAllowRefresh($allowRefresh);
+
+    /**
+     * @return bool
+     */
+    public function getAllowRefresh();
 }

--- a/src/Core/Kpi/Row/KpiRowInterface.php
+++ b/src/Core/Kpi/Row/KpiRowInterface.php
@@ -53,5 +53,5 @@ interface KpiRowInterface
     /**
      * @return bool
      */
-    public function getAllowRefresh();
+    public function isRefreshAllowed();
 }

--- a/src/Core/Kpi/Row/KpiRowPresenter.php
+++ b/src/Core/Kpi/Row/KpiRowPresenter.php
@@ -47,7 +47,7 @@ final class KpiRowPresenter implements KpiRowPresenterInterface
 
         return [
             'kpis' => $renderedKpis,
-            'allowRefresh' => $kpiRow->getAllowRefresh(),
+            'allowRefresh' => $kpiRow->isRefreshAllowed(),
         ];
     }
 }

--- a/src/Core/Kpi/Row/KpiRowPresenter.php
+++ b/src/Core/Kpi/Row/KpiRowPresenter.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi\Row;
+
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+
+/**
+ * Class KpiRowPresenter presents a KPI row
+ */
+final class KpiRowPresenter implements KpiRowPresenterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function present(KpiRowInterface $kpiRow)
+    {
+        $renderedKpis = [];
+
+        /** @var KpiInterface $kpi */
+        foreach ($kpiRow->getKpis() as $kpi) {
+            $renderedKpis[] = $kpi->render();
+        }
+
+        return [
+            'kpis' => $renderedKpis,
+        ];
+    }
+}

--- a/src/Core/Kpi/Row/KpiRowPresenter.php
+++ b/src/Core/Kpi/Row/KpiRowPresenter.php
@@ -47,6 +47,7 @@ final class KpiRowPresenter implements KpiRowPresenterInterface
 
         return [
             'kpis' => $renderedKpis,
+            'allowRefresh' => $kpiRow->getAllowRefresh(),
         ];
     }
 }

--- a/src/Core/Kpi/Row/KpiRowPresenterInterface.php
+++ b/src/Core/Kpi/Row/KpiRowPresenterInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi\Row;
+
+/**
+ * Interface KpiRowPresenterInterface describes a KPI row presenter
+ */
+interface KpiRowPresenterInterface
+{
+    /**
+     * @param KpiRowInterface $kpiRow
+     *
+     * @return array
+     */
+    public function present(KpiRowInterface $kpiRow);
+}

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -29,6 +29,7 @@ use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
+use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowPresenterInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -213,18 +214,18 @@ class CommonController extends FrameworkBundleAdminController
     }
 
     /**
-     * Renders a KPI row, built by provided factory
+     * Renders a KPI row
      *
-     * @param KpiRowFactoryInterface $factory
+     * @param KpiRowInterface $kpiRow
      *
      * @return Response
      */
-    public function renderKpiRowAction(KpiRowFactoryInterface $factory)
+    public function renderKpiRowAction(KpiRowInterface $kpiRow)
     {
         $presenter = $this->get('prestashop.core.kpi_row.presenter');
 
         return $this->render('@PrestaShop/Admin/Common/Kpi/kpi_row.html.twig', [
-            'kpiRow' => $presenter->present($factory->build()),
+            'kpiRow' => $presenter->present($kpiRow),
         ]);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -28,9 +28,12 @@ namespace PrestaShopBundle\Controller\Admin;
 use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
+use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
+use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowPresenterInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use PrestaShopBundle\Service\DataProvider\Admin\RecommendedModules;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Admin controller for the common actions across the whole admin interface.
@@ -60,7 +63,8 @@ class CommonController extends FrameworkBundleAdminController
      * @param integer $offset
      * @param integer $total
      * @param string $view full|quicknav To change default template used to render the content
-     * @return array|\Symfony\Component\HttpFoundation\Response
+     *
+     * @return array|Response
      */
     public function paginationAction(Request $request, $limit = 10, $offset = 0, $total = 0, $view = 'full')
     {
@@ -195,7 +199,7 @@ class CommonController extends FrameworkBundleAdminController
      * @param $url
      * @param string $title
      * @param string $footer
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function renderSidebarAction($url, $title = '', $footer = '')
     {
@@ -205,6 +209,22 @@ class CommonController extends FrameworkBundleAdminController
             'footer' => $tools->purifyHTML($footer),
             'title' => $title,
             'url' => urldecode($url),
+        ]);
+    }
+
+    /**
+     * Renders a KPI row, built by provided factory
+     *
+     * @param KpiRowFactoryInterface $factory
+     *
+     * @return Response
+     */
+    public function renderKpiRowAction(KpiRowFactoryInterface $factory)
+    {
+        $presenter = $this->get('prestashop.core.kpi_row.presenter');
+
+        return $this->render('@PrestaShop/Admin/Common/Kpi/kpi_row.html.twig', [
+            'kpiRow' => $presenter->present($factory->build()),
         ]);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin;
 
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -139,5 +140,31 @@ class TranslationsController extends FrameworkBundleAdminController
         $themeExporter->cleanArtifacts($themeName);
 
         return $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT);
+    }
+
+    /**
+     * Show translations settings page
+     *
+     * @Template("@PrestaShop/Admin/Improve/International/Translations/translations_settings.html.twig")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     *
+     * @param Request $request
+     *
+     * @return array
+     */
+    public function showSettingsAction(Request $request)
+    {
+        $legacyController = $request->attributes->get('_legacy_controller');
+        $kpiRowFactory = $this->get('prestashop.core.kpi_row.factory.translations_page');
+        $presenter = $this->get('prestashop.core.kpi_row.presenter');
+
+        $presentedKpiRow = $presenter->present($kpiRowFactory->build());
+
+        return [
+            'layoutTitle' => $this->trans('Translations', 'Admin.Navigation.Menu'),
+            'enableSidebar' => true,
+            'help_link' => $this->generateSidebarLink($legacyController),
+            'kpiRow' => $presentedKpiRow,
+        ];
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -161,7 +161,7 @@ class TranslationsController extends FrameworkBundleAdminController
             'layoutTitle' => $this->trans('Translations', 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($legacyController),
-            'kpiRowFactory' => $kpiRowFactory,
+            'kpiRow' => $kpiRowFactory->build(),
         ];
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -156,15 +156,12 @@ class TranslationsController extends FrameworkBundleAdminController
     {
         $legacyController = $request->attributes->get('_legacy_controller');
         $kpiRowFactory = $this->get('prestashop.core.kpi_row.factory.translations_page');
-        $presenter = $this->get('prestashop.core.kpi_row.presenter');
-
-        $presentedKpiRow = $presenter->present($kpiRowFactory->build());
 
         return [
             'layoutTitle' => $this->trans('Translations', 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($legacyController),
-            'kpiRow' => $presentedKpiRow,
+            'kpiRowFactory' => $kpiRowFactory,
         ];
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
@@ -27,3 +27,10 @@ admin_international_translations_export_theme:
     defaults:
         _controller: PrestaShopBundle:Admin/Translations:exportTheme
         _legacy_controller: AdminTranslations
+
+admin_international_translations_show_settings:
+    path: /settings
+    methods: [GET]
+    defaults:
+        _controller: PrestaShopBundle:Admin/Translations:showSettings
+        _legacy_controller: AdminTranslations

--- a/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
@@ -9,7 +9,6 @@ services:
             - '@prestashop.adapter.legacy.context'
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
-            - '@prestashop.smarty'
 
     prestashop.adapter.kpi.main_country:
         class: PrestaShop\PrestaShop\Adapter\Kpi\MainCountryKpi

--- a/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
@@ -19,8 +19,8 @@ services:
             - '@prestashop.adapter.legacy.kpi_configuration'
 
     prestashop.adapter.kpi.translations:
-            class: PrestaShop\PrestaShop\Adapter\Kpi\TranslationsKpi
-            arguments:
-                - '@prestashop.adapter.legacy.context'
-                - '@translator'
-                - '@prestashop.adapter.legacy.kpi_configuration'
+        class: PrestaShop\PrestaShop\Adapter\Kpi\TranslationsKpi
+        arguments:
+            - '@prestashop.adapter.legacy.context'
+            - '@translator'
+            - '@prestashop.adapter.legacy.kpi_configuration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
@@ -6,20 +6,21 @@ services:
     prestashop.adapter.kpi.enabled_languages:
         class: PrestaShop\PrestaShop\Adapter\Kpi\EnabledLanguagesKpi
         arguments:
-            - '@prestashop.adapter.legacy.context'
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
+            - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminLanguages")'
+            - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "enabled_languages"})'
 
     prestashop.adapter.kpi.main_country:
         class: PrestaShop\PrestaShop\Adapter\Kpi\MainCountryKpi
         arguments:
-            - '@prestashop.adapter.legacy.context'
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
+            - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "main_country"})'
 
     prestashop.adapter.kpi.translations:
         class: PrestaShop\PrestaShop\Adapter\Kpi\TranslationsKpi
         arguments:
-            - '@prestashop.adapter.legacy.context'
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
+            - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "frontoffice_translations"})'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
@@ -1,0 +1,26 @@
+services:
+    _defaults:
+        public: true
+
+    # KPI implementations
+    prestashop.adapter.kpi.enabled_languages:
+        class: PrestaShop\PrestaShop\Adapter\Kpi\EnabledLanguagesKpi
+        arguments:
+            - '@prestashop.adapter.legacy.context'
+            - '@translator'
+            - '@prestashop.adapter.legacy.kpi_configuration'
+            - '@prestashop.smarty'
+
+    prestashop.adapter.kpi.main_country:
+        class: PrestaShop\PrestaShop\Adapter\Kpi\MainCountryKpi
+        arguments:
+            - '@prestashop.adapter.legacy.context'
+            - '@translator'
+            - '@prestashop.adapter.legacy.kpi_configuration'
+
+    prestashop.adapter.kpi.translations:
+            class: PrestaShop\PrestaShop\Adapter\Kpi\TranslationsKpi
+            arguments:
+                - '@prestashop.adapter.legacy.context'
+                - '@translator'
+                - '@prestashop.adapter.legacy.kpi_configuration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -42,6 +42,9 @@ services:
     prestashop.adapter.legacy.configuration:
         class: PrestaShop\PrestaShop\Adapter\Configuration
 
+    prestashop.adapter.legacy.kpi_configuration:
+        class: PrestaShop\PrestaShop\Adapter\Configuration\KpiConfiguration
+
     prestashop.adapter.legacy.context:
         class: PrestaShop\PrestaShop\Adapter\LegacyContext
 

--- a/src/PrestaShopBundle/Resources/config/services/core/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/kpi.yml
@@ -1,0 +1,15 @@
+services:
+    _defaults:
+        public: true
+
+    # KPI Row presenter
+    prestashop.core.kpi_row.presenter:
+        class: PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowPresenter
+
+    # KPI Row factories
+    prestashop.core.kpi_row.factory.translations_page:
+        class: PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactory
+        arguments:
+            - '@prestashop.adapter.kpi.enabled_languages'
+            - '@prestashop.adapter.kpi.main_country'
+            - '@prestashop.adapter.kpi.translations'

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Kpi/kpi_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Kpi/kpi_row.html.twig
@@ -1,0 +1,38 @@
+    {#**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% block kpi_row %}
+    <div class="container-fluid">
+        <div class="kpi-container">
+            <div class="row">
+                {% for kpi in kpiRow.kpis %}
+                    <div class="col">
+                        {{ kpi|raw }}
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Kpi/kpi_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Kpi/kpi_row.html.twig
@@ -26,6 +26,14 @@
 {% block kpi_row %}
     <div class="container-fluid">
         <div class="kpi-container">
+            {% if kpiRow.allowRefresh %}
+                <div class="kpi-refresh">
+                    <button class="refresh-kpis btn btn-primary" type="button">
+                        <i class="material-icons">refresh</i>
+                    </button>
+                </div>
+            {% endif %}
+
             <div class="row">
                 {% for kpi in kpiRow.kpis %}
                     <div class="col">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -30,7 +30,10 @@
 
     {% block translations_kpis_row %}
         <div class="row">
-            {{ include('@PrestaShop/Admin/Common/Kpi/kpi_row.html.twig', {'kpiRow': kpiRow }) }}
+            {{ render(controller(
+                'PrestaShopBundle:Admin\\Common:renderKpiRow',
+                { 'factory': kpiRowFactory }
+            )) }}
         </div>
     {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -1,0 +1,37 @@
+{#**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% trans_default_domain 'Admin.International.Feature' %}
+
+{% block content %}
+
+    {% block translations_kpis_row %}
+        <div class="row">
+            {{ include('@PrestaShop/Admin/Common/Kpi/kpi_row.html.twig', {'kpiRow': kpiRow }) }}
+        </div>
+    {% endblock %}
+
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -32,7 +32,7 @@
         <div class="row">
             {{ render(controller(
                 'PrestaShopBundle:Admin\\Common:renderKpiRow',
-                { 'factory': kpiRowFactory }
+                { 'kpiRow': kpiRow }
             )) }}
         </div>
     {% endblock %}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We needed a common and re-usable system to display KPIs block everywhere in Symfony pages
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Compare to legacy translations page (only the page that you land in when going to International > Translations), for the KPI block on top of the page.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9242)
<!-- Reviewable:end -->
