### PR TITLE
Fixes issue #10417 incorrect argument order

### DIFF
--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -267,7 +267,7 @@ class ManufacturerCore extends ObjectModel
         $idLang = is_null($idLang) ? Context::getContext()->language->id : (int) $idLang;
 
         $manufacturersList = array();
-        $manufacturers = Manufacturer::getManufacturers($idLang, true);
+        $manufacturers = Manufacturer::getManufacturers(false, $idLang);
         if ($manufacturers && count($manufacturers)) {
             foreach ($manufacturers as $manufacturer) {
                 if ($format === 'sitemap') {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The call to function getManufacturers had the arguments in the wrong order, meaning it would only ever work for lanugage with ID of 1. Also changed argument $getNbProducts from "true" to "false" as the resulting value is not used here.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10417 
| How to test?  | Check Manufacturer::getManufacturers() argument order

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10428)
<!-- Reviewable:end -->
