### PR TITLE
Fix Cart::isVirtualCart() method when cart is empty

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3909,9 +3909,9 @@ class CartCore extends ObjectModel
     {
         return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
             'SELECT 1 FROM '._DB_PREFIX_.'cart_product cp '.
-            'JOIN '._DB_PREFIX_.'product p
+            'INNER JOIN '._DB_PREFIX_.'product p
                 ON (p.id_product = cp.id_product) '.
-            'JOIN '._DB_PREFIX_.'product_shop ps
+            'INNER JOIN '._DB_PREFIX_.'product_shop ps
                 ON (ps.id_shop = cp.id_shop AND ps.id_product = p.id_product) '.
             'WHERE cp.id_cart='.(int)$this->id
         );
@@ -3926,9 +3926,9 @@ class CartCore extends ObjectModel
     {
         return $this->hasProducts() && (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
             'SELECT 1 FROM '._DB_PREFIX_.'cart_product cp '.
-            'JOIN '._DB_PREFIX_.'product p
+            'INNER JOIN '._DB_PREFIX_.'product p
                 ON (p.is_virtual = 0 AND p.id_product = cp.id_product) '.
-            'JOIN '._DB_PREFIX_.'product_shop ps
+            'INNER JOIN '._DB_PREFIX_.'product_shop ps
                 ON (ps.id_shop = cp.id_shop AND ps.id_product = p.id_product) '.
             'WHERE cp.id_cart='.(int)$this->id
         );

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2152,6 +2152,10 @@ class CartCore extends ObjectModel
     {
         static $address = array();
 
+        if (!count($this->getProducts())) {
+            return 0;
+        }
+
         $wrapping_fees = (float)Configuration::get('PS_GIFT_WRAPPING_PRICE');
 
         if ($wrapping_fees <= 0) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3888,8 +3888,7 @@ class CartCore extends ObjectModel
         }
 
         if (!isset(self::$_isVirtualCart[$this->id])) {
-            $products = $this->getProducts();
-            if (!count($products)) {
+            if (!$this->hasProducts()) {
                 $isVirtual = false;
             } else {
                 $isVirtual = !$this->hasRealProducts();
@@ -3902,13 +3901,30 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * Check if there's a product in the cart
+     *
+     * @return bool
+     */
+    public function hasProducts()
+    {
+        return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+            'SELECT 1 FROM '._DB_PREFIX_.'cart_product cp '.
+            'JOIN '._DB_PREFIX_.'product p
+                ON (p.id_product = cp.id_product) '.
+            'JOIN '._DB_PREFIX_.'product_shop ps
+                ON (ps.id_shop = cp.id_shop AND ps.id_product = p.id_product) '.
+            'WHERE cp.id_cart='.(int)$this->id
+        );
+    }
+
+    /**
      * Return true if the current cart contains a real product
      *
      * @return bool
      */
     public function hasRealProducts()
     {
-        return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+        return $this->hasProducts() && (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
             'SELECT 1 FROM '._DB_PREFIX_.'cart_product cp '.
             'JOIN '._DB_PREFIX_.'product p
                 ON (p.is_virtual = 0 AND p.id_product = cp.id_product) '.

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3924,7 +3924,7 @@ class CartCore extends ObjectModel
      */
     public function hasRealProducts()
     {
-        return $this->hasProducts() && (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+        return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
             'SELECT 1 FROM '._DB_PREFIX_.'cart_product cp '.
             'INNER JOIN '._DB_PREFIX_.'product p
                 ON (p.is_virtual = 0 AND p.id_product = cp.id_product) '.

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3888,7 +3888,12 @@ class CartCore extends ObjectModel
         }
 
         if (!isset(self::$_isVirtualCart[$this->id])) {
-            $isVirtual = !$this->hasRealProducts();
+            $products = $this->getProducts();
+            if (!count($products)) {
+                $isVirtual = false;
+            } else {
+                $isVirtual = !$this->hasRealProducts();
+            }
 
             self::$_isVirtualCart[$this->id] = $isVirtual;
         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2152,7 +2152,8 @@ class CartCore extends ObjectModel
     {
         static $address = array();
 
-        if (!count($this->getProducts())) {
+        // Check if cart is empty, or if the current cart contains at least a real product (not virtual)
+        if (!$this->hasProducts() || !$this->hasRealProducts()) {
             return 0;
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Cart::isVirtualCart() should return false if cart is empty, like any version before 1.7.4.0
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | yes
| Deprecations? | no
| How to test?  | Compare to PS < 1.7.4.0 behaviour

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9288)
<!-- Reviewable:end -->
