### PR TITLE
Fix detection of APCu on Performance page

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -61,6 +61,7 @@ class CachingType extends TranslatorAwareType
                     $disabled = false;
                     foreach ($this->extensionsList[$index] as $extensionName) {
                         if (extension_loaded($extensionName)) {
+                            $disabled = false;
                             break;
                         }
                         $disabled = true;
@@ -72,6 +73,7 @@ class CachingType extends TranslatorAwareType
                     $disabled = false;
                     foreach ($this->extensionsList[$index] as $extensionName) {
                         if (extension_loaded($extensionName)) {
+                            $disabled = false;
                             break;
                         }
                         $disabled = true;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | PrestaShop 1.7 does not detect the APCu extension on the Performance page, even though it is supported.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Install APCu and the CacheApc option should be selectable.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9279)
<!-- Reviewable:end -->
