### PR TITLE
Small naming update in grid

### DIFF
--- a/src/Core/Grid/DataProvider/DoctrineGridDataProvider.php
+++ b/src/Core/Grid/DataProvider/DoctrineGridDataProvider.php
@@ -28,7 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\DataProvider;
 
 use PDO;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
-use PrestaShop\PrestaShop\Core\Grid\Row\RowCollection;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -58,14 +58,14 @@ final class DoctrineGridDataProvider implements GridDataProviderInterface
         $searchQueryBuilder = $this->gridQueryBuilder->getSearchQueryBuilder($searchCriteria);
         $countQueryBuilder = $this->gridQueryBuilder->getCountQueryBuilder($searchCriteria);
 
-        $rows = $searchQueryBuilder->execute()->fetchAll();
-        $rowsTotal = (int) $countQueryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
+        $records = $searchQueryBuilder->execute()->fetchAll();
+        $recordsTotal = (int) $countQueryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
 
-        $rows = new RowCollection($rows);
+        $records = new RecordCollection($records);
 
         return new GridData(
-            $rows,
-            $rowsTotal,
+            $records,
+            $recordsTotal,
             $searchQueryBuilder->getSQL()
         );
     }

--- a/src/Core/Grid/DataProvider/GridData.php
+++ b/src/Core/Grid/DataProvider/GridData.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\DataProvider;
 
-use PrestaShop\PrestaShop\Core\Grid\Row\RowCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 
 /**
  * Class GridData is responsible for storing grid data
@@ -36,12 +36,12 @@ final class GridData implements GridDataInterface
     /**
      * @var array
      */
-    private $rows;
+    private $records;
 
     /**
      * @var int
      */
-    private $rowsTotal;
+    private $recordsTotal;
 
     /**
      * @var string
@@ -49,31 +49,31 @@ final class GridData implements GridDataInterface
     private $query;
 
     /**
-     * @param RowCollectionInterface  $rows      Filtered & paginated rows data
-     * @param int                     $rowsTotal Total number of rows (without pagination)
-     * @param string                  $query     Query used to get rows
+     * @param RecordCollectionInterface $records Filtered & paginated rows data
+     * @param int $recordsTotal Total number of rows (without pagination)
+     * @param string $query Query used to get rows
      */
