### PR TITLE
Improve resolving of column options

### DIFF
--- a/src/Core/Grid/Column/AbstractColumn.php
+++ b/src/Core/Grid/Column/AbstractColumn.php
@@ -23,7 +23,7 @@ abstract class AbstractColumn implements ColumnInterface
     /**
      * @var array
      */
-    private $options = [];
+    private $options;
 
     /**
      * @param string $id
@@ -64,7 +64,7 @@ abstract class AbstractColumn implements ColumnInterface
      */
     public function setOptions(array $options)
     {
-        $this->options = $options;
+        $this->resolveOptions($options);
 
         return $this;
     }
@@ -74,13 +74,19 @@ abstract class AbstractColumn implements ColumnInterface
      */
     public function getOptions()
     {
+        if (null === $this->options) {
+            $this->resolveOptions();
+        }
+
         return $this->options;
     }
 
     /**
-     * {@inheritdoc}
+     * Default column options configuration. You can override or extend it needed options.
+     *
+     * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults([
@@ -94,5 +100,19 @@ abstract class AbstractColumn implements ColumnInterface
             ->setAllowedTypes('filter_type_options', 'array')
             ->setAllowedTypes('sortable', 'bool')
         ;
+    }
+
+
+    /**
+     * Resolve column options
+     *
+     * @param array $options
+     */
+    private function resolveOptions(array $options = [])
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+
+        $this->options = $resolver->resolve($options);
     }
 }

--- a/src/Core/Grid/Column/ColumnInterface.php
+++ b/src/Core/Grid/Column/ColumnInterface.php
@@ -26,8 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Column;
 
-use Symfony\Component\OptionsResolver\OptionsResolver;
-
 /**
  * Interface ColumnInterface exposes contract for single column
  */
@@ -80,11 +78,4 @@ interface ColumnInterface
      * @return self
      */
     public function setOptions(array $options);
-
-    /**
-     * Configure column options
-     *
-     * @param OptionsResolver $resolver
-     */
-    public function configureOptions(OptionsResolver $resolver);
 }

--- a/src/Core/Grid/Column/Type/Common/ActionColumn.php
+++ b/src/Core/Grid/Column/Type/Common/ActionColumn.php
@@ -19,7 +19,7 @@ class ActionColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults([

--- a/src/Core/Grid/Column/Type/Common/BulkActionColumn.php
+++ b/src/Core/Grid/Column/Type/Common/BulkActionColumn.php
@@ -18,7 +18,7 @@ final class BulkActionColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setRequired([

--- a/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
+++ b/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
@@ -19,7 +19,7 @@ final class DateTimeColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/src/Core/Grid/Column/Type/Status/SeverityLevelColumn.php
+++ b/src/Core/Grid/Column/Type/Status/SeverityLevelColumn.php
@@ -19,7 +19,7 @@ final class SeverityLevelColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/src/Core/Grid/Presenter/GridPresenter.php
+++ b/src/Core/Grid/Presenter/GridPresenter.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\DefinitionInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class GridPresenter is responsible for presenting grid
@@ -103,9 +102,7 @@ final class GridPresenter implements GridPresenterInterface
 
         /** @var ColumnInterface $column */
         foreach ($definition->getColumns() as $column) {
-            $resolver = new OptionsResolver();
-            $column->configureOptions($resolver);
-            $columnOptions = $resolver->resolve($column->getOptions());
+            $columnOptions = $column->getOptions();
 
             $columnsArray[] = [
                 'id' => $column->getId(),


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description? | This PR aims to improve column options resolving by: 1. removing `configureOptions()` thus allowing column to use (if they want) any options resolving strategy. 2. making `Core` columns to use `OptionsResolver` internally.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9256)
<!-- Reviewable:end -->
