### PR TITLE
Add a link to the addons' favicon generator

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -394,7 +394,7 @@ class AdminThemesControllerCore extends AdminController
         // Employee languages used for link and utm_source
         $lang = new Language($this->context->language->id);
         $iso_lang_uc = strtoupper($lang->iso_code);
-        $url = '<a href="https://addons.prestashop.com/create-favicon.php?pab=1" target="_blank">'.$this->trans('favicon generator on PrestaShop Marketplace', array(), 'Admin.Design.Help').'</a>';
+        $url = 'https://addons.prestashop.com/create-favicon.php?pab=1';
 
         $this->fields_options = array(
             'appearance' => array(
@@ -439,7 +439,7 @@ class AdminThemesControllerCore extends AdminController
                     ),
                     'PS_FAVICON' => array(
                         'title' => $this->trans('Favicon', array(), 'Admin.Design.Feature'),
-                        'desc' => $this->trans('Use our %url% to boost your brand image!', array('%url%' => $url), 'Admin.Design.Help'),
+                        'desc' => $this->trans('Use our [1]favicon generator on PrestaShop Marketplace[/1] to boost your brand image!', array('[1]' => '<a href="'.$url.'" target="_blank">', '[/1]' => '</a>'), 'Admin.Design.Help'),
                         'hint' => $this->trans('It is the small icon that appears in browser tabs, next to the web address', array(), 'Admin.Design.Help'),
                         'type' => 'file',
                         'name' => 'PS_FAVICON',

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -394,6 +394,7 @@ class AdminThemesControllerCore extends AdminController
         // Employee languages used for link and utm_source
         $lang = new Language($this->context->language->id);
         $iso_lang_uc = strtoupper($lang->iso_code);
+        $url = '<a href="https://addons.prestashop.com/create-favicon.php?pab=1" target="_blank">'.$this->trans('favicon generator on PrestaShop Marketplace', array(), 'Admin.Design.Help').'</a>';
 
         $this->fields_options = array(
             'appearance' => array(
@@ -438,6 +439,7 @@ class AdminThemesControllerCore extends AdminController
                     ),
                     'PS_FAVICON' => array(
                         'title' => $this->trans('Favicon', array(), 'Admin.Design.Feature'),
+                        'desc' => $this->trans('Use our %url% to boost your brand image!', array('%url%' => $url), 'Admin.Design.Help'),
                         'hint' => $this->trans('It is the small icon that appears in browser tabs, next to the web address', array(), 'Admin.Design.Help'),
                         'type' => 'file',
                         'name' => 'PS_FAVICON',


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a link on the Theme & logo page to the favicon generator
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5208
| How to test?  | Go in BO > Design > Theme & logo > Favicon, Click on the link under the favicon field

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9306)
<!-- Reviewable:end -->
