### PR TITLE
Buyer verification before downloading the virtual product

### DIFF
--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -53,7 +53,7 @@ class GetFileControllerCore extends FrontController
             }
         } else {
             if (!($key = Tools::getValue('key'))) {
-                if(!($key = $this->context->cookie->file_key)){
+                if (!($key = $this->context->cookie->file_key)){
                     $this->displayCustomError('Invalid key.');
                 }
             }
@@ -70,7 +70,7 @@ class GetFileControllerCore extends FrontController
                 if ($order->secure_key != Tools::getValue('secure_key')) {
                     $this->displayCustomError('Invalid key.');
                 }
-                if(!in_array(1, $this->context->customer->getGroups()) || !in_array(2, $this->context->customer->getGroups())){
+                if (!in_array(1, $this->context->customer->getGroups()) || !in_array(2, $this->context->customer->getGroups())){
                     $this->context->cookie->file_key = $key;
                     Tools::redirect('index.php?controller=authentication&back=get-file.php');
                 }

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -53,12 +53,15 @@ class GetFileControllerCore extends FrontController
             }
         } else {
             if (!($key = Tools::getValue('key'))) {
-                $this->displayCustomError('Invalid key.');
+                if(!($key = $this->context->cookie->file_key)){
+                    $this->displayCustomError('Invalid key.');
+                }
             }
 
             Tools::setCookieLanguage();
             if (!$this->context->customer->isLogged() && !Tools::getValue('secure_key') && !Tools::getValue('id_order')) {
-                Tools::redirect('index.php?controller=authentication&back=get-file.php&key='.$key);
+                $this->context->cookie->file_key = $key;
+                Tools::redirect('index.php?controller=authentication&back=get-file.php');
             } elseif (!$this->context->customer->isLogged() && Tools::getValue('secure_key') && Tools::getValue('id_order')) {
                 $order = new Order((int)Tools::getValue('id_order'));
                 if (!Validate::isLoadedObject($order)) {
@@ -66,6 +69,10 @@ class GetFileControllerCore extends FrontController
                 }
                 if ($order->secure_key != Tools::getValue('secure_key')) {
                     $this->displayCustomError('Invalid key.');
+                }
+                if(!in_array(1, $this->context->customer->getGroups()) || !in_array(2, $this->context->customer->getGroups())){
+                    $this->context->cookie->file_key = $key;
+                    Tools::redirect('index.php?controller=authentication&back=get-file.php');
                 }
             }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Currently when you buy a virtual product, you can share the download link and download the product without credentials of the customer account.
| Type?         | new feature
| Category?     | FO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5864
| How to test?  | Make an order with a virtual product, place the order in accepted payment, disconnect from the customer area, click on the download link of the product in the download email, enter your login details to download the virtual product.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9262)
<!-- Reviewable:end -->
