### PR TITLE
CO : Error when post_max_size is 0

### DIFF
--- a/classes/Uploader.php
+++ b/classes/Uploader.php
@@ -115,6 +115,10 @@ class UploaderCore
     public function getPostMaxSizeBytes()
     {
         $post_max_size = ini_get('post_max_size');
+        if (!$post_max_size) {
+            return self::DEFAULT_MAX_SIZE;
+        }
+        
         $bytes         = (int)trim($post_max_size);
         $last          = strtolower($post_max_size[strlen($post_max_size) - 1]);
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | If you configure `post_max_size = 0` in php.ini and try to edit a product, there's a JS error in files `admin/themes/default/template/controllers/products/helpers/uploader/attachment_ajax.tpl` and `admin/themes/default/template/controllers/products/helpers/uploader/ajax.tpl` because variable `$post_max_size` is empty.
| Type?         | bug fix
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10531
| How to test?  | Set `post_max_size = 0` in php.ini. Try to edit a product.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10532)
<!-- Reviewable:end -->
