### PR TITLE
Remove hard-coded-version in assets URL

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -13,7 +13,7 @@ parameters:
 
 framework:
     assets:
-        version: '1.7.0'
+        version: !php/const \AppKernel::VERSION
 
     #esi:             ~
     secret:          "%secret%"


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We remove an hardcoded version in the assets URL, which prevent the new files to be loaded after an upgrade.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/10330
| How to test?  | Go to a Symfony related page, and check the assets in the browser developper tools, network tab. You should get the current PS version in the URL

![capture du 2018-09-07 11-21-29](https://user-images.githubusercontent.com/6768917/45213709-37713180-b290-11e8-81a2-7abc9ae08423.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10337)
<!-- Reviewable:end -->
