### PR TITLE
Reuse getAdminLink instead of copy pasting its content

### DIFF
--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -35,8 +35,6 @@ use Language;
 use AdminController;
 use Link;
 use Tab;
-use Tools as ToolsLegacy;
-use Dispatcher;
 use AdminLegacyLayoutControllerCore;
 
 /**
@@ -102,15 +100,7 @@ class LegacyContext
      */
     public function getAdminLink($controller, $withToken = true, $extraParams = array())
     {
-        $id_lang = Context::getContext()->language->id;
-        $params = $extraParams;
-        if ($withToken) {
-            $params['token'] = ToolsLegacy::getAdminTokenLite($controller);
-        }
-
-        $link = new Link();
-
-        return $link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . Dispatcher::getInstance()->createUrl($controller, $id_lang, $params, false);
+        return $this->getContext()->link->getAdminLink($controller, $withToken, $extraParams, $extraParams);
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | It seems the content of getAdminLink has been copy pasted in the Adapter equivalent class. Because of the lack of 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/10794
| How to test?  | See issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10796)
<!-- Reviewable:end -->
