### PR TITLE
Migrate Employee options configuration

### DIFF
--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -75,7 +75,7 @@ class Context implements MultistoreContextCheckerInterface
      *
      * @return bool
      *
-     * @deprecated Use $this->isGroupShopContext() instead.
+     * @deprecated use $this->isGroupShopContext() instead
      */
     public function isShopGroupContext()
     {
@@ -97,7 +97,7 @@ class Context implements MultistoreContextCheckerInterface
      *
      * @return bool
      *
-     * @deprecated Use $this->isAllShopContext() instead.
+     * @deprecated use $this->isAllShopContext() instead
      */
     public function isAllContext()
     {

--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -75,7 +75,7 @@ class Context implements MultistoreContextCheckerInterface
      *
      * @return bool
      *
-     * @deprecated use $this->isGroupShopContext() instead
+     * @deprecated since 1.7.6.0, to be removed in 1.8. Use $this->isGroupShopContext() instead.
      */
     public function isShopGroupContext()
     {
@@ -97,7 +97,7 @@ class Context implements MultistoreContextCheckerInterface
      *
      * @return bool
      *
-     * @deprecated use $this->isAllShopContext() instead
+     * @deprecated since 1.7.6.0, to be removed in 1.8. Use $this->isAllShopContext() instead.
      */
     public function isAllContext()
     {

--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -74,10 +74,12 @@ class Context implements MultistoreContextCheckerInterface
      * Get if it's a GroupShop context.
      *
      * @return bool
+     *
+     * @deprecated Use $this->isGroupShopContext() instead.
      */
     public function isShopGroupContext()
     {
-        return Shop::getContext() === Shop::CONTEXT_GROUP;
+        return $this->isGroupShopContext();
     }
 
     /**
@@ -94,10 +96,12 @@ class Context implements MultistoreContextCheckerInterface
      * Get if it's a All context.
      *
      * @return bool
+     *
+     * @deprecated Use $this->isAllShopContext( instead.
      */
     public function isAllContext()
     {
-        return Shop::getContext() === Shop::CONTEXT_ALL;
+        return $this->isAllShopContext();
     }
 
     /**
@@ -170,5 +174,21 @@ class Context implements MultistoreContextCheckerInterface
     public function ShopGroup($shopGroupId)
     {
         return new ShopGroup($shopGroupId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAllShopContext()
+    {
+        return Shop::getContext() === Shop::CONTEXT_ALL;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isGroupShopContext()
+    {
+        return Shop::getContext() === Shop::CONTEXT_GROUP;
     }
 }

--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -97,7 +97,7 @@ class Context implements MultistoreContextCheckerInterface
      *
      * @return bool
      *
-     * @deprecated Use $this->isAllShopContext( instead.
+     * @deprecated Use $this->isAllShopContext() instead.
      */
     public function isAllContext()
     {

--- a/src/Core/Multistore/MultistoreContextCheckerInterface.php
+++ b/src/Core/Multistore/MultistoreContextCheckerInterface.php
@@ -36,5 +36,19 @@ interface MultistoreContextCheckerInterface
      *
      * @return bool
      */
+    public function isAllShopContext();
+
+    /**
+     * Check if current shop is in group shop context.
+     *
+     * @return bool
+     */
+    public function isGroupShopContext();
+
+    /**
+     * Check if current shop is in single shop context.
+     *
+     * @return bool
+     */
     public function isSingleShopContext();
 }

--- a/src/Core/Multistore/MultistoreContextCheckerInterface.php
+++ b/src/Core/Multistore/MultistoreContextCheckerInterface.php
@@ -39,14 +39,14 @@ interface MultistoreContextCheckerInterface
     public function isAllShopContext();
 
     /**
-     * Check if current shop is in group shop context.
+     * Check if current shop is in "Group" shop context.
      *
      * @return bool
      */
     public function isGroupShopContext();
 
     /**
-     * Check if current shop is in single shop context.
+     * Check if current shop is in "Single" shop context.
      *
      * @return bool
      */

--- a/src/Core/Team/Employee/Configuration/EmployeeOptionsConfiguration.php
+++ b/src/Core/Team/Employee/Configuration/EmployeeOptionsConfiguration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/Core/Team/Employee/Configuration/EmployeeOptionsConfiguration.php
+++ b/src/Core/Team/Employee/Configuration/EmployeeOptionsConfiguration.php
@@ -64,10 +64,10 @@ final class EmployeeOptionsConfiguration implements DataConfigurationInterface
     public function updateConfiguration(array $configuration)
     {
         if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set('PS_PASSWD_TIME_BACK', $configuration['password_change_time']);
+            $this->configuration->set('PS_PASSWD_TIME_BACK', (int) $configuration['password_change_time']);
             $this->configuration->set(
                 'PS_BO_ALLOW_EMPLOYEE_FORM_LANG',
-                $configuration['allow_employee_specific_language']
+                (bool) $configuration['allow_employee_specific_language']
             );
         }
 

--- a/src/Core/Team/Employee/Configuration/EmployeeOptionsConfiguration.php
+++ b/src/Core/Team/Employee/Configuration/EmployeeOptionsConfiguration.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Team\Employee\Configuration;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+
+/**
+ * Class EmployeeOptionsConfiguration handles configuration data for employee options.
+ */
+final class EmployeeOptionsConfiguration implements DataConfigurationInterface
+{
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(ConfigurationInterface $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        return [
+            'password_change_time' => (int) $this->configuration->get('PS_PASSWD_TIME_BACK'),
+            'allow_employee_specific_language' => (int) $this->configuration->get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG'),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration)
+    {
+        if ($this->validateConfiguration($configuration)) {
+            $this->configuration->set('PS_PASSWD_TIME_BACK', $configuration['password_change_time']);
+            $this->configuration->set(
+                'PS_BO_ALLOW_EMPLOYEE_FORM_LANG',
+                $configuration['allow_employee_specific_language']
+            );
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateConfiguration(array $configuration)
+    {
+        return isset(
+            $configuration['password_change_time'],
+            $configuration['allow_employee_specific_language']
+        );
+    }
+}

--- a/src/Core/Team/Employee/Configuration/EmployeeOptionsConfiguration.php
+++ b/src/Core/Team/Employee/Configuration/EmployeeOptionsConfiguration.php
@@ -40,11 +40,17 @@ final class EmployeeOptionsConfiguration implements DataConfigurationInterface
     private $configuration;
 
     /**
+     * @var OptionsCheckerInterface
+     */
+    private $optionsChecker;
+
+    /**
      * @param ConfigurationInterface $configuration
      */
-    public function __construct(ConfigurationInterface $configuration)
+    public function __construct(ConfigurationInterface $configuration, OptionsCheckerInterface $optionsChecker)
     {
         $this->configuration = $configuration;
+        $this->optionsChecker = $optionsChecker;
     }
 
     /**
@@ -63,6 +69,18 @@ final class EmployeeOptionsConfiguration implements DataConfigurationInterface
      */
     public function updateConfiguration(array $configuration)
     {
+        $errors = [];
+
+        if (!$this->optionsChecker->canBeChanged()) {
+            $errors[] = [
+                'key' => 'You can\'t change the value of this configuration field in the context of this shop .',
+                'parameters' => [],
+                'domain' => 'Admin.Notifications.Warning',
+            ];
+
+            return $errors;
+        }
+
         if ($this->validateConfiguration($configuration)) {
             $this->configuration->set('PS_PASSWD_TIME_BACK', (int) $configuration['password_change_time']);
             $this->configuration->set(
@@ -71,7 +89,7 @@ final class EmployeeOptionsConfiguration implements DataConfigurationInterface
             );
         }
 
-        return [];
+        return $errors;
     }
 
     /**

--- a/src/Core/Team/Employee/Configuration/OptionsChecker.php
+++ b/src/Core/Team/Employee/Configuration/OptionsChecker.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/Core/Team/Employee/Configuration/OptionsChecker.php
+++ b/src/Core/Team/Employee/Configuration/OptionsChecker.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Team\Employee\Configuration;
+
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+use PrestaShop\PrestaShop\Core\Multistore\MultistoreContextCheckerInterface;
+
+/**
+ * Class OptionsChecker checks if employee options can be changed depending on current shop context.
+ */
+final class OptionsChecker implements OptionsCheckerInterface
+{
+    /**
+     * @var FeatureInterface
+     */
+    private $multistoreFeature;
+
+    /**
+     * @var MultistoreContextCheckerInterface
+     */
+    private $multistoreContextChecker;
+
+    /**
+     * @param FeatureInterface $multistoreFeature
+     * @param MultistoreContextCheckerInterface $multistoreContextChecker
+     */
+    public function __construct(
+        FeatureInterface $multistoreFeature,
+        MultistoreContextCheckerInterface $multistoreContextChecker
+    ) {
+        $this->multistoreFeature = $multistoreFeature;
+        $this->multistoreContextChecker = $multistoreContextChecker;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canBeChanged()
+    {
+        if (!$this->multistoreFeature->isUsed()
+            && $this->multistoreContextChecker->isSingleShopContext()
+        ) {
+            return true;
+        }
+
+        return $this->multistoreContextChecker->isAllShopContext();
+    }
+}

--- a/src/Core/Team/Employee/Configuration/OptionsCheckerInterface.php
+++ b/src/Core/Team/Employee/Configuration/OptionsCheckerInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/Core/Team/Employee/Configuration/OptionsCheckerInterface.php
+++ b/src/Core/Team/Employee/Configuration/OptionsCheckerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Team\Employee\Configuration;
+
+/**
+ * Interface OptionsCheckerInterface.
+ */
+interface OptionsCheckerInterface
+{
+    /**
+     * Check if employee options can be changed.
+     *
+     * @return bool
+     */
+    public function canBeChanged();
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -39,11 +39,9 @@ class EmployeeController extends FrameworkBundleAdminController
     /**
      * Show employees list & options page.
      *
-     * @param Request $request
-     *
      * @return Response
      */
-    public function indexAction(Request $request)
+    public function indexAction()
     {
         $employeeOptionsFormHandler = $this->get('prestashop.admin.employee_options.form_handler');
         $employeeOptionsForm = $employeeOptionsFormHandler->getForm();

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -46,8 +46,11 @@ class EmployeeController extends FrameworkBundleAdminController
         $employeeOptionsFormHandler = $this->get('prestashop.admin.employee_options.form_handler');
         $employeeOptionsForm = $employeeOptionsFormHandler->getForm();
 
+        $multistoreContextChecker = $this->get('prestashop.adapter.shop.context');
+
         return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/Employee/index.html.twig', [
             'employeeOptionsForm' => $employeeOptionsForm->createView(),
+            'isAllShopContext' => $multistoreContextChecker->isAllShopContext(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
+
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+
+class EmployeeController extends FrameworkBundleAdminController
+{
+    public function indexAction()
+    {
+        return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/Employee/index.html.twig');
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -46,11 +46,11 @@ class EmployeeController extends FrameworkBundleAdminController
         $employeeOptionsFormHandler = $this->get('prestashop.admin.employee_options.form_handler');
         $employeeOptionsForm = $employeeOptionsFormHandler->getForm();
 
-        $multistoreContextChecker = $this->get('prestashop.adapter.shop.context');
+        $employeeOptionsChecker = $this->get('prestashop.core.team.employee.configuration.options_checker');
 
         return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/Employee/index.html.twig', [
             'employeeOptionsForm' => $employeeOptionsForm->createView(),
-            'isAllShopContext' => $multistoreContextChecker->isAllShopContext(),
+            'canOptionsBeChanged' => $employeeOptionsChecker->canBeChanged(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -55,7 +55,7 @@ class EmployeeController extends FrameworkBundleAdminController
     }
 
     /**
-     * Save employee options submit.
+     * Save employee options.
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -27,11 +27,57 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * Class EmployeeController handles pages under "Configure > Advanced Parameters > Team > Employees".
+ */
 class EmployeeController extends FrameworkBundleAdminController
 {
-    public function indexAction()
+    /**
+     * Show employees list & options page.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function indexAction(Request $request)
     {
-        return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/Employee/index.html.twig');
+        $employeeOptionsFormHandler = $this->get('prestashop.admin.employee_options.form_handler');
+        $employeeOptionsForm = $employeeOptionsFormHandler->getForm();
+
+        return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/Employee/index.html.twig', [
+            'employeeOptionsForm' => $employeeOptionsForm->createView(),
+        ]);
+    }
+
+    /**
+     * Save employee options submit.
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function saveOptionsAction(Request $request)
+    {
+        $employeeOptionsFormHandler = $this->get('prestashop.admin.employee_options.form_handler');
+        $employeeOptionsForm = $employeeOptionsFormHandler->getForm();
+        $employeeOptionsForm->handleRequest($request);
+
+        if ($employeeOptionsForm->isSubmitted()) {
+            $errors = $employeeOptionsFormHandler->save($employeeOptionsForm->getData());
+
+            if (!empty($errors)) {
+                $this->flashErrors($errors);
+
+                return $this->redirectToRoute('admin_employees_index');
+            }
+
+            $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+        }
+
+        return $this->redirectToRoute('admin_employees_index');
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsFormDataProvider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsFormDataProvider.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+/**
+ * Class EmployeeOptionsFormDataProvider manages data for employee options form.
+ */
+final class EmployeeOptionsFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * @var DataConfigurationInterface
+     */
+    private $employeeOptionsConfiguration;
+
+    /**
+     * @param DataConfigurationInterface $employeeOptionsConfiguration
+     */
+    public function __construct(DataConfigurationInterface $employeeOptionsConfiguration)
+    {
+        $this->employeeOptionsConfiguration = $employeeOptionsConfiguration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+        return [
+            'options' => $this->employeeOptionsConfiguration->getConfiguration(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setData(array $data)
+    {
+        return $this->employeeOptionsConfiguration->updateConfiguration($data['options']);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -30,12 +30,33 @@ use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class EmployeeOptionsType defines form for employee options.
  */
 class EmployeeOptionsType extends TranslatorAwareType
 {
+    /**
+     * @var bool
+     */
+    private $isAllShopContext;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param $isAllShopContext
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        $isAllShopContext
+    ) {
+        parent::__construct($translator, $locales);
+
+        $this->isAllShopContext = $isAllShopContext;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -45,9 +66,11 @@ class EmployeeOptionsType extends TranslatorAwareType
             ->add('password_change_time', TextWithUnitType::class, [
                 'required' => false,
                 'unit' => $this->trans('minutes', 'Admin.Advparameters.Feature'),
+                'disabled' => !$this->isAllShopContext,
             ])
             ->add('allow_employee_specific_language', SwitchType::class, [
                 'required' => false,
+                'disabled' => !$this->isAllShopContext,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -40,21 +40,21 @@ class EmployeeOptionsType extends TranslatorAwareType
     /**
      * @var bool
      */
-    private $isAllShopContext;
+    private $canOptionsBeChanged;
 
     /**
      * @param TranslatorInterface $translator
      * @param array $locales
-     * @param $isAllShopContext
+     * @param bool $canOptionsBeChanged
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        $isAllShopContext
+        $canOptionsBeChanged
     ) {
         parent::__construct($translator, $locales);
 
-        $this->isAllShopContext = $isAllShopContext;
+        $this->canOptionsBeChanged = $canOptionsBeChanged;
     }
 
     /**
@@ -66,11 +66,11 @@ class EmployeeOptionsType extends TranslatorAwareType
             ->add('password_change_time', TextWithUnitType::class, [
                 'required' => false,
                 'unit' => $this->trans('minutes', 'Admin.Advparameters.Feature'),
-                'disabled' => !$this->isAllShopContext,
+                'disabled' => !$this->canOptionsBeChanged,
             ])
             ->add('allow_employee_specific_language', SwitchType::class, [
                 'required' => false,
-                'disabled' => !$this->isAllShopContext,
+                'disabled' => !$this->canOptionsBeChanged,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -27,14 +27,14 @@
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * Class EmployeeOptionsType defines form for employee options.
  */
-class EmployeeOptionsType extends AbstractType
+class EmployeeOptionsType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -42,8 +42,9 @@ class EmployeeOptionsType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('password_change_time', NumberType::class, [
+            ->add('password_change_time', TextWithUnitType::class, [
                 'required' => false,
+                'unit' => $this->trans('minutes', 'Admin.Advparameters.Feature'),
             ])
             ->add('allow_employee_specific_language', SwitchType::class, [
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class EmployeeOptionsType defines form for employee options.
+ */
+class EmployeeOptionsType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('password_change_time', NumberType::class, [
+                'required' => false,
+            ])
+            ->add('allow_employee_specific_language', SwitchType::class, [
+                'required' => false,
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/_advanced_parameters.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/_advanced_parameters.yml
@@ -33,3 +33,7 @@ _webservice:
 _backup:
     resource: "backup.yml"
     prefix: /backup
+
+_employee:
+    resource: "employee.yml"
+    prefix: /employees

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
@@ -3,3 +3,9 @@ admin_employees_index:
   methods: [GET]
   defaults:
     _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Employee:index'
+
+admin_employees_save_options:
+  path: /process-options
+  methods: [POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Employee:saveOptions'

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
@@ -1,0 +1,5 @@
+admin_employees_index:
+  path: /
+  methods: [GET]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Employee:index'

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
@@ -3,9 +3,11 @@ admin_employees_index:
   methods: [GET]
   defaults:
     _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Employee:index'
+    _legacy_controller: AdminEmployees
 
 admin_employees_save_options:
   path: /save-options
   methods: [POST]
   defaults:
     _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Employee:saveOptions'
+    _legacy_controller: AdminEmployees

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
@@ -5,7 +5,7 @@ admin_employees_index:
     _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Employee:index'
 
 admin_employees_save_options:
-  path: /process-options
+  path: /save-options
   methods: [POST]
   defaults:
     _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Employee:saveOptions'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -236,3 +236,8 @@ services:
         arguments:
             - '@prestashop.adapter.legacy.configuration'
             - '@=service("prestashop.adapter.data_provider.default_route").getRules()'
+
+    prestashop.core.team.employee.configuration.employee_options_configuration:
+        class: 'PrestaShop\PrestaShop\Core\Team\Employee\Configuration\EmployeeOptionsConfiguration'
+        arguments:
+            - '@prestashop.adapter.legacy.configuration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -241,3 +241,4 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Team\Employee\Configuration\EmployeeOptionsConfiguration'
         arguments:
             - '@prestashop.adapter.legacy.configuration'
+            - '@prestashop.core.team.employee.configuration.options_checker'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -145,3 +145,8 @@ services:
             - '@translator'
             - '@prestashop.adapter.routes.route_validator'
             - '@prestashop.adapter.validate'
+
+    prestashop.admin.employee_options.form_data_provider:
+        class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeOptionsFormDataProvider'
+        arguments:
+            - '@prestashop.core.team.employee.configuration.employee_options_configuration'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -275,6 +275,16 @@ services:
               'url_schema': 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta\UrlSchemaType'
             - 'MetaPage'
 
+    prestashop.admin.employee_options.form_handler:
+        class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'
+        arguments:
+            - '@=service("form.factory").createBuilder()'
+            - '@prestashop.core.hook.dispatcher'
+            - '@prestashop.admin.traffic_seo.meta_settings.form_data_provider'
+            -
+              'options': 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeOptionsType'
+            - 'Employee'
+
     # Entity form handler
     prestashop.admin.request_sql.form_handler:
         class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\RequestSql\SqlRequestFormHandler'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -280,7 +280,7 @@ services:
         arguments:
             - '@=service("form.factory").createBuilder()'
             - '@prestashop.core.hook.dispatcher'
-            - '@prestashop.admin.traffic_seo.meta_settings.form_data_provider'
+            - '@prestashop.admin.employee_options.form_data_provider'
             -
               'options': 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeOptionsType'
             - 'Employee'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -571,3 +571,10 @@ services:
         public: true
         tags:
             - { name: form.type }
+
+    form.type.team.employee.employee_options:
+        class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeOptionsType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -576,7 +576,7 @@ services:
         class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeOptionsType'
         parent: 'form.type.translatable.aware'
         arguments:
-            - '@=service("prestashop.adapter.shop.context").isAllShopContext()'
+            - '@=service("prestashop.core.team.employee.configuration.options_checker").canBeChanged()'
         public: true
         tags:
             - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -575,6 +575,8 @@ services:
     form.type.team.employee.employee_options:
         class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeOptionsType'
         parent: 'form.type.translatable.aware'
+        arguments:
+            - '@=service("prestashop.adapter.shop.context").isAllShopContext()'
         public: true
         tags:
             - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/core/employee.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/employee.yml
@@ -1,0 +1,9 @@
+services:
+  _defaults:
+    public: true
+
+  prestashop.core.team.employee.configuration.options_checker:
+    class: 'PrestaShop\PrestaShop\Core\Team\Employee\Configuration\OptionsChecker'
+    arguments:
+      - '@prestashop.adapter.multistore_feature'
+      - '@prestashop.adapter.shop.context'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -23,55 +23,57 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{{ form_start(employeeOptionsForm, {'action': path('admin_employees_save_options') }) }}
-<div class="card">
-  <h3 class="card-header">
-    <i class="material-icons">settings</i>
-    {{ 'Employee options'|trans({}, 'Admin.Advparameters.Feature') }}
-  </h3>
-  <div class="card-block row">
-    <div class="card-text">
-      <div class="form-group row">
-        {{ ps.label_with_help(('Password regeneration'|trans({}, 'Admin.Advparameters.Feature')), 'Security: Minimum time to wait between two password changes.'|trans({}, 'Admin.Advparameters.Feature')) }}
-        <div class="col-sm">
-          {{ form_errors(employeeOptionsForm.options.password_change_time) }}
-          {{ form_widget(employeeOptionsForm.options.password_change_time) }}
+{% block employee_options_form %}
+  {{ form_start(employeeOptionsForm, {'action': path('admin_employees_save_options') }) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i>
+      {{ 'Employee options'|trans({}, 'Admin.Advparameters.Feature') }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="form-group row">
+          {{ ps.label_with_help(('Password regeneration'|trans({}, 'Admin.Advparameters.Feature')), 'Security: Minimum time to wait between two password changes.'|trans({}, 'Admin.Advparameters.Feature')) }}
+          <div class="col-sm">
+            {{ form_errors(employeeOptionsForm.options.password_change_time) }}
+            {{ form_widget(employeeOptionsForm.options.password_change_time) }}
 
-          {% if not isAllShopContext %}
-          <div class="alert alert-warning mt-2" role="alert">
-            <p class="alert-text">
-              {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
-            </p>
+            {% if not isAllShopContext %}
+            <div class="alert alert-warning mt-2" role="alert">
+              <p class="alert-text">
+                {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
+              </p>
+            </div>
+            {% endif %}
           </div>
-          {% endif %}
         </div>
-      </div>
 
-      <div class="form-group row">
-        {{ ps.label_with_help(('Memorize the language used in Admin panel forms'|trans({}, 'Admin.Advparameters.Feature')), 'Allow employees to select a specific language for the Admin panel form.'|trans({}, 'Admin.Advparameters.Feature')) }}
-        <div class="col-sm">
-          {{ form_errors(employeeOptionsForm.options.allow_employee_specific_language) }}
-          {{ form_widget(employeeOptionsForm.options.allow_employee_specific_language) }}
+        <div class="form-group row">
+          {{ ps.label_with_help(('Memorize the language used in Admin panel forms'|trans({}, 'Admin.Advparameters.Feature')), 'Allow employees to select a specific language for the Admin panel form.'|trans({}, 'Admin.Advparameters.Feature')) }}
+          <div class="col-sm">
+            {{ form_errors(employeeOptionsForm.options.allow_employee_specific_language) }}
+            {{ form_widget(employeeOptionsForm.options.allow_employee_specific_language) }}
 
-          {% if not isAllShopContext %}
-          <div class="alert alert-warning mt-2" role="alert">
-            <p class="alert-text">
-              {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
-            </p>
+            {% if not isAllShopContext %}
+            <div class="alert alert-warning mt-2" role="alert">
+              <p class="alert-text">
+                {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
+              </p>
+            </div>
+            {% endif %}
           </div>
-          {% endif %}
         </div>
-      </div>
 
-      {% block employee_options_form_rest %}
-        {{ form_rest(employeeOptionsForm) }}
-      {% endblock %}
+        {% block employee_options_form_rest %}
+          {{ form_rest(employeeOptionsForm) }}
+        {% endblock %}
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary pull-right">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
     </div>
   </div>
-  <div class="card-footer">
-    <div class="d-flex justify-content-end">
-      <button class="btn btn-primary pull-right">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-    </div>
-  </div>
-</div>
-{{ form_end(employeeOptionsForm) }}
+  {{ form_end(employeeOptionsForm) }}
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -36,6 +36,14 @@
         <div class="col-sm">
           {{ form_errors(employeeOptionsForm.options.password_change_time) }}
           {{ form_widget(employeeOptionsForm.options.password_change_time) }}
+
+          {% if not isAllShopContext %}
+          <div class="alert alert-warning mt-2" role="alert">
+            <p class="alert-text">
+              {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
+            </p>
+          </div>
+          {% endif %}
         </div>
       </div>
 
@@ -44,6 +52,14 @@
         <div class="col-sm">
           {{ form_errors(employeeOptionsForm.options.allow_employee_specific_language) }}
           {{ form_widget(employeeOptionsForm.options.allow_employee_specific_language) }}
+
+          {% if not isAllShopContext %}
+          <div class="alert alert-warning mt-2" role="alert">
+            <p class="alert-text">
+              {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
+            </p>
+          </div>
+          {% endif %}
         </div>
       </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -71,7 +71,11 @@
     </div>
     <div class="card-footer">
       <div class="d-flex justify-content-end">
-        <button class="btn btn-primary pull-right">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        <button class="btn btn-primary pull-right"
+                {% if not canOptionsBeChanged %}disabled{% endif %}
+        >
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
       </div>
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -38,7 +38,7 @@
             {{ form_errors(employeeOptionsForm.options.password_change_time) }}
             {{ form_widget(employeeOptionsForm.options.password_change_time) }}
 
-            {% if not isAllShopContext %}
+            {% if not canOptionsBeChanged %}
             <div class="alert alert-warning mt-2 mb-0" role="alert">
               <p class="alert-text">
                 {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
@@ -54,7 +54,7 @@
             {{ form_errors(employeeOptionsForm.options.allow_employee_specific_language) }}
             {{ form_widget(employeeOptionsForm.options.allow_employee_specific_language) }}
 
-            {% if not isAllShopContext %}
+            {% if not canOptionsBeChanged %}
             <div class="alert alert-warning mt-2 mb-0" role="alert">
               <p class="alert-text">
                 {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -39,7 +39,7 @@
             {{ form_widget(employeeOptionsForm.options.password_change_time) }}
 
             {% if not isAllShopContext %}
-            <div class="alert alert-warning mt-2" role="alert">
+            <div class="alert alert-warning mt-2 mb-0" role="alert">
               <p class="alert-text">
                 {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
               </p>
@@ -55,7 +55,7 @@
             {{ form_widget(employeeOptionsForm.options.allow_employee_specific_language) }}
 
             {% if not isAllShopContext %}
-            <div class="alert alert-warning mt-2" role="alert">
+            <div class="alert alert-warning mt-2 mb-0" role="alert">
               <p class="alert-text">
                 {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
               </p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -1,0 +1,61 @@
+{#**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{{ form_start(employeeOptionsForm, {'action': path('admin_employees_save_options') }) }}
+<div class="card">
+  <h3 class="card-header">
+    <i class="material-icons">settings</i>
+    {{ 'Employee options'|trans({}, 'Admin.Advparameters.Feature') }}
+  </h3>
+  <div class="card-block row">
+    <div class="card-text">
+      <div class="form-group row">
+        {{ ps.label_with_help(('Password regeneration'|trans({}, 'Admin.Advparameters.Feature')), 'Security: Minimum time to wait between two password changes.'|trans({}, 'Admin.Advparameters.Feature')) }}
+        <div class="col-sm">
+          {{ form_errors(employeeOptionsForm.options.password_change_time) }}
+          {{ form_widget(employeeOptionsForm.options.password_change_time) }}
+        </div>
+      </div>
+
+      <div class="form-group row">
+        {{ ps.label_with_help(('Memorize the language used in Admin panel forms'|trans({}, 'Admin.Advparameters.Feature')), 'Allow employees to select a specific language for the Admin panel form.'|trans({}, 'Admin.Advparameters.Feature')) }}
+        <div class="col-sm">
+          {{ form_errors(employeeOptionsForm.options.allow_employee_specific_language) }}
+          {{ form_widget(employeeOptionsForm.options.allow_employee_specific_language) }}
+        </div>
+      </div>
+
+      {% block employee_options_form_rest %}
+        {{ form_rest(employeeOptionsForm) }}
+      {% endblock %}
+    </div>
+  </div>
+  <div class="card-footer">
+    <div class="d-flex justify-content-end">
+      <button class="btn btn-primary pull-right">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+    </div>
+  </div>
+</div>
+{{ form_end(employeeOptionsForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/index.html.twig
@@ -1,0 +1,30 @@
+{#**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  OK
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/index.html.twig
@@ -26,5 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  OK
+  {% block employee_options %}
+    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig' %}
+  {% endblock %}
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR migrates Employee options part of Employee controller.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially migrates https://github.com/PrestaShop/PrestaShop/issues/10502
| How to test?  | Employee options configuration should work the same as it did in legacy page at "Advanced Parameters > Team > Employees". You can access new page directly via url at `admin-dev/index.php/configure/advanced/employees`

**FOR QA TEAM**: only the configuration form is visible in this PR. The listing will be migrated into a new PR.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10790)
<!-- Reviewable:end -->
