### PR TITLE
Wrong generated template path when using getCurrentSubTemplate with a full path name.

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2291,7 +2291,10 @@ abstract class ModuleCore implements ModuleInterface
     protected function getCurrentSubTemplate($template, $cache_id = null, $compile_id = null)
     {
         if (!isset($this->current_subtemplate[$template.'_'.$cache_id.'_'.$compile_id])) {
-            if (false === strpos($template, 'module:') && !file_exists(_PS_ROOT_DIR_ . '/' . $template)) {
+            if (false === strpos($template, 'module:') &&
+                !file_exists(_PS_ROOT_DIR_ . '/' . $template) &&
+                !file_exists($template)
+            ) {
                 $template = $this->getTemplatePath($template);
             }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Make sur the $template isn't in modules directory or isn't a full path before trying to get a template path. 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5915 again
| How to test?  | http://forge.prestashop.com/browse/BOOM-5915?focusedCommentId=172399&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-172399

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9365)
<!-- Reviewable:end -->
