### PR TITLE
Add form handler for Translations settings forms

### DIFF
--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -96,7 +96,7 @@ class TranslationRouteFinder
      */
     public function findRoute(ParameterBag $query)
     {
-        $routeProperties = $query->get('modify_translations');
+        $routeProperties = $query->get('form')['modify_translations'];
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $route = 'admin_international_translation_overview';
 
@@ -152,7 +152,7 @@ class TranslationRouteFinder
      */
     public function findRouteParameters(ParameterBag $query)
     {
-        $routeProperties = $query->get('modify_translations');
+        $routeProperties = $query->get('form')['modify_translations'];
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $language = $propertyAccessor->getValue($routeProperties, '[language]');
 

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -103,21 +103,15 @@ class TranslationsController extends FrameworkBundleAdminController
         $legacyController = $request->attributes->get('_legacy_controller');
         $legacyContext = $this->get('prestashop.adapter.legacy.context');
         $kpiRowFactory = $this->get('prestashop.core.kpi_row.factory.translations_page');
-
-        $modifyTranslationsForm = $this->createForm(ModifyTranslationsType::class);
-        $addUpdateLanguageForm = $this->createForm(AddUpdateLanguageType::class);
-        $copyLanguageForm = $this->createForm(CopyLanguageType::class);
-        $exportLanguageForm = $this->createForm(ExportThemeLanguageType::class);
+        $formHandler = $this->get('prestashop.admin.translations_settings.form_handler');
+        $form = $formHandler->getForm();
 
         return [
             'layoutTitle' => $this->trans('Translations', 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($legacyController),
             'kpiRow' => $kpiRowFactory->build(),
-            'modifyTranslationsForm' => $modifyTranslationsForm->createView(),
-            'addUpdateLanguageForm' => $addUpdateLanguageForm->createView(),
-            'exportLanguageForm' => $exportLanguageForm->createView(),
-            'copyLanguageForm' => $copyLanguageForm->createView(),
+            'translationSettingsForm' => $form->createView(),
             'addLanguageUrl' => $legacyContext->getAdminLink('AdminLanguages', true, ['addlang' => '']),
         ];
     }
@@ -152,12 +146,13 @@ class TranslationsController extends FrameworkBundleAdminController
      */
     public function addUpdateLanguageAction(Request $request)
     {
-        $addUpdateLanguageForm = $this->createForm(AddUpdateLanguageType::class);
+        $formHandler = $this->get('prestashop.admin.translations_settings.form_handler');
+        $addUpdateLanguageForm = $formHandler->getForm();
         $addUpdateLanguageForm->handleRequest($request);
 
         if ($addUpdateLanguageForm->isSubmitted()) {
             $data = $addUpdateLanguageForm->getData();
-            $isoCode = $data['iso_localization_pack'];
+            $isoCode = $data['add_update_language']['iso_localization_pack'];
 
             $languagePackImporter = $this->get('prestashop.adapter.language.pack.importer');
             $errors = $languagePackImporter->import($isoCode);
@@ -190,14 +185,15 @@ class TranslationsController extends FrameworkBundleAdminController
      */
     public function exportThemeLanguageAction(Request $request)
     {
-        $exportThemeLanguageForm = $this->createForm(ExportThemeLanguageType::class);
+        $formHandler = $this->get('prestashop.admin.translations_settings.form_handler');
+        $exportThemeLanguageForm = $formHandler->getForm();
         $exportThemeLanguageForm->handleRequest($request);
 
         if ($exportThemeLanguageForm->isSubmitted()) {
             $data = $exportThemeLanguageForm->getData();
 
-            $themeName = $data['theme_name'];
-            $isoCode = $data['iso_code'];
+            $themeName = $data['export_language']['theme_name'];
+            $isoCode = $data['export_language']['iso_code'];
 
             $langRepository = $this->get('prestashop.core.admin.lang.repository');
             $locale = $langRepository->getLocaleByIsoCode($isoCode);
@@ -227,17 +223,18 @@ class TranslationsController extends FrameworkBundleAdminController
      */
     public function copyLanguageAction(Request $request)
     {
-        $form = $this->createForm(CopyLanguageType::class);
+        $formHandler = $this->get('prestashop.admin.translations_settings.form_handler');
+        $form = $formHandler->getForm();
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
             $languageCopier = $this->get('prestashop.adapter.language.copier');
             $data = $form->getData();
             $languageCopierConfig = new LanguageCopierConfig(
-                $data['from_theme'],
-                $data['from_language'],
-                $data['to_theme'],
-                $data['to_language']
+                $data['copy_language']['from_theme'],
+                $data['copy_language']['from_language'],
+                $data['copy_language']['to_theme'],
+                $data['copy_language']['to_language']
             );
 
             if ($errors = $languageCopier->copy($languageCopierConfig)) {

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -27,10 +27,6 @@
 namespace PrestaShopBundle\Controller\Admin;
 
 use PrestaShop\PrestaShop\Core\Language\Copier\LanguageCopierConfig;
-use PrestaShopBundle\Form\Admin\Improve\International\Translations\AddUpdateLanguageType;
-use PrestaShopBundle\Form\Admin\Improve\International\Translations\CopyLanguageType;
-use PrestaShopBundle\Form\Admin\Improve\International\Translations\ExportThemeLanguageType;
-use PrestaShopBundle\Form\Admin\Improve\International\Translations\ModifyTranslationsType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Improve\International\Translations;
+
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class TranslationsSettingsFormHandler implements FormHandlerInterface
+{
+    /**
+     * @var FormBuilderInterface the form builder
+     */
+    protected $formBuilder;
+
+    /**
+     * @var HookDispatcherInterface the event dispatcher
+     */
+    protected $hookDispatcher;
+
+    /**
+     * @var string the hook name to be dispatched
+     */
+    protected $hookName;
+
+    /**
+     * @var array the list of Form Types
+     */
+    protected $formTypes;
+
+    /**
+     * @param FormBuilderInterface $formBuilder
+     * @param HookDispatcherInterface $hookDispatcher
+     * @param array $formTypes
+     * @param string $hookName
+     */
+    public function __construct(
+        FormBuilderInterface $formBuilder,
+        HookDispatcherInterface $hookDispatcher,
+        array $formTypes,
+        $hookName
+    ) {
+        $this->formBuilder = $formBuilder;
+        $this->hookDispatcher = $hookDispatcher;
+        $this->formTypes = $formTypes;
+        $this->hookName = $hookName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getForm()
+    {
+        foreach ($this->formTypes as $formName => $formType) {
+            $this->formBuilder->add($formName, $formType);
+        }
+
+        $this->hookDispatcher->dispatchWithParameters(
+            "action{$this->hookName}Form",
+            [
+                'form_builder' => $this->formBuilder,
+            ]
+        );
+
+        return $this->formBuilder->getForm();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(array $data)
+    {
+        // Translations forms do not save data
+        return [];
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -251,6 +251,18 @@ services:
               'webservice_configuration': 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Webservice\WebserviceType'
             - 'WebservicePage'
 
+    prestashop.admin.translations_settings.form_handler:
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Translations\TranslationsSettingsFormHandler'
+        arguments:
+            - '@=service("form.factory").createBuilder()'
+            - '@prestashop.core.hook.dispatcher'
+            -
+              'modify_translations': 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ModifyTranslationsType'
+              'add_update_language': 'PrestaShopBundle\Form\Admin\Improve\International\Translations\AddUpdateLanguageType'
+              'export_language': 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ExportThemeLanguageType'
+              'copy_language': 'PrestaShopBundle\Form\Admin\Improve\International\Translations\CopyLanguageType'
+            - 'TranslationSettingsPage'
+
     # Entity form handler
     prestashop.admin.request_sql.form_handler:
         class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\RequestSql\RequestSqlFormHandler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
@@ -52,6 +52,7 @@
           {{ form_widget(addUpdateLanguageForm.iso_localization_pack, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}) }}
         </div>
       </div>
+      {{ form_rest(addUpdateLanguageForm) }}
     </div>
   </div>
 
@@ -64,5 +65,5 @@
     </div>
   </div>
 </div>
-{{ form_rest(addUpdateLanguageForm) }}
+
 {{ form_end(addUpdateLanguageForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
@@ -76,8 +76,8 @@
             </div>
           </div>
         </div>
+        {{ form_rest(copyLanguageForm) }}
       </div>
-      {{ form_rest(copyLanguageForm) }}
     </div>
 
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
@@ -63,6 +63,7 @@
           {{ form_widget(exportLanguageForm.theme_name) }}
         </div>
       </div>
+      {{ form_rest(exportLanguageForm) }}
     </div>
   </div>
 
@@ -76,5 +77,4 @@
   </div>
 </div>
 
-{{ form_rest(exportLanguageForm) }}
 {{ form_end(exportLanguageForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
@@ -92,8 +92,8 @@
             {{ form_widget(modifyTranslationsForm.language) }}
           </div>
         </div>
+        {{ form_rest(modifyTranslationsForm) }}
       </div>
-      {{ form_rest(modifyTranslationsForm) }}
     </div>
 
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -26,6 +26,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain 'Admin.International.Feature' %}
 
+{% set addUpdateLanguageForm, copyLanguageForm, exportLanguageForm, modifyTranslationsForm =
+        translationSettingsForm.add_update_language, translationSettingsForm.copy_language,
+        translationSettingsForm.export_language, translationSettingsForm.modify_translations
+%}
+
 {% block content %}
   <div class="row justify-content-center">
     <div class="col-xl-10">


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR adds a form handler for translations forms, enabling form-related hooks
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Install a demo module: (https://github.com/rokaszygmantas/hooktest). After installation in the Improve -> International -> Translations page you should see new form fields in every form. Expected view: https://prnt.sc/knp97w 

All fieldsets should have this new "Test field" which is coming from the module, meaning the form hook is working.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10165)
<!-- Reviewable:end -->
