### PR TITLE
Fix compatibility with PHP 5.6 for PS exception

### DIFF
--- a/src/Core/Exception/PrestaShopCoreException.php
+++ b/src/Core/Exception/PrestaShopCoreException.php
@@ -26,12 +26,13 @@
 
 namespace PrestaShop\PrestaShop\Core\Exception;
 
+use Exception;
 use Throwable;
 
 /**
  * Class PrestaShopCoreException.
  */
-class PrestaShopCoreException extends \Exception
+class PrestaShopCoreException extends Exception
 {
     /**
      * @var string
@@ -53,7 +54,7 @@ class PrestaShopCoreException extends \Exception
      * @param string $domain
      * @param array $parameters
      * @param int $code
-     * @param Throwable|\Exception|null $previous
+     * @param Throwable|Exception|null $previous
      */
     public function __construct(
         $key,

--- a/src/Core/Exception/PrestaShopCoreException.php
+++ b/src/Core/Exception/PrestaShopCoreException.php
@@ -53,14 +53,14 @@ class PrestaShopCoreException extends \Exception
      * @param string $domain
      * @param array $parameters
      * @param int $code
-     * @param Throwable|null $previous
+     * @param Throwable|\Exception|null $previous
      */
     public function __construct(
         $key,
         $domain,
         $parameters = [],
         $code = 0,
-        Throwable $previous = null
+        $previous = null
     ) {
         parent::__construct($key, $code, $previous);
         $this->key = $key;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | `Throwable` was introduced in PHP 7, PR removes it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | See code changes.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10865)
<!-- Reviewable:end -->
