### PR TITLE
IN: don't delete the smarty cache in Tools::clearSf2Cache()

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3158,11 +3158,17 @@ exit;
             $env = _PS_MODE_DEV_ ? 'dev' : 'prod';
         }
 
-        $dir = _PS_ROOT_DIR_ . '/var/cache/' . $env . '/';
-
-        register_shutdown_function(function() use ($dir) {
-            $fs = new Filesystem();
-            $fs->remove($dir);
+        register_shutdown_function(function() use ($env) {
+            $directory = _PS_ROOT_DIR_ . '/var/cache/' . $env . '/';
+            if (is_dir($directory)) {
+                $directories = new DirectoryIterator($directory);
+                $fs = new Filesystem();
+                foreach ($directories as $fileinfo) {
+                    if (!$fileinfo->isDot() && !in_array($fileinfo->getFilename(), ['smarty', 'cacert.pem'])) {
+                        $fs->remove($fileinfo->getPathName());
+                    }
+                }
+            }
             Hook::exec('actionClearSf2Cache');
         });
     }

--- a/install-dev/controllers/http/smarty_compile.php
+++ b/install-dev/controllers/http/smarty_compile.php
@@ -25,21 +25,28 @@
  */
 
 define('_PS_DO_NOT_LOAD_CONFIGURATION_', true);
+$directories = [];
 if (Tools::getValue('bo')) {
     if (!is_dir(_PS_ROOT_DIR_.'/admin/')) {
         exit;
     }
     define('_PS_ADMIN_DIR_', _PS_ROOT_DIR_.'/admin/');
-    $directory = _PS_ADMIN_DIR_.'themes/default/';
+    $directories = [
+        _PS_ADMIN_DIR_.'themes/default/template',
+        _PS_ADMIN_DIR_.'themes/new-theme/template',
+    ];
 } else {
-    $directory = _PS_THEME_DIR_.'templates/';
+    $directories[] = _PS_THEME_DIR_.'templates/';
 }
 
 require_once(_PS_ROOT_DIR_.'/config/smarty.config.inc.php');
 
-$smarty->setTemplateDir($directory);
 ob_start();
-$smarty->compileAllTemplates('.tpl', false);
+foreach ($directories as $directory) {
+    $smarty->setTemplateDir($directory);
+    $smarty->compileAllTemplates('.tpl', false);
+}
+
 if (ob_get_level() && ob_get_length() > 0) {
     ob_end_clean();
 }

--- a/src/PrestaShopBundle/Service/Command/AbstractCommand.php
+++ b/src/PrestaShopBundle/Service/Command/AbstractCommand.php
@@ -88,7 +88,7 @@ abstract class AbstractCommand
     /**
      * Add cache:clear to the execution.
      */
-    public function addCacheClear()
+    public function addCacheClear($all = true)
     {
         $this->commands[] = array(
             'command' => 'doctrine:cache:clear-metadata',
@@ -105,9 +105,11 @@ abstract class AbstractCommand
             '--flush' => true,
         );
 
-        $this->commands[] = array(
-            'command' => 'cache:clear',
-            '--no-warmup' => true,
-        );
+        if ($all) {
+            $this->commands[] = array(
+                'command' => 'cache:clear',
+                '--no-warmup' => true,
+            );
+        }
     }
 }

--- a/src/PrestaShopBundle/Service/Database/Upgrade.php
+++ b/src/PrestaShopBundle/Service/Database/Upgrade.php
@@ -38,7 +38,7 @@ class Upgrade extends AbstractCommand
         $command = new UpdateSchemaCommand();
         $this->application->add($command);
 
-        $this->addCacheClear();
+        $this->addCacheClear(false);
 
         $this->commands[] = array(
             'command' => 'prestashop:schema:update-without-foreign'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Currently Tools::clearSf2Cache() clear all the cache and not only the Symfony caches. It leads to several race condition especially in the installer.
| Type?         | bug fix 
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9376)
<!-- Reviewable:end -->
