### PR TITLE
Move module instantiation methods in ModuleRepository

### DIFF
--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -432,28 +432,4 @@ class Module implements ModuleInterface
         return $this->attributes->get('version_available') !== 0
             && version_compare($this->database->get('version'), $this->attributes->get('version_available'), '<');
     }
-
-    /**
-     * Return installed modules.
-     *
-     * @param int $position Take only positionnables modules
-     *
-     * @return array Modules
-     */
-    public function getModulesInstalled($position = 0)
-    {
-        return LegacyModule::getModulesInstalled((int) $position);
-    }
-
-    /**
-     * Return an instance of the specified module.
-     *
-     * @param int $moduleId Module id
-     *
-     * @return Module instance
-     */
-    public function getInstanceById($moduleId)
-    {
-        return LegacyModule::getInstanceById((int) $moduleId);
-    }
 }

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -192,12 +192,25 @@ class ModuleRepository implements ModuleRepositoryInterface
      *
      * @param string $name The technical module name to instanciate
      *
-     * @return \Module|null Instance of legacy Module, if valid
+     * @return LegacyModule|null Instance of legacy Module, if valid
      */
     public function getInstanceByName($name)
     {
         // Return legacy instance !
         return $this->getModule($name)->getInstance();
+    }
+
+    /**
+     * Get the **Legacy** Module object from its ID (local database).
+     * Return an instance of the specified module.
+     *
+     * @param int $moduleId Module id
+     *
+     * @return LegacyModule instance
+     */
+    public function getInstanceById($moduleId)
+    {
+        return LegacyModule::getInstanceById((int) $moduleId);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Api/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Api/Improve/Design/PositionsController.php
@@ -47,7 +47,7 @@ class PositionsController extends ApiController
         $positions = $request->request->get('positions');
         $position = (int) is_array($positions) ? array_search($hookId . '_' . $moduleId, $positions) + 1 : null;
 
-        $module = $this->container->get('prestashop.adapter.legacy.module')->getInstanceById($moduleId);
+        $module = $this->container->get('prestashop.core.admin.module.repository')->getInstanceById($moduleId);
         if (empty($module->id)) {
             return $this->jsonResponse(
                 [

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -76,6 +76,3 @@ services:
             - '@prestashop.core.admin.module.repository'
             - '@prestashop.bundle.repository.module'
             - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
-
-    prestashop.adapter.legacy.module:
-        class: PrestaShop\PrestaShop\Adapter\Module\Module


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Methods instantiating Module objects were found in the Module class. They are moved in `ModuleRepository` before release.
| Type?         |  improvement
| Category?     | CO
| BC breaks?    | Nope, methods haven't been released yet.
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Page "module positions" still works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10273)
<!-- Reviewable:end -->
