### PR TITLE
FO: 1.7.4.x version for  Fix product quantity in order return details table #9276

### DIFF
--- a/admin-dev/backups/.htaccess
+++ b/admin-dev/backups/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/admin-dev/export/.htaccess
+++ b/admin-dev/export/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/admin-dev/import/.htaccess
+++ b/admin-dev/import/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,7 +1,10 @@
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
-</IfModule>
-<IfModule !mod_authz_core.c>
-    Order deny,allow
-    Deny from all
 </IfModule>

--- a/bin/.htaccess
+++ b/bin/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/classes/.htaccess
+++ b/classes/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -328,8 +328,8 @@ class CartRuleCore extends ObjectModel
                 '" AND `id_customer` IN (0,' . (int)$idCustomer . ') LIMIT 1)';
 
             $sql .= 'UNION ALL (SELECT 1 FROM `' . _DB_PREFIX_ . 'cart_rule` ' .
-                'WHERE date_to < "' . date('Y-m-d 00:00:00') .
-                '" AND date_from > "' . date('Y-m-d 23:59:59') .
+                'WHERE date_from < "' . date('Y-m-d 00:00:00') .
+                '" AND date_to > "' . date('Y-m-d 23:59:59') .
                 '" AND `id_customer` IN (0,' . (int)$idCustomer . ') LIMIT 1) LIMIT 1';
 
             $haveCartRuleToday[$idCustomer] = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -317,9 +317,20 @@ class CartRuleCore extends ObjectModel
         static $haveCartRuleToday = array();
 
         if (!isset($haveCartRuleToday[$idCustomer])) {
-            $sql = 'SELECT 1 FROM `' . _DB_PREFIX_ . 'cart_rule` ' .
-                 'WHERE NOW() BETWEEN date_from AND date_to '.
-                 'AND `id_customer` IN (0,' . (int)$idCustomer . ') LIMIT 1';
+            $sql = '(SELECT 1 FROM `' . _DB_PREFIX_ . 'cart_rule` ' .
+                'WHERE date_to >= "' . date('Y-m-d 00:00:00') .
+                '" AND date_to <= "' . date('Y-m-d 23:59:59') .
+                '" AND `id_customer` IN (0,' . (int)$idCustomer . ') LIMIT 1)';
+
+            $sql .= 'UNION ALL (SELECT 1 FROM `' . _DB_PREFIX_ . 'cart_rule` ' .
+                'WHERE date_from >= "' . date('Y-m-d 00:00:00') .
+                '" AND date_from <= "' . date('Y-m-d 23:59:59') .
+                '" AND `id_customer` IN (0,' . (int)$idCustomer . ') LIMIT 1)';
+
+            $sql .= 'UNION ALL (SELECT 1 FROM `' . _DB_PREFIX_ . 'cart_rule` ' .
+                'WHERE date_to < "' . date('Y-m-d 00:00:00') .
+                '" AND date_from > "' . date('Y-m-d 23:59:59') .
+                '" AND `id_customer` IN (0,' . (int)$idCustomer . ') LIMIT 1) LIMIT 1';
 
             $haveCartRuleToday[$idCustomer] = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
         }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2351,21 +2351,15 @@ class ToolsCore
                 if ($uri['virtual']) {
                     if (!$rewrite_settings) {
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^'.trim($uri['virtual'], '/').'/?$ '.$uri['physical'].$uri['virtual']."index.php [L,R]\n");
                     } else {
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^'.trim($uri['virtual'], '/').'$ '.$uri['physical'].$uri['virtual']." [L,R]\n");
                     }
                     fwrite($write_fd, $media_domains);
-                    if (Shop::isFeatureActive()) {
-                        fwrite($write_fd, $domain_rewrite_cond);
-                    }
+                    fwrite($write_fd, $domain_rewrite_cond);
                     fwrite($write_fd, 'RewriteRule ^'.ltrim($uri['virtual'], '/').'(.*) '.$uri['physical']."$1 [L]\n\n");
                 }
 
