### PR TITLE
Hook for custom validation methods

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1224,4 +1224,33 @@ class ValidateCore
     {
         return (bool) preg_match('/^[\w-]{3,255}$/u', $theme_name);
     }
+
+    /**
+     * Calls a hook for undefined methods on the Validate class. This hook is
+     * of the form `actionValidate + $name`.
+     *
+     * # Examples
+     * * `isUuid`, which is called as `actionValidateIsUuid`
+     * * `isEan8`, which is called as `actionValidateIsEan8`
+     *
+     * @param string $name Validation method name (used for hook)
+     * @param array $arguments Arguments passed to method
+     *
+     * @return bool Validation result
+     */
+    public static function __callStatic($name, $arguments)
+    {
+        $name = lcfirst($name);
+
+        $results = Hook::exec('actionValidate'.$name, $arguments, null, true);
+
+        if (empty($results)) { // there are no registered modules to validate
+            return false;      // the argument.
+        }
+
+        // it's unlikely many modules will register to any specific validation
+        // method, but if they do they should at the very least agree on the
+        // outcome.
+        return !in_array(false, $results, true);
+    }
 }

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1240,7 +1240,7 @@ class ValidateCore
      */
     public static function __callStatic($name, $arguments)
     {
-        $name = lcfirst($name);
+        $name = ucfirst($name);
 
         $results = Hook::exec('actionValidate'.$name, $arguments, null, true);
 

--- a/tests/Unit/Classes/ValidateCoreTest.php
+++ b/tests/Unit/Classes/ValidateCoreTest.php
@@ -115,6 +115,13 @@ class ValidateCoreTest extends TestCase
         $this->assertSame($expected, Validate::isOptFloat($input));
     }
 
+    public function testNonExistentMethod()
+    {
+        // Does not exist, but there is also no registered module for it,
+        // which implies it should return false.
+        $this->assertFalse(Validate::isUuid('test'));
+    }
+
     // --- providers ---
 
     public function isIp2LongDataProvider()


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Currently, to extend the Validate class we need to override it with our own methods. That works but is not very nice to do every time, and might clash when we have several methods of the same signature. This PR proposes the use of `__callStatic` to allow the use of a hook instead.
| Type?         | improvement / new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Run tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11045)
<!-- Reviewable:end -->
