### PR TITLE
Enable pagination when offset is set

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% block grid_pagination %}
-  {% if grid.data.records_total > 10 %}
+  {% if grid.data.records_total > 10 or grid.pagination.offset %}
     <div class="row">
       <div class="col-md-12">
         {{ render(controller('PrestaShopBundle:Admin\\Common:pagination', {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | When deleting a last item from a page, you still remain in the same page even though it's empty after deletion. The pagination disappears aswell, so there's no way to get back to the previous page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | See below.

**To reproduce before PR:** have 11 items in the grid, showing 10 per page. Delete the 11th item while being in the second page. After deletion you will stay in 2nd page without pagination. Can be reproduced in sql manager list.

**After applying this PR:** follow same steps as above. After deletion you will stay in same page and see pagination even though list for 2nd page is empty.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10778)
<!-- Reviewable:end -->
