### PR TITLE
Fixed error with inheritance

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -498,7 +498,7 @@ class CartRuleCore extends ObjectModel
         $customerId,
         Cart $cart
     ) {
-        return self::getCustomerCartRules(
+        return static::getCustomerCartRules(
            $languageId,
            $customerId,
            $active = true,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Is not possible to extend function getCustomerCartRules() because it's called from getCustomerHighlightedDiscounts() as "self". 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | Override function getCustomerCartRules(). Then add a trace at getCustomerHighlightedDiscounts(), parent getCustomerCartRules() and overrided getCustomerCartRules() functions. It always executes getCustomerHighlightedDiscounts() and parent getCustomerCartRules() functions, but not overrided getCustomerCartRules() function

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/9473)
<!-- Reviewable:end -->
