### PR TITLE
[BO] Verify stock if needed before updating to delivered

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -389,7 +389,7 @@ class AdminOrdersControllerCore extends AdminController
                                 $this->errors[] = $this->trans('Order #%d has already been assigned this status.', array('#%d' => $id_order), 'Admin.Orderscustomers.Notification');
                             } else {
                                 if(!$this->canRemoveQuantitiesIfNeeded($order->getProductsDetail(), $current_order_state, $order_state)) {
-                                    $this->errors[] = $this->trans('Some quantities from order #%d cannot be removed from the stock.', array('#%d' => $id_order), 'Admin.Orderscustomers.Notification');
+                                    $this->errors[] = $this->trans('Order #%d cannot be changed to a delivered status, because at least one product cannot be removed from the stock. Verify the usable quantities for this order in the stock manager.', array('#%d' => $id_order), 'Admin.Orderscustomers.Notification');
                                 } else {
                                     $history = new OrderHistory();
                                     $history->id_order = $order->id;
@@ -581,7 +581,7 @@ class AdminOrdersControllerCore extends AdminController
                             }
                             $this->errors[] = $this->trans('An error occurred while changing order status, or we were unable to send an email to the customer.', array(), 'Admin.Orderscustomers.Notification');
                         } else {
-                            $this->errors[] = $this->trans('Some quantities from order #%d cannot be removed from the stock.', array('#%d' => $id_order), 'Admin.Orderscustomers.Notification');   
+                            $this->errors[] = $this->trans('Order #%d cannot be changed to a delivered status, because at least one product cannot be removed from the stock. Verify the usable quantities for this order in the stock manager.', array('#%d' => $id_order), 'Admin.Orderscustomers.Notification');   
                         }
                     } else {
                         $this->errors[] = $this->trans('The order has already been assigned this status.', array(), 'Admin.Orderscustomers.Notification');

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -451,25 +451,20 @@ class AdminOrdersControllerCore extends AdminController
     
     private function canRemoveQuantitiesIfNeeded($products, $old_os, $new_os)
     {
-        if(Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT'))
-        {
-          if($new_os->shipped == 1 && (!Validate::isLoadedObject($old_os) || $old_os->shipped == 0))
-          {
-            $manager = StockManagerFactory::getManager();
-            foreach($products as $product)
-            {
-              if((int)$product['advanced_stock_management'] == 1 && Warehouse::exists($product['id_warehouse']))
-              {
-                $quantity_in_stock = (int)$manager->getProductPhysicalQuantities($product['product_id'], $product['product_attribute_id'], array($product['id_warehouse']), true);
+        if(Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
+            if ($new_os->shipped == 1 && (!Validate::isLoadedObject($old_os) || $old_os->shipped == 0)) {
+                $manager = StockManagerFactory::getManager();
+                foreach ($products as $product) {
+                    if ((int)$product['advanced_stock_management'] == 1 && Warehouse::exists($product['id_warehouse'])) {
+                        $quantity_in_stock = (int)$manager->getProductPhysicalQuantities($product['product_id'], $product['product_attribute_id'], array($product['id_warehouse']), true);
 
-                // checks if it's possible to remove the given quantity
-                if($quantity_in_stock < ($product['product_quantity'] - $product['product_quantity_refunded'] - $product['product_quantity_return']))
-                {
-                    return false;
+                        // checks if it's possible to remove the given quantity
+                        if ($quantity_in_stock < ($product['product_quantity'] - $product['product_quantity_refunded'] - $product['product_quantity_return'])) {
+                            return false;
+                        }
+                    }
                 }
-              }
             }
-          }
         }
 
         return true;


### PR DESCRIPTION
There is a stock issue occurring if you follow these steps :

- On a Prestashop with Advanced Stock Management and Back-order allowed
- Create two warehouses A and B
- Create a product P that can be stored in both warehouses
- Create an order with 2 P
- Update the order status to payment accepted ( the warehouse A is the default one, so it's real quantity goes to -2 )
- When your supplier deliver you the 2 P, you make a mistake and increase the quantity in the warehouse B
- Update the order status to delivered

The warehouse A usable and real quantity are now at 0, and the warehouse B usable and real quantity are at 2, resulting in an overall quantity of 2, which is wrong.

One can think that the physical quantity of the warehouse A should be at -2, resulting in an overall quantity of 0. But that is just wrong, we can't have negative stock value in the physical world. 0 is the correct value here.

The problem is that when removeProduct() is called, there is no check for success, it is just assumed that it was done correctly.

As there is not enough quantity in warehouse A to deliver the products, it should not let us update the status to delivered.

This commit fix that by checking if the quantity can be removed, if necessary, before allowing the status update to delivered.

In this case an error will be displayed and a transfer of 2 P from warehouse B to A will be necessary before being able to deliver the product.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.5.x / 1.6.1.x
| Description?  | See this PR message
| Type?         | bug fix / improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See this PR message

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10919)
<!-- Reviewable:end -->
