### PR TITLE
Check $sfRouter before using it

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -811,14 +811,16 @@ class LinkCore
                 }
         }
 
-        if (empty($routeName)) {
-            $routeName = $this->searchRouteFromRouter($sfRouter, $controller);
-        }
+        if (isset($sfRouter)) {
+            if (empty($routeName)) {
+                $routeName = $this->searchRouteFromRouter($sfRouter, $controller);
+            }
 
-        if (!empty($routeName)) {
-            $sfRoute = array_key_exists('route', $sfRouteParams) ? $sfRouteParams['route'] : $routeName;
+            if (!empty($routeName)) {
+                $sfRoute = array_key_exists('route', $sfRouteParams) ? $sfRouteParams['route'] : $routeName;
 
-            return $sfRouter->generate($sfRoute, $sfRouteParams, UrlGeneratorInterface::ABSOLUTE_URL);
+                return $sfRouter->generate($sfRoute, $sfRouteParams, UrlGeneratorInterface::ABSOLUTE_URL);
+            }
         }
 
         $idLang = Context::getContext()->language->id;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | $sfRouter is sometimes undefined
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | When installed from cli, pshomeslider must work.

```
PHP Notice:  Undefined variable: sfRouter in /workspace/core/classes/Link.php on line 815
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to LinkCore::searchRouteFromRouter() must implement interface Symfony\Component\Routing\RouterInterface, null given, called in /workspace/core/classes/Link.php on line 815 and defined in /workspace/core/classes/Link.php:835
Stack trace:
#0 /workspace/core/classes/Link.php(815): LinkCore->searchRouteFromRouter(NULL, 'AdminAjaxPsHome...')
#1 /workspace/core/modules/pshomeslider/pshomeslider.php(48): LinkCore->getAdminLink('AdminAjaxPsHome...')
#2 [internal function]: Pshomeslider->__construct()
#3 /workspace/core/src/Core/Foundation/IoC/Container.php(130): ReflectionClass->newInstance()
#4 /workspace/core/src/Core/Foundation/IoC/Container.php(163): PrestaShop\PrestaShop\Core\Foundation\IoC\Container->makeInstanceFromClassName('pshomeslider', Array)
#5 /workspace/core/src/Core/Foundation/IoC/Container.php(176): PrestaShop\PrestaShop\Core\Foundation\IoC\Container->doMake('pshomeslider', Array)
#6 /workspace/core/src/Adapter/ServiceLocator.php(65): PrestaShop\PrestaShop\Core\F in /workspace/core/classes/Link.php on line 835
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10696)
<!-- Reviewable:end -->
