### PR TITLE
Add nightly tasks to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,26 @@ matrix:
       env: EXTRA_DEPS=phpHigh  PRESTASHOP_TEST_TYPE=unit
     - php: 7.2
       env: PRESTASHOP_TEST_TYPE=e2e EXTRA_TESTS=functional
+    - stage: deploy
+      php: 7.2
+      before_install: skip
+      script:
+        - mkdir -p /tmp/ps-release
+        - php tools/build/CreateRelease.php --destination-dir=/tmp/ps-release
+        - cd /tmp/ps-release
+          && today=`date +%Y-%m-%d-`; for i in *; do mv $i $today$i; done
+          && cd -
+      if: type = cron
+      deploy: 
+        provider: gcs
+        access_key_id: $GCS_ACCESS_KEY
+        secret_access_key: $GCS_ACCESS_SECRET
+        bucket: prestashop-core-nightly
+        skip_cleanup: true
+        acl: public-read
+        local-dir: "/tmp/ps-release"
+        on:
+          all_branches: true
   exclude:
     - php: 7.2 # Replaced with additional tests
       env: PRESTASHOP_TEST_TYPE=e2e

--- a/tools/build/CreateRelease.php
+++ b/tools/build/CreateRelease.php
@@ -42,7 +42,6 @@ if (php_sapi_name() !== 'cli') {
 
 $releaseOptions = [
     'version' => [
-        'required' => true,
         'description' => 'Desired release version of PrestaShop',
         'longopt' => 'version:',
     ],
@@ -65,7 +64,7 @@ $releaseOptions = [
         'longopt' => 'help',
     ],
 ];
-$helpMessage = "Usage: php {prestashop_root_path}/tools/build/CreateRelease.php --version=<version> [options]{$lineSeparator}{$lineSeparator}"
+$helpMessage = "Usage: php {prestashop_root_path}/tools/build/CreateRelease.php [--version=<version>] [options]{$lineSeparator}{$lineSeparator}"
     . "Available options are:{$lineSeparator}{$lineSeparator}";
 
 foreach ($releaseOptions as $optionName => $option) {
@@ -83,7 +82,6 @@ $userOptions = getopt(implode('', array_column($releaseOptions, 'opt')), array_c
 // Show help and exit
 if (isset($userOptions['h'])
     || isset($userOptions['help'])
-    || empty($userOptions)
 ) {
     echo $helpMessage;
 
@@ -102,9 +100,14 @@ foreach ($releaseOptions as $optionName => $option) {
         exit(1);
     }
 }
-$version = $userOptions['version'];
 $destinationDir = '';
 $useZip = $useInstaller = true;
+
+if (isset($userOptions['version'])) {
+    $version = $userOptions['version'];
+} else {
+    $version = null;
+}
 
 if (isset($userOptions['no-zip'])) {
     $useZip = false;

--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -195,7 +195,7 @@ class ReleaseCreator
      * @param bool $useZip
      * @param string $destinationDir
      */
-    public function __construct($version, $useInstaller = true, $useZip = true, $destinationDir = '')
+    public function __construct($version = null, $useInstaller = true, $useZip = true, $destinationDir = '')
     {
         $this->consoleWriter = new ConsoleWriter();
         $tmpDir = sys_get_temp_dir();
@@ -206,8 +206,12 @@ class ReleaseCreator
             ConsoleWriter::COLOR_GREEN
         );
         $this->projectPath = realpath(__DIR__ . '/../../..');
-        $this->version = $version;
+        $this->version = $version ? $version : $this->getCurrentVersion();
         $this->zipFileName = "prestashop_$this->version.zip";
+
+        if (empty($this->version)) {
+            throw new Exception('Version is not provided and cannot be found in project.');
+        }
 
         if (empty($destinationDir)) {
             $releasesDir = self::RELEASES_DIR_RELATIVE_PATH;
@@ -341,6 +345,26 @@ class ReleaseCreator
         }
 
         return $this;
+    }
+
+    /**
+     * Get the current version in the project
+     * 
+     * @return string PrestaShop version
+     */
+    protected function getCurrentVersion()
+    {
+        $kernelFile = $this->projectPath.'/app/AppKernel.php';
+        $matches = [];
+
+        $kernelFileContent = file_get_contents($kernelFile);
+        $kernelFileContent = preg_match(
+            '~const VERSION = \'(.*)\';~',
+            $kernelFileContent,
+            $matches
+        ); 
+
+        return $matches[1];
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Travis will be the initiator of the nightly build process. Thanks to the cron feature, we will be able to run additional tests and trigger a release build if they pass. This PR also includes #10834.
| Type?         | new feature
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Travis build remains green. Nothing instead a new cron task will change.

## Post merge steps:

* Define a cron task on the `1.7.5.x` branch.
* Define secure data for uploads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10987)
<!-- Reviewable:end -->
