### PR TITLE
Add free shipping info in cart vouchers on FO

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -532,6 +532,7 @@ class CartPresenter implements PresenterInterface
                     'token' => Tools::getToken(false),
                 )
             );
+            $vouchers[$cartVoucher['id_cart_rule']]['free_shipping'] = $cartVoucher['free_shipping'];
         }
 
         return array(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Currently on FO we can't know if added voucher is of type "free shipping"
| Type?         |  improvement 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Create a cart rule with Free shipping offer. On FO add the voucher code to get it. In `templates/checkout/_partials/cart-voucher.tpl` you have `$cart.vouchers.added` variable but you can't know if voucher is of type "Free shipping". It would be useful to be able to do specific things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9346)
<!-- Reviewable:end -->
