### PR TITLE
 Make it unnecessary to append a '_' to the controller name when using the AdminSecurity annotation

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
@@ -44,7 +44,7 @@ class AdministrationController extends FrameworkBundleAdminController
     /**
      * Show Administration page
      * @Template("@PrestaShop/Admin/Configure/AdvancedParameters/administration.html.twig")
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param FormInterface $form
      * @return Response
@@ -68,7 +68,7 @@ class AdministrationController extends FrameworkBundleAdminController
 
     /**
      * Process the Administration configuration form.
-     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to update this.", redirectRoute="admin_administration")
+     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_administration")
      * @DemoRestricted(redirectRoute="admin_administration")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
@@ -46,7 +46,7 @@ class EmailController extends FrameworkBundleAdminController
     /**
      * Show email configuration page
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request         $request
      * @param EmailLogsFilter $filters
@@ -88,7 +88,7 @@ class EmailController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -116,7 +116,7 @@ class EmailController extends FrameworkBundleAdminController
      * Process email configuration saving
      *
      * @DemoRestricted(redirectRoute="admin_email")
-     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -148,7 +148,7 @@ class EmailController extends FrameworkBundleAdminController
      * Delete selected email logs
      *
      * @DemoRestricted(redirectRoute="admin_email")
-     * @AdminSecurity("is_granted(['delete'], request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted(['delete'], request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -177,7 +177,7 @@ class EmailController extends FrameworkBundleAdminController
      * Delete all email logs
      *
      * @DemoRestricted(redirectRoute="admin_email")
-     * @AdminSecurity("is_granted(['delete'], request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted(['delete'], request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return RedirectResponse
      */
@@ -196,7 +196,7 @@ class EmailController extends FrameworkBundleAdminController
      * Delete single email log
      *
      * @DemoRestricted(redirectRoute="admin_email")
