### PR TITLE
Fixed performance rights on Performance Clear Cache action

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
@@ -33,7 +33,6 @@ use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Responsible of "Configure > Advanced Parameters > Performance" page display.
@@ -50,7 +49,7 @@ class PerformanceController extends FrameworkBundleAdminController
      *
      * @param FormInterface $form
      *
-     * @return Response
+     * @return array
      */
     public function indexAction(FormInterface $form = null)
     {
@@ -112,6 +111,11 @@ class PerformanceController extends FrameworkBundleAdminController
     }
 
     /**
+     * @AdminSecurity("is_granted(['delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_performance"
+     * )
+     *
      * @return RedirectResponse
      */
     public function clearCacheAction()


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Introduced a missing authorization check in Performance page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create a user who has access to Performance Page but not the rights of DELETE and try to clear the cache. Before, it was possible and now it's now: which is the intended behavior.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10898)
<!-- Reviewable:end -->
