### PR TITLE
Test if $tabs is instanceof Countable

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -563,7 +563,7 @@ class AdminControllerCore extends Controller
      */
     public function initBreadcrumbs($tab_id = null, $tabs = null)
     {
-        if (is_array($tabs)) {
+        if (is_array($tabs) || $tabs instanceof Countable) {
             $tabs = array();
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Test if $tabs is instanceof Countable. PHP 7.2 send a warning when count function is used on an object that don't implement Accountable interface.
| Type?         | bug fix
| Category?     |  BO 
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | 
| How to test?  | [2] count(): Parameter must be an array or an object that implements Countable message will disappear from log. (with php7.2)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10103)
<!-- Reviewable:end -->
