### PR TITLE
Limit subquery results in upgrade sql 1.7.0.0

### DIFF
--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -210,7 +210,7 @@ ALTER TABLE `PREFIX_tab` ADD `icon` varchar(32) DEFAULT '';
 
 /* Save the new IDs */
 UPDATE `PREFIX_tab_transit` tt SET `id_new_tab` = (
-  SELECT `id_tab` FROM `PREFIX_tab` WHERE CONCAT(`class_name`, COALESCE(`module`, '')) = tt.`key`
+  SELECT `id_tab` FROM `PREFIX_tab` WHERE CONCAT(`class_name`, COALESCE(`module`, '')) = tt.`key` LIMIT 1
 );
 /* Update default tab IDs for employees */
 UPDATE `PREFIX_employee` e SET `default_tab` = (


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | With https://github.com/PrestaShop/PrestaShop/pull/8020, an issue has been introduced in 1.6 > 1.7 upgrade, because some tabs are defined several times in the tab.xml file. This PR limits the rows from a subquery, used later for migrating the permissions.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Upgrade a shop from 1.6 to 1.7

## Issue during upgrade

https://travis-ci.org/PrestaShop/autoupgrade/jobs/399632787

```
=== Step upgradeDb
WARNING - 
            <div class="upgradeDbError">
            [WARNING] SQL 1.7.0.0
            1242 in /* Save the new IDs */
UPDATE `ps_tab_transit` tt SET `id_new_tab` = (
  SELECT `id_tab` FROM `ps_tab` WHERE CONCAT(`class_name`, COALESCE(`module`, '')) = tt.`key`
): Subquery returns more than 1 row</div>
ERROR - SQL 1.7.0.0 1242 in /* Save the new IDs */
UPDATE `ps_tab_transit` tt SET `id_new_tab` = (
  SELECT `id_tab` FROM `ps_tab` WHERE CONCAT(`class_name`, COALESCE(`module`, '')) = tt.`key`
): Subquery returns more than 1 row
```

## Duplicated tab

* https://github.com/PrestaShop/PrestaShop/blob/f29a72a84b37daf61f5321df9dea1c3ee35d754f/install-dev/data/xml/tab.xml#L91
* https://github.com/PrestaShop/PrestaShop/blob/f29a72a84b37daf61f5321df9dea1c3ee35d754f/install-dev/data/xml/tab.xml#L142

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9258)
<!-- Reviewable:end -->
