### PR TITLE
Don't display the system step if mandatory requirements are OK

### DIFF
--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -242,6 +242,12 @@ class InstallControllerHttp
             if (self::$steps->current()->getControllerInstance()->validate()) {
                 self::$steps->next();
             }
+
+            // Don't display system step if mandatory requirements is valid
+            if (self::$steps->current()->getName() == 'system' && self::$steps->current()->getControllerInstance()->validate()) {
+                self::$steps->next();
+            }
+
             $session->step = self::$steps->current()->getName();
 
             // Change last step


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | devleop
| Description?  | Since the 1.7.0 version (71717b89b619b13ee85045490433df873b6924fb), the system step was displayed every times on the installer.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test? | In install wizard, System compatibility step is ignored when green.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9366)
<!-- Reviewable:end -->
