### PR TITLE
Do not apply wrapping fees if cart is empty

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2158,6 +2158,10 @@ class CartCore extends ObjectModel
             return $wrapping_fees;
         }
 
+        if (!count($this->getProducts())) {
+            return 0;
+        }
+
         if ($with_taxes) {
             if (Configuration::get('PS_ATCP_SHIPWRAP')) {
                 // With PS_ATCP_SHIPWRAP, wrapping fee is by default tax included


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Fix tests on PR https://github.com/PrestaShop/PrestaShop/pull/9288
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Run vendor/bin/phpunit -c tests/phpunit.xml tests/Unit/Core/Cart/Calculation/Products/CartGiftWrappingTest.php

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9304)
<!-- Reviewable:end -->
