### PR TITLE
Catch more exceptions during install & display the error intead of a JS error

### DIFF
--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -82,42 +82,46 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
             $this->session->process_validated = array();
         }
 
-        if (Tools::getValue('generateSettingsFile')) {
-            $this->processGenerateSettingsFile();
-        } elseif (Tools::getValue('installDatabase') && !empty($this->session->process_validated['generateSettingsFile'])) {
-            $this->processInstallDatabase();
-        } elseif (Tools::getValue('installDefaultData')) {
-            $this->processInstallDefaultData();
-        } elseif (Tools::getValue('populateDatabase') && !empty($this->session->process_validated['installDatabase'])) {
-            $this->processPopulateDatabase();
-            // download and install language pack
-            Language::downloadAndInstallLanguagePack($this->session->lang);
-        } elseif (Tools::getValue('configureShop') && !empty($this->session->process_validated['populateDatabase'])) {
-            Language::getRtlStylesheetProcessor()
-                ->setIsInstall(true)
-                ->setLanguageCode($this->session->lang)
-                ->setProcessFOThemes(array('classic'))
-                ->process();
-            $this->processConfigureShop();
-        } elseif (Tools::getValue('installFixtures') && !empty($this->session->process_validated['configureShop'])) {
-            $this->processInstallFixtures();
-        } elseif (Tools::getValue('installModules') && (!empty($this->session->process_validated['installFixtures']) || $this->session->install_type != 'full')) {
-            $this->processInstallModules();
-        } elseif (Tools::getValue('installModulesAddons') && !empty($this->session->process_validated['installModules'])) {
-            $this->processInstallAddonsModules();
-        } elseif (Tools::getValue('installTheme') && !empty($this->session->process_validated['installModulesAddons'])) {
-            $this->processInstallTheme();
-        } else {
-            // With no parameters, we consider that we are doing a new install, so session where the last process step
-            // was stored can be cleaned
-            if (Tools::getValue('restart')) {
-                $this->session->process_validated = array();
-                $this->session->database_clear = true;
-            } elseif (!Tools::getValue('submitNext')) {
-                $this->session->step = 'configure';
-                $this->session->last_step = 'configure';
-                Tools::redirect('index.php');
+        try {
+            if (Tools::getValue('generateSettingsFile')) {
+                $this->processGenerateSettingsFile();
+            } elseif (Tools::getValue('installDatabase') && !empty($this->session->process_validated['generateSettingsFile'])) {
+                $this->processInstallDatabase();
+            } elseif (Tools::getValue('installDefaultData')) {
+                $this->processInstallDefaultData();
+            } elseif (Tools::getValue('populateDatabase') && !empty($this->session->process_validated['installDatabase'])) {
+                $this->processPopulateDatabase();
+                // download and install language pack
+                Language::downloadAndInstallLanguagePack($this->session->lang);
+            } elseif (Tools::getValue('configureShop') && !empty($this->session->process_validated['populateDatabase'])) {
+                Language::getRtlStylesheetProcessor()
+                    ->setIsInstall(true)
+                    ->setLanguageCode($this->session->lang)
+                    ->setProcessFOThemes(array('classic'))
+                    ->process();
+                $this->processConfigureShop();
+            } elseif (Tools::getValue('installFixtures') && !empty($this->session->process_validated['configureShop'])) {
+                $this->processInstallFixtures();
+            } elseif (Tools::getValue('installModules') && (!empty($this->session->process_validated['installFixtures']) || $this->session->install_type != 'full')) {
+                $this->processInstallModules();
+            } elseif (Tools::getValue('installModulesAddons') && !empty($this->session->process_validated['installModules'])) {
+                $this->processInstallAddonsModules();
+            } elseif (Tools::getValue('installTheme') && !empty($this->session->process_validated['installModulesAddons'])) {
+                $this->processInstallTheme();
             }
+        } catch (\Exception $e) {
+            $this->ajaxJsonAnswer(false, $e->getMessage());
+        }
+
+        // With no parameters, we consider that we are doing a new install, so session where the last process step
+        // was stored can be cleaned
+        if (Tools::getValue('restart')) {
+            $this->session->process_validated = array();
+            $this->session->database_clear = true;
+        } elseif (!Tools::getValue('submitNext')) {
+            $this->session->step = 'configure';
+            $this->session->last_step = 'configure';
+            Tools::redirect('index.php');
         }
     }
 

--- a/install-dev/theme/js/process.js
+++ b/install-dev/theme/js/process.js
@@ -177,7 +177,7 @@ function install_error(step, errors)
 			list_errors = [];
 			list_errors[0] = errors;
 		} else if ($.type(list_errors) == 'array') {
-			list_errors = list_errors[0];
+			list_errors = [list_errors[0]];
 		}
 
 		var display = '<ol>';

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -478,39 +478,46 @@ class Install extends AbstractInstall
             $xml_loader->setIds($this->xml_loader_ids);
         }
 
