### PR TITLE
Fixed Product form when stock management is disabled

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -57,6 +57,7 @@
 
         {# PANEL ESSENTIALS #}
         {% block product_panel_essentials %}
+          {% set formQuantityShortcut = form.step1.qty_0_shortcut is defined ? form.step1.qty_0_shortcut : null  %}
           {{ include('@Product/ProductPage/Panels/essentials.html.twig', {
               'formPackItems': form.step1.inputPackItems,
               'productId': id_product,
@@ -69,7 +70,7 @@
               'is_combination_active': is_combination_active,
               'has_combinations': has_combinations,
               'formReference': form.step6.reference,
-              'formQuantityShortcut': form.step1.qty_0_shortcut,
+              'formQuantityShortcut': formQuantityShortcut,
               'formPriceShortcut': form.step1.price_shortcut,
               'formPriceShortcutTTC': form.step1.price_ttc_shortcut,
               'formCategories': form.step1,
@@ -79,10 +80,11 @@
 
         {# PANEL COMBINATIONS #}
         {% block product_panel_combinations %}
+          {% set formStockQuantity = form.step3.qty_0 is defined ? form.step3.qty_0 : null  %}
           {{ include('@Product/ProductPage/Panels/combinations.html.twig', {
               'formDependsOnStocks': form.step3.depends_on_stock,
               'productId': id_product,
-              'formStockQuantity': form.step3.qty_0,
+              'formStockQuantity': formStockQuantity,
               'formStockMinimalQuantity': form.step3.minimal_quantity,
               'formLowStockThreshold': form.step3.low_stock_threshold,
               'formLowStockAlert': form.step3.low_stock_alert,


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | The product form was broken when stock management feature was disabled
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-6000
| How to test?  | See ticket => http://forge.prestashop.com/browse/BOOM-6000
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9327)
<!-- Reviewable:end -->
