### PR TITLE
WebserviceKey.php

### DIFF
--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -79,13 +79,26 @@ class WebserviceKeyCore extends ObjectModel
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 			SELECT p.*
 			FROM `' . _DB_PREFIX_ . 'webservice_permission` p
-			LEFT JOIN `' . _DB_PREFIX_ . 'webservice_account` a ON (a.id_webservice_account = p.id_webservice_account)
+			INNER JOIN `' . _DB_PREFIX_ . 'webservice_account` a ON (a.id_webservice_account = p.id_webservice_account)
 			WHERE a.key = \'' . pSQL($auth_key) . '\'
 		');
         $permissions = array();
         if ($result) {
             foreach ($result as $row) {
                 $permissions[$row['resource']][] = $row['method'];
+            }
+        }
+
+        if (!empty($permissions['employees'])) {
+            if (count($permissions) > 1) {
+                unset($permissions['employees']);
+                    Db::getInstance()->execute('
+                        DELETE p.*
+                        FROM `'._DB_PREFIX_.'webservice_permission` p
+                        INNER JOIN `'._DB_PREFIX_.'webservice_account` a ON (a.id_webservice_account = p.id_webservice_account)
+                        WHERE a.key = \''.pSQL($auth_key).'\'
+                        AND p.resource = "employees"
+                    ');
             }
         }
 


### PR DESCRIPTION
Security:
Enforce APIKY for Employee not to mix with other object

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.5.x / 1.6.1.x / 1.6.0.x / 1.5.x
| Description?  | all versions - security
| Type?         |  critical
| Category?     |  WS 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | To be tested

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10973)
<!-- Reviewable:end -->
