### PR TITLE
Made the installed theme configurable

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -6,7 +6,7 @@ imports:
 # Put parameters here that don't need to change on each machine where the app is deployed
 # http://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
-    env(_PS_THEME_NAME_): "classic"
+    env(PS_THEME_NAME): "classic"
     AdapterSecurityAdminClass: PrestaShop\PrestaShop\Adapter\Security\Admin
     translator.class: PrestaShopBundle\Translation\Translator
     translator.data_collector: PrestaShopBundle\Translation\DataCollectorTranslator

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -6,6 +6,7 @@ imports:
 # Put parameters here that don't need to change on each machine where the app is deployed
 # http://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
+    env(_PS_THEME_NAME_): "classic"
     AdapterSecurityAdminClass: PrestaShop\PrestaShop\Adapter\Security\Admin
     translator.class: PrestaShopBundle\Translation\Translator
     translator.data_collector: PrestaShopBundle\Translation\DataCollectorTranslator

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -87,12 +87,13 @@ if (file_exists(_PS_CORE_DIR_.'/app/config/parameters.php')) {
 }
 
 if (!defined('_THEME_NAME_')) {
-    if (getenv('_PS_THEME_NAME_') !== false) {
-        define('_THEME_NAME_', getenv('_PS_THEME_NAME_'));
+    // @see app/config.yml _PS_THEME_NAME default value is "classic".
+    if (getenv('PS_THEME_NAME') !== false) {
+        define('_THEME_NAME_', getenv('PS_THEME_NAME'));
     } else {
         /**
          * @deprecated since 1.7.5.x to be removed in 1.8.x
-         * Rely on _PS_THEME_NAME environment variable value
+         * Rely on "PS_THEME_NAME" environment variable value
          */
         $themes = glob(dirname(__DIR__).'/themes/*/config/theme.yml', GLOB_NOSORT);
         usort($themes, function ($a, $b) {

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -70,16 +70,9 @@ if ((!is_dir(_PS_CORE_DIR_.DIRECTORY_SEPARATOR.'vendor') ||
     die('Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
 }
 
-$themes = glob(dirname(dirname(__FILE__)).'/themes/*/config/theme.yml', GLOB_NOSORT);
-usort($themes, function ($a, $b) {
-    return strcmp($b, $a);
-});
-if (!defined('_THEME_NAME_')) {
-    define('_THEME_NAME_', basename(substr($themes[0], 0, -strlen('/config/theme.yml'))));
-}
-
 require_once _PS_CORE_DIR_.'/config/defines.inc.php';
 require_once _PS_CORE_DIR_.'/config/autoload.php';
+
 if (file_exists(_PS_CORE_DIR_.'/app/config/parameters.php')) {
     require_once _PS_CORE_DIR_.'/config/bootstrap.php';
 
@@ -92,6 +85,24 @@ if (file_exists(_PS_CORE_DIR_.'/app/config/parameters.php')) {
     $kernel->loadClassCache();
     $kernel->boot();
 }
+
+if (!defined('_THEME_NAME_')) {
+    if (getenv('_PS_THEME_NAME_') !== false) {
+        define('_THEME_NAME_', getenv('_PS_THEME_NAME_'));
+    } else {
+        /**
+         * @deprecated since 1.7.5.x to be removed in 1.8.x
+         * Rely on _PS_THEME_NAME environment variable value
+         */
+        $themes = glob(dirname(__DIR__).'/themes/*/config/theme.yml', GLOB_NOSORT);
+        usort($themes, function ($a, $b) {
+            return strcmp($b, $a);
+        });
+
+        define('_THEME_NAME_', basename(substr($themes[0], 0, -strlen('/config/theme.yml'))));
+    }
+}
+
 require_once _PS_CORE_DIR_.'/config/defines_uri.inc.php';
 
 // Generate common constants


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | If you set `PS_THEME_NAME` environment variable, it will be used during the installation.
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Set `PS_THEME_NAME` environment variable and check at the first step of installation that `_THEME_NAME_` constant is defined.

>  In apache2, this can be done by adding `SetEnv PS_THEME_NAME otherThemeYouHave` in apache2 vhost configuration file, then install again PrestaShop: the other theme 'otherThemeYouHave' should be installed by default.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10909)
<!-- Reviewable:end -->
