### PR TITLE
Removed onclick from URL column in BO Shop URLs

### DIFF
--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -66,6 +66,7 @@ class AdminShopUrlControllerCore extends AdminController
                 'title' => $this->trans('URL', array(), 'Admin.Global'),
                 'filter_key' => 'url',
                 'havingFilter' => true,
+                'remove_onclick' => true,
             ),
             'main' => array(
                 'title' => $this->trans('Is it the main URL?', array(), 'Admin.Advparameters.Feature'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Removed onclick from URL column in BO Shop URLs
| Type?         | bug fix / improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Visit the BO Admin Shop URLs page and click on a URL in the list.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10435)
<!-- Reviewable:end -->
