### PR TITLE
Propose improvement

### DIFF
--- a/classes/QuickAccess.php
+++ b/classes/QuickAccess.php
@@ -81,34 +81,37 @@ class QuickAccessCore extends ObjectModel
             return false;
         }
 
+        $baselink = Context::getContext()->link->getBaseLink();
         foreach ($quickAccess as $index => $quick) {
-            // first, clean url to have a real quickLink
-            $quick['link'] = Context::getContext()->link->getQuickLink($quick['link']);
-            $tokenString = $idEmployee;
-
-            if ('../' === $quick['link'] && Shop::getContext() == Shop::CONTEXT_SHOP) {
-                $url = Context::getContext()->shop->getBaseURL();
-                if (!$url) {
-                    unset($quickAccess[$index]);
-                    continue;
-                }
-                $quickAccess[$index]['link'] = $url;
-            } else {
-                preg_match('/controller=(.+)(&.+)?$/', $quick['link'], $admin_tab);
-                if (isset($admin_tab[1])) {
-                    if (strpos($admin_tab[1], '&')) {
-                        $admin_tab[1] = substr($admin_tab[1], 0, strpos($admin_tab[1], '&'));
+            if(strpos($quickAccess[$index]['link'], 'http') !== 0 or strpos($quickAccess[$index]['link'], $baselink) === 0){
+                if ('../' === $quick['link'] && Shop::getContext() == Shop::CONTEXT_SHOP) {
+                    $url = Context::getContext()->shop->getBaseURL();
+                    if (!$url) {
+                        unset($quickAccess[$index]);
+                        continue;
                     }
-                    $quick_access[$index]['target'] = $admin_tab[1];
+                    $quickAccess[$index]['link'] = $url;
+                } else{
+                    // first, clean url to have a real quickLink
+                    $quick['link'] = Context::getContext()->link->getQuickLink($quick['link']);
+                    $tokenString = $idEmployee;
+                    
+                    preg_match('/controller=(.+)(&.+)?$/', $quick['link'], $admin_tab);
+                    if (isset($admin_tab[1])) {
+                        if (strpos($admin_tab[1], '&')) {
+                            $admin_tab[1] = substr($admin_tab[1], 0, strpos($admin_tab[1], '&'));
+                        }
+                        $quick_access[$index]['target'] = $admin_tab[1];
 
-                    $tokenString = $admin_tab[1] . (int) Tab::getIdFromClassName($admin_tab[1]) . $idEmployee;
+                        $tokenString = $admin_tab[1].(int)Tab::getIdFromClassName($admin_tab[1]).$idEmployee;
+                    }
+                    $quickAccess[$index]['link'] = $baselink.basename(_PS_ADMIN_DIR_).'/'.$quick['link'];
+                    if (false === strpos($quickAccess[$index]['link'], 'token')) {
+                        $separator = strpos($quickAccess[$index]['link'], '?') ? '&' : '?';
+                        $quickAccess[$index]['link'] .= $separator.'token='.Tools::getAdminToken($tokenString);
+                    }
+
                 }
-                $quickAccess[$index]['link'] = Context::getContext()->link->getBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . $quick['link'];
-            }
-
-            if (false === strpos($quickAccess[$index]['link'], 'token')) {
-                $separator = strpos($quickAccess[$index]['link'], '?') ? '&' : '?';
-                $quickAccess[$index]['link'] .= $separator . 'token=' . Tools::getAdminToken($tokenString);
             }
         }
 


### PR DESCRIPTION
First, get baselink only once, instead of each time -> could have a very slight speed improvement.
Second, the if(strpos($quickAccess[$index]['link'], 'http') !== 0 or strpos($quickAccess[$index]['link'], $baselink) === 0) is used to allow other links, like the https://google.com, etc... It only adds the baselink and token to the link that do not start with http (or https of course) or to those that start with http, but it's the same as the current used link. If it's another link for the same shop, it will ask for login any way.
Third, moved the check to add the admin token to inside the else.  This way it doesn't add to store url.
Fourth, moved the clean url, to be inside the else to generate the shop front office url when link is '../'.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4
| Description?  | No PR. Seen this in SO https://stackoverflow.com/questions/52163426/prestashop-quick-address-links-to-external-url and 1.6 allowed external url
| Type?         |  improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No ticket
| How to test?  | Create a quick access link for https://google.com (for example), also another for "../" for FO.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10268)
<!-- Reviewable:end -->
