### PR TITLE
Removed all translations errors from localization page

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
@@ -67,6 +67,7 @@ class ImportLocalizationPackType extends TranslatorAwareType
         $builder
             ->add('iso_localization_pack', ChoiceType::class, [
                 'choices' => $this->localizationPackChoices,
+                'choice_translation_domain' => false,
             ])
             ->add('content_to_import', ChoiceType::class, [
                 'expanded' => true,
@@ -79,6 +80,7 @@ class ImportLocalizationPackType extends TranslatorAwareType
                     LocalizationPackImportConfigInterface::CONTENT_LANGUAGES,
                     LocalizationPackImportConfigInterface::CONTENT_UNITS,
                 ],
+                'choice_translation_domain' => false,
             ])
             ->add('download_pack_data', SwitchType::class, [
                 'data' => 1,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
@@ -83,17 +83,21 @@ class LocalizationConfigurationType extends AbstractType
         $builder
             ->add('default_language', ChoiceType::class, [
                 'choices' => $this->languageChoices,
+                'choice_translation_domain' => false,
             ])
             ->add('detect_language_from_browser', SwitchType::class)
             ->add('default_country', ChoiceType::class, [
                 'choices' => $this->countryChoices,
+                'choice_translation_domain' => false,
             ])
             ->add('detect_country_from_browser', SwitchType::class)
             ->add('default_currency', ChoiceType::class, [
                 'choices' => $this->currencyChoices,
+                'choice_translation_domain' => false,
             ])
             ->add('timezone', ChoiceType::class, [
                 'choices' => $this->timezoneChoices,
+                'choice_translation_domain' => false,
             ])
         ;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I've noticed we have a lot of logs errors in this page, this is because the forms try to translate already translated strings, so he can't find the related translation.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Improve > Translations > Localization page should behave the same, but in debug mode, you should not have so many logs anymore.

### Before

![before](https://user-images.githubusercontent.com/1247388/44214821-4bce7c80-a171-11e8-97bc-8c2580678dfa.png)

### After

![after](https://user-images.githubusercontent.com/1247388/44214834-512bc700-a171-11e8-88f0-99be1e4b9993.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9455)
<!-- Reviewable:end -->
