### PR TITLE
Fix download product mail template

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -119,15 +119,26 @@ class OrderHistoryCore extends ObjectModel
                     // If this virtual item has an associated file, we'll provide the link to download the file in the email
                     if ($product_download->display_filename != '') {
                         $assign[$key]['name'] = $product_download->display_filename;
+                        $assign[$key]['nameUTF8'] = Tools::htmlentitiesUTF8($product_download->display_filename);
                         $dl_link = $product_download->getTextLink(false, $virtual_product['download_hash'])
                             . '&id_order=' . (int) $order->id
                             . '&secure_key=' . $order->secure_key;
                         $assign[$key]['link'] = $dl_link;
                         if (isset($virtual_product['download_deadline']) && $virtual_product['download_deadline'] != '0000-00-00 00:00:00') {
                             $assign[$key]['deadline'] = Tools::displayDate($virtual_product['download_deadline']);
+                            $assign[$key]['localizedDeadline'] = $this->trans(
+                                'expires on %s.',
+                                array(Tools::displayDate($virtual_product['download_deadline'])),
+                                'Admin.Orderscustomers.Notification'
+                            );
                         }
                         if ($product_download->nb_downloadable != 0) {
                             $assign[$key]['downloadable'] = (int) $product_download->nb_downloadable;
+                            $assign[$key]['localizedDownloadable'] = $this->trans(
+                                'downloadable %d time(s)',
+                                array((int) $product_download->nb_downloadable),
+                                'Admin.Orderscustomers.Notification'
+                            );
                         }
                     }
                 }
@@ -137,12 +148,12 @@ class OrderHistoryCore extends ObjectModel
                 $links = '<ul>';
                 foreach ($assign as $product) {
                     $links .= '<li>';
-                    $links .= '<a href="' . $product['link'] . '">' . Tools::htmlentitiesUTF8($product['name']) . '</a>';
-                    if (isset($product['deadline'])) {
-                        $links .= '&nbsp;' . $this->trans('expires on %s.', array($product['deadline']), 'Admin.Orderscustomers.Notification');
+                    $links .= '<a href="' . $product['link'] . '">' . $product['nameUTF8'] . '</a>';
+                    if (isset($product['localizedDeadline'])) {
+                        $links .= '&nbsp;' . $product['localizedDeadline'];
                     }
-                    if (isset($product['downloadable'])) {
-                        $links .= '&nbsp;' . $this->trans('downloadable %d time(s)', array((int) $product['downloadable']), 'Admin.Orderscustomers.Notification');
+                    if (isset($product['localizedDownloadable'])) {
+                        $links .= '&nbsp;' . $product['localizedDownloadable'];
                     }
                     $links .= '</li>';
                 }

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -165,6 +165,7 @@ class OrderHistoryCore extends ObjectModel
                     '{order_name}' => $order->getUniqReference(),
                     '{nbProducts}' => count($virtual_products),
                     '{virtualProducts}' => $links,
+                    '{virtualProductsArray}' => $assign,
                 );
                 // If there is at least one downloadable file
                 if (!empty($assign)) {

--- a/mails/en/download_product.html
+++ b/mails/en/download_product.html
@@ -89,7 +89,19 @@
 							Product(s) now available for download						</p>
 						<span style="color:#777">
 							You have <span style="color:#333"><strong>{nbProducts}</strong></span> product(s) now available for download using the following link(s):<br/><br/>
-							{virtualProducts}
+							<ul>
+								{foreach virtualProducts as product}
+								<li>
+									<a href="{product['link']}">{product['nameUTF8']}</a>
+									{if isset(product['localizedDeadline'])}
+										&nbsp;{product['localizedDeadline']}
+									{/if}
+									{if isset(product['localizedDownloadable'])}
+										&nbsp;{product['localizedDownloadable']}
+									{/if}
+								</li>
+								{/foreach}
+							</ul>
 						</span>
 					</font>
 				</td>

--- a/mails/en/download_product.txt
+++ b/mails/en/download_product.txt
@@ -9,7 +9,16 @@ Thank you for your order with the reference {order_name} from
 You have {nbProducts} product(s) now available for download using the
 following link(s):
 
-{virtualProducts} 		 
+{foreach virtualProducts as product}
+- Product: {product['nameUTF8']}
+  Link: {product['link']}
+  {if isset(product['localizedDeadline'])}
+    {product['localizedDeadline']}
+  {/if}
+  {if isset(product['localizedDownloadable'])}
+    {product['localizedDownloadable']}
+  {/if}
+{/foreach}
 
 You can review your order and download your invoice from the
 "Order history" [{history_url}]


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixing download product mail template
| Type?         | bug fix
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10915 
| How to test?  | Check html and txt mail after buying one or more virtual products

@marionf  I'm not very familiar with this templating system, but I suppose it will work. Can you give it a try? Now it should send a mail displaying a list of virtualProducts both in html and in txt mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10897)
<!-- Reviewable:end -->
