### PR TITLE
Fix attribute import with reference as key if product doesn't exist

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2068,6 +2068,8 @@ class AdminImportControllerCore extends AdminController
                 ', false);
                 if (isset($datas['id_product']) && $datas['id_product']) {
                     $product = new Product((int)$datas['id_product'], false, $default_language);
+                } else {
+                    continue;
                 }
             } else {
                 continue;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When you import attributes with reference as key, if the product doesn't exist, the attribute is added to the previous exiting product
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Import attributes with reference as key. Attributes without product should not be taken into account

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9438)
<!-- Reviewable:end -->
