### PR TITLE
Change brand and supplier default rule for SEO purposes

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -63,7 +63,7 @@ class DispatcherCore
         ),
         'supplier_rule' => array(
             'controller' => 'supplier',
-            'rule' => '{id}__{rewrite}',
+            'rule' => 'supplier/{id}-{rewrite}',
             'keywords' => array(
                 'id' => array('regexp' => '[0-9]+', 'param' => 'id_supplier'),
                 'rewrite' => array('regexp' => '[_a-zA-Z0-9\pL\pS-]*'),
@@ -73,7 +73,7 @@ class DispatcherCore
         ),
         'manufacturer_rule' => array(
             'controller' => 'manufacturer',
-            'rule' => '{id}_{rewrite}',
+            'rule' => 'brand/{id}-{rewrite}',
             'keywords' => array(
                 'id' => array('regexp' => '[0-9]+', 'param' => 'id_manufacturer'),
                 'rewrite' => array('regexp' => '[_a-zA-Z0-9\pL\pS-]*'),

--- a/install-dev/upgrade/php/add_supplier_manufacturer_routes.php
+++ b/install-dev/upgrade/php/add_supplier_manufacturer_routes.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * In Prestashop 1.7.5 the supplier_rule and manufacturer_rule have been modified:
+ *      {id}__{rewrite} => supplier/{id}-{rewrite}
+ *      {id}_{rewrite}  => brand/{id}-{rewrite}
+ *
+ * If the merchant kept the original routes the former urls won't be reachable any
+ * more and SEO will be lost. So we force a custom rule matching the former format.
+ *
+ * If the route was customized, no need to do anything. We don't change anything for
+ * multi shop either since it will be used it the merchant has already changed them.
+ */
+function add_supplier_manufacturer_routes()
+{
+    Configuration::loadConfiguration();
+    $legacyRoutes = array(
+        'supplier_rule' => '{id}__{rewrite}',
+        'manufacturer_rule' => '{id}_{rewrite}',
+    );
+    foreach ($legacyRoutes as $routeId => $rule) {
+        if (!Configuration::get('PS_ROUTE_'.$routeId, null, 0, 0)) {
+            Configuration::updateGlobalValue('PS_ROUTE_'.$routeId, $rule);
+        }
+    }
+}

--- a/install-dev/upgrade/sql/1.7.5.0.sql
+++ b/install-dev/upgrade/sql/1.7.5.0.sql
@@ -1,0 +1,4 @@
+SET SESSION sql_mode = '';
+SET NAMES 'utf8';
+
+/* PHP:add_supplier_manufacturer_routes(); */;

--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -301,9 +301,8 @@ namespace PrestaShopBundle\Install {
             Shop::setContext(Shop::CONTEXT_SHOP, 1);
 
             if (!isset(Context::getContext()->language) || !Validate::isLoadedObject(Context::getContext()->language)) {
-                if ($id_lang = (int) $this->getConfValue('PS_LANG_DEFAULT')) {
-                    Context::getContext()->language = new Language($id_lang);
-                }
+                $idLang = (int) $this->getConfValue('PS_LANG_DEFAULT');
+                Context::getContext()->language = new Language($idLang ? $idLang : null);
             }
             if (!isset(Context::getContext()->country) || !Validate::isLoadedObject(Context::getContext()->country)) {
                 if ($id_country = (int) $this->getConfValue('PS_COUNTRY_DEFAULT')) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Change brand and supplier default rule for SEO purposes, brand url is brand/IDOFBRAND-BRANDNAME, supplier url is supplier/IDOFSUPPLIER-SUPPLIER
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-6258
| How to test?  | Go to the site map to find brand links and check that the urls use the new format

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9458)
<!-- Reviewable:end -->
