### PR TITLE
Do not display product Reference if empty

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-details.tpl
+++ b/themes/classic/templates/catalog/_partials/product-details.tpl
@@ -18,7 +18,7 @@
         {/if}
       </div>
     {/if}
-    {if isset($product.reference_to_display)}
+    {if !empty($product.reference_to_display)}
       <div class="product-reference">
         <label class="label">{l s='Reference' d='Shop.Theme.Catalog'} </label>
         <span itemprop="sku">{$product.reference_to_display}</span>

--- a/themes/classic/templates/catalog/_partials/product-details.tpl
+++ b/themes/classic/templates/catalog/_partials/product-details.tpl
@@ -18,7 +18,7 @@
         {/if}
       </div>
     {/if}
-    {if !empty($product.reference_to_display)}
+    {if isset($product.reference_to_display) && $product.reference_to_display neq ''}
       <div class="product-reference">
         <label class="label">{l s='Reference' d='Shop.Theme.Catalog'} </label>
         <span itemprop="sku">{$product.reference_to_display}</span>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x 
| Description?  | Bug fix on FO product details display
| Type?         | bug fix
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10749
| How to test?  | Create a new product with an empty reference. Go to the FO to see this product, in the Product Details tab you will see the text "Reference" with nothing below.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10750)
<!-- Reviewable:end -->
