### PR TITLE
CO: Use SSL for all redirections

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -358,7 +358,7 @@ class ShopCore extends ObjectModel
                         $redirect_header = ($redirect_type == 1 ? 'Found' : 'Moved Permanently');
                         header('HTTP/1.0 '.$redirect_code.' '.$redirect_header);
                         header('Cache-Control: no-cache');
-                        header('Location: http://'.$url);
+                        header('Location: '.(Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE')?'https':'http').'://'.$url);
                         exit;
                     }
                 }
@@ -426,7 +426,7 @@ class ShopCore extends ObjectModel
                 $redirect_code = ($redirect_type == 1 ? '302' : '301');
                 $redirect_header = ($redirect_type == 1 ? 'Found' : 'Moved Permanently');
                 header('HTTP/1.0 '.$redirect_code.' '.$redirect_header);
-                header('Location: http://'.$url);
+                header('Location: '.(Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE')?'https':'http').'://'.$url);
                 exit;
             } elseif (defined('_PS_ADMIN_DIR_') && empty($shop->physical_uri)) {
                 $shop_default = new Shop((int)Configuration::get('PS_SHOP_DEFAULT'));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Currently if you call a shop in SSL without specifying the sub-domain (https://mydomain.tld) it causes 2 redirections to reach the right domain. first it refers to http://www.mydomain.tld then to https//www.mydomain.tld. This makes an unnecessary redirection..
| Type?         | bug fix
| Category?     |  CO 
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Use the site https://httpstatus.io/ with a call to https//mydomain.tld for a site whose domain name is configured with the www subdomain and whose SSL is enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11004)
<!-- Reviewable:end -->
