### PR TITLE
Migrate "Layout customization" part of Them & Logo controller

### DIFF
--- a/src/Adapter/Meta/QueryHandler/GetPagesForLayoutCustomizationHandler.php
+++ b/src/Adapter/Meta/QueryHandler/GetPagesForLayoutCustomizationHandler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -32,7 +32,7 @@ use PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetPagesForLayoutCustomization;
 use PrestaShop\PrestaShop\Core\Domain\Meta\QueryHandler\GetPagesForLayoutCustomizationHandlerInterface;
 
 /**
- * Class GetMetaPagesListHandler
+ * Class GetMetaPagesListHandler.
  */
 final class GetPagesForLayoutCustomizationHandler implements GetPagesForLayoutCustomizationHandlerInterface
 {

--- a/src/Adapter/Meta/QueryHandler/GetPagesForLayoutCustomizationHandler.php
+++ b/src/Adapter/Meta/QueryHandler/GetPagesForLayoutCustomizationHandler.php
@@ -24,33 +24,46 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Controller\Admin\Improve\Design;
+namespace PrestaShop\PrestaShop\Adapter\Meta\QueryHandler;
 
+use Meta;
+use PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject\LayoutCustomizationPage;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetPagesForLayoutCustomization;
-use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
-use PrestaShopBundle\Form\Admin\Improve\Design\Theme\PageLayoutCustomizationType;
-use Symfony\Component\HttpFoundation\Response;
+use PrestaShop\PrestaShop\Core\Domain\Meta\QueryHandler\GetPagesForLayoutCustomizationHandlerInterface;
 
 /**
- * Class ThemeController manages "Improve > Design > Theme & Logo" pages.
+ * Class GetMetaPagesListHandler
  */
-class ThemeController extends AbstractAdminController
+final class GetPagesForLayoutCustomizationHandler implements GetPagesForLayoutCustomizationHandlerInterface
 {
     /**
-     * Show current theme's pages layout customization.
-     *
-     * @return Response
+     * @var int
      */
-    public function customizePageLayoutsAction()
+    private $contextLangId;
+
+    /**
+     * @param int $contextLangId
+     */
+    public function __construct($contextLangId)
     {
-        $pageLayoutCustomizationForm = $this->createForm(PageLayoutCustomizationType::class);
+        $this->contextLangId = $contextLangId;
+    }
 
-        $pages = $this->getQueryBus()->handle(new GetPagesForLayoutCustomization());
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(GetPagesForLayoutCustomization $query)
+    {
+        $metas = Meta::getAllMeta($this->contextLangId);
+        $pages = [];
 
-        dump($pages);
+        foreach ($metas as $meta) {
+            $pages[] = new LayoutCustomizationPage(
+                $meta['page'],
+                $meta['description']
+            );
+        }
 
-        return $this->render('@PrestaShop/Admin/Improve/Design/Theme/customize_page_layouts.twig', [
-            'pageLayoutCustomizationForm' => $pageLayoutCustomizationForm->createView(),
-        ]);
+        return $pages;
     }
 }

--- a/src/Adapter/Meta/QueryHandler/GetPagesForLayoutCustomizationHandler.php
+++ b/src/Adapter/Meta/QueryHandler/GetPagesForLayoutCustomizationHandler.php
@@ -60,6 +60,7 @@ final class GetPagesForLayoutCustomizationHandler implements GetPagesForLayoutCu
         foreach ($metas as $meta) {
             $pages[] = new LayoutCustomizationPage(
                 $meta['page'],
+                $meta['title'],
                 $meta['description']
             );
         }

--- a/src/Core/Addon/Theme/ThemePageLayoutsCustomizer.php
+++ b/src/Core/Addon/Theme/ThemePageLayoutsCustomizer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/Core/Addon/Theme/ThemePageLayoutsCustomizer.php
+++ b/src/Core/Addon/Theme/ThemePageLayoutsCustomizer.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Addon\Theme;
+
+/**
+ * Class PagesLayoutCustomizer customizes pages layout for shop's Front Office theme.
+ */
+final class ThemePageLayoutsCustomizer implements ThemePageLayoutsCustomizerInterface
+{
+    /**
+     * @var Theme
+     */
+    private $theme;
+
+    /**
+     * @var ThemeManager
+     */
+    private $themeManager;
+
+    /**
+     * @param Theme $theme
+     * @param ThemeManager $themeManager
+     */
+    public function __construct(Theme $theme, ThemeManager $themeManager)
+    {
+        $this->theme = $theme;
+        $this->themeManager = $themeManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function customize(array $pageLayouts)
+    {
+        $this->theme->setPageLayouts($pageLayouts);
+        $this->themeManager->saveTheme($this->theme);
+    }
+}

--- a/src/Core/Addon/Theme/ThemePageLayoutsCustomizer.php
+++ b/src/Core/Addon/Theme/ThemePageLayoutsCustomizer.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
+use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
+
 /**
  * Class PagesLayoutCustomizer customizes pages layout for shop's Front Office theme.
  */
@@ -42,13 +44,20 @@ final class ThemePageLayoutsCustomizer implements ThemePageLayoutsCustomizerInte
     private $themeManager;
 
     /**
+     * @var CacheClearerInterface
+     */
+    private $smartyCacheClearer;
+
+    /**
      * @param Theme $theme
      * @param ThemeManager $themeManager
+     * @param CacheClearerInterface $smartyCacheClearer
      */
-    public function __construct(Theme $theme, ThemeManager $themeManager)
+    public function __construct(Theme $theme, ThemeManager $themeManager, CacheClearerInterface $smartyCacheClearer)
     {
         $this->theme = $theme;
         $this->themeManager = $themeManager;
+        $this->smartyCacheClearer = $smartyCacheClearer;
     }
 
     /**
@@ -58,5 +67,7 @@ final class ThemePageLayoutsCustomizer implements ThemePageLayoutsCustomizerInte
     {
         $this->theme->setPageLayouts($pageLayouts);
         $this->themeManager->saveTheme($this->theme);
+
+        $this->smartyCacheClearer->clear();
     }
 }

--- a/src/Core/Addon/Theme/ThemePageLayoutsCustomizerInterface.php
+++ b/src/Core/Addon/Theme/ThemePageLayoutsCustomizerInterface.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Addon\Theme;
+
+/**
+ * Interface PageLayoutCustomizerInterface
+ */
+interface ThemePageLayoutsCustomizerInterface
+{
+    /**
+     * @param array $pageLayouts Customized layouts for pages
+     */
+    public function customize(array $pageLayouts);
+}

--- a/src/Core/Addon/Theme/ThemePageLayoutsCustomizerInterface.php
+++ b/src/Core/Addon/Theme/ThemePageLayoutsCustomizerInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
 /**
- * Interface PageLayoutCustomizerInterface
+ * Interface PageLayoutCustomizerInterface.
  */
 interface ThemePageLayoutsCustomizerInterface
 {

--- a/src/Core/Domain/Meta/DataTransferObject/LayoutCustomizationPage.php
+++ b/src/Core/Domain/Meta/DataTransferObject/LayoutCustomizationPage.php
@@ -42,13 +42,20 @@ class LayoutCustomizationPage
     private $description;
 
     /**
+     * @var string
+     */
+    private $title;
+
+    /**
      * @param string $page
+     * @param string $title
      * @param string $description
      */
-    public function __construct($page, $description)
+    public function __construct($page, $title, $description)
     {
         $this->page = $page;
         $this->description = $description;
+        $this->title = $title;
     }
 
     /**
@@ -57,6 +64,14 @@ class LayoutCustomizationPage
     public function getPage()
     {
         return $this->page;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
     }
 
     /**

--- a/src/Core/Domain/Meta/DataTransferObject/LayoutCustomizationPage.php
+++ b/src/Core/Domain/Meta/DataTransferObject/LayoutCustomizationPage.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject;
 
 /**
- * Class LayoutCustomizationPage
+ * Class LayoutCustomizationPage.
  */
 class LayoutCustomizationPage
 {

--- a/src/Core/Domain/Meta/DataTransferObject/LayoutCustomizationPage.php
+++ b/src/Core/Domain/Meta/DataTransferObject/LayoutCustomizationPage.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject;
+
+/**
+ * Class LayoutCustomizationPage
+ */
+class LayoutCustomizationPage
+{
+    /**
+     * @var string
+     */
+    private $page;
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @param string $page
+     * @param string $description
+     */
+    public function __construct($page, $description)
+    {
+        $this->page = $page;
+        $this->description = $description;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPage()
+    {
+        return $this->page;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+}

--- a/src/Core/Domain/Meta/Query/GetPagesForLayoutCustomization.php
+++ b/src/Core/Domain/Meta/Query/GetPagesForLayoutCustomization.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/Core/Domain/Meta/Query/GetPagesForLayoutCustomization.php
+++ b/src/Core/Domain/Meta/Query/GetPagesForLayoutCustomization.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Meta\Query;
+
+/**
+ * Class GetPagesForLayoutCustomization gets pages which layout can be customized.
+ */
+class GetPagesForLayoutCustomization
+{
+}

--- a/src/Core/Domain/Meta/QueryHandler/GetPagesForLayoutCustomizationHandlerInterface.php
+++ b/src/Core/Domain/Meta/QueryHandler/GetPagesForLayoutCustomizationHandlerInterface.php
@@ -24,33 +24,17 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Controller\Admin\Improve\Design;
+namespace PrestaShop\PrestaShop\Core\Domain\Meta\QueryHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetPagesForLayoutCustomization;
-use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
-use PrestaShopBundle\Form\Admin\Improve\Design\Theme\PageLayoutCustomizationType;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Class ThemeController manages "Improve > Design > Theme & Logo" pages.
+ * Interface GetMetaPagesHandlerInterface
  */
-class ThemeController extends AbstractAdminController
+interface GetPagesForLayoutCustomizationHandlerInterface
 {
     /**
-     * Show current theme's pages layout customization.
-     *
-     * @return Response
+     * @param GetPagesForLayoutCustomization $query
      */
-    public function customizePageLayoutsAction()
-    {
-        $pageLayoutCustomizationForm = $this->createForm(PageLayoutCustomizationType::class);
-
-        $pages = $this->getQueryBus()->handle(new GetPagesForLayoutCustomization());
-
-        dump($pages);
-
-        return $this->render('@PrestaShop/Admin/Improve/Design/Theme/customize_page_layouts.twig', [
-            'pageLayoutCustomizationForm' => $pageLayoutCustomizationForm->createView(),
-        ]);
-    }
+    public function handle(GetPagesForLayoutCustomization $query);
 }

--- a/src/Core/Domain/Meta/QueryHandler/GetPagesForLayoutCustomizationHandlerInterface.php
+++ b/src/Core/Domain/Meta/QueryHandler/GetPagesForLayoutCustomizationHandlerInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Meta\QueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetPagesForLayoutCustomization;
 
 /**
- * Interface GetMetaPagesHandlerInterface
+ * Interface GetMetaPagesHandlerInterface.
  */
 interface GetPagesForLayoutCustomizationHandlerInterface
 {

--- a/src/Core/Form/ChoiceProvider/ThemePageLayoutsChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ThemePageLayoutsChoiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/Core/Form/ChoiceProvider/ThemePageLayoutsChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ThemePageLayoutsChoiceProvider.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+
+/**
+ * Class ThemePageLayoutsChoiceProvider proves page layout choices for given theme.
+ */
+final class ThemePageLayoutsChoiceProvider implements FormChoiceProviderInterface
+{
+    /**
+     * @var Theme
+     */
+    private $theme;
+
+    /**
+     * @param Theme $theme
+     */
+    public function __construct(Theme $theme)
+    {
+        $this->theme = $theme;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChoices()
+    {
+        $choices = [];
+
+        foreach ($this->theme->getAvailableLayouts() as $layoutId => $availableLayout) {
+            $choices[sprintf('%s - %s', $availableLayout['name'], $availableLayout['description'])] = $layoutId;
+        }
+
+        return $choices;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 use PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject\LayoutCustomizationPage;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetPagesForLayoutCustomization;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -39,6 +40,8 @@ class ThemeController extends AbstractAdminController
 {
     /**
      * Show Front Office theme's pages layout customization.
+     *
+     * @AdminSecurity("is_granted(['delete'], request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -55,6 +58,12 @@ class ThemeController extends AbstractAdminController
         $pageLayoutCustomizationForm->handleRequest($request);
 
         if ($pageLayoutCustomizationForm->isSubmitted()) {
+            if ($this->isDemoModeEnabled()) {
+                $this->addFlash('error', $this->getDemoModeErrorMessage());
+
+                return $this->redirectToRoute('admin_theme_customize_page_layouts');
+            }
+
             $themePageLayoutsCustomizer = $this->get('prestashop.core.addon.theme.theme.page_layouts_customizer');
             $themePageLayoutsCustomizer->customize($pageLayoutCustomizationForm->getData()['layouts']);
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -74,8 +74,6 @@ class ThemeController extends AbstractAdminController
             $themePageLayoutsCustomizer = $this->get('prestashop.core.addon.theme.theme.page_layouts_customizer');
             $themePageLayoutsCustomizer->customize($pageLayoutCustomizationForm->getData()['layouts']);
 
-            \Tools::clearCache();
-
             $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
 
             return $this->redirectToRoute('admin_theme_customize_page_layouts');

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 use PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject\LayoutCustomizationPage;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetPagesForLayoutCustomization;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
-use PrestaShopBundle\Form\Admin\Improve\Design\Theme\PageLayoutCustomizationType;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -46,24 +45,10 @@ class ThemeController extends AbstractAdminController
     {
         /** @var LayoutCustomizationPage[] $pages */
         $pages = $this->getQueryBus()->handle(new GetPagesForLayoutCustomization());
-        $themeRepository = $this->get('prestashop.core.addon.theme.theme_repository');
 
-        $theme = $themeRepository->getInstanceByName($this->getContext()->shop->theme->getName());
-
-        $defaultLayout = $theme->getDefaultLayout();
-        $pageLayouts = $theme->getPageLayouts();
-
-        $layouts = [];
-
-        foreach ($pages as $page) {
-            $selectedLayout = isset($pageLayouts[$page->getPage()]) ? $pageLayouts[$page->getPage()] : $defaultLayout['key'];
-
-            $layouts[$page->getPage()] = $selectedLayout;
-        }
-
-        $pageLayoutCustomizationForm = $this->createForm(PageLayoutCustomizationType::class, [
-            'layouts' => $layouts,
-        ]);
+        $pageLayoutCustomizationFormFactory =
+            $this->get('prestashop.bundle.form.admin.improve.design.theme.page_layout_customization_form_factory');
+        $pageLayoutCustomizationForm = $pageLayoutCustomizationFormFactory->create($pages);
 
         return $this->render('@PrestaShop/Admin/Improve/Design/Theme/customize_page_layouts.twig', [
             'pageLayoutCustomizationForm' => $pageLayoutCustomizationForm->createView(),

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Controller\Admin\Improve\Design;
+
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
+use PrestaShopBundle\Form\Admin\Improve\Design\Theme\PageLayoutCustomizationType;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class ThemeController manages "Improve > Design > Theme & Logo" pages.
+ */
+class ThemeController extends AbstractAdminController
+{
+    /**
+     * Show current theme's pages layout customization.
+     *
+     * @return Response
+     */
+    public function customizePageLayoutsAction()
+    {
+        $pageLayoutCustomizationForm = $this->createForm(PageLayoutCustomizationType::class);
+
+        return $this->render('@PrestaShop/Admin/Improve/Design/Theme/customize_page_layouts.twig', [
+            'pageLayoutCustomizationForm' => $pageLayoutCustomizationForm->createView(),
+        ]);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactory.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactory.php
@@ -29,6 +29,8 @@ namespace PrestaShopBundle\Form\Admin\Improve\Design\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
 use PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject\LayoutCustomizationPage;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormFactoryInterface;
 
 /**
@@ -73,8 +75,8 @@ final class PageLayoutCustomizationFormFactory implements PageLayoutCustomizatio
     {
         $theme = $this->themeRepository->getInstanceByName($this->shopThemeName);
 
-        $pageLayoutCustomizationForm = $this->formFactory->create(PageLayoutCustomizationType::class, [
-            'layouts' => $this->getCustomizablePageLayoutsForTheme($theme, $customizablePages),
+        $pageLayoutCustomizationForm = $this->formFactory->create(PageLayoutsCustomizationType::class, [
+            'layouts' => $this->getCustomizablePageLayouts($theme, $customizablePages),
         ]);
 
         return $pageLayoutCustomizationForm;
@@ -86,7 +88,7 @@ final class PageLayoutCustomizationFormFactory implements PageLayoutCustomizatio
      *
      * @return array
      */
-    private function getCustomizablePageLayoutsForTheme(Theme $theme, array $customizationPages)
+    private function getCustomizablePageLayouts(Theme $theme, array $customizationPages)
     {
         $defaultLayout = $theme->getDefaultLayout();
         $pageLayouts = $theme->getPageLayouts();
@@ -103,5 +105,21 @@ final class PageLayoutCustomizationFormFactory implements PageLayoutCustomizatio
         }
 
         return $layouts;
+    }
+
+    /**
+     * @param Theme $theme
+     *
+     * @return array
+     */
+    private function getAvailableLayoutChoices(Theme $theme)
+    {
+        $choices = [];
+
+        foreach ($theme->getAvailableLayouts() as $layoutId => $availableLayout) {
+            $choices[$layoutId] = sprintf('%s - %s', $availableLayout['name'], $availableLayout['description']);
+        }
+
+        return $choices;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactory.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactory.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\Theme;
+
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
+use PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject\LayoutCustomizationPage;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * Class PageLayoutCustomizationFormFactory creates form for Front Office theme's pages layout customization.
+ */
+final class PageLayoutCustomizationFormFactory implements PageLayoutCustomizationFormFactoryInterface
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var ThemeRepository
+     */
+    private $themeRepository;
+
+    /**
+     * @var string
+     */
+    private $shopThemeName;
+
+    /**
+     * @param FormFactoryInterface $formFactory
+     * @param ThemeRepository $themeRepository
+     * @param string $shopThemeName
+     */
+    public function __construct(
+        FormFactoryInterface $formFactory,
+        ThemeRepository $themeRepository,
+        $shopThemeName
+    ) {
+        $this->formFactory = $formFactory;
+        $this->themeRepository = $themeRepository;
+        $this->shopThemeName = $shopThemeName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $customizablePages)
+    {
+        $theme = $this->themeRepository->getInstanceByName($this->shopThemeName);
+
+        $pageLayoutCustomizationForm = $this->formFactory->create(PageLayoutCustomizationType::class, [
+            'layouts' => $this->getCustomizablePageLayoutsForTheme($theme, $customizablePages),
+        ]);
+
+        return $pageLayoutCustomizationForm;
+    }
+
+    /**
+     * @param Theme $theme
+     * @param LayoutCustomizationPage[] $customizationPages
+     *
+     * @return array
+     */
+    private function getCustomizablePageLayoutsForTheme(Theme $theme, array $customizationPages)
+    {
+        $defaultLayout = $theme->getDefaultLayout();
+        $pageLayouts = $theme->getPageLayouts();
+
+        $layouts = [];
+
+        foreach ($customizationPages as $page) {
+            $selectedLayout = isset($pageLayouts[$page->getPage()]) ?
+                $pageLayouts[$page->getPage()] :
+                $defaultLayout['key']
+            ;
+
+            $layouts[$page->getPage()] = $selectedLayout;
+        }
+
+        return $layouts;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactory.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactory.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -29,8 +29,6 @@ namespace PrestaShopBundle\Form\Admin\Improve\Design\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
 use PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject\LayoutCustomizationPage;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormFactoryInterface;
 
 /**

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactory.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactory.php
@@ -104,20 +104,4 @@ final class PageLayoutCustomizationFormFactory implements PageLayoutCustomizatio
 
         return $layouts;
     }
-
-    /**
-     * @param Theme $theme
-     *
-     * @return array
-     */
-    private function getAvailableLayoutChoices(Theme $theme)
-    {
-        $choices = [];
-
-        foreach ($theme->getAvailableLayouts() as $layoutId => $availableLayout) {
-            $choices[$layoutId] = sprintf('%s - %s', $availableLayout['name'], $availableLayout['description']);
-        }
-
-        return $choices;
-    }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactoryInterface.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactoryInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -30,7 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject\LayoutCustomizatio
 use Symfony\Component\Form\FormInterface;
 
 /**
- * Interface PageLayoutCustomizationFormFactoryInterface
+ * Interface PageLayoutCustomizationFormFactoryInterface.
  */
 interface PageLayoutCustomizationFormFactoryInterface
 {

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactoryInterface.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationFormFactoryInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\Theme;
+
+use PrestaShop\PrestaShop\Core\Domain\Meta\DataTransferObject\LayoutCustomizationPage;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * Interface PageLayoutCustomizationFormFactoryInterface
+ */
+interface PageLayoutCustomizationFormFactoryInterface
+{
+    /**
+     * @param LayoutCustomizationPage[] $customizablePages
+     *
+     * @return FormInterface
+     */
+    public function create(array $customizablePages);
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationType.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\Theme;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class PageLayoutCustomizationType is used in theme page layout customization form.
+ */
+class PageLayoutCustomizationType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('layouts', CollectionType::class, [
+                'entry_type' => ChoiceType::class,
+                'entry_options' => [
+                    'choices' => [
+                        'Full width' => 'fw',
+                        'Left side' => 'ls',
+                        'Right side' => 'rs',
+                    ],
+                ],
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationType.php
@@ -46,9 +46,10 @@ class PageLayoutCustomizationType extends AbstractType
                 'entry_type' => ChoiceType::class,
                 'entry_options' => [
                     'choices' => [
-                        'Full width' => 'fw',
-                        'Left side' => 'ls',
-                        'Right side' => 'rs',
+                        'Full width - No side columns, ideal for distraction-free pages such as product pages.' => 'layout-full-width',
+                        'Three Columns - One large central column and 2 side columns.' => 'layout-both-columns',
+                        'Two Columns, small left column - Two columns with a small left column' => 'layout-left-column',
+                        'Two Columns, small right column - Two columns with a small right column' => 'layout-right-column',
                     ],
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutCustomizationType.php
@@ -45,6 +45,7 @@ class PageLayoutCustomizationType extends AbstractType
             ->add('layouts', CollectionType::class, [
                 'entry_type' => ChoiceType::class,
                 'entry_options' => [
+                    'label' => false,
                     'choices' => [
                         'Full width - No side columns, ideal for distraction-free pages such as product pages.' => 'layout-full-width',
                         'Three Columns - One large central column and 2 side columns.' => 'layout-both-columns',

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutsCustomizationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutsCustomizationType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2018 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutsCustomizationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutsCustomizationType.php
@@ -32,10 +32,23 @@ use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class PageLayoutCustomizationType is used in theme page layout customization form.
+ * Class PageLayoutsCustomizationType is used to customize Front Office theme's page layouts.
  */
-class PageLayoutCustomizationType extends AbstractType
+class PageLayoutsCustomizationType extends AbstractType
 {
+    /**
+     * @var array
+     */
+    private $pageLayoutsChoices;
+
+    /**
+     * @param array $pageLayoutsChoices
+     */
+    public function __construct(array $pageLayoutsChoices)
+    {
+        $this->pageLayoutsChoices = $pageLayoutsChoices;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -44,14 +57,11 @@ class PageLayoutCustomizationType extends AbstractType
         $builder
             ->add('layouts', CollectionType::class, [
                 'entry_type' => ChoiceType::class,
+                'translation_domain' => false,
                 'entry_options' => [
                     'label' => false,
-                    'choices' => [
-                        'Full width - No side columns, ideal for distraction-free pages such as product pages.' => 'layout-full-width',
-                        'Three Columns - One large central column and 2 side columns.' => 'layout-both-columns',
-                        'Two Columns, small left column - Two columns with a small left column' => 'layout-left-column',
-                        'Two Columns, small right column - Two columns with a small right column' => 'layout-right-column',
-                    ],
+                    'translation_domain' => false,
+                    'choices' => $this->pageLayoutsChoices,
                 ],
             ])
         ;

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/_design.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/_design.yml
@@ -5,3 +5,7 @@ _theme_catalog:
 _positions:
     resource: "positions.yml"
     prefix: /modules/positions
+
+_theme:
+    resource: "theme.yml"
+    prefix: /theme

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
@@ -1,6 +1,6 @@
 admin_theme_customize_page_layouts:
   path: /page-layout-customization
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:customizePageLayouts
     _legacy_controller: AdminThemes

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
@@ -1,0 +1,6 @@
+admin_theme_customize_page_layouts:
+  path: /page-layout-customization
+  methods: [GET]
+  defaults:
+    _controller: PrestaShopBundle:Admin\Improve\Design\Theme:customizePageLayouts
+    _legacy_controller: AdminThemes

--- a/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
@@ -8,3 +8,10 @@ services:
             - "@session"
         decorates: prestashop.core.admin.page_preference_interface
         public: false
+
+    prestashop.adapter.admin.controller.category:
+        class: PrestaShop\PrestaShop\Adapter\Category\AdminCategoryControllerWrapper
+
+    prestashop.adapter.legacy_db:
+        class: 'Db'
+        factory: ['Db', 'getInstance']

--- a/src/PrestaShopBundle/Resources/config/services/adapter/meta.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/meta.yml
@@ -7,3 +7,11 @@ services:
 
     prestashop.adapter.meta.data_provider:
         class: 'PrestaShop\PrestaShop\Adapter\Meta\MetaDataProvider'
+
+    prestashop.adapter.meta.query_handler.get_pages_for_layout_customization_handler:
+        class: 'PrestaShop\PrestaShop\Adapter\Meta\QueryHandler\GetPagesForLayoutCustomizationHandler'
+        arguments:
+            - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
+        tags:
+            - name: 'tactician.handler'
+              command: 'PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetPagesForLayoutCustomization'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_factory.yml
@@ -1,0 +1,10 @@
+services:
+  _defaults:
+    public: true
+
+  prestashop.bundle.form.admin.improve.design.theme.page_layout_customization_form_factory:
+    class: 'PrestaShopBundle\Form\Admin\Improve\Design\Theme\PageLayoutCustomizationFormFactory'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.addon.theme.repository'
+      - '@=service("prestashop.adapter.legacy.context").getContext().shop.theme.getName()'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -590,3 +590,10 @@ services:
             - '@=service("prestashop.core.form.choice_provider.import_entity_field").getChoices()'
         tags:
             - { name: form.type }
+
+    form.type.design.theme.page_layouts_customization:
+        class: 'PrestaShopBundle\Form\Admin\Improve\Design\Theme\PageLayoutsCustomizationType'
+        arguments:
+            - '@=service("prestashop.core.form.choice_provider.theme_page_layouts").getChoices()'
+        tags:
+            - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/core/addon.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/addon.yml
@@ -35,3 +35,13 @@ services:
         arguments:
             - '@=service("prestashop.adapter.legacy.context").getContext()'
             - '@prestashop.adapter.legacy_db'
+
+    prestashop.core.addon.theme.theme_manager:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager
+        factory: 'prestashop.core.addon.theme.theme_manager_builder:build'
+
+    prestashop.core.addon.theme.theme.page_layouts_customizer:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemePageLayoutsCustomizer
+        arguments:
+           - '@=service("prestashop.adapter.legacy.context").getContext().shop.theme'
+           - '@prestashop.core.addon.theme.theme_manager'

--- a/src/PrestaShopBundle/Resources/config/services/core/addon.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/addon.yml
@@ -29,3 +29,13 @@ services:
           - "@filesystem"
           - "@prestashop.core.admin.lang.repository"
           - "@prestashop.translation.theme.exporter"
+
+    prestashop.core.addon.theme.theme_manager_builder:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder
+        arguments:
+            - '@=service("prestashop.adapter.legacy.context").getContext()'
+            - '@prestashop.adapter.legacy_db'
+
+    prestashop.core.addon.theme.theme_repository:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository
+        factory: 'prestashop.core.addon.theme.theme_manager_builder:buildRepository'

--- a/src/PrestaShopBundle/Resources/config/services/core/addon.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/addon.yml
@@ -35,7 +35,3 @@ services:
         arguments:
             - '@=service("prestashop.adapter.legacy.context").getContext()'
             - '@prestashop.adapter.legacy_db'
-
-    prestashop.core.addon.theme.theme_repository:
-        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository
-        factory: 'prestashop.core.addon.theme.theme_manager_builder:buildRepository'

--- a/src/PrestaShopBundle/Resources/config/services/core/addon.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/addon.yml
@@ -45,3 +45,4 @@ services:
         arguments:
            - '@=service("prestashop.adapter.legacy.context").getContext().shop.theme'
            - '@prestashop.core.addon.theme.theme_manager'
+           - '@prestashop.adapter.cache.clearer.smarty_cache_clearer'

--- a/src/PrestaShopBundle/Resources/config/services/core/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form.yml
@@ -124,3 +124,8 @@ services:
         arguments:
             - '@=service("prestashop.core.import.fields_provider_finder")'
             - '@=service("session").get("entity")'
+
+    prestashop.core.form.choice_provider.theme_page_layouts:
+        class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemePageLayoutsChoiceProvider'
+        arguments:
+            - '@=service("prestashop.adapter.legacy.context").getContext().shop.theme'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
@@ -34,15 +34,15 @@
             <div class="card">
               <h3 class="card-header">
                 <i class="material-icons">settings</i>
-                {{ 'Choose layouts'|trans({}, 'Admin.Design.Feature') }}
+                {{ 'Choose layouts'|trans({}, 'Admin.Actions') }}
               </h3>
               <div class="card-body">
                 <table class="table">
                   <thead>
                     <tr>
-                      <th>{{ 'Page'|trans({}, 'Admin.Design.Feature') }}</th>
-                      <th>{{ 'Description'|trans({}, 'Admin.Design.Feature') }}</th>
-                      <th>{{ 'Layout'|trans({}, 'Admin.Design.Feature') }}</th>
+                      <th>{{ 'Page'|trans({}, 'Admin.Global') }}</th>
+                      <th>{{ 'Description'|trans({}, 'Admin.Global') }}</th>
+                      <th>{{ 'Layout'|trans({}, 'Admin.Global') }}</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.twig
@@ -26,6 +26,45 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  {{ form_start(pageLayoutCustomizationForm) }}
-  {{ form_end(pageLayoutCustomizationForm) }}
+  <div class="row">
+    <div class="col-12">
+      {{ form_start(pageLayoutCustomizationForm) }}
+        <div class="row justify-content-center">
+          <div class="col-xl-10">
+            <div class="card">
+              <h3 class="card-header">
+                <i class="material-icons">settings</i>
+                {{ 'Choose layouts'|trans({}, 'Admin.Design.Feature') }}
+              </h3>
+              <div class="card-body">
+                <table class="table">
+                  <thead>
+                    <tr>
+                      <th>{{ 'Page'|trans({}, 'Admin.Design.Feature') }}</th>
+                      <th>{{ 'Description'|trans({}, 'Admin.Design.Feature') }}</th>
+                      <th>{{ 'Layout'|trans({}, 'Admin.Design.Feature') }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for customizablePage in pages %}
+                      <tr>
+                        <td>{{ customizablePage.title|default(customizablePage.page) }}</td>
+                        <td>{{ customizablePage.description }}</td>
+                        <td>{{ form_widget(pageLayoutCustomizationForm['layouts'][customizablePage.page]) }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+              <div class="card-footer">
+                <div class="d-flex justify-content-end">
+                  <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {{ form_end(pageLayoutCustomizationForm) }}
+    </div>
+  </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.twig
@@ -1,0 +1,31 @@
+{#**
+  * 2007-2018 PrestaShop
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Open Software License (OSL 3.0)
+  * that is bundled with this package in the file LICENSE.txt.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/OSL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to http://www.prestashop.com for more information.
+  *
+  * @author    PrestaShop SA <contact@prestashop.com>
+  * @copyright 2007-2018 PrestaShop SA
+  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+  * International Registered Trademark & Property of PrestaShop SA
+  *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  {{ form_start(pageLayoutCustomizationForm) }}
+  {{ form_end(pageLayoutCustomizationForm) }}
+{% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR migrates part where user can customize Front Office theme's page layouts.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/10578
| How to test?  | You can access new page via url `admin-dev/index.php/improve/design/theme/page-layout-customization`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10816)
<!-- Reviewable:end -->
