### PR TITLE
Change BO product list price source for multistore

### DIFF
--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -202,7 +202,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         $sqlSelect = array(
             'id_product' => array('table' => 'p', 'field' => 'id_product', 'filtering' => ' %s '),
             'reference' => array('table' => 'p', 'field' => 'reference', 'filtering' => self::FILTERING_LIKE_BOTH),
-            'price' => array('table' => 'p', 'field' => 'price', 'filtering' => ' %s '),
+            'price' => array('table' => 'sa', 'field' => 'price', 'filtering' => ' %s '),
             'id_shop_default' => array('table' => 'p', 'field' => 'id_shop_default'),
             'is_virtual' => array('table' => 'p', 'field' => 'is_virtual'),
             'name' => array('table' => 'pl', 'field' => 'name', 'filtering' => self::FILTERING_LIKE_BOTH),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Previously price on the list was taken from product table and does not always match current store price. That price was the last updated price no metter which store was selected. Now price is taken from product_shop table and match current shop price.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  |  Set up multistore with different currency for each one. Change price for product in first shop, change store and then price for second store and see the list. Price on the list show value from second store with second store currency sign. Now change back to first store. Price on the list show value from second store but with first store currency sign. After change price value for each store are correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10981)
<!-- Reviewable:end -->
