### PR TITLE
Fix ObjectModel namespace handling

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -463,7 +463,7 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
 
         // @hook actionObject*AddBefore
         Hook::exec('actionObjectAddBefore', array('object' => $this));
-        Hook::exec('actionObject'.get_class($this).'AddBefore', array('object' => $this));
+        Hook::exec('actionObject' . $this->getFullyQualifiedName() . 'AddBefore', array('object' => $this));
 
         // Automatically fill dates
         if ($auto_date && property_exists($this, 'date_add')) {
@@ -534,9 +534,15 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
 
         // @hook actionObject*AddAfter
         Hook::exec('actionObjectAddAfter', array('object' => $this));
-        Hook::exec('actionObject'.get_class($this).'AddAfter', array('object' => $this));
+        Hook::exec('actionObject' . $this->getFullyQualifiedName() . 'AddAfter', array('object' => $this));
 
         return $result;
+    }
+	
+	
+    private function getFullyQualifiedName()
+    {
+        return str_replace('\\', '', get_class($this));
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fix bug when a class extends ObjectModel and is namespaced (autoloading with composer). The add() method of the ObjectModel class does a "get_class" on the action hook Object add and when the child class uses a namespace, there is a problem with the class name containing specials caracters. This bug was fixed in Prestashop 1.7
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | See https://github.com/PrestaShop/PrestaShop/commit/d73d962d68f7355b8bbd4c518ad2950cac5ce04c#diff-3a9696437ae9aa19d7b202bbefbe87da

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10391)
<!-- Reviewable:end -->
