### PR TITLE
Make documentation link on the dashboard point to the 1.7 docs instead of 1.6

### DIFF
--- a/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
@@ -107,7 +107,7 @@
 			<section class="dash_links panel">
 				<h3><i class="icon-link"></i> {l s="Useful links" d='Admin.Dashboard.Feature'}</h3>
 					<dl>
-						<dt><a href="http://doc.prestashop.com/display/PS16?utm_source=back-office&amp;utm_medium=dashboard&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank">{l s="Official Documentation" d='Admin.Dashboard.Feature'}</a></dt>
+						<dt><a href="http://doc.prestashop.com/display/PS17?utm_source=back-office&amp;utm_medium=dashboard&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank">{l s="Official Documentation" d='Admin.Dashboard.Feature'}</a></dt>
 						<dd>{l s="User, Developer and Designer Guides" d='Admin.Dashboard.Feature'}</dd>
 					</dl>
 					<dl>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The documentation link on the dashboard was pointing to the 1.6 version of the documentation instead of 1.7 (see screenshot below)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | The link should now point to the 1.7 docs

![screencap](https://user-images.githubusercontent.com/1009343/42699645-aaae359e-86c1-11e8-96b3-3a05f0e8cf4a.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9318)
<!-- Reviewable:end -->