@@ -2374,14 +2368,10 @@ class ToolsCore
                     fwrite($write_fd, "# Images\n");
                     if (Configuration::get('PS_LEGACY_IMAGES')) {
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/p/$1-$2$3$4.jpg [L]'."\n");
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^([0-9]+)\-([0-9]+)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/p/$1-$2$3.jpg [L]'."\n");
                     }
 
@@ -2394,20 +2384,14 @@ class ToolsCore
                         }
                         $img_name .= '$'.$j;
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^'.str_repeat('([0-9])', $i).'(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/p/'.$img_path.$img_name.'$'.($j + 1).".jpg [L]\n");
                     }
                     fwrite($write_fd, $media_domains);
-                    if (Shop::isFeatureActive()) {
-                        fwrite($write_fd, $domain_rewrite_cond);
-                    }
+                    fwrite($write_fd, $domain_rewrite_cond);
                     fwrite($write_fd, 'RewriteRule ^c/([0-9]+)(\-[\.*_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2$3.jpg [L]'."\n");
                     fwrite($write_fd, $media_domains);
-                    if (Shop::isFeatureActive()) {
-                        fwrite($write_fd, $domain_rewrite_cond);
-                    }
+                    fwrite($write_fd, $domain_rewrite_cond);
                     fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-]+)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2.jpg [L]'."\n");
                 }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2167,7 +2167,7 @@ class AdminControllerCore extends Controller
 
     protected function getAdminModulesUrl()
     {
-        return $this->context->link->getAdminLink('AdminModulesSf');
+        return $this->context->link->getAdminLink('AdminModulesCatalog');
     }
 
     protected function filterTabModuleList()

--- a/composer.lock
+++ b/composer.lock
@@ -3707,16 +3707,16 @@
         },
         {
             "name": "prestashop/ps_themecusto",
-            "version": "v1.0.5",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_themecusto.git",
-                "reference": "e198abbd17b3aaa5a4c09e34bb65f8552b9ee832"
+                "reference": "b52fa3b11f03c38389eda33ba6de5123f1d4fc84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_themecusto/zipball/e198abbd17b3aaa5a4c09e34bb65f8552b9ee832",
-                "reference": "e198abbd17b3aaa5a4c09e34bb65f8552b9ee832",
+                "url": "https://api.github.com/repos/PrestaShop/ps_themecusto/zipball/b52fa3b11f03c38389eda33ba6de5123f1d4fc84",
+                "reference": "b52fa3b11f03c38389eda33ba6de5123f1d4fc84",
                 "shasum": ""
             },
             "require": {
@@ -3735,7 +3735,7 @@
             ],
             "description": "PrestaShop module ps_themecusto",
             "homepage": "https://github.com/PrestaShop/ps_themecusto",
