### PR TITLE
Handle boolean returns from RequestSql validation

### DIFF
--- a/src/Adapter/SqlManager/SqlQueryValidator.php
+++ b/src/Adapter/SqlManager/SqlQueryValidator.php
@@ -84,6 +84,10 @@ class SqlQueryValidator
         $errors = [];
 
         foreach ($sqlErrors as $key => $sqlError) {
+            if (false === is_array($sqlError)) {
+                $sqlError = [];
+            }
+
             if ('checkedFrom' === $key) {
                 $errors[] = $this->getFromKeywordError($sqlError);
             } elseif ('checkedSelect' === $key) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Avoid SqlQueryValidator crash (fatal error) if SQL Parser returns a boolean error instead of an array
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Follow https://github.com/PrestaShop/PrestaShop/issues/10316 behavior and see that the "symfony error" page does not show anymore, instead user has a nice error message and can keep working.

This eases behavior of issue https://github.com/PrestaShop/PrestaShop/issues/10316.
It does not fix it but at least user has an error message instead of a 500 error page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10426)
<!-- Reviewable:end -->
