### PR TITLE
Allow to install PrestaShop without allow_url_fopen enabled

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1089,9 +1089,10 @@ class LanguageCore extends ObjectModel
         if (!is_writable(dirname($file))) {
             // @todo Throw exception
             $errors[] = Context::getContext()->getTranslator()->trans('Server does not have permissions for writing.', array(), 'Admin.International.Notification').' ('.$file.')';
+        } elseif ($content = Tools::file_get_contents($url)) {
+            file_put_contents($file, $content);
         } else {
-            $fs = new Filesystem();
-            $fs->copy($url, $file, true);
+            $errors[] = Context::getContext()->getTranslator()->trans('Language pack unavailable.', array(), 'Admin.International.Notification').' '.$url;
         }
     }
 
@@ -1394,7 +1395,7 @@ class LanguageCore extends ObjectModel
 
                 // Update table
                 if (!empty($updateWhere) && !empty($updateField)) {
-                    $sql = 'UPDATE `' . bqSQL($tableName) . '` SET ' . $updateField . ' 
+                    $sql = 'UPDATE `' . bqSQL($tableName) . '` SET ' . $updateField . '
                     WHERE ' . $updateWhere . ' AND `id_lang` = "' . (int) $lang->id . '"
                     ' . ($shopFieldExists ? ' AND `id_shop` = ' . (int) $shop->id : '') . '
                     LIMIT 1;';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | When you try to install PrestaShop with allow_url_fopen disabled, it will fail
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9355)
<!-- Reviewable:end -->
