### PR TITLE
Do not display product Specific References if empty

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-details.tpl
+++ b/themes/classic/templates/catalog/_partials/product-details.tpl
@@ -66,7 +66,7 @@
 
   {* if product have specific references, a table will be added to product details section *}
   {block name='product_specific_references'}
-    {if isset($product.specific_references)}
+    {if !empty($product.specific_references)}
       <section class="product-features">
         <p class="h6">{l s='Specific References' d='Shop.Theme.Catalog'}</p>
           <dl class="data-sheet">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Bugfix on FO product details display
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-6289
| How to test?  | Go in FO to see a demo product. In the tab "product details" the text "Specific references" should not appear with nothing below.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9469)
<!-- Reviewable:end -->
