### PR TITLE
Use https only for API calls and limit use of guzzle 

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3679,32 +3679,25 @@ exit;
 
         $post_data = http_build_query($post_query_data);
 
-        $protocols = array('https');
         $end_point = 'api.addons.prestashop.com';
 
         switch ($request) {
             case 'native':
-                $protocols[] = 'http';
                 $post_data .= '&method=listing&action=native';
                 break;
             case 'partner':
-                $protocols[] = 'http';
                 $post_data .= '&method=listing&action=partner';
                 break;
             case 'service':
-                $protocols[] = 'http';
                 $post_data .= '&method=listing&action=service';
                 break;
             case 'native_all':
-                $protocols[] = 'http';
                 $post_data .= '&method=listing&action=native&iso_code=all';
                 break;
             case 'must-have':
-                $protocols[] = 'http';
                 $post_data .= '&method=listing&action=must-have';
                 break;
             case 'must-have-themes':
-                $protocols[] = 'http';
                 $post_data .= '&method=listing&action=must-have-themes';
                 break;
             case 'customer':
@@ -3725,8 +3718,6 @@ exit;
                 $post_data .= '&method=module&id_module=' . urlencode($params['id_module']);
                 if (isset($params['username_addons']) && isset($params['password_addons'])) {
                     $post_data .= '&username=' . urlencode($params['username_addons']) . '&password=' . urlencode($params['password_addons']);
-                } else {
-                    $protocols[] = 'http';
                 }
                 break;
             case 'hosted_module':
@@ -3734,10 +3725,8 @@ exit;
                     . '&password=' . urlencode($params['password_addons'])
                     . '&shop_url=' . urlencode(isset($params['shop_url']) ? $params['shop_url'] : Tools::getShopDomain())
                     . '&mail=' . urlencode(isset($params['email']) ? $params['email'] : Configuration::get('PS_SHOP_EMAIL'));
-                $protocols[] = 'https';
                 break;
             case 'install-modules':
-                $protocols[] = 'http';
                 $post_data .= '&method=listing&action=install-modules';
                 $post_data .= defined('_PS_HOST_MODE_') ? '-od' : '';
                 break;
@@ -3754,10 +3743,8 @@ exit;
             ),
         ));
 
-        foreach ($protocols as $protocol) {
-            if ($content = Tools::file_get_contents($protocol . '://' . $end_point, false, $context)) {
-                return $content;
-            }
+        if ($content = Tools::file_get_contents('https://' . $end_point, false, $context)) {
+            return $content;
         }
 
         self::$is_addons_up = false;

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -462,14 +462,16 @@ class AdminModuleDataProvider implements ModuleInterface
                     }
                 }
 
-                $this->catalog_modules = $listAddons;
-                if ($this->cacheProvider) {
-                    $this->cacheProvider->save($this->languageISO . self::_CACHEKEY_MODULES_, $this->catalog_modules, self::_DAY_IN_SECONDS_);
+                if (!empty($listAddons)) {
+                    $this->catalog_modules = $listAddons;
+                    if ($this->cacheProvider) {
+                        $this->cacheProvider->save($this->languageISO . self::_CACHEKEY_MODULES_, $this->catalog_modules, self::_DAY_IN_SECONDS_);
+                    }
+                } else {
+                    $this->fallbackOnCatalogCache();
                 }
             } catch (\Exception $e) {
                 if (!$this->fallbackOnCatalogCache()) {
-                    $this->catalog_modules = array();
-                    $this->failed = true;
                     $this->logger->error('Data from PrestaShop Addons is invalid, and cannot fallback on cache. ', array('exception' => $e->getMessage()));
                 }
             }
@@ -479,7 +481,7 @@ class AdminModuleDataProvider implements ModuleInterface
     /**
      * If cache exists, get the Catalogue from the cache.
      *
-     * @return array|false|mixed
+     * @return array Module loaded from the cache
      */
     protected function fallbackOnCatalogCache()
     {
@@ -487,6 +489,12 @@ class AdminModuleDataProvider implements ModuleInterface
         if ($this->cacheProvider) {
             $this->catalog_modules = $this->cacheProvider->fetch($this->languageISO . self::_CACHEKEY_MODULES_);
         }
+
+        if (!$this->catalog_modules) {
+            $this->catalog_modules = array();
+        }
+
+        $this->failed = true;
 
         return $this->catalog_modules;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | When module list is empty, avoid duplicating the calls to the Guzzle lib.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Fill the guzzle cache with empty data, then load the module page. You should see the number of calls decreasing. Note that even if the number is really high, it actually gets the data from a local cache.

Then: 
![capture du 2018-10-01 14-55-51](https://user-images.githubusercontent.com/6768917/46290709-d554d500-c58c-11e8-93f5-539a9052109e.png)
Now: 
![capture du 2018-10-01 15-08-05](https://user-images.githubusercontent.com/6768917/46290715-db4ab600-c58c-11e8-8471-98386a7df355.png)

Blackfire report: https://blackfire.io/profiles/compare/5ec005a2-4cbd-4f5e-ab3b-94d2f9956d4b/graph


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10795)
<!-- Reviewable:end -->
