### PR TITLE
FIX deprecated call to Tools::replaceByAbsoluteURL

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -202,7 +202,7 @@ class MediaCore
             $css_content = str_replace(array(':0px', ':0em', ':0pt', ':0%'), ':0', $css_content);
             $css_content = str_replace(array(' 0px', ' 0em', ' 0pt', ' 0%'), ' 0', $css_content);
             $css_content = str_replace('\'images_ie/', '\'images/', $css_content);
-            $css_content = preg_replace_callback('#(AlphaImageLoader\(src=\')([^\']*\',)#s', array('Tools', 'replaceByAbsoluteURL'), $css_content);
+            $css_content = preg_replace_callback('#(AlphaImageLoader\(src=\')([^\']*\',)#s', array('Media', 'replaceByAbsoluteURL'), $css_content);
             // Store all import url
             preg_match_all('#@(import|charset) .*?;#i', $css_content, $m);
             for ($i = 0, $total = count($m[0]); $i < $total; $i++) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Deprecated call to Tools::replaceByAbsoluteURL
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | With 1.6.1.20 ans PHP errors displayed (_PS_MODE_DEV_ is on), enable CSS compression in the "Performances" settings. Clear cache, then go to FO: you should see the PHP error messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10181)
<!-- Reviewable:end -->
