### PR TITLE
Change getcwd() for __DIR__

### DIFF
--- a/admin-dev/index.php
+++ b/admin-dev/index.php
@@ -32,7 +32,7 @@ umask(0000); // This will let the permissions be 0777
 
 $timer_start = microtime(true);
 if (!defined('_PS_ADMIN_DIR_')) {
-    define('_PS_ADMIN_DIR_', getcwd());
+    define('_PS_ADMIN_DIR_', __DIR__);
 }
 
 if (!defined('PS_ADMIN_DIR')) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Changing getwd() to __DIR__ , so the path in _PS_ADMIN_DIR_ is the absolute path. Which for example makes it easier to create cronjobs 
| Type?         | improvement
| Category?     | CO
| BC breaks?    | It should not break anything, the path is just more flexible
| Deprecations? | no
| Fixed ticket? |  Fixes #10697
| How to test?  | run e.g. `php -f admin/index.php "controller=AdminCronJobs token={mytoken}"`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10699)
<!-- Reviewable:end -->
