### PR TITLE
Fatal error when saving product with tags

### DIFF
--- a/classes/Tag.php
+++ b/classes/Tag.php
@@ -129,8 +129,8 @@ class TagCore extends ObjectModel
         foreach ($list as $tag) {
             $data[] = array(
                 'id_tag' => (int) $tag,
-                'id_product' => (int) $id_product,
-                'id_lang' => (int) $id_lang,
+                'id_product' => (int) $idProduct,
+                'id_lang' => (int) $idLang,
             );
         }
         $result = Db::getInstance()->insert('product_tag', $data);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | A bug was introduced in https://github.com/PrestaShop/PrestaShop/pull/10448, where incorrect variable names were used when saving product tags. Therefore you cannot save product if it has tags.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Go to product edit form. Set some tags on the product, click save. With this PR you will be able to save it successfully, prior to this PR you would get an error "Unable to update settings.".

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10854)
<!-- Reviewable:end -->
