### PR TITLE
FO: Improve contact form widget

### DIFF
--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -62,7 +62,7 @@
               class="form-control"
               name="from"
               type="email"
-              value="{$contact.email}"
+              value="{$customer.email}"
               placeholder="{l s='your@email.com' d='Shop.Forms.Help'}"
             >
           </div>
@@ -75,7 +75,7 @@
               <select name="id_order" class="form-control form-control-select">
                 <option value="">{l s='Select reference' d='Shop.Forms.Help'}</option>
                 {foreach from=$contact.orders item=order}
-                  <option value="{$order.id_order}">{$order.reference}</option>
+                  <option value="{$order.id_order}">{$order.reference} - {$order.date_add|date_format} - {$order.order_state}</option>
                 {/foreach}
               </select>
             </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR aims to improve the usability of the contact form widget: 1. Prepopulate the e-mail field with the logged-in customer e-mail address; 2. Make the "Select reference" field more user friendly. A customer cannot be expected to remember each abstract order reference. But if you add to that the order date and status, the cusomer is more likely to identify the order.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | (optional) If this PR fixes a [Forge](http://forge.prestashop.com/) ticket, please add its complete Forge URL.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9408)
<!-- Reviewable:end -->
