### PR TITLE
1.7.4.x

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -295,6 +295,7 @@ GitHub contributors:
 - Jonadabe
 - Jonatan Nunez
 - Jonathan Danse
+- Jonathan Lelievre
 - Jonathan SAHM
 - Jorge Vargas
 - joseantgv

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -91,11 +91,7 @@ class PrestaShopExceptionCore extends Exception
         } else {
             // If not in mode dev, display an error page
             if (file_exists(_PS_ROOT_DIR_.'/error500.html')) {
-                $errorPage = file_get_contents(_PS_ROOT_DIR_.'/error500.html');
-                if (defined('_PS_ADMIN_DIR_')) {
-                    $errorPage = str_replace('<!-- ADMIN_ERROR_MESSAGE -->', '<h3>' . $this->getExtendedMessage() . '</h3>', $errorPage);
-                }
-                echo $errorPage;
+                echo file_get_contents(_PS_ROOT_DIR_.'/error500.html');
             }
         }
         // Log the error in the disk

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -42,7 +42,7 @@ class PrestaShopExceptionCore extends Exception
         if (ToolsCore::isPHPCLI()) { 
             echo get_class($this).' in '. $this->getFile() .' line '. $this->getLine()."\n";
             echo $this->getTraceAsString()."\n";
-        } elseif (_PS_MODE_DEV_ || defined('_PS_ADMIN_DIR_')) {
+        } elseif (_PS_MODE_DEV_) {
             // Display error message
             echo '<style>
                 #psException{font-family: Verdana; font-size: 14px}
@@ -81,7 +81,8 @@ class PrestaShopExceptionCore extends Exception
                     $this->displayFileDebug($trace['file'], $trace['line'], $id);
                 }
                 if (isset($trace['args']) && count($trace['args'])) {
-                    $this->displayArgsDebug($trace['args'], $id);
+                    $args = $this->hideCriticalArgs($trace);
+                    $this->displayArgsDebug($args, $id);
                 }
                 echo '</li>';
             }
@@ -90,7 +91,11 @@ class PrestaShopExceptionCore extends Exception
         } else {
             // If not in mode dev, display an error page
             if (file_exists(_PS_ROOT_DIR_.'/error500.html')) {
-                echo file_get_contents(_PS_ROOT_DIR_.'/error500.html');
+                $errorPage = file_get_contents(_PS_ROOT_DIR_.'/error500.html');
+                if (defined('_PS_ADMIN_DIR_')) {
+                    $errorPage = str_replace('<!-- ADMIN_ERROR_MESSAGE -->', '<h3>' . $this->getExtendedMessage() . '</h3>', $errorPage);
+                }
+                echo $errorPage;
             }
         }
         // Log the error in the disk
@@ -127,6 +132,49 @@ class PrestaShopExceptionCore extends Exception
             }
         }
         echo '</pre></div>';
