### PR TITLE
Fix reduction exclude special feature

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -693,10 +693,10 @@ class CartRuleCore extends ObjectModel
 
         if ($this->reduction_exclude_special) {
             $products = $context->cart->getProducts();
-            $is_ok = false;
+            $is_ok = true;
             foreach ($products as $product) {
-                if (!$product['reduction_applies']) {
-                    $is_ok = true;
+                if ($product['reduction_applies']) {
+                    $is_ok = false;
                     break;
                 }
             }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | before this fix you can use voucher on cart containing products with reduction even tho back-office option is checked to "yes" for excluding this scenario
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | i guess
| How to test?  | Instruction below

1. Add two products, for 100 EUR, one with 10% discount.
2. Add these two products to cart, you should have two products in cart for a total amount of 180 EUR, (100 + 80)
3. Add voucher for an order without shipping, 10%, exclude special products.
4. Result? Order is worth 162 EUR which shouldn't be a case as this coupon shouldn't be valid
5. Apply fix
6. Test again

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9383)
<!-- Reviewable:end -->
