### PR TITLE
includes inactive locales in Shop parameters -> Product settings -> Products stock block

### DIFF
--- a/src/Adapter/Configuration/MultiLangConfiguration.php
+++ b/src/Adapter/Configuration/MultiLangConfiguration.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Adapter\Configuration;
+
+use Configuration as ConfigurationLegacy;
+use Language as LanguageLegacy;
+use PrestaShop\PrestaShop\Core\Configuration\MultiLangConfigurationInterface;
+
+/**
+ * Class MultiLangConfiguration is responsible for getting multi-language configuration
+ */
+class MultiLangConfiguration implements MultiLangConfigurationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function get($key, $idShopGroup = null, $idShop = null)
+    {
+        return ConfigurationLegacy::getInt($key, $idShopGroup, $idShop);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIncludingInactiveLocales($key, $idShopGroup = null, $idShop = null)
+    {
+        $languageIds = LanguageLegacy::getIDs(false);
+        $result = [];
+        foreach ($languageIds as $idLang) {
+            $result[$idLang] = ConfigurationLegacy::get($key, $idLang, $idShopGroup, $idShop);
+        }
+        return $result;
+    }
+}

--- a/src/Adapter/Configuration/MultiLangConfiguration.php
+++ b/src/Adapter/Configuration/MultiLangConfiguration.php
@@ -31,20 +31,12 @@ use Language as LanguageLegacy;
 use PrestaShop\PrestaShop\Core\Configuration\MultiLangConfigurationInterface;
 
 /**
- * Class MultiLangConfiguration is responsible for getting multi-language configuration
+ * Class MultiLangConfiguration is responsible for getting multi-language configuration.
  */
 final class MultiLangConfiguration implements MultiLangConfigurationInterface
 {
     /**
-     * {@inheritDoc}
-     */
-    public function get($key, $idShopGroup = null, $idShop = null)
-    {
-        return ConfigurationLegacy::getInt($key, $idShopGroup, $idShop);
-    }
-
-    /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getIncludingInactiveLocales($key, $idShopGroup = null, $idShop = null)
     {
@@ -53,6 +45,7 @@ final class MultiLangConfiguration implements MultiLangConfigurationInterface
         foreach ($languageIds as $idLang) {
             $result[$idLang] = ConfigurationLegacy::get($key, $idLang, $idShopGroup, $idShop);
         }
+
         return $result;
     }
 }

--- a/src/Adapter/Configuration/MultiLangConfiguration.php
+++ b/src/Adapter/Configuration/MultiLangConfiguration.php
@@ -1,4 +1,28 @@
 <?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
 
 namespace PrestaShop\PrestaShop\Adapter\Configuration;
 
@@ -9,10 +33,10 @@ use PrestaShop\PrestaShop\Core\Configuration\MultiLangConfigurationInterface;
 /**
  * Class MultiLangConfiguration is responsible for getting multi-language configuration
  */
