### PR TITLE
Fixed bug on inc/dec product quantity in cart with vouchers  discounts

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1458,6 +1458,7 @@ class CartCore extends ObjectModel
         $context = Context::getContext()->cloneContext();
         $context->cart = $this;
         Cache::clean('getContextualValue_*');
+        CartRule::autoRemoveFromCart();
         if ($auto_add_cart_rule) {
             CartRule::autoAddToCart($context);
         }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Bug Fix on increase/decrease qty. Remain invalid vouchers.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Create a voucher (with voucher code empty) with 10% discount and priority 2. Create another voucher (with voucher code empty) with 15% discount and priority 1, with 2 units as minimal quantity. Create a backoffice order and add 1 product. 10% discount is applied (OK). Increase quantity. Voucher changes, 15% discount is applied (OK). Decrease quantity. Voucher remains, 15% discount is applied. It's wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/8528)
<!-- Reviewable:end -->