### PR TITLE
Hide arguments in debug trace page

### DIFF
--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -91,11 +91,7 @@ class PrestaShopExceptionCore extends Exception
         } else {
             // If not in mode dev, display an error page
             if (file_exists(_PS_ROOT_DIR_.'/error500.html')) {
-                $errorPage = file_get_contents(_PS_ROOT_DIR_.'/error500.html');
-                if (defined('_PS_ADMIN_DIR_')) {
-                    $errorPage = str_replace('<!-- ADMIN_ERROR_MESSAGE -->', '<h3>' . $this->getExtendedMessage() . '</h3>', $errorPage);
-                }
-                echo $errorPage;
+                echo file_get_contents(_PS_ROOT_DIR_.'/error500.html');
             }
         }
         // Log the error in the disk

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -42,7 +42,7 @@ class PrestaShopExceptionCore extends Exception
         if (ToolsCore::isPHPCLI()) { 
             echo get_class($this).' in '. $this->getFile() .' line '. $this->getLine()."\n";
             echo $this->getTraceAsString()."\n";
-        } elseif (_PS_MODE_DEV_ || defined('_PS_ADMIN_DIR_')) {
+        } elseif (_PS_MODE_DEV_) {
             // Display error message
             echo '<style>
                 #psException{font-family: Verdana; font-size: 14px}
@@ -81,7 +81,8 @@ class PrestaShopExceptionCore extends Exception
                     $this->displayFileDebug($trace['file'], $trace['line'], $id);
                 }
                 if (isset($trace['args']) && count($trace['args'])) {
-                    $this->displayArgsDebug($trace['args'], $id);
+                    $args = $this->hideCriticalArgs($trace);
+                    $this->displayArgsDebug($args, $id);
                 }
                 echo '</li>';
             }
@@ -90,7 +91,11 @@ class PrestaShopExceptionCore extends Exception
         } else {
             // If not in mode dev, display an error page
             if (file_exists(_PS_ROOT_DIR_.'/error500.html')) {
-                echo file_get_contents(_PS_ROOT_DIR_.'/error500.html');
+                $errorPage = file_get_contents(_PS_ROOT_DIR_.'/error500.html');
+                if (defined('_PS_ADMIN_DIR_')) {
+                    $errorPage = str_replace('<!-- ADMIN_ERROR_MESSAGE -->', '<h3>' . $this->getExtendedMessage() . '</h3>', $errorPage);
+                }
+                echo $errorPage;
             }
         }
         // Log the error in the disk
@@ -127,6 +132,49 @@ class PrestaShopExceptionCore extends Exception
             }
         }
         echo '</pre></div>';
+    }
+
+    /**
+     * Prevent critical arguments to be displayed in the debug trace page (e.g. database password)
+     * Returns the array of args with critical arguments replaced by placeholders
+     *
+     * @param array $trace
+     * @return array
+     */
+    protected function hideCriticalArgs(array $trace)
+    {
+        $args = $trace['args'];
+        if (empty($trace['class']) || empty($trace['function'])) {
+            return $args;
+        }
+
+        $criticalParameters = [
+            'password',
+            'database',
+            'server',
+        ];
+        $hiddenArgs = [];
+        try {
+            $class = new \ReflectionClass($trace['class']);
+            /** @var \ReflectionMethod $method */
+            $method = $class->getMethod($trace['function']);
+            /** @var \ReflectionParameter $parameter */
+            foreach ($method->getParameters() as $argIndex => $parameter) {
+                if ($argIndex >= count($args)) {
+                    break;
+                }
+
+                if (in_array(strtolower($parameter->getName()), $criticalParameters)) {
+                    $hiddenArgs[] = '**hidden_' . $parameter->getName() . '**';
+                } else {
+                    $hiddenArgs[] = $args[$argIndex];
+                }
+            }
+        } catch (ReflectionException $e) {
+            //In worst case scenario there are some critical args we could't detect so we return an empty array
+        }
+
+        return $hiddenArgs;
     }
 
     /**

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -146,6 +146,9 @@ class PrestaShopExceptionCore extends Exception
 
         $criticalParameters = [
             'password',
+            'passwd',
+            'pwd',
+            'pass',
             'database',
             'server',
         ];
@@ -160,7 +163,14 @@ class PrestaShopExceptionCore extends Exception
                     break;
                 }
 
-                if (in_array(strtolower($parameter->getName()), $criticalParameters)) {
+                $isCritical = false;
+                foreach ($criticalParameters as $criticalParameter) {
+                    if (preg_match('/' . $criticalParameter . '/', $parameter->getName())) {
+                        $isCritical = true;
+                    }
+                }
+
+                if ($isCritical) {
                     $hiddenArgs[] = '**hidden_' . $parameter->getName() . '**';
                 } else {
                     $hiddenArgs[] = $args[$argIndex];

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -145,8 +145,6 @@ class PrestaShopExceptionCore extends Exception
         }
 
         $criticalParameters = [
-            'password',
-            'passwd',
             'pwd',
             'pass',
             'database',
@@ -163,14 +161,7 @@ class PrestaShopExceptionCore extends Exception
                     break;
                 }
 
-                $isCritical = false;
-                foreach ($criticalParameters as $criticalParameter) {
-                    if (preg_match('/' . $criticalParameter . '/', $parameter->getName())) {
-                        $isCritical = true;
-                    }
-                }
-
-                if ($isCritical) {
+                if (preg_match('/(' . implode('|', $criticalParameters) . ')/i', $parameter->getName())) {
                     $hiddenArgs[] = '**hidden_' . $parameter->getName() . '**';
                 } else {
                     $hiddenArgs[] = $args[$argIndex];

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -147,6 +147,8 @@ class PrestaShopExceptionCore extends Exception
         $criticalParameters = [
             'pwd',
             'pass',
+            'passwd',
+            'password',
             'database',
             'server',
         ];
@@ -161,7 +163,7 @@ class PrestaShopExceptionCore extends Exception
                     break;
                 }
 
-                if (preg_match('/(' . implode('|', $criticalParameters) . ')/i', $parameter->getName())) {
+                if (in_array(strtolower($parameter->getName()), $criticalParameters)) {
                     $hiddenArgs[] = '**hidden_' . $parameter->getName() . '**';
                 } else {
                     $hiddenArgs[] = $args[$argIndex];

--- a/error500.html
+++ b/error500.html
@@ -89,7 +89,6 @@
     <body>
         <div class="container">
             <h2><span>500</span> Server Error</h2>
-            <!-- ADMIN_ERROR_MESSAGE -->
             <p>Oops, something went wrong.<br /><br />Try to refresh this page or feel free to contact us if the problem persists.</p>
         </div>
     </body>

--- a/error500.html
+++ b/error500.html
@@ -89,6 +89,7 @@
     <body>
         <div class="container">
             <h2><span>500</span> Server Error</h2>
+            <!-- ADMIN_ERROR_MESSAGE -->
             <p>Oops, something went wrong.<br /><br />Try to refresh this page or feel free to contact us if the problem persists.</p>
         </div>
     </body>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | Hide parameters in debug trace page
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Turn off your database server and try to access to your website, on debug mode the critical parameters are hidden On prod mode you only see an error page, even in the admin folder
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10829)
<!-- Reviewable:end -->
