### PR TITLE
Unable to copy theme translations

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -402,10 +402,10 @@ class AdminTranslationsControllerCore extends AdminController
         } else {
             $theme_exists = array('from_theme' => false, 'to_theme' => false);
             foreach ($this->themes as $theme) {
-                if ($theme->getDirectory() == $from_theme) {
+                if ($theme->getName() == $from_theme) {
                     $theme_exists['from_theme'] = true;
                 }
-                if ($theme->getDirectory() == $to_theme) {
+                if ($theme->getName() == $to_theme) {
                     $theme_exists['to_theme'] = true;
                 }
             }


### PR DESCRIPTION
While copying theme translations prestashop shows message about non existing themes. It tries to match directory to a theme name. I dunno if its bug on form side, and $from_theme and $to_theme should be directories or prestashop should match names with names rather than directories. This helped to copy most of the translations. but I still received an error message "Unable to copy "/var/www/html/lagaminai/themes/classic/lang/lt.php" to "/var/www/html/lagaminai/themes/***/lang/lt.php""

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | 1.7.4.0 PS version
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try copying theme translations before and after.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9267)
<!-- Reviewable:end -->
