### PR TITLE
Property Address->id_country is empty

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -220,6 +220,10 @@ class AddressCore extends ObjectModel
             Customer::resetAddressCache($this->id_customer, $this->id);
         }
 
+        if (empty($this->id)) {
+            return true;
+        }
+        
         if (!$this->isUsed()) {
             return parent::delete();
         } else {

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -220,10 +220,6 @@ class AddressCore extends ObjectModel
             Customer::resetAddressCache($this->id_customer, $this->id);
         }
 
-        if (empty($this->id)) {
-            return true;
-        }
-
         if (!$this->isUsed()) {
             return parent::delete();
         } else {

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -223,7 +223,7 @@ class AddressCore extends ObjectModel
         if (empty($this->id)) {
             return true;
         }
-        
+
         if (!$this->isUsed()) {
             return parent::delete();
         } else {

--- a/classes/form/CustomerAddressPersister.php
+++ b/classes/form/CustomerAddressPersister.php
@@ -63,6 +63,7 @@ class CustomerAddressPersisterCore
         }
 
         $address->id_customer = $this->customer->id;
+        $address->save();
 
         if ($address->isUsed()) {
             $old_address = new Address($address->id);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When trying to delete old address called from CustomerAddressPersister.php:73 "return $address->save() && $old_address->delete();" Fatal error is thrown about id_country being empty. This is because old address does not exists and at the same time prestashop tries to validate it and update it and then throws error. At this case if ID is empty means records is not present on database and shouldnt be updated nor deleted. And there is a another bug that isUsed() returns true on non persisted address record. But in any way if ID is empty no further actions should be performed.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Maybe #9812
| How to test?  | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Repost of https://github.com/PrestaShop/PrestaShop/pull/9266

Credit to @vytsci

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10373)
<!-- Reviewable:end -->
