### PR TITLE
Enable 'edit specific price' button on Product page

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -611,8 +611,9 @@ var specificPrices = (function() {
             '<td>' + specific_price.impact + '</td>' +
             '<td>' + specific_price.period + '</td>' +
             '<td>' + specific_price.from_quantity + '</td>' +
-            '<td>' + (specific_price.can_delete ? '<a href="' + $('#js-specific-price-list').attr('data-action-delete').replace(/delete\/\d+/, 'delete/' + specific_price.id_specific_price) + '" class="js-delete delete btn tooltip-link delete pl-0 pr-0"><i class="material-icons">delete</i></a>' : '') +
-            (specific_price.can_edit ? '<a href="#js-specific-price-list-edit" data-specific-price-id="'+specific_price.id_specific_price+'" class="specific-price-edit btn tooltip-link edit pl-0 pr-0"><i class="material-icons">edit</i></a>' : '') + '</td>' +
+            '<td>' + specific_price.from_quantity + '</td>' +
+            '<td>' + (specific_price.can_edit ? '<a href="#js-specific-price-list-edit" data-specific-price-id="'+specific_price.id_specific_price+'" class="specific-price-edit btn tooltip-link edit pl-0 pr-0"><i class="material-icons">edit</i></a>' : '') +
+            (specific_price.can_delete ? '<a href="' + $('#js-specific-price-list').attr('data-action-delete').replace(/delete\/\d+/, 'delete/' + specific_price.id_specific_price) + '" class="js-delete delete btn tooltip-link delete pl-0 pr-0"><i class="material-icons">delete</i></a>' : '') + '</td>' +
             '</tr>';
 
           tbody.append(row);

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -23,10 +23,12 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
 use Attachment;
 use PrestaShop\PrestaShop\Adapter\Entity\Customization;
+use PrestaShop\PrestaShop\Adapter\Entity\PrestaShopObjectNotFoundException;
 use SpecificPrice;
 use Customer;
 use Combination;
@@ -215,16 +217,17 @@ class AdminProductWrapper
     }
 
     /**
-     * processProductSpecificPrice
-     * Add/Update specific price
+     * Add/Update a SpecificPrice object
      *
      * @param int $id_product
      * @param array $specificPriceValues the posted values
+     * @param int (optional) $id_specific_price if this is an update of an existing specific price, null else
      *
      * @return AdminProductsController instance
      */
-    public function processProductSpecificPrice($id_product, $specificPriceValues)
+    public function processProductSpecificPrice($id_product, $specificPriceValues, $id_specific_price = null)
     {
+        // ---- data formatting ----
         $id_product_attribute = $specificPriceValues['sp_id_product_attribute'];
         $id_shop = $specificPriceValues['sp_id_shop'] ? $specificPriceValues['sp_id_shop'] : 0;
         $id_currency = $specificPriceValues['sp_id_currency'] ? $specificPriceValues['sp_id_currency'] : 0;
@@ -245,34 +248,69 @@ class AdminProductWrapper
         if (!$to) {
             $to = '0000-00-00 00:00:00';
         }
+        $isThisAnUpdate = (null !== $id_specific_price);
 
+        // ---- validation ----
         if (($price == '-1') && ((float)$reduction == '0')) {
             $this->errors[] = $this->translator->trans('No reduction value has been submitted', array(), 'Admin.Catalog.Notification');
         } elseif ($to != '0000-00-00 00:00:00' && strtotime($to) < strtotime($from)) {
             $this->errors[] = $this->translator->trans('Invalid date range', array(), 'Admin.Catalog.Notification');
         } elseif ($reduction_type == 'percentage' && ((float)$reduction <= 0 || (float)$reduction > 100)) {
             $this->errors[] = $this->translator->trans('Submitted reduction value (0-100) is out-of-range', array(), 'Admin.Catalog.Notification');
-        } elseif ($this->validateSpecificPrice($id_product, $id_shop, $id_currency, $id_country, $id_group, $id_customer, $price, $from_quantity, $reduction, $reduction_type, $from, $to, $id_product_attribute)) {
-            $specificPrice = new SpecificPrice();
-            $specificPrice->id_product = (int)$id_product;
-            $specificPrice->id_product_attribute = (int)$id_product_attribute;
-            $specificPrice->id_shop = (int)$id_shop;
-            $specificPrice->id_currency = (int)($id_currency);
-            $specificPrice->id_country = (int)($id_country);
-            $specificPrice->id_group = (int)($id_group);
-            $specificPrice->id_customer = (int)$id_customer;
-            $specificPrice->price = (float)($price);
-            $specificPrice->from_quantity = (int)($from_quantity);
-            $specificPrice->reduction = (float)($reduction_type == 'percentage' ? $reduction / 100 : $reduction);
-            $specificPrice->reduction_tax = $reduction_tax;
-            $specificPrice->reduction_type = $reduction_type;
-            $specificPrice->from = $from;
-            $specificPrice->to = $to;
-
-            if (!$specificPrice->add()) {
-                $this->errors[] = $this->translator->trans('An error occurred while updating the specific price.', array(), 'Admin.Catalog.Notification');
-            }
         }
+        $validationResult = $this->validateSpecificPrice(
+            $id_product,
+            $id_shop,
+            $id_currency,
+            $id_country,
+            $id_group,
+            $id_customer,
+            $price,
+            $from_quantity,
+            $reduction,
+            $reduction_type,
+            $from,
+            $to,
+            $id_product_attribute,
+            $isThisAnUpdate
+        );
+
+        if (false === $validationResult) {
+            return $this->errors;
+        }
+
+        // ---- data modification ----
+        if ($isThisAnUpdate) {
+            $specificPrice = new SpecificPrice($id_specific_price);
+        } else {
+            $specificPrice = new SpecificPrice();
+        }
+
+        $specificPrice->id_product = (int)$id_product;
+        $specificPrice->id_product_attribute = (int)$id_product_attribute;
+        $specificPrice->id_shop = (int)$id_shop;
+        $specificPrice->id_currency = (int)($id_currency);
+        $specificPrice->id_country = (int)($id_country);
+        $specificPrice->id_group = (int)($id_group);
+        $specificPrice->id_customer = (int)$id_customer;
+        $specificPrice->price = (float)($price);
+        $specificPrice->from_quantity = (int)($from_quantity);
+        $specificPrice->reduction = (float)($reduction_type == 'percentage' ? $reduction / 100 : $reduction);
+        $specificPrice->reduction_tax = $reduction_tax;
+        $specificPrice->reduction_type = $reduction_type;
+        $specificPrice->from = $from;
+        $specificPrice->to = $to;
+
+        if ($isThisAnUpdate) {
+            $dataSavingResult = $specificPrice->save();
+        } else {
+            $dataSavingResult = $specificPrice->add();
+        }
+
+        if (false === $dataSavingResult) {
+            $this->errors[] = $this->translator->trans('An error occurred while updating the specific price.', array(), 'Admin.Catalog.Notification');
+        }
+
 
         return $this->errors;
     }
@@ -280,7 +318,22 @@ class AdminProductWrapper
     /**
      * Validate a specific price
      */
-    private function validateSpecificPrice($id_product, $id_shop, $id_currency, $id_country, $id_group, $id_customer, $price, $from_quantity, $reduction, $reduction_type, $from, $to, $id_combination = 0)
+    private function validateSpecificPrice(
+        $id_product,
+        $id_shop,
+        $id_currency,
+        $id_country,
+        $id_group,
+        $id_customer,
+        $price,
+        $from_quantity,
+        $reduction,
+        $reduction_type,
+        $from,
+        $to,
+        $id_combination = 0,
+        $isThisAnUpdate = false
+    )
     {
         if (!Validate::isUnsignedId($id_shop) || !Validate::isUnsignedId($id_currency) || !Validate::isUnsignedId($id_country) || !Validate::isUnsignedId($id_group) || !Validate::isUnsignedId($id_customer)) {
             $this->errors[] = 'Wrong IDs';
@@ -292,12 +345,30 @@ class AdminProductWrapper
             $this->errors[] = 'Please select a discount type (amount or percentage).';
         } elseif ($from && $to && (!Validate::isDateFormat($from) || !Validate::isDateFormat($to))) {
             $this->errors[] = 'The from/to date is invalid.';
-        } elseif (SpecificPrice::exists((int)$id_product, $id_combination, $id_shop, $id_group, $id_country, $id_currency, $id_customer, $from_quantity, $from, $to, false)) {
+        } elseif (!$isThisAnUpdate && SpecificPrice::exists((int)$id_product, $id_combination, $id_shop, $id_group, $id_country, $id_currency, $id_customer, $from_quantity, $from, $to, false)) {
             $this->errors[] = 'A specific price already exists for these parameters.';
         } else {
             return true;
         }
         return false;
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return SpecificPrice
+     *
+     * @throws PrestaShopObjectNotFoundException
+     */
+    public function getSpecificPriceDataById($id)
+    {
+        $price = new SpecificPrice($id);
+
+        if (null === $price->id) {
+            throw new PrestaShopObjectNotFoundException(sprintf('Cannot find specific price with id %d', $id));
+        }
+
+        return $price;
     }
 
     /**
@@ -390,9 +461,9 @@ class AdminProductWrapper
                 }
 
                 if (!$specific_price['id_shop'] || in_array($specific_price['id_shop'], Shop::getContextListShopID())) {
-                    $can_delete_specific_prices = true;
+                    $can_edit_or_delete_specific_prices = true;
                     if (Shop::isFeatureActive()) {
-                        $can_delete_specific_prices = (count($this->legacyContext->employee->getAssociatedShops()) > 1 && !$specific_price['id_shop']) || $specific_price['id_shop'];
+                        $can_edit_or_delete_specific_prices = (count($this->legacyContext->employee->getAssociatedShops()) > 1 && !$specific_price['id_shop']) || $specific_price['id_shop'];
                     }
 
                     $price = Tools::ps_round($specific_price['price'], 2);
@@ -412,7 +483,8 @@ class AdminProductWrapper
                         'impact' => $impact,
                         'period' => $period,
                         'from_quantity' => $specific_price['from_quantity'],
-                        'can_delete' => (!$rule->id && $can_delete_specific_prices) ? true : false
+                        'can_delete' => (!$rule->id && $can_edit_or_delete_specific_prices) ? true : false,
+                        'can_edit' => (!$rule->id && $can_edit_or_delete_specific_prices) ? true : false,
                     ];
 
                     unset($customer_full_name);
@@ -444,13 +516,13 @@ class AdminProductWrapper
         if (isset($error)) {
             return array(
                 'status' => 'error',
-                'message'=> $error
+                'message' => $error
             );
         }
 
         return array(
             'status' => 'ok',
-            'message'=> $this->translator->trans('Successful deletion', array(), 'Admin.Notifications.Success'),
+            'message' => $this->translator->trans('Successful deletion', array(), 'Admin.Notifications.Success'),
         );
     }
 
@@ -542,19 +614,19 @@ class AdminProductWrapper
                 //create label
                 if (isset($customization['id_customization_field'])) {
                     $id_customization_field = (int)$customization['id_customization_field'];
-                    Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.'customization_field`
+                    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'customization_field`
 					SET `required` = ' . ($customization['require'] ? 1 : 0) . ', `type` = ' . (int)$customization['type'] . '
-					WHERE `id_customization_field` = '.$id_customization_field);
+					WHERE `id_customization_field` = ' . $id_customization_field);
                 } else {
                     Db::getInstance()->execute(
-                        'INSERT INTO `'._DB_PREFIX_.'customization_field` (`id_product`, `type`, `required`)
+                        'INSERT INTO `' . _DB_PREFIX_ . 'customization_field` (`id_product`, `type`, `required`)
                     	VALUES ('
-                            .(int) $product->id.', '
-                            .(int) $customization['type'].', '
-                            .($customization['require'] ? 1 : 0)
-                        .')'
+                        . (int)$product->id . ', '
+                        . (int)$customization['type'] . ', '
+                        . ($customization['require'] ? 1 : 0)
+                        . ')'
                     );
-                    $id_customization_field = (int) Db::getInstance()->Insert_ID();
+                    $id_customization_field = (int)Db::getInstance()->Insert_ID();
                 }
 
                 $new_customization_fields_ids[$key] = $id_customization_field;
@@ -565,16 +637,16 @@ class AdminProductWrapper
                     $name = $customization['label'][$language['id_lang']];
                     foreach ($shopList as $id_shop) {
                         $langValues .= '('
-                            .(int) $id_customization_field.', '
-                            .(int) $language['id_lang'].', '
-                            .(int) $id_shop.',\''
-                            .pSQL($name)
-                            .'\'), ';
+                            . (int)$id_customization_field . ', '
+                            . (int)$language['id_lang'] . ', '
+                            . (int)$id_shop . ',\''
+                            . pSQL($name)
+                            . '\'), ';
                     }
                 }
                 Db::getInstance()->execute(
-                    'INSERT INTO `'._DB_PREFIX_.'customization_field_lang` (`id_customization_field`, `id_lang`, `id_shop`, `name`) VALUES '
-                    .rtrim(
+                    'INSERT INTO `' . _DB_PREFIX_ . 'customization_field_lang` (`id_customization_field`, `id_lang`, `id_shop`, `name`) VALUES '
+                    . rtrim(
                         $langValues,
                         ', '
                     )
@@ -591,14 +663,14 @@ class AdminProductWrapper
         }
 
         //update product count fields labels
-        Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.'product` SET `customizable` = '.$productCustomizableValue.', `uploadable_files` = '.(int)$countFieldFile.', `text_fields` = '.(int)$countFieldText.' WHERE `id_product` = '.(int)$product->id);
+        Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'product` SET `customizable` = ' . $productCustomizableValue . ', `uploadable_files` = ' . (int)$countFieldFile . ', `text_fields` = ' . (int)$countFieldText . ' WHERE `id_product` = ' . (int)$product->id);
 
         //update product_shop count fields labels
         ObjectModel::updateMultishopTable('product', array(
             'customizable' => $productCustomizableValue,
             'uploadable_files' => (int)$countFieldFile,
             'text_fields' => (int)$countFieldText,
-        ), 'a.id_product = '.(int)$product->id);
+        ), 'a.id_product = ' . (int)$product->id);
 
         Configuration::updateGlobalValue('PS_CUSTOMIZATION_FEATURE_ACTIVE', '1');
 
@@ -633,7 +705,7 @@ class AdminProductWrapper
             $download->display_filename = $data['name'];
             $download->filename = $fileName ? $fileName : $download->filename;
             $download->date_add = date('Y-m-d H:i:s');
-            $download->date_expiration = $data['expiration_date'] ? $data['expiration_date'].' 23:59:59' : '';
+            $download->date_expiration = $data['expiration_date'] ? $data['expiration_date'] . ' 23:59:59' : '';
             $download->nb_days_accessible = (int)$data['nb_days'];
             $download->nb_downloadable = (int)$data['nb_downloadable'];
             $download->active = 1;
@@ -666,8 +738,8 @@ class AdminProductWrapper
         $download = new ProductDownload($id_product_download ? $id_product_download : null);
 
         if ($download && !empty($download->filename)) {
-            unlink(_PS_DOWNLOAD_DIR_.$download->filename);
-            Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.'product_download` SET filename = "" WHERE `id_product_download` = '.(int)$download->id);
+            unlink(_PS_DOWNLOAD_DIR_ . $download->filename);
+            Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'product_download` SET filename = "" WHERE `id_product_download` = ' . (int)$download->id);
         }
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
@@ -23,10 +23,18 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Controller\Admin;
 
+use DateTime;
+use PrestaShop\PrestaShop\Adapter\Entity\PrestaShopObjectNotFoundException;
+use PrestaShop\PrestaShop\Adapter\Product\AdminProductWrapper;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
 
 /**
  * Admin controller for the attribute / attribute group
@@ -34,9 +42,10 @@ use Symfony\Component\HttpFoundation\Request;
 class SpecificPriceController extends FrameworkBundleAdminController
 {
     /**
-     * get specific price list for a product
+     * Get the specific price list for a product
+     * to be displayed
      *
-     * @param $idProduct The product ID
+     * @param int $idProduct
      *
      * @return string JSON
      */
@@ -47,6 +56,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
         $contextAdapter = $this->get('prestashop.adapter.legacy.context');
         $locales = $contextAdapter->getLanguages();
         $productAdapter = $this->get('prestashop.adapter.data_provider.product');
+        /** @var AdminProductWrapper $adminProductWrapper */
         $adminProductWrapper = $this->get('prestashop.adapter.admin.wrapper.product');
         $shopContextAdapter = $this->get('prestashop.adapter.shop.context');
         $shops = $shopContextAdapter->getShops();
@@ -61,32 +71,50 @@ class SpecificPriceController extends FrameworkBundleAdminController
             return $response;
         }
 
-        $response->setData($adminProductWrapper->getSpecificPricesList(
-            $product,
-            $contextAdapter->getContext()->currency,
-            $shops,
-            $currencies,
-            $countries,
-            $groups
-        ));
+        $response->setData(
+            $adminProductWrapper->getSpecificPricesList(
+                $product,
+                $contextAdapter->getContext()->currency,
+                $shops,
+                $currencies,
+                $countries,
+                $groups
+            )
+        );
 
         return $response;
     }
 
     /**
-     * Add specific price Form process
+     * Handle form submission of 'add/update a specific price' action
      *
-     * @param Request $request The request
+     * @param Request $request
      *
-     * @return string
+     * @return JsonResponse
      */
     public function addAction(Request $request)
     {
         $response = new JsonResponse();
         $idProduct = isset($request->get('form')['id_product']) ? $request->get('form')['id_product'] : null;
 
+        $idSpecificPrice = null;
+        if (isset($request->get('form')['step2']['specific_price']['sp_update_id'])) {
+            $idSpecificPrice = $request->get('form')['step2']['specific_price']['sp_update_id'];
+
+            if (is_numeric($idSpecificPrice)) {
+                $idSpecificPrice = (int)$idSpecificPrice;
+            } else {
+                $idSpecificPrice = null;
+            }
+        }
+
+        /** @var AdminProductWrapper $adminProductWrapper */
         $adminProductWrapper = $this->get('prestashop.adapter.admin.wrapper.product');
-        $errors = $adminProductWrapper->processProductSpecificPrice($idProduct, $request->get('form')['step2']['specific_price']);
+        $errors = $adminProductWrapper->processProductSpecificPrice(
+            $idProduct,
+            $request->get('form')['step2']['specific_price'],
+            $idSpecificPrice
+        );
 
         if (!empty($errors)) {
             $response->setData(implode(', ', $errors));
@@ -94,6 +122,40 @@ class SpecificPriceController extends FrameworkBundleAdminController
         }
 
         return $response;
+    }
+
+    /**
+     * Get one specific price list for a product
+     *
+     * @Template("@PrestaShop/Admin/Product/ProductPage\Forms/form_specific_price.html.twig")
+     *
+     * @param int $idSpecificPrice
+     *
+     * @return array
+     */
+    public function getUpdateFormAction($idSpecificPrice)
+    {
+        /** @var AdminProductWrapper $adminProductWrapper */
+        $adminProductWrapper = $this->get('prestashop.adapter.admin.wrapper.product');
+        try {
+            $price = $adminProductWrapper->getSpecificPriceDataById($idSpecificPrice);
+        } catch (PrestaShopObjectNotFoundException $e) {
+            return new Response(sprintf('Cannot find specific price %d', $idSpecificPrice), Response::HTTP_BAD_REQUEST);
+        }
+
+        $formData = $this->formatSpecificPriceToPrefillForm($idSpecificPrice, $price);
+
+        $options = ['selected_product_attribute' => $price->id_product_attribute];
+        $formBuilder = $this->createFormBuilder();
+        $formBuilder->add('step2', 'PrestaShopBundle\Form\Admin\Product\EmbeddedSpecificPrice', $options);
+
+        $form = $formBuilder->getForm();
+        $form->setData($formData);
+
+        return [
+            'form' => $form->createView()->offsetGet('step2')->offsetGet('specific_price'),
+            'has_combinations' => ($price->id_product_attribute !== '0')
+        ];
     }
 
     /**
@@ -109,7 +171,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
         $response = new JsonResponse();
 
         $adminProductWrapper = $this->get('prestashop.adapter.admin.wrapper.product');
-        $res = $adminProductWrapper->deleteSpecificPrice((int) $idSpecificPrice);
+        $res = $adminProductWrapper->deleteSpecificPrice((int)$idSpecificPrice);
 
         if ($res['status'] == 'error') {
             $response->setStatusCode(400);
@@ -117,5 +179,74 @@ class SpecificPriceController extends FrameworkBundleAdminController
 
         $response->setData($res['message']);
         return $response;
+    }
+
+    /**
+     * @param int $id
+     * @param \SpecificPrice $price
+     *
+     * @return array
+     */
+    private function formatSpecificPriceToPrefillForm($id, $price)
+    {
+        if ($price->reduction_type === 'percentage') {
+            $reduction = $price->reduction*100;
+        } else {
+            $reduction = $price->reduction;
+        }
+
+        $formattedFormData = [
+            'sp_update_id' => $id,
+            'sp_id_shop' => $price->id_shop,
+            'sp_id_currency' => $price->id_currency,
+            'sp_id_country' => $price->id_country,
+            'sp_id_group' => $price->id_group,
+            'sp_id_customer' => null,
+            'sp_id_product_attribute' => $price->id_product_attribute,
+            'sp_from' => self::formatForDatePicker($price->from),
+            'sp_to' => self::formatForDatePicker($price->to),
+            'sp_from_quantity' => $price->from_quantity,
+            'sp_price' => ($price->price !== '-1.000000') ? $price->price : '',
+            'leave_bprice' => ($price->price === '-1.000000'),
+            'sp_reduction' => $reduction,
+            'sp_reduction_type' => $price->reduction_type,
+            'sp_reduction_tax' => $price->reduction_tax,
+        ];
+
+        if ($price->id_customer !== '0') {
+            $formattedFormData['sp_id_customer'] = ['data' => [$price->id_customer]];
+        }
+
+        $cleanedFormData = array_map(function ($item) {
+            if (!$item) {
+                return null;
+            } else {
+                return $item;
+            }
+        }, $formattedFormData);
+
+        return ['step2' => ['specific_price' => $cleanedFormData]];
+    }
+
+    /**
+     * @param string $dateAsString
+     *
+     * @return null|string If date is 0000-00-00 00:00:00, null is returned
+     *
+     * @throws \PrestaShopDatabaseExceptionCore if date is not valid
+     */
+    private static function formatForDatePicker($dateAsString)
+    {
+        if ('0000-00-00 00:00:00' === $dateAsString) {
+            return null;
+        }
+
+        try {
+            $dateTime = new DateTime($dateAsString);
+        } catch (\Exception $e) {
+            throw new \PrestaShopDatabaseExceptionCore(sprintf('Found bad date for specific price: %s', $dateAsString));
+        }
+
+        return $dateTime->format('Y-m-d');
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Product/EmbeddedSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/EmbeddedSpecificPrice.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Product;
+
+use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * A simple form that embeds a ProductSpecificPrice
+ * in order to mimic ProductPrice form structure
+ */
+class EmbeddedSpecificPrice extends CommonAbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('specific_price', ProductSpecificPrice::class, $options);
+
+        return $builder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'selected_product_attribute' => '0', // used to force selected select option after options have been loaded
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'embedded_specific_price';
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -33,6 +33,7 @@ use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -181,7 +182,11 @@ class ProductSpecificPrice extends CommonAbstractType
                     'required' => false,
                     'placeholder' => $this->translator->trans('Apply to all combinations', [], 'Admin.Catalog.Feature'),
                     'label' => $this->translator->trans('Combinations', [], 'Admin.Catalog.Feature'),
-                    'attr' => ['data-action' => $this->router->generate('admin_get_product_combinations', ['idProduct' => 1])],
+                    'attr' => [
+                        'data-action' => $this->router->generate('admin_get_product_combinations', ['idProduct' => 1]),
+                        // used to force selected select option after options have been loaded
+                        'data-selected-attribute' => (array_keys($options, 'selected_product_attribute')) ? $options['selected_product_attribute'] : '0',
+                    ],
                 ]
             )
             ->add(
@@ -265,6 +270,11 @@ class ProductSpecificPrice extends CommonAbstractType
                     'required' => true,
                 ]
             )
