### PR TITLE
Fix error while duplicating a product when catalog specific price rules are stored

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -704,6 +704,22 @@ class SpecificPriceCore extends ObjectModel
             $this->id_product = (int)$id_product;
         }
         unset($this->id);
+        // specific price row may already have been created for catalog specific price rule
+        if (static::exists(
+            $this->id_product,
+            $this->id_product_attribute,
+            $this->id_shop,
+            $this->id_group,
+            $this->id_country,
+            $this->id_currency,
+            $this->id_customer,
+            $this->from_quantity,
+            $this->from,
+            $this->to,
+            true
+        )) {
+            return true;
+        }
         return $this->add();
     }
 

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -716,7 +716,7 @@ class SpecificPriceCore extends ObjectModel
             $this->from_quantity,
             $this->from,
             $this->to,
-            true
+            $this->id_specific_price_rule != 0
         )) {
             return true;
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | fix error while duplicating a product when catalog specific price rules are stored
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4001
| How to test?  | create a catalog price rule, try to duplicate a product

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9299)
<!-- Reviewable:end -->
