### PR TITLE
Fix label "Use this address for invoice too'"

### DIFF
--- a/themes/classic/templates/checkout/_partials/address-form.tpl
+++ b/themes/classic/templates/checkout/_partials/address-form.tpl
@@ -22,8 +22,8 @@
   {if $type === "delivery"}
     <div class="form-group row">
       <div class="col-md-9 col-md-offset-3">
-        <input name = "use_same_address" type = "checkbox" value = "1" {if $use_same_address} checked {/if}>
-        <label>{l s='Use this address for invoice too' d='Shop.Theme.Checkout'}</label>
+        <input name = "use_same_address" id="use_same_address" type = "checkbox" value = "1" {if $use_same_address} checked {/if}>
+        <label for="use_same_address">{l s='Use this address for invoice too' d='Shop.Theme.Checkout'}</label>
       </div>
     </div>
   {/if}


### PR DESCRIPTION
Label was not clickable

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | fix not clickable label of "use same addres for invoice".
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9381)
<!-- Reviewable:end -->
