### PR TITLE
Bring back Addons Catalog controller

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -771,6 +771,7 @@ class LinkCore
 
             default:
                 $routes = array(
+                    'AdminAddonsCatalog' => 'admin_module_addons_store',
                     'AdminAdminPreferences' => 'admin_administration',
                     'AdminCustomerPreferences' => 'admin_customer_preferences',
                     'AdminDeliverySlip' => 'admin_order_delivery_slip',

--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -186,6 +186,9 @@
                 <tab id="Module_Page_old" id_parent="Modules" active="0" hide_host_mode="0" icon="">
                     <class_name>AdminModules</class_name>
                 </tab>
+                <tab id="Marketing_tools" id_parent="Modules" active="1" hide_host_mode="0" icon="">
+                    <class_name>AdminAddonsCatalog</class_name>
+                </tab>
 
             <!--LOOK & FEEL-->
             <tab id="Look_feel" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="desktop_mac">

--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -168,26 +168,31 @@
             <tab id="Modules" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="extension">
                 <class_name>AdminParentModulesSf</class_name>
             </tab>
-                <tab id="Module_Page_Catalog" id_parent="Modules" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminModulesCatalog</class_name>
+                <tab id="Module_Catalog" id_parent="Modules" active="1" hide_host_mode="0" icon="">
+                    <class_name>AdminParentModulesCatalog</class_name>
                 </tab>
+                    <tab id="Module_Page_Catalog" id_parent="Module_Catalog" active="1" hide_host_mode="0" icon="">
+                        <class_name>AdminModulesCatalog</class_name>
+                    </tab>
+                    <tab id="Marketing_tools" id_parent="Module_Catalog" active="1" hide_host_mode="0" icon="">
+                        <class_name>AdminAddonsCatalog</class_name>
+                    </tab>
+
                 <tab id="Module_Page" id_parent="Modules" active="1" hide_host_mode="0" icon="">
                     <class_name>AdminModulesSf</class_name>
                 </tab>
-                <tab id="Module_Page_Manage" id_parent="Module_Page" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminModulesManage</class_name>
-                </tab>
-                <tab id="Module_Page_Notifications" id_parent="Module_Page" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminModulesNotifications</class_name>
-                </tab>
-                <tab id="Module_Page_Updates" id_parent="Module_Page" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminModulesUpdates</class_name>
-                </tab>
+                    <tab id="Module_Page_Manage" id_parent="Module_Page" active="1" hide_host_mode="0" icon="">
+                        <class_name>AdminModulesManage</class_name>
+                    </tab>
+                    <tab id="Module_Page_Notifications" id_parent="Module_Page" active="1" hide_host_mode="0" icon="">
+                        <class_name>AdminModulesNotifications</class_name>
+                    </tab>
+                    <tab id="Module_Page_Updates" id_parent="Module_Page" active="1" hide_host_mode="0" icon="">
+                        <class_name>AdminModulesUpdates</class_name>
+                    </tab>
+
                 <tab id="Module_Page_old" id_parent="Modules" active="0" hide_host_mode="0" icon="">
                     <class_name>AdminModules</class_name>
-                </tab>
-                <tab id="Marketing_tools" id_parent="Modules" active="1" hide_host_mode="0" icon="">
-                    <class_name>AdminAddonsCatalog</class_name>
                 </tab>
 
             <!--LOOK & FEEL-->

--- a/install-dev/langs/en/data/tab.xml
+++ b/install-dev/langs/en/data/tab.xml
@@ -128,4 +128,5 @@
     <tab id="Warehouses" name="Warehouses" />
     <tab id="Webservice" name="Webservice" />
     <tab id="Zones" name="Zones" />
+    <tab id="Marketing_tools" name="Modules Catalog" />
 </entity_tab>

--- a/install-dev/langs/en/data/tab.xml
+++ b/install-dev/langs/en/data/tab.xml
@@ -6,6 +6,7 @@
     <tab id="DEFAULT" name="More" />
     <tab id="Addresses" name="Addresses" />
     <tab id="Administration" name="Administration" />
+    <tab id="Module_Catalog" name="Module Catalog" />
     <tab id="Module_Page" name="Module Manager" />
     <tab id="Module_Page_Catalog" name="Module Catalog" />
     <tab id="Module_Page_Manage" name="Modules" />
@@ -128,5 +129,5 @@
     <tab id="Warehouses" name="Warehouses" />
     <tab id="Webservice" name="Webservice" />
     <tab id="Zones" name="Zones" />
-    <tab id="Marketing_tools" name="Modules Catalog" />
+    <tab id="Marketing_tools" name="Modules Selections" />
 </entity_tab>

--- a/install-dev/langs/fa/data/tab.xml
+++ b/install-dev/langs/fa/data/tab.xml
@@ -124,4 +124,5 @@
     <tab id="Warehouses" name="انبارها" />
     <tab id="Webservice" name="وب سرویس" />
     <tab id="Zones" name="منطقه ها" />
+    <tab id="Marketing_tools" name="کاتالوگ ماژول ها" />
 </entity_tab>

--- a/install-dev/upgrade/php/ps_1750_update_module_tabs.php
+++ b/install-dev/upgrade/php/ps_1750_update_module_tabs.php
@@ -31,19 +31,26 @@ function ps_1750_update_module_tabs()
 {
     // STEP 1: Add new sub menus for modules
     $moduleTabsToBeAdded = array(
-        'AdminModulesUpdates' => 'en:Updates|fr:Mises à jour|es:Actualizaciones|de:Aktualisierung|it:Aggiornamenti',
+        'AdminModulesUpdates' => array(
+            'translations' => 'en:Updates|fr:Mises à jour|es:Actualizaciones|de:Aktualisierung|it:Aggiornamenti',
+            'parent' => 'AdminModulesSf'
+        ),
+        'AdminParentModulesCatalog' => array(
+            'translations' => 'en:Module Catalog|fr:Catalogue de modules|es:Catálogo de módulos|de:Modulkatalog|it:Catalogo dei moduli',
+            'parent' => 'AdminParentModulesSf'
+        ),
     );
 
     include_once 'add_new_tab.php';
-    foreach ($moduleTabsToBeAdded as $className => $translations) {
-        add_new_tab_17($className, $translations, 0, false, 'AdminModulesSf');
+    foreach ($moduleTabsToBeAdded as $className => $tabDetails) {
+        add_new_tab_17($className, $tabDetails['translations'], 0, false, $tabDetails['parent']);
         Db::getInstance()->execute(
             'UPDATE `'._DB_PREFIX_.'tab` SET `active`= 1 WHERE `class_name` = "' . $className . '"'
         );
     }
 
 
-    // STEP 2: Rename Notifications as Alerts
+    // STEP 2: Rename module tabs (Notifications as Alerts, Module selection as Module Catalog, Module Catalog as Module Selections)
     include_once 'clean_tabs_15.php';
     $adminModulesNotificationsTabId = Db::getInstance()->getValue(
         'SELECT id_tab FROM '._DB_PREFIX_.'tab WHERE class_name = "AdminModulesNotifications"'
@@ -69,12 +76,12 @@ function ps_1750_update_module_tabs()
         renameTab(
             $adminModulesCatalogTabId,
             [
-                'fr' => 'Catalogue',
-                'es' => 'Catálogo',
-                'en' => 'Catalog',
-                'gb' => 'Catalog',
-                'de' => 'Catalogus',
-                'it' => 'Catalogo',
+                'fr' => 'Catalogue de modules',
+                'es' => 'Catálogo de módulos',
+                'en' => 'Module Catalog',
+                'gb' => 'Module Catalog',
+                'de' => 'Versanddienst',
+                'it' => 'Catalogo dei moduli',
             ]
         );
     }
@@ -93,6 +100,34 @@ function ps_1750_update_module_tabs()
                 'de' => 'Modules',
                 'it' => 'Moduli',
             ]
+        );
+    }
+
+    $adminModulesAddonsSelectionsTabId = Db::getInstance()->getValue(
+        'SELECT id_tab FROM '._DB_PREFIX_.'tab WHERE class_name = "AdminAddonsCatalog"'
+    );
+    if (!empty($adminModulesAddonsSelectionsTabId)) {
+        renameTab(
+            $adminModulesAddonsSelectionsTabId,
+            [
+                'fr' => 'Sélections de modules',
+                'es' => 'Selecciones de módulos',
+                'en' => 'Module Selections',
+                'gb' => 'Module Selections',
+                'de' => 'Auswahl von Modulen',
+                'it' => 'Selezioni Moduli',
+            ]
+        );
+    }
+
+    // STEP 3: Move the 2 module catalog controllers in the parent one
+    // Get The ID of the parent
+    $adminParentModuleCatalogTabId = Db::getInstance()->getValue(
+        'SELECT id_tab FROM '._DB_PREFIX_.'tab WHERE class_name = "AdminParentModulesCatalog"'
+    );
+    foreach (array('AdminModulesCatalog', 'AdminAddonsCatalog') as $key => $className) {
+        Db::getInstance()->execute(
+            'UPDATE `'._DB_PREFIX_.'tab` SET `id_parent`= ' . (int) $adminParentModuleCatalogTabId . ', position = '. $key . ' WHERE `class_name` = "' . $className . '"'
         );
     }
 }

