### PR TITLE
Use parent javascripts used for displaying help

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig
@@ -73,6 +73,7 @@
   {% endblock %}
 {% endblock %}
 {% block javascripts %}
+  {{ parent() }}
   <script src="{{ asset('themes/new-theme/public/logs.bundle.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/positions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/positions.html.twig
@@ -209,5 +209,6 @@
 {% endblock %}
 
 {% block javascripts %}
+  {{ parent() }}
   <script src="{{ asset('themes/new-theme/public/improve_design_positions.bundle.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Load javascript from parent template, or help in the sidepanel won't work.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #10403
| How to test?  | Go to module positions page, and click on the "Help" button. The content must be displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10857)
<!-- Reviewable:end -->
