### PR TITLE
Fixed mismatch of PHPDocs + unit tests

### DIFF
--- a/src/Adapter/Admin/LegacyBlockHelperSubscriber.php
+++ b/src/Adapter/Admin/LegacyBlockHelperSubscriber.php
@@ -58,10 +58,11 @@ class LegacyBlockHelperSubscriber implements EventSubscriberInterface
         if (!array_key_exists('kpi_controller', $event->getHookParameters())) {
             throw new \Exception('The legacy_kpi hook need a kpi_controller parameter (legacy controller full class name).');
         }
+
         $controller = $event->getHookParameters()['kpi_controller'];
-
         $controller = new $controller('new-theme');
+        $renderKpis = $controller->renderKpis() !== null ? $controller->renderKpis() : [];
 
-        $event->setContent($controller->renderKpis());
+        $event->setContent($renderKpis);
     }
 }

--- a/src/Adapter/Hook/HookDispatcher.php
+++ b/src/Adapter/Hook/HookDispatcher.php
@@ -45,7 +45,14 @@ use PrestaShop\PrestaShop\Core\Hook\Hook;
  */
 class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
 {
+    /**
+     * @var array
+     */
     private $renderingContent = array();
+
+    /**
+     * @var bool
+     */
     private $propagationStoppedCalledBy = false;
 
     /**
@@ -175,7 +182,7 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
      */
     public function dispatchRendering(HookInterface $hook)
     {
-        $event = $this->hookDispatcherService->renderForParameters(
+        $event = $this->renderForParameters(
             $hook->getName(),
             $hook->getParameters()
         );

--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -296,7 +296,7 @@ class LegacyHookSubscriber implements EventSubscriberInterface
             && 0 !== $moduleId
             && !empty($content)
         ) {
-            $event->setContent(array_values($content)[0], array_keys($content)[0]);
+            $event->setContent([array_values($content)[0]], array_keys($content)[0]);
         }
     }
 }

--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -291,7 +291,11 @@ class LegacyHookSubscriber implements EventSubscriberInterface
         /* @var $event HookEvent */
         $content = Hook::exec($hookName, $event->getHookParameters(), $moduleId, ($event instanceof RenderingHookEvent));
 
-        if ($event instanceof RenderingHookEvent && 0 !== $moduleId) {
+        if (
+            $event instanceof RenderingHookEvent
+            && 0 !== $moduleId
+            && !empty($content)
+        ) {
             $event->setContent(array_values($content)[0], array_keys($content)[0]);
         }
     }

--- a/src/Core/Hook/HookDispatcher.php
+++ b/src/Core/Hook/HookDispatcher.php
@@ -77,7 +77,12 @@ final class HookDispatcher implements HookDispatcherInterface
             $hook->getParameters()
         );
 
-        return new RenderedHook($hook, $event->getContent());
+        $content = $event->getContent();
+        array_walk($content, function (&$partialContent) {
+            $partialContent = empty($partialContent) ? '' : current($partialContent);
+        });
+
+        return new RenderedHook($hook, $content);
     }
 
     /**

--- a/src/Core/Hook/RenderedHook.php
+++ b/src/Core/Hook/RenderedHook.php
@@ -75,7 +75,7 @@ final class RenderedHook implements RenderedHookInterface
         $output = '';
 
         foreach ($this->content as $partialContent) {
-            $output .= array_values($partialContent)[0];
+            $output .= array_slice($partialContent, 0, 1);
         }
 
         return $output;

--- a/src/Core/Hook/RenderedHook.php
+++ b/src/Core/Hook/RenderedHook.php
@@ -66,4 +66,18 @@ final class RenderedHook implements RenderedHookInterface
     {
         return $this->content;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function outputContent()
+    {
+        $output = '';
+
+        foreach ($this->content as $partialContent) {
+            $output .= array_values($partialContent)[0];
+        }
+
+        return $output;
+    }
 }

--- a/src/Core/Hook/RenderedHook.php
+++ b/src/Core/Hook/RenderedHook.php
@@ -72,12 +72,6 @@ final class RenderedHook implements RenderedHookInterface
      */
     public function outputContent()
     {
-        $output = '';
-
-        foreach ($this->content as $partialContent) {
-            $output .= $partialContent;
-        }
-
-        return $output;
+        return implode('', $this->content);
     }
 }

