### PR TITLE
Fix Type of formfield to number

### DIFF
--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -95,6 +95,7 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                 if ($field === 'postcode') {
                     if ($this->country->need_zip_code) {
                         $formField->setRequired(true);
+                        $formField->setType('number');
                     }
                 } elseif ($field === 'phone') {
                     $formField->setType('tel');


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Set type of zipcode to numbers, to help users with the right keyboard when using mobile devices
| Type?         | bug fix / improvement
| Category?     | FO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | 
| How to test?  | Fill zipcode on a mobile device.
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

To hide up and down arrows in the text box, we need to add a little css. Where should I place the CSS?
`.form-control{
    -moz-appearance: textfield;
}`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9380)
<!-- Reviewable:end -->
