### PR TITLE
Get link of the first ACTIVE tab in nav

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2010,8 +2010,9 @@ class AdminControllerCore extends Controller
             $tabs[$index]['href'] = $this->context->link->getAdminLink($tab['class_name']);
             $tabs[$index]['sub_tabs'] = array_values($this->getTabs($tab['id_tab'], $level + 1));
 
-            if (isset($tabs[$index]['sub_tabs'][0])) {
-                $tabs[$index]['href'] = $tabs[$index]['sub_tabs'][0]['href'];
+            $subTabHref = $this->getTabLinkFromSubTabs($tabs[$index]['sub_tabs']);
+            if (!empty($subTabHref)) {
+                $tabs[$index]['href'] = $subTabHref;
             } elseif (0 == $tabs[$index]['id_parent'] && '' == $tabs[$index]['icon']) {
                 unset($tabs[$index]);
             } elseif (empty($tabs[$index]['icon'])) {
@@ -4712,5 +4713,23 @@ class AdminControllerCore extends Controller
         } else {
             return 0;
         }
+    }
+
+    /**
+     * Get the url of the first active sub-tab.
+     *
+     * @param array[] $subtabs
+     *
+     * @return string Url, or empty if no active sub-tab
+     */
+    private function getTabLinkFromSubTabs(array $subtabs)
+    {
+        foreach ($subtabs as $tab) {
+            if ($tab['active']) {
+                return $tab['href'];
+            }
+        }
+
+        return '';
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Back-office side menu always get the first sub-tab link, even if it is disabled. This leads to unwanted results, which makes a tab disabled but still accessible.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_mbo/issues/32
| How to test?  | Install ps_mbo. The link IMPROVE > Modules > Modules catalog must now target a module controller instead a disabled core controller. No need to reinstall the module when applying the PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10427)
<!-- Reviewable:end -->
