### PR TITLE
Missing class const on cert refresh

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -26,6 +26,8 @@
 
 class ToolsCore
 {
+    const CACERT_LOCATION = 'https://curl.haxx.se/ca/cacert.pem';
+
     protected static $file_exists_cache = array();
     protected static $_forceCompile;
     protected static $_caching;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When the certificate used to make secure calls is refreshed, Tools use an undefined constant. This PR fixes a fatal error.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Refresh the certificate by removing the file `/cache/cacert.pem`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10921)
<!-- Reviewable:end -->
