### PR TITLE
[POC] Add Release Checker to build tools

### DIFF
--- a/tools/build/CheckGitBranch.php
+++ b/tools/build/CheckGitBranch.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+require_once 'Library/ConsoleWriter.php';
+require_once 'Library/ReleaseChecker.php';
+require_once 'Library/VersionNumber.php';
+
+$consoleWrite = new ConsoleWriter();
+$lineSeparator = PHP_EOL;
+
+if (php_sapi_name() !== 'cli') {
+    $consoleWrite->displayText(
+        "ERROR:{$lineSeparator}Must be run has a CLI script.{$lineSeparator}",
+        ConsoleWriter::COLOR_RED
+    );
+
+    exit(1);
+}
+
+$releaseOptions = [
+    'version' => [
+        'required' => true,
+        'description' => 'Desired release version of PrestaShop',
+        'longopt' => 'version:'
+    ],
+    'help' => [
+        'description' => 'Show help',
+        'opt' => 'h',
+        'longopt' => 'help'
+    ]
+];
+$helpMessage = "Usage: php {prestashop_root_path}/tools/build/CheckGitBranch.php --version=<version>";
+$userOptions = getopt(implode('', array_column($releaseOptions, 'opt')), array_column($releaseOptions, 'longopt'));
+
+// Show help and exit
+if (isset($userOptions['h'])
+    || isset($userOptions['help'])
+    || empty($userOptions)
+) {
+    echo $helpMessage;
+
+    exit(0);
+}
+
+$version = $userOptions['version'];
+
+try {
+    $releaseChecker = new ReleaseChecker($version);
+    $releaseChecker->checkRelease();
+} catch (Exception $e) {
+    $consoleWrite->displayText(
+        "ERROR:{$lineSeparator}Can not check release.{$lineSeparator}Message: '{$e->getMessage()}'{$lineSeparator}",
+        ConsoleWriter::COLOR_RED
+    );
+
+    exit(1);
+}
+
+exit(0);

--- a/tools/build/Library/ReleaseChecker.php
+++ b/tools/build/Library/ReleaseChecker.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Checks that conditions for building the desired releases are met
+ *
+ * @todo: add unit tests
+ */
+class ReleaseChecker
+{
+    /**
+     * @var VersionNumber
+     */
+    private $version;
+
+    /**
+     * @var ConsoleWriter
+     */
+    private $consoleWriter;
+
+    /**
+     * @var string
+     */
+    protected $lineSeparator = PHP_EOL;
+
+    /**
+     * @param string $versionNumber
+     */
+    public function __construct($versionNumber)
+    {
+        $version = new VersionNumber($versionNumber);
+
+        $this->version = $version;
+        $this->consoleWriter = new ConsoleWriter();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function checkRelease()
+    {
+        $currentBranchName = $this->getCurrentBranchName();
+        $branchNameShouldBe = $this->getWhatBranchNameShouldBe($this->version);
+
+        if (null === $currentBranchName) {
+            throw new \RuntimeException('Could not find what git branch is currently checked out');
+        }
+
+        if ($currentBranchName === $branchNameShouldBe) {
+            $this->consoleWriter->displayText(
+                "Current branch: {$currentBranchName}. Valid for release !{$this->lineSeparator}",
+                ConsoleWriter::COLOR_GREEN
+            );
+        } else {
+            $this->consoleWriter->displayText(
+                "Current branch: {$currentBranchName}. PROBLEM ! Should be {$branchNameShouldBe} instead.{$this->lineSeparator}",
+                ConsoleWriter::COLOR_RED
+            );
+        }
+    }
+
+    /**
+     * Gets name of current branch
+     *
+     * @return string
+     *
+     * @throws \Exception
+     */
+    public function getCurrentBranchName()
+    {
+        $cmd = 'git branch';
+        $output = [];
+        $exitCode = null;
+
+        exec("$cmd", $output, $exitCode);
+
+        if ($exitCode !== 0 || (false === is_array($output))) {
+            throw new \Exception("Command $cmd failed.");
+        }
+
+        foreach ($output as $line) {
+            $isCurrentBranchLine = (isset($line[0]) && $line[0] === '*');
+
+            if ($isCurrentBranchLine) {
+                return trim(substr($line, 1));
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param VersionNumber $version
+     *
+     * @return string
+     */
+    private function getWhatBranchNameShouldBe(VersionNumber $version)
+    {
+        if ($version->isMajorVersion()) {
+            return 'develop';
+        }
+
+        $branchNameShouldBe = $version->getMajorNumber() . '.' . $version->getMinorNumber() . '.x';
+
+        return $branchNameShouldBe;
+    }
+}

--- a/tools/build/Library/VersionNumber.php
+++ b/tools/build/Library/VersionNumber.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Represents a version object
+ *
+ * @todo: add unit tests
+ */
+class VersionNumber
+{
+    /** @var string */
+    private $majorNumber;
+    /** @var string */
+    private $minorNumber;
+    /** @var string */
+    private $patchNumber;
+
+    /**
+     * @param string $prestashopVersionNumber
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($prestashopVersionNumber)
+    {
+        $split = $this->parseVersionNumber($prestashopVersionNumber);
+
+        if (5 !== count($split)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Could not parse given PrestaShop version number %s. Wrong format.',
+                $prestashopVersionNumber
+            ));
+        }
+
+        $this->majorNumber = $split[1] . '.' . $split[2];
+        $this->minorNumber = $split[3];
+        $this->patchNumber = $split[4];
+    }
+
+    /**
+     * @return bool
+     */
+    public function isMajorVersion()
+    {
+        return ('0' === $this->patchNumber);
+    }
+
+    /**
+     * @return string
+     */
+    public function getMajorNumber()
+    {
+        return $this->majorNumber;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMinorNumber()
+    {
+        return $this->minorNumber;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPatchNumber()
+    {
+        return $this->patchNumber;
+    }
+
+    /**
+     * @param string $number
+     *
+     * @return array
+     */
+    private function parseVersionNumber($number)
+    {
+        $matches = [];
+        preg_match("#(\d+)\.(\d+)\.(\d+)\.(\d)#", $number, $matches);
+
+        return $matches;
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a "release checker" to build tools. It is in charge of checking your project settings.
| Type?         | improvement
| Category?     | CO
| BC breaks?    |no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Cannot be tested as this is a dev tool

This is a POC to introduce a build tool in charge of checking the project requirements before building a release. Here it checks whether the checked out git branch is the right one for the desired version number. It could be expanded to other checks such as "check git repository is up-to-date with github upstream".

This is a Prototype. If you like the idea, I can polish it with unit tests and doc before shipping it to `develop`. It might also benefit from some proper class autoloading and domain Exceptions.

## Usage
```
$ php tools/build/CheckGitBranch.php --version=<version>
```
_Example:_ `$ php tools/build/CheckGitBranch.php --version=1.7.4.1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9325)
<!-- Reviewable:end -->
