### PR TITLE
Fix deprecated call to Tools::replaceByAbsoluteURL

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -163,7 +163,7 @@ class MediaCore
             $limit = Media::getBackTrackLimit();
             $cssContent = preg_replace_callback(Media::$pattern_callback, array('Media', 'replaceByAbsoluteURL'), $cssContent, $limit);
             $cssContent = str_replace('\'images_ie/', '\'images/', $cssContent);
-            $cssContent = preg_replace_callback('#(AlphaImageLoader\(src=\')([^\']*\',)#s', array('Tools', 'replaceByAbsoluteURL'), $cssContent);
+            $cssContent = preg_replace_callback('#(AlphaImageLoader\(src=\')([^\']*\',)#s', array('Media', 'replaceByAbsoluteURL'), $cssContent);
 
             // Store all import url
             preg_match_all('#@(import|charset) .*?;#i', $cssContent, $m);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Deprecated call to Tools::replaceByAbsoluteURL
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | With 1.6.1.20 ans PHP errors displayed (PS_MODE_DEV is on), enable CSS compression in the "Performances" settings. Clear cache, then go to FO: you should see the PHP error messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10182)
<!-- Reviewable:end -->
