### PR TITLE
Added an Error Data Listener

### DIFF
--- a/tests-legacy/phpunit-admin.xml
+++ b/tests-legacy/phpunit-admin.xml
@@ -1,6 +1,9 @@
 <phpunit
   bootstrap="bootstrap-admin.php"
   processIsolation="false"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
 >
     <php>
         <env name="SYMFONY_ENV" value="test"/>
@@ -8,6 +11,10 @@
         <server name="KERNEL_CLASS" value="AppKernel" />
         <const name="_PS_IN_TEST_" value="1" />
     </php>
+    <listeners>
+        <listener class="Tests\TestCase\ErrorsDataListener" />
+        <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+    </listeners>
     <groups>
       <include>
         <group>admin</group>

--- a/tests-legacy/phpunit.xml
+++ b/tests-legacy/phpunit.xml
@@ -1,6 +1,9 @@
 <phpunit bootstrap="bootstrap.php"
          color="true"
          stopOnFailure="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
 >
     <php>
         <server name="KERNEL_CLASS" value="AppKernel" />
@@ -8,6 +11,7 @@
         <env name="kernel.environment" value="test" />
     </php>
     <listeners>
+        <listener class="Tests\TestCase\ErrorsDataListener" />
         <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
     </listeners>
     <groups>

--- a/tests-legacy/sf-tests.xml
+++ b/tests-legacy/sf-tests.xml
@@ -6,13 +6,19 @@
   colors                      = "true"
   processIsolation            = "true"
   bootstrap                   = "bootstrap-sf.php"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
 >
   <php>
     <server name="KERNEL_CLASS" value="AppKernel" />
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
     <const name="_PS_IN_TEST_" value="1" />
   </php>
-
+  <listeners>
+    <listener class="Tests\TestCase\ErrorsDataListener" />
+    <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+  </listeners>
   <groups>
     <exclude>
       <group>controller</group>

--- a/tests/TestCase/ErrorsDataListener.php
+++ b/tests/TestCase/ErrorsDataListener.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\TestCase;
+
+use PHPUnit\Framework\BaseTestListener;
+use PHPUnit_Framework_TestSuite;
+
+class ErrorsDataListener extends BaseTestListener
+{
+    /**
+     * @var PhpErrorsCounter a dedicated error handler.
+     */
+    private $errorsCounter;
+
+    /**
+     * @var bool error handler is registered
+     */
+    private $isRegistered = false;
+
+    /**
+     * Internal tracking for test suites.
+     *
+     * Increments as more suites are run, then decremented as they finish. All
+     * suites have been run when returns to 0.
+     */
+    protected $suites = 0;
+
+    public function __construct()
+    {
+        $this->errorsCounter = new PhpErrorsCounter();
+    }
+
+    public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
+    {
+        $this->suites++;
+        if (!$this->isRegistered) {
+            $this->errorsCounter->registerErrorHandler();
+            $this->isRegistered = true;
+        }
+    }
+
+    public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
+    {
+        $this->suites--;
+
+        if ($this->suites === 0) {
+            printf(PHP_EOL . PHP_EOL . 'Current report of phpErrorsHandler:');
+            printf(PHP_EOL . $this->errorsCounter->displaySummary() . PHP_EOL);
+            $this->errorsCounter->restoreErrorHandler();
+        }
+    }
+}

--- a/tests/TestCase/PhpErrorsCounter.php
+++ b/tests/TestCase/PhpErrorsCounter.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\TestCase;
+
+class PhpErrorsCounter
+{
+    private $notices = 0;
+    private $warnings = 0;
+    private $errors = 0;
+    private $deprecations = 0;
+
+    /**
+     * This error handler allow us to count every errors
+     * in our test suite. Once we will have fixed all we will
+     * enable the error handler of PHPUnit that convert errors to exceptions.
+     */
+    public function registerErrorHandler()
+    {
+        set_error_handler(function ($errorType) {
+            switch($errorType) {
+                case E_WARNING:
+                    $this->warnings++;
+                break;
+                case E_DEPRECATED:
+                case E_USER_DEPRECATED:
+                    $this->deprecations++;
+                break;
+                case E_ERROR:
+                    $this->errors++;
+                break;
+                case E_NOTICE:
+                    $this->notices++;
+                break;
+                default:
+                    // nothing to do.
+            }
+        }, E_ALL);
+    }
+
+    public function restoreErrorHandler()
+    {
+        restore_error_handler();
+    }
+
+    /**
+     * @return int the number of notices
+     */
+    public function getNotices()
+    {
+        return $this->notices;
+    }
+
+    /**
+     * @return int the number of warnings
+     */
+    public function getWarnings()
+    {
+        return $this->warnings;
+    }
+
+    /**
+     * @return int the number of deprecations
+     */
+    public function getDeprecations()
+    {
+        return $this->deprecations;
+    }
+
+    /**
+     * @return int the number of errors
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return string a summary report of errors.
+     */
+    public function displaySummary()
+    {
+        return sprintf(
+            'Errors: %d / Warnings: %d / Notices: %d / Deprecations: %d',
+            $this->getErrors(),
+            $this->getWarnings(),
+            $this->getNotices(),
+            $this->getDeprecations()
+        );
+    }
+
+    /**
+     * Reset all counters to 0.
+     */
+    public function reset()
+    {
+        $this->deprecations = 0;
+        $this->errors = 0;
+        $this->notices = 0;
+        $this->warnings = 0;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Get information about silent errors in test suite
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of https://github.com/PrestaShop/PrestaShop/projects/1#card-13082162
| How to test?  | Launch a test suite (`composer phpunit-admin` for instance)

### Exemple (See travis builds)

```
> @php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/phpunit-admin.xml
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.
...............................................................  63 / 114 ( 55%)
...................................................             114 / 114 (100%)

Current report of phpErrorsHandler:
Errors: 0 / Warnings: 381 / Notices: 0 / Deprecations: 159
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10477)
<!-- Reviewable:end -->
