### PR TITLE
Fix JS error after add to cart

### DIFF
--- a/themes/classic/_dev/js/components/block-cart.js
+++ b/themes/classic/_dev/js/components/block-cart.js
@@ -42,6 +42,7 @@ prestashop.blockcart.showModal = (html) => {
   $blockCartModal = getBlockCartModal();
   $blockCartModal.modal('show').on('hidden.bs.modal', (event) => {
     prestashop.emit('updateProduct', {
+      reason: event.currentTarget.dataset,
       event: event
     });
   });

--- a/themes/classic/_dev/js/components/block-cart.js
+++ b/themes/classic/_dev/js/components/block-cart.js
@@ -42,7 +42,7 @@ prestashop.blockcart.showModal = (html) => {
   $blockCartModal = getBlockCartModal();
   $blockCartModal.modal('show').on('hidden.bs.modal', (event) => {
     prestashop.emit('updateProduct', {
-      reason: event.currentTarget.dataset
+      event: event
     });
   });
 };


### PR DESCRIPTION
After add to cart there was JS error in console which was blocking refresh of product page

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Fix js issue after add to cart https://pasteboard.co/HvLuX0p.png
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | go to product page, and add to cart, click contiune and check chrome debug javascript console

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9364)
<!-- Reviewable:end -->
