### PR TITLE
FO: override a method uses private variable when you inheritance CustomerAddressFormatterCore

### DIFF
--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -29,10 +29,10 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class CustomerAddressFormatterCore implements FormFormatterInterface
 {
-    private $country;
-    private $translator;
-    private $availableCountries;
-    private $definition;
+    protected $country;
+    protected $translator;
+    protected $availableCountries;
+    protected $definition;
 
     public function __construct(
         Country $country,


### PR DESCRIPTION

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | this PR  solves same thing in different class, check #9417  
| Type?         | improvement
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | these access modifiers cant break anything

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9420)
<!-- Reviewable:end -->
