### PR TITLE
Prevent unvalidated form without checkboxes

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
@@ -133,7 +133,7 @@ class InvoicesController extends FrameworkBundleAdminController
     private function processForm(FormHandlerInterface $formHandler, Request $request)
     {
         $form = $formHandler->getForm();
-        $form->handleRequest($request);
+        $form->submit($request->request->get($form->getName()));
 
         if ($form->isSubmitted()) {
             if ($errors = $formHandler->save($form->getData())) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | When you try to generate an invoice pdf from order statuses, we expect an error when you don't check any checkbox.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #10474
| How to test?  | See ticket for details. When you generate the invoices from order statuses without checking any status, an error message must be displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10936)
<!-- Reviewable:end -->
