### PR TITLE
Fix param name on email delete all bulk action

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
@@ -155,7 +155,7 @@ class EmailController extends FrameworkBundleAdminController
      */
     public function deleteBulkAction(Request $request)
     {
-        $mailLogsToDelete = $request->request->get('email_logs_delete_email_logs');
+        $mailLogsToDelete = $request->request->get('emaillogs_delete_email_logs');
 
         $mailLogsEraser = $this->get('prestashop.adapter.email.email_log_eraser');
         $errors = $mailLogsEraser->erase($mailLogsToDelete);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | bulk action param name on email delete was wrong
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11051
| How to test?  | Go to Advanced parameters > Email, Click on Select all, Click on bulk action > delete all
--




<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11136)
<!-- Reviewable:end -->
