### PR TITLE
Add stock quantity variable inside cart summary notification error

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -426,8 +426,8 @@ class CartControllerCore extends FrontController
         // Check product quantity availability
         if ('update' !== $mode && $this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
             $this->{$ErrorKey}[] = $this->trans(
-                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
-                array('%product%' => $product->name),
+                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted. Maximum quantity is %quantity%',
+                array('%product%' => $product->name, '%quantity%' => $product->quantity),
                 'Shop.Notifications.Error'
             );
         }
@@ -498,8 +498,8 @@ class CartControllerCore extends FrontController
                 } elseif ($this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
                     // check quantity after cart quantity update
                     $this->{$ErrorKey}[] = $this->trans(
-                        'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
-                        array('%product%' => $product->name),
+                        'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted. Maximum quantity is %quantity%',
+                        array('%product%' => $product->name, '%quantity%' => $product->quantity),
                         'Shop.Notifications.Error'
                     );
                 }
@@ -581,8 +581,8 @@ class CartControllerCore extends FrontController
         }
         if ($product['active']) {
             return $this->trans(
-                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
-                array('%product%' => $product['name']),
+                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted. Maximum quantity is %quantity%',
+                array('%product%' => $product['name'], '%quantity%' => $product['stock_quantity'),
                 'Shop.Notifications.Error'
             );
         }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -406,7 +406,12 @@ class CartControllerCore extends FrontController
 
         $qty_to_check = $this->qty;
         $cart_products = $this->context->cart->getProducts();
-
+        
+        $qty_available = $product->quantity;
+        if ($product->hasAttributes()) {
+            $qty_available = StockAvailable::getQuantityAvailableByProduct(null, (int) $this->id_product_attribute, $this->context->shop->id);
+        }
+        
         if (is_array($cart_products)) {
             foreach ($cart_products as $cart_product) {
                 if ($this->productInCartMatchesCriteria($cart_product)) {
@@ -427,7 +432,7 @@ class CartControllerCore extends FrontController
         if ('update' !== $mode && $this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
             $this->{$ErrorKey}[] = $this->trans(
                 'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted. Maximum quantity is %quantity%',
-                array('%product%' => $product->name, '%quantity%' => $product->quantity),
+                array('%product%' => $product->name, '%quantity%' => $qty_available),
                 'Shop.Notifications.Error'
             );
         }
@@ -499,7 +504,7 @@ class CartControllerCore extends FrontController
                     // check quantity after cart quantity update
                     $this->{$ErrorKey}[] = $this->trans(
                         'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted. Maximum quantity is %quantity%',
-                        array('%product%' => $product->name, '%quantity%' => $product->quantity),
+                        array('%product%' => $product->name, '%quantity%' => $qty_available),
                         'Shop.Notifications.Error'
                     );
                 }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -581,8 +581,8 @@ class CartControllerCore extends FrontController
         }
         if ($product['active']) {
             return $this->trans(
-                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
-                array('%product%' => $product['name']),
+                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted. Maximum quantity is %quantity%',
+                array('%product%' => $product['name'], '%quantity%' => $product['stock_quantity'),
                 'Shop.Notifications.Error'
             );
         }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -581,8 +581,8 @@ class CartControllerCore extends FrontController
         }
         if ($product['active']) {
             return $this->trans(
-                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted. Maximum quantity is %quantity%',
-                array('%product%' => $product['name'], '%quantity%' => $product['stock_quantity'),
+                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
+                array('%product%' => $product['name']),
                 'Shop.Notifications.Error'
             );
         }


### PR DESCRIPTION
When user adjust quantity in cart summary and wanted quantity is more than 'in-stock', than error notification shown, but with this improvement user knows maximum product quantity he can buy.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add maximum stock quantity with error notification.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [Forge](http://forge.prestashop.com/browse/BOOM-5987) ticket.
| How to test?  | If you know that for example Product quantity is 1, than in cart summary try to change quantity to 2 and buy it. You will get notification I'm talking about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9323)
<!-- Reviewable:end -->
