### PR TITLE
Can't install prestashop in dev mode with open_basedir

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -67,7 +67,8 @@ class AppKernel extends Kernel
         if ($this->parametersFileExists()) {
             try {
                 $this->enableComposerAutoloaderOnModules($this->getActiveModules());
-            } catch (\Exception $e) {}
+            } catch (\Exception $e) {
+            }
         }
 
         return $bundles;
@@ -87,7 +88,8 @@ class AppKernel extends Kernel
             try {
                 $this->getConnection()->connect();
                 $activeModules = $this->getActiveModules();
-            } catch (\Exception $e) {}
+            } catch (\Exception $e) {
+            }
         }
 
         return array_merge(
@@ -218,5 +220,18 @@ class AppKernel extends Kernel
                 include_once $autoloader;
             }
         }
+    }
+
+    /**
+     * Gets the application root dir.
+     * Override Kernel due to the fact that we remove the composer.json in
+     * downloaded package. More we are not a framework and the root directory
+     * should always be the parent of this file.
+     *
+     * @return string The project root dir
+     */
+    public function getProjectDir()
+    {
+        return realpath(__DIR__ . '/..');
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | When composer.json file is missing and the open_basedir directive is set we are not able to install Prestashop. More, there can be more issues because the getProjectDir is wrong.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Install prestashop in debug mode, without composer.json (From download page).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9345)
<!-- Reviewable:end -->