--- a/src/Core/Hook/RenderedHook.php
+++ b/src/Core/Hook/RenderedHook.php
@@ -75,7 +75,7 @@ final class RenderedHook implements RenderedHookInterface
         $output = '';
 
         foreach ($this->content as $partialContent) {
-            $output .= array_slice($partialContent, 0, 1);
+            $output .= $partialContent;
         }
 
         return $output;

--- a/src/Core/Hook/RenderedHookInterface.php
+++ b/src/Core/Hook/RenderedHookInterface.php
@@ -44,4 +44,11 @@ interface RenderedHookInterface
      * @return array
      */
     public function getContent();
+
+    /**
+     * Returns displayable content.
+     *
+     * @return string
+     */
+    public function outputContent();
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -245,7 +245,7 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'
         arguments:
             - '@=service("form.factory").createBuilder()'
-            - '@prestashop.hook.dispatcher'
+            - '@prestashop.core.hook.dispatcher'
             - '@prestashop.admin.webservice.form_data_provider'
             -
               'webservice_configuration': 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Webservice\WebserviceType'

--- a/src/PrestaShopBundle/Service/Hook/RenderingHookEvent.php
+++ b/src/PrestaShopBundle/Service/Hook/RenderingHookEvent.php
@@ -35,13 +35,13 @@ namespace PrestaShopBundle\Service\Hook;
 class RenderingHookEvent extends HookEvent
 {
     /**
+     * @var array
+     */
+    private $currentContent = [];
+    /**
      * @var string
      */
-    private $currentContent = '';
-    /**
-     * @var undefined
-     */
-    private $currentListener = null;
+    private $currentListener = '';
 
     /**
      * Sets the response from the listener.
@@ -50,12 +50,12 @@ class RenderingHookEvent extends HookEvent
      * This content will be pushed in a stack between each listener call.
      * Every response is kept, but a given listener cannot see the previous listeners' responses.
      *
-     * @param string $content The rendering content returned by the listener
-     * @param undefined $fromListener The listener that sets the content
+     * @param array $content The rendering content returned by the listener
+     * @param string $fromListener The listener that sets the content
      *
      * @return $this for fluent use
      */
-    public function setContent($content, $fromListener = null)
+    public function setContent(array $content, $fromListener = '')
     {
         $this->currentContent = $content;
         $this->currentListener = $fromListener;
@@ -66,7 +66,7 @@ class RenderingHookEvent extends HookEvent
     /**
      * Gets the last pushed content (for the current listener).
      *
-     * @return string
+     * @return array
      */
     public function getContent()
     {
@@ -76,7 +76,7 @@ class RenderingHookEvent extends HookEvent
     /**
      * Retrieves the last pushed content (and cleans the corresponding attribute).
      *
-     * @return string
+     * @return array
      */
     public function popContent()
     {
@@ -89,12 +89,12 @@ class RenderingHookEvent extends HookEvent
     /**
      * Gets the current listener that put the response (and cleans the corresponding attribute).
      *
-     * @return undefined a listener
+     * @return string a listener
      */
     public function popListener()
     {
         $listener = $this->currentListener;
-        $this->currentListener = null;
+        $this->currentListener = '';
 
         return $listener;
     }

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -124,16 +124,17 @@ class HookExtension extends \Twig_Extension
         // The call to the render of the hooks is encapsulated into a ob management to avoid any call of echo from the
         // modules.
         ob_start();
-        $hookRenders = $this->hookDispatcher->dispatchRenderingWithParameters($hookName, $hookParameters)->getContent();
+        $renderedHook = $this->hookDispatcher->dispatchRenderingWithParameters($hookName, $hookParameters);
+        $renderedHook->outputContent();
         ob_clean();
 
         $render = [];
-        foreach ($hookRenders as $module => $hookRender) {
+        foreach ($renderedHook->getContent() as $module => $hookRender) {
             $moduleAttributes = $this->moduleRepository->getModuleAttributes($module);
             $render[] = [
                 'id' => $module,
                 'name' => $this->moduleDataProvider->getModuleName($module),
-                'content' => $hookRender,
+                'content' => array_values($hookRender)[0],
                 'attributes' => $moduleAttributes->all(),
             ];
         }
@@ -158,20 +159,11 @@ class HookExtension extends \Twig_Extension
         if ($hookName == '') {
             throw new \Exception('Hook name missing');
         }
-        $hookRenders = $this->hookDispatcher
+
+        return $this->hookDispatcher
             ->dispatchRenderingWithParameters($hookName, $hookParameters)
-            ->getContent()
+            ->outputContent()
         ;
-
-        $output = '';
-
-        foreach ($hookRenders as $hookRender) {
-            if (!empty($hookRender)) {
-                $output .= array_values($hookRender)[0];
-            }
-        }
-
-        return $output;
     }
 
     /**

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -154,7 +154,7 @@ class HookExtension extends \Twig_Extension
      *
      * @return string all listener's responses, concatenated in a simple string, ordered by the listeners' priorities
      */
-    public function renderHook($hookName, $hookParameters = array())
+    public function renderHook($hookName, array $hookParameters = array())
     {
         if ($hookName == '') {
             throw new \Exception('Hook name missing');

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -113,7 +113,7 @@ class HookExtension extends \Twig_Extension
      *
      * @throws \Exception if the hookName is missing
      *
-     * @return array[string] All listener's reponses, ordered by the listeners' priorities
+     * @return array[string] All listener's responses, ordered by the listeners' priorities
      */
     public function renderHooksArray($hookName, $hookParameters = array())
     {
@@ -151,7 +151,7 @@ class HookExtension extends \Twig_Extension
      *
      * @throws \Exception if the hookName is missing
      *
-     * @return string all listener's reponses, concatened in a simple string, ordered by the listeners' priorities
+     * @return string all listener's responses, concatenated in a simple string, ordered by the listeners' priorities
      */
     public function renderHook($hookName, $hookParameters = array())
     {
@@ -163,7 +163,15 @@ class HookExtension extends \Twig_Extension
             ->getContent()
         ;
 
-        return empty($hookRenders) ? '' : implode('<br class="hook-separator" />', $hookRenders);
+        $output = '';
+
+        foreach ($hookRenders as $hookRender) {
+            if (!empty($hookRender)) {
+                $output .= array_values($hookRender)[0];
+            }
+        }
+
+        return $output;
     }
 
     /**

--- a/tests/PrestaShopBundle/Service/Hook/HookDispatcherTest.php
+++ b/tests/PrestaShopBundle/Service/Hook/HookDispatcherTest.php
@@ -80,21 +80,24 @@ class HookDispatcherTest extends KernelTestCase
     {
         $kernel = $this->createKernel();
         $kernel->boot();
-        $hookDisptacher = $kernel->getContainer()->get('prestashop.hook.dispatcher');
+        $hookDispatcher = $kernel->getContainer()->get('prestashop.hook.dispatcher');
 
-        $hookDisptacher->addListener('test_test_2', array($this, 'listenerCallback2'));
-        $hookDisptacher->addListener('test_test_2', array($this, 'listenerCallback2b'));
-        $event = $hookDisptacher->dispatch('test_test_2', new RenderingHookEvent());
+        $hookDispatcher->addListener('test_test_2', array($this, 'listenerCallback2'));
+        $hookDispatcher->addListener('test_test_2', array($this, 'listenerCallback2b'));
+        $event = $hookDispatcher->dispatch('test_test_2', new RenderingHookEvent());
+
         $this->assertArraySubset(array(
-            'listenerCallback2' => "result_test_2",
-            'overriden_listener_name' => "result_test_2b"
+            'listenerCallback2' => ["result_test_2"],
+            'overriden_listener_name' => ["result_test_2b"],
         ), $event->getContent());
     }
+
     public function listenerCallback2(RenderingHookEvent $event, $eventName)
     {
         $this->assertEquals('test_test_2', $eventName);
         $event->setContent(['result_test_2']);
     }
+
     public function listenerCallback2b(RenderingHookEvent $event, $eventName)
     {
         $this->assertEquals('test_test_2', $eventName);

--- a/tests/PrestaShopBundle/Service/Hook/HookDispatcherTest.php
+++ b/tests/PrestaShopBundle/Service/Hook/HookDispatcherTest.php
@@ -90,14 +90,14 @@ class HookDispatcherTest extends KernelTestCase
             'overriden_listener_name' => "result_test_2b"
         ), $event->getContent());
     }
-    public function listenerCallback2(Event $event, $eventName)
+    public function listenerCallback2(RenderingHookEvent $event, $eventName)
     {
         $this->assertEquals('test_test_2', $eventName);
-        $event->setContent('result_test_2');
+        $event->setContent(['result_test_2']);
     }
-    public function listenerCallback2b(Event $event, $eventName)
+    public function listenerCallback2b(RenderingHookEvent $event, $eventName)
     {
         $this->assertEquals('test_test_2', $eventName);
-        $event->setContent('result_test_2b', 'overriden_listener_name');
+        $event->setContent(['result_test_2b'], 'overriden_listener_name');
     }
 }

--- a/tests/PrestaShopBundle/Service/Hook/HookDispatcherTest.php
+++ b/tests/PrestaShopBundle/Service/Hook/HookDispatcherTest.php
@@ -87,8 +87,8 @@ class HookDispatcherTest extends KernelTestCase
         $event = $hookDispatcher->dispatch('test_test_2', new RenderingHookEvent());
 
         $this->assertArraySubset(array(
-            'listenerCallback2' => ["result_test_2"],
-            'overriden_listener_name' => ["result_test_2b"],
+            'listenerCallback2' => ['result_test_2'],
+            'overriden_listener_name' => ['result_test_2b'],
         ), $event->getContent());
     }
 

--- a/tests/Unit/Core/Hook/HookDispatcherTest.php
+++ b/tests/Unit/Core/Hook/HookDispatcherTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Hook;
+
+use PrestaShop\PrestaShop\Adapter\Hook\HookDispatcher as HookDispatcherAdapter;
+use PrestaShopBundle\Service\Hook\RenderingHookEvent;
+use PrestaShop\PrestaShop\Core\Hook\HookInterface;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcher;
+use PrestaShop\PrestaShop\Core\Hook\RenderedHook;
+use PrestaShop\PrestaShop\Core\Hook\Hook;
+
+class HookDispatcherTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HookDispatcherAdapter
+     */
+    private $hookDispatcherAdapter;
+
+    /**
+     * @var HookDispatcher
+     */
+    private $hookDispatcher;
+
+    public function setUp()
+    {
+        $this->hookDispatcherAdapter = $this->createMock(HookDispatcherAdapter::class);
+        $this->hookDispatcher = new HookDispatcher($this->hookDispatcherAdapter);
+    }
+
+    public function testDispatchHook()
+    {
+        // stub hook behavior
+        $hook = $this->createHook();
+
+        // stub adapter expectations
+        $this->hookDispatcherAdapter
+            ->expects($this->once())
+            ->method('dispatchForParameters')
+            ->with($this->equalTo('hookName'), $this->equalTo([]))
+        ;
+
+        $this->hookDispatcher->dispatchHook($hook);
+
+    }
+
+    public function testDispatchWithParameters()
+    {
+        // stub adapter expectations
+        $this->hookDispatcherAdapter
+            ->expects($this->once())
+            ->method('dispatchForParameters')
+            ->with($this->equalTo('fooHook'), $this->equalTo(['bar' => 'Bar']))
+        ;
+
+        $this->hookDispatcher->dispatchWithParameters('fooHook', ['bar' => 'Bar']);
+    }
+
+    public function testDispatchRendering()
+    {
+        $hook = new Hook('hookName', []);
+
+        // stub rendering hook event behavior
+        $hookEvent = $this->createRenderingHookEvent($hook->getParameters());
+
+        // stub adapter expectations
+        $this->hookDispatcherAdapter
+            ->expects($this->once())
+            ->method('renderForParameters')
+            ->with(
+                $hook->getName(),
+                $hook->getParameters()
+            )
+            ->willReturn($hookEvent)
+        ;
+
+        $renderedHook = $this->hookDispatcher->dispatchRendering($hook);
+
+        $this->assertInstanceOf(RenderedHook::class, $renderedHook);
+        $this->assertEquals($hook, $renderedHook->getHook());
+        $this->assertEquals([], $renderedHook->getContent());
+    }
+
+    public function testDispatchRenderingWithParameters()
+    {
+        $hook = new Hook('Baz', ['hello' => 'World']);
+
+        // stub rendering hook event behavior
+        $hookEvent = $this->createRenderingHookEvent($hook->getParameters());
+
+        // stub adapter expectations
+        $this->hookDispatcherAdapter
+            ->expects($this->once())
+            ->method('renderForParameters')
+            ->with(
+                $hook->getName(),
+                $hook->getParameters()
+            )
+            ->willReturn($hookEvent)
+        ;
+
+        $renderedHook = $this->hookDispatcher->dispatchRenderingWithParameters('Baz', ['hello' => 'World']);
+
+        $this->assertInstanceOf(RenderedHook::class, $renderedHook);
+        $this->assertEquals($hook, $renderedHook->getHook());
+        $this->assertEquals(['hello' => 'World'], $renderedHook->getContent());
+    }
+
+    private function createHook($name = 'hookName', $parameters = [])
+    {
+        $hookStub = $this->createMock(HookInterface::class);
+
+        $hookStub->method('getName')->willReturn($name);
+        $hookStub->method('getParameters')->willReturn($parameters);
+
+        return $hookStub;
+    }
+
+    private function createRenderingHookEvent($parameters = [])
+    {
+        $renderingHookEventStub = $this->createMock(RenderingHookEvent::class);
+        $renderingHookEventStub->method('getContent')->willReturn($parameters);
+
+        return $renderingHookEventStub;
+    }
+}

--- a/tests/Unit/Core/Hook/HookDispatcherTest.php
+++ b/tests/Unit/Core/Hook/HookDispatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -32,8 +32,9 @@ use PrestaShop\PrestaShop\Core\Hook\HookInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcher;
 use PrestaShop\PrestaShop\Core\Hook\RenderedHook;
 use PrestaShop\PrestaShop\Core\Hook\Hook;
+use PHPUnit\Framework\TestCase;
 
-class HookDispatcherTest extends \PHPUnit_Framework_TestCase
+class HookDispatcherTest extends TestCase
 {
     /**
      * @var HookDispatcherAdapter
@@ -64,7 +65,6 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase
         ;
 
         $this->hookDispatcher->dispatchHook($hook);
-
     }
 
     public function testDispatchWithParameters()

--- a/tests/Unit/Core/Hook/HookDispatcherTest.php
+++ b/tests/Unit/Core/Hook/HookDispatcherTest.php
@@ -139,10 +139,20 @@ class HookDispatcherTest extends TestCase
         return $hookStub;
     }
 
+    /**
+     * The event dispatcher puts every parameter dispatched in an array.
+     * @param array $parameters
+     * @return \PHPUnit_Framework_MockObject_MockObject|RenderingHookEvent
+     */
     private function createRenderingHookEvent($parameters = [])
     {
+        $parametersDispatched = [];
+        foreach ($parameters as $key => $parameter) {
+            $parametersDispatched[$key] = empty($parameter) ? [] : [$parameter];
+        }
+
         $renderingHookEventStub = $this->createMock(RenderingHookEvent::class);
-        $renderingHookEventStub->method('getContent')->willReturn($parameters);
+        $renderingHookEventStub->method('getContent')->willReturn($parametersDispatched);
 
         return $renderingHookEventStub;
     }

--- a/tests/Unit/Core/Hook/RenderedHookTest.php
+++ b/tests/Unit/Core/Hook/RenderedHookTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Hook;
+
+use PrestaShop\PrestaShop\Core\Hook\HookInterface;
+use PrestaShop\PrestaShop\Core\Hook\RenderedHook;
+use PHPUnit\Framework\TestCase;
+
+class RenderedHookTest extends TestCase
+{
+    /**
+     * @var HookInterface
+     */
+    private $hookStub;
+
+    /**
+     * @var RenderedHook
+     */
+    private $renderedHook;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->hookStub = $this->createMock(HookInterface::class);
+
+        $this->renderedHook = new RenderedHook($this->hookStub, $this->content());
+    }
+
+    public function testGetHook()
+    {
+        $this->assertInstanceOf(HookInterface::class, $this->renderedHook->getHook());
+        $this->assertSame($this->hookStub, $this->renderedHook->getHook());
+    }
+
+    public function testGetContent()
+    {
+        $this->assertInternalType('array', $this->renderedHook->getContent());
+        $this->assertSame($this->content(), $this->renderedHook->getContent());
+    }
+
+    public function testOutputContent()
+    {
+        /** @see RenderedHookTest::content() */
+        $expected = '<h1>Hello World</h1><p>How are you?</p> '; // one extra space in the end is intended.
+        $this->assertInternalType('string', $this->renderedHook->outputContent());
+        $this->assertSame($expected, $this->renderedHook->outputContent());
+    }
+
+    /**
+     * This will return the expected content for the rendered Hook.
+     *
+     * @return array
+     */
+    private function content()
+    {
+        return [
+            'module_1' => '<h1>Hello World</h1>',
+            'module_2' => '<p>How are you?</p>',
+            'module_3' => ' ',
+        ];
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | While reviewing the pull request on HookDispatcherInterface, @jolelievre noticed some mismatch in the implementation of the HookDispatcher: sometimes a content was expected a string, sometimes an array... now the expectations are strict and the behavior covered :+1: 
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | yes, it is but it's not impacting PrestaShop developers/users.
| Deprecations? | no
| How to test?  | Nothing to test, tests should pass.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10038)
<!-- Reviewable:end -->
