### PR TITLE
Fix a bug when you try to update a carrier range.

### DIFF
--- a/classes/range/RangePrice.php
+++ b/classes/range/RangePrice.php
@@ -100,8 +100,13 @@ class RangePriceCore extends ObjectModel
 
     public static function rangeExist($id_carrier, $delimiter1, $delimiter2, $id_reference = null)
     {
+        return (bool) RangePrice::getRangeIdByDelimiter($id_carrier, $delimiter1, $delimiter2, $id_reference);
+    }
+
+    public static function getRangeIdByDelimiter($id_carrier, $delimiter1, $delimiter2, $id_reference = null)
+    {
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
-            SELECT count(*)
+            SELECT rp.id_range_price
             FROM `' . _DB_PREFIX_ . 'range_price` rp' .
             (is_null($id_carrier) && $id_reference ? '
             INNER JOIN `' . _DB_PREFIX_ . 'carrier` c on (rp.`id_carrier` = c.`id_carrier`)' : '') . '

--- a/classes/range/RangeWeight.php
+++ b/classes/range/RangeWeight.php
@@ -100,8 +100,13 @@ class RangeWeightCore extends ObjectModel
 
     public static function rangeExist($id_carrier, $delimiter1, $delimiter2, $id_reference = null)
     {
+        return (bool) RangeWeight::getRangeIdByDelimiter($id_carrier, $delimiter1, $delimiter2, $id_reference);
+    }
+
+    public static function getRangeIdByDelimiter($id_carrier, $delimiter1, $delimiter2, $id_reference = null)
+    {
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
-            SELECT count(*)
+            SELECT rw.id_range_weight
             FROM `' . _DB_PREFIX_ . 'range_weight` rw' .
             (is_null($id_carrier) && $id_reference ? '
             INNER JOIN `' . _DB_PREFIX_ . 'carrier` c on (rw.`id_carrier` = c.`id_carrier`)' : '') . '

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -694,10 +694,12 @@ class AdminCarrierWizardControllerCore extends AdminController
                 }
                 $add_range = true;
                 if ($range_type == Carrier::SHIPPING_METHOD_WEIGHT) {
-                    if (!RangeWeight::rangeExist(null, (float) $delimiter1, (float) $range_sup[$key], $carrier->id_reference)) {
+                    $id_range_weight = RangeWeight::getRangeIdByDelimiter(null, (float) $delimiter1, (float) $range_sup[$key], $carrier->id_reference);
+
+                    if (!$id_range_weight) {
                         $range = new RangeWeight();
                     } else {
-                        $range = new RangeWeight((int) $key);
+                        $range = new RangeWeight((int) $id_range_weight);
                         $range->id_carrier = (int) $carrier->id;
                         $range->save();
                         $add_range = false;
@@ -705,10 +707,12 @@ class AdminCarrierWizardControllerCore extends AdminController
                 }
 
                 if ($range_type == Carrier::SHIPPING_METHOD_PRICE) {
-                    if (!RangePrice::rangeExist(null, (float) $delimiter1, (float) $range_sup[$key], $carrier->id_reference)) {
+                    $id_range_price = RangePrice::getRangeIdByDelimiter(null, (float) $delimiter1, (float) $range_sup[$key], $carrier->id_reference);
+
+                    if (!$id_range_price) {
                         $range = new RangePrice();
                     } else {
-                        $range = new RangePrice((int) $key);
+                        $range = new RangePrice((int) $id_range_price);
                         $range->id_carrier = (int) $carrier->id;
                         $range->save();
                         $add_range = false;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you try to update a range and the delimiters existed previously, on a carrier with the same id_reference, the range is not updated and the carrier keeps the current ranges. <br><br> Now, instead of only checking if a range exists, we get the id of the range with the provided delimiters. The id of the range is used to load the range object and assign to it the id of the updated carrier .<br><br> This bug is in version 1.6.x too.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Enter the backoffice and edit a carrier usign the carrier wizard. Go to the step where you can configure the carrier ranges, change the range delimiter values and save the changes. <br><br> Then edit the same carrier and edit again the range delimiters, but use the, for the delimiters, the values that the range had before you updated the previous time. <br><br> Example: you edit a carrier that has a price range from 0€ to 10€, you edit this range to go from 0€ to 11€ and saves the changes. Then edit the same carrier and configure the price range to go from 0€ to 10€, like before the update. <br><br> Without the changes from this commit, the range delimiters are not updated. This change makes possible to update the range delimiters to a previously used values.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10327)
<!-- Reviewable:end -->