-            "time": "2018-06-25T13:27:25+00:00"
+            "time": "2018-07-05T13:22:53+00:00"
         },
         {
             "name": "prestashop/ps_wirepayment",

--- a/config/.htaccess
+++ b/config/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -124,7 +124,7 @@ function smartyWidgetBlock($params, $content, &$smarty)
         withWidget($params, function ($widget, $params) use (&$smarty, &$backedUpVariablesStack) {
             // Assign widget variables and backup all the variables they override
             $currentVariables = $smarty->getTemplateVars();
-            $scopedVariables = $widget->getWidgetVariables(null, $params);
+            $scopedVariables = $widget->getWidgetVariables(isset($params['hook']) ? $params['hook'] : null, $params);
             $backedUpVariables = array();
             foreach ($scopedVariables as $key => $value) {
                 if (array_key_exists($key, $currentVariables)) {

--- a/config/xml/.htaccess
+++ b/config/xml/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/controllers/.htaccess
+++ b/controllers/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/docs/.htaccess
+++ b/docs/.htaccess
@@ -1,1 +1,10 @@
-Deny from ALL
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/docs/csv_import/.htaccess
+++ b/docs/csv_import/.htaccess
@@ -1,1 +1,10 @@
-Allow from ALL
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order alllow, deny
+    Allow from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all granted
+</IfModule>

--- a/download/.htaccess
+++ b/download/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/img/.htaccess
+++ b/img/.htaccess
@@ -1,8 +1,20 @@
 <IfModule mod_php5.c>
 	php_flag engine off
 </IfModule>
-deny from all
-<Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico)$">
-	order deny,allow
-	allow from all
-</Files>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico)$">
+        Allow from all
+    </Files>
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico)$">
+        Require all granted
+    </Files>
+</IfModule>

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -208,7 +208,9 @@ CREATE TABLE `PREFIX_cart_rule` (
 	KEY `id_customer` (`id_customer`, `active`, `date_to`),
 	KEY `group_restriction` (`group_restriction`, `active`, `date_to`),
 	KEY `id_customer_2` (`id_customer`,`active`,`highlight`,`date_to`),
-  KEY `group_restriction_2` (`group_restriction`,`active`,`highlight`,`date_to`)
+  KEY `group_restriction_2` (`group_restriction`,`active`,`highlight`,`date_to`),
+  KEY `date_from` (`date_from`),
+  KEY `date_to` (`date_to`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 
 /* Localized name assocatied with a promo code */

--- a/install-dev/upgrade/sql/1.7.4.1.sql
+++ b/install-dev/upgrade/sql/1.7.4.1.sql
@@ -1,0 +1,4 @@
+SET SESSION sql_mode = '';
+SET NAMES 'utf8';
+
+ALTER TABLE `PREFIX_cart_rule` ADD KEY `date_from` (`date_from`), ADD KEY `date_to` (`date_to`);

--- a/localization/.htaccess
+++ b/localization/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/mails/.htaccess
+++ b/mails/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/modules/.htaccess
+++ b/modules/.htaccess
@@ -1,3 +1,12 @@
 <FilesMatch "\.tpl$">
-Deny from all
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order deny, allow
+        Deny from all
+    </IfModule>
+
+    # Apache 2.4
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
 </FilesMatch>

--- a/override/.htaccess
+++ b/override/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/pdf/.htaccess
+++ b/pdf/.htaccess
@@ -1,3 +1,12 @@
 <FilesMatch "\.tpl$">
-Deny from all
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order deny, allow
+        Deny from all
+    </IfModule>
+
+    # Apache 2.4
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
 </FilesMatch>

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,7 +1,10 @@
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
-</IfModule>
-<IfModule !mod_authz_core.c>
-    Order deny,allow
-    Deny from all
 </IfModule>

--- a/tests/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests/Unit/Core/Cart/AbstractCartTest.php
@@ -274,7 +274,7 @@ abstract class AbstractCartTest extends IntegrationTestCase
         }
         $now = new DateTime();
         // sub 1s to avoid bad comparisons with strictly greater than
-        $now->sub(new DateInterval('PT1S'));
+        $now->sub(new DateInterval('P2D'));
         $cartRule->date_from = $now->format('Y-m-d H:i:s');
         $now->add(new DateInterval('P1Y'));
         $cartRule->date_to = $now->format('Y-m-d H:i:s');

--- a/tests/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
+++ b/tests/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
@@ -76,6 +76,7 @@ class AddRuleTest extends AbstractCartTest
             $this->cart->addCartRule($cartRule->id);
         }
         $this->assertEquals($shouldRulesBeApplied, $result);
+        $this->assertTrue( \CartRule::haveCartRuleToday(0));
         $this->assertEquals($expectedProductCountAfterRules, Cart::getNbProducts($this->cart->id));
     }
 

--- a/tests/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
+++ b/tests/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
@@ -29,6 +29,7 @@ namespace Tests\Unit\Core\Cart\Adding\CartRule;
 use Cart;
 use Configuration;
 use Tests\Unit\Core\Cart\AbstractCartTest;
+use CartRule;
 
 class AddRuleTest extends AbstractCartTest
 {
@@ -76,7 +77,7 @@ class AddRuleTest extends AbstractCartTest
             $this->cart->addCartRule($cartRule->id);
         }
         $this->assertEquals($shouldRulesBeApplied, $result);
-        $this->assertTrue( \CartRule::haveCartRuleToday(0));
+        $this->assertTrue(CartRule::haveCartRuleToday(0));
         $this->assertEquals($expectedProductCountAfterRules, Cart::getNbProducts($this->cart->id));
     }
 

