### PR TITLE
Restore PrestashopCollection::join() functionnality

### DIFF
--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -125,6 +125,8 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
         if (!$association) {
             return;
         }
+        //Prevent sensitive case array
+        $association = strtolower($association);
 
         if (!isset($this->join_list[$association])) {
             $definition = $this->getDefinition($association);

--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -537,10 +537,11 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
                 $asso = $split[$i];
 
                 // Check is current association exists in current definition
-                if (!isset($definition['associations'][$asso])) {
-                    throw new PrestaShopException('Association '.$asso.' not found for class '.$this->definition['classname']);
+                if (isset($definition['associations'][$asso])) {
+                    $current_def = $definition['associations'][$asso];
+                } else {
+                    $current_def = array();
                 }
-                $current_def = $definition['associations'][$asso];
 
                 // Special case for lang alias
                 if ($asso == self::LANG_ALIAS) {

--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -636,6 +636,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
      */
     protected function getFieldInfo($field)
     {
+        $field = strtolower($field);
         if (!isset($this->fields[$field])) {
             $split = explode('.', $field);
             $total = count($split);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | We have some problems on this method :<br/>  * Associative array is used and it's sensitive case  then "Order" != "order" <br/>  * An exception is raised before to do any association, without we can't do any join action.  |
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11117
| How to test?  | Do any PrestashopCollection::join (as Order and CartRule objects)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11120)
<!-- Reviewable:end -->