--- a/install-dev/upgrade/sql/1.7.5.0.sql
+++ b/install-dev/upgrade/sql/1.7.5.0.sql
@@ -2,3 +2,5 @@ SET SESSION sql_mode = '';
 SET NAMES 'utf8';
 
 /* PHP:add_supplier_manufacturer_routes(); */;
+
+/* PHP:ps_1750_update_module_tabs(); */;

--- a/src/PrestaShopBundle/Controller/Admin/Improve/AddonsStoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/AddonsStoreController.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Controller\Admin\Improve;
+
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Responsible of "Improve > Modules > Modules Catalog" page display
+ */
+class AddonsStoreController extends FrameworkBundleAdminController
+{
+    /**
+     * @var string The controller name for routing.
+     */
+    const CONTROLLER_NAME = 'AdminAddonsCatalog';
+
+    /**
+     * @param Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function indexAction(Request $request)
+    {
+        return $this->render('@PrestaShop/Admin/Improve/Module/addons_store.html.twig', array(
+            'pageContent' => file_get_contents($this->getAddonsUrl($request)),
+            'layoutHeaderToolbarBtn' => array(),
+            'layoutTitle' => $this->trans('Modules catalog', 'Admin.Navigation.Menu'),
+            'requireAddonsSearch' => true,
+            'requireBulkActions' => false,
+            'showContentHeader' => true,
+            'enableSidebar' => true,
+            'help_link' => $this->generateSidebarLink('AdminAddonsCatalog'),
+            'requireFilterStatus' => false,
+            'level' => $this->authorizationLevel($this::CONTROLLER_NAME),
+        ));
+    }
+
+    /**
+     * @param Request $request
+     * @return string
+     */
+    private function getAddonsUrl(Request $request)
+    {
+        $psVersion = $this->get('prestashop.core.foundation.version')->getVersion();
+        $parent_domain = $request->getSchemeAndHttpHost();
+        $context = $this->getContext();
+        $currencyCode = $context->currency->iso_code;
+        $languageCode = $context->language->iso_code;
+        $countryCode = $context->country->iso_code;
+        $activity = (int) $this->get('prestashop.adapter.legacy.configuration')->get('PS_SHOP_ACTIVITY');
+
+        return "https://addons.prestashop.com/iframe/search-1.7.php?psVersion=$psVersion&isoLang=$languageCode&isoCurrency=$currencyCode&isoCountry=$countryCode&activity=$activity&parentUrl=$parent_domain";
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/AddonsStoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/AddonsStoreController.php
@@ -49,7 +49,7 @@ class AddonsStoreController extends FrameworkBundleAdminController
         return $this->render('@PrestaShop/Admin/Improve/Module/addons_store.html.twig', array(
             'pageContent' => file_get_contents($this->getAddonsUrl($request)),
             'layoutHeaderToolbarBtn' => array(),
-            'layoutTitle' => $this->trans('Modules catalog', 'Admin.Navigation.Menu'),
+            'layoutTitle' => $this->trans('Module selection', 'Admin.Navigation.Menu'),
             'requireAddonsSearch' => true,
             'requireBulkActions' => false,
             'showContentHeader' => true,

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -67,7 +67,7 @@ class ModuleController extends ModuleAbstractController
             'PrestaShopBundle:Admin/Module:catalog.html.twig',
             [
                 'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
-                'layoutTitle' => $this->trans('Module selection', 'Admin.Navigation.Menu'),
+                'layoutTitle' => $this->trans('Modules catalog', 'Admin.Navigation.Menu'),
                 'requireAddonsSearch' => true,
                 'requireBulkActions' => false,
                 'showContentHeader' => true,

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Controller\Admin\Improve;
+namespace PrestaShopBundle\Controller\Admin\Improve\Modules;
 
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -26,22 +26,22 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\Modules;
 
-use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Responsible of "Improve > Modules > Modules Catalog" page display
+ * Responsible of "Improve > Modules > Modules Catalog" page display.
  */
 class AddonsStoreController extends FrameworkBundleAdminController
 {
     /**
-     * @var string The controller name for routing.
+     * @var string the controller name for routing
      */
     const CONTROLLER_NAME = 'AdminAddonsCatalog';
 
     /**
      * @param Request $request
+     *
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function indexAction(Request $request)
@@ -62,6 +62,7 @@ class AddonsStoreController extends FrameworkBundleAdminController
 
     /**
      * @param Request $request
+     *
      * @return string
      */
     private function getAddonsUrl(Request $request)

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
@@ -98,3 +98,10 @@ admin_module_updates:
     defaults:
         _controller: PrestaShopBundle:Admin/Improve/Modules/Updates:index
         _legacy_controller: AdminModulesUpdates
+
+admin_module_addons_store:
+    path:     /addons-store
+    methods:  [GET]
+    defaults:
+        _controller: 'PrestaShopBundle:Admin\Improve\AddonsStore:index'
+        _legacy_controller: AdminAddonsCatalog

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
@@ -103,5 +103,5 @@ admin_module_addons_store:
     path:     /addons-store
     methods:  [GET]
     defaults:
-        _controller: 'PrestaShopBundle:Admin\Improve\AddonsStore:index'
+        _controller: 'PrestaShopBundle:Admin\Improve\Modules\AddonsStore:index'
         _legacy_controller: AdminAddonsCatalog

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Module/addons_store.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Module/addons_store.html.twig
@@ -1,0 +1,29 @@
+{#**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  {{ pageContent|raw }}
+{% endblock %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Bring back the controller AddonsCatalog removed one month ago. Fixes upgrade of #9454
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/10203
| How to test?  | Module catalog should be back, whatever you install or you upgrade your shop

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10200)
<!-- Reviewable:end -->
