### PR TITLE
Fix bug shipping number is empty in {followup}

### DIFF
--- a/classes/order/OrderCarrier.php
+++ b/classes/order/OrderCarrier.php
@@ -128,7 +128,7 @@ class OrderCarrierCore extends ObjectModel
 
         $orderLanguage = new Language((int) $order->id_lang);
         $templateVars = array(
-            '{followup}' => str_replace('@', $order->shipping_number, $carrier->url),
+            '{followup}' => str_replace('@', $this->tracking_number, $carrier->url),
             '{firstname}' => $customer->firstname,
             '{lastname}' => $customer->lastname,
             '{id_order}' => $order->id,


### PR DESCRIPTION
When you call update OrderCarrier with Prestashop WebService, the Shipping number is empty in the `{followup}` URL in the "In Transit" email to customer.

When the web service is called, `$order->shipping_number` is empty in `sendInTransitEmail()`.
The shipping number has to be retrieved in OrderCarrier, not in Order : that's my fix.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Shipping number is empty in {followup} if In transit email is launched with the WebService
| Type?         | bug fix
| Category?     | WS
| Deprecations? | no
| Fixed ticket? | Fixes #10115
| How to test?  | Call OrderCarrier->update via rest WebService

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10117)
<!-- Reviewable:end -->
