### PR TITLE
Allow overriding getRobotsContent in Tools.php

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2526,7 +2526,7 @@ FileETag none
             return false;
         }
 
-        $robots_content = self::getRobotsContent();
+        $robots_content = static::getRobotsContent();
 
         if (true === $executeHook) {
             Hook::exec('actionAdminMetaBeforeWriteRobotsFile', array(


### PR DESCRIPTION
change how to call getRobotsContent() in Tools.php
If the method getRobotsContent is overrided when we call Tools::generateRobotsFile() the method of ToolsCore is still call


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | override of ToolsCore::getRobotsContent() don't work
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9257)
<!-- Reviewable:end -->
