### PR TITLE
Fixed keywords disappear from search index

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1890,10 +1890,14 @@ class ProductCore extends ObjectModel
     {
         return (
             Db::getInstance()->execute(
-                'DELETE `'._DB_PREFIX_.'search_index`, `'._DB_PREFIX_.'search_word`
-				FROM `'._DB_PREFIX_.'search_index` JOIN `'._DB_PREFIX_.'search_word`
-				WHERE `'._DB_PREFIX_.'search_index`.`id_product` = '.(int)$this->id.'
-						AND `'._DB_PREFIX_.'search_word`.`id_word` = `'._DB_PREFIX_.'search_index`.id_word'
+                'DELETE FROM `'._DB_PREFIX_.'search_index`
+                WHERE `id_product` = '.(int)$this->id
+            )
+            &&
+            Db::getInstance()->execute(
+                'DELETE sw FROM `'._DB_PREFIX_.'search_word` sw
+        LEFT JOIN `'._DB_PREFIX_.'search_index` si ON (sw.id_word=si.id_word)
+        WHERE si.id_word IS NULL;'
             )
         );
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Delete a product, and you delete words that is shared in search_word tabel, make other product disapear from search until next full reindex.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8239
| How to test?  | See ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10859)
<!-- Reviewable:end -->
