### PR TITLE
CO: fixed multilingual fields processing for PHP7

### DIFF
--- a/classes/AdminTab.php
+++ b/classes/AdminTab.php
@@ -1193,6 +1193,9 @@ abstract class AdminTabCore
             $language_ids = Language::getIDs(false);
             foreach ($language_ids as $id_lang) {
                 foreach (array_keys($rules['validateLang']) as $field) {
+                    if (!is_array($object->{$field})) {
+                        $object->{$field} = array();
+                    }
                     if (Tools::isSubmit($field.'_'.(int)$id_lang)) {
                         $object->{$field}[(int)$id_lang] = Tools::getValue($field.'_'.(int)$id_lang);
                     }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3578,6 +3578,9 @@ class AdminControllerCore extends Controller
 
         foreach ($fields as $field => $params) {
             if (array_key_exists('lang', $params) && $params['lang']) {
+                if (!is_array($object->{$field})) {
+                    $object->{$field} = array();
+                }
                 foreach (Language::getIDs(false) as $id_lang) {
                     if (Tools::isSubmit($field.'_'.(int)$id_lang)) {
                         $object->{$field}[(int)$id_lang] = Tools::getValue($field.'_'.(int)$id_lang);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | PHP 7+ handles string properties as strings changing the character on the position specified by the index, while PHP 5 casted the property to an array.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a string property and compare the result of assigning a value to its index in PHP 5 and PHP 7.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11056)
<!-- Reviewable:end -->
