### PR TITLE
Fix grid tests after column names update

### DIFF
--- a/tests/Unit/Core/Grid/Definition/Factory/AbstractGridDefinitionFactoryTest.php
+++ b/tests/Unit/Core/Grid/Definition/Factory/AbstractGridDefinitionFactoryTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Grid\Action\BulkActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\SimpleColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\DefinitionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory;
 
@@ -77,9 +77,18 @@ class AbstractGridDefinitionFactoryTest extends TestCase
     private function getColumns()
     {
         return (new ColumnCollection())
-            ->add(new SimpleColumn('test_1'))
-            ->add(new SimpleColumn('test_2'))
-            ->add(new SimpleColumn('test_3'))
+            ->add($this->createColumnMock('test_1'))
+            ->add($this->createColumnMock('test_2'))
+            ->add($this->createColumnMock('test_3'))
         ;
+    }
+
+    private function createColumnMock($id)
+    {
+        $column = $this->createMock(ColumnInterface::class);
+        $column->method('getId')
+            ->willReturn($id);
+
+        return $column;
     }
 }

--- a/tests/Unit/Core/Grid/Presenter/GridPresenterTest.php
+++ b/tests/Unit/Core/Grid/Presenter/GridPresenterTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Grid\Action\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\SimpleColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
 use PrestaShop\PrestaShop\Core\Grid\DataProvider\GridDataInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\DefinitionInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
@@ -104,9 +104,9 @@ class GridPresenterTest extends TestCase
         $definition = $this->createMock(DefinitionInterface::class);
         $definition->method('getColumns')
             ->willReturn((new ColumnCollection())
-                ->add(new SimpleColumn('test_1'))
-                ->add(new SimpleColumn('test_2'))
-                ->add(new SimpleColumn('test_3'))
+                ->add($this->createColumnMock('test_1'))
+                ->add($this->createColumnMock('test_2'))
+                ->add($this->createColumnMock('test_3'))
             );
         $definition->method('getBulkActions')
             ->willReturn(new BulkActionCollection());
@@ -124,5 +124,14 @@ class GridPresenterTest extends TestCase
             ->willReturn($criteria);
 
         return $grid;
+    }
+
+    private function createColumnMock($id)
+    {
+        $column = $this->createMock(ColumnInterface::class);
+        $column->method('getId')
+            ->willReturn($id);
+
+        return $column;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | After updating column names in https://github.com/PrestaShop/PrestaShop/pull/9283, it makes tests fail, this PR fixes it.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Build should be green.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9290)
<!-- Reviewable:end -->