-    public function __construct(RowCollectionInterface $rows, $rowsTotal, $query = '')
+    public function __construct(RecordCollectionInterface $records, $recordsTotal, $query = '')
     {
-        $this->rows = $rows;
-        $this->rowsTotal = $rowsTotal;
+        $this->records = $records;
+        $this->recordsTotal = $recordsTotal;
         $this->query = $query;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getRows()
+    public function getRecords()
     {
-        return $this->rows;
+        return $this->records;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getRowsTotal()
+    public function getRecordsTotal()
     {
-        return $this->rowsTotal;
+        return $this->recordsTotal;
     }
 
     /**

--- a/src/Core/Grid/DataProvider/GridDataInterface.php
+++ b/src/Core/Grid/DataProvider/GridDataInterface.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\DataProvider;
 
-use PrestaShop\PrestaShop\Core\Grid\Row\RowCollection;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 
 /**
  * Interface GridDataInterface exposes contract for final grid data
@@ -36,16 +36,16 @@ interface GridDataInterface
     /**
      * Returns final grid rows ready for rendering
      *
-     * @return RowCollection
+     * @return RecordCollection
      */
-    public function getRows();
+    public function getRecords();
 
     /**
      * Returns total rows in data source
      *
      * @return int
      */
-    public function getRowsTotal();
+    public function getRecordsTotal();
 
     /**
      * Return query which was used to get rows

--- a/src/Core/Grid/Presenter/GridPresenter.php
+++ b/src/Core/Grid/Presenter/GridPresenter.php
@@ -52,8 +52,8 @@ final class GridPresenter implements GridPresenterInterface
                 'bulk' => $definition->getBulkActions()->toArray(),
             ],
             'data' => [
-                'rows' => $data->getRows(),
-                'rows_total' => $data->getRowsTotal(),
+                'records' => $data->getRecords(),
+                'records_total' => $data->getRecordsTotal(),
                 'query' => $data->getQuery(),
             ],
             'pagination' => [

--- a/src/Core/Grid/Record/RecordCollection.php
+++ b/src/Core/Grid/Record/RecordCollection.php
@@ -24,27 +24,27 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Grid\Row;
+namespace PrestaShop\PrestaShop\Core\Grid\Record;
 
 use PrestaShop\PrestaShop\Core\Grid\Collection\AbstractCollection;
 
 /**
- * Class RowCollection is a wrapper around rows from database
+ * Class RecordCollection is a wrapper around rows from database
  */
-class RowCollection extends AbstractCollection implements RowCollectionInterface
+final class RecordCollection extends AbstractCollection implements RecordCollectionInterface
 {
     /**
-     * @param array $rows Raw rows data
+     * @param array $records Raw records data
      */
-    public function __construct(array $rows = [])
+    public function __construct(array $records = [])
     {
-        $this->items = $rows;
+        $this->items = $records;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getRows()
+    public function all()
     {
         return $this->items;
     }

--- a/src/Core/Grid/Record/RecordCollectionInterface.php
+++ b/src/Core/Grid/Record/RecordCollectionInterface.php
@@ -24,20 +24,20 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Grid\Row;
+namespace PrestaShop\PrestaShop\Core\Grid\Record;
 
 use Countable;
 use Iterator;
 
 /**
- * Interface RowCollectionInterface defines interface for raw rows wrapper
+ * Interface RecordCollectionInterface defines interface for raw rows wrapper
  */
-interface RowCollectionInterface extends Countable, Iterator
+interface RecordCollectionInterface extends Countable, Iterator
 {
     /**
      * Get raw rows
      *
      * @return array
      */
-    public function getRows();
+    public function all();
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/link.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/link.html.twig
@@ -30,7 +30,7 @@
 {% endif %}
 
 <a class="{{ class }}"
-   href="{{ path(action.options.route, { (action.options.route_param_name) : row[action.options.route_param_field]}) }}"
+   href="{{ path(action.options.route, { (action.options.route_param_name) : record[action.options.route_param_field]}) }}"
    data-confirm-message="{{ action.options.confirm_message }}"
 >
   {% if action.icon is not empty %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% if grid.filter_form|length > 1 %}
-  <tr class="column-filters {% if 0 == grid.data.rows_total and grid.filters is empty %}d-none{% endif %}">
+  <tr class="column-filters {% if 0 == grid.data.records_total and grid.filters is empty %}d-none{% endif %}">
     {% for column in grid.columns %}
       <th>
         {% if grid.filter_form[column.id] is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/headers_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/headers_row.html.twig
@@ -28,7 +28,7 @@
 
   {% for column in grid.columns %}
     <th scope="col">
-      {% if column.options.sortable is defined and column.options.sortable and grid.data.rows_total > 0 %}
+      {% if column.options.sortable is defined and column.options.sortable and grid.data.records_total > 0 %}
         {{ ps.sortable_column_header(column.name, column.id, orderBy, orderWay) }}
       {% else %}
         {{ column.name }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/bulk_actions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/bulk_actions.html.twig
@@ -23,20 +23,20 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% if grid.actions.bulk|length > 0 and grid.data.rows_total > 0 %}
-  <div class="btn-group">
-    <button class="btn btn-outline-secondary dropdown-toggle js-bulk-actions-btn"
-            data-toggle="dropdown"
-            disabled
-    >
-      {{ 'Bulk actions'|trans({}, 'Admin.Global') }}
-      <i class="icon-caret-up"></i>
-    </button>
+{% if grid.actions.bulk|length > 0 and grid.data.records_total > 0 %}
+    <div class="btn-group">
+      <button class="btn btn-outline-secondary dropdown-toggle js-bulk-actions-btn"
+              data-toggle="dropdown"
+              disabled
+      >
+        {{ 'Bulk actions'|trans({}, 'Admin.Global') }}
+        <i class="icon-caret-up"></i>
+      </button>
 
-    <div class="dropdown-menu">
-      {% for action in grid.actions.bulk %}
-        {{ include('@PrestaShop/Admin/Common/Grid/Actions/Bulk/'~action.type~'.html.twig', {'action': action, 'grid': grid}) }}
-      {% endfor %}
+      <div class="dropdown-menu">
+        {% for action in grid.actions.bulk %}
+          {{ include('@PrestaShop/Admin/Common/Grid/Actions/Bulk/'~action.type~'.html.twig', {'action': action, 'grid': grid}) }}
+        {% endfor %}
+      </div>
     </div>
-  </div>
 {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/bulk_actions_select_all.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/bulk_actions_select_all.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% if grid.actions.bulk|length > 0 and grid.data.rows_total > 0 %}
+{% if grid.actions.bulk|length > 0 and grid.data.records_total > 0 %}
   <div class="md-checkbox mt-3">
     <label>
       <input type="checkbox"

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
@@ -24,13 +24,13 @@
  *#}
 
 {% block grid_pagination %}
-  {% if grid.data.rows_total > 10 %}
+  {% if grid.data.records_total > 10 %}
     <div class="row">
       <div class="col-md-12">
         {{ render(controller('PrestaShopBundle:Admin\\Common:pagination', {
           'limit': grid.pagination.limit,
           'offset': grid.pagination.offset,
-          'total': grid.data.rows_total,
+          'total': grid.data.records_total,
           'caller_route': app.request.attributes.get('_route')
         })) }}
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
@@ -33,12 +33,12 @@
   {{ include('@PrestaShop/Admin/Common/Grid/Blocks/Table/filters_row.html.twig', {'grid': grid}) }}
   </thead>
   <tbody>
-  {% if grid.data.rows is not empty %}
-    {% for row in grid.data.rows %}
+  {% if grid.data.records is not empty %}
+    {% for record in grid.data.records %}
       <tr>
         {% for column in grid.columns %}
           <td>
-            {{ include('@PrestaShop/Admin/Common/Grid/Columns/'~column.type~'.html.twig', {'grid': grid, 'column': column, 'row': row}) }}
+            {{ include('@PrestaShop/Admin/Common/Grid/Columns/'~column.type~'.html.twig', {'grid': grid, 'column': column, 'record': record}) }}
           </td>
         {% endfor %}
       </tr>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/action.html.twig
@@ -23,31 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{#**
- * 2007-2018 PrestaShop
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to http://www.prestashop.com for more information.
- *
- * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2018 PrestaShop SA
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- * International Registered Trademark & Property of PrestaShop SA
- *#}
-
 {% set actions = column.options.actions %}
 
 {% if actions is not empty %}
@@ -56,7 +31,7 @@
       {{ include('@PrestaShop/Admin/Common/Grid/Actions/Row/'~actions|first.type~'.html.twig', {
         'grid': grid,
         'column': column,
-        'row': row,
+        'record': record,
         'action': actions|first
       }) }}
 
@@ -73,9 +48,9 @@
               {{ include('@PrestaShop/Admin/Common/Grid/Actions/Row/'~action.type~'.html.twig', {
                 'grid': grid,
                 'column': column,
-                'row': row,
-                'action': action,
                 'attributes': {'class': 'dropdown-item'}
+                'record': record,
+                'action': action
               }) }}
           {% endfor %}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/action.html.twig
@@ -48,7 +48,7 @@
               {{ include('@PrestaShop/Admin/Common/Grid/Actions/Row/'~action.type~'.html.twig', {
                 'grid': grid,
                 'column': column,
-                'attributes': {'class': 'dropdown-item'}
+                'attributes': {'class': 'dropdown-item'},
                 'record': record,
                 'action': action
               }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/bulk_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/bulk_action.html.twig
@@ -29,7 +29,7 @@
            title="{{ column.name }}"
            class="js-bulk-action-checkbox"
            name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ row[column.options.bulk_field] }}"
+           value="{{ record[column.options.bulk_field] }}"
     >
     <i class="md-checkbox-control"></i>
   </label>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/data.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/data.html.twig
@@ -23,4 +23,4 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{{ row[column.options.field] }}
+{{ record[column.options.field] }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/date_time.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/date_time.html.twig
@@ -23,4 +23,4 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{{ row[column.id]|date(column.options.format) }}
+{{ record[column.id]|date(column.options.format) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/employee_name_with_avatar.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/employee_name_with_avatar.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {%
-  set employeeName, employeeImage = row.employee, 'http://profile.prestashop.com/'~row.email|url_encode~'.jpg'
+  set employeeName, employeeImage = record.employee, 'http://profile.prestashop.com/'~record.email|url_encode~'.jpg'
 %}
 <span class="employee_avatar_small">
     <img class="img rounded-circle" alt="{{ employeeName }}" src="{{ employeeImage }}" height="32" width="32" />

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/severity_level.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/severity_level.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% set severity = row.severity %}
+{% set severity = record.severity %}
 {% set withMessage = column.options.with_message %}
 
 {% if severity == 1 %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/grid_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/grid_panel.html.twig
@@ -26,7 +26,7 @@
 <div class="card js-grid-panel" id="{{ grid.id }}_grid_panel">
   {% block grid_header %}
     <div class="card-header">
-      <h3>{{ grid.name }} ({{ grid.data.rows_total }})</h3>
+      <h3>{{ grid.name }} ({{ grid.data.records_total }})</h3>
     </div>
   {% endblock %}
 

--- a/tests/Unit/Core/Grid/DataProvider/DoctrineGridDataProviderTest.php
+++ b/tests/Unit/Core/Grid/DataProvider/DoctrineGridDataProviderTest.php
@@ -32,7 +32,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Grid\DataProvider\DoctrineGridDataProvider;
 use PrestaShop\PrestaShop\Core\Grid\DataProvider\GridDataInterface;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
-use PrestaShop\PrestaShop\Core\Grid\Row\RowCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 class DoctrineGridDataProviderTest extends TestCase
@@ -54,10 +54,10 @@ class DoctrineGridDataProviderTest extends TestCase
         $data = $this->doctrineDataProvider->getData($criteria);
 
         $this->assertInstanceOf(GridDataInterface::class, $data);
-        $this->assertInstanceOf(RowCollectionInterface::class, $data->getRows());
+        $this->assertInstanceOf(RecordCollectionInterface::class, $data->getRecords());
 
-        $this->assertEquals(4, $data->getRowsTotal());
-        $this->assertCount(2, $data->getRows());
+        $this->assertEquals(4, $data->getRecordsTotal());
+        $this->assertCount(2, $data->getRecords());
         $this->assertEquals('SELECT * FROM ps_test', $data->getQuery());
     }
 

--- a/tests/Unit/Core/Grid/Presenter/GridPresenterTest.php
+++ b/tests/Unit/Core/Grid/Presenter/GridPresenterTest.php
@@ -61,7 +61,7 @@ class GridPresenterTest extends TestCase
             'filter_form' => [],
             'columns' => [],
             'actions' => ['grid', 'bulk'],
-            'data' => ['rows', 'rows_total', 'query'],
+            'data' => ['records', 'records_total', 'query'],
             'pagination' => ['offset', 'limit'],
             'sorting' => ['order_by', 'order_way'],
             'filters' => [],


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It changes naming from from using _rows_ to _records_, e.g. Previous: `RowCollection`, now `RecordCollection`. _Record_ - item, that can be retrieved from database or any other data source and displayed in grid as single row.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | No behaviour has changed. But pages with grid should work as they did before.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9452)
<!-- Reviewable:end -->
