### PR TITLE
Update list and settings layout

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
@@ -25,7 +25,7 @@
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block email_configuration %}
-  <div class="col-xl-10">
+  <div class="col-12">
     <div class="card">
       <h3 class="card-header">
         <i class="material-icons">mail</i> {{ 'Email'|trans({}, 'Admin.Global') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig
@@ -25,7 +25,7 @@
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block smtp_configuration %}
-  <div class="col-xl-10">
+  <div class="col-12">
     <div class="card js-smtp-configuration {% if emailConfigurationForm.email_config.mail_method.vars.value != smtpMailMethod %}d-none{% endif %}">
       <h3 class="card-header">
         <i class="material-icons">settings</i> {{ 'Email'|trans({}, 'Admin.Global') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig
@@ -27,7 +27,7 @@
 {% block test_email_sending %}
   {{ form_start(testEmailSendingForm, {'action': path('admin_send_test_email')}) }}
   <div class="row justify-content-center">
-    <div class="col-xl-10">
+    <div class="col-12">
       <div class="card">
         <h3 class="card-header">
           <i class="material-icons">settings</i> {{ 'Test your email configuration'|trans }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig
@@ -27,7 +27,7 @@
 {% block test_email_sending %}
   {{ form_start(testEmailSendingForm, {'action': path('admin_send_test_email')}) }}
   <div class="row justify-content-center">
-    <div class="col-12">
+    <div class="col">
       <div class="card">
         <h3 class="card-header">
           <i class="material-icons">settings</i> {{ 'Test your email configuration'|trans }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig
@@ -44,7 +44,7 @@
   {% block logs_by_mail %}
     {{ form_start(logsByEmailForm, {'action': path('admin_logs_save')}) }}
     <div class="row justify-content-center">
-      <div class="col-xl-10">
+      <div class="col-12">
         <div class="card">
           <h3 class="card-header">
             <i class="material-icons">business_center</i> {{ 'Logs by email'|trans }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig
@@ -44,7 +44,7 @@
   {% block logs_by_mail %}
     {{ form_start(logsByEmailForm, {'action': path('admin_logs_save')}) }}
     <div class="row justify-content-center">
-      <div class="col-12">
+      <div class="col">
         <div class="card">
           <h3 class="card-header">
             <i class="material-icons">business_center</i> {{ 'Logs by email'|trans }}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When list and settings are in the same page, then settings block width should be the same as list.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | "Advanced parameters > Email" and "Advanced parameters > Logs" pages where updated so configuration forms have the same width as lists.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10358)
<!-- Reviewable:end -->
