### PR TITLE
Fix category tree in BO Products Catalog page

### DIFF
--- a/admin-dev/themes/default/js/bundle/category-tree.js
+++ b/admin-dev/themes/default/js/bundle/category-tree.js
@@ -38,11 +38,11 @@
           break;
         case 'unfold':
           this.find('ul').show();
-          this.find('li').has('ul').addClass('less');
+          this.find('li').has('ul').removeClass('more').addClass('less');
           break;
         case 'fold':
           this.find('ul ul').hide();
-          this.find('li').has('ul').addClass('more');
+          this.find('li').has('ul').removeClass('less').addClass('more');
           break;
         default:
           throw 'Unknown method';
@@ -64,9 +64,9 @@
 
           $ui.next('ul').toggle();
           if ($ui.next('ul').is(':visible')) {
-            $ui.parent('li').removeClass().addClass('less');
+            $ui.parent('li').removeClass('more').addClass('less');
           } else {
-            $ui.parent('li').removeClass().addClass('more');
+            $ui.parent('li').removeClass('less').addClass('more');
           }
 
           return false;
@@ -77,9 +77,9 @@
         $inputWrapper.find('label').on('click', clickHandler);
 
         if ($(item).is(':visible')) {
-          $(item).parent('li').removeClass().addClass('less');
+          $(item).parent('li').removeClass('more').addClass('less');
         } else {
-          $(item).parent('li').removeClass().addClass('more');
+          $(item).parent('li').removeClass('less').addClass('more');
         }
       });
     }

--- a/admin-dev/themes/default/js/bundle/product/catalog.js
+++ b/admin-dev/themes/default/js/bundle/product/catalog.js
@@ -148,17 +148,17 @@ function updateFilterMenu() {
 }
 
 function productCategoryFilterReset(div) {
-	$('#choice_tree').categorytree('unselect');
+	$('#product_categories').categorytree('unselect');
 	$('#product_catalog_list input[name="filter_category"]').val('');
 	$('#product_catalog_list').submit();
 }
 
 function productCategoryFilterExpand(div, btn) {
-	$('#choice_tree').categorytree('unfold');
+	$('#product_categories').categorytree('unfold');
 }
 
 function productCategoryFilterCollapse(div, btn) {
-	$('#choice_tree').categorytree('fold');
+	$('#product_categories').categorytree('fold');
 }
 
 function categoryFilterButtons() {

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCategories.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCategories.php
@@ -74,6 +74,7 @@ class ProductCategories extends TranslatorAwareType
             'list' => $this->categoryProvider->getNestedCategories(null, $this->languageId, false),
             'valid_list' => [],
             'multiple' => false,
+            'expanded' => false,
         ));
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
@@ -46,6 +46,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
     {
         $view->vars['choices'] = $options['list'];
         $view->vars['multiple'] = $options['multiple'];
+        $view->vars['expanded'] = $options['expanded'];
 
         //if form is submitted, inject categories values array to check or not each field
         if (!empty($view->vars['value']) && !empty($view->vars['value']['tree'])) {
@@ -80,6 +81,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
             'list' => [],
             'valid_list' => [],
             'multiple' => true,
+            'expanded' => true,
         ]);
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Themes/categories_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Themes/categories_theme.html.twig
@@ -25,11 +25,13 @@
 {% block choice_tree_widget -%}
   <div {{ block('widget_container_attributes') }}>
     <ul class="category-tree">
+
       {%- for child in choices %}
         {{ block('choice_tree_item_widget') }}
       {% endfor -%}
     </ul>
   </div>
+
 {%- endblock choice_tree_widget %}
 
 {% block choice_tree_item_widget -%}
@@ -39,16 +41,16 @@
     <div class="radio">
       <label class="category-label" for="form[{{ form.vars.id }}][tree]">{{ child.name }}
         <input
-          type="radio"
-          name="form[{{ form.vars.id }}][tree]"
-          value="{{ child.id_category }}" {{ checked }}
-          class="category float-right"
+            type="radio"
+            name="form[{{ form.vars.id }}][tree]"
+            value="{{ child.id_category }}" {{ checked }}
+            class="category float-right"
         >
       </label>
     </div>
 
     {% if child.children is defined %}
-      <ul>
+      <ul {% if (form.vars.expanded == false) %}style="display: none"{% endif %}>
         {% for item in child.children %}
           {% set child = item %}
           {{ block('choice_tree_item_widget') }}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Category filtrers tree on BO Catalog Products page was broken: buttons "collapse"
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/10321
| How to test?  | See fixed issue for bug description. This PR should fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10375)
<!-- Reviewable:end -->
