### PR TITLE
Correctly handle hyphens in search index

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -104,18 +104,16 @@ class SearchCore
             // eg: t-shirt => tshirt
             foreach ($words2 as $word) {
                 if (strpos($word, '-') !== false) {
-                    $word = str_replace(['-'], '', $word);
+                    $word = str_replace('-', '', $word);
                     if (!empty($word)) {
-                        $words[] = str_replace(['-'], '', $word);
+                        $words[] = $word;
                     }
                 }
             }
-            $words = array_unique(array_merge($words, $words2));
-        } else {
-            $words = array_unique($words);
+            $words = array_merge($words, $words2);
         }
 
-        return $words;
+        return array_unique($words);
     }
 
     public static function sanitize($string, $id_lang, $indexation = false, $iso_code = false, $keepHyphens = false)

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -226,7 +226,7 @@ class SearchCore
 
         $intersect_array = array();
         $score_array = array();
-        $words = explode(' ', Search::sanitize($expr, $id_lang, false, $context->language->iso_code));
+        $words = Search::extractKeyWords($expr, $id_lang, false, $context->language->iso_code);
 
         foreach ($words as $key => $word) {
             if (!empty($word) && strlen($word) >= (int)Configuration::get('PS_SEARCH_MINWORDLEN')) {
@@ -587,7 +587,7 @@ class SearchCore
     protected static function fillProductArray(&$product_array, $weight_array, $key, $value, $id_lang, $iso_code)
     {
         if (strncmp($key, 'id_', 3) && isset($weight_array[$key])) {
-            $words = explode(' ', Search::sanitize($value, (int)$id_lang, true, $iso_code));
+            $words = Search::extractKeyWords($value, (int)$id_lang, true, $iso_code);
             foreach ($words as $word) {
                 if (!empty($word)) {
                     $word = Tools::substr($word, 0, PS_SEARCH_MAX_WORD_LENGTH);

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -131,9 +131,9 @@ class SearchCore
 
         if ($indexation) {
             if (!$keepHyphens) {
-                $string = str_replace(['.', '_', '-'], '', $string);
+                $string = str_replace(['.', '_', '-'], ' ', $string);
             } else {
-                $string = str_replace(['.', '_'], '', $string);
+                $string = str_replace(['.', '_'], ' ', $string);
             }
         } else {
             $words = explode(' ', $string);

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -96,10 +96,20 @@ class SearchCore
     public static function extractKeyWords($string, $id_lang, $indexation = false, $iso_code = false)
     {
         $sanitizedString = Search::sanitize($string, $id_lang, $indexation, $iso_code, false);
-        $words          = explode(' ', $sanitizedString);
+        $words = explode(' ', $sanitizedString);
         if (strpos($string, '-') !== false) {
             $sanitizedString = Search::sanitize($string, $id_lang, $indexation, $iso_code, true);
             $words2          = explode(' ', $sanitizedString);
+            // foreach word containing hyphen, we want to index additional word removing the hyphen
+            // eg: t-shirt => tshirt
+            foreach ($words2 as $word) {
+                if (strpos($word, '-') !== false) {
+                    $word = str_replace(['-'], '', $word);
+                    if (!empty($word)) {
+                        $words[] = str_replace(['-'], '', $word);
+                    }
+                }
+            }
             $words = array_unique(array_merge($words, $words2));
         } else {
             $words = array_unique($words);

--- a/tests/Unit/Core/Business/Product/Search/SearchTest.php
+++ b/tests/Unit/Core/Business/Product/Search/SearchTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Product\Search;
+
+use PHPUnit\Framework\TestCase;
+use Search;
+
+class SearchTest extends Testcase
+{
+    /**
+     *
+     * @dataProvider searchStringProvider()
+     *
+     * @param $input
+     * @param $langId
+     * @param $expected
+     */
+    public function testSearchSanitizer($input, $langId, $expected)
+    {
+        $result = Search::extractKeyWords($input, $langId);
+        // array_values used to prevent issues with indexes keeped from array_unique
+        $this->assertEquals($expected, array_values($result));
+    }
+
+    public function searchStringProvider()
+    {
+        return [
+            'simple'                                => [
+                'input'    => 'test',
+                'langId'   => 1,
+                'expected' => ['test'],
+            ],
+            'with hyphen'                           => [
+                'input'    => 'test1-test2',
+                'langId'   => 1,
+                'expected' => ['test1', 'test2', 'test1-test2'],
+            ],
+            'with hyphen with double'               => [
+                'input'    => 'test1-test-test',
+                'langId'   => 1,
+                'expected' => ['test1', 'test', 'test1-test-test'],
+            ],
+            'with space'                            => [
+                'input'    => 'test1 test2',
+                'langId'   => 1,
+                'expected' => ['test1', 'test2'],
+            ],
+            'with double space'                     => [
+                'input'    => 'test1  test2',
+                'langId'   => 1,
+                'expected' => ['test1', 'test2'],
+            ],
+            'with space with double'                => [
+                'input'    => 'test test',
+                'langId'   => 1,
+                'expected' => ['test'],
+            ],
+            'with space before hyphen'              => [
+                'input'    => 'test1 -test2',
+                'langId'   => 1,
+                'expected' => ['test1', '-test2'],
+            ],
+            'with double space before hyphen'       => [
+                'input'    => 'test1  -test2',
+                'langId'   => 1,
+                'expected' => ['test1', '-test2'],
+            ],
+            'with multiple hyphens'                 => [
+                'input'    => 'test1--test2',
+                'langId'   => 1,
+                'expected' => ['test1', '-test2', 'test1--test2'],
+            ],
+            'with space separated hyphen'           => [
+                'input'    => 'test1 - test2',
+                'langId'   => 1,
+                'expected' => ['test1', '-', 'test2'],
+            ],
+            'with strange double hyphens'           => [
+                'input'    => 'test1 -- test2',
+                'langId'   => 1,
+                'expected' => ['test1', '-', 'test2', '--'],
+            ],
+            'with space after hyphen'               => [
+                'input'    => 'test1- test2',
+                'langId'   => 1,
+                'expected' => ['test1', 'test2', 'test1-'],
+            ],
+            'with multiple space separated hyphens' => [
+                'input'    => 'test1 - - test2',
+                'langId'   => 1,
+                'expected' => ['test1', '-', 'test2'],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Core/Business/Product/Search/SearchTest.php
+++ b/tests/Unit/Core/Business/Product/Search/SearchTest.php
@@ -57,12 +57,12 @@ class SearchTest extends Testcase
             'with hyphen'                           => [
                 'input'    => 'test1-test2',
                 'langId'   => 1,
-                'expected' => ['test1', 'test2', 'test1-test2'],
+                'expected' => ['test1', 'test2', 'test1test2', 'test1-test2'],
             ],
             'with hyphen with double'               => [
                 'input'    => 'test1-test-test',
                 'langId'   => 1,
-                'expected' => ['test1', 'test', 'test1-test-test'],
+                'expected' => ['test1', 'test', 'test1testtest', 'test1-test-test'],
             ],
             'with space'                            => [
                 'input'    => 'test1 test2',
@@ -82,17 +82,17 @@ class SearchTest extends Testcase
             'with space before hyphen'              => [
                 'input'    => 'test1 -test2',
                 'langId'   => 1,
-                'expected' => ['test1', '-test2'],
+                'expected' => ['test1', '-test2', 'test2'],
             ],
             'with double space before hyphen'       => [
                 'input'    => 'test1  -test2',
                 'langId'   => 1,
-                'expected' => ['test1', '-test2'],
+                'expected' => ['test1', '-test2', 'test2'],
             ],
             'with multiple hyphens'                 => [
                 'input'    => 'test1--test2',
                 'langId'   => 1,
-                'expected' => ['test1', '-test2', 'test1--test2'],
+                'expected' => ['test1', '-test2', 'test1test2', 'test1--test2'],
             ],
             'with space separated hyphen'           => [
                 'input'    => 'test1 - test2',


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix hyphen indexation on product search
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-4148
| How to test?  | create product with hyphen in its name, check the FO search header behavior. Try with multiple hyphens, space separated ones...
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9353)
<!-- Reviewable:end -->
