### PR TITLE
Added a new hook to custom SwiftMessage before sending mail

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -579,7 +579,7 @@ class MailCore extends ObjectModel
             $message->setFrom(array($from => $fromName));
 
             // Hook to alter Swift Message before sending mail
-            Hook::exec('actionEmailAlterMessageBeforeSend', [
+            Hook::exec('actionMailAlterMessageBeforeSend', [
                 'message' => &$message,
             ]);
 

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -577,6 +577,12 @@ class MailCore extends ObjectModel
             }
             /* Send mail */
             $message->setFrom(array($from => $fromName));
+
+            // Hook to alter Swift Message before sending mail
+            Hook::exec('actionEmailAlterMessageBeforeSend', [
+                'message' => &$message,
+            ]);
+
             $send = $swift->send($message);
 
             ShopUrl::resetMainDomainCache();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  |  Adding hook to `Mail::send()` method to be able to custom SwiftMessage before sending mail.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Follow example bellow.


**Example of usage in a module :** 

```php
public function hookActionMailAlterMessageBeforeSend($params)
{
     /**
     * @var Swift_Message $message
     */
     $message = $params['message'];
     $headers = $message->getHeaders();
     $headers->addTextHeader('MY-CUSTOM-HEADER-KEY', 'MY-VALUE']);
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9428)
<!-- Reviewable:end -->
