### PR TITLE
Make PrestaShop fully compatible with Twig 2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: php
 
 addons:
-    chrome: stable
-    apt:
-        packages:
-        - apache2
-        - postfix
-        - libapache2-mod-fastcgi
-        - libappindicator1
-        - fonts-liberation
+  chrome: stable
+  apt:
+    packages:
+      - apache2
+      - postfix
+      - libapache2-mod-fastcgi
+      - libappindicator1
+      - fonts-liberation
 
 cache:
   directories:
@@ -34,6 +34,8 @@ matrix:
   include:
     - php: 7.1
       env: EXTRA_TESTS=functional PRESTASHOP_TEST_TYPE=e2e
+    - php: 7.2
+      env: EXTRA_DEPS=phpHigh EXTRA_TESTS=functional PRESTASHOP_TEST_TYPE=unit
 
 before_install:
   # Apache & php-fpm configuration
@@ -48,7 +50,12 @@ notifications:
   hipchat: ec4e21c5eb82066ba8be5fd1afefde@1184657
 
 script:
-  - composer install --prefer-dist --no-interaction --no-progress
+  - if [ $EXTRA_DEPS = "phpHigh" ]; then
+        composer update --ignore-platform-reqs;
+    else
+        composer install --prefer-dist --no-interaction --no-progress;
+    fi
+
   - bash travis-scripts/install-prestashop
   - if [ $PRESTASHOP_TEST_TYPE = "lint" ]; then
         bash tests/check_file_syntax.sh;

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -28,7 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Presenter\Module;
 use Currency;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
