### PR TITLE
Handle validation for boolean returns of SQLParser

### DIFF
--- a/src/Adapter/SqlManager/SqlQueryValidator.php
+++ b/src/Adapter/SqlManager/SqlQueryValidator.php
@@ -113,11 +113,11 @@ class SqlQueryValidator
     /**
      * Get SQL error for "FROM" keyword validation.
      *
-     * @param array $legacyError
+     * @param array|bool $legacyError
      *
      * @return array
      */
-    private function getFromKeywordError(array $legacyError)
+    private function getFromKeywordError($legacyError)
     {
         if (isset($legacyError['table'])) {
             return [


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Avoid SqlQueryValidator crash (fatal error) if SQL Parser returns a boolean error instead of an array
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Follow https://github.com/PrestaShop/PrestaShop/issues/10316 behavior and see that the "symfony error" page does not show anymore, instead user has a nice error message and can keep working.

This eases behavior of issue https://github.com/PrestaShop/PrestaShop/issues/10316.
It does not fix it but at least user has an error message instead of a 500 error page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10380)
<!-- Reviewable:end -->
