### PR TITLE
No need for SSL redirection with PHP-CLI

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -785,7 +785,7 @@ class FrontControllerCore extends Controller
     protected function sslRedirection()
     {
         // If we call a SSL controller without SSL or a non SSL controller with SSL, we redirect with the right protocol
-        if (Configuration::get('PS_SSL_ENABLED') && $_SERVER['REQUEST_METHOD'] != 'POST' && $this->ssl != Tools::usingSecureMode()) {
+        if (!Tools::isPHPCLI() && Configuration::get('PS_SSL_ENABLED') && $_SERVER['REQUEST_METHOD'] != 'POST' && $this->ssl != Tools::usingSecureMode()) {
             $this->context->cookie->disallowWriting();
             header('HTTP/1.1 301 Moved Permanently');
             header('Cache-Control: no-cache');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | If you call a ModuleFrontController with PHP CLI, PrestaShop tries to detect the HTTP REQUEST_METHOD but you can't have one since you are in CLI ;-)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to call any front controller with PHP CLI, for example: `php /var/www/html/index.php "fc=module&module=blocknewsletter&controller=verification"` (not a good example, but when you have modules with cron tasks it makes sense !). You should get the result without error, but you get 2 errors: `PHP Notice: undefined index: REQUEST_METHOD...` then `PHP Warning: Cannot modify header information - headers already sent by...`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10832)
<!-- Reviewable:end -->
