### PR TITLE
Fix broken service definition

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form.yml
@@ -101,6 +101,8 @@ services:
 
     prestashop.core.form.choice_provider.status:
         class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\StatusChoiceProvider'
+        arguments:
+            - '@translator'
 
     prestashop.core.form.choice_provider.canonical_redirect_type:
         class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CanonicalRedirectTypeChoiceProvider'


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Once you try accessing Webservice page through `admin-dev/index.php/configure/advanced/webservice/` you will get an error, this RR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Accessing Webservice page through `admin-dev/index.php/configure/advanced/webservice/` should load without an error.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10571)
<!-- Reviewable:end -->
