### PR TITLE
Add nightly tasks to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,10 @@ script:
 after_script:
   - sudo cat /var/log/apache2/error.log
 
+after_success:
+  # If tests pass, create a tag to trigger a release.
+  - bash nightly/create-tag.sh
+
 after_failure:
   - curl -L http://localhost/
   - cat /etc/apache2/envvars

--- a/travis-scripts/nightly/create-tag.sh
+++ b/travis-scripts/nightly/create-tag.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if [[ $TRAVIS_EVENT_TYPE != *"cron"* ]]; then
+  exit 0
+fi
+
+GIT_TAG=nightly
+
+setup_git() {
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "Travis CI"
+}
+
+create_and_push_tag() {
+  git tag -f -a nightly -m "Nightly from Travis build: $TRAVIS_BUILD_NUMBER"
+  git remote add origin-push https://${GITHUB_OAUTH_TOKEN}@github.com/PrestaShop/PrestaShop.git > /dev/null 2>&1
+  git push --quiet origin-push :refs/tags/$GIT_TAG && git push --quiet origin-push $GIT_TAG
+}
+
+setup_git
+create_and_push_tag


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Travis will be initiator of the nightly build process. Thanks to the cron feature, we will be able to run additional tests and trigger a release build if they pass.
| Type?         | new feature
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Travis build remains green. Nothing instead a new cron task will change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10969)
<!-- Reviewable:end -->
