### PR TITLE
Fix popin recommended modules install

### DIFF
--- a/admin-dev/themes/default/js/bundle/module/module_card.js
+++ b/admin-dev/themes/default/js/bundle/module/module_card.js
@@ -1,12 +1,5 @@
 var module_card_controller = {};
 
-$(document).ready(function () {
-
-    module_card_controller = new AdminModuleCard();
-    module_card_controller.init();
-
-});
-
 /**
  * AdminModule card Controller.
  * @constructor
@@ -245,3 +238,10 @@ var AdminModuleCard = function () {
     };
 
 };
+
+$(document).ready(function () {
+
+    module_card_controller = new AdminModuleCard();
+    module_card_controller.init();
+
+});

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
@@ -23,6 +23,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 {% if modulesList is defined and modulesList is not empty %}
+<script src="{{ asset('themes/default/js/bundle/module/module_card.js') }}"></script>
+
 <div class="row row-margin-bottom">
   <div class="col-lg-12">
     <ul class="nav nav-pills">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Fix the 'recommended modules' popin behavior
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5953
| How to test?  | Go on 'carriers' page in BackOffice `/admin-dev/index.php?controller=AdminCarriers`/ and click on 'recommended modules' button in the top right corner of the screen. Install one module, uninstall another. The display is dirty, but it works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9317)
<!-- Reviewable:end -->
