### PR TITLE
Improve PositionColumn to allow more route params

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.js
@@ -69,8 +69,6 @@ export default class PositionExtension {
         const paginationOffset = parseInt($rowPositionContainer.data('pagination-offset'));
         const positions = this._getRowsPositions(paginationOffset);
         const params = {
-            updatedRowId: $rowPositionContainer.data('id'),
-            parentId: $rowPositionContainer.data('id-parent'),
             positions: positions,
         };
 
@@ -136,19 +134,6 @@ export default class PositionExtension {
             'method': isGetOrPostMethod ? method : 'POST',
         }).appendTo('body');
 
-        $form.append(
-            $('<input>', {
-                'type': 'hidden',
-                'name': 'updatedRowId',
-                'value': params.updatedRowId
-            }),
-            $('<input>', {
-                'type': 'hidden',
-                'name': 'parentId',
-                'value': params.parentId
-            })
-        );
-
         const positionsNb = params.positions.length;
         let position;
         for (let i = 0; i < positionsNb; ++i) {
@@ -172,7 +157,7 @@ export default class PositionExtension {
             );
         }
 
-
+        //This _method param is used by Symfony to simulate DELETE and PUT methods
         if (!isGetOrPostMethod) {
             $form.append($('<input>', {
                 'type': 'hidden',

--- a/src/Core/Grid/Column/Type/Common/PositionColumn.php
+++ b/src/Core/Grid/Column/Type/Common/PositionColumn.php
@@ -55,21 +55,21 @@ final class PositionColumn extends AbstractColumn
     {
         $resolver
             ->setRequired([
-                'field',
                 'id_field',
-                'id_parent_field',
+                'position_field',
                 'update_route',
             ])
             ->setDefaults([
                 'sortable' => true,
                 'update_method' => 'GET',
+                'route_params' => [],
             ])
+            ->setAllowedTypes('id_field', 'string')
+            ->setAllowedTypes('position_field', 'string')
+            ->setAllowedTypes('update_route', 'string')
             ->setAllowedTypes('sortable', 'bool')
             ->setAllowedTypes('update_method', 'string')
-            ->setAllowedTypes('field', 'string')
-            ->setAllowedTypes('id_field', 'string')
-            ->setAllowedTypes('id_parent_field', 'string')
-            ->setAllowedTypes('update_route', 'string')
+            ->setAllowedTypes('route_params', ['array'])
             ->setAllowedValues('update_method', ['GET', 'POST'])
         ;
     }

--- a/src/Core/Grid/Position/PositionUpdateFactoryInterface.php
+++ b/src/Core/Grid/Position/PositionUpdateFactoryInterface.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Position;
 
+use PrestaShop\PrestaShop\Core\Grid\Position\Exception\PositionDataException;
+
 /**
  * Interface PositionUpdateFactoryInterface is used to interpret the provided
  * data array and transform it in a fully filled PositionUpdate object.
@@ -39,6 +41,8 @@ interface PositionUpdateFactoryInterface
      * @param PositionDefinition $positionDefinition
      *
      * @return PositionUpdate
+     *
+     * @throws PositionDataException
      */
     public function buildPositionUpdate(array $data, PositionDefinition $positionDefinition);
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/position.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/position.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
  {% if grid.sorting.order_by == 'position' and grid.sorting.order_way == 'asc' %}
-     {% set updateRouteParams = extractArray(record, column.options.route_params) %}
+     {% set updateRouteParams = record|arrayPluck(column.options.route_params) %}
 
      <div class="js-drag-handle js-{{ grid.id }}-position"
           style="cursor: move;"

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/position.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/position.html.twig
@@ -23,22 +23,23 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
  {% if grid.sorting.order_by == 'position' and grid.sorting.order_way == 'asc' %}
+     {% set updateRouteParams = extractArray(record, column.options.route_params) %}
+
      <div class="js-drag-handle js-{{ grid.id }}-position"
           style="cursor: move;"
           data-id="{{ record[column.options.id_field] }}"
-          data-id-parent="{{ record[column.options.id_parent_field] }}"
-          data-position="{{ record[column.options.field] }}"
-          data-update-url="{{ url(column.options.update_route) }}"
+          data-position="{{ record[column.options.position_field] }}"
+          data-update-url="{{ url(column.options.update_route, updateRouteParams) }}"
           data-update-method="{{ column.options.update_method }}"
           data-pagination-offset="{{ grid.pagination.offset }}"
      >
          <i class="material-icons">swap_vert</i>
          <span class="badge badge-secondary rounded js-position">
-            {{ record[column.options.field] + 1 }}
+            {{ record[column.options.position_field] + 1 }}
          </span>
      </div>
  {% else %}
      <div class="text-center">
-         {{ record[column.options.field] + 1 }}
+         {{ record[column.options.position_field] + 1 }}
      </div>
  {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/position.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/position.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
  {% if grid.sorting.order_by == 'position' and grid.sorting.order_way == 'asc' %}
-     {% set updateRouteParams = record|arrayPluck(column.options.route_params) %}
+     {% set updateRouteParams = record|array_pluck(column.options.route_params) %}
 
      <div class="js-drag-handle js-{{ grid.id }}-position"
           style="cursor: move;"

--- a/src/PrestaShopBundle/Twig/DataFormatterExtension.php
+++ b/src/PrestaShopBundle/Twig/DataFormatterExtension.php
@@ -42,6 +42,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFilter('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFilter('intCast', array($this, 'intCast')),
             new \Twig_SimpleFilter('unsetElement', array($this, 'unsetElement')),
+            new \Twig_SimpleFilter('extractArray', array($this, 'extractArray')),
         );
     }
 
@@ -56,6 +57,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFunction('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFunction('intCast', array($this, 'intCast')),
             new \Twig_SimpleFunction('unsetElement', array($this, 'unsetElement')),
+            new \Twig_SimpleFunction('extractArray', array($this, 'extractArray')),
         );
     }
 
@@ -94,6 +96,39 @@ class DataFormatterExtension extends \Twig_Extension
         unset($array[$key]);
 
         return $array;
+    }
+
+    /**
+     * Extract a subset of an array and returns only the wanted keys.
+     * If $extractedKeys is an associative array you can even rename the
+     * keys of the extracted array.
+     *
+     * ex:
+     *  extractArray(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name']) => ['first_name' => 'John']
+     *  extractArray(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name' => 'name']) => ['name' => 'John']
+     *
+     * @param array $array
+     * @param array $extractedKeys
+     *
+     * @return array
+     */
+    public function extractArray(array $array, array $extractedKeys)
+    {
+        $extractedArray = [];
+        foreach ($extractedKeys as $key => $value) {
+            if (is_int($key)) {
+                $oldKey = $value;
+                $newKey = $value;
+            } else {
+                $oldKey = $key;
+                $newKey = $value;
+            }
+            if (isset($array[$oldKey])) {
+                $extractedArray[$newKey] = $array[$oldKey];
+            }
+        }
+
+        return $extractedArray;
     }
 
     /**

--- a/src/PrestaShopBundle/Twig/DataFormatterExtension.php
+++ b/src/PrestaShopBundle/Twig/DataFormatterExtension.php
@@ -42,7 +42,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFilter('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFilter('intCast', array($this, 'intCast')),
             new \Twig_SimpleFilter('unsetElement', array($this, 'unsetElement')),
-            new \Twig_SimpleFilter('extractArray', array($this, 'extractArray')),
+            new \Twig_SimpleFilter('arrayPluck', array($this, 'arrayPluck')),
         );
     }
 
@@ -57,7 +57,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFunction('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFunction('intCast', array($this, 'intCast')),
             new \Twig_SimpleFunction('unsetElement', array($this, 'unsetElement')),
-            new \Twig_SimpleFunction('extractArray', array($this, 'extractArray')),
+            new \Twig_SimpleFunction('arrayPluck', array($this, 'arrayPluck')),
         );
     }
 
@@ -104,15 +104,15 @@ class DataFormatterExtension extends \Twig_Extension
      * keys of the extracted array.
      *
      * ex:
-     *  extractArray(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name']) => ['first_name' => 'John']
-     *  extractArray(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name' => 'name']) => ['name' => 'John']
+     *  arrayPluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name']) => ['first_name' => 'John']
+     *  arrayPluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name' => 'name']) => ['name' => 'John']
      *
      * @param array $array
      * @param array $extractedKeys
      *
      * @return array
      */
-    public function extractArray(array $array, array $extractedKeys)
+    public function arrayPluck(array $array, array $extractedKeys)
     {
         $extractedArray = [];
         foreach ($extractedKeys as $key => $value) {

--- a/src/PrestaShopBundle/Twig/DataFormatterExtension.php
+++ b/src/PrestaShopBundle/Twig/DataFormatterExtension.php
@@ -42,7 +42,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFilter('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFilter('intCast', array($this, 'intCast')),
             new \Twig_SimpleFilter('unsetElement', array($this, 'unsetElement')),
-            new \Twig_SimpleFilter('arrayPluck', array($this, 'arrayPluck')),
+            new \Twig_SimpleFilter('array_pluck', array($this, 'array_pluck')),
         );
     }
 
@@ -57,7 +57,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFunction('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFunction('intCast', array($this, 'intCast')),
             new \Twig_SimpleFunction('unsetElement', array($this, 'unsetElement')),
-            new \Twig_SimpleFunction('arrayPluck', array($this, 'arrayPluck')),
+            new \Twig_SimpleFunction('array_pluck', array($this, 'array_pluck')),
         );
     }
 
@@ -104,15 +104,15 @@ class DataFormatterExtension extends \Twig_Extension
      * keys of the extracted array.
      *
      * ex:
-     *  arrayPluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name']) => ['first_name' => 'John']
-     *  arrayPluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name' => 'name']) => ['name' => 'John']
+     *  array_pluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name']) => ['first_name' => 'John']
+     *  array_pluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name' => 'name']) => ['name' => 'John']
      *
      * @param array $array
      * @param array $extractedKeys
      *
      * @return array
      */
-    public function arrayPluck(array $array, array $extractedKeys)
+    public function array_pluck(array $array, array $extractedKeys)
     {
         $extractedArray = [];
         foreach ($extractedKeys as $key => $value) {

--- a/src/PrestaShopBundle/Twig/DataFormatterExtension.php
+++ b/src/PrestaShopBundle/Twig/DataFormatterExtension.php
@@ -42,7 +42,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFilter('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFilter('intCast', array($this, 'intCast')),
             new \Twig_SimpleFilter('unsetElement', array($this, 'unsetElement')),
-            new \Twig_SimpleFilter('array_pluck', array($this, 'array_pluck')),
+            new \Twig_SimpleFilter('array_pluck', array($this, 'arrayPluck')),
         );
     }
 
@@ -57,7 +57,7 @@ class DataFormatterExtension extends \Twig_Extension
             new \Twig_SimpleFunction('arrayCast', array($this, 'arrayCast')),
             new \Twig_SimpleFunction('intCast', array($this, 'intCast')),
             new \Twig_SimpleFunction('unsetElement', array($this, 'unsetElement')),
-            new \Twig_SimpleFunction('array_pluck', array($this, 'array_pluck')),
+            new \Twig_SimpleFunction('array_pluck', array($this, 'arrayPluck')),
         );
     }
 
@@ -104,15 +104,15 @@ class DataFormatterExtension extends \Twig_Extension
      * keys of the extracted array.
      *
      * ex:
-     *  array_pluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name']) => ['first_name' => 'John']
-     *  array_pluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name' => 'name']) => ['name' => 'John']
+     *  arrayPluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name']) => ['first_name' => 'John']
+     *  arrayPluck(['first_name' => 'John', 'last_name' => 'Doe'], ['first_name' => 'name']) => ['name' => 'John']
      *
      * @param array $array
      * @param array $extractedKeys
      *
      * @return array
      */
-    public function array_pluck(array $array, array $extractedKeys)
+    public function arrayPluck(array $array, array $extractedKeys)
     {
         $extractedArray = [];
         foreach ($extractedKeys as $key => $value) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Improve PositionColumn you can now insert an array of parameters into the udpate_route (extracted from the grid result). This allow this extension to manage more use cases and the javascript code is simpler since it doesn't need to send the extra parameters like parentId (which are now in the url) and it focuses on what it needs to do, send the positions.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11063)
<!-- Reviewable:end -->
