### PR TITLE
Modify product canonical url and title value

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1237,6 +1237,16 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
         $page['admin_notifications'] = array_merge($page['admin_notifications'], $this->adminNotifications);
 
+        $idProductAttribute = $this->getIdProductAttribute(true);
+        if ($idProductAttribute) {
+            $attributes = $this->product->getAttributeCombinationsById($this->getIdProductAttribute(), $this->context->language->id);
+            if ($attributes && count($attributes) > 0) {
+                foreach ($attributes as $attribute) {
+                    $page['meta']['title'] .= ' '.$attribute['group_name'].' '.$attribute['attribute_name'];
+                }
+            }
+        }
+
         return $page;
     }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -60,7 +60,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             } elseif (!$this->isValidCombination(Tools::getValue('id_product_attribute'), $this->product->id)) {
                 $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
             }
-            $idProductAttribute = $this->getIdProductAttribute(false);
+            $idProductAttribute = $this->getIdProductAttributeByRequest();
             parent::canonicalRedirection($this->context->link->getProductLink(
                 $this->product,
                 null,
@@ -951,49 +951,89 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     }
 
     /**
-     * Return id_product_attribute by id_product_attribute request parameter
-     * or by the group request parameter.
-     *
-     * @param bool $useGroups
+     * Return id_product_attribute by id_product_attribute request parameter.
      *
      * @return int
      */
-    private function getIdProductAttribute($useGroups = false)
+    private function getIdProductAttributeByRequest()
     {
         $requestedIdProductAttribute = (int) Tools::getValue('id_product_attribute');
 
-        if ($useGroups === true) {
-            $groups = Tools::getValue('group');
+        return $this->tryToGetAvailableIdProductAttribute($requestedIdProductAttribute);
+    }
 
-            if (!empty($groups)) {
-                $requestedIdProductAttribute = (int) Product::getIdProductAttributeByIdAttributes(
-                    $this->product->id,
-                    $groups,
-                    true
-                );
-            }
-        }
+    /**
+     * Return id_product_attribute by id_product_attribute request parameter
+     * or by the group request parameter.
+     *
+     * @return int|null
+     *
+     * @throws PrestaShopException
+     */
+    private function getIdProductAttributeByRequestOrGroup()
+    {
+        $requestedIdProductAttribute = (int) Tools::getValue('id_product_attribute');
 
+        $groupIdProductAttribute = $this->getIdProductAttributeByGroup();
+        $requestedIdProductAttribute = null !== $groupIdProductAttribute ? $groupIdProductAttribute : $requestedIdProductAttribute;
+
+        return $this->tryToGetAvailableIdProductAttribute($requestedIdProductAttribute);
+    }
+
+    /**
+     * If the PS_DISP_UNAVAILABLE_ATTR functionality is enabled, this method check
+     * if $checkedIdProductAttribute is available.
+     * If not try to return the first available attribute, if none are available
+     * simply returns the input.
+     *
+     * @param int $checkedIdProductAttribute
+     *
+     * @return int
+     */
+    private function tryToGetAvailableIdProductAttribute($checkedIdProductAttribute)
+    {
         if (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
-            $productAttributes = array_filter(
+            $availableProductAttributes = array_filter(
                 $this->product->getAttributeCombinations(),
                 function ($elem) {
                     return $elem['quantity'] > 0;
                 }
             );
-            $productAttribute = array_filter(
-                $productAttributes,
-                function ($elem) use ($requestedIdProductAttribute) {
-                    return $elem['id_product_attribute'] == $requestedIdProductAttribute;
+
+            $availableProductAttribute = array_filter(
+                $availableProductAttributes,
+                function ($elem) use ($checkedIdProductAttribute) {
+                    return $elem['id_product_attribute'] == $checkedIdProductAttribute;
                 }
             );
 
-            if (empty($productAttribute) && !empty($productAttributes)) {
-                return (int) array_shift($productAttributes)['id_product_attribute'];
+            if (empty($availableProductAttribute) && count($availableProductAttributes)) {
+                return (int) array_shift($availableProductAttributes)['id_product_attribute'];
             }
         }
 
-        return $requestedIdProductAttribute;
+        return $checkedIdProductAttribute;
+    }
+
+    /**
+     * Return id_product_attribute by the group request parameter.
+     *
+     * @return int|null
+     *
+     * @throws PrestaShopException
+     */
+    private function getIdProductAttributeByGroup()
+    {
+        $groups = Tools::getValue('group');
+        if (empty($groups)) {
+            return null;
+        }
+
+        return (int) Product::getIdProductAttributeByIdAttributes(
+            $this->product->id,
+            $groups,
+            true
+        );
     }
 
     public function getTemplateVarProduct()
@@ -1006,7 +1046,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['id_product'] = (int) $this->product->id;
         $product['out_of_stock'] = (int) $this->product->out_of_stock;
         $product['new'] = (int) $this->product->new;
-        $product['id_product_attribute'] = $this->getIdProductAttribute(true);
+        $product['id_product_attribute'] = $this->getIdProductAttributeByRequestOrGroup();
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);
         $product['extraContent'] = $extraContentFinder->addParams(array('product' => $this->product))->present();
@@ -1120,7 +1160,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         $breadcrumb['links'][] = array(
             'title' => $this->product->name,
-            'url' => $this->context->link->getProductLink($this->product, null, null, null, null, null, (int) $this->getIdProductAttribute()),
+            'url' => $this->context->link->getProductLink($this->product, null, null, null, null, null, (int) $this->getIdProductAttributeByRequest()),
         );
 
         return $breadcrumb;
@@ -1237,12 +1277,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
         $page['admin_notifications'] = array_merge($page['admin_notifications'], $this->adminNotifications);
 
-        $idProductAttribute = $this->getIdProductAttribute(true);
+        $idProductAttribute = $this->getIdProductAttributeByRequest();
         if ($idProductAttribute) {
-            $attributes = $this->product->getAttributeCombinationsById($this->getIdProductAttribute(), $this->context->language->id);
-            if ($attributes && count($attributes) > 0) {
+            $attributes = $this->product->getAttributeCombinationsById($idProductAttribute, $this->context->language->id);
+            if (is_array($attributes) && count($attributes) > 0) {
                 foreach ($attributes as $attribute) {
-                    $page['meta']['title'] .= ' '.$attribute['group_name'].' '.$attribute['attribute_name'];
+                    $page['meta']['title'] .= ' ' . $attribute['group_name'] . ' ' . $attribute['attribute_name'];
                 }
             }
         }

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Presenter\Product;
 
 use PrestaShop\Decimal\Number;
 use PrestaShop\Decimal\Operation\Rounding;
+use PrestaShop\PrestaShop\Adapter\Entity\Product;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
@@ -720,7 +721,7 @@ class ProductLazyArray extends AbstractLazyArray
             $ean13,
             $language->id,
             null,
-            (!$canonical) ? $product['id_product_attribute'] : null,
+            $canonical ? Product::getDefaultAttribute($this->product['id_product']) : $product['id_product_attribute'],
             false,
             false,
             true


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Modify product canonical url and title value for SEO purposes, the title contains the combination attribute infos, the canonical url is the default combination
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/9508
| How to test?  | In the product page source code check the canonical tag and the title page, title has the current page attributes, canonical is the default combination Try changing the default combination in the admin and check the canonical has changed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9456)
<!-- Reviewable:end -->
