### PR TITLE
Fix very slow speed when having a lot of combinations

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -4318,7 +4318,9 @@ class AdminProductsControllerCore extends AdminController
                     $attributes = Attribute::getAttributes($this->context->language->id, true);
                     foreach ($attributes as $k => $attribute) {
                         $attribute_js[$attribute['id_attribute_group']][$attribute['id_attribute']] = $attribute['name'];
-                        natsort($attribute_js[$attribute['id_attribute_group']]);
+                    }
+                    foreach (array_keys($attribute_js) as $id_attribute_group) {
+                        natsort($attribute_js[$id_attribute_group]);
                     }
 
                     $currency = $this->context->currency;

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -4319,8 +4319,8 @@ class AdminProductsControllerCore extends AdminController
                     foreach ($attributes as $k => $attribute) {
                         $attribute_js[$attribute['id_attribute_group']][$attribute['id_attribute']] = $attribute['name'];
                     }
-                    foreach (array_keys($attribute_js) as $id_attribute_group) {
-                        natsort($attribute_js[$id_attribute_group]);
+                    foreach ($attribute_js as &$attribute_group) {
+                        natsort($attribute_group);
                     }
 
                     $currency = $this->context->currency;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | natsort is called for each row, but we can only call it for every array keys and save a lot of call. We had a shop with more than 8000 combinations, loading time of Combinations tab was about 15s. This fix provide the same result with a loading time of 350ms
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Check the loading tab of the Combinations tab using a shop with a lot of combinations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10693)
<!-- Reviewable:end -->

**Blackfire compare results:**

![capture d ecran 2018-09-25 a 12 07 05](https://user-images.githubusercontent.com/1162527/46007926-953cb080-c0bb-11e8-8138-964441f3cf8a.png)
