### PR TITLE
Allow release creator to be run without version parameter

### DIFF
--- a/tools/build/CreateRelease.php
+++ b/tools/build/CreateRelease.php
@@ -42,7 +42,6 @@ if (php_sapi_name() !== 'cli') {
 
 $releaseOptions = [
     'version' => [
-        'required' => true,
         'description' => 'Desired release version of PrestaShop',
         'longopt' => 'version:',
     ],
@@ -65,7 +64,7 @@ $releaseOptions = [
         'longopt' => 'help',
     ],
 ];
-$helpMessage = "Usage: php {prestashop_root_path}/tools/build/CreateRelease.php --version=<version> [options]{$lineSeparator}{$lineSeparator}"
+$helpMessage = "Usage: php {prestashop_root_path}/tools/build/CreateRelease.php [--version=<version>] [options]{$lineSeparator}{$lineSeparator}"
     . "Available options are:{$lineSeparator}{$lineSeparator}";
 
 foreach ($releaseOptions as $optionName => $option) {
@@ -83,7 +82,6 @@ $userOptions = getopt(implode('', array_column($releaseOptions, 'opt')), array_c
 // Show help and exit
 if (isset($userOptions['h'])
     || isset($userOptions['help'])
-    || empty($userOptions)
 ) {
     echo $helpMessage;
 
@@ -102,9 +100,14 @@ foreach ($releaseOptions as $optionName => $option) {
         exit(1);
     }
 }
-$version = $userOptions['version'];
 $destinationDir = '';
 $useZip = $useInstaller = true;
+
+if (isset($userOptions['version'])) {
+    $version = $userOptions['version'];
+} else {
+    $version = null;
+}
 
 if (isset($userOptions['no-zip'])) {
     $useZip = false;

--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -195,7 +195,7 @@ class ReleaseCreator
      * @param bool $useZip
      * @param string $destinationDir
      */
-    public function __construct($version, $useInstaller = true, $useZip = true, $destinationDir = '')
+    public function __construct($version = null, $useInstaller = true, $useZip = true, $destinationDir = '')
     {
         $this->consoleWriter = new ConsoleWriter();
         $tmpDir = sys_get_temp_dir();
@@ -206,8 +206,12 @@ class ReleaseCreator
             ConsoleWriter::COLOR_GREEN
         );
         $this->projectPath = realpath(__DIR__ . '/../../..');
-        $this->version = $version;
+        $this->version = $version ? $version : $this->getCurrentVersion();
         $this->zipFileName = "prestashop_$this->version.zip";
+
+        if (empty($this->version)) {
+            throw new Exception('Version is not provided and cannot be found in project.');
+        }
 
         if (empty($destinationDir)) {
             $releasesDir = self::RELEASES_DIR_RELATIVE_PATH;
@@ -341,6 +345,26 @@ class ReleaseCreator
         }
 
         return $this;
+    }
+
+    /**
+     * Get the current version in the project
+     * 
+     * @return string PrestaShop version
+     */
+    protected function getCurrentVersion()
+    {
+        $kernelFile = $this->projectPath.'/app/AppKernel.php';
+        $matches = [];
+
+        $kernelFileContent = file_get_contents($kernelFile);
+        $kernelFileContent = preg_match(
+            '~const VERSION = \'(.*)\';~',
+            $kernelFileContent,
+            $matches
+        ); 
+
+        return $matches[1];
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow Release Creator to be run without providing a version to apply. In that case, the current one is kept.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Generate a release directly by running `php CreateRelease.php` in `tools/build`. The current version must be found in the project, then used in the zip name.


## Output example from branch 1.7.5.x:

```
--- Temp dir used will be '/tmp'
--- Destination dir used will be '/home/thomas/Documents/github/PrestaShop/tools/build/releases/1.7.5.0_20181003_152058'
--- Release will have the installer and will be zipped.
--- Script started at 15:20:58

Copy project in /tmp/prestashop... DONE
Setting files constants... DONE
Generating licences file... DONE
Running composer install... DONE
Creating package...
--- Cleaning project... DONE
--- Generating XML checksum... DONE
--- Creating zip archive... DONE
--- Move package... DONE
Package successfully created...

--- Script ended at 15:22:10
--- Release size: 67M
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10834)
<!-- Reviewable:end -->
