### PR TITLE
Localization downloads does not work without allow_url_fopen

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1090,8 +1090,30 @@ class LanguageCore extends ObjectModel
             // @todo Throw exception
             $errors[] = Context::getContext()->getTranslator()->trans('Server does not have permissions for writing.', array(), 'Admin.International.Notification').' ('.$file.')';
         } else {
-            $fs = new Filesystem();
-            $fs->copy($url, $file, true);
+
+            if (function_exists('curl_init')) {
+
+                $ch = curl_init($url);
+                curl_setopt($ch, CURLOPT_HEADER, 1);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+                curl_setopt($ch, CURLOPT_BINARYTRANSFER, 1);
+                curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
+                $raw_file_data = curl_exec($ch);
+           
+                if(curl_errno($ch)){
+                   echo 'error:' . curl_error($ch);
+                }
+                curl_close($ch);
+           
+                file_put_contents($file, $raw_file_data);
+                
+            } elseif (in_array(ini_get('allow_url_fopen'), array('On', 'on', '1'))) {
+
+                $fs = new Filesystem();
+                $fs->copy($url, $file, true);
+
+            }
+            
         }
     }
 

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Core\Cldr\Repository as cldrRepository;
 use PrestaShop\PrestaShop\Core\Localization\RTL\Processor as RtlStylesheetProcessor;
 use PrestaShopBundle\Translation\Translator;
 use Symfony\Component\Filesystem\Filesystem;
+use Exception;
 
 class LanguageCore extends ObjectModel
 {
@@ -686,7 +687,7 @@ class LanguageCore extends ObjectModel
             $allLanguages = json_decode($allLanguages, true);
 
             if (JSON_ERROR_NONE !== json_last_error()) {
-                throw new \Exception(
+                throw new Exception(
                     sprintf(
                         'The legacy to standard locales JSON could not be decoded %s',
                         json_last_error_msg()
@@ -737,7 +738,7 @@ class LanguageCore extends ObjectModel
 
         $jsonLastErrorCode = json_last_error();
         if (JSON_ERROR_NONE !== $jsonLastErrorCode) {
-            throw new \Exception('The legacy to standard locales JSON could not be decoded', $jsonLastErrorCode);
+            throw new Exception('The legacy to standard locales JSON could not be decoded', $jsonLastErrorCode);
         }
 
         return $allLanguages[$iso] ?: false;
@@ -1100,8 +1101,8 @@ class LanguageCore extends ObjectModel
                 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
                 $raw_file_data = curl_exec($ch);
            
-                if (curl_errno($ch)){
-                    throw new \Exception(
+                if (curl_errno($ch)) {
+                    throw new Exception(
                         sprintf(
                             'Download of localization package failed %s',
                             curl_error($ch)
@@ -1118,7 +1119,7 @@ class LanguageCore extends ObjectModel
                 $fs->copy($url, $file, true);
 
             } else {
-                throw new \Exception('No download methods available');
+                throw new Exception('No download methods available');
             }
             
         }

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1100,8 +1100,13 @@ class LanguageCore extends ObjectModel
                 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
                 $raw_file_data = curl_exec($ch);
            
-                if(curl_errno($ch)){
-                   echo 'error:' . curl_error($ch);
+                if (curl_errno($ch)){
+                    throw new \Exception(
+                        sprintf(
+                            'Download of localization package failed %s',
+                            curl_error($ch)
+                        )
+                    );
                 }
                 curl_close($ch);
            
@@ -1112,6 +1117,8 @@ class LanguageCore extends ObjectModel
                 $fs = new Filesystem();
                 $fs->copy($url, $file, true);
 
+            } else {
+                throw new \Exception('No download methods available');
             }
             
         }


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.4.x
| Description?  | The localization package download only worked with fopen and not curl. This commit includes a curl implementation for the package download, and in alignment with #7114 curl is the default and fopen is the fallback.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Disable allow_url_fopen and notice that downloads of packages still works. Without this commit the download of packages will fail with a 500 or with debug enabled an error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9273)
<!-- Reviewable:end -->
