### PR TITLE
Add formatted field file_size_formatted in attachments

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -286,6 +286,22 @@ class ProductLazyArray extends AbstractLazyArray
 
     /**
      * @arrayAccess
+     * @return array
+     * @throws \ReflectionException
+     */
+    public function getAttachments()
+    {
+        foreach ($this->product['attachments'] as &$attachment) {
+            if (!isset($attachment['file_size_formatted'])) {
+                $attachment['file_size_formatted'] = Tools::formatBytes($attachment['file_size'], 2);
+            }
+        }
+
+        return $this->product['attachments'];
+    }
+
+    /**
+     * @arrayAccess
      * @return array|mixed
      */
     public function getQuantityDiscounts()


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | the product page did not work anymore when files were attached to it because of a missing file_size_formatted field, so it is added in ProductLazyArray::getAttachments
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-6020
| How to test?  | See ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9429)
<!-- Reviewable:end -->
