### PR TITLE
Fix popin recommended modules install

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -33,14 +33,14 @@
 
   {% if url_active == 'buy' %}
   <div class="form-action-button-container">
-    <a class="btn btn-primary btn-primary-reverse btn-block btn-outline-primary light-button module_action_menu_go_to_addons" href="{{ url }}" target="_blank">
+    <a class="btn btn-primary btn-primary btn--reverse btn-block btn-outline-primary light-button module_action_menu_go_to_addons" href="{{ url }}" target="_blank">
       {{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}
     </a>
   </div>
   {% elseif urls|length %}
   <div class="btn-group form-action-button-container">
     <form class="btn-group form-action-button" method="post" action="{{ urls[url_active] }}">
-      <button type="submit" class="btn btn-primary-reverse btn-outline-primary light-button module_action_menu_{{ url_active }}"
+      <button type="submit" class="btn btn-primary btn-reverse btn-outline-primary light-button module_action_menu_{{ url_active }}"
           data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">
           {{ url_active|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions') }}
       </button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -23,47 +23,73 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 {% set url, priceRaw, priceDisplay, url_active, urls, name =
-  module.attributes.url,
-  module.attributes.price.raw,
-  module.attributes.price.displayPrice,
-  module.attributes.url_active,
-  module.attributes.urls,
-  module.attributes.name
-%}
+    module.attributes.url,
+    module.attributes.price.raw,
+    module.attributes.price.displayPrice,
+    module.attributes.url_active,
+    module.attributes.urls,
+    module.attributes.name %}
 
   {% if url_active == 'buy' %}
-  <div class="form-action-button-container">
-    <a class="btn btn-primary btn-primary btn--reverse btn-block btn-outline-primary light-button module_action_menu_go_to_addons" href="{{ url }}" target="_blank">
-      {{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}
-    </a>
-  </div>
+      <div class="form-action-button-container">
+          <a class="btn btn-primary btn-primary btn--reverse btn-block btn-outline-primary light-button module_action_menu_go_to_addons"
+             href="{{ url }}" target="_blank">
+              {{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}
+          </a>
+      </div>
   {% elseif urls|length %}
-  <div class="btn-group form-action-button-container">
-    <form class="btn-group form-action-button" method="post" action="{{ urls[url_active] }}">
-      <button type="submit" class="btn btn-primary btn-reverse btn-outline-primary light-button module_action_menu_{{ url_active }}"
-          data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">
-          {{ url_active|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions') }}
-      </button>
-    </form>
-    {% if (urls|length > 1) %}
-          <input type="hidden" class="btn">
-          <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="caret"></span>
-            <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
-          </button>
-          <div class="dropdown-menu">
-            {% for module_action, module_url in urls %}
-              {% if module_action != url_active %}
-                  <li>
-                    <form method="post" action="{{ module_url }}">
-                      <button type="submit" class="dropdown-item module_action_menu_{{ module_action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">
-                        {{module_action|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions')}}
-                      </button>
-                    </form>
-                  </li>
-              {% endif %}
-            {% endfor %}
+      <div class="btn-group form-action-button-container">
+          <form class="btn-group form-action-button import-module-from-popin-form" method="post" action="{{ urls[url_active] }}">
+              <button type="submit"
+                      class="btn btn-primary btn-reverse btn-outline-primary light-button module_action_menu_{{ url_active }}"
+                      data-confirm_modal="module-modal-confirm-{{ name }}-{{ url_active }}">
+                  {{ url_active|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions') }}
+              </button>
+          </form>
+
+          <div id="loading_message" style="display: none;">
+              <p class=module-import-processing-main-text>{{ 'In progress...'|trans({}, 'Admin.Modules.Notification') }}</p>
           </div>
-    {% endif %}
-  </div>
+
+          {% if (urls|length > 1) %}
+              <input type="hidden" class="btn">
+              <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split"
+                      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <span class="caret"></span>
+                  <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
+              </button>
+              <div class="dropdown-menu">
+                  {% for module_action, module_url in urls %}
+                      {% if module_action != url_active %}
+                          <li>
+                              <form class="import-module-from-popin-form" method="post" action="{{ module_url }}">
+                                  <button type="submit" class="dropdown-item module_action_menu_{{ module_action }}"
+                                          data-confirm_modal="module-modal-confirm-{{ name }}-{{ module_action }}">
+                                      {{ module_action|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions') }}
+                                  </button>
+                              </form>
+                          </li>
+                      {% endif %}
+                  {% endfor %}
+              </div>
+          {% endif %}
+      </div>
   {% endif %}
+
+<script>
+    $(document).ready(function () {
+        $('#import-module-from-popin-form').on('submit', function (e) {
+            e.preventDefault();
+            $(this).after( "<p class=module-import-processing-main-text>{{ 'Installing module...'|trans({}, 'Admin.Modules.Notification') }}</p>" );
+            $(this).hide();
+            $.ajax({
+                url: $(this).attr('action') || window.location.pathname,
+                type: "POST",
+                data: $(this).serialize(),
+                success: function (data) {
+                    location.reload();
+                }
+            });
+        });
+    });
+</script>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
@@ -70,3 +70,23 @@
     <a href="https://addons.prestashop.com/?utm_source=back-office&amp;utm_medium=dispatch&amp;utm_campaign=back-office-{{ app.request.locale }}&amp;utm_content=download{% if adminListFromSource is defined %}&amp;utm_term={{ adminListFromSource }}{% endif %}" onclick="return !window.open(this.href);">{{ 'More modules on addons.prestashop.com'|trans({}) }}</a>
   </p>
 </div>
+
+<script>
+    $(document).ready(function () {
+        $('.import-module-from-popin-form').on('submit', function (e) {
+            e.preventDefault();
+
+            $('.import-module-from-popin-form').hide();
+            $('#loading_message').show();
+
+            $.ajax({
+                url: $(this).attr('action') || window.location.pathname,
+                type: "POST",
+                data: $(this).serialize(),
+                success: function (data) {
+                    location.reload();
+                }
+            });
+        });
+    });
+</script>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Fix in a dirty way the 'recommended modules' popin actions
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5953
| How to test?  | Go on 'carriers' page in BackOffice `/admin-dev/index.php?controller=AdminCarriers`/ and click on 'recommende modules' button in the top right corner of the screen. Install one module, uninstall another.

This is a **dirty fix** because it solves the issue partially. I am open to discuss how to fix it properly as I do not know the history of this usecase and what should be done / what is the proper way to handle these kind of usecases.

Also I do not know where to put my JS script. Should we do everything using webpack for these pages ?

#### The context

In the 'recommended modules' popin we display a list of installed or not-installed modules.
- not-installed modules have 1 CTA "INSTALL"
- installed modules have 1 CTA "CONFIGURE" and a list of other CTAs "UNINSTALL", "DISABLE", "RESET" ...

#### The bug

These CTAs are in fact `submit` buttons inside forms with POST actions. So when the user clicks on it, the page loads the response. However the response is a JSON response so the user can see the JSON response for its CTA...

## Possible solutions

#### Return HTML

If the route called by the form was only used here, we could return a redirect. However I believe this route (which is handled by `PrestaShopBundle\Controller\Admin\ModuleController::importModuleAction()`) is used in other parts of PrestaShop.

#### Transform submit buttons + forms into ajax POST calls and reload the page

This is what this PR does. However:
- I did it poorly with a crappy loading message to wait for the AJAX call to end
- After the AJAX call return, I reload the whole page although we could only reload the modal.
- It seems the "CONFIGURE" CTA should be a link instead of a submit button 😮 

#### Call another Controller that will dispatch the right jobs, and return HTML

This way, the form return logic works. And we can return Redirects from this controller to handle the "CONFIGURE" way. But we still reload the whole page although only the modal needs to be reloaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9307)
<!-- Reviewable:end -->
