### PR TITLE
CLDR fixes for Denmark (danish)

### DIFF
--- a/localization/CLDR/core/common/main/da.xml
+++ b/localization/CLDR/core/common/main/da.xml
@@ -5767,8 +5767,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>dansk krone</displayName>
 				<displayName count="one">dansk krone</displayName>
 				<displayName count="other">danske kroner</displayName>
-				<symbol>kr.</symbol>
-				<symbol alt="narrow" draft="contributed">kr.</symbol>
+				<symbol>DKK</symbol>
+				<symbol alt="narrow" draft="contributed">DKK</symbol>
 			</currency>
 			<currency type="DOP">
 				<displayName>dominikansk peso</displayName>
@@ -6045,7 +6045,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">islandsk krone</displayName>
 				<displayName count="other">islandske kroner</displayName>
 				<symbol>ISK</symbol>
-				<symbol alt="narrow" draft="contributed">kr.</symbol>
+				<symbol alt="narrow" draft="contributed">ISK</symbol>
 			</currency>
 			<currency type="ITL">
 				<displayName>Italiensk lire</displayName>
@@ -6404,7 +6404,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">norsk krone</displayName>
 				<displayName count="other">norske kroner</displayName>
 				<symbol>NOK</symbol>
-				<symbol alt="narrow" draft="contributed">kr.</symbol>
+				<symbol alt="narrow" draft="contributed">NOK</symbol>
 			</currency>
 			<currency type="NPR">
 				<displayName>nepalesisk rupee</displayName>
@@ -6580,7 +6580,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">svensk krone</displayName>
 				<displayName count="other">svenske kroner</displayName>
 				<symbol>SEK</symbol>
-				<symbol alt="narrow" draft="contributed">kr.</symbol>
+				<symbol alt="narrow" draft="contributed">SEK</symbol>
 			</currency>
 			<currency type="SGD">
 				<displayName>singaporeansk dollar</displayName>

--- a/localization/CLDR/core/common/main/en_DK.xml
+++ b/localization/CLDR/core/common/main/en_DK.xml
@@ -77,7 +77,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</dates>
 	<numbers>
 		<symbols numberSystem="latn">
-			<timeSeparator>.</timeSeparator>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<percentFormats numberSystem="latn">
 			<percentFormatLength>
@@ -88,7 +88,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</percentFormats>
 		<currencies>
 			<currency type="DKK">
-				<symbol>kr.</symbol>
+				<symbol>DKK</symbol>
 			</currency>
 		</currencies>
 	</numbers>

--- a/localization/CLDR/core/common/main/fo_DK.xml
+++ b/localization/CLDR/core/common/main/fo_DK.xml
@@ -14,7 +14,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<currencies>
 			<currency type="DKK">
-				<symbol>kr.</symbol>
+				<symbol>DKK</symbol>
 			</currency>
 		</currencies>
 	</numbers>

--- a/localization/dk.xml
+++ b/localization/dk.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <localizationPack name="Denmark" version="1.0">
   <currencies>
-    <currency name="Danish krone" iso_code="DKK" iso_code_num="208" sign="kr" blank="1" conversion_rate="7.45201" format="2" decimals="1"/>
+    <currency name="Danish krone" iso_code="DKK" iso_code_num="208" sign="DKK" blank="1" conversion_rate="7.45201" format="2" decimals="1"/>
   </currencies>
   <languages>
     <language iso_code="da"/>
@@ -156,8 +156,8 @@
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>
-    <unit type="short_distance" value="in"/>
-    <unit type="base_distance" value="ft"/>
-    <unit type="long_distance" value="mi"/>
+    <unit type="short_distance" value="cm"/>
+    <unit type="base_distance" value="m"/>
+    <unit type="long_distance" value="km"/>
   </units>
 </localizationPack>

--- a/localization/dk.xml
+++ b/localization/dk.xml
@@ -64,64 +64,6 @@
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="uk" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="DK Foodstuff Rate (25%)">
-      <taxRule iso_code_country="be" id_tax="1"/>
-      <taxRule iso_code_country="bg" id_tax="1"/>
-      <taxRule iso_code_country="cz" id_tax="1"/>
-      <taxRule iso_code_country="dk" id_tax="1"/>
-      <taxRule iso_code_country="de" id_tax="1"/>
-      <taxRule iso_code_country="ee" id_tax="1"/>
-      <taxRule iso_code_country="gr" id_tax="1"/>
-      <taxRule iso_code_country="es" id_tax="1"/>
-      <taxRule iso_code_country="fr" id_tax="1"/>
-      <taxRule iso_code_country="ie" id_tax="1"/>
-      <taxRule iso_code_country="it" id_tax="1"/>
-      <taxRule iso_code_country="cy" id_tax="1"/>
-      <taxRule iso_code_country="lv" id_tax="1"/>
-      <taxRule iso_code_country="lt" id_tax="1"/>
-      <taxRule iso_code_country="lu" id_tax="1"/>
-      <taxRule iso_code_country="hu" id_tax="1"/>
-      <taxRule iso_code_country="mt" id_tax="1"/>
-      <taxRule iso_code_country="nl" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="1"/>
-      <taxRule iso_code_country="pl" id_tax="1"/>
-      <taxRule iso_code_country="pt" id_tax="1"/>
-      <taxRule iso_code_country="ro" id_tax="1"/>
-      <taxRule iso_code_country="si" id_tax="1"/>
-      <taxRule iso_code_country="sk" id_tax="1"/>
-      <taxRule iso_code_country="fi" id_tax="1"/>
-      <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="DK Books Rate (25%)">
-      <taxRule iso_code_country="be" id_tax="1"/>
-      <taxRule iso_code_country="bg" id_tax="1"/>
-      <taxRule iso_code_country="cz" id_tax="1"/>
-      <taxRule iso_code_country="dk" id_tax="1"/>
-      <taxRule iso_code_country="de" id_tax="1"/>
-      <taxRule iso_code_country="ee" id_tax="1"/>
-      <taxRule iso_code_country="gr" id_tax="1"/>
-      <taxRule iso_code_country="es" id_tax="1"/>
-      <taxRule iso_code_country="fr" id_tax="1"/>
-      <taxRule iso_code_country="ie" id_tax="1"/>
-      <taxRule iso_code_country="it" id_tax="1"/>
-      <taxRule iso_code_country="cy" id_tax="1"/>
-      <taxRule iso_code_country="lv" id_tax="1"/>
-      <taxRule iso_code_country="lt" id_tax="1"/>
-      <taxRule iso_code_country="lu" id_tax="1"/>
-      <taxRule iso_code_country="hu" id_tax="1"/>
-      <taxRule iso_code_country="mt" id_tax="1"/>
-      <taxRule iso_code_country="nl" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="1"/>
-      <taxRule iso_code_country="pl" id_tax="1"/>
-      <taxRule iso_code_country="pt" id_tax="1"/>
-      <taxRule iso_code_country="ro" id_tax="1"/>
-      <taxRule iso_code_country="si" id_tax="1"/>
-      <taxRule iso_code_country="sk" id_tax="1"/>
-      <taxRule iso_code_country="fi" id_tax="1"/>
-      <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
-    </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="dk" id_tax="1"/>
       <taxRule iso_code_country="at" id_tax="2"/>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We do never use kr. on websites. Because kr. is "used" in Sweden, Norway, Irland and Denmark. If a customer from Norway visits the website, the customer will think that the price is in his currency. Also I did some fixes for other related CLDR for Denmark. I am danish, therefor I am sure on this.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | yes, will add later
| How to test?  | kr. should be DKK

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9413)
<!-- Reviewable:end -->
