### PR TITLE
Fix getTotalWeight Notice

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3652,7 +3652,7 @@ class CartCore extends ObjectModel
             $this->updateProductWeight($this->id);
         }
 
-        return isset(self::$_totalWeight[$this->id]) ? self::$_totalWeight[$this->id] : null;
+        return self::$_totalWeight[(int) $this->id];
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3652,7 +3652,7 @@ class CartCore extends ObjectModel
             $this->updateProductWeight($this->id);
         }
 
-        return self::$_totalWeight[$this->id];
+        return isset(self::$_totalWeight[$this->id]) ? self::$_totalWeight[$this->id] : null;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

getTotalWeight function (Cart.php) can return "Notice: Undefined index: " if $products is null and $this->id is null to 

getTotalWeight call updateProductWeight with null

```
if (!isset(self::$_totalWeight[$this->id])) {
    $this->updateProductWeight($this->id);
 }
```

but updateProductWeight return self::$_totalWeight[$productId] with $productId = 0 ($productId = (int) $productId);

so we retrun self::$_totalWeight[0] but into getTotalWeight we return self::$_totalWeight[$this->id];
self::$_totalWeight[null] != self::$_totalWeight[0]

it's possible to solve this by changing return line

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10254)
<!-- Reviewable:end -->