+    }
+
+    /**
+     * Prevent critical arguments to be displayed in the debug trace page (e.g. database password)
+     * Returns the array of args with critical arguments replaced by placeholders
+     *
+     * @param array $trace
+     * @return array
+     */
+    protected function hideCriticalArgs(array $trace)
+    {
+        $args = $trace['args'];
+        if (empty($trace['class']) || empty($trace['function'])) {
+            return $args;
+        }
+
+        $criticalParameters = [
+            'password',
+            'database',
+            'server',
+        ];
+        $hiddenArgs = [];
+        try {
+            $class = new \ReflectionClass($trace['class']);
+            /** @var \ReflectionMethod $method */
+            $method = $class->getMethod($trace['function']);
+            /** @var \ReflectionParameter $parameter */
+            foreach ($method->getParameters() as $argIndex => $parameter) {
+                if ($argIndex >= count($args)) {
+                    break;
+                }
+
+                if (in_array(strtolower($parameter->getName()), $criticalParameters)) {
+                    $hiddenArgs[] = '**hidden_' . $parameter->getName() . '**';
+                } else {
+                    $hiddenArgs[] = $args[$argIndex];
+                }
+            }
+        } catch (ReflectionException $e) {
+            //In worst case scenario there are some critical args we could't detect so we return an empty array
+        }
+
+        return $hiddenArgs;
     }
 
     /**

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -146,6 +146,9 @@ class PrestaShopExceptionCore extends Exception
 
         $criticalParameters = [
             'password',
+            'passwd',
+            'pwd',
+            'pass',
             'database',
             'server',
         ];
@@ -160,7 +163,14 @@ class PrestaShopExceptionCore extends Exception
                     break;
                 }
 
-                if (in_array(strtolower($parameter->getName()), $criticalParameters)) {
+                $isCritical = false;
+                foreach ($criticalParameters as $criticalParameter) {
+                    if (preg_match('/' . $criticalParameter . '/', $parameter->getName())) {
+                        $isCritical = true;
+                    }
+                }
+
+                if ($isCritical) {
                     $hiddenArgs[] = '**hidden_' . $parameter->getName() . '**';
                 } else {
                     $hiddenArgs[] = $args[$argIndex];

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -145,8 +145,6 @@ class PrestaShopExceptionCore extends Exception
         }
 
         $criticalParameters = [
-            'password',
-            'passwd',
             'pwd',
             'pass',
             'database',
@@ -163,14 +161,7 @@ class PrestaShopExceptionCore extends Exception
                     break;
                 }
 
-                $isCritical = false;
-                foreach ($criticalParameters as $criticalParameter) {
-                    if (preg_match('/' . $criticalParameter . '/', $parameter->getName())) {
-                        $isCritical = true;
-                    }
-                }
-
-                if ($isCritical) {
+                if (preg_match('/(' . implode('|', $criticalParameters) . ')/i', $parameter->getName())) {
                     $hiddenArgs[] = '**hidden_' . $parameter->getName() . '**';
                 } else {
                     $hiddenArgs[] = $args[$argIndex];

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -147,6 +147,8 @@ class PrestaShopExceptionCore extends Exception
         $criticalParameters = [
             'pwd',
             'pass',
+            'passwd',
+            'password',
             'database',
             'server',
         ];
@@ -161,7 +163,7 @@ class PrestaShopExceptionCore extends Exception
                     break;
                 }
 
-                if (preg_match('/(' . implode('|', $criticalParameters) . ')/i', $parameter->getName())) {
+                if (in_array(strtolower($parameter->getName()), $criticalParameters)) {
                     $hiddenArgs[] = '**hidden_' . $parameter->getName() . '**';
                 } else {
                     $hiddenArgs[] = $args[$argIndex];

--- a/config/autoload.php
+++ b/config/autoload.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-define('_PS_VERSION_', '1.7.4.2');
+define('_PS_VERSION_', '1.7.4.3');
 
 require_once(_PS_CONFIG_DIR_.'alias.php');
 require_once(_PS_CLASS_DIR_.'PrestaShopAutoload.php');

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -24,6 +24,13 @@ International Registered Trademark & Property of PrestaShop SA
 Release Notes for PrestaShop 1.7
 --------------------------------
 ####################################
+#   v1.7.4.3 - (2018-07-27)
+####################################
+- Core:
+  - Bug fix:
+    - #10829: Hide arguments in debug trace page
+
+####################################
 #   v1.7.4.2 - (2018-07-27)
 ####################################
 - Back Office:

--- a/docs/readme_de.txt
+++ b/docs/readme_de.txt
@@ -21,9 +21,6 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.4.2
-VERSION: 1.7.4.2
-
 VORBEREITUNG
 ===========
 

--- a/docs/readme_en.txt
+++ b/docs/readme_en.txt
@@ -21,9 +21,6 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.4.2
-VERSION: 1.7.4.2
-
 PREPARATION
 ===========
 

--- a/docs/readme_es.txt
+++ b/docs/readme_es.txt
@@ -21,9 +21,6 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.4.2
-VERSION: 1.7.4.2
-
 PREPARACIÓN
 ===========
 

--- a/docs/readme_fr.txt
+++ b/docs/readme_fr.txt
@@ -21,9 +21,6 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.4.2
-VERSION: 1.7.4.2
-
 PREPARATION
 ===========
 

--- a/docs/readme_it.txt
+++ b/docs/readme_it.txt
@@ -21,9 +21,6 @@ needs please refer to http://www.prestashop.com for more information.
 @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 International Registered Trademark & Property of PrestaShop SA
 
-NAME: Prestashop 1.7.4.2
-VERSION: 1.7.4.2
-
 PREPARAZIONE
 ===========
 

--- a/error500.html
+++ b/error500.html
@@ -89,7 +89,6 @@
     <body>
         <div class="container">
             <h2><span>500</span> Server Error</h2>
-            <!-- ADMIN_ERROR_MESSAGE -->
             <p>Oops, something went wrong.<br /><br />Try to refresh this page or feel free to contact us if the problem persists.</p>
         </div>
     </body>

--- a/error500.html
+++ b/error500.html
@@ -89,6 +89,7 @@
     <body>
         <div class="container">
             <h2><span>500</span> Server Error</h2>
+            <!-- ADMIN_ERROR_MESSAGE -->
             <p>Oops, something went wrong.<br /><br />Try to refresh this page or feel free to contact us if the problem persists.</p>
         </div>
     </body>

--- a/install-dev/install_version.php
+++ b/install-dev/install_version.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-define('_PS_INSTALL_VERSION_', '1.7.4.2');
+define('_PS_INSTALL_VERSION_', '1.7.4.3');
 
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 50600);
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '5.6');


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.x
| Description?  | Sur une page produit, lorsque l'on clique sur le bouton d'ajout au panier (avant que la page soit complètement chargée et que le javascript de la génération du pop-up panier soit chargé) nous sommes redirigé vers le panier dans lequel notre produit n'est pas ajouté. 
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Facilement reproductible avec une connexion lente (type 3G) et en désactivant le cache navigateur. Lors de la redirection, aucun paramètre "action" n'est spécifié, l'appel de la méthode "processDeleteProductInCart()" n'est pas fait. 
[CartController.zip](https://github.com/PrestaShop/PrestaShop/files/2449721/CartController.zip)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10872)
<!-- Reviewable:end -->
