### PR TITLE
_legacy_link no longer used

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -841,7 +841,7 @@ class LinkCore
         foreach ($sfRouter->getRouteCollection() as $routeName => $route) {
             if (in_array('GET', $route->getMethods())) {
                 $routeDefaults = $route->getDefaults();
-                if (isset($routeDefaults['_legacy_link']) && $controller == $routeDefaults['_legacy_link']) {
+                if (isset($routeDefaults['_legacy_controller']) && $controller == $routeDefaults['_legacy_controller']) {
                     return $routeName;
                 }
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Fix all getAdminLink containing a legacy name.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Don't really know how QA can test it :(.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10727)
<!-- Reviewable:end -->
