### PR TITLE
Fixed the Show SQL query action

### DIFF
--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -96,6 +96,7 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
 
     /**
      * @param QueryBuilder $queryBuilder
+     *
      * @return string
      */
     private function getRawQuery(QueryBuilder $queryBuilder)

--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -30,6 +30,7 @@ use PDO;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
+use PrestaShop\PrestaShop\Core\Grid\Query\QueryParserInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
@@ -50,6 +51,11 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
     private $hookDispatcher;
 
     /**
+     * @var QueryParserInterface
+     */
+    private $queryParser;
+
+    /**
      * @var string
      */
     private $gridId;
@@ -62,10 +68,12 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
     public function __construct(
         DoctrineQueryBuilderInterface $gridQueryBuilder,
         HookDispatcherInterface $hookDispatcher,
+        QueryParserInterface $queryParser,
         $gridId
     ) {
         $this->gridQueryBuilder = $gridQueryBuilder;
         $this->hookDispatcher = $hookDispatcher;
+        $this->queryParser = $queryParser;
         $this->gridId = $gridId;
     }
 
@@ -104,10 +112,6 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
         $query = $queryBuilder->getSQL();
         $parameters = $queryBuilder->getParameters();
 
-        foreach ($parameters as $pattern => $value) {
-            $query = str_replace(":$pattern", $value, $query);
-        }
-
-        return $query;
+        return $this->queryParser->parse($query, $parameters);
     }
 }

--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use PDO;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
@@ -89,7 +90,23 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
         return new GridData(
             $records,
             $recordsTotal,
-            $searchQueryBuilder->getSQL()
+            $this->getRawQuery($searchQueryBuilder)
         );
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @return string
+     */
+    private function getRawQuery(QueryBuilder $queryBuilder)
+    {
+        $query = $queryBuilder->getSQL();
+        $parameters = $queryBuilder->getParameters();
+
+        foreach ($parameters as $pattern => $value) {
+            $query = str_replace(":$pattern", $value, $query);
+        }
+
+        return $query;
     }
 }

--- a/src/Core/Grid/Exception/UnsupportedParameterException.php
+++ b/src/Core/Grid/Exception/UnsupportedParameterException.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Exception;
+
+use Exception;
+
+class UnsupportedParameterException extends Exception implements ExceptionInterface
+{
+}

--- a/src/Core/Grid/Query/DoctrineQueryParser.php
+++ b/src/Core/Grid/Query/DoctrineQueryParser.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 /**
  * This class offers a DBAL implementation of Query parser.
  */
-class DoctrineQueryParser implements QueryParserInterface
+final class DoctrineQueryParser implements QueryParserInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Core/Grid/Query/DoctrineQueryParser.php
+++ b/src/Core/Grid/Query/DoctrineQueryParser.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+class DoctrineQueryParser implements QueryParserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function parse($query, array $queryParameters)
+    {
+        $keys = array();
+        $values = $queryParameters;
+
+        foreach ($queryParameters as $key => $value) {
+            if (is_string($key)) {
+                $keys[] = '/:' . $key . '/';
+            } else {
+                $keys[] = '/[?]/';
+            }
+
+            if (is_string($value)) {
+                $values[$key] = "'" . $value . "'";
+            }
+
+            if (is_array($value)) {
+                $values[$key] = "'" . implode("','", $value) . "'";
+            }
+
+            if ($value === null) {
+                $values[$key] = 'NULL';
+            }
+        }
+
+        $query = preg_replace($keys, $values, $query);
+
+        return $query;
+    }
+}

--- a/src/Core/Grid/Query/DoctrineQueryParser.php
+++ b/src/Core/Grid/Query/DoctrineQueryParser.php
@@ -49,8 +49,10 @@ final class DoctrineQueryParser implements QueryParserInterface
     }
 
     /**
-     * @param mixed $value the parameter value.
-     * @return string the partial raw parameter.
+     * @param mixed $value the parameter value
+     *
+     * @return string the partial raw parameter
+     *
      * @throws UnsupportedParameterException
      */
     private function parseValue($value)
@@ -80,6 +82,7 @@ final class DoctrineQueryParser implements QueryParserInterface
 
     /**
      * @param string $value
+     *
      * @return string
      */
     private function parseStringParameter($value)
@@ -89,6 +92,7 @@ final class DoctrineQueryParser implements QueryParserInterface
 
     /**
      * @param array $value
+     *
      * @return string
      */
     private function parseArrayParameter(array $value)
@@ -98,6 +102,7 @@ final class DoctrineQueryParser implements QueryParserInterface
 
     /**
      * @param bool $value
+     *
      * @return string
      */
     private function parseBooleanParameter($value)

