### PR TITLE
Init Kernel when possible during installation process

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -420,27 +420,27 @@ class AdminControllerCore extends Controller
             $this->multishop_context = Shop::CONTEXT_ALL | Shop::CONTEXT_GROUP | Shop::CONTEXT_SHOP;
         }
 
-        if (defined('_PS_BO_DEFAULT_THEME_') && _PS_BO_DEFAULT_THEME_
-            && @filemtime(_PS_BO_ALL_THEMES_DIR_ . _PS_BO_DEFAULT_THEME_ . DIRECTORY_SEPARATOR . 'template')) {
-            $default_theme_name = _PS_BO_DEFAULT_THEME_;
-        }
-
-        $this->bo_theme = $default_theme_name;
-
-        if (!@filemtime(_PS_BO_ALL_THEMES_DIR_ . $this->bo_theme . DIRECTORY_SEPARATOR . 'template')) {
-            $this->bo_theme = 'default';
-        }
-
-        $this->bo_css = ((Validate::isLoadedObject($this->context->employee)
-            && $this->context->employee->bo_css) ? $this->context->employee->bo_css : 'theme.css');
-
-        $adminThemeCSSFile = _PS_BO_ALL_THEMES_DIR_ . $this->bo_theme . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR . $this->bo_css;
-
-        if (file_exists($adminThemeCSSFile)) {
-            $this->bo_css = 'theme.css';
-        }
-
         if (defined('_PS_BO_ALL_THEMES_DIR_')) {
+            if (defined('_PS_BO_DEFAULT_THEME_') && _PS_BO_DEFAULT_THEME_
+                && @filemtime(_PS_BO_ALL_THEMES_DIR_ . _PS_BO_DEFAULT_THEME_ . DIRECTORY_SEPARATOR . 'template')) {
+                $default_theme_name = _PS_BO_DEFAULT_THEME_;
+            }
+
+            $this->bo_theme = $default_theme_name;
+
+            if (!@filemtime(_PS_BO_ALL_THEMES_DIR_ . $this->bo_theme . DIRECTORY_SEPARATOR . 'template')) {
+                $this->bo_theme = 'default';
+            }
+
+            $this->bo_css = ((Validate::isLoadedObject($this->context->employee)
+                && $this->context->employee->bo_css) ? $this->context->employee->bo_css : 'theme.css');
+
+            $adminThemeCSSFile = _PS_BO_ALL_THEMES_DIR_ . $this->bo_theme . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR . $this->bo_css;
+
+            if (file_exists($adminThemeCSSFile)) {
+                $this->bo_css = 'theme.css';
+            }
+
             $this->context->smarty->setTemplateDir(array(
                 _PS_BO_ALL_THEMES_DIR_ . $this->bo_theme . DIRECTORY_SEPARATOR . 'template',
                 _PS_OVERRIDE_DIR_ . 'controllers' . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'templates',

--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,8 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
         ],
         "create-test-db": [
-            "@php ./tests/create-test-db.php"
+            "@php ./tests/create-test-db.php",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache"
         ],
         "test-all": [
             "composer phpunit-legacy",

--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
         ],
         "create-test-db": [
-            "Tests\\PrestaShopBundle\\Utils\\DatabaseCreator::createTestDB"
+            "@php ./tests/create-test-db.php"
         ],
         "test-all": [
             "composer phpunit-legacy",

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -82,6 +82,10 @@ require_once _PS_CORE_DIR_.'/config/defines.inc.php';
 require_once _PS_CORE_DIR_.'/config/autoload.php';
 if (file_exists(_PS_CORE_DIR_.'/app/config/parameters.php')) {
     require_once _PS_CORE_DIR_.'/config/bootstrap.php';
+
+    $kernel = new AppKernel(_PS_MODE_DEV_ ? 'dev' : 'prod', _PS_MODE_DEV_);
+    $kernel->loadClassCache();
+    $kernel->boot();
 }
 require_once _PS_CORE_DIR_.'/config/defines_uri.inc.php';
 

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -83,7 +83,12 @@ require_once _PS_CORE_DIR_.'/config/autoload.php';
 if (file_exists(_PS_CORE_DIR_.'/app/config/parameters.php')) {
     require_once _PS_CORE_DIR_.'/config/bootstrap.php';
 
-    $kernel = new AppKernel(_PS_MODE_DEV_ ? 'dev' : 'prod', _PS_MODE_DEV_);
+    if (defined('_PS_IN_TEST_') && _PS_IN_TEST_) {
+        $env = 'test';
+    } else {
+        $env = _PS_MODE_DEV_ ? 'dev' : 'prod';
+    }
+    $kernel = new AppKernel($env, _PS_MODE_DEV_);
     $kernel->loadClassCache();
     $kernel->boot();
 }

--- a/src/PrestaShopBundle/Service/Database/Upgrade.php
+++ b/src/PrestaShopBundle/Service/Database/Upgrade.php
@@ -39,8 +39,6 @@ class Upgrade extends AbstractCommand
         $command = new UpdateSchemaCommand();
         $this->application->add($command);
 
-        $this->addCacheClear();
-
         $this->commands[] = array(
             'command' => 'prestashop:schema:update-without-foreign',
         );

--- a/tests/create-test-db.php
+++ b/tests/create-test-db.php
@@ -1,0 +1,6 @@
+#!/usr/bin/env php
+<?php
+
+require_once(__DIR__ . '/PrestaShopBundle/Utils/DatabaseCreator.php');
+
+\Tests\PrestaShopBundle\Utils\DatabaseCreator::createTestDB();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Taken from @PierreRambaud's work. https://github.com/PrestaShop/PrestaShop/commit/9a7142d79be6827926af5777ac0a941cb1216394. Allow the Symfony container to be available during the installation as soon as the parameters file is created.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/10062
| How to test?  | Retrieve the module [ps_mbo v1.0.7](https://github.com/PrestaShop/ps_mbo/releases/tag/v1.0.7), unzip it in the modules folder, and update the code to make it installed with the shop.

## Installing a module natively

Add the technical module name in this list:
https://github.com/PrestaShop/PrestaShop/blob/d6723d8272b02989d0b2939479635bd8535bfe1f/src/PrestaShopBundle/Install/Install.php#L879-L933

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10296)
<!-- Reviewable:end -->
