### PR TITLE
Module translations aren't working when using Smarty Extend into TPL

### DIFF
--- a/classes/Smarty/SmartyCustom.php
+++ b/classes/Smarty/SmartyCustom.php
@@ -46,9 +46,9 @@ class SmartyCustomCore extends Smarty
         if ($resource_name == null) {
             Db::getInstance()->execute('REPLACE INTO `'._DB_PREFIX_.'smarty_last_flush` (`type`, `last_flush`) VALUES (\'compile\', FROM_UNIXTIME('.time().'))');
             return 0;
-        } else {
-            return parent::clearCompiledTemplate($resource_name, $compile_id, $exp_time);
         }
+
+        return parent::clearCompiledTemplate($resource_name, $compile_id, $exp_time);
     }
 
     /**
@@ -118,10 +118,9 @@ class SmartyCustomCore extends Smarty
         $this->check_compile_cache_invalidation();
         if ($this->caching) {
             $this->check_template_invalidation($template, $cache_id, $compile_id);
-            return parent::createTemplate($template, $cache_id, $compile_id, $parent, $do_clone);
-        } else {
-            return parent::createTemplate($template, $cache_id, $compile_id, $parent, $do_clone);
         }
+
+        return parent::createTemplate($template, $cache_id, $compile_id, $parent, $do_clone);
     }
 
     /**

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -199,6 +199,7 @@ class TranslateCore
             }
             $translationsMerged[$name][$iso] = true;
         }
+
         $string = preg_replace("/\\\*'/", "\'", $originalString);
         $key = md5($string);
 

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -235,7 +235,6 @@ function smartyTranslate($params, $smarty)
         return Translate::smartyPostProcessTranslation(Translate::getPdfTranslation($params['s'], $params['sprintf']), $params);
     }
 
-
     if ($_LANG != null && isset($_LANG[$key])) {
         $msg = $_LANG[$key];
     } elseif ($_LANG != null && isset($_LANG[Tools::strtolower($key)])) {

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -213,9 +213,7 @@ function smartyTranslate($params, $smarty)
     }
 
     $string = str_replace('\'', '\\\'', $params['s']);
-    $filename = ((!isset($smarty->compiler_object) || !is_object($smarty->compiler_object->template)) ? $smarty->template_resource : $smarty->compiler_object->template->getTemplateFilepath());
-
-    $basename = basename($filename, '.tpl');
+    $basename = basename($smarty->source->name, '.tpl');
     $key = $basename.'_'.md5($string);
 
     if (isset($smarty->source) && (strpos($smarty->source->filepath, DIRECTORY_SEPARATOR.'override'.DIRECTORY_SEPARATOR) !== false)) {
@@ -223,10 +221,20 @@ function smartyTranslate($params, $smarty)
     }
 
     if ($params['mod']) {
-        return Translate::smartyPostProcessTranslation(Translate::getModuleTranslation($params['mod'], $params['s'], $basename, $params['sprintf'], $params['js']), $params);
+        return Translate::smartyPostProcessTranslation(
+            Translate::getModuleTranslation(
+                $params['mod'],
+                $params['s'],
+                $basename,
+                $params['sprintf'],
+                $params['js']
+            ),
+            $params
+        );
     } elseif ($params['pdf']) {
         return Translate::smartyPostProcessTranslation(Translate::getPdfTranslation($params['s'], $params['sprintf']), $params);
     }
+
 
     if ($_LANG != null && isset($_LANG[$key])) {
         $msg = $_LANG[$key];

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -232,7 +232,13 @@ function smartyTranslate($params, $smarty)
             $params
         );
     } elseif ($params['pdf']) {
-        return Translate::smartyPostProcessTranslation(Translate::getPdfTranslation($params['s'], $params['sprintf']), $params);
+        return Translate::smartyPostProcessTranslation(
+            Translate::getPdfTranslation(
+                $params['s'],
+                $params['sprintf']
+            ),
+            $params
+        );
     }
 
     if ($_LANG != null && isset($_LANG[$key])) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Currently the selected source is the extend module. Always use $smarty->resource->name to retrieve the template name
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5983
| How to test?  | Follow instruction on Jira..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9326)
<!-- Reviewable:end -->
