### PR TITLE
Bring back functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,12 @@ env:
 matrix:
   include:
     - php: 7.2
-      env: EXTRA_DEPS=phpHigh EXTRA_TESTS=functional PRESTASHOP_TEST_TYPE=unit
+      env: EXTRA_DEPS=phpHigh  PRESTASHOP_TEST_TYPE=unit
+    - php: 7.2
+      env: PRESTASHOP_TEST_TYPE=e2e EXTRA_TESTS=functional
+  exclude:
+    - php: 7.2 # Replaced with additional tests
+      env: PRESTASHOP_TEST_TYPE=e2e
 
 before_install:
   # Avoid Composer authentication issues

--- a/tests/E2E/test/selectors/FO/index.js
+++ b/tests/E2E/test/selectors/FO/index.js
@@ -1,7 +1,7 @@
 module.exports = Object.assign({
     languageFO: {
       language_selector: '//*[@id="_desktop_language_selector"]/div/div/button',
-      language_option: '//*[@id="_desktop_language_selector"]//a[contains(@href, "%LANG")]',
+      language_option: '//*[@id="_desktop_language_selector"]//a[@data-iso-code="%LANG"]',
       selected_language_button: '//*[@id="_desktop_language_selector"]//span[@class="expand-more"]'
     }
   },

--- a/themes/classic/modules/ps_languageselector/ps_languageselector.tpl
+++ b/themes/classic/modules/ps_languageselector/ps_languageselector.tpl
@@ -33,13 +33,15 @@
       <ul class="dropdown-menu hidden-sm-down" aria-labelledby="language-selector-label">
         {foreach from=$languages item=language}
           <li {if $language.id_lang == $current_language.id_lang} class="current" {/if}>
-            <a href="{url entity='language' id=$language.id_lang}" class="dropdown-item">{$language.name_simple}</a>
+            <a href="{url entity='language' id=$language.id_lang}" class="dropdown-item" data-iso-code="{$language.iso_code}">{$language.name_simple}</a>
           </li>
         {/foreach}
       </ul>
       <select class="link hidden-md-up" aria-labelledby="language-selector-label">
         {foreach from=$languages item=language}
-          <option value="{url entity='language' id=$language.id_lang}"{if $language.id_lang == $current_language.id_lang} selected="selected"{/if}>{$language.name_simple}</option>
+          <option value="{url entity='language' id=$language.id_lang}"{if $language.id_lang == $current_language.id_lang} selected="selected"{/if} data-iso-code="{$language.iso_code}">
+            {$language.name_simple}
+          </option>
         {/foreach}
       </select>
     </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Functional tests are run with e2e tests. The previous matrix with unit & extra functional tests wasn't running them.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Travis must run the functional tests in the job `PHP=7.2 PRESTASHOP_TEST_TYPE=e2e EXTRA_TESTS=functional` and must be green.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10594)
<!-- Reviewable:end -->
