### PR TITLE
Fix: classic theme footer block design #10483

### DIFF
--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-<div class="block-contact col-md-4 links wrapper">
+<div class="block-contact col-md-3 links wrapper">
   <div class="hidden-sm-down">
     <p class="h4 text-uppercase block-contact-title">{l s='Store information' d='Shop.Theme.Global'}</p>
       {$contact_infos.address.formatted nofilter}

--- a/themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
+++ b/themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-<div id="block_myaccount_infos" class="col-md-2 links wrapper">
+<div id="block_myaccount_infos" class="col-md-3 links wrapper">
   <p class="h3 myaccount-title hidden-sm-down">
     <a class="text-uppercase" href="{$urls.pages.my_account}" rel="nofollow">
       {l s='Your account' d='Shop.Theme.Customeraccount'}

--- a/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-<div class="col-md-4 links">
+<div class="col-md-6 links">
   <div class="row">
   {foreach $linkBlocks as $linkBlock}
     <div class="col-md-6 wrapper">


### PR DESCRIPTION
Fix for #10483

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As reported in #10483, the footer columns are not eavenly distributed to the bootstrap 12 col grid (there is an extra 2 col space).
| Type?         | improvement
| Category?     | FO
| BC breaks?    | Does it break backward compatibility?no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | #10483
| How to test?  | Check the footer column distribution. Now the 12 column grid is complete.
![image](https://user-images.githubusercontent.com/12268701/45741319-f5d17680-bbff-11e8-9ad2-65c08970fb9a.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10484)
<!-- Reviewable:end -->
