### PR TITLE
Fixes new webservice list behavior in multishop context and fixes warning message display

### DIFF
--- a/src/Core/Grid/Query/WebserviceKeyQueryBuilder.php
+++ b/src/Core/Grid/Query/WebserviceKeyQueryBuilder.php
@@ -75,6 +75,7 @@ final class WebserviceKeyQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->getModifiedOrderBy($searchCriteria->getOrderBy()),
                 $searchCriteria->getOrderWay()
             )
+            ->groupBy('wa.`id_webservice_account`');
         ;
 
         $this->searchCriteriaApplicator->applyPagination($searchCriteria, $qb);
@@ -88,8 +89,7 @@ final class WebserviceKeyQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('SQL_CALC_FOUND_ROWS')
-            ->select('FOUND_ROWS()')
+            ->select('COUNT(DISTINCT wa.`id_webservice_account`)')
         ;
 
         return $qb;
@@ -116,7 +116,6 @@ final class WebserviceKeyQueryBuilder extends AbstractDoctrineQueryBuilder
         ;
 
         $qb->andWhere('was.`id_shop` IN (:shops)');
-        $qb->groupBy('wa.`id_webservice_account`');
 
         $qb->setParameter('shops', $this->contextShopIds, Connection::PARAM_INT_ARRAY);
 

--- a/src/Core/Grid/Query/WebserviceKeyQueryBuilder.php
+++ b/src/Core/Grid/Query/WebserviceKeyQueryBuilder.php
@@ -75,7 +75,7 @@ final class WebserviceKeyQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->getModifiedOrderBy($searchCriteria->getOrderBy()),
                 $searchCriteria->getOrderWay()
             )
-            ->groupBy('wa.`id_webservice_account`');
+            ->groupBy('wa.`id_webservice_account`')
         ;
 
         $this->searchCriteriaApplicator->applyPagination($searchCriteria, $qb);

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -63,12 +63,6 @@ class WebserviceController extends FrameworkBundleAdminController
 
         $configurationWarnings = $this->lookForWarnings($request);
 
-        if (false === empty($configurationWarnings)) {
-            foreach ($configurationWarnings as $warningMessage) {
-                $this->addFlash('warning', $warningMessage);
-            }
-        }
-
         $twigValues = [
             'layoutHeaderToolbarBtn' => [
                 'add' => [
@@ -86,6 +80,7 @@ class WebserviceController extends FrameworkBundleAdminController
             'requireFilterStatus' => false,
             'form' => $form->createView(),
             'grid' => $presentedGrid,
+            'configurationWarnings' => $configurationWarnings,
         ];
 
         return $this->render('@AdvancedParameters/WebservicePage/webservice.html.twig', $twigValues);

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -182,6 +182,7 @@ services:
         parent: 'prestashop.core.grid.abstract_query_builder'
         arguments:
             - '@prestashop.core.query.doctrine_search_criteria_applicator'
+            - '@=service("prestashop.adapter.shop.context").getContextListShopID()'
         public: true
 
     prestashop.core.grid.query_builder.meta:

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice.html.twig
@@ -27,6 +27,19 @@
 {% trans_default_domain "Admin.Advparameters.Feature" %}
 
 {% block content %}
+
+  {% if configurationWarnings is not empty  %}
+    <div class="row">
+      <div class="col">
+        <div class="alert alert-warning" role="alert">
+          {% for warning in configurationWarnings %}
+            <p class="alert-text">{{ warning }}</p>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
   <div class="row">
     <div class="col">
       {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice.html.twig
@@ -28,17 +28,19 @@
 
 {% block content %}
 
-  {% if configurationWarnings is not empty  %}
-    <div class="row">
-      <div class="col">
-        <div class="alert alert-warning" role="alert">
-          {% for warning in configurationWarnings %}
-            <p class="alert-text">{{ warning }}</p>
-          {% endfor %}
+  {% block webservice_list_notifications %}
+    {% if configurationWarnings is not empty  %}
+      <div class="row">
+        <div class="col">
+          <div class="alert alert-warning" role="alert">
+            {% for warning in configurationWarnings %}
+              <p class="alert-text">{{ warning }}</p>
+            {% endfor %}
+          </div>
         </div>
       </div>
-    </div>
-  {% endif %}
+    {% endif %}
+  {% endblock %}
 
   <div class="row">
     <div class="col">


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The new webservie list which for now can be reached only via **admin-dev/index.php/configure/advanced/webservice** had missing multi-shop functionality. After the fix, the list will work the same as the legacy list in multishop context. Also improved a warning messages appearance above the list due to before messages sometimes duplicated itself.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create some webservice keys in shop 1 then create some keys in shop2. Then try to switch between shop contexts, try also go to "All shops" link - both legacy list and the new list located in **admin-dev/index.php/configure/advanced/webservice** should display the same amount of data in different shop contexts

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10781)
<!-- Reviewable:end -->
