### PR TITLE
Fix free shipping display on cart

### DIFF
--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -78,9 +78,9 @@ class CartRuleCalculator
 
         // Free shipping on selected carriers
         if ($cartRule->free_shipping) {
-            $this->calculator->getFees()->subDiscountValueShipping(
-                $this->calculator->getFees()->getInitialShippingFees()
-            );
+            $initialShippingFees = $this->calculator->getFees()->getInitialShippingFees();
+            $this->calculator->getFees()->subDiscountValueShipping($initialShippingFees);
+            $cartRuleData->addDiscountApplied($initialShippingFees);
         }
 
         // Free gift


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Free shipping discount display was removed on cart
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5665
| How to test?  | create a cart rule with free shipping. On FO, order some product, add the free shipping cart rule in order process

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9295)
<!-- Reviewable:end -->
