### PR TITLE
Removed inline-style color in demo product description

### DIFF
--- a/install-dev/fixtures/fashion/langs/bn/data/product.xml
+++ b/install-dev/fixtures/fashion/langs/bn/data/product.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <entity_product>
   <product id="Hummingbird_printed_t-shirt" id_shop="1">
-    <description>&lt;p&gt;&lt;span style="font-size:10pt;font-style:normal;"&gt;&lt;span style="font-size:10pt;font-style:normal;color:#efefef;"&gt;Symbol of lightness and delicacy, the hummingbird evokes curiosity and joy.&lt;/span&gt;&lt;span style="font-size:10pt;font-style:normal;"&gt; Studio Design' PolyFaune collection features classic products with colorful patterns, inspired by the traditional japanese origamis. To wear with a chino or jeans. The sublimation textile printing process provides an exceptional color rendering and a color, guaranteed overtime.&lt;/span&gt;&lt;/span&gt;&lt;/p&gt;</description>
+    <description>&lt;p&gt;&lt;span style="font-size:10pt;font-style:normal;"&gt;&lt;span style="font-size:10pt;font-style:normal;"&gt;Symbol of lightness and delicacy, the hummingbird evokes curiosity and joy.&lt;/span&gt;&lt;span style="font-size:10pt;font-style:normal;"&gt; Studio Design' PolyFaune collection features classic products with colorful patterns, inspired by the traditional japanese origamis. To wear with a chino or jeans. The sublimation textile printing process provides an exceptional color rendering and a color, guaranteed overtime.&lt;/span&gt;&lt;/span&gt;&lt;/p&gt;</description>
     <description_short>&lt;p&gt;&lt;span style="font-size:10pt;font-style:normal;"&gt;Regular fit, round neckline, short sleeves. Made of extra long staple pima cotton. &lt;/span&gt;&lt;/p&gt;&#xD;
 &lt;p&gt;&lt;/p&gt;</description_short>
     <link_rewrite>hummingbird-printed-t-shirt</link_rewrite>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Removed inline-style of color in demo product desciption of "Hummingbird_printed_t-shirt" for design improvement.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11211 
| How to test?  | Go to: http://demo.prestashop.com/en/?view=front ,Where on product page of "Hummingbird_printed_t-shirt" font color should be consistence in description tab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11133)
<!-- Reviewable:end -->
