### PR TITLE
Fix product quantity in order return details table

### DIFF
--- a/themes/classic/templates/customer/order-return.tpl
+++ b/themes/classic/templates/customer/order-return.tpl
@@ -90,13 +90,7 @@
                 {/if}
               </td>
               <td>
-                {if !$product.customizations}
-                  {$product.product_quantity}
-                {else}
-                  {foreach $product.customizations as $customization}
-                    {$customization.quantity}
-                  {/foreach}
-                {/if}
+                {$product.product_quantity}
               </td>
             </tr>
           {/foreach}

--- a/themes/classic/templates/customer/order-return.tpl
+++ b/themes/classic/templates/customer/order-return.tpl
@@ -90,7 +90,7 @@
                 {/if}
               </td>
               <td>
-                {if $product.customizations}
+                {if !$product.customizations}
                   {$product.product_quantity}
                 {else}
                   {foreach $product.customizations as $customization}


### PR DESCRIPTION
In order return details page (customer/order-return.tpl), in the products to be returned table, quantity column is empty. This PR fixes that.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In order return details page (customer/order-return.tpl), in the products to be returned table, quantity column is empty. This PR fixes that.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5920
| How to test?  | Make an order, go to acount ->orders -_order details and request a return. Go to return details and see that the quantity column in the products to be returned table is now correct
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9276)
<!-- Reviewable:end -->