-        if ($entity) {
-            $xml_loader->populateEntity($entity);
-        } else {
-            $xml_loader->populateFromXmlFiles();
-        }
-        if ($errors = $xml_loader->getErrors()) {
-            $this->setError($errors);
-            return false;
-        }
-
-        // IDS from xmlLoader are stored in order to use them for fixtures
-        $this->xml_loader_ids = $xml_loader->getIds();
-        unset($xml_loader);
-
-        // Install custom SQL data (db_data.sql file)
-        if (file_exists(_PS_INSTALL_DATA_PATH_.'db_data.sql')) {
-            $sql_loader = new SqlLoader();
-            $sql_loader->setMetaData(array(
-                'PREFIX_' => _DB_PREFIX_,
-                'ENGINE_TYPE' => _MYSQL_ENGINE_,
-            ));
-
-            $sql_loader->parse_file(_PS_INSTALL_DATA_PATH_.'db_data.sql', false);
-            if ($errors = $sql_loader->getErrors()) {
+        try {
+            if ($entity) {
+                $xml_loader->populateEntity($entity);
+            } else {
+                $xml_loader->populateFromXmlFiles();
+            }
+            if ($errors = $xml_loader->getErrors()) {
                 $this->setError($errors);
                 return false;
             }
+
+            // IDS from xmlLoader are stored in order to use them for fixtures
+            $this->xml_loader_ids = $xml_loader->getIds();
+            unset($xml_loader);
+
+            // Install custom SQL data (db_data.sql file)
+            if (file_exists(_PS_INSTALL_DATA_PATH_.'db_data.sql')) {
+                $sql_loader = new SqlLoader();
+                $sql_loader->setMetaData(array(
+                    'PREFIX_' => _DB_PREFIX_,
+                    'ENGINE_TYPE' => _MYSQL_ENGINE_,
+                ));
+
+                $sql_loader->parse_file(_PS_INSTALL_DATA_PATH_.'db_data.sql', false);
+                if ($errors = $sql_loader->getErrors()) {
+                    $this->setError($errors);
+                    return false;
+                }
+            }
+
+            // Copy language default images (we do this action after database in populated because we need image types information)
+            foreach ($languages as $iso) {
+                $this->copyLanguageImages($iso);
+            }
+
+        } catch (PrestashopInstallerException $e) {
+            $this->setError($e->getMessage());
+            return false;
         }
 
-        // Copy language default images (we do this action after database in populated because we need image types information)
-        foreach ($languages as $iso) {
-            $this->copyLanguageImages($iso);
-        }
 
         return true;
     }
@@ -577,6 +584,7 @@ class Install extends AbstractInstall
                 EntityLanguage::downloadAndInstallLanguagePack($iso);
                 continue;
             }
+
             if (!file_exists(_PS_INSTALL_LANGS_PATH_.$iso.'/language.xml')) {
                 throw new PrestashopInstallerException($this->translator->trans('File "language.xml" not found for language iso "%iso%"', array('%iso%' => $iso), 'Install'));
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Some exceptions are not catched during the installation which lead to a 500 error instead of a message displayed. Also, in some case, the error message is not displayed (JS error).
| Type?         | bug fix 
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9271)
<!-- Reviewable:end -->
