### PR TITLE
FO: You can now select a combination without stock when "Display unav…

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -993,12 +993,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     private function tryToGetAvailableIdProductAttribute($checkedIdProductAttribute)
     {
         if (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
-            $availableProductAttributes = array_filter(
-                $this->product->getAttributeCombinations(),
-                function ($elem) {
-                    return $elem['quantity'] > 0;
-                }
-            );
+            $availableProductAttributes = $this->product->getAttributeCombinations();
 
             $availableProductAttribute = array_filter(
                 $availableProductAttributes,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If "Display unavailable product attributes on the product page" in Product Settings page is set to "No" and "Behavior when out of stock" is set to "Allow orders" on a product. In this case the combination without stock cannot be selected if the other combinations are in stock. Actually it can be selected but the selection goes back to the first in stock combination. Version: PS1.7.4.2, warehouse theme.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9667
| How to test?  | 1. Set "Display unavailable product attributes on the product page" in Product Settings page is set to "No" <br/> 2. Create new product with combinations <br/> 3. set "Behavior when out of stock" to "Allow orders" <br/>4. set quantity on the first combination to 0, set the quantity of the second combination to 10. <br/>5. After it is fixed you are able to select combination 1.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10452)
<!-- Reviewable:end -->
