### PR TITLE
Add missing appendArray in OrderReturnLazyArray (BOOM-6039)

### DIFF
--- a/src/Adapter/Presenter/Order/OrderReturnLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderReturnLazyArray.php
@@ -48,17 +48,18 @@ class OrderReturnLazyArray extends AbstractLazyArray
 
     /**
      * OrderReturnLazyArray constructor.
-     * @param $prefix
+     * @param string $prefix
      * @param Link $link
-     * @param $orderReturn
+     * @param array $orderReturn
      * @throws \ReflectionException
      */
-    public function __construct($prefix, Link $link, $orderReturn)
+    public function __construct($prefix, Link $link, array $orderReturn)
     {
         $this->prefix = $prefix;
         $this->link = $link;
         $this->orderReturn = $orderReturn;
         parent::__construct();
+        $this->appendArray($orderReturn);
     }
 
     /**


### PR DESCRIPTION


<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The FO page presenting the OrderReturn did not work anymore due to modifications on the OrderReturnPresenter::present method which no longer returns an array but a OrderReturnLazyArray object which is perfect to access the generated fields like detail_url through the getDetailsUrl method. But it removed to access to original array data like state_name and such. <br><br>Rather than implementing all the getter methods we simply use the AbstractLazyArray::appendArray method to open access to all the missing array fields.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-6039
| How to test?  | See forge ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9422)
<!-- Reviewable:end -->
