### PR TITLE
Apply shop context in configuration

### DIFF
--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -116,8 +116,8 @@ class Configuration extends ParameterBag implements ConfigurationInterface
     public function set($key, $value)
     {
         // By default, set a piece of configuration for all available shops and shop groups
-        $shopGroupId = 0;
-        $shopId = 0;
+        $shopGroupId = null;
+        $shopId = null;
 
         if ($this->shop instanceof Shop) {
             $shopGroupId = $this->shop->id_shop_group;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Handle the shop context automatically when updating the configuration. This PR is set in the `develop` branch because it updates the behavior of every controller running under Symfony.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5946
| How to test?  | Try to enable the maintenance mode of a single shop, only the selected one must be impacted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9311)
<!-- Reviewable:end -->