+            // field used to know whether this is a create or an update
+            ->add(
+                'sp_update_id',
+                FormType\HiddenType::class
+            )
             ->add(
                 'save',
                 FormType\ButtonType::class,
@@ -306,6 +316,16 @@ class ProductSpecificPrice extends CommonAbstractType
                 ]
             );
         });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'selected_product_attribute' => '0', // used to force selected select option after options have been loaded
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/specific_prices.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/specific_prices.yml
@@ -8,6 +8,15 @@ admin_specific_price_list:
     requirements:
         idProduct: \d+
 
+admin_get_specific_price_update_form:
+    path:     /get-form/{idSpecificPrice}/
+    methods:  [GET]
+    defaults:
+        _controller: PrestaShopBundle\Controller\Admin\SpecificPriceController::getUpdateFormAction
+        idSpecificPrice: 0
+    requirements:
+        idSpecificPrice: \d+
+
 admin_specific_price_add:
     path:     /add
     methods:  [POST]

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
@@ -148,6 +148,9 @@
       </fieldset>
     </div>
   </div>
+
+  {{ form_widget(form.sp_update_id) }}
+
   <div class="col-md-12 text-sm-right">
     {{ form_widget(form.cancel) }}
     {{ form_widget(form.save) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig
@@ -132,7 +132,7 @@
               </div>
               <div class="col-md-12">
                 <div id="specific-price" class="mb-2">
-                  <a class="btn btn-outline-primary mb-3" data-toggle="collapse" href="#specific_price_form" aria-expanded="false">
+                  <a id="specific-price-add-button" class="btn btn-outline-primary mb-3" data-toggle="collapse" href="#specific_price_form" aria-expanded="false">
                     <i class="material-icons">add_circle</i>
                     {{ 'Add a specific price'|trans({}, 'Admin.Catalog.Feature') }}
                   </a>
@@ -155,7 +155,7 @@
                     <tbody></tbody>
                   </table>
                 </div>
-                <div class="collapse" id="specific_price_form" data-action="{{ path('admin_specific_price_add') }}">
+                <div class="collapse" id="specific_price_form" data-action="{{ path('admin_specific_price_add') }}" data-url-get-update-form="{{ path('admin_get_specific_price_update_form') }}">
                   {{ include('@Product/ProductPage/Forms/form_specific_price.html.twig', {'form': pricingForm.specific_price, 'is_multishop_context': is_multishop_context}) }}
                 </div>
               </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
@@ -211,7 +211,18 @@
 {% block typeahead_customer_collection_widget %}
     {{ form_errors(form) }}
     <input type="text" id="{{ form.vars.id }}" class="form-control typeahead {{ form.vars.id }}" placeholder="{{ placeholder }}" autocomplete="off" />
-    <ul id="{{ form.vars.id }}-data" class="typeahead-list product-list nostyle col-sm-12"></ul>
+    <ul id="{{ form.vars.id }}-data" class="typeahead-list product-list nostyle col-sm-12">
+        {% if collection is defined and collection|length > 0 %}
+            {% for item in collection %}
+                <li class="media">
+                    <div class="media-body">
+                        {{ template_collection|format(item.name)|raw }}
+                    </div>
+                    <input type="hidden" name="{{ form.vars.full_name }}[data][]" value="{{ item.id }}" />
+                </li>
+            {% endfor %}
+        {% endif %}
+    </ul>
     <script>
         $( document ).ready(function() {
             //remove collection item
@@ -221,6 +232,7 @@
 
                 modalConfirmation.create(translate_javascripts['Are you sure to delete this?'], null, {
                     onContinue: function(){
+                        _this.closest('li').remove();
                         _this.parent().parent().hide();
                         _this.parent().remove();
                     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In BackOffice "Catalog" > "Products", currently admins can either "add" or "delete" a "specific price" on the "Edit a Product" page. This PR enables to edit a specific price.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | yes, see below
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/FF-160
| How to test?  | See below

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

## Possible BC break

Currently, in the "Edit a product" page, **all the forms** are being loaded at once using `PrestaShopBundle\Form\Admin\Product\ProductPrice` Symfony Form.
But the "Add a Specific Price" form is submitted through an AJAX call.

I reused the submit ajax call however, with this PR merged, now the "edit a specific price" button removes the initial "Add a specific price" form and replaces it with another `PrestaShopBundle\Form\Admin\Product\EmbeddedSpecificPrice`. The behavior is iso to `ProductPrice` except is someone overrides it. The submit process has not changed, hooks are preserved.

## How to test

Go on a "Edit a product" page on the BackOffice. Add a specific price. It appears on the page. Now you can edit any of its properties (user group ? customer ? combination ? from and to dates ? how much ? percentage or fixed price ?) and check that the edit process works correctly.

Be careful: in multi-shop context another field appears. Also products with combination have another field that single-combination products do not display.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9388)
<!-- Reviewable:end -->
