### PR TITLE
Allow configuration to save html data

### DIFF
--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -127,7 +127,7 @@ class Configuration extends ParameterBag implements ConfigurationInterface
             $shopId = $this->shop->id;
         }
 
-        $html = isset($options['html']) ? $options['html'] : false;
+        $html = isset($options['html']) ? (bool) $options['html'] : false;
 
         $success = ConfigurationLegacy::updateValue(
             $key,

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -108,14 +108,15 @@ class Configuration extends ParameterBag implements ConfigurationInterface
 
     /**
      * Set configuration value
-     * @param $key
-     * @param $value
-     * @param bool   $html   Specify if html is authorized in value
+     *
+     * @param string $key
+     * @param mixed  $value
+     * @param array  $options Options
      *
      * @return $this
      * @throws \Exception
      */
-    public function set($key, $value, $html = false)
+    public function set($key, $value, $options = [])
     {
         // By default, set a piece of configuration for all available shops and shop groups
         $shopGroupId = null;
@@ -125,6 +126,8 @@ class Configuration extends ParameterBag implements ConfigurationInterface
             $shopGroupId = $this->shop->id_shop_group;
             $shopId = $this->shop->id;
         }
+
+        $html = isset($options['html']) ? $options['html'] : false;
 
         $success = ConfigurationLegacy::updateValue(
             $key,

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -52,7 +52,7 @@ class Configuration extends ParameterBag implements ConfigurationInterface
     {
         throw new NotImplementedException();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -110,10 +110,12 @@ class Configuration extends ParameterBag implements ConfigurationInterface
      * Set configuration value
      * @param $key
      * @param $value
+     * @param bool   $html   Specify if html is authorized in value
+     *
      * @return $this
      * @throws \Exception
      */
-    public function set($key, $value)
+    public function set($key, $value, $html = false)
     {
         // By default, set a piece of configuration for all available shops and shop groups
         $shopGroupId = null;
@@ -127,7 +129,7 @@ class Configuration extends ParameterBag implements ConfigurationInterface
         $success = ConfigurationLegacy::updateValue(
             $key,
             $value,
-            false,
+            $html,
             $shopGroupId,
             $shopId
         );
@@ -149,7 +151,7 @@ class Configuration extends ParameterBag implements ConfigurationInterface
 
     /**
      * Removes a configuration key.
-     * 
+     *
      * @param type $key
      * @return type
      */

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -116,7 +116,7 @@ class Configuration extends ParameterBag implements ConfigurationInterface
      * @return $this
      * @throws \Exception
      */
-    public function set($key, $value, $options = [])
+    public function set($key, $value, array $options = [])
     {
         // By default, set a piece of configuration for all available shops and shop groups
         $shopGroupId = null;

--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -61,15 +61,13 @@ class MaintenanceConfiguration implements DataConfigurationInterface
      */
     public function updateConfiguration(array $configuration)
     {
-        $errors = array();
-
         if ($this->validateConfiguration($configuration)) {
             $this->configuration->set('PS_SHOP_ENABLE', $configuration['enable_shop']);
             $this->configuration->set('PS_MAINTENANCE_IP', $configuration['maintenance_ip']);
-            $this->configuration->set('PS_MAINTENANCE_TEXT', $configuration['maintenance_text']);
+            $this->configuration->set('PS_MAINTENANCE_TEXT', $configuration['maintenance_text'], true);
         }
 
-        return $errors;
+        return [];
     }
 
     /**

--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -64,7 +64,7 @@ class MaintenanceConfiguration implements DataConfigurationInterface
         if ($this->validateConfiguration($configuration)) {
             $this->configuration->set('PS_SHOP_ENABLE', $configuration['enable_shop']);
             $this->configuration->set('PS_MAINTENANCE_IP', $configuration['maintenance_ip']);
-            $this->configuration->set('PS_MAINTENANCE_TEXT', $configuration['maintenance_text'], true);
+            $this->configuration->set('PS_MAINTENANCE_TEXT', $configuration['maintenance_text'], ['html' => true]);
         }
 
         return [];

--- a/src/Core/Form/FormHandler.php
+++ b/src/Core/Form/FormHandler.php
@@ -114,5 +114,4 @@ class FormHandler implements FormHandlerInterface
 
         return $errors;
     }
-
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MaintenanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MaintenanceController.php
@@ -89,7 +89,10 @@ class MaintenanceController extends FrameworkBundleAdminController
                 PageVoter::LEVEL_DELETE,
             )
         )) {
-            $this->addFlash('error', $this->trans('You do not have permission to update this.', 'Admin.Notifications.Error'));
+            $this->addFlash(
+                'error',
+                $this->trans('You do not have permission to update this.', 'Admin.Notifications.Error')
+            );
             return $redirectResponse;
         }
 

--- a/tests/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
+++ b/tests/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
@@ -305,7 +305,7 @@ class ConfigurationMock extends Configuration
 {
     private $configurationData = array();
 
-    public function set($key, $value)
+    public function set($key, $value, array $options = [])
     {
         $this->configurationData[$key] = $value;
         return $this;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | UpdateValue already allows data to be saved with html, when using Configuration::set() we need to add a parameter to allow it again
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-6007
| How to test?  | Follow video in the forge ticket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9359)
<!-- Reviewable:end -->
