### PR TITLE
fix hyphen in search sanitize

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -107,7 +107,7 @@ class SearchCore
         $string = preg_replace('/['.PREG_CLASS_SEARCH_EXCLUDE.']+/u', ' ', $string);
 
         if ($indexation) {
-            $string = preg_replace('/[._-]+/', ' ', $string);
+            $string = preg_replace('/[._]+/', ' ', $string);
         } else {
             $words = explode(' ', $string);
             $processed_words = array();
@@ -122,9 +122,7 @@ class SearchCore
             }
             $string = implode(' ', $processed_words);
             $string = preg_replace('/[._]+/', '', $string);
-            $string = ltrim(preg_replace('/([^ ])-/', '$1 ', ' '.$string));
             $string = preg_replace('/[._]+/', '', $string);
-            $string = preg_replace('/[^\s]-+/', '', $string);
         }
 
         $blacklist = Tools::strtolower(Configuration::get('PS_SEARCH_BLACKLIST', $id_lang));

--- a/tests/Unit/Core/Business/Product/Search/SearchTest.php
+++ b/tests/Unit/Core/Business/Product/Search/SearchTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Product\Search;
+
+use PHPUnit\Framework\TestCase;
+use Search;
+
+class SearchTest extends Testcase
+{
+
+    /**
+     *
+     * @dataProvider searchStringProvider()
+     *
+     * @param $input
+     * @param $langId
+     * @param $expected
+     */
+    public function testSearchSanitizer($input, $langId, $expected)
+    {
+        $result = Search::sanitize($input, $langId);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function searchStringProvider()
+    {
+        return [
+            'simple'            => [
+                'input'    => 'test',
+                'langId'   => 1,
+                'expected' => 'test',
+            ],
+            'with hyphen'       => [
+                'input'    => 'test-test',
+                'langId'   => 1,
+                'expected' => 'test-test',
+            ],
+            'with space'        => [
+                'input'    => 'test test',
+                'langId'   => 1,
+                'expected' => 'test test',
+            ],
+            'with double space' => [
+                'input'    => 'test  test',
+                'langId'   => 1,
+                'expected' => 'test test',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | hyphen were used as word separator in search : now it does not separate words
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4148
| How to test?  | in BO create a product with hyphen in its name, and use the search header on FO

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9336)
<!-- Reviewable:end -->
