### PR TITLE
Remove rebuild of SymfonyRequirements file after every composer run

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,6 @@
         "post-install-cmd": [
             "PrestaShop\\PrestaShop\\Core\\Cldr\\Composer\\Hook::init",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
         ],
         "post-update-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,6 @@
             "PrestaShopBundle\\Install\\Upgrade::migrateSettingsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
         ],
         "create-test-db": [

--- a/var/SymfonyRequirements.php
+++ b/var/SymfonyRequirements.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Note: This file has been modified for PHP 7.2 compatibility.
+ * See:
+ * - https://github.com/PrestaShop/PrestaShop/pull/9409
+ * - https://github.com/sensiolabs/SensioDistributionBundle/pull/336
+ */
 
 /*
  * This file is part of the Symfony package.


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | We had to modify SymfonyRequirements.php to make it compatible with PHP 7.2 because Sensio won't. However, it was being overwritten by composer on each run. This PR stops it from being overwritten.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | No test needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10837)
<!-- Reviewable:end -->
