### PR TITLE
Added breadcrumb to the manufacturers pages

### DIFF
--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -193,4 +193,22 @@ class ManufacturerControllerCore extends ProductListingFrontController
     {
         return $this->label;
     }
+    
+    public function getBreadcrumbLinks()
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+        $breadcrumb['links'][] = [
+            'title' => $this->getTranslator()->trans('Brands', [], 'Shop.Theme.Global'),
+            'url' => $this->context->link->getPageLink('manufacturer', true)
+        ];
+
+        if (Validate::isLoadedObject($this->manufacturer) && $this->manufacturer->active && $this->manufacturer->isAssociatedToShop()) {
+            $breadcrumb['links'][] = [
+                'title' => $this->manufacturer->name,
+                'url' => $this->context->link->getManufacturerLink($this->manufacturer)
+            ];
+        }
+
+        return $breadcrumb;
+    }
 }

--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -193,19 +193,19 @@ class ManufacturerControllerCore extends ProductListingFrontController
     {
         return $this->label;
     }
-    
+
     public function getBreadcrumbLinks()
     {
         $breadcrumb = parent::getBreadcrumbLinks();
         $breadcrumb['links'][] = [
             'title' => $this->getTranslator()->trans('Brands', [], 'Shop.Theme.Global'),
-            'url' => $this->context->link->getPageLink('manufacturer', true)
+            'url' => $this->context->link->getPageLink('manufacturer', true),
         ];
 
         if (Validate::isLoadedObject($this->manufacturer) && $this->manufacturer->active && $this->manufacturer->isAssociatedToShop()) {
             $breadcrumb['links'][] = [
                 'title' => $this->manufacturer->name,
-                'url' => $this->context->link->getManufacturerLink($this->manufacturer)
+                'url' => $this->context->link->getManufacturerLink($this->manufacturer),
             ];
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | add the missing breadcrumb function
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Just visit the brands listing and a brand page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10487)
<!-- Reviewable:end -->
