### PR TITLE
Fix links to HTTPS on Admin area when SSL is enabled

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1976,7 +1976,7 @@ class AdminControllerCore extends Controller
             'full_language_code' => $this->context->language->language_code,
             'link' => $this->context->link,
             'shop_name' => Configuration::get('PS_SHOP_NAME'),
-            'base_url' => $this->context->shop->getBaseURL(),
+            'base_url' => $this->context->shop->getBaseURL(true),
             'tab' => isset($tab) ? $tab : null, // Deprecated, this tab is declared in the foreach, so it's the last tab in the foreach
             'current_parent_id' => (int)Tab::getCurrentParentId(),
             'tabs' => $tabs,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Most of Admin links to frontend on stores with SSL enabled still have the links to http only witch requires an redirect from http to https. This PR will prevent that from happening sending the link correctly to https
| Type?         | improvement
| Category?     |BO
| BC breaks?    | No
| Deprecations? | No
| How to test?  | Check for example the link on Admin header on the right top corner "My store" on a store with SSL enabled this is still with http url

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9431)
<!-- Reviewable:end -->
