### PR TITLE
Avoid displaying the addon modal twice, change form names/IDs to avoid collision

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -34,7 +34,7 @@
 {if isset($identifier_bk) && $identifier_bk == $identifier}{capture name='identifier_count'}{counter name='identifier_count'}{/capture}{/if}
 {assign var='identifier_bk' value=$identifier scope='parent'}
 {if isset($table_bk) && $table_bk == $table}{capture name='table_count'}{counter name='table_count'}{/capture}{/if}
-{assign var='table_bk' value=$table scope='parent'}
+{assign var='table_bk' value=$table scope='root'}
 <form id="{if isset($fields.form.form.id_form)}{$fields.form.form.id_form|escape:'html':'UTF-8'}{else}{if $table == null}configuration_form{else}{$table}_form{/if}{if isset($smarty.capture.table_count) && $smarty.capture.table_count}_{$smarty.capture.table_count|intval}{/if}{/if}" class="defaultForm form-horizontal{if isset($name_controller) && $name_controller} {$name_controller}{/if}"{if isset($current) && $current} action="{$current|escape:'html':'UTF-8'}{if isset($token) && $token}&amp;token={$token|escape:'html':'UTF-8'}{/if}"{/if} method="post" enctype="multipart/form-data"{if isset($style)} style="{$style}"{/if} novalidate>
 	{if $form_id}
 		<input type="hidden" name="{$identifier}" id="{$identifier}{if isset($smarty.capture.identifier_count) && $smarty.capture.identifier_count}_{$smarty.capture.identifier_count|intval}{/if}" value="{$form_id}" />

--- a/admin-dev/themes/default/template/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/helpers/options/options.tpl
@@ -34,7 +34,7 @@
 </script>
 {block name="defaultOptions"}
 {if isset($table_bk) && $table_bk == $table}{capture name='table_count'}{counter name='table_count'}{/capture}{/if}
-{assign var='table_bk' value=$table scope='parent'}
+{assign var='table_bk' value=$table scope='root'}
 <form action="{$current|escape:'html':'UTF-8'}&amp;token={$token|escape:'html':'UTF-8'}" id="{if $table == null}configuration_form{else}{$table}_form{/if}{if isset($smarty.capture.table_count) && $smarty.capture.table_count}_{$smarty.capture.table_count|intval}{/if}" method="post" enctype="multipart/form-data" class="form-horizontal">
 	{foreach $option_list AS $category => $categoryData}
 		{if isset($categoryData['top'])}{$categoryData['top']}{/if}

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1834,10 +1834,8 @@ class AdminControllerCore extends Controller
                         'modal_module_list' => $this->context->smarty->fetch($modal_module_list),
                     )
                 );
-
             }
         }
-
 
         $this->context->smarty->assign('baseAdminUrl', __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/');
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1786,7 +1786,7 @@ class AdminControllerCore extends Controller
         $header_tpl = file_exists($dir . 'header.tpl') ? $dir . 'header.tpl' : 'header.tpl';
         $page_header_toolbar = file_exists($dir . 'page_header_toolbar.tpl') ? $dir . 'page_header_toolbar.tpl' : 'page_header_toolbar.tpl';
         $footer_tpl = file_exists($dir . 'footer.tpl') ? $dir . 'footer.tpl' : 'footer.tpl';
-        $modal_module_list = file_exists($module_list_dir . 'modal.tpl') ? $module_list_dir . 'modal.tpl' : 'modal.tpl';
+        $modal_module_list = file_exists($module_list_dir . 'modal.tpl') ? $module_list_dir . 'modal.tpl' : '';
         $tpl_action = $this->tpl_folder . $this->display . '.tpl';
 
         // Check if action template has been overridden
@@ -1826,10 +1826,18 @@ class AdminControllerCore extends Controller
             $this->context->smarty->assign(
                 array(
                     'page_header_toolbar' => $this->context->smarty->fetch($page_header_toolbar),
-                    'modal_module_list' => $this->context->smarty->fetch($modal_module_list),
                 )
             );
+            if (!empty($modal_module_list)) {
+                $this->context->smarty->assign(
+                    array(
+                        'modal_module_list' => $this->context->smarty->fetch($modal_module_list),
+                    )
+                );
+
+            }
         }
