### PR TITLE
Set order update date on address change

### DIFF
--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -419,7 +419,7 @@ class AdminAddressesControllerCore extends AdminController
         $address_type = (int)Tools::getValue('address_type') == 2 ? 'invoice' : 'delivery';
 
         if ($this->action == 'save' && ($id_order = (int)Tools::getValue('id_order')) && !count($this->errors) && !empty($address_type)) {
-            if (!Db::getInstance()->Execute('UPDATE '._DB_PREFIX_.'orders SET `id_address_'.bqSQL($address_type).'` = '.(int)$this->object->id.' WHERE `id_order` = '.(int)$id_order)) {
+            if (!Db::getInstance()->Execute('UPDATE '._DB_PREFIX_.'orders SET `date_upd` = NOW(), `id_address_'.bqSQL($address_type).'` = '.(int)$this->object->id.' WHERE `id_order` = '.(int)$id_order)) {
                 $this->errors[] = Tools::displayError('An error occurred while linking this address to its order.');
             } else {
                 Tools::redirectAdmin(urldecode(Tools::getValue('back')).'&conf=4');


### PR DESCRIPTION
Set order update date when delivery or billing address is changed

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Set order update date when delivery or billing address is changed
| Type?         | bug fix 
| Category?     |  BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | edit address from order in BO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10847)
<!-- Reviewable:end -->
