### PR TITLE
Fix Bad annotations (backport of #10939)

### DIFF
--- a/src/PrestaShopBundle/Entity/AttributeGroupLang.php
+++ b/src/PrestaShopBundle/Entity/AttributeGroupLang.php
@@ -45,7 +45,6 @@ class AttributeGroupLang
 
     /**
      * @ORM\Id
-     * @ORM\Column(name="id_lang", type="integer")
      * @ORM\ManyToOne(targetEntity="PrestaShopBundle\Entity\Lang")
      * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false, onDelete="CASCADE")
      */

--- a/src/PrestaShopBundle/Entity/AttributeLang.php
+++ b/src/PrestaShopBundle/Entity/AttributeLang.php
@@ -45,7 +45,6 @@ class AttributeLang
 
     /**
      * @ORM\Id
-     * @ORM\Column(name="id_lang", type="integer")
      * @ORM\ManyToOne(targetEntity="PrestaShopBundle\Entity\Lang")
      * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false, onDelete="CASCADE")
      */

--- a/src/PrestaShopBundle/Entity/TabLang.php
+++ b/src/PrestaShopBundle/Entity/TabLang.php
@@ -45,7 +45,6 @@ class TabLang
 
     /**
      * @ORM\Id
-     * @ORM\Column(name="id_lang", type="integer")
      * @ORM\ManyToOne(targetEntity="PrestaShopBundle\Entity\Lang")
      * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false, onDelete="CASCADE")
      */


### PR DESCRIPTION
> Backport of #10939 

No more Column annotation with ManyToOne attribute
This commit fix my own issue #10937

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | No need to use ORM\Column annotation with ManyToOne attribute association
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10937
| How to test?  | Try to persist and flush PrestaShopBundle\Entity\AttributeGroupLang entity

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10967)
<!-- Reviewable:end -->