-     * @AdminSecurity("is_granted(['delete'], request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted(['delete'], request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param int $mailId
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -163,7 +163,7 @@ class ImportController extends FrameworkBundleAdminController
 
     /**
      * Delete import file
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller')~'_')", message="You do not have permission to update this.", redirectRoute="admin_import")
+     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_import")
      * @DemoRestricted(redirectRoute="admin_import")
      *
      * @param Request $request
@@ -182,7 +182,7 @@ class ImportController extends FrameworkBundleAdminController
 
     /**
      * Download import file from history
-     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to update this.", redirectRoute="admin_import")
+     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_import")
      * @DemoRestricted(redirectRoute="admin_import")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/LogsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/LogsController.php
@@ -48,7 +48,7 @@ class LogsController extends FrameworkBundleAdminController
     const CONTROLLER_NAME = 'AdminLogs';
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      * @param LogsFilters $filters the list of filters from the request.
      * @return \Symfony\Component\HttpFoundation\Response
      */
@@ -77,7 +77,7 @@ class LogsController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to update this.", redirectRoute="admin_logs")
+     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_logs")
      * @DemoRestricted(redirectRoute="admin_logs")
      * @param Request $request
      * @return RedirectResponse
@@ -98,7 +98,7 @@ class LogsController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to update this.", redirectRoute="admin_logs")
+     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_logs")
      * @DemoRestricted(redirectRoute="admin_logs")
      *
      * @param Request $request
@@ -130,7 +130,7 @@ class LogsController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller')~'_')", message="You do not have permission to update this.", redirectRoute="admin_logs")
+     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_logs")
      *
      * @return RedirectResponse
      * @throws \Doctrine\DBAL\Exception\InvalidArgumentException

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
@@ -46,7 +46,7 @@ class PerformanceController extends FrameworkBundleAdminController
     /**
      * Displays the Performance main page.
      * @Template("@PrestaShop/Admin/Configure/AdvancedParameters/performance.html.twig")
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param FormInterface $form
      * @return Response
@@ -77,7 +77,7 @@ class PerformanceController extends FrameworkBundleAdminController
 
     /**
      * Process the Performance configuration form.
-     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to update this.")
+     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller'))", message="You do not have permission to update this.")
      * @DemoRestricted(redirectRoute="admin_performance")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
@@ -38,7 +38,7 @@ use Symfony\Component\HttpFoundation\Request;
 class SystemInformationController extends FrameworkBundleAdminController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      * @Template("@PrestaShop/Admin/Configure/AdvancedParameters/system_information.html.twig")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
@@ -43,7 +43,7 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
      * Show customer preferences page
      *
      * @Template("@PrestaShop/Admin/Configure/ShopParameters/customer_preferences.html.twig")
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      * @return array Template parameters
@@ -65,7 +65,7 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
 
     /**
      * Process the Customer Preferences configuration form.
-     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to update this.", redirectRoute="admin_customer_preferences")
+     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_customer_preferences")
      * @DemoRestricted(redirectRoute="admin_customer_preferences")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/GeolocationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/GeolocationController.php
@@ -44,7 +44,7 @@ class GeolocationController extends FrameworkBundleAdminController
      *
      * @Template("@PrestaShop/Admin/Improve/International/Geolocation/geolocation.html.twig")
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -70,7 +70,7 @@ class GeolocationController extends FrameworkBundleAdminController
      * Process geolocation configuration form
      *
      * @AdminSecurity(
-     *     "is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller')~'_')",
+     *     "is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_geolocation"
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LocalizationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LocalizationController.php
@@ -46,7 +46,7 @@ class LocalizationController extends FrameworkBundleAdminController
      *
      * @Template("@PrestaShop/Admin/Improve/International/Localization/localization.html.twig")
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -77,7 +77,7 @@ class LocalizationController extends FrameworkBundleAdminController
     /**
      * Save localization settings
      *
-     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      * @DemoRestricted(redirectRoute="admin_localization_show_settings")
      *
      * @param Request $request
@@ -110,7 +110,7 @@ class LocalizationController extends FrameworkBundleAdminController
     /**
      * Handles localization pack import
      *
-     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller')~'_')", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(['read','update', 'create','delete'], request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      * @DemoRestricted(redirectRoute="admin_localization_show_settings")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Payment/PaymentPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Payment/PaymentPreferencesController.php
@@ -42,7 +42,7 @@ class PaymentPreferencesController extends FrameworkBundleAdminController
      * Show payment preferences page
      *
      * @AdminSecurity(
-     *     "is_granted(['read'], request.get('_legacy_controller')~'_')",
+     *     "is_granted(['read'], request.get('_legacy_controller'))",
      *      message="Access denied."
      * )
      *
@@ -80,7 +80,7 @@ class PaymentPreferencesController extends FrameworkBundleAdminController
      * Process payment modules preferences form
      *
      * @AdminSecurity(
-     *     "is_granted(['update', 'create', 'delete'], request.get('_legacy_controller')~'_')",
+     *     "is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
      *     message="Access denied.",
      *     redirectRoute="admin_payment_preferences"
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
@@ -42,7 +42,7 @@ class DeliveryController extends FrameworkBundleAdminController
      * Main page for Delivery slips.
      *
      * @Template("@PrestaShop/Admin/Sell/Order/Delivery/slip.html.twig")
-     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -85,7 +85,7 @@ class DeliveryController extends FrameworkBundleAdminController
     /**
      * Delivery slips PDF generator
      *
-     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
@@ -44,7 +44,7 @@ class InvoicesController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @Template("@PrestaShop/Admin/Sell/Order/Invoices/invoices.html.twig")
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return array Template parameters
      */
@@ -72,7 +72,7 @@ class InvoicesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return RedirectResponse
      */
@@ -89,7 +89,7 @@ class InvoicesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
 
      * @return RedirectResponse
      */
@@ -106,7 +106,7 @@ class InvoicesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return RedirectResponse
      */

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -146,7 +146,7 @@ class TranslationsController extends FrameworkBundleAdminController
      * Show translations settings page
      *
      * @Template("@PrestaShop/Admin/Improve/International/Translations/translations_settings.html.twig")
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Security/Voter/PageVoter.php
+++ b/src/PrestaShopBundle/Security/Voter/PageVoter.php
@@ -30,6 +30,9 @@ use Access;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
+/**
+ * Decides on access rights to a Page
+ */
 class PageVoter extends Voter
 {
     const CREATE = 'create';
@@ -49,22 +52,20 @@ class PageVoter extends Voter
     const LEVEL_READ   = 1;
 
     /**
-     * @param string $attribute
-     * @param mixed $subject
+     * Indicates if this voter should pronounce on this attribute and subject
+     *
+     * @param string $attribute Rights to test
+     * @param mixed $subject Subject to secure (a controller name)
      * @return bool
      */
     protected function supports($attribute, $subject)
     {
-        if (!in_array($attribute, array(self::CREATE, self::UPDATE, self::DELETE, self::READ))) {
-            return false;
-        }
-
-        return true;
+        return in_array($attribute, array(self::CREATE, self::UPDATE, self::DELETE, self::READ));
     }
 
     /**
-     * @param string $attribute
-     * @param mixed $subject
+     * @param string $attribute Access right to test
+     * @param string $subject Controller name
      * @param TokenInterface $token
      * @return bool
      */
@@ -72,18 +73,42 @@ class PageVoter extends Voter
     {
         $user = $token->getUser();
         $employeeProfileId = $user->getData()->id_profile;
-        $global =  $subject . $attribute;
+        $action = $this->buildAction($subject, $attribute);
 
-        return $this->can($global, $employeeProfileId);
+        return $this->can($action, $employeeProfileId);
     }
 
     /**
-     * @param $action
-     * @param $employeeProfileId
+     * Checks if the provided user profile is allowed to perform the requested action
+     *
+     * @param string $action
+     * @param int $employeeProfileId
+     *
      * @return bool
+     * @throws \Exception
      */
     protected function can($action, $employeeProfileId)
     {
         return Access::isGranted('ROLE_MOD_TAB_' . strtoupper($action), $employeeProfileId);
+    }
+
+    /**
+     * Builds the action name by joining subject and attribute
+     *
+     * @param string $subject Subject the attribute is performed onto (usually a controller name)
+     * @param string $attribute
+     *
+     * @return string
+     */
+    private function buildAction($subject, $attribute)
+    {
+        $action = $subject;
+
+        // add underscore to join if needed
+        if (substr($action, -1) !== '_') {
+            $action .= '_';
+        }
+
+        return $action . $attribute;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Read below
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Access any of the migrated pages. If you can, it means the change works.

Currently, if you use the `@AdminSecurity` annotation in "modern" controllers, you need to append an underscore to the legacy controller name, like this:

```
request.get('_legacy_controller')~'_'
```
Let's take the following example from AdministrationController.php:

```php
/**
 * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')", message="Access denied.")
 */
```

Roles (permissions) for controllers are stored in the database as `ROLE_MOD_TAB_<CONTROLLERNAME>_<CREATE|READ|UPDATE|DELETE>`. 

In this example, the corresponding role is `ROLE_MOD_TAB_ADMINADMINPREFERENCES_READ`.

The `PageVoter` that is invoked when calling `is_granted()` receives "read" as attribute, and "AdminAdminPreferences" as subject (specified by the `_legacy_controller` property in the route yaml).

Using those elements, it builds the role ID and then hands it over to the legacy access control which performs the check.

Until now, the role was created by joining the subject and the attribute together, then converting them to upper case. This PR adds an underscore between them if there isn't one there already (to ensure backwards compatibility).

That's all! Now we can have cleaner calls to AdminSecurity. Check out said change in this commit: https://github.com/PrestaShop/PrestaShop/commit/95ce71caa181e07c0bd53d1fb04a42ddc0bfe3cf

The second commit is where I changed all the current calls so that they conform to the new spec.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9432)
<!-- Reviewable:end -->