+
 
         $this->context->smarty->assign('baseAdminUrl', __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/');
 

--- a/src/Core/Form/FormHandler.php
+++ b/src/Core/Form/FormHandler.php
@@ -61,14 +61,30 @@ class FormHandler implements FormHandlerInterface
      */
     protected $formTypes;
 
+    /**
+     * @var string the form name
+     */
+    protected $formName;
+
+    /**
+     * FormHandler constructor.
+     * @param FormBuilderInterface $formBuilder
+     * @param HookDispatcherInterface $hookDispatcher
+     * @param FormDataProviderInterface $formDataProvider
+     * @param array $formTypes
+     * @param string $hookName
+     * @param string $formName
+     */
     public function __construct(
         FormBuilderInterface $formBuilder,
         HookDispatcherInterface $hookDispatcher,
         FormDataProviderInterface $formDataProvider,
         array $formTypes,
-        $hookName
+        $hookName,
+        $formName = 'form'
     ) {
-        $this->formBuilder = $formBuilder;
+        $this->formName = $formName;
+        $this->formBuilder = $formBuilder->getFormFactory()->createNamedBuilder($formName);
         $this->hookDispatcher = $hookDispatcher;
         $this->formDataProvider = $formDataProvider;
         $this->formTypes = $formTypes;
@@ -82,8 +98,6 @@ class FormHandler implements FormHandlerInterface
      */
     public function getForm()
     {
-        $this->formBuilder = $this->formBuilder->getFormFactory()->createNamedBuilder($this->hookName);
-
         foreach ($this->formTypes as $formName => $formType) {
             $this->formBuilder->add($formName, $formType);
         }

--- a/src/Core/Form/FormHandler.php
+++ b/src/Core/Form/FormHandler.php
@@ -82,6 +82,8 @@ class FormHandler implements FormHandlerInterface
      */
     public function getForm()
     {
+        $this->formBuilder = $this->formBuilder->getFormFactory()->createNamedBuilder($this->hookName);
+
         foreach ($this->formTypes as $formName => $formType) {
             $this->formBuilder->add($formName, $formType);
         }

--- a/src/Core/Form/FormHandler.php
+++ b/src/Core/Form/FormHandler.php
@@ -68,6 +68,7 @@ class FormHandler implements FormHandlerInterface
 
     /**
      * FormHandler constructor.
+     *
      * @param FormBuilderInterface $formBuilder
      * @param HookDispatcherInterface $hookDispatcher
      * @param FormDataProviderInterface $formDataProvider

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -275,6 +275,7 @@ services:
               'shop_urls': 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta\ShopUrlType'
               'url_schema': 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta\UrlSchemaType'
             - 'MetaPage'
+            - 'meta_settings_form'
 
     # Entity form handler
     prestashop.admin.request_sql.form_handler:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -164,7 +164,7 @@ services:
             - '@prestashop.adapter.order.delivery.slip.options.form_provider'
             -
               'options': 'PrestaShopBundle\Form\Admin\Sell\Order\Delivery\SlipOptionsType'
-            - 'OrderDeliverySlipPage'
+            - 'OrderDeliverySlipOptions'
 
     prestashop.adapter.order.delivery.slip.pdf.form_handler:
         class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'
@@ -174,7 +174,8 @@ services:
             - '@prestashop.adapter.order.delivery.slip.pdf.form_provider'
             -
               'pdf': 'PrestaShopBundle\Form\Admin\Sell\Order\Delivery\SlipPdfType'
-            - 'OrderDeliverySlipPage'
+            - 'OrderDeliverySlipPdf'
+            - 'slip_pdf_form'
 
     prestashop.admin.geolocation.form_handler:
         class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
@@ -108,14 +108,14 @@ class DeliveryControllerTest extends WebTestCase
 
     public function testPdfActionWithInvalidData()
     {
-        $token = $this->client->getContainer()->get('security.csrf.token_manager')->getToken('form');
+        $token = $this->client->getContainer()->get('security.csrf.token_manager')->getToken('slip_pdf_form');
         $this->client->request(
             'POST',
             $this->router->generate(
                 'admin_order_delivery_slip_pdf'
             ),
             [
-                'form' => [
+                'slip_pdf_form' => [
                     'pdf' => [
                         'date_from' => 'foo'
                     ],
@@ -137,14 +137,14 @@ class DeliveryControllerTest extends WebTestCase
 
     public function testPdfActionWithEmptyData()
     {
-        $token = $this->client->getContainer()->get('security.csrf.token_manager')->getToken('form');
+        $token = $this->client->getContainer()->get('security.csrf.token_manager')->getToken('slip_pdf_form');
         $this->client->request(
             'POST',
             $this->router->generate(
                 'admin_order_delivery_slip_pdf'
             ),
             [
-                'form' => [
+                'slip_pdf_form' => [
                     'pdf' => [],
                     '_token' => $token
                 ],


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | The javascript console displays error due to form elements having equal ids, this happens for three reasons. First addon modal is displayed twice in Symfony pages Second on pages with several forms a _token input is added for each form with the same form__token id Thus in the FormHandler class we allow to change the form_name so you can (manually) change the form name in its config Third in legacy form template the smarty countdown of forms did not work thus two forms with the same ids could occur
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10469
| How to test?  | Go to a migrated page, you shouldn't have errors about id duplication any more

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10684)
<!-- Reviewable:end -->
