### PR TITLE
Restore legacy sql manager page 175

### DIFF
--- a/admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl
@@ -1,0 +1,116 @@
+{**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+{extends file="helpers/form/form.tpl"}
+
+{block name="after"}
+<div class="row">
+	<div class="col-lg-3">
+		<div class="panel">
+			<h3><i class="icon-list"></i> {l s='List of MySQL Tables' d='Admin.Advparameters.Feature'}</h3>
+			<div class="form-group" id="selectTables">
+				<select id="table" size="10">
+					{foreach $tables as $table}
+						<option value="{$table}">{$table}</option>
+					{/foreach}
+				</select>
+			</div>
+			<div class="form-group">
+				<button type="button" id="add_table" class="btn btn-default"><i class="icon-plus-sign"></i> {l s='Add table name to SQL query' d='Admin.Advparameters.Feature'}</button>
+			</div>
+		</div>
+	</div>
+	<div class="col-lg-9">
+		<div class="panel">
+			<h3><i class="icon-list"></i> {l s='List of attributes for this MySQL table' d='Admin.Advparameters.Feature'}</h3>
+			<div id="listAttributes">
+				<div class="alert alert-warning">{l s='Please choose a MySQL table' d='Admin.Advparameters.Notification'}</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+{/block}
+
+{block name="script"}
+	$(document).ready(function() {
+		$('#selectTables select option').click(function(){
+			var table = $(this).val();
+			//list attributes:
+			$.ajax({
+				url: 'index.php',
+				data: {
+					table: table,
+					controller: 'adminrequestsql',
+					token: '{$token|escape:'html':'UTF-8'}',
+					action: 'addrequest_sql',
+					ajax: true
+				},
+				context: document.body,
+				dataType: 'json',
+				context: this,
+				async: false,
+				success: function(data){
+					var html = "<table class='table'>";
+						html += "<thead>";
+							html += "<tr>";
+								html += "<th><span class=\"title_box\">{l s='Attribute'}</span></th>";
+								html += "<th class=\"fixed-width-md\"><span class=\"title_box\">{l s='Type' d='Admin.Global'}</span></th>";
+								html += "<th class=\"fixed-width-md\"><span class=\"title_box\">{l s='Action' d='Admin.Advparameters.Feature'}</span></th>";
+							html += "</tr>";
+						html += "</thead>";
+						html += "<tbody>";
+						for (var i=0; i < data.length; i++)
+						{
+							html += "<tr>";
+								html += "<td>"+data[i].Field+"</td>";
+								html += "<td>"+data[i].Type+"</td>";
+								html += "<td><button type=\"button\" class=\"btn btn-default\" onclick=\"javascript:AddRequestSql('"+data[i].Field+"');\">{l s='Add attribute to SQL query' d='Admin.Advparameters.Feature'}</button></td>";
+							html += "</tr>";
+						}
+						html += "</tbody>";
+					html += "</table>";
+					$('#listAttributes').html(html);
+				}
+			});
+		});
+
+		$('#add_table').click(function(){
+			var table = $('#selectTables select').val();
+
+			if (!table)
+				jAlert("{l s='Please choose a table.' js=1 d='Admin.Advparameters.Feature'}");
+			else
+				AddRequestSql(table);
+		});
+	});
+
+	function AddRequestSql(string)
+	{
+		var sql = $('#sql').val();
+		$('#sql').val(sql+' '+string);
+		return false;
+	}
+{/block}

--- a/admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl
@@ -1,0 +1,67 @@
+{**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+{extends file="helpers/view/view.tpl"}
+
+{block name="override_tpl"}
+<div class="panel">
+	<h3><i class="icon-cog"></i> {l s='SQL query result' d='Admin.Advparameters.Feature'}</h3>
+	{if isset($view['error'])}
+		<div class="alert alert-warning">{l s='This SQL query has no result.' d='Admin.Advparameters.Notification'}</div>
+	{else}
+		<table class="table" id="viewRequestSql">
+			<thead>
+				<tr>
+					{foreach $view['key'] AS $key}
+					<th><span class="title_box">{$key}</span></th>
+					{/foreach}
+				</tr>
+			</thead>
+			<tbody>
+			{foreach $view['results'] AS $result}
+				<tr>
+					{foreach $view['key'] AS $name}
+						{if isset($view['attributes'][$name])}
+							<td>{$view['attributes'][$name]|escape:'html':'UTF-8'}</td>
+						{else}
+							<td>{$result[$name]|escape:'html':'UTF-8'}</td>
+						{/if}
+					{/foreach}
+				</tr>
+			{/foreach}
+			</tbody>
+		</table>
+
+		<script type="text/javascript">
+			$(function(){
+				var width = $('#viewRequestSql').width();
+				if (width > 990){
+					$('#viewRequestSql').css('display','block').css('overflow-x', 'scroll');
+				}
+			});
+		</script>
+	{/if}
+</div>
+{/block}

--- a/admin-dev/themes/default/template/controllers/request_sql/list_action_export.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/list_action_export.tpl
@@ -1,0 +1,27 @@
+{**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+<a href="{$href|escape:'html':'UTF-8'}" title="{$action}" class="btn btn-default">
+	<i class="icon-cloud-upload"></i> {$action}
+</a>

--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -107,7 +107,7 @@
 
 <div class="alert alert-warning" id="{$list_id}-empty-filters-alert" style="display:none;">{l s='Please fill at least one field to perform a search in this list.'}</div>
 {if isset($sql) && $sql}
-	<form id="sql_form_{$list_id|escape:'html':'UTF-8'}" action="{url entity='sf' route='admin_sql_request_create' }" method="post" class="hide">
+	<form id="sql_form_{$list_id|escape:'html':'UTF-8'}" action="{$link->getAdminLink('AdminRequestSql')|escape}&amp;addrequest_sql" method="post" class="hide">
 		<input type="hidden" id="sql_query_{$list_id|escape:'html':'UTF-8'}" name="sql" value="{$sql|escape}"/>
 		<input type="hidden" id="sql_name_{$list_id|escape:'html':'UTF-8'}" name="name" value=""/>
 	</form>

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -800,7 +800,7 @@ class LinkCore
                     'AdminPaymentPreferences' => 'admin_payment_preferences',
                     'AdminInvoices' => 'admin_order_invoices',
                     'AdminEmails' => 'admin_email',
-                    'AdminRequestSql' => 'admin_sql_request',
+                    // 'AdminRequestSql' => 'admin_sql_request', @todo: uncomment when CQRS pages are hookable
                     'AdminMeta' => 'admin_meta',
                     // 'AdminWebservice' => 'admin_webservice', @todo: uncomment when grid and entity form are done.
                     'AdminBackup' => 'admin_backup',

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -1,0 +1,528 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @property RequestSql $object
+ */
+class AdminRequestSqlControllerCore extends AdminController
+{
+    /**
+     * @var array : List of encoding type for a file
+     */
+    public static $encoding_file = array(
+        array('value' => 1, 'name' => 'utf-8'),
+        array('value' => 2, 'name' => 'iso-8859-1')
+    );
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        $this->table = 'request_sql';
+        $this->className = 'RequestSql';
+        $this->lang = false;
+        $this->export = true;
+
+        parent::__construct();
+
+        $this->fields_list = array(
+            'id_request_sql' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'class' => 'fixed-width-xs'),
+            'name' => array('title' => $this->trans('SQL query Name', array(), 'Admin.Advparameters.Feature')),
+            'sql' => array('title' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature')),
+        );
+
+        $this->fields_options = array(
+            'general' => array(
+                'title' =>    $this->trans('Settings', array(), 'Admin.Global'),
+                'fields' =>    array(
+                    'PS_ENCODING_FILE_MANAGER_SQL' => array(
+                        'title' => $this->trans('Select your default file encoding', array(), 'Admin.Advparameters.Feature'),
+                        'cast' => 'intval',
+                        'type' => 'select',
+                        'identifier' => 'value',
+                        'list' => self::$encoding_file,
+                        'visibility' => Shop::CONTEXT_ALL
+                    )
+                ),
+                'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions'))
+            )
+        );
+
+        $this->bulk_actions = array(
+            'delete' => array(
+                'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
+                'icon' => 'icon-trash'
+            )
+        );
+    }
+
+    public function renderOptions()
+    {
+        // Set toolbar options
+        $this->display = 'options';
+        $this->show_toolbar = true;
+        $this->toolbar_scroll = true;
+        $this->initToolbar();
+
+        return parent::renderOptions();
+    }
+
+    public function initToolbar()
+    {
+        if ($this->display == 'view' && $id_request = Tools::getValue('id_request_sql')) {
+            $this->toolbar_btn['edit'] = array(
+                'href' => self::$currentIndex.'&amp;updaterequest_sql&amp;token='.$this->token.'&amp;id_request_sql='.(int)$id_request,
+                'desc' => $this->trans('Edit this SQL query', array(), 'Admin.Advparameters.Feature')
+            );
+        }
+
+        parent::initToolbar();
+
+        if ($this->display == 'options') {
+            unset($this->toolbar_btn['new']);
+        }
+    }
+
+    public function renderList()
+    {
+        // Set toolbar options
+        $this->display = null;
+        $this->initToolbar();
+
+        $this->displayWarning($this->trans('When saving the query, only the "SELECT" SQL statement is allowed.', array(), 'Admin.Advparameters.Notification'));
+        $this->displayInformation('
+		<strong>'.$this->trans('How do I create a new SQL query?', array(), 'Admin.Advparameters.Help').'</strong><br />
+		<ul>
+			<li>'.$this->trans('Click "Add New".', array(), 'Admin.Advparameters.Help').'</li>
+			<li>'.$this->trans('Fill in the fields and click "Save".', array(), 'Admin.Advparameters.Help').'</li>
+			<li>'.$this->trans('You can then view the query results by clicking on the Edit action in the dropdown menu', array(), 'Admin.Advparameters.Help').' <i class="icon-pencil"></i></li>
+			<li>'.$this->trans('You can also export the query results as a CSV file by clicking on the Export button', array(), 'Admin.Advparameters.Help').' <i class="icon-cloud-upload"></i></li>
+		</ul>');
+
+        $this->addRowAction('export');
+        $this->addRowAction('view');
+        $this->addRowAction('edit');
+        $this->addRowAction('delete');
+
+        return parent::renderList();
+    }
+
+    public function renderForm()
+    {
+        $this->fields_form = array(
+            'legend' => array(
+                'title' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature'),
+                'icon' => 'icon-cog'
+            ),
+            'input' => array(
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('SQL query name', array(), 'Admin.Advparameters.Feature'),
+                    'name' => 'name',
+                    'size' => 103,
+                    'required' => true
+                ),
+                array(
+                    'type' => 'textarea',
+                    'label' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature'),
+                    'name' => 'sql',
+                    'cols' => 100,
+                    'rows' => 10,
+                    'required' => true
+                )
+            ),
+            'submit' => array(
+                'title' => $this->trans('Save', array(), 'Admin.Actions')
+            )
+        );
+
+        $request = new RequestSql();
+        $this->tpl_form_vars = array('tables' => $request->getTables());
+
+        return parent::renderForm();
+    }
+
+
+    public function postProcess()
+    {
+        /* PrestaShop demo mode */
+        if (_PS_MODE_DEMO_) {
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
+            return;
+        }
+        return parent::postProcess();
+    }
+
+    /**
+     * method call when ajax request is made with the details row action
+     * @see AdminController::postProcess()
+     */
+    public function ajaxProcess()
+    {
+        /* PrestaShop demo mode */
+        if (_PS_MODE_DEMO_) {
+            die($this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error'));
+        }
+        if ($table = Tools::getValue('table')) {
+            $request_sql = new RequestSql();
+            $attributes = $request_sql->getAttributesByTable($table);
+            foreach ($attributes as $key => $attribute) {
+                unset($attributes[$key]['Null']);
+                unset($attributes[$key]['Key']);
+                unset($attributes[$key]['Default']);
+                unset($attributes[$key]['Extra']);
+            }
+            die(json_encode($attributes));
+        }
+    }
+
+    public function renderView()
+    {
+        /** @var RequestSql $obj */
+        if (!($obj = $this->loadObject(true))) {
+            return;
+        }
+
+        $view = array();
+        if ($results = Db::getInstance()->executeS($obj->sql)) {
+            foreach (array_keys($results[0]) as $key) {
+                $tab_key[] = $key;
+            }
+
+            $view['name'] = $obj->name;
+            $view['key'] = $tab_key;
+            $view['results'] = $results;
+
+            $this->toolbar_title = $obj->name;
+
+            $request_sql = new RequestSql();
+            $view['attributes'] = $request_sql->attributes;
+        } else {
+            $view['error'] = true;
+        }
+
+        $this->tpl_view_vars = array(
+            'view' => $view
+        );
+        return parent::renderView();
+    }
+
+    public function _childValidation()
+    {
+        if (Tools::getValue('submitAdd'.$this->table) && $sql = Tools::getValue('sql')) {
+            $request_sql = new RequestSql();
+            $parser = $request_sql->parsingSql($sql);
+            $validate = $request_sql->validateParser($parser, false, $sql);
+
+            if (!$validate || count($request_sql->error_sql)) {
+                $this->displayError($request_sql->error_sql);
+            }
+        }
+    }
+
+    /**
+     * Display export action link
+     *
+     * @param $token
+     * @param int $id
+     *
+     * @return string
+     * @throws Exception
+     * @throws SmartyException
+     */
+    public function displayExportLink($token, $id)
+    {
+        $tpl = $this->createTemplate('list_action_export.tpl');
+
+        $tpl->assign(array(
+            'href' => self::$currentIndex.'&token='.$this->token.'&'.$this->identifier.'='.$id.'&export'.$this->table.'=1',
+            'action' => $this->trans('Export', array(), 'Admin.Actions')
+        ));
+
+        return $tpl->fetch();
+    }
+
+    public function initProcess()
+    {
+        parent::initProcess();
+        if (Tools::getValue('export'.$this->table)) {
+            $this->display = 'export';
+            $this->action = 'export';
+        }
+    }
+
+    public function initContent()
+    {
+        if ($this->display == 'edit' || $this->display == 'add') {
+            if (!$this->loadObject(true)) {
+                return;
+            }
+
+            $this->content .= $this->renderForm();
+        } elseif ($this->display == 'view') {
+            // Some controllers use the view action without an object
+            if ($this->className) {
+                $this->loadObject(true);
+            }
+            $this->content .= $this->renderView();
+        } elseif ($this->display == 'export') {
+            $this->processExport();
+        } elseif (!$this->ajax) {
+            $this->content .= $this->renderList();
+            $this->content .= $this->renderOptions();
+        }
+
+        $this->context->smarty->assign(array(
+            'content' => $this->content,
+        ));
+    }
+
+    public function initPageHeaderToolbar()
+    {
+        if (empty($this->display)) {
+            $this->page_header_toolbar_btn['new_request'] = array(
+                'href' => self::$currentIndex.'&addrequest_sql&token='.$this->token,
+                'desc' => $this->trans('Add new SQL query', array(), 'Admin.Advparameters.Feature'),
+                'icon' => 'process-icon-new'
+            );
+        }
+
+        parent::initPageHeaderToolbar();
+    }
+
+    /**
+     * Genrating a export file
+     */
+    public function processExport($textDelimiter = '"')
+    {
+        $id = Tools::getValue($this->identifier);
+        $export_dir = defined('_PS_HOST_MODE_') ? _PS_ROOT_DIR_.'/export/' : _PS_ADMIN_DIR_.'/export/';
+        if (!Validate::isFileName($id)) {
+            die(Tools::displayError());
+        }
+        $file = 'request_sql_'.$id.'.csv';
+        if ($csv = fopen($export_dir.$file, 'w')) {
+            $sql = RequestSql::getRequestSqlById($id);
+
+            if ($sql) {
+                $results = Db::getInstance()->executeS($sql[0]['sql']);
+                foreach (array_keys($results[0]) as $key) {
+                    $tab_key[] = $key;
+                    fputs($csv, $key.';');
+                }
+                foreach ($results as $result) {
+                    fputs($csv, "\n");
+                    foreach ($tab_key as $name) {
+                        fputs($csv, $textDelimiter.strip_tags($result[$name]).$textDelimiter.';');
+                    }
+                }
+                if (file_exists($export_dir.$file)) {
+                    $filesize = filesize($export_dir.$file);
+                    $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
+                    if ($filesize < $upload_max_filesize) {
+                        if (Configuration::get('PS_ENCODING_FILE_MANAGER_SQL')) {
+                            $charset = Configuration::get('PS_ENCODING_FILE_MANAGER_SQL');
+                        } else {
+                            $charset = self::$encoding_file[0]['name'];
+                        }
+
+                        header('Content-Type: text/csv; charset='.$charset);
+                        header('Cache-Control: no-store, no-cache');
+                        header('Content-Disposition: attachment; filename="'.$file.'"');
+                        header('Content-Length: '.$filesize);
+                        readfile($export_dir.$file);
+                        die();
+                    } else {
+                        $this->errors[] = $this->trans('The file is too large and cannot be downloaded. Please use the LIMIT clause in this query.', array(), 'Admin.Advparameters.Notification');
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Display all errors
+     *
+     * @param $e : array of errors
+     */
+    public function displayError($e)
+    {
+        foreach (array_keys($e) as $key) {
+            switch ($key) {
+                case 'checkedFrom':
+                    if (isset($e[$key]['table'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%tablename%" table does not exist.',
+                            array(
+                                '%tablename%' => $e[$key]['table'],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                                'The "%attribute%" attribute does not exist in the "%table%" table.',
+                                array(
+                                    '%attribute%' => $e[$key]['attribut'][0],
+                                    '%table%' => $e[$key]['attribut'][1],
+                                ),
+                                'Admin.Advparameters.Notification'
+                            );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedForm'), 'Admin.Advparameters.Notification');
+                    }
+                    break;
+
+                case 'checkedSelect':
+                    if (isset($e[$key]['table'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%tablename%" table does not exist.',
+                            array(
+                                '%tablename%' => $e[$key]['table'],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['*'])) {
+                        $this->errors[] = $this->trans('The "*" operator cannot be used in a nested query.', array(), 'Admin.Advparameters.Notification');
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedSelect'), 'Admin.Advparameters.Notification');
+                    }
+                    break;
+
+                case 'checkedWhere':
+                    if (isset($e[$key]['operator'])) {
+                        $this->errors[] = $this->trans(
+                            'The operator "%s" is incorrect.',
+                            array(
+                                '%operator%' => $e[$key]['operator'],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedWhere'), 'Admin.Advparameters.Notification');
+                    }
+                    break;
+
+                case 'checkedHaving':
+                    if (isset($e[$key]['operator'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%operator%" operator is incorrect.',
+                            array(
+                                '%operator%' => $e[$key]['operator']
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedHaving'), 'Admin.Advparameters.Notification');
+                    }
+                    break;
+
+                case 'checkedOrder':
+                    if (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedOrder'), 'Admin.Advparameters.Notification');
+                    }
+                    break;
+
+                case 'checkedGroupBy':
+                    if (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedGroupBy'), 'Admin.Advparameters.Notification');
+                    }
+                    break;
+
+                case 'checkedLimit':
+                    $this->errors[] = $this->trans('The LIMIT clause must contain numeric arguments.', array(), 'Admin.Advparameters.Notification');
+                    break;
+
+                case 'returnNameTable':
+                    if (isset($e[$key]['reference'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%reference%" reference does not exist in the "%table%" table.',
+                            array(
+                                '%reference%' => $e[$key]['reference'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('When multiple tables are used, each attribute must refer back to a table.', array(), 'Admin.Advparameters.Notification');
+                    }
+                    break;
+
+                case 'testedRequired':
+                    $this->errors[] = $this->trans('"%key%" does not exist.', array('%key%' => $e[$key]), 'Admin.Notifications.Error');
+                    break;
+
+                case 'testedUnauthorized':
+                    $this->errors[] = $this->trans('"%key%" is an unauthorized keyword.', array('%key%' => $e[$key]), 'Admin.Advparameters.Notification');
+                    break;
+            }
+        }
+    }
+}

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -34,7 +34,7 @@ class AdminRequestSqlControllerCore extends AdminController
      */
     public static $encoding_file = array(
         array('value' => 1, 'name' => 'utf-8'),
-        array('value' => 2, 'name' => 'iso-8859-1')
+        array('value' => 2, 'name' => 'iso-8859-1'),
     );
 
     public function __construct()
@@ -55,27 +55,27 @@ class AdminRequestSqlControllerCore extends AdminController
 
         $this->fields_options = array(
             'general' => array(
-                'title' =>    $this->trans('Settings', array(), 'Admin.Global'),
-                'fields' =>    array(
+                'title' => $this->trans('Settings', array(), 'Admin.Global'),
+                'fields' => array(
                     'PS_ENCODING_FILE_MANAGER_SQL' => array(
                         'title' => $this->trans('Select your default file encoding', array(), 'Admin.Advparameters.Feature'),
                         'cast' => 'intval',
                         'type' => 'select',
                         'identifier' => 'value',
                         'list' => self::$encoding_file,
-                        'visibility' => Shop::CONTEXT_ALL
-                    )
+                        'visibility' => Shop::CONTEXT_ALL,
+                    ),
                 ),
-                'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions'))
-            )
+                'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions')),
+            ),
         );
 
         $this->bulk_actions = array(
             'delete' => array(
                 'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
                 'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
-                'icon' => 'icon-trash'
-            )
+                'icon' => 'icon-trash',
+            ),
         );
     }
 
@@ -94,8 +94,8 @@ class AdminRequestSqlControllerCore extends AdminController
     {
         if ($this->display == 'view' && $id_request = Tools::getValue('id_request_sql')) {
             $this->toolbar_btn['edit'] = array(
-                'href' => self::$currentIndex.'&amp;updaterequest_sql&amp;token='.$this->token.'&amp;id_request_sql='.(int)$id_request,
-                'desc' => $this->trans('Edit this SQL query', array(), 'Admin.Advparameters.Feature')
+                'href' => self::$currentIndex . '&amp;updaterequest_sql&amp;token=' . $this->token . '&amp;id_request_sql=' . (int) $id_request,
+                'desc' => $this->trans('Edit this SQL query', array(), 'Admin.Advparameters.Feature'),
             );
         }
 
@@ -114,12 +114,12 @@ class AdminRequestSqlControllerCore extends AdminController
 
         $this->displayWarning($this->trans('When saving the query, only the "SELECT" SQL statement is allowed.', array(), 'Admin.Advparameters.Notification'));
         $this->displayInformation('
-		<strong>'.$this->trans('How do I create a new SQL query?', array(), 'Admin.Advparameters.Help').'</strong><br />
+		<strong>' . $this->trans('How do I create a new SQL query?', array(), 'Admin.Advparameters.Help') . '</strong><br />
 		<ul>
-			<li>'.$this->trans('Click "Add New".', array(), 'Admin.Advparameters.Help').'</li>
-			<li>'.$this->trans('Fill in the fields and click "Save".', array(), 'Admin.Advparameters.Help').'</li>
-			<li>'.$this->trans('You can then view the query results by clicking on the Edit action in the dropdown menu', array(), 'Admin.Advparameters.Help').' <i class="icon-pencil"></i></li>
-			<li>'.$this->trans('You can also export the query results as a CSV file by clicking on the Export button', array(), 'Admin.Advparameters.Help').' <i class="icon-cloud-upload"></i></li>
+			<li>' . $this->trans('Click "Add New".', array(), 'Admin.Advparameters.Help') . '</li>
+			<li>' . $this->trans('Fill in the fields and click "Save".', array(), 'Admin.Advparameters.Help') . '</li>
+			<li>' . $this->trans('You can then view the query results by clicking on the Edit action in the dropdown menu', array(), 'Admin.Advparameters.Help') . ' <i class="icon-pencil"></i></li>
+			<li>' . $this->trans('You can also export the query results as a CSV file by clicking on the Export button', array(), 'Admin.Advparameters.Help') . ' <i class="icon-cloud-upload"></i></li>
 		</ul>');
 
         $this->addRowAction('export');
@@ -135,7 +135,7 @@ class AdminRequestSqlControllerCore extends AdminController
         $this->fields_form = array(
             'legend' => array(
                 'title' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature'),
-                'icon' => 'icon-cog'
+                'icon' => 'icon-cog',
             ),
             'input' => array(
                 array(
@@ -143,7 +143,7 @@ class AdminRequestSqlControllerCore extends AdminController
                     'label' => $this->trans('SQL query name', array(), 'Admin.Advparameters.Feature'),
                     'name' => 'name',
                     'size' => 103,
-                    'required' => true
+                    'required' => true,
                 ),
                 array(
                     'type' => 'textarea',
@@ -151,12 +151,12 @@ class AdminRequestSqlControllerCore extends AdminController
                     'name' => 'sql',
                     'cols' => 100,
                     'rows' => 10,
-                    'required' => true
-                )
+                    'required' => true,
+                ),
             ),
             'submit' => array(
-                'title' => $this->trans('Save', array(), 'Admin.Actions')
-            )
+                'title' => $this->trans('Save', array(), 'Admin.Actions'),
+            ),
         );
 
         $request = new RequestSql();
@@ -165,19 +165,21 @@ class AdminRequestSqlControllerCore extends AdminController
         return parent::renderForm();
     }
 
-
     public function postProcess()
     {
         /* PrestaShop demo mode */
         if (_PS_MODE_DEMO_) {
             $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
+
             return;
         }
+
         return parent::postProcess();
     }
 
     /**
-     * method call when ajax request is made with the details row action
+     * method call when ajax request is made with the details row action.
+     *
      * @see AdminController::postProcess()
      */
     public function ajaxProcess()
@@ -225,14 +227,15 @@ class AdminRequestSqlControllerCore extends AdminController
         }
 
         $this->tpl_view_vars = array(
-            'view' => $view
+            'view' => $view,
         );
+
         return parent::renderView();
     }
 
     public function _childValidation()
     {
-        if (Tools::getValue('submitAdd'.$this->table) && $sql = Tools::getValue('sql')) {
+        if (Tools::getValue('submitAdd' . $this->table) && $sql = Tools::getValue('sql')) {
             $request_sql = new RequestSql();
             $parser = $request_sql->parsingSql($sql);
             $validate = $request_sql->validateParser($parser, false, $sql);
@@ -244,12 +247,13 @@ class AdminRequestSqlControllerCore extends AdminController
     }
 
     /**
-     * Display export action link
+     * Display export action link.
      *
      * @param $token
      * @param int $id
      *
      * @return string
+     *
      * @throws Exception
      * @throws SmartyException
      */
@@ -258,8 +262,8 @@ class AdminRequestSqlControllerCore extends AdminController
         $tpl = $this->createTemplate('list_action_export.tpl');
 
         $tpl->assign(array(
-            'href' => self::$currentIndex.'&token='.$this->token.'&'.$this->identifier.'='.$id.'&export'.$this->table.'=1',
-            'action' => $this->trans('Export', array(), 'Admin.Actions')
+            'href' => self::$currentIndex . '&token=' . $this->token . '&' . $this->identifier . '=' . $id . '&export' . $this->table . '=1',
+            'action' => $this->trans('Export', array(), 'Admin.Actions'),
         ));
 
         return $tpl->fetch();
@@ -268,7 +272,7 @@ class AdminRequestSqlControllerCore extends AdminController
     public function initProcess()
     {
         parent::initProcess();
-        if (Tools::getValue('export'.$this->table)) {
+        if (Tools::getValue('export' . $this->table)) {
             $this->display = 'export';
             $this->action = 'export';
         }
@@ -304,9 +308,9 @@ class AdminRequestSqlControllerCore extends AdminController
     {
         if (empty($this->display)) {
             $this->page_header_toolbar_btn['new_request'] = array(
-                'href' => self::$currentIndex.'&addrequest_sql&token='.$this->token,
+                'href' => self::$currentIndex . '&addrequest_sql&token=' . $this->token,
                 'desc' => $this->trans('Add new SQL query', array(), 'Admin.Advparameters.Feature'),
-                'icon' => 'process-icon-new'
+                'icon' => 'process-icon-new',
             );
         }
 
@@ -314,33 +318,33 @@ class AdminRequestSqlControllerCore extends AdminController
     }
 
     /**
-     * Genrating a export file
+     * Genrating a export file.
      */
     public function processExport($textDelimiter = '"')
     {
         $id = Tools::getValue($this->identifier);
-        $export_dir = defined('_PS_HOST_MODE_') ? _PS_ROOT_DIR_.'/export/' : _PS_ADMIN_DIR_.'/export/';
+        $export_dir = defined('_PS_HOST_MODE_') ? _PS_ROOT_DIR_ . '/export/' : _PS_ADMIN_DIR_ . '/export/';
         if (!Validate::isFileName($id)) {
             die(Tools::displayError());
         }
-        $file = 'request_sql_'.$id.'.csv';
-        if ($csv = fopen($export_dir.$file, 'w')) {
+        $file = 'request_sql_' . $id . '.csv';
+        if ($csv = fopen($export_dir . $file, 'w')) {
             $sql = RequestSql::getRequestSqlById($id);
 
             if ($sql) {
                 $results = Db::getInstance()->executeS($sql[0]['sql']);
                 foreach (array_keys($results[0]) as $key) {
                     $tab_key[] = $key;
-                    fputs($csv, $key.';');
+                    fputs($csv, $key . ';');
                 }
                 foreach ($results as $result) {
                     fputs($csv, "\n");
                     foreach ($tab_key as $name) {
-                        fputs($csv, $textDelimiter.strip_tags($result[$name]).$textDelimiter.';');
+                        fputs($csv, $textDelimiter . strip_tags($result[$name]) . $textDelimiter . ';');
                     }
                 }
-                if (file_exists($export_dir.$file)) {
-                    $filesize = filesize($export_dir.$file);
+                if (file_exists($export_dir . $file)) {
+                    $filesize = filesize($export_dir . $file);
                     $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
                     if ($filesize < $upload_max_filesize) {
                         if (Configuration::get('PS_ENCODING_FILE_MANAGER_SQL')) {
@@ -349,11 +353,11 @@ class AdminRequestSqlControllerCore extends AdminController
                             $charset = self::$encoding_file[0]['name'];
                         }
 
-                        header('Content-Type: text/csv; charset='.$charset);
+                        header('Content-Type: text/csv; charset=' . $charset);
                         header('Cache-Control: no-store, no-cache');
-                        header('Content-Disposition: attachment; filename="'.$file.'"');
-                        header('Content-Length: '.$filesize);
-                        readfile($export_dir.$file);
+                        header('Content-Disposition: attachment; filename="' . $file . '"');
+                        header('Content-Length: ' . $filesize);
+                        readfile($export_dir . $file);
                         die();
                     } else {
                         $this->errors[] = $this->trans('The file is too large and cannot be downloaded. Please use the LIMIT clause in this query.', array(), 'Admin.Advparameters.Notification');
@@ -364,7 +368,7 @@ class AdminRequestSqlControllerCore extends AdminController
     }
 
     /**
-     * Display all errors
+     * Display all errors.
      *
      * @param $e : array of errors
      */
@@ -448,7 +452,7 @@ class AdminRequestSqlControllerCore extends AdminController
                         $this->errors[] = $this->trans(
                             'The "%operator%" operator is incorrect.',
                             array(
-                                '%operator%' => $e[$key]['operator']
+                                '%operator%' => $e[$key]['operator'],
                             ),
                             'Admin.Advparameters.Notification'
                         );

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -207,7 +207,7 @@ class ProductController extends FrameworkBundleAdminController
                 'categories' => $categoriesForm->createView(),
                 'pagination_limit_choices' => $productProvider->getPaginationLimitChoices(),
                 'import_link' => $this->generateUrl('admin_import', ['import_type' => 'products']),
-                'sql_manager_add_link' => $this->generateUrl('admin_sql_request_create', ['addrequest_sql' => 1]),
+                'sql_manager_add_link' => $this->get('prestashop.adapter.legacy.context')->getAdminLink('AdminRequestSql', true, ['addrequest_sql' => 1]),
                 'enableSidebar' => true,
                 'help_link' => $this->generateSidebarLink('AdminProducts'),
                 'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Restore legacy page for SQL manager and hide SF page as it is not 100% ready for release
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/10652
| How to test?  | "Advanced parameters > Database" Sql manager page is back to its legacy version. Please check it works as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10814)
<!-- Reviewable:end -->
