### PR TITLE
FilterParametersUpdater manages filters in a better way

### DIFF
--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -117,7 +117,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
     {
         $filters = $this->getPersistedFilterParameters();
 
-        return isset($filters['filter_category']) && $filters['filter_category'] > 0;
+        return !empty($filters['filter_category']) && $filters['filter_category'] > 0;
     }
 
     /**
@@ -163,6 +163,12 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         }
 
         $this->entityManager->flush();
+
+        //Flush cache
+        $employee = Context::getContext()->employee;
+        $employeeId = $employee->id ?: 0;
+
+        $this->cache->deleteItem("app.product_filters_${employeeId}");
     }
 
     /**

--- a/src/Adapter/Product/FilterParametersUpdater.php
+++ b/src/Adapter/Product/FilterParametersUpdater.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
+use PrestaShop\PrestaShop\Core\Exception\ProductException;
+
 /**
  * Can manage filter parameters from request in Product Catalogue Page.
  * For internal use only.
@@ -86,12 +88,18 @@ final class FilterParametersUpdater
         array $persistedFilterParameters,
         array $defaultFilterParameters
     ) {
-        if (!empty($queryFilterParameters) && isset($queryFilterParameters[$parameterName])) {
+        if (isset($queryFilterParameters[$parameterName])) {
             $value = $queryFilterParameters[$parameterName];
-        } else if (!empty($persistedFilterParameters) && isset($persistedFilterParameters[$parameterName])) {
+        } else if (isset($persistedFilterParameters[$parameterName])) {
             $value = $persistedFilterParameters[$parameterName];
-        } else {
+        } else if (isset($defaultFilterParameters[$parameterName])) {
             $value = $defaultFilterParameters[$parameterName];
+        } else {
+            throw new ProductException(
+                'Could not find the parameter %s',
+                'Admin.Notifications.Error',
+                [$parameterName]
+            );
         }
 
         if ($value === 'last' && isset($persistedFilterParameters['last_'.$parameterName])) {

--- a/src/Adapter/Product/FilterParametersUpdater.php
+++ b/src/Adapter/Product/FilterParametersUpdater.php
@@ -60,7 +60,10 @@ final class FilterParametersUpdater
      * @param array $queryFilterParameters
      * @param array $persistedFilterParameters
      * @param array $defaultFilterParameters
+     *
      * @return array
+     *
+     * @throws ProductException
      */
     public function buildFilters(
         array $queryFilterParameters,
@@ -80,7 +83,10 @@ final class FilterParametersUpdater
      * @param array $queryFilterParameters
      * @param array $persistedFilterParameters
      * @param array $defaultFilterParameters
+     *
      * @return string|int
+     *
+     * @throws ProductException
      */
     private function getParameter(
         $parameterName,
@@ -90,9 +96,9 @@ final class FilterParametersUpdater
     ) {
         if (isset($queryFilterParameters[$parameterName])) {
             $value = $queryFilterParameters[$parameterName];
-        } else if (isset($persistedFilterParameters[$parameterName])) {
+        } elseif (isset($persistedFilterParameters[$parameterName])) {
             $value = $persistedFilterParameters[$parameterName];
-        } else if (isset($defaultFilterParameters[$parameterName])) {
+        } elseif (isset($defaultFilterParameters[$parameterName])) {
             $value = $defaultFilterParameters[$parameterName];
         } else {
             throw new ProductException(
@@ -102,8 +108,8 @@ final class FilterParametersUpdater
             );
         }
 
-        if ($value === 'last' && isset($persistedFilterParameters['last_'.$parameterName])) {
-            $value = $persistedFilterParameters['last_'.$parameterName];
+        if ($value === 'last' && isset($persistedFilterParameters['last_' . $parameterName])) {
+            $value = $persistedFilterParameters['last_' . $parameterName];
         }
 
         return $value;

--- a/src/Core/Exception/ProductException.php
+++ b/src/Core/Exception/ProductException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Exception;
+
+/**
+ * Class ProductException used when an error linked to a product occurs.
+ */
+class ProductException extends PrestaShopCoreException
+{
+}

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin;
 
 use Exception;
+use PrestaShop\PrestaShop\Adapter\Product\FilterParametersUpdater;
 use PrestaShop\PrestaShop\Adapter\Tax\TaxRuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Warehouse\WarehouseDataProvider;
 use PrestaShopBundle\Component\CsvResponse;
@@ -126,21 +127,14 @@ class ProductController extends FrameworkBundleAdminController
 
         // Set values from persistence and replace in the request
         $persistedFilterParameters = $productProvider->getPersistedFilterParameters();
+        /** @var FilterParametersUpdater $filterParametersUpdater */
         $filterParametersUpdater = $this->get('prestashop.adapter.product.filter_parameters_updater');
-
-        $filters = $filterParametersUpdater->setValues(
+        $filters = $filterParametersUpdater->buildFilters(
+            $request->query->all(),
             $persistedFilterParameters,
-            $offset,
-            $limit,
-            $orderBy,
-            $sortOrder
+            compact('offset', 'limit', 'orderBy', 'sortOrder')
         );
-
-        // mimic native extract() function.
-        $offset = $filters['offset'];
-        $limit = $filters['limit'];
-        $orderBy = $filters['orderBy'];
-        $sortOrder = $filters['sortOrder'];
+        extract($filters);
 
         $persistedFilterParameters = array_replace($persistedFilterParameters, $request->request->all());
 
@@ -181,7 +175,7 @@ class ProductController extends FrameworkBundleAdminController
             }
         }
 
-        $persistedFilterParameters = $filterParametersUpdater->setPositionOrdering($persistedFilterParameters, $orderBy, $hasCategoryFilter);
+        $cleanFilterParameters = $filterParametersUpdater->cleanFiltersForPositionOrdering($persistedFilterParameters, $orderBy, $hasCategoryFilter);
 
         $permissionError = null;
         if ($this->get('session')->getFlashBag()->has('permission_error')) {
@@ -192,7 +186,7 @@ class ProductController extends FrameworkBundleAdminController
             || ('position' === $orderBy && 'asc' === $sortOrder && !$hasColumnFilter);
         // Template vars injection
         return array_merge(
-            $persistedFilterParameters,
+            $cleanFilterParameters,
             [
                 'limit' => $limit,
                 'offset' => $offset,
@@ -258,7 +252,14 @@ class ProductController extends FrameworkBundleAdminController
         if ($products === null) {
             // get old values from persistence (before the current update)
             $persistedFilterParameters = $productProvider->getPersistedFilterParameters();
-            $this->get('prestashop.adapter.filter_parameters_updater')->setValues($persistedFilterParameters, $offset, $limit, $orderBy, $sortOrder);
+            /** @var FilterParametersUpdater $filterParametersUpdater */
+            $filterParametersUpdater = $this->get('prestashop.adapter.product.filter_parameters_updater');
+            $filters = $filterParametersUpdater->buildFilters(
+                $request->query->all(),
+                $persistedFilterParameters,
+                compact('offset', 'limit', 'orderBy', 'sortOrder')
+            );
+            extract($filters);
 
             /**
              * 2 hooks are triggered here:

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -171,7 +171,7 @@ class ProductController extends FrameworkBundleAdminController
                     [
                         'categories' => [
                             'tree' => [0 => $persistedFilterParameters['filter_category']],
-                        ]
+                        ],
                     ]
                 );
             }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -168,9 +168,11 @@ class ProductController extends FrameworkBundleAdminController
             $categoriesForm = $this->createForm(ProductCategories::class);
             if (!empty($persistedFilterParameters['filter_category'])) {
                 $categoriesForm->setData(
-                    array(
-                        'tree' => array(0 => $persistedFilterParameters['filter_category']),
-                    )
+                    [
+                        'categories' => [
+                            'tree' => [0 => $persistedFilterParameters['filter_category']],
+                        ]
+                    ]
                 );
             }
         }
@@ -192,7 +194,7 @@ class ProductController extends FrameworkBundleAdminController
                 'offset' => $offset,
                 'orderBy' => $orderBy,
                 'sortOrder' => $sortOrder,
-                'has_filter' => $hasCategoryFilter | $hasColumnFilter,
+                'has_filter' => $hasCategoryFilter || $hasColumnFilter,
                 'has_category_filter' => $hasCategoryFilter,
                 'has_column_filter' => $hasColumnFilter,
                 'products' => $products,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | FilterParametersUpdater manages overriding between request, persisted and default parameters in list and catalog
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/10703 <br /> Fixes https://github.com/PrestaShop/PrestaShop/issues/10257
| How to test?  | Go to Catalog > Products, test the filters in the list you will see that they work, then go to a product page Click on the product list you will see the last list of products you had in the catalog

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10728)
<!-- Reviewable:end -->
