### PR TITLE
Add magic methods on LazyArray classes for object-like use

### DIFF
--- a/src/Adapter/Presenter/AbstractLazyArray.php
+++ b/src/Adapter/Presenter/AbstractLazyArray.php
@@ -153,6 +153,67 @@ abstract class AbstractLazyArray implements Iterator, ArrayAccess, Countable, Js
     }
 
     /**
+     * The properties are provided as an array. But callers checking the type of this class (is_object === true)
+     * think they must use the object syntax.
+     *
+     * Check if the index exists inside the lazyArray.
+     *
+     * @param string $index
+     *
+     * @return bool
+     */
+    public function __isset($index)
+    {
+        return $this->offsetExists($index);
+    }
+
+    /**
+     * The properties are provided as an array. But callers checking the type of this class (is_object === true)
+     * think they must use the object syntax.
+     *
+     * Get the value associated with the $index from the lazyArray.
+     *
+     * @param mixed $index
+     *
+     * @return mixed
+     *
+     * @throws RuntimeException
+     */
+    public function __get($index)
+    {
+        return $this->offsetGet($index);
+    }
+
+    /**
+     * The properties are provided as an array. But callers checking the type of this class (is_object === true)
+     * think they must use the object syntax.
+     *
+     * @param mixed $offset
+     * @param mixed $value
+     * @param bool $force if set, allow override of an existing method
+     *
+     * @throws RuntimeException
+     */
+    public function __set($name, $value)
+    {
+        $this->offsetSet($name, $value);
+    }
+
+    /**
+     * The properties are provided as an array. But callers checking the type of this class (is_object === true)
+     * think they must use the object syntax.
+     *
+     * @param mixed $offset
+     * @param bool $force if set, allow unset of an existing method
+     *
+     * @throws RuntimeException
+     */
+    public function __unset($name)
+    {
+        $this->offsetUnset($name);
+    }
+
+    /**
      * Get the value associated with the $index from the lazyArray.
      *
      * @param mixed $index


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Before getting a property, module are checking if they are using an array or an object. As LazyArray are obviously considered as object, existing tests automatically get the properties accordingly. This PR covers this use case.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Install the module ps_productinfo and go to a product page. Without this PR, you will have the following error:

![capture du 2018-08-31 14-47-05](https://user-images.githubusercontent.com/6768917/44918815-d0a1c480-ad33-11e8-8b91-c613cc3c8a84.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10230)
<!-- Reviewable:end -->
