### PR TITLE
CO: Remove static path from adapter to allow overrides

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -661,7 +661,7 @@ class ImageCore extends ObjectModel
 
         if (!$this->existing_path) {
             if (Configuration::get('PS_LEGACY_IMAGES') && file_exists(_PS_PROD_IMG_DIR_.$this->id_product.'-'.$this->id.'.'.$this->image_format)) {
-                $this->existing_path = $this->id_product.'-'.$this->id;
+                $this->existing_path = _PS_PROD_IMG_DIR_.$this->id_product.'-'.$this->id;
             } else {
                 $this->existing_path = $this->getImgPath();
             }
@@ -726,7 +726,7 @@ class ImageCore extends ObjectModel
             return false;
         }
 
-        $path = $this->getImgFolder().$this->id;
+        $path = _PS_PROD_IMG_DIR_.$this->getImgFolder().$this->id;
 
         return $path;
     }
@@ -778,7 +778,7 @@ class ImageCore extends ObjectModel
 
                     // if there's already a file at the new image path, move it to a dump folder
                     // most likely the preexisting image is a demo image not linked to a product and it's ok to replace it
-                    $newPath = _PS_PROD_IMG_DIR_.$image->getImgPath().(isset($matches[3]) ? $matches[3] : '').'.jpg';
+                    $newPath = $image->getImgPath().(isset($matches[3]) ? $matches[3] : '').'.jpg';
                     if (file_exists($newPath)) {
                         if (!file_exists(_PS_PROD_IMG_DIR_.$tmpFolder)) {
                             @mkdir(_PS_PROD_IMG_DIR_.$tmpFolder, self::$access_rights);
@@ -850,12 +850,12 @@ class ImageCore extends ObjectModel
             if (!$this->id_product) {
                 return false;
             }
-            $path = $this->id_product.'-'.$this->id;
+            $path = _PS_PROD_IMG_DIR_.$this->id_product.'-'.$this->id;
         } else {
             $path = $this->getImgPath();
             $this->createImgFolder();
         }
 
-        return _PS_PROD_IMG_DIR_.$path;
+        return $path;
     }
 }

--- a/src/Adapter/Product/ProductDataProvider.php
+++ b/src/Adapter/Product/ProductDataProvider.php
@@ -144,7 +144,7 @@ class ProductDataProvider
             'cover' => $imageData->cover ? true : false,
             'legend' => $imageData->legend,
             'format' => $imageData->image_format,
-            'base_image_url' => _THEME_PROD_DIR_.$imageData->getImgPath(),
+            'base_image_url' => $imageData->getImgPath(),
         ];
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | With the current configuration you can easily override image paths on the frontend by overriding classes and controllers. But for the admin panel there are a few places image path is pulled from an adapter which concatenates a string to data coming from the class. This PR removes that dependency and gives the whole image path responsibility to the class, allowing to override image paths both on frontend and admin. Also at the same time it resolves a few path inconsistencies.
| Type?         |  improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Check if images are visible both frontend and admin catalogue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9395)
<!-- Reviewable:end -->
