### PR TITLE
Fix/remove mbo from tests

### DIFF
--- a/tests/Integration/classes/module/ModuleGetOverrideTest.php
+++ b/tests/Integration/classes/module/ModuleGetOverrideTest.php
@@ -33,40 +33,42 @@ use Tests\TestCase\Module as HelperModule;
 
 class ModulesGetOverrideTest extends IntegrationTestCase
 {
+    /**
+     * @return array a list of modules to control override features.
+     */
     public function listModulesOnDisk()
     {
-        $modules = array();
-
-        foreach (scandir(_PS_MODULE_DIR_) as $entry)
-        {
-            if ($entry[0] !== '.')
-            {
-                if (file_exists(_PS_MODULE_DIR_.$entry.DIRECTORY_SEPARATOR.$entry.'.php'))
-                {
-                    $modules[] = array($entry);
-                }
-            }
-        }
-
-        return $modules;
+        return [
+            ['bankwire'],
+            ['cronjobs'],
+            ['gamification'],
+            ['ganalytics'],
+            ['ps_emailsubscription'],
+            ['ps_featuredproducts'],
+            ['psaddonsconnect'],
+            ['pscsx3241'],
+        ];
     }
 
     /**
      * @dataProvider listModulesOnDisk
      * Note: improves module list fixtures in order to cancel any override.
-     * @todo: PHP7 incompatability on module overidding
+     * @param string $moduleName the module name.
      */
     public function testDummyGetOverride($moduleName)
     {
         $module = Module::getInstanceByName($moduleName);
-        $this->assertEmpty($module->getOverrides());
+
+        if ($module instanceof Module) {
+            self::assertEmpty($module->getOverrides());
+        }
     }
 
     public function testRealOverrideInModuleDir()
     {
         HelperModule::addModule('pscsx3241');
         $module = Module::getInstanceByName('pscsx3241');
-        $this->assertSame([
+        self::assertSame([
             'Cart',
             'AdminProductsController'
         ], $module->getOverrides()


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Fixed test suite
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Nothing to do, I've removed MBO modules from tests as it breaks our "unit" test suite

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9298)
<!-- Reviewable:end -->
