### PR TITLE
Check minimal quantity

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -436,7 +436,7 @@ class CartControllerCore extends FrontController
         // Check minimal_quantity
         if (!$this->id_product_attribute) {
             if ($qty_to_check < $product->minimal_quantity) {
-                $this->{$ErrorKey}[] = $this->trans(
+                $this->errors[] = $this->trans(
                      'The minimum purchase order quantity for the product %product% is %quantity%.',
                      array('%product%' => $product->name, '%quantity%' => $product->minimal_quantity),
                      'Shop.Notifications.Error'
@@ -447,7 +447,7 @@ class CartControllerCore extends FrontController
         } else {
             $combination = new Combination($this->id_product_attribute);
             if ($qty_to_check < $combination->minimal_quantity) {
-                $this->{$ErrorKey}[] = $this->trans(
+                $this->errors[] = $this->trans(
                      'The minimum purchase order quantity for the product %product% is %quantity%.',
                      array('%product%' => $product->name, '%quantity%' => $combination->minimal_quantity),
                      'Shop.Notifications.Error'

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -432,6 +432,35 @@ class CartControllerCore extends FrontController
                 'Shop.Notifications.Error'
             );
         }
+        
+        // Check minimal_quantity
+        if(!$this->id_product_attribute){
+            if($qty_to_check < $product->minimal_quantity){
+                 array_push(
+                     $this->{$ErrorKey},
+                     $this->trans(
+                         'The minimum purchase order quantity for the product %product% is %quantity%.',
+                         array('%product%' => $product->name, '%quantity%' => $product->minimal_quantity),
+                         'Shop.Notifications.Error'
+                     )
+                 );
+                 return;
+            }
+        }
+        else{
+             $combination = new Combination($this->id_product_attribute);
+             if($qty_to_check < $combination->minimal_quantity){
+                 array_push(
+                     $this->{$ErrorKey},
+                     $this->trans(
+                         'The minimum purchase order quantity for the product %product% is %quantity%.',
+                         array('%product%' => $product->name, '%quantity%' => $combination->minimal_quantity),
+                         'Shop.Notifications.Error'
+                     )
+                 );
+                 return;
+            }
+        }
 
         // If no errors, process product addition
         if (!$this->errors) {

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -436,13 +436,10 @@ class CartControllerCore extends FrontController
         // Check minimal_quantity
         if(!$this->id_product_attribute){
             if($qty_to_check < $product->minimal_quantity){
-                 array_push(
-                     $this->{$ErrorKey},
-                     $this->trans(
-                         'The minimum purchase order quantity for the product %product% is %quantity%.',
-                         array('%product%' => $product->name, '%quantity%' => $product->minimal_quantity),
-                         'Shop.Notifications.Error'
-                     )
+                 $this->{$ErrorKey}[] = $this->trans(
+                     'The minimum purchase order quantity for the product %product% is %quantity%.',
+                     array('%product%' => $product->name, '%quantity%' => $product->minimal_quantity),
+                     'Shop.Notifications.Error'
                  );
                  return;
             }
@@ -450,13 +447,10 @@ class CartControllerCore extends FrontController
         else{
              $combination = new Combination($this->id_product_attribute);
              if($qty_to_check < $combination->minimal_quantity){
-                 array_push(
-                     $this->{$ErrorKey},
-                     $this->trans(
-                         'The minimum purchase order quantity for the product %product% is %quantity%.',
-                         array('%product%' => $product->name, '%quantity%' => $combination->minimal_quantity),
-                         'Shop.Notifications.Error'
-                     )
+                 $this->{$ErrorKey}[] = $this->trans(
+                     'The minimum purchase order quantity for the product %product% is %quantity%.',
+                     array('%product%' => $product->name, '%quantity%' => $combination->minimal_quantity),
+                     'Shop.Notifications.Error'
                  );
                  return;
             }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -432,27 +432,28 @@ class CartControllerCore extends FrontController
                 'Shop.Notifications.Error'
             );
         }
-        
+
         // Check minimal_quantity
-        if(!$this->id_product_attribute){
-            if($qty_to_check < $product->minimal_quantity){
-                 $this->{$ErrorKey}[] = $this->trans(
+        if (!$this->id_product_attribute) {
+            if ($qty_to_check < $product->minimal_quantity) {
+                $this->{$ErrorKey}[] = $this->trans(
                      'The minimum purchase order quantity for the product %product% is %quantity%.',
                      array('%product%' => $product->name, '%quantity%' => $product->minimal_quantity),
                      'Shop.Notifications.Error'
                  );
-                 return;
+
+                return;
             }
-        }
-        else{
-             $combination = new Combination($this->id_product_attribute);
-             if($qty_to_check < $combination->minimal_quantity){
-                 $this->{$ErrorKey}[] = $this->trans(
+        } else {
+            $combination = new Combination($this->id_product_attribute);
+            if ($qty_to_check < $combination->minimal_quantity) {
+                $this->{$ErrorKey}[] = $this->trans(
                      'The minimum purchase order quantity for the product %product% is %quantity%.',
                      array('%product%' => $product->name, '%quantity%' => $combination->minimal_quantity),
                      'Shop.Notifications.Error'
                  );
-                 return;
+
+                return;
             }
         }
 


### PR DESCRIPTION
Solve #10162. After the product is added to the cart, it will return an error if the customer tries to decrease the product quantity below the minimal_quantity (for the product or combination).

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | issue #10162 from github
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10162.
| How to test?  | As indicated in the issue, Have a product (or combination) with minimal_quantity > 1. Add to cart the minimal_quantity. With this fix, when you try to remove below the minimal_quantity it will display/return an error message.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10279)
<!-- Reviewable:end -->
