### PR TITLE
Implement addBefore() & addAfter() methods of ColumnCollection

### DIFF
--- a/src/Core/Grid/Column/ColumnCollection.php
+++ b/src/Core/Grid/Column/ColumnCollection.php
@@ -111,9 +111,9 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
             $existingColumnKeyPosition++;
         }
 
-        $columns = array_slice($this->items, 0, $existingColumnKeyPosition);
-        $columns = array_merge($columns, [$newColumn->getId() => $newColumn]);
-        $columns = array_merge($columns, array_slice($this->items, $existingColumnKeyPosition));
+        $columns = array_slice($this->items, 0, $existingColumnKeyPosition, true) +
+            [$newColumn->getId() => $newColumn] +
+            array_slice($this->items, $existingColumnKeyPosition, $this->count(), true);
 
         $this->items = $columns;
     }

--- a/src/Core/Grid/Column/ColumnCollection.php
+++ b/src/Core/Grid/Column/ColumnCollection.php
@@ -37,6 +37,16 @@ use PrestaShop\PrestaShop\Core\Grid\Exception\ColumnNotFoundException;
 final class ColumnCollection extends AbstractCollection implements ColumnCollectionInterface
 {
     /**
+     * @internal
+     */
+    const POSITION_AFTER = 'after';
+
+    /**
+     * @internal
+     */
+    const POSITION_BEFORE = 'before';
+
+    /**
      * {@inheritdoc}
      */
     public function add(ColumnInterface $column)
@@ -51,7 +61,7 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
      */
     public function addAfter($id, ColumnInterface $newColumn)
     {
-        $this->insertByPosition($id, $newColumn, 'after');
+        $this->insertByPosition($id, $newColumn, self::POSITION_AFTER);
 
         return $this;
     }
@@ -61,7 +71,7 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
      */
     public function addBefore($id, ColumnInterface $newColumn)
     {
-        $this->insertByPosition($id, $newColumn, 'before');
+        $this->insertByPosition($id, $newColumn, self::POSITION_BEFORE);
 
         return $this;
     }
@@ -97,7 +107,7 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
 
         $existingColumnKeyPosition = array_search($id, array_keys($this->items));
 
-        if ('after' === $position) {
+        if (self::POSITION_AFTER === $position) {
             $existingColumnKeyPosition++;
         }
 

--- a/src/Core/Grid/Column/ColumnCollection.php
+++ b/src/Core/Grid/Column/ColumnCollection.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Core\Grid\Column;
 
 use PrestaShop\PrestaShop\Core\Grid\Collection\AbstractCollection;
 use PrestaShop\PrestaShop\Core\Grid\Exception\ColumnNotFoundException;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class ColumnCollection holds collection of columns for grid
@@ -52,16 +51,9 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
      */
     public function addAfter($id, ColumnInterface $newColumn)
     {
-        if (!isset($this->items[$id])) {
-            throw new ColumnNotFoundException(sprintf(
-                'Column with id "%s" was not found.',
-                $id
-            ));
-        }
+        $this->insertByPosition($id, $newColumn, 'after');
 
-        //@todo: implement actual inserting after column
-
-        $this->add($newColumn);
+        return $this;
     }
 
     /**
@@ -69,16 +61,9 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
      */
     public function addBefore($id, ColumnInterface $newColumn)
     {
-        if (!isset($this->items[$id])) {
-            throw new ColumnNotFoundException(sprintf(
-                'Column with id "%s" was not found.',
-                $id
-            ));
-        }
+        $this->insertByPosition($id, $newColumn, 'before');
 
-        //@todo: implement actual inserting before column
-
-        $this->add($newColumn);
+        return $this;
     }
 
     /**
@@ -91,5 +76,35 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
         }
 
         return $this;
+    }
+
+    /**
+     * Insert new column into collection at given position
+     *
+     * @param string          $id        Existing column id
+     * @param ColumnInterface $newColumn Column to insert
+     * @param string          $position  Position: "before" or "after"
+     *
+     * @throws ColumnNotFoundException When column with gieven $id does not exist
+     */
+    private function insertByPosition($id, ColumnInterface $newColumn, $position)
+    {
+        if (!isset($this->items[$id])) {
+            throw new ColumnNotFoundException(sprintf(
+                'Cannot insert new column into collection. Column with id "%s" was not found.', $id
+            ));
+        }
+
+        $existingColumnKeyPosition = array_search($id, array_keys($this->items));
+
+        if ('after' === $position) {
+            $existingColumnKeyPosition++;
+        }
+
+        $columns = array_slice($this->items, 0, $existingColumnKeyPosition);
+        $columns = array_merge($columns, [$newColumn->getId() => $newColumn]);
+        $columns = array_merge($columns, array_slice($this->items, $existingColumnKeyPosition));
+
+        $this->items = $columns;
     }
 }

--- a/tests/Unit/Core/Grid/Column/ColumnCollectionTest.php
+++ b/tests/Unit/Core/Grid/Column/ColumnCollectionTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Grid\Column;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
+use PrestaShop\PrestaShop\Core\Grid\Exception\ColumnNotFoundException;
+
+class ColumnCollectionTest extends TestCase
+{
+    public function testItAddsColumnsToCollection()
+    {
+        $columns = (new ColumnCollection())
+            ->add($this->createColumnMock('first'))
+            ->add($this->createColumnMock('second'))
+            ->add($this->createColumnMock('third'))
+        ;
+
+        $this->assertEquals([
+            'first',
+            'second',
+            'third',
+        ], $this->getColumnPositions($columns));
+
+        return $columns;
+    }
+
+    /**
+     * @depends testItAddsColumnsToCollection
+     */
+    public function testItAddsColumnsBeforeGivenColumn(ColumnCollection $columns)
+    {
+        $columns
+            ->addBefore('first', $this->createColumnMock('before_first'))
+            ->addBefore('second', $this->createColumnMock('before_second'))
+            ->addBefore('third', $this->createColumnMock('before_third'))
+        ;
+
+        $this->assertEquals([
+            'before_first',
+            'first',
+            'before_second',
+            'second',
+            'before_third',
+            'third',
+        ], $this->getColumnPositions($columns));
+
+        return $columns;
+    }
+
+    /**
+     * @depends testItAddsColumnsBeforeGivenColumn
+     */
+    public function testItAddsColumnsAfterGivenColumn(ColumnCollection $columns)
+    {
+        $columns
+            ->addAfter('first', $this->createColumnMock('after_first'))
+            ->addAfter('second', $this->createColumnMock('after_second'))
+            ->addAfter('third', $this->createColumnMock('after_third'))
+        ;
+
+        $this->assertEquals([
+            'before_first',
+            'first',
+            'after_first',
+            'before_second',
+            'second',
+            'after_second',
+            'before_third',
+            'third',
+            'after_third'
+        ], $this->getColumnPositions($columns));
+
+        return $columns;
+    }
+
+    /**
+     * @depends testItAddsColumnsAfterGivenColumn
+     */
+    public function testItRemovesColumnById(ColumnCollection $columns)
+    {
+        $columns->remove('first');
+        $columns->remove('third');
+        $columns->remove('non_existing');
+
+        $this->assertCount(7, $columns);
+    }
+
+    public function testItThrowsExceptionWhenAddingColumnAfterNonExistingColumn()
+    {
+        $this->expectException(ColumnNotFoundException::class);
+
+        (new ColumnCollection())->addAfter('non_existing', $this->createColumnMock('first'));
+    }
+
+    public function testItThrowsExceptionWhenAddingColumnBeforeNonExistingColumn()
+    {
+        $this->expectException(ColumnNotFoundException::class);
+
+        (new ColumnCollection())->addBefore('non_existing', $this->createColumnMock('first'));
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|ColumnInterface
+     */
+    private function createColumnMock($id)
+    {
+        $column = $this->createMock(ColumnInterface::class);
+        $column->method('getId')
+            ->willReturn($id);
+
+        return $column;
+    }
+
+    /**
+     * @param ColumnCollection $columns
+     *
+     * @return string[]
+     */
+    private function getColumnPositions(ColumnCollection $columns)
+    {
+        $positions= [];
+
+        foreach ($columns as $id => $column) {
+            $positions[] = $id;
+        }
+
+        return $positions;
+    }
+}

--- a/tests/Unit/Core/Grid/Column/ColumnCollectionTest.php
+++ b/tests/Unit/Core/Grid/Column/ColumnCollectionTest.php
@@ -111,6 +111,36 @@ class ColumnCollectionTest extends TestCase
         $this->assertCount(7, $columns);
     }
 
+    public function testMixingMethodsProducesCollectionWithCorrectColumnPositions()
+    {
+        $columns = (new ColumnCollection())
+            ->add($this->createColumnMock('first'))
+            ->addAfter('first', $this->createColumnMock('to_be_removed'))
+            ->addBefore('first', $this->createColumnMock('before_first'))
+            ->addBefore('first', $this->createColumnMock('before_first_2'))
+            ->addAfter('first', $this->createColumnMock('after_first'))
+            ->addBefore('first', $this->createColumnMock('before_first_3'))
+            ->remove('non_existing')
+            ->addAfter('after_first', $this->createColumnMock('after_first_2'))
+            ->add($this->createColumnMock('second'))
+            ->remove('to_be_removed')
+            ->add($this->createColumnMock('third'))
+            ->addAfter('second', $this->createColumnMock('after_second'))
+        ;
+
+        $this->assertEquals([
+            'before_first',
+            'before_first_2',
+            'before_first_3',
+            'first',
+            'after_first',
+            'after_first_2',
+            'second',
+            'after_second',
+            'third',
+        ], $this->getColumnPositions($columns));
+    }
+
     public function testItThrowsExceptionWhenAddingColumnAfterNonExistingColumn()
     {
         $this->expectException(ColumnNotFoundException::class);
@@ -148,8 +178,8 @@ class ColumnCollectionTest extends TestCase
     {
         $positions= [];
 
-        foreach ($columns as $id => $column) {
-            $positions[] = $id;
+        foreach ($columns as $column) {
+            $positions[] = $column->getId();
         }
 
         return $positions;

--- a/tests/Unit/Core/Grid/Column/ColumnCollectionTest.php
+++ b/tests/Unit/Core/Grid/Column/ColumnCollectionTest.php
@@ -141,6 +141,29 @@ class ColumnCollectionTest extends TestCase
         ], $this->getColumnPositions($columns));
     }
 
+    public function testNumericColumnIdAreAccepted()
+    {
+        $columns = (new ColumnCollection())
+            ->add($this->createColumnMock(3))
+            ->addAfter(3, $this->createColumnMock(1))
+            ->addBefore(3, $this->createColumnMock(2))
+            ->add($this->createColumnMock('second'))
+            ->addAfter('second', $this->createColumnMock(9))
+            ->addBefore('second', $this->createColumnMock('7'))
+            ->add($this->createColumnMock(5))
+        ;
+
+        $this->assertEquals([
+            2,
+            3,
+            1,
+            '7',
+            'second',
+            9,
+            5,
+        ], $this->getColumnPositions($columns));
+    }
+
     public function testItThrowsExceptionWhenAddingColumnAfterNonExistingColumn()
     {
         $this->expectException(ColumnNotFoundException::class);


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description? | It implements `addBefore()` & `addAfter()` methods of ColumnCollection. These methods are especially useful when modifying grid's columns from hooks.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9250)
<!-- Reviewable:end -->
