### PR TITLE
Add themes in gitignore (except classic)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,10 @@ app/config/config.php
 
 modules/*
 override/*
-/themes/StarterTheme
+themes/*/
+!themes/classic
+!themes/_core
+!themes/_libraries
 
 # Vendors and dependencies
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Avoid other themes than `classic` to be show in "to be committed` files.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Add a personal theme, and checks it does not appear when you execute `git status`. Core element must still appear when modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9247)
<!-- Reviewable:end -->
