### PR TITLE
Use PHP_BINARY while using createTestDb

### DIFF
--- a/tests/PrestaShopBundle/Utils/DatabaseCreator.php
+++ b/tests/PrestaShopBundle/Utils/DatabaseCreator.php
@@ -48,7 +48,7 @@ class DatabaseCreator
         \DbPDOCore::createDatabase(_DB_SERVER_, _DB_USER_, _DB_PASSWD_, _DB_NAME_, false);
         $install->clearDatabase(false);
         $install->installDatabase(true);
-        $process = new Process('php bin/console prestashop:schema:update-without-foreign --env=test');
+        $process = new Process(PHP_BINARY . ' bin/console prestashop:schema:update-without-foreign --env=test');
         $process->run();
         $install->initializeTestContext();
         $install->installDefaultData('test_shop', false, false, false);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Without this, it use the default php binary from $PATH which can be different if you use many php versions on your system.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Waiting for CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10249)
<!-- Reviewable:end -->
