### PR TITLE
Delivery price cannot be defined by shop

### DIFF
--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -43,7 +43,7 @@ class AdminCarrierWizardControllerCore extends AdminController
         $this->step_number = 0;
         $this->type_context = Shop::getContext();
         $this->old_context = Context::getContext();
-        $this->multishop_context = Shop::CONTEXT_ALL;
+        
         $this->context = Context::getContext();
 
         $this->fieldImageSettings = array(

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -43,7 +43,6 @@ class AdminCarrierWizardControllerCore extends AdminController
         $this->step_number = 0;
         $this->type_context = Shop::getContext();
         $this->old_context = Context::getContext();
-        
         $this->context = Context::getContext();
 
         $this->fieldImageSettings = array(


### PR DESCRIPTION
The context was forced to "All shops" with this : $this->multishop_context = Shop::CONTEXT_ALL;
I've tried to remove this and it works fine : you can define a delivery price for a specific shop. I've tested on front side and the correct price is applied.
This fix need to be more intensively tested.


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In multishop context, it's impossible to configure a delivery price for a specific shop. The context is forced to "All shops".
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10383
| How to test?  | Select a shop in multoshop context<br/>Go to the add carrier wizard<br/>The shop dropdown is locked to "All shops"<br/>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10384)
<!-- Reviewable:end -->
