### PR TITLE
Set correct Employee Css after update

### DIFF
--- a/install-dev/upgrade/sql/1.7.4.1.sql
+++ b/install-dev/upgrade/sql/1.7.4.1.sql
@@ -2,3 +2,5 @@ SET SESSION sql_mode = '';
 SET NAMES 'utf8';
 
 ALTER TABLE `PREFIX_cart_rule` ADD KEY `date_from` (`date_from`), ADD KEY `date_to` (`date_to`);
+
+UPDATE `PREFIX_employee` SET `bo_css` = "theme.css";

--- a/install-dev/upgrade/sql/1.7.4.1.sql
+++ b/install-dev/upgrade/sql/1.7.4.1.sql
@@ -2,5 +2,3 @@ SET SESSION sql_mode = '';
 SET NAMES 'utf8';
 
 ALTER TABLE `PREFIX_cart_rule` ADD KEY `date_from` (`date_from`), ADD KEY `date_to` (`date_to`);
-
-UPDATE `PREFIX_employee` SET `bo_css` = "theme.css";

--- a/install-dev/upgrade/sql/1.7.4.2.sql
+++ b/install-dev/upgrade/sql/1.7.4.2.sql
@@ -1,0 +1,4 @@
+SET SESSION sql_mode = '';
+SET NAMES 'utf8';
+
+UPDATE `PREFIX_employee` SET `bo_css` = "theme.css";


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | After a migration from versions earlier than 1.7.4 , Back office css have some interference whith old admin-css
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Intall a 1.7 version earlier than 1.7.4.1 , update it to 1.7.4.1, whithout this page header of back office is quite too much on the left

- this pull apply the modification on employee class visible on : https://github.com/PrestaShop/PrestaShop/pull/9102/files#diff-d373723286a172a4ca3d76c4858f565b
when migrating.
` $this->bo_css = 'theme.css';`

- please see the picture bellow for the bug : 
![image](https://user-images.githubusercontent.com/3170104/42953094-ea3db74a-8b79-11e8-9f83-a9bc956e4d45.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9354)
<!-- Reviewable:end -->
