### PR TITLE
Fix access to SEO & URLS Form page

### DIFF
--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -36,6 +36,8 @@ use AdminController;
 use Link;
 use Tab;
 use AdminLegacyLayoutControllerCore;
+use Tools as ToolsLegacy;
+use Dispatcher;
 
 /**
  * This adapter will complete the new architecture Context with legacy values.
@@ -100,7 +102,15 @@ class LegacyContext
      */
     public function getAdminLink($controller, $withToken = true, $extraParams = array())
     {
-        return $this->getContext()->link->getAdminLink($controller, $withToken, $extraParams, $extraParams);
+        $id_lang = Context::getContext()->language->id;
+        $params = $extraParams;
+        if ($withToken) {
+            $params['token'] = ToolsLegacy::getAdminTokenLite($controller);
+        }
+
+        $link = new Link();
+
+        return $link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . Dispatcher::getInstance()->createUrl($controller, $id_lang, $params, false);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
@@ -72,20 +72,21 @@
   <div class="row">
     <div class="col-md-9">
       <div class="alert alert-info" role="alert">
+        {% set metaUrl = path('admin_meta') ~ '#meta_fieldset_general' %}
         <p class="alert-text">
           {% if 'PS_REWRITING_SETTINGS'|configuration == 0 %}
             <strong>{{ 'Friendly URLs are currently disabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
-            {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
+            {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="'~ metaUrl ~'">', '[/1]': '</a>'})|raw }}
           {% else %}
             <strong>{{ 'Friendly URLs are currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
-            {{ 'To disable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
+            {{ 'To disable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="'~ metaUrl ~'">', '[/1]': '</a>'})|raw }}
           {% endif %}
         </p>
         <p class="alert-text">
           {% if 'PS_FORCE_FRIENDLY_PRODUCT'|configuration == 1 %}
             <strong>{{ 'The "Force update of friendly URL" option is currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
             {# "It" refers to the option "Force update of friendly URL" #}
-            {{ 'To disable it, go to [1]Product Settings[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminPPreferences") ~ '#configuration_fieldset_products">', '[/1]': '</a>'})|raw }}
+            {{ 'To disable it, go to [1]Product Settings[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ path('admin_meta') ~ '#configuration_fieldset_products">', '[/1]': '</a>'})|raw }}
           {% endif %}
         </p>
       </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | LegacyContext::getAdminLink was changed on develop branch... why? /c @PrestaShop/prestashop-core-developers 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/10804 and https://github.com/PrestaShop/PrestaShop/issues/10817 and #10794
| How to test?  | On "SEO & URLS" page, try to access edit page by clicking on the "pencil" icon.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10821)
<!-- Reviewable:end -->
