### PR TITLE
Fix Error 500 from API request with PHP 7.2

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -183,7 +183,7 @@ class WebserviceRequestCore
     public static $ws_current_classname;
 
 
-    public static $shopIDs;
+    public static $shopIDs = array();
 
 
     public function getOutputEnabled()

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -182,7 +182,9 @@ class WebserviceRequestCore
      */
     public static $ws_current_classname;
 
-
+    /**
+     * @var array the list of shop ids, can be empty.
+     */
     public static $shopIDs = array();
 
 


### PR DESCRIPTION
line 800 (file: classes/webservice/WebserviceRequest.php) 
assumes that self::$shopIDs is an array that can be counted.

But self::$shopIDs is null and the following error appears:

[PHP Warning #2] count(): Parameter must be an array or an object that implements Countable (/home/jojo/public_html/mydomain.com/presta2/classes/webservice/WebserviceRequest.php, line 800)

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When using API with PHP 7.2, we get an error: count(): Parameter must be an array or an object that implements Countable
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5922
| How to test?  | Try to get customers using API

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9439)
<!-- Reviewable:end -->