--- a/src/Core/Grid/Query/DoctrineQueryParser.php
+++ b/src/Core/Grid/Query/DoctrineQueryParser.php
@@ -38,6 +38,7 @@ final class DoctrineQueryParser implements QueryParserInterface
      */
     public function parse($query, array $queryParameters)
     {
+        $values = [];
         foreach ($queryParameters as $key => $value) {
             if (!is_string($key)) {
                 throw new UnsupportedParameterException('Only named parameters are supported in prepared queries.');

--- a/src/Core/Grid/Query/DoctrineQueryParser.php
+++ b/src/Core/Grid/Query/DoctrineQueryParser.php
@@ -26,6 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
+/**
+ * This class offers a DBAL implementation of Query parser.
+ */
 class DoctrineQueryParser implements QueryParserInterface
 {
     /**

--- a/src/Core/Grid/Query/QueryParserInterface.php
+++ b/src/Core/Grid/Query/QueryParserInterface.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+/**
+ * Returns the executable query from a prepared one.
+ */
+interface QueryParserInterface
+{
+    /**
+     * @param string $query the prepared query
+     * @param array $queryParameters the query parameters
+     *
+     * @return string
+     */
+    public function parse($query, array $queryParameters);
+}

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -17,6 +17,7 @@ services:
         arguments:
             - '@prestashop.core.admin.log.repository'
             - '@prestashop.core.hook.dispatcher'
+            - '@prestashop.core.grid.query.doctrine_query_parser'
             - 'logs'
 
     prestashop.core.grid.data_provider.email_logs:
@@ -24,6 +25,7 @@ services:
         arguments:
             - '@prestashop.core.grid.query_builder.email_logs'
             - '@prestashop.core.hook.dispatcher'
+            - '@prestashop.core.grid.query.doctrine_query_parser'
             - 'email_logs'
 
     prestashop.core.grid.data_provider.request_sql:
@@ -31,6 +33,7 @@ services:
         arguments:
             - '@prestashop.core.admin.request_sql.repository'
             - '@prestashop.core.hook.dispatcher'
+            - '@prestashop.core.grid.query.doctrine_query_parser'
             - 'request_sql'
 
     prestashop.core.grid.data_provider.webservice:
@@ -38,6 +41,7 @@ services:
         arguments:
             - '@prestashop.core.grid.query_builder.webservice'
             - '@prestashop.core.hook.dispatcher'
+            - '@prestashop.core.grid.query.doctrine_query_parser'
             - 'webservice'
 
     # Grid definition factories
@@ -134,7 +138,7 @@ services:
         arguments:
             - '@prestashop.core.hook.dispatcher'
 
-    # Query builder
+    # Grid Query builder
     prestashop.core.grid.abstract_query_builder:
         class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory'
         abstract: true
@@ -154,6 +158,10 @@ services:
         parent: 'prestashop.core.grid.abstract_query_builder'
         public: true
 
-    # Query applicators
+    # Grid Query parser
+    prestashop.core.grid.query.doctrine_query_parser:
+        class: 'PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryParser'
+
+    # Grid Query applicators
     prestashop.core.query.doctrine_search_criteria_applicator:
         class: 'PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicator'

--- a/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
@@ -26,16 +26,16 @@
 
 namespace Tests\Unit\Core\Grid\Data\Factory;
 
-use Doctrine\DBAL\Query\QueryBuilder;
-use PDOStatement;
-use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Grid\Data\Factory\DoctrineGridDataFactory;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridDataInterface;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
+use PrestaShop\PrestaShop\Core\Grid\Query\QueryParserInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use PrestaShopBundle\Service\Hook\HookDispatcher;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use PDOStatement;
 
 class DoctrineGridDataFactoryTest extends TestCase
 {
@@ -48,6 +48,7 @@ class DoctrineGridDataFactoryTest extends TestCase
         $doctrineGridDataFactory = new DoctrineGridDataFactory(
             $this->createDoctrineQueryBuilderMock(),
             $hookDispatcher,
+            $this->createMock(QueryParserInterface::class),
             'test_grid_id'
         );
 

--- a/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
@@ -58,6 +58,7 @@ class DoctrineGridDataFactoryTest extends TestCase
         $this->assertInstanceOf(GridDataInterface::class, $data);
         $this->assertInstanceOf(RecordCollectionInterface::class, $data->getRecords());
 
+
         $this->assertEquals(4, $data->getRecordsTotal());
         $this->assertCount(2, $data->getRecords());
         $this->assertEquals('SELECT * FROM ps_test', $data->getQuery());
@@ -84,7 +85,12 @@ class DoctrineGridDataFactoryTest extends TestCase
         $qb->method('execute')
             ->willReturn($statement);
         $qb->method('getSQL')
-            ->willReturn('SELECT * FROM ps_test');
+            ->willReturn('SELECT * FROM ps_test WHERE id = :id');
+        $qb->method('getParameters')
+            ->willReturn([
+                'id' => 1,
+            ])
+        ;
 
         $doctrineQueryBuilder = $this->createMock(DoctrineQueryBuilderInterface::class);
         $doctrineQueryBuilder->method('getSearchQueryBuilder')

--- a/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
@@ -43,12 +43,15 @@ class DoctrineGridDataFactoryTest extends TestCase
     {
         $hookDispatcher = $this->createHookDispatcherMock();
         $hookDispatcher->expects($this->once())
-            ->method('dispatchWithParameters');
+            ->method('dispatchWithParameters')
+        ;
+
+        $queryParser = $this->createQueryParserMock();
 
         $doctrineGridDataFactory = new DoctrineGridDataFactory(
             $this->createDoctrineQueryBuilderMock(),
             $hookDispatcher,
-            $this->createMock(QueryParserInterface::class),
+            $queryParser,
             'test_grid_id'
         );
 
@@ -62,9 +65,12 @@ class DoctrineGridDataFactoryTest extends TestCase
 
         $this->assertEquals(4, $data->getRecordsTotal());
         $this->assertCount(2, $data->getRecords());
-        $this->assertEquals('SELECT * FROM ps_test', $data->getQuery());
+        $this->assertEquals('SELECT * FROM ps_test WHERE id = 1', $data->getQuery());
     }
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
     private function createDoctrineQueryBuilderMock()
     {
         $statement = $this->createMock(PDOStatement::class);
@@ -102,6 +108,9 @@ class DoctrineGridDataFactoryTest extends TestCase
         return $doctrineQueryBuilder;
     }
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
     private function createHookDispatcherMock()
     {
         $hookDispatcher = $this->createMock(HookDispatcherInterface::class);
@@ -109,5 +118,19 @@ class DoctrineGridDataFactoryTest extends TestCase
             ->willReturn(null);
 
         return $hookDispatcher;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createQueryParserMock()
+    {
+        $queryParser = $this->getMockBuilder(QueryParserInterface::class)
+            ->setMethods(['parse'])
+            ->getMockForAbstractClass();;
+
+        $queryParser->method('parse')->willReturn('SELECT * FROM ps_test WHERE id = 1');
+
+        return $queryParser;
     }
 }

--- a/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
@@ -127,7 +127,7 @@ class DoctrineGridDataFactoryTest extends TestCase
     {
         $queryParser = $this->getMockBuilder(QueryParserInterface::class)
             ->setMethods(['parse'])
-            ->getMockForAbstractClass();;
+            ->getMockForAbstractClass();
 
         $queryParser->method('parse')->willReturn('SELECT * FROM ps_test WHERE id = 1');
 

--- a/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
+++ b/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
@@ -26,6 +26,7 @@
 
 namespace Tests\Unit\Core\Grid\Query;
 
+use stdClass;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Grid\Exception\UnsupportedParameterException;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryParser;
@@ -63,6 +64,7 @@ class DoctrineQueryParserTest extends TestCase
      */
     public function testParseWithParametersMustThrowAnException()
     {
+        $this->expectExceptionMessage('Only named parameters are supported in prepared queries.');
         $this->expectException(UnsupportedParameterException::class);
 
         $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation = ? AND energy = ?';
@@ -94,6 +96,7 @@ class DoctrineQueryParserTest extends TestCase
      */
     public function testParseWithArrayParametersMustThrowAnException()
     {
+        $this->expectExceptionMessage('Only named parameters are supported in prepared queries.');
         $this->expectException(UnsupportedParameterException::class);
 
         $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation IN (?)';
@@ -141,5 +144,18 @@ class DoctrineQueryParserTest extends TestCase
         $expectedQuery2 = "SELECT tests FROM pierre_rambaud WHERE energy = TRUE";
 
         $this->assertSame($expectedQuery2, $this->queryParser->parse($preparedQuery2, $queryParameters2));
+    }
+
+    public function testParseWithUnsupportedTypeMustThrowAnException()
+    {
+        $this->expectExceptionMessage('Unsupported value type: object');
+        $this->expectException(UnsupportedParameterException::class);
+
+        $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation IN (:motivation)';
+        $queryParameters = [
+            'motivation' => new stdClass(),
+        ];
+
+        $this->queryParser->parse($preparedQuery, $queryParameters);
     }
 }

--- a/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
+++ b/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Grid\Query;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Grid\Exception\UnsupportedParameterException;
+use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryParser;
+
+class DoctrineQueryParserTest extends TestCase
+{
+    /**
+     * @var DoctrineQueryParser
+     */
+    private $queryParser;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->queryParser = new DoctrineQueryParser();
+    }
+
+    public function testParseWithNamedParameters()
+    {
+        $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation = :motivation AND energy = :energy';
+        $queryParameters = [
+            'motivation' => 'OK',
+            'energy' => 'none',
+        ];
+
+        $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation = 'OK' AND energy = 'none'";
+
+        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+    }
+
+    /**
+     * @throws \PrestaShop\PrestaShop\Core\Grid\Exception\UnsupportedParameterException
+     */
+    public function testParseWithParameters()
+    {
+        $this->expectException(UnsupportedParameterException::class);
+
+        $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation = ? AND energy = ?';
+        $queryParameters = ['OK', 'none'];
+
+        $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation = 'OK' AND energy = 'none'";
+
+        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+    }
+
+    public function testParseWithArrayNamedParameters()
+    {
+        $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation IN (:motivation)';
+        $queryParameters = [
+            'motivation' => [
+                'great',
+                'good',
+                'ok',
+                'nok',
+                'none',
+            ]
+        ];
+
+        $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation IN ('great', 'good', 'ok', 'nok', 'none')";
+
+        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+    }
+
+    /**
+     * @throws \PrestaShop\PrestaShop\Core\Grid\Exception\UnsupportedParameterException
+     */
+    public function testParseWithArrayParameters()
+    {
+        $this->expectException(UnsupportedParameterException::class);
+
+        $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation IN (?)';
+        $queryParameters = [
+            [
+                'great',
+                'good',
+                'ok',
+                'nok',
+                'none',
+            ]
+        ];
+
+        $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation IN ('great', 'good', 'ok', 'nok', 'none')";
+
+        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+    }
+
+    public function testParseWithNullParameters()
+    {
+        $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation IS :motivation';
+        $queryParameters = [
+            'motivation' => null,
+        ];
+
+        $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation IS NULL";
+
+        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+    }
+
+    public function testParseWithBooleanParameters()
+    {
+        $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation = :motivation';
+        $queryParameters = [
+            'motivation' => false,
+        ];
+
+        $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation = FALSE";
+
+        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+
+        $preparedQuery2 = 'SELECT tests FROM pierre_rambaud WHERE energy = :energy';
+        $queryParameters2 = [
+            'energy' => true,
+        ];
+
+        $expectedQuery2 = "SELECT tests FROM pierre_rambaud WHERE energy = TRUE";
+
+        $this->assertSame($expectedQuery2, $this->queryParser->parse($preparedQuery2, $queryParameters2));
+    }
+}

--- a/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
+++ b/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
@@ -61,16 +61,14 @@ class DoctrineQueryParserTest extends TestCase
     /**
      * @throws \PrestaShop\PrestaShop\Core\Grid\Exception\UnsupportedParameterException
      */
-    public function testParseWithParameters()
+    public function testParseWithParametersMustThrowAnException()
     {
         $this->expectException(UnsupportedParameterException::class);
 
         $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation = ? AND energy = ?';
         $queryParameters = ['OK', 'none'];
 
-        $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation = 'OK' AND energy = 'none'";
-
-        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+        $this->queryParser->parse($preparedQuery, $queryParameters);
     }
 
     public function testParseWithArrayNamedParameters()
@@ -94,7 +92,7 @@ class DoctrineQueryParserTest extends TestCase
     /**
      * @throws \PrestaShop\PrestaShop\Core\Grid\Exception\UnsupportedParameterException
      */
-    public function testParseWithArrayParameters()
+    public function testParseWithArrayParametersMustThrowAnException()
     {
         $this->expectException(UnsupportedParameterException::class);
 
@@ -109,12 +107,10 @@ class DoctrineQueryParserTest extends TestCase
             ]
         ];
 
-        $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation IN ('great', 'good', 'ok', 'nok', 'none')";
-
-        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+        $this->queryParser->parse($preparedQuery, $queryParameters);
     }
 
-    public function testParseWithNullParameters()
+    public function testParseWithNullNamedParameters()
     {
         $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation IS :motivation';
         $queryParameters = [
@@ -126,7 +122,7 @@ class DoctrineQueryParserTest extends TestCase
         $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
     }
 
-    public function testParseWithBooleanParameters()
+    public function testParseWithBooleanNamedParameters()
     {
         $preparedQuery = 'SELECT tests FROM pierre_rambaud WHERE motivation = :motivation';
         $queryParameters = [


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The "Show SQL query" action was wrong, it showed the prepared SQL query instead of the complete one.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Access (again) to the logs page (http://prestashop.local/admin-dev/index.php/configure/advanced/logs/), add a filter to the query and read the SQL query: you should see the value of your filter.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

![updated](https://user-images.githubusercontent.com/1247388/45171956-1400a500-b204-11e8-8a3a-1bdc4c82eef0.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9324)
<!-- Reviewable:end -->
