### PR TITLE
Warning babel-loader on core.js

### DIFF
--- a/themes/package.json
+++ b/themes/package.json
@@ -11,6 +11,7 @@
     "license": "OSL-3.0",
     "devDependencies": {
         "jquery": "^2.1.4",
+        "babel-core": "^5.8.38",
         "babel-loader": "^5.3.2",
         "webpack": "^1.12.2"
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.4.x 
| Description?  |  When I compile core.js I receive this warning message "npm WARN babel-loader@5.4.2 requires a peer of babel-core@^5.0.0 but none is installed. You must install peer dependencies yourself."
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | Does it break backward compatibility? yes/no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | I do not know
| How to test?  | "npm run build" on "~/themes/"

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11044)
<!-- Reviewable:end -->
