### PR TITLE
Use product_id instead of image_id in Backoffice's products-thumb…

### DIFF
--- a/src/Adapter/ImageManager.php
+++ b/src/Adapter/ImageManager.php
@@ -52,11 +52,21 @@ class ImageManager
      * @param string $imageType
      * @param string $tableName
      * @param string $imageDir
+     * @param $productId
      * @return string The HTML < img > tag
      */
-    public function getThumbnailForListing($imageId, $imageType = 'jpg', $tableName = 'product', $imageDir = 'p')
-    {
-        $thumbPath = $this->getThumbnailTag($imageId, $imageType, $tableName, $imageDir);
+    public function getThumbnailForListing(
+        $imageId,
+        $imageType = 'jpg',
+        $tableName = 'product',
+        $imageDir = 'p',
+        $productId = null
+    ) {
+        if ($productId === null) {
+            $productId = $imageId;
+        }
+
+        $thumbPath = $this->getThumbnailTag($imageId, $imageType, $tableName, $imageDir, $productId);
 
         // because legacy uses relative path to reach a directory under root directory...
         $replacement = 'src="'.$this->legacyContext->getRootUrl();
@@ -88,15 +98,16 @@ class ImageManager
      * @param string $imageType
      * @param string $tableName
      * @param string $imageDir
+     * @param $productId
      * @return string
      */
-    private function getThumbnailTag($imageId, $imageType, $tableName, $imageDir)
+    private function getThumbnailTag($imageId, $imageType, $tableName, $imageDir, $productId)
     {
         $imagePath = $this->getImagePath($imageId, $imageType, $tableName, $imageDir);
 
         return LegacyImageManager::thumbnail(
             $imagePath,
-            $this->makeCachedImageName($imageId, $imageType, $tableName),
+            $this->makeCachedImageName($productId, $imageType, $tableName),
             45,
             $imageType
         );

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -354,7 +354,13 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
                 $product['price'] = Tools::displayPrice($product['price'], $currency);
                 $product['price_final'] = Tools::displayPrice($product['price_final'], $currency);
             }
-            $product['image'] = $this->imageManager->getThumbnailForListing($product['id_image']);
+            $product['image'] = $this->imageManager->getThumbnailForListing(
+                $product['id_image'],
+                'jpg',
+                'product',
+                'p',
+                $product['id_product']
+            );
             $product['image_link'] = Context::getContext()->link->getImageLink($product['link_rewrite'], $product['id_image']);
         }
 


### PR DESCRIPTION
…nails list

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | Develop
| Description?  | Fixes a bug that happens sometimes in the backoffice's product listing. Thumbnail image isn't matching product image.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-6064
| How to test?  | Happened randomly on our shop, unfortunately

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9379)
<!-- Reviewable:end -->
