### PR TITLE
Update Controller name for link generation to modules catalog

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2167,7 +2167,7 @@ class AdminControllerCore extends Controller
 
     protected function getAdminModulesUrl()
     {
-        return $this->context->link->getAdminLink('AdminModulesSf');
+        return $this->context->link->getAdminLink('AdminModulesCatalog');
     }
 
     protected function filterTabModuleList()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | With the new module controller links, the "Recommended modules" link wasn't redirecting the merchant to the catalog anymore.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5704
| How to test?  | Click on recommended modules

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9261)
<!-- Reviewable:end -->
