### PR TITLE
Fix sorting issue in the SQL Manager page

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3375,7 +3375,7 @@ class AdminControllerCore extends Controller
             $orderBySplit = preg_split('/[.!]/', $orderBy);
             $orderBy = bqSQL($orderBySplit[0]) . '.`' . bqSQL($orderBySplit[1]) . '`';
         } elseif ($orderBy) {
-            $orderBy = bqSQL($orderBy);
+            $orderBy = '`' . bqSQL($orderBy) . '`';
         }
 
         return $orderBy;

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -50,7 +50,10 @@ class AdminRequestSqlControllerCore extends AdminController
         $this->fields_list = array(
             'id_request_sql' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'class' => 'fixed-width-xs'),
             'name' => array('title' => $this->trans('SQL query Name', array(), 'Admin.Advparameters.Feature')),
-            'sql' => array('title' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature')),
+            'sql' => array(
+                'title' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature'),
+                'filter_key' => 'a!sql',
+            ),
         );
 
         $this->fields_options = array(

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -50,10 +50,7 @@ class AdminRequestSqlControllerCore extends AdminController
         $this->fields_list = array(
             'id_request_sql' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'class' => 'fixed-width-xs'),
             'name' => array('title' => $this->trans('SQL query Name', array(), 'Admin.Advparameters.Feature')),
-            'sql' => array(
-                'title' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature'),
-                'filter_key' => 'a!sql',
-            ),
+            'sql' => array('title' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature')),
         );
 
         $this->fields_options = array(


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | It is impossible to sort by SQL query in the SQL Manager page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10990
| How to test?  | Go to BO => Database / SQL Manager page => Create at least 2 SQL Query => After that, try to apply a sort on SQL Query with the icon
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/10991)
<!-- Reviewable:end -->
