### PR TITLE
Change Javascript indent to 2 spaces, per AirBnb rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
     'html',
   ],
   rules: {
-    'indent': ['error', 4, {'SwitchCase': 1}],
+    'indent': ['error', 2, {'SwitchCase': 1}],
     'import/no-unresolved': 0,
     'no-use-before-define': 0,
     'function-paren-newline': ['off', 'never'],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The eslintrc file had the wrong indentation configuration, which was set to 4 spaces instead of 2. See [Coding standards](https://devdocs.prestashop.com/1.7/development/coding-standards/#javascript-code-conventions) and and [Whitespace](https://github.com/airbnb/javascript#whitespace--spaces).
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | This PR is about linting, no test required

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10419)
<!-- Reviewable:end -->
