### PR TITLE
FO: If I type 0 as desired quantity, now the behavior is correct.

### DIFF
--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -230,7 +230,7 @@ $(document).ready(() => {
 
     // There should be a valid product quantity in cart
     const targetValue = $target.val();
-    if (targetValue != parseInt(targetValue) || targetValue < 0 || isNaN(targetValue)) {
+    if (targetValue != parseInt(targetValue) || targetValue <= 0 || isNaN(targetValue)) {
       $target.val(baseValue);
       return;
     }
@@ -239,6 +239,10 @@ $(document).ready(() => {
     const qty = targetValue - baseValue;
     if (qty === 0) {
       return;
+    }
+    
+    if (targetValue == 0) {
+        qty = baseValue;
     }
 
     $target.attr('value', targetValue);

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -230,7 +230,7 @@ $(document).ready(() => {
 
     // There should be a valid product quantity in cart
     const targetValue = $target.val();
-    if (targetValue != parseInt(targetValue) || targetValue <= 0 || isNaN(targetValue)) {
+    if (targetValue != parseInt(targetValue) || targetValue < 0 || isNaN(targetValue)) {
       $target.val(baseValue);
       return;
     }

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -236,7 +236,7 @@ $(document).ready(() => {
     }
 
     // There should be a new product quantity in cart
-    const qty = targetValue - baseValue;
+    let qty = targetValue - baseValue;
     if (qty === 0) {
       return;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Classic theme issue. The cart.js method: updateProductQuantityInCart does not take in consideration the case when user type 0 as desired quantity and behave in a wrong way. 
| Type?         | bug fix
| Category?     | FO 
| BC breaks?    | No
| Deprecations? | No
| How to test?  | Just open the cart after adding some products, then type 0 in the product_quantity_spin input

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10215)
<!-- Reviewable:end -->
