### PR TITLE
[BO] Add support for suffix "G" of php.ini

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -511,7 +511,7 @@ class ModuleController extends ModuleAbstractController
             preg_match('/^([0-9]+)([MGK]){0,1}$/i', $ini_max_filesize, $filesize_match);
             if (is_array($filesize_match) && count($filesize_match) == 3) {
                 if ($filesize_match[2] == 'G'|| $filesize_match[2] == 'g') {
-                    $ini_max_filesize = ($filesize_match[1]*1024)."M";
+                    $ini_max_filesize = ($filesize_match[1]*1024).'M';
                 }
             }
             $fileUploaded = $request->files->get('file_uploaded');

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -506,12 +506,20 @@ class ModuleController extends ModuleAbstractController
         $moduleZipManager = $this->get('prestashop.module.zip.manager');
 
         try {
+            $ini_max_filesize = ini_get('upload_max_filesize');
+            $filesize_match = null;
+            preg_match('/^([0-9]+)([MGK]){0,1}$/i', $ini_max_filesize, $filesize_match);
+            if (is_array($filesize_match) && count($filesize_match) == 3) {
+                if ($filesize_match[2] == 'G'|| $filesize_match[2] == 'g') {
+                    $ini_max_filesize = ($filesize_match[1] * 1024)."M";
+                }
+            }
             $fileUploaded = $request->files->get('file_uploaded');
             $constraints = [
                 new Assert\NotNull(),
                 new Assert\File(
                     [
-                        'maxSize' => ini_get('upload_max_filesize'),
+                        'maxSize' => $ini_max_filesize,
                         'mimeTypes' => [
                             'application/zip',
                             'application/x-gzip',

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -511,7 +511,7 @@ class ModuleController extends ModuleAbstractController
             preg_match('/^([0-9]+)([MGK]){0,1}$/i', $ini_max_filesize, $filesize_match);
             if (is_array($filesize_match) && count($filesize_match) == 3) {
                 if ($filesize_match[2] == 'G'|| $filesize_match[2] == 'g') {
-                    $ini_max_filesize = ($filesize_match[1] * 1024)."M";
+                    $ini_max_filesize = ($filesize_match[1]*1024)."M";
                 }
             }
             $fileUploaded = $request->files->get('file_uploaded');


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.5.x
| Description?  | PHP allows shortcuts for byte values, including K (kilo), M (mega) and G (giga) and maxSize of Symfony not support this. More info here http://php.net/manual/en/ini.core.php and here https://symfony.com/doc/current/reference/constraints/File.html#maxsize
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10890)
<!-- Reviewable:end -->
