### PR TITLE
Improved error handling of theme favicon update

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -1103,8 +1103,12 @@ class AdminThemesControllerCore extends AdminController
                 $this->logo_uploader->updateInvoice();
             }
             if (Tools::getValue('PS_FAVICON')) {
-                $this->logo_uploader->updateFavicon();
-                $this->redirect_after = self::$currentIndex . '&token=' . $this->token;
+                try {
+                    $this->logo_uploader->updateFavicon();
+                    $this->redirect_after = self::$currentIndex . '&token=' . $this->token;
+                } catch (Exception $e) {
+                    $this->errors[] = $e->getMessage();
+                }
             }
 
             Hook::exec('actionAdminThemesControllerUpdate_optionsAfter');


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | When the favicon file was invalid, an unhandled error was thrown, now an exception is handled and a nice error message is returned to the user.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to update the Theme favicon with an invalid file.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10899)
<!-- Reviewable:end -->
