### PR TITLE
Product detail - a specific price with quantity_from = 1 -> wrong prices displayed upon a quantity input changes

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -338,8 +338,6 @@ class ProductControllerCore extends FrontController
                 $quantity_discount['base_price'] = 0;
             }
             if ($quantity_discount['id_product_attribute']) {
-                $quantity_discount['base_price'] = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, $quantity_discount['id_product_attribute'], 6, null, false, false, $quantity_discount['from_quantity']);
-
                 $combination = new Combination((int)$quantity_discount['id_product_attribute']);
                 $attributes = $combination->getAttributesName((int)$this->context->language->id);
                 foreach ($attributes as $attribute) {
@@ -347,6 +345,7 @@ class ProductControllerCore extends FrontController
                 }
                 $quantity_discount['attributes'] = rtrim($quantity_discount['attributes'], ' - ');
             }
+            $quantity_discount['base_price'] = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, $quantity_discount['id_product_attribute'], 6, null, false, false, $quantity_discount['from_quantity']);
             if ((int)$quantity_discount['id_currency'] == 0 && $quantity_discount['reduction_type'] == 'amount') {
                 $quantity_discount['reduction'] = Tools::convertPriceFull($quantity_discount['reduction'], null, Context::getContext()->currency);
             }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -338,7 +338,7 @@ class ProductControllerCore extends FrontController
                 $quantity_discount['base_price'] = 0;
             }
             if ($quantity_discount['id_product_attribute']) {
-                $quantity_discount['base_price'] = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, $quantity_discount['id_product_attribute']);
+                $quantity_discount['base_price'] = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, $quantity_discount['id_product_attribute'], 6, null, false, false, $quantity_discount['from_quantity']);
 
                 $combination = new Combination((int)$quantity_discount['id_product_attribute']);
                 $attributes = $combination->getAttributesName((int)$this->context->language->id);


### PR DESCRIPTION
Fixes overlap code changes in not merged PR https://github.com/PrestaShop/PrestaShop/pull/8099


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Type?         | bug fix
| Description? | Product detail - a specific price with quantity_from = 1 -> wrong prices displayed upon a quantity input changes
| Category?     | FO
| Fixed ticket? | Fixes #10730

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10711)
<!-- Reviewable:end -->
