### PR TITLE
No unset id_attribute, could be usefull to theme development

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -491,7 +491,6 @@ class ProductLazyArray extends AbstractLazyArray
             $color['type'] = 'color';
             $color['html_color_code'] = $color['color'];
             unset($color['color']);
-            unset($color['id_attribute']); // because what is a template supposed to do with it?
 
             return $color;
         }, $colors);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Why unset a previously setted variable without a good reason? For example,  I need this id_attribute value in order to use a module to filter images by attribute in lists of products. You can see it in action at piraito.com if click in a color/model attribute, images matching this attribute are showed.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | In variant-links.tpl adding at the beginning {$variants&#124;dump} you can see info array associated with every attribute showed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10746)
<!-- Reviewable:end -->
