### PR TITLE
Make title different from meta title on CMS for SEO purpose

### DIFF
--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -32,6 +32,7 @@ class CMSCore extends ObjectModel
     /** @var string Name */
     public $id;
     public $id_cms;
+    public $head_seo_title;
     public $meta_title;
     public $meta_description;
     public $meta_keywords;
@@ -60,6 +61,7 @@ class CMSCore extends ObjectModel
             'meta_description' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 255),
             'meta_keywords' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 255),
             'meta_title' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 128),
+            'head_seo_title' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 128),
             'link_rewrite' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isLinkRewrite', 'required' => true, 'size' => 128),
             'content' => array('type' => self::TYPE_HTML, 'lang' => true, 'validate' => 'isCleanHtml', 'size' => 3999999999999),
         ),

--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -61,7 +61,7 @@ class CMSCore extends ObjectModel
             'meta_description' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 255),
             'meta_keywords' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 255),
             'meta_title' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 128),
-            'head_seo_title' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 128),
+            'head_seo_title' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 255),
             'link_rewrite' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isLinkRewrite', 'required' => true, 'size' => 128),
             'content' => array('type' => self::TYPE_HTML, 'lang' => true, 'validate' => 'isCleanHtml', 'size' => 3999999999999),
         ),

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -482,6 +482,7 @@ class MetaCore extends ObjectModel
         $cms = new CMS($idCms, $idLang);
         if (Validate::isLoadedObject($cms)) {
             $row = Meta::getPresentedObject($cms);
+            $row['meta_title'] = !empty($row['head_seo_title']) ? $row['head_seo_title'] : $row['meta_title'];
 
             return Meta::completeMetaTags($row, $row['meta_title']);
         }

--- a/controllers/admin/AdminCmsController.php
+++ b/controllers/admin/AdminCmsController.php
@@ -153,7 +153,7 @@ class AdminCmsControllerCore extends AdminController
                     'name' => 'head_seo_title',
                     'lang' => true,
                     'hint' => array(
-                        $this->trans('Used to override the title tag value. If left blank the default title value is used.', array(), 'Admin.Design.Help'),
+                        $this->trans('Used to override the title tag value. If left blank, the default title value is used.', array(), 'Admin.Design.Help'),
                         $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
                     ),
                 ),

--- a/controllers/admin/AdminCmsController.php
+++ b/controllers/admin/AdminCmsController.php
@@ -59,6 +59,7 @@ class AdminCmsControllerCore extends AdminController
             'id_cms' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'align' => 'center', 'class' => 'fixed-width-xs'),
             'link_rewrite' => array('title' => $this->trans('URL', array(), 'Admin.Global')),
             'meta_title' => array('title' => $this->trans('Title', array(), 'Admin.Global'), 'filter_key' => 'b!meta_title'),
+            'head_seo_title' => array('title' => $this->trans('Meta title', array(), 'Admin.Global'), 'filter_key' => 'b!head_seo_title'),
             'position' => array('title' => $this->trans('Position', array(), 'Admin.Global'), 'filter_key' => 'position', 'align' => 'center', 'class' => 'fixed-width-sm', 'position' => 'position'),
             'active' => array('title' => $this->trans('Displayed', array(), 'Admin.Global'), 'align' => 'center', 'active' => 'status', 'class' => 'fixed-width-sm', 'type' => 'bool', 'orderby' => false),
         );
@@ -135,13 +136,26 @@ class AdminCmsControllerCore extends AdminController
                 ),
                 array(
                     'type' => 'text',
-                    'label' => $this->trans('Meta title', array(), 'Admin.Global'),
+                    'label' => $this->trans('Title', array(), 'Admin.Global'),
                     'name' => 'meta_title',
                     'id' => 'name', // for copyMeta2friendlyURL compatibility
                     'lang' => true,
                     'required' => true,
                     'class' => 'copyMeta2friendlyURL',
-                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                    'hint' => array(
+                        $this->trans('Used in the h1 page tag, and as the default title tag value.', array(), 'Admin.Design.Help'),
+                        $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                    ),
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Meta title', array(), 'Admin.Global'),
+                    'name' => 'head_seo_title',
+                    'lang' => true,
+                    'hint' => array(
+                        $this->trans('Used to override the title tag value. If left blank the default title value is used.', array(), 'Admin.Design.Help'),
+                        $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                    ),
                 ),
                 array(
                     'type' => 'text',

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -376,6 +376,7 @@ CREATE TABLE `PREFIX_cms_lang` (
   `id_lang` int(10) unsigned NOT NULL,
   `id_shop` int(10) unsigned NOT NULL DEFAULT '1',
   `meta_title` varchar(128) NOT NULL,
+  `head_seo_title` varchar(255) DEFAULT NULL,
   `meta_description` varchar(255) DEFAULT NULL,
   `meta_keywords` varchar(255) DEFAULT NULL,
   `content` longtext,

--- a/install-dev/upgrade/sql/1.7.5.0.sql
+++ b/install-dev/upgrade/sql/1.7.5.0.sql
@@ -4,3 +4,6 @@ SET NAMES 'utf8';
 /* PHP:add_supplier_manufacturer_routes(); */;
 
 /* PHP:ps_1750_update_module_tabs(); */;
+
+ALTER TABLE `PREFIX_cms_lang`
+	ADD `head_seo_title` varchar(255) DEFAULT NULL AFTER `meta_title`;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Read ticket.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | No, but a line of code in theme is needed to make this work.
| Deprecations? | No
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-5262?filter=-2
| How to test?  | You should be able to set a meta title different from title. Try with string length higher than 255

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9475)
<!-- Reviewable:end -->
