### PR TITLE
Fix discount display when display preference is set without tax

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -810,6 +810,7 @@ class CartCore extends ObjectModel
 
                 $additionalRow = Product::getProductProperties((int) $this->id_lang, $row);
                 $row['reduction'] = $additionalRow['reduction'];
+                $row['reduction_without_tax'] = $additionalRow['reduction_without_tax'];
                 $row['price_without_reduction'] = $additionalRow['price_without_reduction'];
                 $row['specific_prices'] = $additionalRow['specific_prices'];
                 unset($additionalRow);
@@ -895,6 +896,27 @@ class CartCore extends ObjectModel
         $row['price_without_reduction'] = Product::getPriceStatic(
             (int) $row['id_product'],
             true,
+            isset($row['id_product_attribute']) ? (int) $row['id_product_attribute'] : null,
+            6,
+            null,
+            false,
+            false,
+            $productQuantity,
+            false,
+            (int) $this->id_customer ? (int) $this->id_customer : null,
+            (int) $this->id,
+            $address_id,
+            $specific_price_output,
+            true,
+            true,
+            $shopContext,
+            true,
+            $row['id_customization']
+        );
+
+        $row['price_without_reduction_without_tax'] = Product::getPriceStatic(
+            (int) $row['id_product'],
+            false,
             isset($row['id_product_attribute']) ? (int) $row['id_product_attribute'] : null,
             6,
             null,

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4791,7 +4791,8 @@ class ProductCore extends ObjectModel
                 true,
                 $quantity
             );
-            $row['price_without_reduction'] = Product::getPriceStatic(
+            $row['price_without_reduction'] =
+            $row['price_without_reduction_without_tax'] = Product::getPriceStatic(
                 (int) $row['id_product'],
                 false,
                 $id_product_attribute,
@@ -4825,11 +4826,37 @@ class ProductCore extends ObjectModel
                 false,
                 $quantity
             );
+            $row['price_without_reduction_without_tax'] = Product::getPriceStatic(
+                (int) $row['id_product'],
+                false,
+                $id_product_attribute,
+                6,
+                null,
+                false,
+                false,
+                $quantity
+            );
         }
 
         $row['reduction'] = Product::getPriceStatic(
             (int) $row['id_product'],
             (bool) $usetax,
+            $id_product_attribute,
+            6,
+            null,
+            true,
+            true,
+            $quantity,
+            true,
+            null,
+            null,
+            null,
+            $specific_prices
+        );
+
+        $row['reduction_without_tax'] = Product::getPriceStatic(
+            (int) $row['id_product'],
+            false,
             $id_product_attribute,
             6,
             null,

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -131,6 +131,7 @@ class CartPresenter implements PresenterInterface
             'customizable',
             'online_only',
             'reduction',
+            'reduction_without_tax',
             'new',
             'condition',
             'pack',

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -623,12 +623,18 @@ class ProductLazyArray extends AbstractLazyArray
             // TODO: add percent sign according to locale preferences
             $this->product['discount_percentage'] = Tools::displayNumber($presNegativeReduction) . '%';
             $this->product['discount_percentage_absolute'] = Tools::displayNumber($presAbsoluteReduction) . '%';
-            // TODO: Fix issue with tax calculation
-            $this->product['discount_amount'] = $this->priceFormatter->format(
-                $product['reduction']
-            );
+            if ($settings->include_taxes) {
+                $regular_price = $product['price_without_reduction'];
+                $this->product['discount_amount'] = $this->priceFormatter->format(
+                    $product['reduction']
+                );
+            } else {
+                $regular_price = $product['price_without_reduction_without_tax'];
+                $this->product['discount_amount'] = $this->priceFormatter->format(
+                    $product['reduction_without_tax']
+                );
+            }
             $this->product['discount_amount_to_display'] = '-' . $this->product['discount_amount'];
-            $regular_price = $product['price_without_reduction'];
         }
 
         $this->product['price_amount'] = $price;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix discount display when display preference is set without tax
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/9696
| How to test?  | create a product with specific price (should display discount on productpage / cart). Set customer group preference to display prices without tax. The original price and the discount amount will now be displayed without tax

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11103)
<!-- Reviewable:end -->
