### PR TITLE
Allow import entity to be preselected

### DIFF
--- a/src/Core/Import/Entity.php
+++ b/src/Core/Import/Entity.php
@@ -51,8 +51,8 @@ final class Entity
         'addresses' => self::TYPE_ADDRESSES,
         'manufacturers' => self::TYPE_MANUFACTURERS,
         'suppliers' => self::TYPE_SUPPLIERS,
-        'alias'=> self::TYPE_ALIAS,
-        'contacts'=> self::TYPE_STORE_CONTACTS,
+        'alias' => self::TYPE_ALIAS,
+        'contacts' => self::TYPE_STORE_CONTACTS,
     ];
 
     /**
@@ -64,7 +64,7 @@ final class Entity
      */
     public static function getFromName($importType)
     {
-        if (isset(self::AVAILABLE_TYPES[$importType])) {
+        if (array_key_exists($importType, self::AVAILBALE_TYPES)) {
             return self::AVAILABLE_TYPES[$importType];
         }
 

--- a/src/Core/Import/Entity.php
+++ b/src/Core/Import/Entity.php
@@ -38,7 +38,7 @@ final class Entity
     const TYPE_COMBINATIONS = 2;
     const TYPE_CUSTOMERS = 3;
     const TYPE_ADDRESSES = 4;
-    const TYPE_BRANDS = 5;
+    const TYPE_MANUFACTURERS = 5;
     const TYPE_SUPPLIERS = 6;
     const TYPE_ALIAS = 7;
     const TYPE_STORE_CONTACTS = 8;
@@ -49,9 +49,9 @@ final class Entity
         'combinations' => self::TYPE_COMBINATIONS,
         'customers' => self::TYPE_CUSTOMERS,
         'addresses' => self::TYPE_ADDRESSES,
-        'brands' => self::TYPE_BRANDS,
+        'manufacturers' => self::TYPE_MANUFACTURERS,
         'suppliers' => self::TYPE_SUPPLIERS,
-        'alis'=> self::TYPE_ALIAS,
+        'alias'=> self::TYPE_ALIAS,
         'contacts'=> self::TYPE_STORE_CONTACTS,
     ];
 

--- a/src/Core/Import/Entity.php
+++ b/src/Core/Import/Entity.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Import;
+
+use PrestaShop\PrestaShop\Core\Import\Exception\NotSupportedImportTypeException;
+
+/**
+ * Class Entity defines available import entities
+ */
+final class Entity
+{
+    const TYPE_CATEGORIES = 0;
+    const TYPE_PRODUCTS = 1;
+    const TYPE_COMBINATIONS = 2;
+    const TYPE_CUSTOMERS = 3;
+    const TYPE_ADDRESSES = 4;
+    const TYPE_BRANDS = 5;
+    const TYPE_SUPPLIERS = 6;
+    const TYPE_ALIAS = 7;
+    const TYPE_STORE_CONTACTS = 8;
+
+    /**
+     * Get import entity type from name
+     *
+     * @param string $importType
+     *
+     * @return string
+     */
+    public static function getFromName($importType)
+    {
+        switch ($importType) {
+            case 'categories':
+                return self::TYPE_CATEGORIES;
+            case 'products':
+                return self::TYPE_PRODUCTS;
+            case 'combinations':
+                return self::TYPE_COMBINATIONS;
+            case 'customers':
+                return self::TYPE_CUSTOMERS;
+            case 'addresses':
+                return self::TYPE_ADDRESSES;
+            case 'manufacturers':
+                return self::TYPE_BRANDS;
+            case 'suppliers':
+                return self::TYPE_SUPPLIERS;
+            case 'alias':
+                return self::TYPE_ALIAS;
+        }
+
+        throw new NotSupportedImportTypeException(sprintf('Import type with name "%s" is not supported.', $importType));
+    }
+
+    /**
+     * Class is not suppose to be initialized as it only use case
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/Core/Import/Entity.php
+++ b/src/Core/Import/Entity.php
@@ -43,6 +43,18 @@ final class Entity
     const TYPE_ALIAS = 7;
     const TYPE_STORE_CONTACTS = 8;
 
+    const AVAILABLE_TYPES = [
+        'categories' => self::TYPE_CATEGORIES,
+        'products' => self::TYPE_PRODUCTS,
+        'combinations' => self::TYPE_COMBINATIONS,
+        'customers' => self::TYPE_CUSTOMERS,
+        'addresses' => self::TYPE_ADDRESSES,
+        'brands' => self::TYPE_BRANDS,
+        'suppliers' => self::TYPE_SUPPLIERS,
+        'alis'=> self::TYPE_ALIAS,
+        'contacts'=> self::TYPE_STORE_CONTACTS,
+    ];
+
     /**
      * Get import entity type from name
      *
@@ -52,23 +64,8 @@ final class Entity
      */
     public static function getFromName($importType)
     {
-        switch ($importType) {
-            case 'categories':
-                return self::TYPE_CATEGORIES;
-            case 'products':
-                return self::TYPE_PRODUCTS;
-            case 'combinations':
-                return self::TYPE_COMBINATIONS;
-            case 'customers':
-                return self::TYPE_CUSTOMERS;
-            case 'addresses':
-                return self::TYPE_ADDRESSES;
-            case 'manufacturers':
-                return self::TYPE_BRANDS;
-            case 'suppliers':
-                return self::TYPE_SUPPLIERS;
-            case 'alias':
-                return self::TYPE_ALIAS;
+        if (isset(self::AVAILABLE_TYPES[$importType])) {
+            return self::AVAILABLE_TYPES[$importType];
         }
 
         throw new NotSupportedImportTypeException(sprintf('Import type with name "%s" is not supported.', $importType));

--- a/src/Core/Import/Entity.php
+++ b/src/Core/Import/Entity.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Import;
 use PrestaShop\PrestaShop\Core\Import\Exception\NotSupportedImportTypeException;
 
 /**
- * Class Entity defines available import entities
+ * Class Entity defines available import entities.
  */
 final class Entity
 {
@@ -56,7 +56,7 @@ final class Entity
     ];
 
     /**
-     * Get import entity type from name
+     * Get import entity type from name.
      *
      * @param string $importType
      *
@@ -72,7 +72,7 @@ final class Entity
     }
 
     /**
-     * Class is not suppose to be initialized as it only use case
+     * Class is not suppose to be initialized as it only use case.
      */
     private function __construct()
     {

--- a/src/Core/Import/Entity.php
+++ b/src/Core/Import/Entity.php
@@ -64,7 +64,7 @@ final class Entity
      */
     public static function getFromName($importType)
     {
-        if (array_key_exists($importType, self::AVAILBALE_TYPES)) {
+        if (array_key_exists($importType, self::AVAILABLE_TYPES)) {
             return self::AVAILABLE_TYPES[$importType];
         }
 

--- a/src/Core/Import/Exception/ExceptionInterface.php
+++ b/src/Core/Import/Exception/ExceptionInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Import\Exception;
+
+interface ExceptionInterface
+{
+
+}

--- a/src/Core/Import/Exception/ExceptionInterface.php
+++ b/src/Core/Import/Exception/ExceptionInterface.php
@@ -26,7 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Core\Import\Exception;
 
+/**
+ * Interface ExceptionInterface is implemented by all import exceptions
+ */
 interface ExceptionInterface
 {
-
 }

--- a/src/Core/Import/Exception/ExceptionInterface.php
+++ b/src/Core/Import/Exception/ExceptionInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Import\Exception;
 
 /**
- * Interface ExceptionInterface is implemented by all import exceptions
+ * Interface ExceptionInterface is implemented by all import exceptions.
  */
 interface ExceptionInterface
 {

--- a/src/Core/Import/Exception/NotSupportedImportTypeException.php
+++ b/src/Core/Import/Exception/NotSupportedImportTypeException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Import\Exception;
+
+use Exception;
+
+/**
+ * Class NotSupportedImportTypeException is thrown when no supported import type is provided
+ */
+class NotSupportedImportTypeException extends Exception implements ExceptionInterface
+{
+}

--- a/src/Core/Import/Exception/NotSupportedImportTypeException.php
+++ b/src/Core/Import/Exception/NotSupportedImportTypeException.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Import\Exception;
 use Exception;
 
 /**
- * Class NotSupportedImportTypeException is thrown when no supported import type is provided
+ * Class NotSupportedImportTypeException is thrown when no supported import type is provided.
  */
 class NotSupportedImportTypeException extends Exception implements ExceptionInterface
 {

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
+use PrestaShop\PrestaShop\Core\Import\Entity;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Exception\FileUploadException;
 use PrestaShopBundle\Security\Voter\PageVoter;
@@ -86,6 +87,13 @@ class ImportController extends FrameworkBundleAdminController
         $iniConfiguration = $this->get('prestashop.core.configuration.ini_configuration');
 
         $form = $formHandler->getForm();
+
+        if ($request->query->has('import_type')) {
+            $formData = $form->getData();
+            $formData['entity'] = Entity::getFromName($request->query->get('import_type'));
+            $form->setData($formData);
+        }
+
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -210,7 +210,7 @@ class ProductController extends FrameworkBundleAdminController
                 'layoutHeaderToolbarBtn' => $toolbarButtons,
                 'categories' => $categoriesForm->createView(),
                 'pagination_limit_choices' => $productProvider->getPaginationLimitChoices(),
-                'import_link' => $this->getAdminLink('AdminImport', ['import_type' => 'products']),
+                'import_link' => $this->generateUrl('admin_import', ['import_type' => 'products']),
                 'sql_manager_add_link' => $this->generateUrl('admin_sql_request_create', ['addrequest_sql' => 1]),
                 'enableSidebar' => true,
                 'help_link' => $this->generateSidebarLink('AdminProducts'),

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import;
 
+use PrestaShop\PrestaShop\Core\Import\Entity;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -49,15 +50,15 @@ class ImportType extends TranslatorAwareType
             ->add('csv', HiddenType::class)
             ->add('entity', ChoiceType::class, [
                 'choices' => [
-                    $this->trans('Categories', 'Admin.Global') => 0,
-                    $this->trans('Products', 'Admin.Global') => 1,
-                    $this->trans('Combinations', 'Admin.Global') => 2,
-                    $this->trans('Customers', 'Admin.Global') => 3,
-                    $this->trans('Addresses', 'Admin.Global') => 4,
-                    $this->trans('Brands', 'Admin.Global') => 5,
-                    $this->trans('Suppliers', 'Admin.Global') => 6,
-                    $this->trans('Alias', 'Admin.Shopparameters.Feature') => 7,
-                    $this->trans('Store contacts', 'Admin.Advparameters.Feature') => 8,
+                    $this->trans('Categories', 'Admin.Global') => Entity::TYPE_CATEGORIES,
+                    $this->trans('Products', 'Admin.Global') => Entity::TYPE_PRODUCTS,
+                    $this->trans('Combinations', 'Admin.Global') => Entity::TYPE_COMBINATIONS,
+                    $this->trans('Customers', 'Admin.Global') => Entity::TYPE_CUSTOMERS,
+                    $this->trans('Addresses', 'Admin.Global') => Entity::TYPE_ADDRESSES,
+                    $this->trans('Brands', 'Admin.Global') => Entity::TYPE_BRANDS,
+                    $this->trans('Suppliers', 'Admin.Global') => Entity::TYPE_SUPPLIERS,
+                    $this->trans('Alias', 'Admin.Shopparameters.Feature') => Entity::TYPE_ALIAS,
+                    $this->trans('Store contacts', 'Admin.Advparameters.Feature') => Entity::TYPE_STORE_CONTACTS,
                 ],
             ])
             ->add('file', FileType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -56,7 +56,7 @@ class ImportType extends TranslatorAwareType
                     $this->trans('Combinations', 'Admin.Global') => Entity::TYPE_COMBINATIONS,
                     $this->trans('Customers', 'Admin.Global') => Entity::TYPE_CUSTOMERS,
                     $this->trans('Addresses', 'Admin.Global') => Entity::TYPE_ADDRESSES,
-                    $this->trans('Brands', 'Admin.Global') => Entity::TYPE_BRANDS,
+                    $this->trans('Brands', 'Admin.Global') => Entity::TYPE_MANUFACTURERS,
                     $this->trans('Suppliers', 'Admin.Global') => Entity::TYPE_SUPPLIERS,
                     $this->trans('Alias', 'Admin.Shopparameters.Feature') => Entity::TYPE_ALIAS,
                     $this->trans('Store contacts', 'Admin.Advparameters.Feature') => Entity::TYPE_STORE_CONTACTS,

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import;
 use PrestaShop\PrestaShop\Core\Import\Entity;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -83,7 +84,23 @@ class ImportType extends TranslatorAwareType
             ])
             ->add('sendemail', SwitchType::class, [
                 'data' => true,
-            ]);
+            ])
+        ;
+
+        $builder->get('entity')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($entity) {
+                    if (null === $entity) {
+                        return $entity;
+                    }
+
+                    return is_numeric($entity) ? $entity : Entity::getFromName($entity);
+                },
+                function ($entity) {
+                    return $entity;
+                }
+            ))
+        ;
     }
 
     public function configureOptions(OptionsResolver $resolver)


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See https://github.com/PrestaShop/prestafony-project/issues/58
| Type?         | bug fix
| Category?     | BO
| BC breaks?    |no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Click "Import" in Back Office Catalog page and after redirect to Import page, "Products" should be preselected. Same should work for other import data (Categories, Customers, Addresses & etc.)
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9453)
<!-- Reviewable:end -->
