### PR TITLE
BO: Right side block of attribute and attribute groups in combination tab not appears.

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -543,7 +543,7 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         $doctrine = $this->getDoctrine()->getManager();
-        $attributeGroups = $doctrine->getRepository('PrestaShopBundle:Attribute')->findByLangAndShop(1, 1);
+        $attributeGroups = $doctrine->getRepository('PrestaShopBundle:Attribute')->findByLangAndShop((int)$languages[0]['id_lang'],(int)['shop_id']);
 
         $drawerModules = (new HookFinder())->setHookName('displayProductPageDrawer')
             ->setParams(['product' => $product])

--- a/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
@@ -52,7 +52,7 @@ class ProductImageController extends FrameworkBundleAdminController
         $adminProductWrapper = $this->get('prestashop.adapter.admin.wrapper.product');
         $return_data = [];
 
-        if ($idProduct == 0 || !$request->isXmlHttpRequest()) {
+        if ($idProduct == 1 || !$request->isXmlHttpRequest()) {
             return $response;
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
@@ -52,7 +52,7 @@ class ProductImageController extends FrameworkBundleAdminController
         $adminProductWrapper = $this->get('prestashop.adapter.admin.wrapper.product');
         $return_data = [];
 
-        if ($idProduct == 1 || !$request->isXmlHttpRequest()) {
+        if ($idProduct == 0 || !$request->isXmlHttpRequest()) {
             return $response;
         }
 


### PR DESCRIPTION
develop
In multi-shop and multi-language, Right side block of attribute and attribute groups in combination tab not appears.
bug fix
BO
no
no
https://github.com/PrestaShop/PrestaShop/issues/10377
Check the back-office right side block in combination tab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10390)
<!-- Reviewable:end -->
