### PR TITLE
Prevent CS Fixer from adding a trailing dot to the first paragraph of phpdoc

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -24,6 +24,7 @@ return PhpCsFixer\Config::create()
         'function_to_constant' => false,
         'no_alias_functions' => false,
         'non_printable_character' => false,
+        'phpdoc_summary' => false,
         'phpdoc_align' => [
             'align' => 'left',
         ],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | CS Fixer adds a trailing dot to the first paragraph of PHPdoc, regardless of what it is. Not only the value of this is pretty limited, but it also changes our class header to add a dot.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | No test needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11068)
<!-- Reviewable:end -->
