### PR TITLE
Convert ProductLazyArray when using render function

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -23,12 +23,13 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
-use PrestaShop\PrestaShop\Core\Product\ProductExtraContentFinder;
+use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
+use PrestaShop\PrestaShop\Core\Product\ProductExtraContentFinder;
 
 class ProductControllerCore extends ProductPresentingFrontControllerCore
 {
@@ -375,13 +376,17 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     public function displayAjaxQuickview()
     {
-        $product_for_template = $this->getTemplateVarProduct();
-
+        $productForTemplate = $this->getTemplateVarProduct();
         ob_end_clean();
         header('Content-Type: application/json');
         $this->ajaxRender(Tools::jsonEncode(array(
-            'quickview_html' => $this->render('catalog/_partials/quickview', $product_for_template),
-            'product' => $product_for_template,
+            'quickview_html' => $this->render(
+                'catalog/_partials/quickview',
+                $productForTemplate instanceof AbstractLazyArray ?
+                $productForTemplate->jsonSerialize() :
+                $productForTemplate
+            ),
+            'product' => $productForTemplate,
         )));
 
         return;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Render need an array as parameter instead of ProductLazyArray.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-6017
| How to test?  | Follow ticket instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9403)
<!-- Reviewable:end -->
