### PR TITLE
Set sortable flag by default to "true" on ToggleColumn

### DIFF
--- a/src/Core/Grid/Column/Type/Common/ToggleColumn.php
+++ b/src/Core/Grid/Column/Type/Common/ToggleColumn.php
@@ -50,6 +50,9 @@ final class ToggleColumn extends AbstractColumn
     protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver
+            ->setDefaults([
+                'sortable' => true,
+            ])
             ->setRequired([
                 'field',
                 'primary_field',

--- a/src/Core/Grid/Query/WebserviceKeyQueryBuilder.php
+++ b/src/Core/Grid/Query/WebserviceKeyQueryBuilder.php
@@ -142,6 +142,6 @@ final class WebserviceKeyQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function getModifiedOrderBy($orderBy)
     {
-        return $orderBy === 'key' ? 'wa.`key`' : $orderBy;
+        return 'wa.`' . $orderBy . '`';
     }
 }


### PR DESCRIPTION

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As mentioned in https://github.com/PrestaShop/PrestaShop/pull/10774#issuecomment-431363447 we should allow active column to be sortable on all migrated lists
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Currently the implementation is available on **admin-dev/index.php/configure/advanced/webservice/**, **admin-dev/index.php/sell/catalog/categories/** and **admin-dev/index.php/configure/advanced/employees/** . On employees list, the actions are not implemented yet which allows to disable employee so to test the sorting there disable the employee in database. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11093)
<!-- Reviewable:end -->