-class MultiLangConfiguration implements MultiLangConfigurationInterface
+final class MultiLangConfiguration implements MultiLangConfigurationInterface
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function get($key, $idShopGroup = null, $idShop = null)
     {
@@ -20,7 +44,7 @@ class MultiLangConfiguration implements MultiLangConfigurationInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getIncludingInactiveLocales($key, $idShopGroup = null, $idShop = null)
     {

--- a/src/Adapter/Configuration/MultiLangConfiguration.php
+++ b/src/Adapter/Configuration/MultiLangConfiguration.php
@@ -38,7 +38,7 @@ final class MultiLangConfiguration implements MultiLangConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getIncludingInactiveLocales($key, $idShopGroup = null, $idShop = null)
+    public function getWithInactiveLocales($key, $idShopGroup = null, $idShop = null)
     {
         $languageIds = LanguageLegacy::getIDs(false);
         $result = [];

--- a/src/Adapter/Language/ContextLanguageDataProvider.php
+++ b/src/Adapter/Language/ContextLanguageDataProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Adapter\Language;
+
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+
+/**
+ * Class ContextLanguageDataProvider is responsible for getting languages related data from legacy content class
+ */
+class ContextLanguageDataProvider
+{
+    /**
+     * @var LegacyContext
+     */
+    private $legacyContext;
+
+    public function __construct(LegacyContext $legacyContext)
+    {
+        $this->legacyContext = $legacyContext;
+    }
+
+    /**
+     * Returns all locales - active and inactive ones. The first one is the employee default one.
+     *
+     * @return array
+     */
+    public function getInstalledLocales()
+    {
+        return $this->legacyContext->getLanguages(false);
+    }
+}

--- a/src/Adapter/Language/ContextLanguageDataProvider.php
+++ b/src/Adapter/Language/ContextLanguageDataProvider.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Language;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 
 /**
- * Class ContextLanguageDataProvider is responsible for getting languages related data from legacy content class
+ * Class ContextLanguageDataProvider is responsible for getting languages related data from legacy content class.
  */
 class ContextLanguageDataProvider
 {
@@ -38,6 +38,11 @@ class ContextLanguageDataProvider
      */
     private $legacyContext;
 
+    /**
+     * ContextLanguageDataProvider constructor.
+     *
+     * @param LegacyContext $legacyContext
+     */
     public function __construct(LegacyContext $legacyContext)
     {
         $this->legacyContext = $legacyContext;

--- a/src/Adapter/Language/ContextLanguageDataProvider.php
+++ b/src/Adapter/Language/ContextLanguageDataProvider.php
@@ -1,4 +1,28 @@
 <?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
 
 namespace PrestaShop\PrestaShop\Adapter\Language;
 

--- a/src/Adapter/Product/StockConfiguration.php
+++ b/src/Adapter/Product/StockConfiguration.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Product;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Configuration\MultiLangConfigurationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -40,9 +41,15 @@ class StockConfiguration implements DataConfigurationInterface
      */
     private $configuration;
 
-    public function __construct(Configuration $configuration)
+    /**
+     * @var MultiLangConfigurationInterface
+     */
+    private $langConfiguration;
+
+    public function __construct(Configuration $configuration, MultiLangConfigurationInterface $langConfiguration)
     {
         $this->configuration = $configuration;
+        $this->langConfiguration = $langConfiguration;
     }
 
     /**
@@ -53,11 +60,16 @@ class StockConfiguration implements DataConfigurationInterface
         return [
             'allow_ordering_oos' => $this->configuration->getBoolean('PS_ORDER_OUT_OF_STOCK'),
             'stock_management' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
-            'in_stock_label' => $this->configuration->get('PS_LABEL_IN_STOCK_PRODUCTS'),
-            'oos_allowed_backorders' => $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOA'),
-            'oos_denied_backorders' => $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD'),
-            'delivery_time' => (array) $this->configuration->get('PS_LABEL_DELIVERY_TIME_AVAILABLE'),
-            'oos_delivery_time' => (array) $this->configuration->get('PS_LABEL_DELIVERY_TIME_OOSBOA'),
+            'in_stock_label' =>
+                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_IN_STOCK_PRODUCTS'),
+            'oos_allowed_backorders' =>
+                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_OOS_PRODUCTS_BOA'),
+            'oos_denied_backorders' =>
+                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_OOS_PRODUCTS_BOD'),
+            'delivery_time' =>
+                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_DELIVERY_TIME_AVAILABLE'),
+            'oos_delivery_time' =>
+                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_DELIVERY_TIME_OOSBOA'),
             'pack_stock_management' => $this->configuration->get('PS_PACK_STOCK_TYPE'),
         ];
     }

--- a/src/Adapter/Product/StockConfiguration.php
+++ b/src/Adapter/Product/StockConfiguration.php
@@ -60,16 +60,11 @@ class StockConfiguration implements DataConfigurationInterface
         return [
             'allow_ordering_oos' => $this->configuration->getBoolean('PS_ORDER_OUT_OF_STOCK'),
             'stock_management' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
-            'in_stock_label' =>
-                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_IN_STOCK_PRODUCTS'),
-            'oos_allowed_backorders' =>
-                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_OOS_PRODUCTS_BOA'),
-            'oos_denied_backorders' =>
-                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_OOS_PRODUCTS_BOD'),
-            'delivery_time' =>
-                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_DELIVERY_TIME_AVAILABLE'),
-            'oos_delivery_time' =>
-                $this->langConfiguration->getIncludingInactiveLocales('PS_LABEL_DELIVERY_TIME_OOSBOA'),
+            'in_stock_label' => $this->langConfiguration->getWithInactiveLocales('PS_LABEL_IN_STOCK_PRODUCTS'),
+            'oos_allowed_backorders' => $this->langConfiguration->getWithInactiveLocales('PS_LABEL_OOS_PRODUCTS_BOA'),
+            'oos_denied_backorders' => $this->langConfiguration->getWithInactiveLocales('PS_LABEL_OOS_PRODUCTS_BOD'),
+            'delivery_time' => $this->langConfiguration->getWithInactiveLocales('PS_LABEL_DELIVERY_TIME_AVAILABLE'),
+            'oos_delivery_time' => $this->langConfiguration->getWithInactiveLocales('PS_LABEL_DELIVERY_TIME_OOSBOA'),
             'pack_stock_management' => $this->configuration->get('PS_PACK_STOCK_TYPE'),
         ];
     }

--- a/src/Core/Configuration/MultiLangConfigurationInterface.php
+++ b/src/Core/Configuration/MultiLangConfigurationInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Configuration;
+
+/**
+ * Interface MultiLangConfigurationInterface defines contract multi-language configuration data
+ */
+interface MultiLangConfigurationInterface
+{
+    /**
+     * Gets configuration from database.
+     *
+     * @param string $key - a key which represents `name` columns in `configuration` table
+     * @param null|int $idShopGroup
+     * @param null|int $idShop
+     *
+     * @return array - returns a value from database. It gets only from active languages. The array key contains
+     * language id
+     */
+    public function get($key, $idShopGroup = null, $idShop = null);
+
+    /**
+     * Gets configuration from database.
+     *
+     * @param string $key - a key which represents `name` columns in `configuration` table
+     * @param null|int $idShopGroup
+     * @param null|int $idShop
+     *
+     * @return array - returns a value from database. It gets from installed languages. The array key contains
+     * language id
+     */
+    public function getIncludingInactiveLocales($key, $idShopGroup = null, $idShop = null);
+}

--- a/src/Core/Configuration/MultiLangConfigurationInterface.php
+++ b/src/Core/Configuration/MultiLangConfigurationInterface.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Configuration;
 
 /**
- * Interface MultiLangConfigurationInterface defines contract multi-language configuration data
+ * Interface MultiLangConfigurationInterface defines contract multi-language configuration data.
  */
 interface MultiLangConfigurationInterface
 {
@@ -39,7 +39,7 @@ interface MultiLangConfigurationInterface
      * @param null|int $idShop
      *
      * @return array - returns a value from database. It gets from installed languages. The array key contains
-     * language id
+     *               language id
      */
     public function getWithInactiveLocales($key, $idShopGroup = null, $idShop = null);
 }

--- a/src/Core/Configuration/MultiLangConfigurationInterface.php
+++ b/src/Core/Configuration/MultiLangConfigurationInterface.php
@@ -38,18 +38,6 @@ interface MultiLangConfigurationInterface
      * @param null|int $idShopGroup
      * @param null|int $idShop
      *
-     * @return array - returns a value from database. It gets only from active languages. The array key contains
-     * language id
-     */
-    public function get($key, $idShopGroup = null, $idShop = null);
-
-    /**
-     * Gets configuration from database.
-     *
-     * @param string $key - a key which represents `name` columns in `configuration` table
-     * @param null|int $idShopGroup
-     * @param null|int $idShop
-     *
      * @return array - returns a value from database. It gets from installed languages. The array key contains
      * language id
      */

--- a/src/Core/Configuration/MultiLangConfigurationInterface.php
+++ b/src/Core/Configuration/MultiLangConfigurationInterface.php
@@ -41,5 +41,5 @@ interface MultiLangConfigurationInterface
      * @return array - returns a value from database. It gets from installed languages. The array key contains
      * language id
      */
-    public function getIncludingInactiveLocales($key, $idShopGroup = null, $idShop = null);
+    public function getWithInactiveLocales($key, $idShopGroup = null, $idShop = null);
 }

--- a/src/Core/Configuration/MultiLangConfigurationInterface.php
+++ b/src/Core/Configuration/MultiLangConfigurationInterface.php
@@ -1,4 +1,28 @@
 <?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
 
 namespace PrestaShop\PrestaShop\Core\Configuration;
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -48,19 +48,19 @@ class StockType extends TranslatorAwareType
             ->add('allow_ordering_oos', SwitchType::class)
             ->add('stock_management', SwitchType::class)
             ->add('in_stock_label', TranslateTextType::class, [
-                'locales' => $this->locales,
+                'locales' => $this->installedLocales,
             ])
             ->add('oos_allowed_backorders', TranslateTextType::class, [
-                'locales' => $this->locales,
+                'locales' => $this->installedLocales,
             ])
             ->add('oos_denied_backorders', TranslateTextType::class, [
-                'locales' => $this->locales,
+                'locales' => $this->installedLocales,
             ])
             ->add('delivery_time', TranslateTextType::class, [
-                'locales' => $this->locales,
+                'locales' => $this->installedLocales,
             ])
             ->add('oos_delivery_time', TranslateTextType::class, [
-                'locales' => $this->locales,
+                'locales' => $this->installedLocales,
             ])
             ->add('pack_stock_management', ChoiceType::class, [
                 'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
@@ -38,26 +38,42 @@ abstract class TranslatorAwareType extends CommonAbstractType
     private $translator;
 
     /**
-     * All languages available on shop. Used for translations.
+     * Active languages available on shop.
      *
      * @param array $locales
      */
     protected $locales;
 
-    public function __construct(TranslatorInterface $translator, array $locales)
-    {
+    /**
+     * Active and in-active languages available on shop. Used to apply translations
+     *
+     * @var array $installedLocales
+     */
+    protected $installedLocales;
+
+    /**
+     * TranslatorAwareType constructor.
+     *
+     * @param TranslatorInterface $translator
+     * @param array $locales - Active and in-active languages available on shop
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales
+    ) {
         $this->translator = $translator;
-        $this->locales = $locales;
+        $this->locales = $this->getActiveLocales($locales);
+        $this->installedLocales = $locales;
     }
 
     /**
-     * Get the translated chain from key.
+     * Get the translated chain from key
      *
-     * @param $key the key to be translated
-     * @param $domain the domain to be selected
+     * @param $key - the key to be translated
+     * @param $domain - the domain to be selected
      * @param array $parameters Optional, pass parameters if needed (uncommon)
      *
-     * @returns string
+     * @return string
      */
     protected function trans($key, $domain, $parameters = [])
     {
@@ -65,18 +81,58 @@ abstract class TranslatorAwareType extends CommonAbstractType
     }
 
     /**
-     * Get locales to be used in form type.
+     * Get locales to be used in form type
      *
      * @return array
      */
     protected function getLocaleChoices()
     {
-        $locales = [];
+        return $this->formatLocales($this->locales);
+    }
 
-        foreach ($this->locales as $locale) {
-            $locales[$locale['name']] = $locale['iso_code'];
+    /**
+     * Get locales to be used in form type including the disabled ones
+     *
+     * @return array
+     */
+    protected function getIncludingInactiveLocalesChoices()
+    {
+        return $this->formatLocales($this->installedLocales);
+    }
+
+    /**
+     * Formats the response so the array key becomes the name of locale and value is the iso code of the locale.
+     *
+     * @param array $locales
+     *
+     * @return array
+     */
+    private function formatLocales(array $locales)
+    {
+        $result = [];
+        foreach ($locales as $locale) {
+            $result[$locale['name']] = $locale['iso_code'];
         }
 
-        return $locales;
+        return $result;
+    }
+
+    /**
+     * Gets active locales
+     *
+     * @param array $locales
+     *
+     * @return array
+     */
+    private function getActiveLocales(array $locales)
+    {
+        $result = [];
+        foreach ($locales as $locale) {
+            if ($locale['active']) {
+                $result[] = $locale;
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
@@ -128,7 +128,7 @@ abstract class TranslatorAwareType extends CommonAbstractType
     {
         $result = [];
         foreach ($locales as $locale) {
-            if ($locale['active']) {
+            if (isset($locale['active']) && $locale['active']) {
                 $result[] = $locale;
             }
         }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
@@ -128,7 +128,7 @@ abstract class TranslatorAwareType extends CommonAbstractType
     {
         $result = [];
         foreach ($locales as $locale) {
-            if (isset($locale['active']) && $locale['active']) {
+            if (!empty($locale['active'])) {
                 $result[] = $locale;
             }
         }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
@@ -95,7 +95,7 @@ abstract class TranslatorAwareType extends CommonAbstractType
      *
      * @return array
      */
-    protected function getIncludingInactiveLocalesChoices()
+    protected function getInstalledLocalesChoices()
     {
         return $this->formatLocales($this->installedLocales);
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
@@ -45,9 +45,9 @@ abstract class TranslatorAwareType extends CommonAbstractType
     protected $locales;
 
     /**
-     * Active and in-active languages available on shop. Used to apply translations
+     * Active and in-active languages available on shop. Used to apply translations.
      *
-     * @var array $installedLocales
+     * @var array
      */
     protected $installedLocales;
 
@@ -67,7 +67,7 @@ abstract class TranslatorAwareType extends CommonAbstractType
     }
 
     /**
-     * Get the translated chain from key
+     * Get the translated chain from key.
      *
      * @param $key - the key to be translated
      * @param $domain - the domain to be selected
@@ -81,7 +81,7 @@ abstract class TranslatorAwareType extends CommonAbstractType
     }
 
     /**
-     * Get locales to be used in form type
+     * Get locales to be used in form type.
      *
      * @return array
      */
@@ -91,7 +91,7 @@ abstract class TranslatorAwareType extends CommonAbstractType
     }
 
     /**
-     * Get locales to be used in form type including the disabled ones
+     * Get locales to be used in form type including the disabled ones.
      *
      * @return array
      */
@@ -118,7 +118,7 @@ abstract class TranslatorAwareType extends CommonAbstractType
     }
 
     /**
-     * Gets active locales
+     * Gets active locales.
      *
      * @param array $locales
      *

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -21,6 +21,7 @@ services:
         class: 'PrestaShop\PrestaShop\Adapter\Product\StockConfiguration'
         arguments:
             - '@prestashop.adapter.legacy.configuration'
+            - '@prestashop.adapter.multi_lang_configuration'
 
     prestashop.adapter.customer.customer_configuration:
         class: 'PrestaShop\PrestaShop\Adapter\Customer\CustomerConfiguration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -222,3 +222,6 @@ services:
         class: 'PrestaShop\PrestaShop\Adapter\Language\ContextLanguageDataProvider'
         arguments:
             - '@prestashop.adapter.legacy.context'
+
+    prestashop.adapter.multi_lang_configuration:
+        class: 'PrestaShop\PrestaShop\Adapter\Configuration\MultiLangConfiguration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -217,3 +217,8 @@ services:
             - '@prestashop.adapter.data_provider.language'
             - '@prestashop.adapter.cache_clearer'
             - '@=service("prestashop.adapter.legacy.configuration").get("_PS_TRANSLATIONS_DIR_")'
+
+    prestashop.adapter.data_provider.context_language:
+        class: 'PrestaShop\PrestaShop\Adapter\Language\ContextLanguageDataProvider'
+        arguments:
+            - '@prestashop.adapter.legacy.context'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -245,7 +245,7 @@ services:
         public: true
         arguments:
             - "@translator"
-            - "@=service('prestashop.adapter.legacy.context').getLanguages()"
+            - "@=service('prestashop.adapter.data_provider.context_language').getInstalledLocales()"
 
     form.type.order.invoices.generate_by_date:
         class: 'PrestaShopBundle\Form\Admin\Sell\Order\Invoices\GenerateByDateType'


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On the currently released PrestaShop version when you disable the language <br>you can still configure it in back-office. Usually people make various modifications <br> when the languages are disabled to them.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | The bug fix is included only in Shop parameters -> Product settings -> Products stock block to demonstrate how it should work. <br> 1. Install another language to have at least two languages enabled. <br> 2. Shop parameters -> Product settings -> Products stock block - you will notice that both languages are displayed which is good. <br> 3. Disable the installed language and repeat step 2 - you will notice that the disabled language is missing <br> 4. If you check currently released version of PrestaShop, like 1.7.3.0 you will notice that even if the language is disabled you can apply any actions to it.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9758)
<!-- Reviewable:end -->
