### PR TITLE
Fix empty row when social title is empty

### DIFF
--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -98,7 +98,7 @@ class CustomerFormatterCore implements FormFormatterInterface
 
         $genders = Gender::getGenders($this->language->id);
         if ($genders->count() > 0) {
-            $genderField = (new FormField)
+            $genderField = (new FormField())
                 ->setName('id_gender')
                 ->setType('radio-buttons')
                 ->setLabel(

--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -96,19 +96,22 @@ class CustomerFormatterCore implements FormFormatterInterface
             ->setType('hidden')
         ;
 
-        $genderField = (new FormField())
-            ->setName('id_gender')
-            ->setType('radio-buttons')
-            ->setLabel(
-                $this->translator->trans(
-                    'Social title', [], 'Shop.Forms.Labels'
+        $genders = Gender::getGenders($this->language->id);
+        if ($genders->count() > 0) {
+            $genderField = (new FormField)
+                ->setName('id_gender')
+                ->setType('radio-buttons')
+                ->setLabel(
+                    $this->translator->trans(
+                        'Social title', [], 'Shop.Forms.Labels'
+                    )
                 )
-            )
-        ;
-        foreach (Gender::getGenders($this->language->id) as $gender) {
-            $genderField->addAvailableValue($gender->id, $gender->name);
+            ;
+            foreach ($genders as $gender) {
+                $genderField->addAvailableValue($gender->id, $gender->name);
+            }
+            $format[$genderField->getName()] = $genderField;
         }
-        $format[$genderField->getName()] = $genderField;
 
         $format['firstname'] = (new FormField())
             ->setName('firstname')


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you do not have any social titles on your shop, you will have a empty line on FO. This PR fix this.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | ?
| How to test?  | Delete all social titles in BO and try to create a customer in FO.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10350)
<!-- Reviewable:end -->
