### PR TITLE
Feature: Initiate RTE on Store edit page

### DIFF
--- a/classes/Store.php
+++ b/classes/Store.php
@@ -109,7 +109,7 @@ class StoreCore extends ObjectModel
             'address1' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isAddress', 'required' => true, 'size' => 255),
             'address2' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isAddress', 'size' => 255),
             'hours' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isJson', 'size' => 65000),
-            'note' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCleanHtml', 'size' => 65000),
+            'note' => array('type' => self::TYPE_HTML, 'lang' => true, 'validate' => 'isCleanHtml', 'size' => 65000),
         ),
     );
 

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -242,7 +242,8 @@ class AdminStoresControllerCore extends AdminController
                     'name' => 'note',
                     'lang' => true,
                     'cols' => 42,
-                    'rows' => 4
+                    'rows' => 10,
+                    'autoload_rte' => true
                 ),
                 array(
                     'type' => 'switch',

--- a/themes/classic/templates/cms/stores.tpl
+++ b/themes/classic/templates/cms/stores.tpl
@@ -65,7 +65,7 @@
           <div class="store-item-footer divide-top">
             <div class="card-block">
               {if $store.note}
-                <p class="text-justify">{$store.note}<p>
+                <p class="text-justify">{$store.note nofilter}<p>
               {/if}
             </div>
             <ul class="card-block">


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There is no need to disallow RTE on store edit page. People may want to add some more photos ir description from ms word or something. I face this change 8 times out of 10 when client has multiple stores.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | -

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9280)
<!-- Reviewable:end -->
