### PR TITLE
Reduce the number of ajax calls if the fixtures are not too larges and if there's enough memory available

### DIFF
--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -372,8 +372,13 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
     private function hasLargeFixtures()
     {
         $size = 0;
-        foreach(glob(__DIR__.'/../../fixtures/fashion/data/*.xml') as $xmlFiles) {
-            $size += filesize($xmlFiles);
+        $fixtureDir = __DIR__.'/../../fixtures/fashion/data/';
+        $dh = @opendir($fixtureDir);
+        if ($dh) {
+            while (($xmlFile = @readdir($dh)) !== false) {
+                $size += filesize($fixtureDir.$xmlFile);
+            }
+            @closedir($dh);
         }
 
         return $size > Tools::getOctets('10M');

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -294,18 +294,25 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
      */
     public function display()
     {
+        $memoryLimit = Tools::getMemoryLimit();
+        // The installer SHOULD take less than 32M, but may take up to 35/36M sometimes. So 42M is a good value :)
+        $lowMemory = ($memoryLimit != '-1' && $memoryLimit < Tools::getOctets('42M'));
+
         // We fill the process step used for Ajax queries
         $this->process_steps[] = array('key' => 'generateSettingsFile', 'lang' => $this->translator->trans('Create file parameters', array(), 'Install'));
         $this->process_steps[] = array('key' => 'installDatabase', 'lang' => $this->translator->trans('Create database tables', array(), 'Install'));
         $this->process_steps[] = array('key' => 'installDefaultData', 'lang' => $this->translator->trans('Create default shop and languages', array(), 'Install'));
 
+        // If low memory or big fixtures, create subtasks for populateDatabase step (entity per entity)
         $populate_step = array('key' => 'populateDatabase', 'lang' => $this->translator->trans('Populate database tables', array(), 'Install'));
-        $populate_step['subtasks'] = array();
-        $xml_loader = new XmlLoader();
-        $xml_loader->setTranslator($this->translator);
+        if ($lowMemory) {
+            $populate_step['subtasks'] = array();
+            $xml_loader = new XmlLoader();
+            $xml_loader->setTranslator($this->translator);
 
-        foreach ($xml_loader->getSortedEntities() as $entity) {
-            $populate_step['subtasks'][] = array('entity' => $entity);
+            foreach ($xml_loader->getSortedEntities() as $entity) {
+                $populate_step['subtasks'][] = array('entity' => $entity);
+            }
         }
 
         $this->process_steps[] = $populate_step;
@@ -313,20 +320,24 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
 
         if ($this->session->install_type == 'full') {
             $fixtures_step = array('key' => 'installFixtures', 'lang' => $this->translator->trans('Install demonstration data', array(), 'Install'));
-            $fixtures_step['subtasks'] = array();
-            $xml_loader = new XmlLoader();
-            $xml_loader->setTranslator($this->translator);
-            $xml_loader->setFixturesPath();
+            if ($lowMemory || $this->hasLargeFixtures()) {
+                $fixtures_step['subtasks'] = array();
+                $xml_loader = new XmlLoader();
+                $xml_loader->setTranslator($this->translator);
+                $xml_loader->setFixturesPath();
 
-            foreach ($xml_loader->getSortedEntities() as $entity) {
-                $fixtures_step['subtasks'][] = array('entity' => $entity);
+                foreach ($xml_loader->getSortedEntities() as $entity) {
+                    $fixtures_step['subtasks'][] = array('entity' => $entity);
+                }
             }
             $this->process_steps[] = $fixtures_step;
         }
 
         $install_modules = array('key' => 'installModules', 'lang' => $this->translator->trans('Install modules', array(), 'Install'));
-        foreach ($this->model_install->getModulesList() as $module) {
-            $install_modules['subtasks'][] = array('module' => $module);
+        if ($lowMemory) {
+            foreach ($this->model_install->getModulesList() as $module) {
+                $install_modules['subtasks'][] = array('module' => $module);
+            }
         }
         $this->process_steps[] = $install_modules;
 
@@ -340,8 +351,10 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
             'version' => _PS_INSTALL_VERSION_
         );
 
-        foreach ($this->model_install->getAddonsModulesList($params) as $module) {
-            $install_modules['subtasks'][] = array('module' => (string)$module['name'], 'id_module' => (string)$module['id_module']);
+        if ($lowMemory) {
+            foreach ($this->model_install->getAddonsModulesList($params) as $module) {
+                $install_modules['subtasks'][] = array('module' => (string)$module['name'], 'id_module' => (string)$module['id_module']);
+            }
         }
 
         $this->process_steps[] = $install_modules;
@@ -349,6 +362,21 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
         $this->process_steps[] = array('key' => 'installTheme', 'lang' => $this->translator->trans('Install theme', array(), 'Install'));
 
         $this->displayTemplate('process');
+    }
+
+    /**
+     * Check if the fixtures directory is large
+     *
+     * return bool
+     */
+    private function hasLargeFixtures()
+    {
+        $size = 0;
+        foreach(glob(__DIR__.'/../../fixtures/fashion/data/*.xml') as $xmlFiles) {
+            $size += filesize($xmlFiles);
+        }
+
+        return $size > Tools::getOctets('10M');
     }
 
     private function clearConfigXML()

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -372,13 +372,13 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
     private function hasLargeFixtures()
     {
         $size = 0;
-        $fixtureDir = __DIR__.'/../../fixtures/fashion/data/';
-        $dh = @opendir($fixtureDir);
+        $fixtureDir = _PS_INSTALL_FIXTURES_PATH_.'fashion/data/';
+        $dh = opendir($fixtureDir);
         if ($dh) {
-            while (($xmlFile = @readdir($dh)) !== false) {
+            while (($xmlFile = readdir($dh)) !== false) {
                 $size += filesize($fixtureDir.$xmlFile);
             }
-            @closedir($dh);
+            closedir($dh);
         }
 
         return $size > Tools::getOctets('10M');


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Fix install speed regression due to too many ajax calls
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Install and check the number of ajax calls (should be only 1 for each steps, no subtasks)
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9302)
<!-- Reviewable:end -->
