### PR TITLE
Fix falsy value returned by upgrade script

### DIFF
--- a/install-dev/upgrade/php/ps1700_stores.php
+++ b/install-dev/upgrade/php/ps1700_stores.php
@@ -31,7 +31,7 @@ function ps1700_stores()
         FROM `'._DB_PREFIX_.'store`
     ');
 
-    $result = false;
+    $result = true;
     foreach ($stores as $store) {
         $hours = Tools::unSerialize($store['hours']);
         if (is_array($hours)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | An upgrade script was flagged with ERROR, even if everything went fine. That was caused by a wrong default value.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | #9513 partially, #9487 and follows up https://github.com/PrestaShop/PrestaShop/pull/8556#issuecomment-362347577
| How to test?  | Upgrade from PrestaShop 1.6. This script should be reported in error during the process in the step UpgradeDb. With this PR, it should get a OK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10218)
<!-- Reviewable:end -->
