### PR TITLE
Fix - color - picker - ps_faviconnotificationbo

### DIFF
--- a/js/jquery/plugins/jquery.colorpicker.js
+++ b/js/jquery/plugins/jquery.colorpicker.js
@@ -78,7 +78,7 @@
   };
 
   $.fn.mColorPicker.defaults = {
-    imageFolder: '../../../img/admin/',
+    imageFolder: '../img/admin/',
     swatches: [
       "#ffffff",
       "#ffff00",


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Color picker isn't correctly displayed in the ps_faviconnotificationbo module
| Type?         | bug fix 
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_faviconnotificationbo/issues/3
| How to test?  | Install the ps_faviconnotificationbo module, in the configure page, the color picker is well displayed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10753)
<!-- Reviewable:end -->
