### PR TITLE
FIX: slow BO when Addons API is down

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3994,7 +3994,7 @@ class AdminControllerCore extends Controller
      */
     public function isFresh($file, $timeout = 604800)
     {
-        if (($time = @filemtime(_PS_ROOT_DIR_.$file)) && filesize(_PS_ROOT_DIR_.$file) > 0) {
+        if (($time = @filemtime(_PS_ROOT_DIR_.$file))) {
             return ((time() - $time) < $timeout);
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.6.1.x
| Description?  | When Addons API is down, a blank XML is written - next  time you load a page, the blank XML is detected and you are then forced to wait for really long time, everytime you open a BO page!
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | N/A
| Deprecations? | N/A
| Fixed ticket? | N/A
| How to test?  | Open a BO with _PS_DEBUG_PROFILING_ set to true, when api.addons.prestashop.com is down (like right now)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10791)
<!-- Reviewable:end -->
