### PR TITLE
Fatal while adding tags

### DIFF
--- a/classes/Tag.php
+++ b/classes/Tag.php
@@ -131,9 +131,13 @@ class TagCore extends ObjectModel
         }
         $data = rtrim($data, ',');
 
-        $result = Db::getInstance()->execute('
-        INSERT INTO `'._DB_PREFIX_.'product_tag` (`id_tag`, `id_product`, `id_lang`)
-        VALUES '.$data);
+        $result = true;
+        if (!empty($data)) {
+            $result = Db::getInstance()->execute('
+                INSERT INTO `'._DB_PREFIX_.'product_tag` (`id_tag`, `id_product`, `id_lang`)
+                VALUES '.$data
+            );
+        }
 
         if ($list != array()) {
             self::updateTagCount($list);


### PR DESCRIPTION
This fatal error occurs when $data variable happens to be empty, commonly when used with import addons.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | Use the "develop" branch if you target the next major version of PrestaShop 1.7, "1.7.4.x" for 1.7 bug fixes, and "1.6.1.x" for PrestaShop 1.6 (bugfixes only).
| Description?  | Please be specific when describing the PR. <br/> Every detail helps: versions, browser/server configuration, specific module/theme, etc.
| Type?         | bug fix / improvement / new feature
| Category?     | See [the Category list](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message#Howtowriteacommitmessage-Category), i.e.: BO
| BC breaks?    | Does it break backward compatibility? yes/no
| Deprecations? | Does it deprecate an existing feature? yes/no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9278)
<!-- Reviewable:end -->
