### PR TITLE
Replace PrestaTrust property with setter

### DIFF
--- a/src/Adapter/Module/PrestaTrust/ModuleEventSubscriber.php
+++ b/src/Adapter/Module/PrestaTrust/ModuleEventSubscriber.php
@@ -45,7 +45,7 @@ class ModuleEventSubscriber implements EventSubscriberInterface
      *
      * @var bool
      */
-    public $enabled;
+    private $enabled;
 
     public function __construct(PrestaTrustChecker $checker)
     {
@@ -76,5 +76,17 @@ class ModuleEventSubscriber implements EventSubscriberInterface
         }
 
         $this->checker->checkModuleZip($event->getModuleZip());
+    }
+
+    /**
+     * Enable / disable the PrestaTrust feature
+     *
+     * @param bool $enable
+     * @return $this
+     */
+    public function toggleService($enable)
+    {
+        $this->enabled = (bool) $enable;
+        return $this;
     }
 }

--- a/src/Adapter/Module/PrestaTrust/ModuleEventSubscriber.php
+++ b/src/Adapter/Module/PrestaTrust/ModuleEventSubscriber.php
@@ -79,7 +79,7 @@ class ModuleEventSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Check if the feature is enabled
+     * Check if the feature is enabled.
      *
      * @return bool
      */
@@ -89,9 +89,10 @@ class ModuleEventSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Enable / disable the PrestaTrust feature
+     * Enable / disable the PrestaTrust feature.
      *
      * @param bool $enabled
+     *
      * @return $this
      */
     public function setEnabled($enabled)

--- a/src/Adapter/Module/PrestaTrust/ModuleEventSubscriber.php
+++ b/src/Adapter/Module/PrestaTrust/ModuleEventSubscriber.php
@@ -79,14 +79,25 @@ class ModuleEventSubscriber implements EventSubscriberInterface
     }
 
     /**
+     * Check if the feature is enabled
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
      * Enable / disable the PrestaTrust feature
      *
-     * @param bool $enable
+     * @param bool $enabled
      * @return $this
      */
-    public function toggleService($enable)
+    public function setEnabled($enabled)
     {
-        $this->enabled = (bool) $enable;
+        $this->enabled = (bool) $enabled;
+
         return $this;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/prestatrust.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/prestatrust.yml
@@ -13,7 +13,7 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Module\PrestaTrust\ModuleEventSubscriber
         arguments:
             - "@prestashop.adapter.module.prestatrust.checker"
-        properties:
-             enabled: '%prestashop.addons.prestatrust.enabled%'
+        calls:
+            - [ toggleService, ['%prestashop.addons.prestatrust.enabled%']]
         tags:
             - { name: kernel.event_subscriber }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/prestatrust.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/prestatrust.yml
@@ -14,6 +14,6 @@ services:
         arguments:
             - "@prestashop.adapter.module.prestatrust.checker"
         calls:
-            - [ toggleService, ['%prestashop.addons.prestatrust.enabled%']]
+            - [ setEnabled, ['%prestashop.addons.prestatrust.enabled%']]
         tags:
             - { name: kernel.event_subscriber }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | From a previous review, it was requested to remove a public property and add a setter instead.
| Type?         | improvement
| Category?     | BO 
| BC breaks?    | Property visibility changed
| Deprecations? | Nope
| Fixed ticket? | Fixed #10082
| How to test?  | Modify your config.yml to disable PrestaTrust, and add a dump in the setter to check everything is properly set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9451)
<!-- Reviewable:end -->
