### PR TITLE
Fix grid sorting by

### DIFF
--- a/src/PrestaShopBundle/Controller/ArgumentResolver/SearchParametersResolver.php
+++ b/src/PrestaShopBundle/Controller/ArgumentResolver/SearchParametersResolver.php
@@ -102,9 +102,11 @@ class SearchParametersResolver implements ArgumentValueResolverInterface
     {
         $filtersClass = $argument->getType();
         list($controller, $action) = ControllerAction::fromString($request->get('_controller'));
-        // is the url contains filters?
+
         $query = $request->query;
-        if ($query->has('filters') || $query->has('limit')) {
+        $doesTheUrlContainsFilters = ($query->has('filters') || $query->has('limit') || $query->has('sortOrder'));
+
+        if ($doesTheUrlContainsFilters) {
             $filters = $this->searchParameters->getFiltersFromRequest($request, $filtersClass);
 
             $this->adminFilterRepository->createOrUpdateByEmployeeAndRouteParams(


### PR DESCRIPTION
Fix grid sorting by enabling SearchParametersResolver to resolve 'sort column' request as well

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop |
| Description?  | Fix BO grid 'sort column' feature |
| Type?         | bug fix |
| Category?     | BO |
| BC breaks?    | no |
| Deprecations? | no |
| Fixed ticket? | 
| How to test?  | Login in BackOffice, visit URL http://localhost/admin-dev/index.php/configure/advanced/logs/ (this is the SF version of this page), then click on arrows on the top of columns. Expected behavior is: this should sort the table data by using the column as a reference, and another click will toggle the order. Example: click on "Date" once to see the table data rows being sorted in ascending order using the dates of the rows. Click another time on "Date" to see the table data rows being sorted in descending order this time. |

Should fix https://github.com/PrestaShop/prestafony-project/issues/44

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9300)
<!-- Reviewable:end -->
