### PR TITLE
Fix the bootstrap classes for left-column ID

### DIFF
--- a/themes/classic/templates/contact.tpl
+++ b/themes/classic/templates/contact.tpl
@@ -27,7 +27,7 @@
 {block name='page_header_container'}{/block}
 
 {block name='left_column'}
-  <div id="left-column" class="col-xs-12 col-sm-3">
+  <div id="left-column" class="col-xs-12 col-sm-4 col-md-3">
     {widget name="ps_contactinfo" hook='displayLeftColumn'}
   </div>
 {/block}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Wrong bootstrap classes for left-column ID on contact page
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | -
| Deprecations? | -
| Fixed ticket? | Fixes #10147
| How to test?  |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10195)
<!-- Reviewable:end -->
