### PR TITLE
Display the company name in outstanding orders

### DIFF
--- a/controllers/admin/AdminOutstandingController.php
+++ b/controllers/admin/AdminOutstandingController.php
@@ -43,6 +43,7 @@ class AdminOutstandingControllerCore extends AdminController
 		CONCAT(LEFT(c.`firstname`, 1), \'. \', c.`lastname`) AS `customer`,
 		c.`outstanding_allow_amount`,
 		r.`color`,
+		c.`company`,
 		rl.`name` AS `risk`';
         $this->_join = 'LEFT JOIN `' . _DB_PREFIX_ . 'orders` o ON (o.`id_order` = a.`id_order`)
 		LEFT JOIN `' . _DB_PREFIX_ . 'customer` c ON (c.`id_customer` = o.`id_customer`)


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | On the "Outstanding" (placed under customers) the "Company" information is missing.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9875
| How to test?  | Enable B2B mode, set the company name of users, BO > Customers > Outstanding and check if the company name appears in the outstanding list.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10295)
<!-- Reviewable:end -->
