### PR TITLE
Multistore shared cart - wrong product price sum

### DIFF
--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -269,7 +269,7 @@ class CartRow
         $stateId   = (int) $address->id_state;
         $zipCode   = $address->postcode;
 
-        $shopId     = (int) $cart->id_shop;
+        $shopId     = (int) $rowData['id_shop'];
         $currencyId = (int) $cart->id_currency;
 
         $groupId = null;


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Change id_shop identity from general id_shop to id_shop by product.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-6067
| How to test?  | Create multistore shop A and shop B then one product in each shop. Then try to add those product to cart and check cart sum total.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9375)
<!-- Reviewable:end -->
