### PR TITLE
Fix for browser back button on product page

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -316,7 +316,7 @@ $(document).ready(() => {
         if (!args.product_url || !args.id_product_attribute) {
             return;
         }
-        window.history.pushState(
+        window.history.replaceState(
             {
               id_product_attribute: args.id_product_attribute
             },


### PR DESCRIPTION
If you go to product page from product list, then if you switch attributes 3 times, then you need to 3 times click on back button to go back to product list page which is not very user friendly. This Pr fix that and only one click on back button is needed.

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix for multiple back button clicks
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | If you go to product page from product list, then if you switch attributes 3 times, then you need to 3 times click on back button to go back to product list page which is not very user friendly. This Pr fix that and only one click on back button is needed.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9387)
<!-- Reviewable:end -->
