### PR TITLE
Improve grid data providers

### DIFF
--- a/controllers/front/ContactController.php
+++ b/controllers/front/ContactController.php
@@ -39,15 +39,16 @@ class ContactControllerCore extends FrontController
 
         $this->setTemplate('contact');
     }
-    
+
     public function getBreadcrumbLinks()
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
         $breadcrumb['links'][] = [
             'title' => $this->getTranslator()->trans('Contact us', [], 'Shop.Theme.Global'),
-            'url' => $this->context->link->getPageLink('contact', true)
+            'url' => $this->context->link->getPageLink('contact', true),
         ];
+
         return $breadcrumb;
     }
 }

--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Service\Hook\HookDispatcher;
 
 /**
@@ -55,12 +56,12 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
 
     /**
      * @param DoctrineQueryBuilderInterface $gridQueryBuilder
-     * @param HookDispatcher                $hookDispatcher
+     * @param HookDispatcherInterface       $hookDispatcher
      * @param string                        $gridId
      */
     public function __construct(
         DoctrineQueryBuilderInterface $gridQueryBuilder,
-        HookDispatcher $hookDispatcher,
+        HookDispatcherInterface $hookDispatcher,
         $gridId
     ) {
         $this->gridQueryBuilder = $gridQueryBuilder;
@@ -79,7 +80,7 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
         $records = $searchQueryBuilder->execute()->fetchAll();
         $recordsTotal = (int) $countQueryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
 
-        $this->hookDispatcher->dispatchForParameters('modifyGridQueryBuilder', [
+        $this->hookDispatcher->dispatchWithParameters('modifyGridQueryBuilder', [
             'grid_id' => $this->gridId,
             'search_query_builder' => $searchQueryBuilder,
             'count_query_builder' => $countQueryBuilder,

--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShopBundle\Service\Hook\HookDispatcher;
 
 /**
  * Class DoctrineGridDataFactory is responsible for returning grid data using Doctrine query builders.
@@ -43,12 +44,28 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
     private $gridQueryBuilder;
 
     /**
+     * @var HookDispatcher
+     */
+    private $hookDispatcher;
+
+    /**
+     * @var string
+     */
+    private $gridId;
+
+    /**
      * @param DoctrineQueryBuilderInterface $gridQueryBuilder
+     * @param HookDispatcher                $hookDispatcher
+     * @param string                        $gridId
      */
     public function __construct(
-        DoctrineQueryBuilderInterface $gridQueryBuilder
+        DoctrineQueryBuilderInterface $gridQueryBuilder,
+        HookDispatcher $hookDispatcher,
+        $gridId
     ) {
         $this->gridQueryBuilder = $gridQueryBuilder;
+        $this->hookDispatcher = $hookDispatcher;
+        $this->gridId = $gridId;
     }
 
     /**
@@ -61,6 +78,12 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
 
         $records = $searchQueryBuilder->execute()->fetchAll();
         $recordsTotal = (int) $countQueryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
+
+        $this->hookDispatcher->dispatchForParameters('modifyGridQueryBuilder', [
+            'grid_id' => $this->gridId,
+            'search_query_builder' => $searchQueryBuilder,
+            'count_query_builder' => $countQueryBuilder,
+        ]);
 
         $records = new RecordCollection($records);
 

--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -80,7 +80,6 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
         $recordsTotal = (int) $countQueryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
 
         $this->hookDispatcher->dispatchWithParameters('action'. $this->gridId .'GridQueryBuilderModifier', [
-            'grid_id' => $this->gridId,
             'search_query_builder' => $searchQueryBuilder,
             'count_query_builder' => $countQueryBuilder,
         ]);

--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -55,8 +55,8 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
 
     /**
      * @param DoctrineQueryBuilderInterface $gridQueryBuilder
-     * @param HookDispatcherInterface       $hookDispatcher
-     * @param string                        $gridId
+     * @param HookDispatcherInterface $hookDispatcher
+     * @param string $gridId
      */
     public function __construct(
         DoctrineQueryBuilderInterface $gridQueryBuilder,
@@ -79,7 +79,7 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
         $records = $searchQueryBuilder->execute()->fetchAll();
         $recordsTotal = (int) $countQueryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
 
-        $this->hookDispatcher->dispatchWithParameters('action'. $this->gridId .'GridQueryBuilderModifier', [
+        $this->hookDispatcher->dispatchWithParameters('action' . $this->gridId . 'GridQueryBuilderModifier', [
             'search_query_builder' => $searchQueryBuilder,
             'count_query_builder' => $countQueryBuilder,
         ]);

--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -32,7 +32,6 @@ use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use PrestaShopBundle\Service\Hook\HookDispatcher;
 
 /**
  * Class DoctrineGridDataFactory is responsible for returning grid data using Doctrine query builders.
@@ -45,7 +44,7 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
     private $gridQueryBuilder;
 
     /**
-     * @var HookDispatcher
+     * @var HookDispatcherInterface
      */
     private $hookDispatcher;
 

--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -80,7 +80,7 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
         $records = $searchQueryBuilder->execute()->fetchAll();
         $recordsTotal = (int) $countQueryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
 
-        $this->hookDispatcher->dispatchWithParameters('modifyGridQueryBuilder', [
+        $this->hookDispatcher->dispatchWithParameters('action'. $this->gridId .'GridQueryBuilderModifier', [
             'grid_id' => $this->gridId,
             'search_query_builder' => $searchQueryBuilder,
             'count_query_builder' => $countQueryBuilder,

--- a/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
@@ -125,7 +125,7 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
             ->add((new DataColumn('language'))
                 ->setName($this->trans('Language', [], 'Admin.Global'))
                 ->setOptions([
-                    'field' => 'lang_name',
+                    'field' => 'language',
                 ])
             )
             ->add((new DataColumn('subject'))

--- a/src/Core/Grid/Query/DoctrineQueryBuilderInterface.php
+++ b/src/Core/Grid/Query/DoctrineQueryBuilderInterface.php
@@ -41,7 +41,7 @@ interface DoctrineQueryBuilderInterface
      *
      * @return QueryBuilder
      */
-    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria = null);
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria);
 
     /**
      * Get query that counts grid rows.
@@ -50,5 +50,5 @@ interface DoctrineQueryBuilderInterface
      *
      * @return QueryBuilder
      */
-    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria = null);
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria);
 }

--- a/src/Core/Grid/Query/DoctrineSearchCriteriaApplicator.php
+++ b/src/Core/Grid/Query/DoctrineSearchCriteriaApplicator.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Class DoctrineSearchCriteriaApplicator applies search criteria to doctrine query builder
+ */
+final class DoctrineSearchCriteriaApplicator implements DoctrineSearchCriteriaApplicatorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function applyPagination(SearchCriteriaInterface $searchCriteria, QueryBuilder $queryBuilder)
+    {
+        if (null !== $searchCriteria->getLimit()) {
+            $queryBuilder->setMaxResults($searchCriteria->getLimit());
+        }
+
+        if (null !== $searchCriteria->getOffset()) {
+            $queryBuilder->setFirstResult($searchCriteria->getOffset());
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applySorting(SearchCriteriaInterface $searchCriteria, QueryBuilder $queryBuilder)
+    {
+        if (null !== $searchCriteria->getOrderBy() && null !== $searchCriteria->getOrderWay()) {
+            $queryBuilder->orderBy(
+                $searchCriteria->getOrderBy(),
+                $searchCriteria->getOrderWay()
+            );
+        }
+
+        return $this;
+    }
+}

--- a/src/Core/Grid/Query/DoctrineSearchCriteriaApplicator.php
+++ b/src/Core/Grid/Query/DoctrineSearchCriteriaApplicator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -30,7 +30,7 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
- * Class DoctrineSearchCriteriaApplicator applies search criteria to doctrine query builder
+ * Class DoctrineSearchCriteriaApplicator applies search criteria to doctrine query builder.
  */
 final class DoctrineSearchCriteriaApplicator implements DoctrineSearchCriteriaApplicatorInterface
 {

--- a/src/Core/Grid/Query/DoctrineSearchCriteriaApplicatorInterface.php
+++ b/src/Core/Grid/Query/DoctrineSearchCriteriaApplicatorInterface.php
@@ -30,31 +30,27 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
- * Trait QueryBuilderHelperTrait provides helper methods for most common grid query building actions
+ * Interface DoctrineSearchCriteriaApplicatorInterface contract for doctrine query builder applicator
  */
-trait QueryBuilderHelperTrait
+interface DoctrineSearchCriteriaApplicatorInterface
 {
     /**
-     * Provides reusable way for adding pagination & sorting to query builder
+     * Apply pagination on query builder
      *
      * @param SearchCriteriaInterface $searchCriteria
      * @param QueryBuilder $queryBuilder
+     *
+     * @return self
      */
-    private function addPaginationAndSorting(SearchCriteriaInterface $searchCriteria, QueryBuilder $queryBuilder)
-    {
-        if (null !== $searchCriteria->getOrderBy() && null !== $searchCriteria->getOrderWay()) {
-            $queryBuilder->orderBy(
-                $searchCriteria->getOrderBy(),
-                $searchCriteria->getOrderWay()
-            );
-        }
+    public function applyPagination(SearchCriteriaInterface $searchCriteria, QueryBuilder $queryBuilder);
 
-        if (null !== $searchCriteria->getLimit()) {
-            $queryBuilder->setMaxResults($searchCriteria->getLimit());
-        }
-
-        if (null !== $searchCriteria->getOffset()) {
-            $queryBuilder->setFirstResult($searchCriteria->getOffset());
-        }
-    }
+    /**
+     * Apply sorting on query builder
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     * @param QueryBuilder $queryBuilder
+     *
+     * @return self
+     */
+    public function applySorting(SearchCriteriaInterface $searchCriteria, QueryBuilder $queryBuilder);
 }

--- a/src/Core/Grid/Query/DoctrineSearchCriteriaApplicatorInterface.php
+++ b/src/Core/Grid/Query/DoctrineSearchCriteriaApplicatorInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -30,12 +30,12 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
- * Interface DoctrineSearchCriteriaApplicatorInterface contract for doctrine query builder applicator
+ * Interface DoctrineSearchCriteriaApplicatorInterface contract for doctrine query builder applicator.
  */
 interface DoctrineSearchCriteriaApplicatorInterface
 {
     /**
-     * Apply pagination on query builder
+     * Apply pagination on query builder.
      *
      * @param SearchCriteriaInterface $searchCriteria
      * @param QueryBuilder $queryBuilder
@@ -45,7 +45,7 @@ interface DoctrineSearchCriteriaApplicatorInterface
     public function applyPagination(SearchCriteriaInterface $searchCriteria, QueryBuilder $queryBuilder);
 
     /**
-     * Apply sorting on query builder
+     * Apply sorting on query builder.
      *
      * @param SearchCriteriaInterface $searchCriteria
      * @param QueryBuilder $queryBuilder

--- a/src/Core/Grid/Query/EmailLogsQueryBuilder.php
+++ b/src/Core/Grid/Query/EmailLogsQueryBuilder.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
@@ -35,18 +36,36 @@ use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 final class EmailLogsQueryBuilder extends AbstractDoctrineQueryBuilder
 {
     /**
+     * @var DoctrineSearchCriteriaApplicatorInterface
+     */
+    private $searchCriteriaApplicator;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
+     */
+    public function __construct(
+        Connection $connection,
+        $dbPrefix,
+        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
+    ) {
+        parent::__construct($connection, $dbPrefix);
+
+        $this->searchCriteriaApplicator = $searchCriteriaApplicator;
+    }
+
+    /**
      * {@inheritdoc}
      */
-    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria = null)
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('m.*, l.name AS lang_name')
-            ->orderBy(
-                $searchCriteria->getOrderBy(),
-                $searchCriteria->getOrderWay()
-            )
-            ->setFirstResult($searchCriteria->getOffset())
-            ->setMaxResults($searchCriteria->getLimit());
+        $qb->select('m.*, l.name AS language');
+
+        $this->searchCriteriaApplicator
+            ->applySorting($searchCriteria, $qb)
+            ->applyPagination($searchCriteria, $qb);
 
         return $qb;
     }
@@ -54,7 +73,7 @@ final class EmailLogsQueryBuilder extends AbstractDoctrineQueryBuilder
     /**
      * {@inheritdoc}
      */
-    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria = null)
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
         $qb->select('COUNT(m.id_mail)');

--- a/src/Core/Grid/Query/QueryBuilderHelperTrait.php
+++ b/src/Core/Grid/Query/QueryBuilderHelperTrait.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Trait QueryBuilderHelperTrait provides helper methods for most common grid query building actions
+ */
+trait QueryBuilderHelperTrait
+{
+    /**
+     * Provides reusable way for adding pagination & sorting to query builder
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     * @param QueryBuilder $queryBuilder
+     */
+    private function addPaginationAndSorting(SearchCriteriaInterface $searchCriteria, QueryBuilder $queryBuilder)
+    {
+        if (null !== $searchCriteria->getOrderBy() && null !== $searchCriteria->getOrderWay()) {
+            $queryBuilder->orderBy(
+                $searchCriteria->getOrderBy(),
+                $searchCriteria->getOrderWay()
+            );
+        }
+
+        if (null !== $searchCriteria->getLimit()) {
+            $queryBuilder->setMaxResults($searchCriteria->getLimit());
+        }
+
+        if (null !== $searchCriteria->getOffset()) {
+            $queryBuilder->setFirstResult($searchCriteria->getOffset());
+        }
+    }
+}

--- a/src/PrestaShopBundle/Entity/Repository/LogRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LogRepository.php
@@ -167,7 +167,7 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
      *
      * @return QueryBuilder
      */
-    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria = null)
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->buildGridQuery($searchCriteria);
         $qb->select('l.*', 'e.email', 'CONCAT(e.firstname, \' \', e.lastname) as employee')
@@ -188,7 +188,7 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
      *
      * @return QueryBuilder
      */
-    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria = null)
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->buildGridQuery($searchCriteria);
         $qb->select('COUNT(*)');
@@ -203,7 +203,7 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
      *
      * @return QueryBuilder
      */
-    private function buildGridQuery(SearchCriteriaInterface $searchCriteria = null)
+    private function buildGridQuery(SearchCriteriaInterface $searchCriteria)
     {
         $employeeTable = $this->databasePrefix . 'employee';
 

--- a/src/PrestaShopBundle/Entity/Repository/LogRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LogRepository.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Entity\Repository;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
+use PrestaShop\PrestaShop\Core\Grid\Query\QueryBuilderHelperTrait;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Repository\RepositoryInterface;
 
@@ -37,6 +38,8 @@ use PrestaShop\PrestaShop\Core\Repository\RepositoryInterface;
  */
 class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterface
 {
+    use QueryBuilderHelperTrait;
+
     private $connection;
     private $databasePrefix;
     private $logTable;
@@ -170,13 +173,9 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->buildGridQuery($searchCriteria);
-        $qb->select('l.*', 'e.email', 'CONCAT(e.firstname, \' \', e.lastname) as employee')
-            ->orderBy(
-                $searchCriteria->getOrderBy(),
-                $searchCriteria->getOrderWay()
-            )
-            ->setFirstResult($searchCriteria->getOffset())
-            ->setMaxResults($searchCriteria->getLimit());
+        $qb->select('l.*', 'e.email', 'CONCAT(e.firstname, \' \', e.lastname) as employee');
+
+        $this->addPaginationAndSorting($searchCriteria, $qb);
 
         return $qb;
     }

--- a/src/PrestaShopBundle/Entity/Repository/LogRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LogRepository.php
@@ -29,7 +29,7 @@ namespace PrestaShopBundle\Entity\Repository;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
-use PrestaShop\PrestaShop\Core\Grid\Query\QueryBuilderHelperTrait;
+use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicatorInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Repository\RepositoryInterface;
 
@@ -38,17 +38,24 @@ use PrestaShop\PrestaShop\Core\Repository\RepositoryInterface;
  */
 class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterface
 {
-    use QueryBuilderHelperTrait;
-
     private $connection;
     private $databasePrefix;
     private $logTable;
 
-    public function __construct(Connection $connection, $databasePrefix)
-    {
+    /**
+     * @var DoctrineSearchCriteriaApplicatorInterface
+     */
+    private $searchCriteriaApplicator;
+
+    public function __construct(
+        Connection $connection,
+        $databasePrefix,
+        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
+    ) {
         $this->connection = $connection;
         $this->databasePrefix = $databasePrefix;
         $this->logTable = $this->databasePrefix . 'log';
+        $this->searchCriteriaApplicator = $searchCriteriaApplicator;
     }
 
     /**
@@ -175,7 +182,9 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
         $qb = $this->buildGridQuery($searchCriteria);
         $qb->select('l.*', 'e.email', 'CONCAT(e.firstname, \' \', e.lastname) as employee');
 
-        $this->addPaginationAndSorting($searchCriteria, $qb);
+        $this->searchCriteriaApplicator
+            ->applyPagination($searchCriteria, $qb)
+            ->applySorting($searchCriteria, $qb);
 
         return $qb;
     }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -29,6 +29,7 @@ services:
         arguments:
             - '@doctrine.dbal.default_connection'
             - '%database_prefix%'
+            - '@prestashop.core.query.doctrine_search_criteria_applicator'
 
     prestashop.core.api.stock.repository:
         class: PrestaShopBundle\Entity\Repository\StockRepository

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -24,7 +24,7 @@ services:
         arguments:
             - '@prestashop.core.grid.query_builder.email_logs'
             - '@prestashop.hook.dispatcher'
-            - 'logs'
+            - 'email_logs'
 
     prestashop.core.grid.data_provider.request_sql:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -30,6 +30,8 @@ services:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:
             - '@prestashop.core.admin.request_sql.repository'
+            - '@prestashop.hook.dispatcher'
+            - 'request_sql'
 
     prestashop.core.grid.data_provider.webservice:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -37,6 +37,8 @@ services:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:
             - '@prestashop.core.grid.query_builder.webservice'
+            - '@prestashop.core.hook.dispatcher'
+            - 'webservice'
 
     # Grid definition factories
     prestashop.core.grid.definition.factory.abstract_grid_definition:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -16,21 +16,21 @@ services:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:
             - '@prestashop.core.admin.log.repository'
-            - '@prestashop.hook.dispatcher'
+            - '@prestashop.core.hook.dispatcher'
             - 'logs'
 
     prestashop.core.grid.data_provider.email_logs:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:
             - '@prestashop.core.grid.query_builder.email_logs'
-            - '@prestashop.hook.dispatcher'
+            - '@prestashop.core.hook.dispatcher'
             - 'email_logs'
 
     prestashop.core.grid.data_provider.request_sql:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:
             - '@prestashop.core.admin.request_sql.repository'
-            - '@prestashop.hook.dispatcher'
+            - '@prestashop.core.hook.dispatcher'
             - 'request_sql'
 
     prestashop.core.grid.data_provider.webservice:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -23,6 +23,8 @@ services:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:
             - '@prestashop.core.grid.query_builder.email_logs'
+            - '@prestashop.hook.dispatcher'
+            - 'logs'
 
     prestashop.core.grid.data_provider.request_sql:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
@@ -145,3 +147,7 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Grid\Query\WebserviceQueryBuilder'
         parent: 'prestashop.core.grid.abstract_query_builder'
         public: true
+
+    # Query applicators
+    prestashop.core.query.doctrine_search_criteria_applicator:
+        class: 'PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicator'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -142,6 +142,8 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Grid\Query\EmailLogsQueryBuilder'
         parent: 'prestashop.core.grid.abstract_query_builder'
         public: true
+        arguments:
+            - '@prestashop.core.query.doctrine_search_criteria_applicator'
 
     prestashop.core.grid.query_builder.webservice:
         class: 'PrestaShop\PrestaShop\Core\Grid\Query\WebserviceQueryBuilder'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -16,6 +16,8 @@ services:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:
             - '@prestashop.core.admin.log.repository'
+            - '@prestashop.hook.dispatcher'
+            - 'logs'
 
     prestashop.core.grid.data_provider.email_logs:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'

--- a/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
@@ -34,24 +34,25 @@ use PrestaShop\PrestaShop\Core\Grid\Data\GridDataInterface;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShopBundle\Service\Hook\HookDispatcher;
 
 class DoctrineGridDataFactoryTest extends TestCase
 {
-    /**
-     * @var DoctrineGridDataFactory
-     */
-    private $doctrineDataProvider;
-
-    public function setUp()
-    {
-        $this->doctrineDataProvider = new DoctrineGridDataFactory($this->createDoctrineQueryBuilderMock());
-    }
-
     public function testItProvidesGridData()
     {
+        $hookDispatcher = $this->createHookDispatcherMock();
+        $hookDispatcher->expects($this->once())
+            ->method('dispatchForParameters');
+
+        $doctrineGridDataFactory = new DoctrineGridDataFactory(
+            $this->createDoctrineQueryBuilderMock(),
+            $hookDispatcher,
+            'test_grid_id'
+        );
+
         $criteria = $this->createMock(SearchCriteriaInterface::class);
 
-        $data = $this->doctrineDataProvider->getData($criteria);
+        $data = $doctrineGridDataFactory->getData($criteria);
 
         $this->assertInstanceOf(GridDataInterface::class, $data);
         $this->assertInstanceOf(RecordCollectionInterface::class, $data->getRecords());
@@ -91,5 +92,14 @@ class DoctrineGridDataFactoryTest extends TestCase
             ->willReturn($qb);
 
         return $doctrineQueryBuilder;
+    }
+
+    private function createHookDispatcherMock()
+    {
+        $hookDispatcher = $this->createMock(HookDispatcher::class);
+        $hookDispatcher->method('dispatchForParameters')
+            ->willReturn(null);
+
+        return $hookDispatcher;
     }
 }

--- a/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Grid\Data\GridDataInterface;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Service\Hook\HookDispatcher;
 
 class DoctrineGridDataFactoryTest extends TestCase
@@ -42,7 +43,7 @@ class DoctrineGridDataFactoryTest extends TestCase
     {
         $hookDispatcher = $this->createHookDispatcherMock();
         $hookDispatcher->expects($this->once())
-            ->method('dispatchForParameters');
+            ->method('dispatchWithParameters');
 
         $doctrineGridDataFactory = new DoctrineGridDataFactory(
             $this->createDoctrineQueryBuilderMock(),
@@ -96,8 +97,8 @@ class DoctrineGridDataFactoryTest extends TestCase
 
     private function createHookDispatcherMock()
     {
-        $hookDispatcher = $this->createMock(HookDispatcher::class);
-        $hookDispatcher->method('dispatchForParameters')
+        $hookDispatcher = $this->createMock(HookDispatcherInterface::class);
+        $hookDispatcher->method('dispatchWithParameters')
             ->willReturn(null);
 
         return $hookDispatcher;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR aims to: 1. make pagination & sorting optional in `SearchCriteria`. This allows to use same data providers to export data when needed. 2. Introduces new hook to allow grid query modifications for modules.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Pages with grid should work as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9402)
<!-- Reviewable:end -->
