### PR TITLE
fix multishop issues

### DIFF
--- a/src/Adapter/CombinationDataProvider.php
+++ b/src/Adapter/CombinationDataProvider.php
@@ -32,6 +32,8 @@ use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Tools as ToolsLegacy;
 use Product;
 use Combination;
+use Shop;
+use Context;
 
 /**
  * This class will provide data from DB / ORM about product combination.
@@ -72,6 +74,9 @@ class CombinationDataProvider
     public function getFormCombination($combinationId)
     {
         $product = new Product((new Combination($combinationId))->id_product);
+        if (Context::getContext()->shop->getContext() == Shop::CONTEXT_SHOP && !$product->isAssociatedToShop()) {
+            $product = new Product($product->id, null, null, $product->id_shop_default);
+        }
 
         return $this->completeCombination(
             $product->getAttributeCombinationsById(
@@ -97,6 +102,9 @@ class CombinationDataProvider
     {
         $productId = (new Combination($combinationIds[0]))->id_product;
         $product = new Product($productId);
+        if (Context::getContext()->shop->getContext() == Shop::CONTEXT_SHOP && !$product->isAssociatedToShop()) {
+            $product = new Product($productId, null, null, $product->id_shop_default);
+        }
         $combinations = array();
 
         foreach ($combinationIds as $combinationId) {

--- a/src/Adapter/Product/ProductDataProvider.php
+++ b/src/Adapter/Product/ProductDataProvider.php
@@ -30,6 +30,8 @@ use Image;
 use Product;
 use Context;
 use StockAvailable;
+use Shop;
+use Configuration;
 
 /**
  * This class will provide data from DB / ORM about Product, for both Front and Admin interfaces.
@@ -134,7 +136,16 @@ class ProductDataProvider
     public function getImages($id_product, $id_lang)
     {
         $data = [];
-        foreach (Image::getImages($id_lang, $id_product) as $image) {
+        $context = Context::getContext();
+        $isMultiShopContext = count($context->shop->getContextListShopID()) > 1;
+        if ($isMultiShopContext) {
+            $images = Image::getImages($id_lang, $id_product);
+        } else {
+            $product = new Product($id_product);
+            $images = $product->getImages($id_lang);
+        }
+
+        foreach ($images as $image) {
             $data[] = $this->getImage($image['id_image']);
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | - images in the BO are now properly displayed depending on the shop context and in product admin page, fix switch from shop A to shop B where product doesn't exist
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Enable multishop, create a product in both shop A and shop B. Add an image in shop A, it should not appear in shop B. Create a product in shop A only. Edit the product, and switch to shop B. Information about the product should remain (only the images are not duplicated)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11028)
<!-- Reviewable:end -->