--- a/themes/.htaccess
+++ b/themes/.htaccess
@@ -1,3 +1,12 @@
 <FilesMatch "\.tpl$">
-Deny from all
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order deny, allow
+        Deny from all
+    </IfModule>
+
+    # Apache 2.4
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
 </FilesMatch>

--- a/themes/classic/_dev/.htaccess
+++ b/themes/classic/_dev/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/themes/classic/config/.htaccess
+++ b/themes/classic/config/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/themes/classic/templates/checkout/_partials/cart-summary-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary-product-line.tpl
@@ -34,10 +34,10 @@
     <span class="product-price float-xs-right">{$product.price}</span>
     {hook h='displayProductPriceBlock' product=$product type="unit_price"}
     {foreach from=$product.attributes key="attribute" item="value"}
-	<div class="product-line-info product-line-info-secondary text-muted">
-	<span class="label">{$attribute}:</span>
-	<span class="value">{$value}</span>
-	</div>
+		<div class="product-line-info product-line-info-secondary text-muted">
+		<span class="label">{$attribute}:</span>
+		<span class="value">{$value}</span>
+		</div>
 	{/foreach}
 	<br/>
   </div>

--- a/themes/classic/templates/checkout/_partials/cart-summary-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary-product-line.tpl
@@ -33,5 +33,12 @@
     <span class="product-quantity">x{$product.quantity}</span>
     <span class="product-price float-xs-right">{$product.price}</span>
     {hook h='displayProductPriceBlock' product=$product type="unit_price"}
+    {foreach from=$product.attributes key="attribute" item="value"}
+	<div class="product-line-info product-line-info-secondary text-muted">
+	<span class="label">{$attribute}:</span>
+	<span class="value">{$value}</span>
+	</div>
+	{/foreach}
+	<br/>
   </div>
 {/block}

--- a/themes/classic/templates/checkout/_partials/cart-summary-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary-product-line.tpl
@@ -34,11 +34,11 @@
     <span class="product-price float-xs-right">{$product.price}</span>
     {hook h='displayProductPriceBlock' product=$product type="unit_price"}
     {foreach from=$product.attributes key="attribute" item="value"}
-		<div class="product-line-info product-line-info-secondary text-muted">
-		<span class="label">{$attribute}:</span>
-		<span class="value">{$value}</span>
-		</div>
-	{/foreach}
-	<br/>
+        <div class="product-line-info product-line-info-secondary text-muted">
+            <span class="label">{$attribute}:</span>
+            <span class="value">{$value}</span>
+        </div>
+    {/foreach}
+    <br/>
   </div>
 {/block}

--- a/themes/classic/templates/customer/order-return.tpl
+++ b/themes/classic/templates/customer/order-return.tpl
@@ -90,7 +90,7 @@
                 {/if}
               </td>
               <td>
-                {if $product.customizations}
+                {if !$product.customizations}
                   {$product.product_quantity}
                 {else}
                   {foreach $product.customizations as $customization}

--- a/tools/htmlpurifier/.htaccess
+++ b/tools/htmlpurifier/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/tools/parser_sql/.htaccess
+++ b/tools/parser_sql/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/tools/profiling/.htaccess
+++ b/tools/profiling/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/translations/.htaccess
+++ b/translations/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/var/.htaccess
+++ b/var/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/vendor/.htaccess
+++ b/vendor/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Deny from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny, allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4x
| Description?  | https://github.com/PrestaShop/PrestaShop/pull/9276; n order return details page (customer/order-return.tpl), in the products to be returned table, quantity column is empty. This PR fixes that.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5920
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9277)
<!-- Reviewable:end -->
