### PR TITLE
Allow product import to change previous id_category_default when you force ID

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1878,12 +1878,11 @@ class AdminImportControllerCore extends AdminController
             $product->id_category = array_values(array_unique($product->id_category));
         }
 
-        // Will update default category if there is none set here. Home if no category at all.
-        if (!isset($product->id_category_default) || !$product->id_category_default) {
-            // this if will avoid ereasing default category if category column is not present in the CSV file (or ignored)
-            if (isset($product->id_category[0])) {
-                $product->id_category_default = (int) $product->id_category[0];
-            } else {
+        // Category default now takes the value of the first new category during import
+        if (isset($product->id_category[0])) {
+            $product->id_category_default = (int) $product->id_category[0];
+        } else {
+            if (!isset($product->id_category_default) || !$product->id_category_default) {
                 $defaultProductShop = new Shop($product->id_shop_default);
                 $product->id_category_default = Category::getRootCategory(null, Validate::isLoadedObject($defaultProductShop) ? $defaultProductShop : null)->id;
             }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow product import to change previous id_category_default when you force ID
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes - You no longer can just add categories to current categories with import to a force ID. You will have to set them all and the first will become the default_category.
| Fixed ticket? | Fixes #10871 
| How to test?  | Import products and force ID. The ID has to be an existing product with a different category from those imported. The category default should change now for the new one.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10930)
<!-- Reviewable:end -->
