### PR TITLE
Fix General options configuration

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -33,6 +33,7 @@ use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class returning the content of the form in the maintenance page.
@@ -40,6 +41,42 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
  */
 class PreferencesType extends TranslatorAwareType
 {
+    /**
+     * @var bool
+     */
+    private $isMultistoreUsed;
+
+    /**
+     * @var bool
+     */
+    private $isSingleShopContext;
+
+    /**
+     * @var bool
+     */
+    private $isAllShopContext;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param bool $isMultistoreUsed
+     * @param bool $isSingleShopContext
+     * @param bool $isAllShopContext
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        $isMultistoreUsed,
+        $isSingleShopContext,
+        $isAllShopContext
+    ) {
+        parent::__construct($translator, $locales);
+
+        $this->isMultistoreUsed = $isMultistoreUsed;
+        $this->isSingleShopContext = $isSingleShopContext;
+        $this->isAllShopContext = $isAllShopContext;
+    }
+
     /**
      * @var bool
      */
@@ -61,7 +98,9 @@ class PreferencesType extends TranslatorAwareType
             ->add('enable_ssl_everywhere', SwitchType::class, [
                 'disabled' => !$isSslEnabled,
             ])
-            ->add('enable_token', SwitchType::class)
+            ->add('enable_token', SwitchType::class, [
+                'disabled' => !$this->isContextDependantOptionEnabled(),
+            ])
             ->add('allow_html_iframes', SwitchType::class)
             ->add('use_htmlpurifier', SwitchType::class)
             ->add('price_round_mode', ChoiceType::class, [
@@ -90,7 +129,9 @@ class PreferencesType extends TranslatorAwareType
             ])
             ->add('display_suppliers', SwitchType::class)
             ->add('display_best_sellers', SwitchType::class)
-            ->add('multishop_feature_active', SwitchType::class)
+            ->add('multishop_feature_active', SwitchType::class, [
+                'disabled' => !$this->isContextDependantOptionEnabled(),
+            ])
             ->add('shop_activity', ChoiceType::class, [
                 'required' => false,
                 'choices_as_values' => true,
@@ -147,5 +188,19 @@ class PreferencesType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'preferences';
+    }
+
+    /**
+     * Check if option which depends on multistore context can be changed.
+     *
+     * @return bool
+     */
+    protected function isContextDependantOptionEnabled()
+    {
+        if (!$this->isMultistoreUsed && $this->isSingleShopContext) {
+            return true;
+        }
+
+        return $this->isAllShopContext;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -315,6 +315,10 @@ services:
     form.type.shop_parameters.general:
         class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\General\PreferencesType'
         parent: 'form.type.translatable.aware'
+        arguments:
+          - '@=service("prestashop.adapter.multistore_feature").isUsed()'
+          - '@=service("prestashop.adapter.shop.context").isShopContext()'
+          - '@=service("prestashop.adapter.shop.context").isAllContext()'
         public: true
         calls:
             - ['setIsSecure', ["@=service('request_stack').getCurrentRequest().isSecure()"]]

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
@@ -76,6 +76,14 @@
                                     {{ form_errors(generalForm.enable_token) }}
                                     {{ form_widget(generalForm.enable_token) }}
                                     <small class="form-text">{{ 'Enable or disable token in the Front Office to improve PrestaShop\'s security.'|trans({}, 'Admin.Shopparameters.Help') }}</small>
+
+                                    {% if generalForm.enable_token.vars.disabled %}
+                                      <div class="alert alert-warning mt-2 mb-0" role="alert">
+                                        <p class="alert-text">
+                                          {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
+                                        </p>
+                                      </div>
+                                    {% endif %}
                                 </div>
                             </div>
                             <div class="form-group row">
@@ -140,6 +148,14 @@
                                     {{ form_errors(generalForm.multishop_feature_active) }}
                                     {{ form_widget(generalForm.multishop_feature_active) }}
                                     <small class="form-text">{{ 'The multistore feature allows you to manage several e-shops with one Back Office. If this feature is enabled, a "Multistore" page will be available in the "Advanced Parameters" menu.'|trans({}, 'Admin.Shopparameters.Help') }}</small>
+
+                                    {% if generalForm.multishop_feature_active.vars.disabled %}
+                                      <div class="alert alert-warning mt-2 mb-0" role="alert">
+                                        <p class="alert-text">
+                                          {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
+                                        </p>
+                                      </div>
+                                    {% endif %}
                                 </div>
                             </div>
                             <div class="form-group row">


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Fixes bug when "Increase front office security" and "Enable Multistore" options can be configured in any shop context.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Access "Configure > Shop Parameters > General" and you should be able to configure "Increase front office security" and "Enable Multistore" options only in "All shops" and single shop context with Multistore is disabled.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10968)
<!-- Reviewable:end -->
