### PR TITLE
Prevent malformed URL like /fr/index.php?

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -897,6 +897,10 @@ class DispatcherCore
         }
 
         if (!isset($this->routes[$id_shop][$id_lang][$route_id])) {
+            if ($this->multilang_activated && !isset($params['id_lang'])) {
+                $params = array_merge(array('id_lang' => (int)$id_lang), $params);
+            }
+
             $query = http_build_query($params, '', '&');
             $index_link = $this->use_routes ? '' : 'index.php';
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1082,6 +1082,10 @@ class LinkCore
 
         $uriPath = Dispatcher::getInstance()->createUrl($controller, $idLang, $request, false, '', $idShop);
 
+        if (substr($uriPath, 0, 10) === 'index.php?') {
+            return $this->getBaseLink($idShop, $ssl, $relativeProtocol) . ltrim($uriPath, '/');
+        } 
+
         return $this->getBaseLink($idShop, $ssl, $relativeProtocol) . $this->getLangLink($idLang, null, $idShop) . ltrim($uriPath, '/');
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This modification prevents the language from being added for URLs that start with `/index.php?`
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Visit the page "Order history" and clic on "Details" on one of your order. Finally, check the URL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9367)
<!-- Reviewable:end -->