-use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
+use PrestaShop\PrestaShop\Core\Foundation\Templating\PresenterInterface;
 use Exception;
 
 class ModulePresenter implements PresenterInterface

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
@@ -38,11 +38,6 @@ use Symfony\Component\HttpFoundation\Request;
 class SystemInformationController extends FrameworkBundleAdminController
 {
     /**
-     * @var string The controller name for routing.
-     */
-    const CONTROLLER_NAME = 'AdminInformation';
-
-    /**
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
      * @Template("@PrestaShop/Admin/Configure/AdvancedParameters/system_information.html.twig")
      *
@@ -51,6 +46,7 @@ class SystemInformationController extends FrameworkBundleAdminController
      */
     public function indexAction(Request $request)
     {
+        $legacyController = $request->get('_legacy_controller');
         $requirementsSummary = $this->getRequirementsChecker()->getSummary();
         $systemInformationSummary = $this->getSystemInformation()->getSummary();
 
@@ -61,9 +57,8 @@ class SystemInformationController extends FrameworkBundleAdminController
             'requireBulkActions' => false,
             'showContentHeader' => true,
             'enableSidebar' => true,
-            'help_link' => $this->generateSidebarLink('AdminInformation'),
+            'help_link' => $this->generateSidebarLink($legacyController),
             'requireFilterStatus' => false,
-            'level' => $this->authorizationLevel($this::CONTROLLER_NAME),
             'errorMessage' => 'ok',
             'system' => $systemInformationSummary,
             'requirements' => $requirementsSummary,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -42,14 +42,6 @@ services:
         tags:
             - { name: twig.extension }
 
-    prestashop.twig.extension.admin:
-       class: PrestaShopBundle\Twig\AdminExtension
-       arguments:
-            - "@request_stack"
-            - "@service_container"
-       tags:
-            - { name: twig.extension }
-
     prestashop.twig.extension.hook:
         class: PrestaShopBundle\Twig\HookExtension
         arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
@@ -23,6 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {{ form_start(importForm, {'attr': { 'data-file-upload-url': importFileUploadUrl, 'class': 'js-import-form' }}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_sample_files.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_sample_files.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 <div class="card">
     <h3 class="card-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig
@@ -24,6 +24,7 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain "Admin.Advparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block content %}
   {% block logs_severity_level_meaning %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
@@ -24,6 +24,7 @@
  *#}
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 {% trans_default_domain "Admin.Advparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% set generalForm, uploadQuotaForm, notificationsForm = form.general, form.upload_quota, form.notifications %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
@@ -24,6 +24,7 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain "Admin.Advparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {%
     set smartyForm, debugModeForm, optionalFeaturesForm, combineCompressCacheForm, mediaServersForm, cachingForm, memcacheForm =

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block customer_preferences_general %}
 <div class="col">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 <div class="col">
     <div class="card" id="configuration_fieldset_products">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 <div class="col">
     <div class="card" id="configuration_fieldset_fo_product_page">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 <div class="col">
     <div class="card" id="configuration_fieldset_order_by_pagination">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 <div class="col">
     <div class="card" id="configuration_fieldset_stock">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block order_preferences_general %}
 <div class="col">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block order_preferences_gift_options %}
 <div class="col">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig
@@ -24,6 +24,7 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {%
     set generalForm = form.general

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
@@ -24,6 +24,7 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {%
   set generalForm = form.general

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig
@@ -24,6 +24,8 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
+
 
 {% block geolocation_by_ip_address %}
   <div class="card">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block localization_advanced_configuration %}
   <div class="card">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block localization_configuration %}
   <div class="card">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block localization_local_units %}
   <div class="card">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -22,6 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 <div class="table-responsive">
   <table
     class="table product mt-3"

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
@@ -86,7 +86,7 @@
         data-content="{{ "Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws."|trans({}, 'Admin.Catalog.Help') }}" ></span>
     </h2>
     <div class="row">
-       <div class="col-md-12" {{ block('widget_container_attributes') }}>
+       <div class="col-md-12" {% if block('widget_container_attributes') is defined %} {{ block('widget_container_attributes') }} {% endif %}>
           {% for child in form.additional_delivery_times %}
             {% if child.vars.value == 1 %}
               <div class="widget-radio-inline">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig
@@ -24,6 +24,7 @@
   *#}
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block content %}
   <div class="container">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block invoices_generate_by_date %}
     <div class="col">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% form_theme generateByStatusForm _self %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
+{% import 'PrestaShopBundle:Admin:macros.html.twig' as ps %}
 
 {% block invoice_options %}
     <div class="col">

--- a/src/PrestaShopBundle/Twig/AdminExtension.php
+++ b/src/PrestaShopBundle/Twig/AdminExtension.php
@@ -31,10 +31,11 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Twig extension for the Symfony Asset component.
+ * @deprecated since 1.7.4.0 to be removed in 1.8.0.0
  *
  * @author Mlanawo Mbechezi <mlanawo.mbechezi@ikimea.com>
  */
-class AdminExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface, \Twig_Extension_InitRuntimeInterface
+class AdminExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
 {
     /**
      * @var RequestStack

--- a/src/PrestaShopBundle/Twig/AdminExtension.php
+++ b/src/PrestaShopBundle/Twig/AdminExtension.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Twig extension for the Symfony Asset component.
- * @deprecated since 1.7.4.0 to be removed in 1.8.0.0
+ * @deprecated since 1.7.5.0 to be removed in 1.8.0.0
  *
  * @author Mlanawo Mbechezi <mlanawo.mbechezi@ikimea.com>
  */

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
@@ -30,9 +30,19 @@ use Tests\Integration\PrestaShopBundle\Test\WebTestCase;
 
 /**
  * @group demo
+ *
+ * To execute these tests: use "./vendor/bin/phpunit -c tests/phpunit-admin.xml --filter=SurvivalTest" command.
  */
 class SurvivalTest extends WebTestCase
 {
+    /**
+     * {@inheritdoc}
+     */
+    public static function setUpBeforeClass()
+    {
+        // Do not reset the Database.
+    }
+
     /**
      * @dataProvider getDataProvider
      * @param $pageName
@@ -80,7 +90,20 @@ class SurvivalTest extends WebTestCase
             'admin_order_preferences' => ['Order Preferences', 'admin_order_preferences'],
             'admin_maintenance' => ['Maintenance', 'admin_maintenance'],
             'admin_product_preferences' => ['Product Preferences', 'admin_product_preferences'],
-            'admin_customer_preferences' => ['Customer preferences', 'admin_customer_preferences'],
+            'admin_customer_preferences' => ['Customer Preferences', 'admin_customer_preferences'],
+            'admin_order_delivery_slip' => ['Delivery Slips', 'admin_order_delivery_slip'],
+            // @todo: why these tests are failing when pages are available?
+            // 'admin_system_information' => ['Information', 'admin_system_information'],
+            // 'admin_international_translation_overview' => ['Translations', 'admin_international_translation_overview'],
+            // 'admin_theme_catalog' => ['Themes Catalog', 'admin_theme_catalog'],
+            'admin_module_catalog' => ['Module selection', 'admin_module_catalog'],
+            'admin_module_notification' => ['Module notifications', 'admin_module_notification'],
+            'admin_module_manage' => ['Manage installed modules', 'admin_module_manage'],
+            'admin_shipping_preferences' => ['Shipping Preferences', 'admin_shipping_preferences'],
+            'admin_payment_methods' => ['Payment Methods', 'admin_payment_methods'],
+            'admin_geolocation' => ['Geolocation', 'admin_geolocation'],
+            'admin_localization_show_settings' => ['Localization', 'admin_localization_show_settings'],
+            'admin_payment_preferences' => ['Payment preferences', 'admin_payment_preferences'],
         ];
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | For people updating their Composer configuration file to use dependencies optimized for PHP 7.1+, every migrated page is broken cause of Twig 2 exceptions. Now the extensions and templates are compatibles for both Twig 1.3+ and 2.0+.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | While using PHP 7.1+, use the following command `composer update --ignore-platform-reqs` at the root of the project: you should see twig update to version 2.4.*. Now, access to every page migrated to Symfony. Go on 1.7.4.x branch and access to every page migrated to Symfony.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9259)
<!-- Reviewable:end -->
