### PR TITLE
Fixed Apache Optimization

### DIFF
--- a/src/Adapter/Cache/CombineCompressCacheConfiguration.php
+++ b/src/Adapter/Cache/CombineCompressCacheConfiguration.php
@@ -194,9 +194,8 @@ class CombineCompressCacheConfiguration implements DataConfigurationInterface
 
         // feature activation
         if (false === $isCurrentlyEnabled && true === $enabled) {
-            if ($this->tools->generateHtaccess()) {
-                $this->configuration->set('PS_HTACCESS_CACHE_CONTROL', true);
-            } else {
+            $this->configuration->set('PS_HTACCESS_CACHE_CONTROL', true);
+            if (!$this->tools->generateHtaccess()) {
                 $errors = array(
                     'key' => 'Before being able to use this tool, you need to:[1][2]Create a blank .htaccess in your root directory.[/2][2]Give it write permissions (CHMOD 666 on Unix system).[/2][/1]',
                     'domain' => 'Admin.Advparameters.Notification',
@@ -214,6 +213,7 @@ class CombineCompressCacheConfiguration implements DataConfigurationInterface
 
         if (true === $isCurrentlyEnabled && false === $enabled) {
             $this->configuration->set('PS_HTACCESS_CACHE_CONTROL', false);
+            $this->tools->generateHtaccess();
         }
 
         return $errors;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When Apache optimization is enabled in the CCC settings, the .htaccess is written as if the cache control was disabled
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |- Setup a shop <br>- Go to Advanced Parameters -> Performance and enable Apache optimization<br>- The browser should now be caching all asset files, including JS and CSS (the main .htaccess should include "ExpiresActive On" and a "ExpiresByType" for each file type)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9244)
<!-- Reviewable:end -->
