### PR TITLE
Fix wrong display of the brand page

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -489,8 +489,6 @@
 											</script>
 										{/if}
 									{/if}
-									<div class="input-group">
-									{if isset($input.maxchar) && $input.maxchar}</div>{/if}
 								{elseif $input.type == 'checkbox'}
 									{if isset($input.expand)}
 										<a class="btn btn-default show_checkbox{if strtolower($input.expand.default) == 'hide'} hidden{/if}" href="#">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | When we try to add a new brand, the description & the logo are not aligned.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no 
| Fixed ticket? | Fixes #10461
| How to test?  | Go to BO => Catalog => Brands page => Click on 'add a new brand'

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10462)
<!-- Reviewable:end -->
