### PR TITLE
Fix htaccess to support Apache 2.4 webservers

### DIFF
--- a/translations/cldr/.htaccess
+++ b/translations/cldr/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-Allow from all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Allow from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all granted
+</IfModule>


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This file was not updated to support Apache 2.4 webservers, causing resources in /translations/cldr/ being refused because of updated parent .htaccess
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Try accessing "http://fo.demo.prestashop.com/translations/cldr/datas/main/en-GB/currencies.json" from your own demo website, you will see 403 forbidden - but those resources should be accessed by backoffice like in previous PS versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10347)
<!-- Reviewable:end -->
