### PR TITLE
Fix step name retrieved in the installer

### DIFF
--- a/install-dev/theme/views/footer.php
+++ b/install-dev/theme/views/footer.php
@@ -35,7 +35,7 @@
 		$.each($('li.fail'), function(i, item){
 			errors.push($(this).text().trim());
 		});
-		psuser_assistance.setStep('install_<?php echo addslashes($this->step) ?>', {'error': errors + ' || {"version": "' + ps_version + '"}'});
+		psuser_assistance.setStep('install_<?php echo addslashes(self::$steps->current()->getName()) ?>', {'error': errors + ' || {"version": "' + ps_version + '"}'});
 		if (errors.length)
 			$('#iframe_help').attr('src', $('#iframe_help').attr('src') + '&errors=' + encodeURI(errors.join(', ')));
 	}

--- a/install-dev/theme/views/header.php
+++ b/install-dev/theme/views/header.php
@@ -59,7 +59,7 @@
 <div id="leftpannel">
 	<ol id="tabs">
 		<?php foreach ($this->getSteps() as $step): ?>
-			<?php if ($this->step == $step->getName()): ?>
+			<?php if (self::$steps->current()->getName() == $step->getName()): ?>
 				<li class="selected"><?php echo $step; ?></li>
 			<?php elseif ($this->isStepFinished($step->getName())): ?>
 				<li class="finished"><a href="index.php?step=<?php echo $step->getName() ?>"><?php echo $step; ?></a></li>
@@ -72,7 +72,7 @@
 	</ol>
 	<?php if (@fsockopen('api.prestashop.com', 80, $errno, $errst, 3)): ?>
 		<iframe scrolling="no" style="height:210px;width:200px;border:none;margin-top:20px" id="iframe_help"
-			src="https://api.prestashop.com/iframe/install.php?step=<?php echo $this->step ?>&lang=<?php echo $this->language->getLanguageIso() ?><?php if (isset($this->session->shop_country)) echo '&country='.$this->session->shop_country; ?>">
+			src="https://api.prestashop.com/iframe/install.php?step=<?php echo self::$steps->current()->getName() ?>&lang=<?php echo $this->language->getLanguageIso() ?><?php if (isset($this->session->shop_country)) echo '&country='.$this->session->shop_country; ?>">
 			<p><?php echo $this->translator->trans('Contact us!', array(), 'Install') ?><br /><?php echo $this->getPhone() ?></p>
 		</iframe>
 	<?php endif; ?>
@@ -81,7 +81,7 @@
 <!-- Page content -->
 <form id="mainForm" action="index.php" method="post">
 <div id="sheets" class="sheet shown">
-	<div id="sheet_<?php echo $this->step ?>" class="sheet shown clearfix">
+	<div id="sheet_<?php echo self::$steps->current()->getName() ?>" class="sheet shown clearfix">
 	<div class="contentTitle">
 		<h1><?php echo $this->translator->trans('Installation Assistant', array(), 'Install'); ?></h1>
 		<ul id="stepList_1" class="stepList clearfix">


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since the 1.7.0 version (71717b8), the system step retrieved was empty on the installer.
| Type?         | bug fix
| Category?     | IN 
| BC breaks?    | no
| Deprecations? | no
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9425)
<!-- Reviewable:end -->
