### PR TITLE
Use new routes for quick access

### DIFF
--- a/install-dev/data/xml/quick_access.xml
+++ b/install-dev/data/xml/quick_access.xml
@@ -12,13 +12,13 @@
       <link>index.php?controller=AdminCartRules&amp;addcart_rule</link>
     </quick_access>
     <quick_access id="New_product" new_window="0">
-      <link>index.php/product/new</link>
+      <link>index.php/sell/catalog/products/new</link>
     </quick_access>
     <quick_access id="New_category" new_window="0">
       <link>index.php?controller=AdminCategories&amp;addcategory</link>
     </quick_access>
     <quick_access id="Installed_modules" new_window="0">
-      <link>index.php/module/manage</link>
+      <link>index.php/improve/modules/manage</link>
     </quick_access>
     <quick_access id="Catalog_evaluation" new_window="0">
       <link>index.php?controller=AdminStats&amp;module=statscheckup</link>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Update quick access links with new routes. This is a quick fix, the feature should be reworked to prevent further issues with next URL updates
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #10480
| How to test?  | Reinstall your shop and check the links "new product" and "manage module" you should be redirected to the proper page instead of the dashboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10736)
<!-- Reviewable:end -->
