### PR TITLE
Fix undefined method in query parser

### DIFF
--- a/src/Core/Grid/Query/DoctrineQueryParser.php
+++ b/src/Core/Grid/Query/DoctrineQueryParser.php
@@ -98,7 +98,7 @@ final class DoctrineQueryParser implements QueryParserInterface
      */
     private function parseNumericParameter($value)
     {
-        return "'".$value."'";
+        return "'" . $value . "'";
     }
 
     /**

--- a/src/Core/Grid/Query/DoctrineQueryParser.php
+++ b/src/Core/Grid/Query/DoctrineQueryParser.php
@@ -92,6 +92,16 @@ final class DoctrineQueryParser implements QueryParserInterface
     }
 
     /**
+     * @param int|float $value
+     *
+     * @return string
+     */
+    private function parseNumericParameter($value)
+    {
+        return "'".$value."'";
+    }
+
+    /**
      * @param array $value
      *
      * @return string

--- a/src/Core/Grid/Query/DoctrineQueryParser.php
+++ b/src/Core/Grid/Query/DoctrineQueryParser.php
@@ -94,11 +94,11 @@ final class DoctrineQueryParser implements QueryParserInterface
     /**
      * @param int|float $value
      *
-     * @return string
+     * @return int|float
      */
     private function parseNumericParameter($value)
     {
-        return "'" . $value . "'";
+        return $value;
     }
 
     /**

--- a/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
+++ b/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
@@ -158,4 +158,25 @@ class DoctrineQueryParserTest extends TestCase
 
         $this->queryParser->parse($preparedQuery, $queryParameters);
     }
+
+    public function testParseWithNumericNamedParameters()
+    {
+        $preparedQuery = 'SELECT * FROM product WHERE id_product = :id_product';
+        $queryParameters = [
+            'id_product' => 2,
+        ];
+
+        $expectedQuery = "SELECT * FROM product WHERE id_product = '2'";
+
+        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+
+        $preparedQuery = 'SELECT * FROM product WHERE price = :price';
+        $queryParameters = [
+            'price' => 3.99,
+        ];
+
+        $expectedQuery = "SELECT * FROM product WHERE price = '3.99'";
+
+        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+    }
 }

--- a/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
+++ b/tests/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
@@ -166,7 +166,7 @@ class DoctrineQueryParserTest extends TestCase
             'id_product' => 2,
         ];
 
-        $expectedQuery = "SELECT * FROM product WHERE id_product = '2'";
+        $expectedQuery = "SELECT * FROM product WHERE id_product = 2";
 
         $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
 
@@ -175,7 +175,7 @@ class DoctrineQueryParserTest extends TestCase
             'price' => 3.99,
         ];
 
-        $expectedQuery = "SELECT * FROM product WHERE price = '3.99'";
+        $expectedQuery = "SELECT * FROM product WHERE price = 3.99";
 
         $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | `parseNumericParameter` was left used but undefined, this PR fixes it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Tests where updated and build should pass

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10363)
<!-- Reviewable:end -->
