### PR TITLE
Unexpected behavior when decreasing product quantity to negatives values

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1359,7 +1359,7 @@ class CartCore extends ObjectModel
                     $updateQuantity = '- ' . $quantity;
                     $newProductQuantity = $productQuantity + $quantity;
 
-                    if ($cartFirstLevelProductQuantity['quantity'] <= 1) {
+                    if ($cartFirstLevelProductQuantity['quantity'] - $quantity <= 0) {
                         return $this->deleteProduct((int)$id_product, (int)$id_product_attribute, (int)$id_customization);
                     }
                 } else {


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When decreasing product quantity by more than 1 and having a total quantity <= 0 the product is not deleted, this fixes this problem.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Try to decrease by more than one to become 0, the product is still in cart but with quantity 0, this creating other bugs

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9260)
<!-- Reviewable:end -->
