### PR TITLE
CO: fix multishop bug fetching deliverable countries

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -624,7 +624,7 @@ class CarrierCore extends ObjectModel
 			LEFT JOIN `' . _DB_PREFIX_ . 'country_lang` cl ON (c.`id_country` = cl.`id_country` AND cl.`id_lang` = ' . (int) $id_lang . ')
 			INNER JOIN (`' . _DB_PREFIX_ . 'carrier_zone` cz INNER JOIN `' . _DB_PREFIX_ . 'carrier` cr ON ( cr.id_carrier = cz.id_carrier AND cr.deleted = 0 ' .
             ($active_carriers ? 'AND cr.active = 1) ' : ') ') .
- 			Shop::addSqlAssociation('carrier', 'cr') . '
+            Shop::addSqlAssociation('carrier', 'cr') . '
 			LEFT JOIN `' . _DB_PREFIX_ . 'zone` zz ON cz.id_zone = zz.id_zone) ON zz.`id_zone` = c.`id_zone`
 			WHERE 1
 			' . ($active_countries ? 'AND c.active = 1' : '') . '

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -623,8 +623,8 @@ class CarrierCore extends ObjectModel
             Shop::addSqlAssociation('country', 'c') . '
 			LEFT JOIN `' . _DB_PREFIX_ . 'country_lang` cl ON (c.`id_country` = cl.`id_country` AND cl.`id_lang` = ' . (int) $id_lang . ')
 			INNER JOIN (`' . _DB_PREFIX_ . 'carrier_zone` cz INNER JOIN `' . _DB_PREFIX_ . 'carrier` cr ON ( cr.id_carrier = cz.id_carrier AND cr.deleted = 0 ' .
-            ($active_carriers ? 'AND cr.active = 1) ' : ') ').
- 			Shop::addSqlAssociation('carrier', 'cr').'
+            ($active_carriers ? 'AND cr.active = 1) ' : ') ') .
+ 			Shop::addSqlAssociation('carrier', 'cr') . '
 			LEFT JOIN `' . _DB_PREFIX_ . 'zone` zz ON cz.id_zone = zz.id_zone) ON zz.`id_zone` = c.`id_zone`
 			WHERE 1
 			' . ($active_countries ? 'AND c.active = 1' : '') . '

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -623,7 +623,8 @@ class CarrierCore extends ObjectModel
             Shop::addSqlAssociation('country', 'c') . '
 			LEFT JOIN `' . _DB_PREFIX_ . 'country_lang` cl ON (c.`id_country` = cl.`id_country` AND cl.`id_lang` = ' . (int) $id_lang . ')
 			INNER JOIN (`' . _DB_PREFIX_ . 'carrier_zone` cz INNER JOIN `' . _DB_PREFIX_ . 'carrier` cr ON ( cr.id_carrier = cz.id_carrier AND cr.deleted = 0 ' .
-            ($active_carriers ? 'AND cr.active = 1) ' : ') ') . '
+            ($active_carriers ? 'AND cr.active = 1) ' : ') ').
+ 			Shop::addSqlAssociation('carrier', 'cr').'
 			LEFT JOIN `' . _DB_PREFIX_ . 'zone` zz ON cz.id_zone = zz.id_zone) ON zz.`id_zone` = c.`id_zone`
 			WHERE 1
 			' . ($active_countries ? 'AND c.active = 1' : '') . '


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | This fixes a bug where countries that have no carriers associated in current shop but have carriers in a different shop are returned incorrectly.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 1) Create shared country between 2 shops.<br />2) Create different zones per shop that contain this country.<br />3) Create a carrier on shop 1 for the zone created.<br />4) Call the getDeliveredCountries function in Carrier.php from a shop 2 context (which has no carrier for the new country, thus the new country is not a "delivered country" --> it will be returned in the list of delivered countries because the carriers are not shop-joined in the query.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11128)
<!-- Reviewable:end -->
