### PR TITLE
Migration of "Catalog > Brand & Suppliers > Suppliers" listing

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/supplier/index.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.js
@@ -28,6 +28,6 @@ import SortingExtension from "../../components/grid/extension/sorting-extension"
 const $ = window.$;
 
 $(() => {
-  const supplierGrid =  new Grid('supplier');
+  const supplierGrid =  new Grid('suppliers');
   supplierGrid.addExtension(new SortingExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/supplier/index.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.js
@@ -28,6 +28,7 @@ import SortingExtension from "../../components/grid/extension/sorting-extension"
 import FiltersResetExtension from "../../components/grid/extension/filters-reset-extension";
 import SubmitGridActionExtension from "../../components/grid/extension/submit-grid-action-extension";
 import ColumnTogglingExtension from "../../components/grid/extension/column-toggling-extension";
+import SubmitRowActionExtension from "../../components/grid/extension/action/row/submit-row-action-extension";
 
 const $ = window.$;
 
@@ -37,4 +38,5 @@ $(() => {
   supplierGrid.addExtension(new SubmitGridActionExtension());
   supplierGrid.addExtension(new FiltersResetExtension());
   supplierGrid.addExtension(new ColumnTogglingExtension());
+  supplierGrid.addExtension(new SubmitRowActionExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/supplier/index.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.js
@@ -1,0 +1,33 @@
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+import Grid from "../../components/grid/grid";
+import SortingExtension from "../../components/grid/extension/sorting-extension";
+
+const $ = window.$;
+
+$(() => {
+  const supplierGrid =  new Grid('supplier');
+  supplierGrid.addExtension(new SortingExtension());
+});

--- a/admin-dev/themes/new-theme/js/pages/supplier/index.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.js
@@ -24,10 +24,14 @@
  */
 import Grid from "../../components/grid/grid";
 import SortingExtension from "../../components/grid/extension/sorting-extension";
+import FiltersResetExtension from "../../components/grid/extension/filters-reset-extension";
+import SubmitGridActionExtension from "../../components/grid/extension/submit-grid-action-extension";
 
 const $ = window.$;
 
 $(() => {
   const supplierGrid =  new Grid('suppliers');
   supplierGrid.addExtension(new SortingExtension());
+  supplierGrid.addExtension(new SubmitGridActionExtension());
+  supplierGrid.addExtension(new FiltersResetExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/supplier/index.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.js
@@ -22,6 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 import Grid from "../../components/grid/grid";
 import SortingExtension from "../../components/grid/extension/sorting-extension";
 import FiltersResetExtension from "../../components/grid/extension/filters-reset-extension";

--- a/admin-dev/themes/new-theme/js/pages/supplier/index.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.js
@@ -31,6 +31,8 @@ import ColumnTogglingExtension from "../../components/grid/extension/column-togg
 import SubmitRowActionExtension from "../../components/grid/extension/action/row/submit-row-action-extension";
 import BulkActionCheckboxExtension from "../../components/grid/extension/bulk-action-checkbox-extension";
 import SubmitBulkActionExtension from "../../components/grid/extension/submit-bulk-action-extension";
+import ReloadListExtension from "../../components/grid/extension/reload-list-extension";
+import ExportToSqlManagerExtension from "../../components/grid/extension/export-to-sql-manager-extension";
 
 const $ = window.$;
 
@@ -43,4 +45,6 @@ $(() => {
   supplierGrid.addExtension(new SubmitRowActionExtension());
   supplierGrid.addExtension(new BulkActionCheckboxExtension());
   supplierGrid.addExtension(new SubmitBulkActionExtension());
+  supplierGrid.addExtension(new ReloadListExtension());
+  supplierGrid.addExtension(new ExportToSqlManagerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/supplier/index.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.js
@@ -27,6 +27,7 @@ import Grid from "../../components/grid/grid";
 import SortingExtension from "../../components/grid/extension/sorting-extension";
 import FiltersResetExtension from "../../components/grid/extension/filters-reset-extension";
 import SubmitGridActionExtension from "../../components/grid/extension/submit-grid-action-extension";
+import ColumnTogglingExtension from "../../components/grid/extension/column-toggling-extension";
 
 const $ = window.$;
 
@@ -35,4 +36,5 @@ $(() => {
   supplierGrid.addExtension(new SortingExtension());
   supplierGrid.addExtension(new SubmitGridActionExtension());
   supplierGrid.addExtension(new FiltersResetExtension());
+  supplierGrid.addExtension(new ColumnTogglingExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/supplier/index.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.js
@@ -29,6 +29,8 @@ import FiltersResetExtension from "../../components/grid/extension/filters-reset
 import SubmitGridActionExtension from "../../components/grid/extension/submit-grid-action-extension";
 import ColumnTogglingExtension from "../../components/grid/extension/column-toggling-extension";
 import SubmitRowActionExtension from "../../components/grid/extension/action/row/submit-row-action-extension";
+import BulkActionCheckboxExtension from "../../components/grid/extension/bulk-action-checkbox-extension";
+import SubmitBulkActionExtension from "../../components/grid/extension/submit-bulk-action-extension";
 
 const $ = window.$;
 
@@ -39,4 +41,6 @@ $(() => {
   supplierGrid.addExtension(new FiltersResetExtension());
   supplierGrid.addExtension(new ColumnTogglingExtension());
   supplierGrid.addExtension(new SubmitRowActionExtension());
+  supplierGrid.addExtension(new BulkActionCheckboxExtension());
+  supplierGrid.addExtension(new SubmitBulkActionExtension());
 });

--- a/admin-dev/themes/new-theme/webpack.config.js
+++ b/admin-dev/themes/new-theme/webpack.config.js
@@ -132,6 +132,9 @@ const config = {
     currency: [
       './js/pages/currency',
     ],
+    supplier: [
+      './js/pages/supplier',
+    ],
   },
   output: {
     path: path.resolve(__dirname, 'public'),

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -30,6 +30,9 @@ use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
  */
 class HelperListCore extends Helper
 {
+    /** @var int size which is used for lists image thumbnail generation. */
+    const LIST_THUMBNAIL_SIZE = 45;
+
     /** @var array Cache for query results */
     protected $_list = array();
 
@@ -316,7 +319,7 @@ class HelperListCore extends Helper
                     } else {
                         $path_to_image = _PS_IMG_DIR_ . $params['image'] . '/' . Image::getImgFolderStatic($tr['id_image']) . (int) $tr['id_image'] . '.' . $this->imageType;
                     }
-                    $this->_list[$index][$key] = ImageManager::thumbnail($path_to_image, $this->table . '_mini_' . $item_id . '_' . $this->context->shop->id . '.' . $this->imageType, 45, $this->imageType);
+                    $this->_list[$index][$key] = ImageManager::thumbnail($path_to_image, $this->table . '_mini_' . $item_id . '_' . $this->context->shop->id . '.' . $this->imageType, self::LIST_THUMBNAIL_SIZE, $this->imageType);
                 } elseif (isset($params['icon'], $tr[$key]) && (isset($params['icon'][$tr[$key]]) || isset($params['icon']['default']))) {
                     if (!$this->bootstrap) {
                         if (isset($params['icon'][$tr[$key]]) && is_array($params['icon'][$tr[$key]])) {

--- a/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
@@ -109,7 +109,6 @@ abstract class AbstractDeleteSupplierHandler
             }
 
             if (false === $this->deleteProductSupplierRelation($supplierId)) {
-
                 throw new CannotDeleteSupplierProductRelationException(
                     sprintf(
                         'Unable to delete suppliers with id "%s" product relation from product_supplier table',
@@ -119,7 +118,6 @@ abstract class AbstractDeleteSupplierHandler
             }
 
             if (false === $this->deleteSupplierAddress($supplierId)) {
-
                 throw new CannotDeleteSupplierAddressException(
                     sprintf(
                         'Unable to set deleted flag for supplier with id "%s" address',
@@ -129,7 +127,6 @@ abstract class AbstractDeleteSupplierHandler
             }
 
             if (false === $entity->delete()) {
-
                 throw new CannotDeleteSupplierException(
                     $supplierId,
                     sprintf(

--- a/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
 
+use Address;
 use Db;
 use PrestaShop\PrestaShop\Adapter\Supplier\SupplierAddressProvider;
 use PrestaShop\PrestaShop\Adapter\Supplier\SupplierOrderValidator;
@@ -124,5 +125,17 @@ abstract class AbstractDeleteSupplierHandler
         }
 
         return true;
+    }
+
+    /**
+     * Checks if the given supplier has pending orders.
+     *
+     * @param SupplierId $supplierId
+     *
+     * @return bool
+     */
+    protected function hasPendingOrders(SupplierId $supplierId)
+    {
+        return $this->supplierOrderValidator->hasPendingOrders($supplierId->getValue());
     }
 }

--- a/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
@@ -108,10 +108,7 @@ abstract class AbstractDeleteSupplierHandler
                 );
             }
 
-            $this->startTransaction();
-
             if (false === $this->deleteProductSupplierRelation($supplierId)) {
-                $this->rollbackTransaction();
 
                 throw new CannotDeleteSupplierProductRelationException(
                     sprintf(
@@ -122,7 +119,6 @@ abstract class AbstractDeleteSupplierHandler
             }
 
             if (false === $this->deleteSupplierAddress($supplierId)) {
-                $this->rollbackTransaction();
 
                 throw new CannotDeleteSupplierAddressException(
                     sprintf(
@@ -133,7 +129,6 @@ abstract class AbstractDeleteSupplierHandler
             }
 
             if (false === $entity->delete()) {
-                $this->rollbackTransaction();
 
                 throw new CannotDeleteSupplierException(
                     $supplierId,
@@ -143,8 +138,6 @@ abstract class AbstractDeleteSupplierHandler
                     )
                 );
             }
-
-            $this->commitTransaction();
         } catch (PrestaShopException $exception) {
             throw new SupplierException(
                 sprintf(
@@ -155,30 +148,6 @@ abstract class AbstractDeleteSupplierHandler
                 $exception
             );
         }
-    }
-
-    /**
-     * Starts mysql transaction.
-     */
-    private function startTransaction()
-    {
-        Db::getInstance()->execute('START TRANSACTION;');
-    }
-
-    /**
-     * Cancels mysql transaction which prevents from adding, updating, deleting unwanted data.
-     */
-    private function rollbackTransaction()
-    {
-        Db::getInstance()->execute('ROLLBACK;');
-    }
-
-    /**
-     * Commits mysql transaction.
-     */
-    private function commitTransaction()
-    {
-        Db::getInstance()->execute('COMMIT;');
     }
 
     /**

--- a/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
+
+use Db;
+use PrestaShop\PrestaShop\Adapter\Supplier\SupplierAddressProvider;
+use PrestaShop\PrestaShop\Adapter\Supplier\SupplierOrderValidator;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
+
+/**
+ * Class AbstractDeleteSupplierHandler defines common actions required for
+ * both BulkDeleteSupplierHandler and DeleteSupplierHandler.
+ */
+abstract class AbstractDeleteSupplierHandler
+{
+    /**
+     * @var SupplierOrderValidator
+     */
+    private $supplierOrderValidator;
+
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    /**
+     * @var SupplierAddressProvider
+     */
+    private $supplierAddressProvider;
+
+    /**
+     * @param SupplierOrderValidator $supplierOrderValidator
+     * @param SupplierAddressProvider $supplierAddressProvider
+     * @param string $dbPrefix
+     */
+    public function __construct(
+        SupplierOrderValidator $supplierOrderValidator,
+        SupplierAddressProvider $supplierAddressProvider,
+        $dbPrefix
+    ) {
+        $this->supplierOrderValidator = $supplierOrderValidator;
+        $this->dbPrefix = $dbPrefix;
+        $this->supplierAddressProvider = $supplierAddressProvider;
+    }
+
+    /**
+     * Starts mysql transaction.
+     */
+    protected function startTransaction()
+    {
+        Db::getInstance()->execute('START TRANSACTION;');
+    }
+
+    /**
+     * Cancels mysql transaction which prevents from adding, updating, deleting unwanted data.
+     */
+    protected function rollbackTransaction()
+    {
+        Db::getInstance()->execute('ROLLBACK;');
+    }
+
+    /**
+     * Commits the transaction.
+     */
+    protected function commitTransaction()
+    {
+        Db::getInstance()->execute('COMMIT;');
+    }
+
+    /**
+     * Deletes product supplier relation.
+     *
+     * @param SupplierId $supplierId
+     *
+     * @return bool
+     */
+    protected function deleteProductSupplierRelation(SupplierId $supplierId)
+    {
+        $sql = 'DELETE FROM `' . $this->dbPrefix . 'product_supplier` WHERE `id_supplier`=' . $supplierId->getValue();
+
+        return Db::getInstance()->execute($sql);
+    }
+
+    /**
+     * Deletes supplier address.
+     *
+     * @param SupplierId $supplierId
+     *
+     * @return bool
+     */
+    protected function deleteSupplierAddress(SupplierId $supplierId)
+    {
+        $supplierAddressId = $this->supplierAddressProvider->getIdBySupplier($supplierId->getValue());
+
+        $address = new Address($supplierAddressId);
+
+        if ($address->id) {
+            $address->deleted = true;
+            return $address->update();
+        }
+
+        return true;
+    }
+}

--- a/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
@@ -210,6 +210,7 @@ abstract class AbstractDeleteSupplierHandler
 
         if ($address->id) {
             $address->deleted = true;
+
             return $address->update();
         }
 

--- a/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
@@ -85,7 +85,7 @@ abstract class AbstractDeleteSupplierHandler
     }
 
     /**
-     * Commits the transaction.
+     * Commits mysql transaction.
      */
     protected function commitTransaction()
     {

--- a/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
@@ -99,7 +99,7 @@ abstract class AbstractDeleteSupplierHandler
 
             if ($this->hasPendingOrders($supplierId)) {
                 throw new CannotDeleteSupplierException(
-                    $supplierId,
+                    $supplierId->getValue(),
                     sprintf(
                         'Supplier with id %s cannot be deleted due to it has pending orders',
                         $supplierId->getValue()
@@ -128,7 +128,7 @@ abstract class AbstractDeleteSupplierHandler
 
             if (false === $entity->delete()) {
                 throw new CannotDeleteSupplierException(
-                    $supplierId,
+                    $supplierId->getValue(),
                     sprintf(
                         'Unable to delete supplier object with id "%s"',
                         $supplierId->getValue()

--- a/src/Adapter/Supplier/CommandHandler/BulkDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/BulkDeleteSupplierHandler.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDeleteSupplierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\BulkDeleteSupplierHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
+use PrestaShopException;
+use Supplier;
+
+/**
+ * Class BulkDeleteSupplierHandler is responsible for deleting multiple suppliers.
+ */
+class BulkDeleteSupplierHandler implements BulkDeleteSupplierHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws SupplierException
+     */
+    public function handle(BulkDeleteSupplierCommand $command)
+    {
+        try {
+            foreach ($command->getSupplierIds() as $supplierId) {
+                $entity = new Supplier($supplierId->getValue());
+
+                if (0 >= $entity->id) {
+                    throw new SupplierNotFoundException(
+                        sprintf(
+                            'Supplier object with id "%s" has not been found for deletion.',
+                            $supplierId->getValue()
+                        )
+                    );
+                }
+
+                if (false === $entity->delete()) {
+                    throw new CannotDeleteSupplierException(
+                        $supplierId,
+                        sprintf(
+                            'Unable to delete supplier object with id "%s"',
+                            $supplierId->getValue()
+                        )
+                    );
+                }
+            }
+        } catch (PrestaShopException $exception) {
+            throw new SupplierException(
+                'Unexpected error occurred when handling bulk delete supplier',
+                0,
+                $exception
+            );
+        }
+    }
+}

--- a/src/Adapter/Supplier/CommandHandler/BulkDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/BulkDeleteSupplierHandler.php
@@ -37,7 +37,7 @@ use Supplier;
 /**
  * Class BulkDeleteSupplierHandler is responsible for deleting multiple suppliers.
  */
-class BulkDeleteSupplierHandler implements BulkDeleteSupplierHandlerInterface
+final class BulkDeleteSupplierHandler implements BulkDeleteSupplierHandlerInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Adapter/Supplier/CommandHandler/BulkDisableSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/BulkDisableSupplierHandler.php
@@ -28,14 +28,14 @@ namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\BulkDisableSupplierHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDisableSupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotUpdateSupplierStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
 use PrestaShopException;
 use Supplier;
 
 /**
- * Class BulkDisableSupplierHandler
+ * Class BulkDisableSupplierHandler is responsible for disabling multiple suppliers.
  */
 final class BulkDisableSupplierHandler implements BulkDisableSupplierHandlerInterface
 {
@@ -62,7 +62,7 @@ final class BulkDisableSupplierHandler implements BulkDisableSupplierHandlerInte
                 $entity->active = false;
 
                 if (false === $entity->update()) {
-                    throw new CannotDisableSupplierException(
+                    throw new CannotUpdateSupplierStatusException(
                         sprintf(
                             'Unable to disable cms category object with id "%s"',
                             $supplierId->getValue()

--- a/src/Adapter/Supplier/CommandHandler/BulkDisableSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/BulkDisableSupplierHandler.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\BulkDisableSupplierHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDisableSupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
+use PrestaShopException;
+use Supplier;
+
+/**
+ * Class BulkDisableSupplierHandler
+ */
+final class BulkDisableSupplierHandler implements BulkDisableSupplierHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws SupplierException
+     */
+    public function handle(BulkDisableSupplierCommand $command)
+    {
+        try {
+            foreach ($command->getSupplierIds() as $supplierId) {
+                $entity = new Supplier($supplierId->getValue());
+
+                if (0 >= $entity->id) {
+                    throw new SupplierNotFoundException(
+                        sprintf(
+                            'Supplier object with id "%s" has not been found for disabling status.',
+                            $supplierId->getValue()
+                        )
+                    );
+                }
+
+                $entity->active = false;
+
+                if (false === $entity->update()) {
+                    throw new CannotDisableSupplierException(
+                        sprintf(
+                            'Unable to disable cms category object with id "%s"',
+                            $supplierId->getValue()
+                        )
+                    );
+                }
+            }
+        } catch (PrestaShopException $e) {
+            throw new SupplierException(
+                'Unexpected error occurred when handling bulk disable supplier',
+                0,
+                $e
+            );
+        }
+    }
+}

--- a/src/Adapter/Supplier/CommandHandler/BulkEnableSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/BulkEnableSupplierHandler.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
 
-use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand;
-use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\BulkDisableSupplierHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkEnableSupplierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\BulkEnableSupplierHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotUpdateSupplierStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
@@ -35,16 +35,16 @@ use PrestaShopException;
 use Supplier;
 
 /**
- * Class BulkDisableSupplierHandler is responsible for disabling multiple suppliers.
+ * Class BulkEnableSupplierHandler is responsible for enabling multiple suppliers.
  */
-final class BulkDisableSupplierHandler implements BulkDisableSupplierHandlerInterface
+final class BulkEnableSupplierHandler implements BulkEnableSupplierHandlerInterface
 {
     /**
      * {@inheritdoc}
      *
      * @throws SupplierException
      */
-    public function handle(BulkDisableSupplierCommand $command)
+    public function handle(BulkEnableSupplierCommand $command)
     {
         try {
             foreach ($command->getSupplierIds() as $supplierId) {
@@ -53,18 +53,18 @@ final class BulkDisableSupplierHandler implements BulkDisableSupplierHandlerInte
                 if (0 >= $entity->id) {
                     throw new SupplierNotFoundException(
                         sprintf(
-                            'Supplier object with id "%s" has not been found for disabling status.',
+                            'Supplier object with id "%s" has not been found for enabling status.',
                             $supplierId->getValue()
                         )
                     );
                 }
 
-                $entity->active = false;
+                $entity->active = true;
 
                 if (false === $entity->update()) {
                     throw new CannotUpdateSupplierStatusException(
                         sprintf(
-                            'Unable to disable supplier object with id "%s"',
+                            'Unable to enable supplier object with id "%s"',
                             $supplierId->getValue()
                         )
                     );
@@ -72,7 +72,7 @@ final class BulkDisableSupplierHandler implements BulkDisableSupplierHandlerInte
             }
         } catch (PrestaShopException $e) {
             throw new SupplierException(
-                'Unexpected error occurred when handling bulk disable supplier',
+                'Unexpected error occurred when handling bulk enable supplier',
                 0,
                 $e
             );

--- a/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Entity\Db;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\DeleteSupplierHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierAddressException;

--- a/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
@@ -27,8 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Entity\Db;
-use PrestaShop\PrestaShop\Adapter\Supplier\SupplierAddressProvider;
-use PrestaShop\PrestaShop\Adapter\Supplier\SupplierOrderValidator;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\DeleteSupplierHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierAddressException;
@@ -63,7 +61,7 @@ final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implemen
                 );
             }
 
-            if ($this->supplierOrderValidator->hasPendingOrders($command->getSupplierId()->getValue())) {
+            if ($this->hasPendingOrders($command->getSupplierId())) {
                 throw new CannotDeleteSupplierException(
                     $command->getSupplierId(),
                     sprintf(

--- a/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\DeleteSupplierHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
+use PrestaShopException;
+use Supplier;
+
+/**
+ * Class DeleteSupplierHandler is responsible for deleting the supplier.
+ */
+final class DeleteSupplierHandler implements DeleteSupplierHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws SupplierException
+     */
+    public function handle(DeleteSupplierCommand $command)
+    {
+        try {
+            $entity = new Supplier($command->getSupplierId()->getValue());
+
+            if (0 >= $entity->id) {
+                throw new SupplierNotFoundException(
+                    sprintf(
+                        'Supplier object with id "%s" has not been found for deletion.',
+                        $command->getSupplierId()->getValue()
+                    )
+                );
+            }
+
+            if (false === $entity->delete()) {
+                throw new CannotDeleteSupplierException(
+                    $command->getSupplierId(),
+                    sprintf(
+                        'Unable to delete supplier object with id "%s"',
+                        $command->getSupplierId()->getValue()
+                    )
+                );
+            }
+        } catch (PrestaShopException $exception) {
+            throw new SupplierException(
+                sprintf(
+                    'An error occurred when deleting the supplier object with id "%s"',
+                    $command->getSupplierId()->getValue()
+                ),
+                0,
+                $exception
+            );
+        }
+    }
+}

--- a/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
@@ -28,13 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\DeleteSupplierHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierAddressException;
-use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierException;
-use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierProductRelationException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
-use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
-use PrestaShopException;
-use Supplier;
 
 /**
  * Class DeleteSupplierHandler is responsible for deleting the supplier.
@@ -48,75 +42,6 @@ final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implemen
      */
     public function handle(DeleteSupplierCommand $command)
     {
-        try {
-            $entity = new Supplier($command->getSupplierId()->getValue());
-
-            if (0 >= $entity->id) {
-                throw new SupplierNotFoundException(
-                    sprintf(
-                        'Supplier object with id "%s" has not been found for deletion.',
-                        $command->getSupplierId()->getValue()
-                    )
-                );
-            }
-
-            if ($this->hasPendingOrders($command->getSupplierId())) {
-                throw new CannotDeleteSupplierException(
-                    $command->getSupplierId(),
-                    sprintf(
-                        'Supplier with id %s cannot be deleted due to it has pending orders',
-                        $command->getSupplierId()->getValue()
-                    ),
-                    CannotDeleteSupplierException::HAS_PENDING_ORDERS
-                );
-            }
-
-            $this->startTransaction();
-
-            if (false === $this->deleteProductSupplierRelation($command->getSupplierId())) {
-                $this->rollbackTransaction();
-
-                throw new CannotDeleteSupplierProductRelationException(
-                    sprintf(
-                        'Unable to delete suppliers with id "%s" product relation from product_supplier table',
-                        $command->getSupplierId()->getValue()
-                    )
-                );
-            }
-
-            if (false === $this->deleteSupplierAddress($command->getSupplierId())) {
-                $this->rollbackTransaction();
-
-                throw new CannotDeleteSupplierAddressException(
-                    sprintf(
-                        'Unable to set deleted flag for supplier with id "%s" address',
-                        $command->getSupplierId()->getValue()
-                    )
-                );
-            }
-
-            if (false === $entity->delete()) {
-                $this->rollbackTransaction();
-
-                throw new CannotDeleteSupplierException(
-                    $command->getSupplierId(),
-                    sprintf(
-                        'Unable to delete supplier object with id "%s"',
-                        $command->getSupplierId()->getValue()
-                    )
-                );
-            }
-
-            $this->commitTransaction();
-        } catch (PrestaShopException $exception) {
-            throw new SupplierException(
-                sprintf(
-                    'An error occurred when deleting the supplier object with id "%s"',
-                    $command->getSupplierId()->getValue()
-                ),
-                0,
-                $exception
-            );
-        }
+        $this->removeSupplier($command->getSupplierId());
     }
 }

--- a/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
@@ -76,6 +76,7 @@ final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implemen
 
             if (false === $this->deleteProductSupplierRelation($command->getSupplierId())) {
                 $this->rollbackTransaction();
+
                 throw new CannotDeleteSupplierProductRelationException(
                     sprintf(
                         'Unable to delete suppliers with id "%s" product relation from product_supplier table',
@@ -86,6 +87,7 @@ final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implemen
 
             if (false === $this->deleteSupplierAddress($command->getSupplierId())) {
                 $this->rollbackTransaction();
+
                 throw new CannotDeleteSupplierAddressException(
                     sprintf(
                         'Unable to set deleted flag for supplier with id "%s" address',
@@ -96,6 +98,7 @@ final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implemen
 
             if (false === $entity->delete()) {
                 $this->rollbackTransaction();
+
                 throw new CannotDeleteSupplierException(
                     $command->getSupplierId(),
                     sprintf(

--- a/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
@@ -26,11 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
 
-use Address;
 use PrestaShop\PrestaShop\Adapter\Entity\Db;
 use PrestaShop\PrestaShop\Adapter\Supplier\SupplierAddressProvider;
 use PrestaShop\PrestaShop\Adapter\Supplier\SupplierOrderValidator;
-use PrestaShop\PrestaShop\Adapter\Validate;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\DeleteSupplierHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierAddressException;
@@ -38,45 +36,14 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierExc
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierProductRelationException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
-use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 use PrestaShopException;
 use Supplier;
 
 /**
  * Class DeleteSupplierHandler is responsible for deleting the supplier.
  */
-final class DeleteSupplierHandler implements DeleteSupplierHandlerInterface
+final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implements DeleteSupplierHandlerInterface
 {
-    /**
-     * @var SupplierOrderValidator
-     */
-    private $supplierOrderValidator;
-
-    /**
-     * @var string
-     */
-    private $dbPrefix;
-
-    /**
-     * @var SupplierAddressProvider
-     */
-    private $supplierAddressProvider;
-
-    /**
-     * @param SupplierOrderValidator $supplierOrderValidator
-     * @param SupplierAddressProvider $supplierAddressProvider
-     * @param string $dbPrefix
-     */
-    public function __construct(
-        SupplierOrderValidator $supplierOrderValidator,
-        SupplierAddressProvider $supplierAddressProvider,
-        $dbPrefix
-    ) {
-        $this->supplierOrderValidator = $supplierOrderValidator;
-        $this->dbPrefix = $dbPrefix;
-        $this->supplierAddressProvider = $supplierAddressProvider;
-    }
-
     /**
      * {@inheritdoc}
      *
@@ -151,40 +118,5 @@ final class DeleteSupplierHandler implements DeleteSupplierHandlerInterface
                 $exception
             );
         }
-    }
-
-    /**
-     * Deletes product supplier relation.
-     *
-     * @param SupplierId $supplierId
-     *
-     * @return bool
-     */
-    private function deleteProductSupplierRelation(SupplierId $supplierId)
-    {
-        $sql = 'DELETE FROM `' . $this->dbPrefix . 'product_supplier` WHERE `id_supplier`=' . $supplierId->getValue();
-
-        return Db::getInstance()->execute($sql);
-    }
-
-    /**
-     * Deletes supplier address.
-     *
-     * @param SupplierId $supplierId
-     *
-     * @return bool
-     */
-    private function deleteSupplierAddress(SupplierId $supplierId)
-    {
-        $supplierAddressId = $this->supplierAddressProvider->getIdBySupplier($supplierId->getValue());
-
-        $address = new Address($supplierAddressId);
-
-        if ($address->id) {
-            $address->deleted = true;
-            return $address->update();
-        }
-
-        return true;
     }
 }

--- a/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/DeleteSupplierHandler.php
@@ -72,10 +72,10 @@ final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implemen
                 );
             }
 
-            Db::getInstance()->execute('START TRANSACTION;');
+            $this->startTransaction();
 
             if (false === $this->deleteProductSupplierRelation($command->getSupplierId())) {
-                Db::getInstance()->execute('ROLLBACK;');
+                $this->rollbackTransaction();
                 throw new CannotDeleteSupplierProductRelationException(
                     sprintf(
                         'Unable to delete suppliers with id "%s" product relation from product_supplier table',
@@ -85,7 +85,7 @@ final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implemen
             }
 
             if (false === $this->deleteSupplierAddress($command->getSupplierId())) {
-                Db::getInstance()->execute('ROLLBACK;');
+                $this->rollbackTransaction();
                 throw new CannotDeleteSupplierAddressException(
                     sprintf(
                         'Unable to set deleted flag for supplier with id "%s" address',
@@ -95,7 +95,7 @@ final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implemen
             }
 
             if (false === $entity->delete()) {
-                Db::getInstance()->execute('ROLLBACK;');
+                $this->rollbackTransaction();
                 throw new CannotDeleteSupplierException(
                     $command->getSupplierId(),
                     sprintf(
@@ -105,7 +105,7 @@ final class DeleteSupplierHandler extends AbstractDeleteSupplierHandler implemen
                 );
             }
 
-            Db::getInstance()->execute('COMMIT;');
+            $this->commitTransaction();
         } catch (PrestaShopException $exception) {
             throw new SupplierException(
                 sprintf(

--- a/src/Adapter/Supplier/CommandHandler/ToggleSupplierStatusHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/ToggleSupplierStatusHandler.php
@@ -66,7 +66,6 @@ final class ToggleSupplierStatusHandler implements ToggleSupplierStatusHandlerIn
                     )
                 );
             }
-
         } catch (PrestaShopException $exception) {
             throw new SupplierException(
                 sprintf(

--- a/src/Adapter/Supplier/CommandHandler/ToggleSupplierStatusHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/ToggleSupplierStatusHandler.php
@@ -47,7 +47,7 @@ final class ToggleSupplierStatusHandler implements ToggleSupplierStatusHandlerIn
     public function handle(ToggleSupplierStatusCommand $command)
     {
         try {
-            $entity = new Supplier($command->getSupplierId());
+            $entity = new Supplier($command->getSupplierId()->getValue());
 
             if (0 >= $entity->id) {
                 throw new SupplierNotFoundException(

--- a/src/Adapter/Supplier/CommandHandler/ToggleSupplierStatusHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/ToggleSupplierStatusHandler.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\ToggleSupplierStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\ToggleSupplierStatusHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotToggleSupplierStatusException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
+use PrestaShopException;
+use Supplier;
+
+/**
+ * Class ToggleSupplierStatusHandler is responsible for toggling supplier status.
+ */
+final class ToggleSupplierStatusHandler implements ToggleSupplierStatusHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws SupplierException
+     */
+    public function handle(ToggleSupplierStatusCommand $command)
+    {
+        try {
+            $entity = new Supplier($command->getSupplierId());
+
+            if (0 >= $entity->id) {
+                throw new SupplierNotFoundException(
+                    sprintf(
+                        'Supplier object with id "%s" has not been found for status changing.',
+                        $command->getSupplierId()->getValue()
+                    )
+                );
+            }
+
+            if (false === $entity->toggleStatus()) {
+                throw new CannotToggleSupplierStatusException(
+                    sprintf(
+                        'Unable to toggle supplier with id "%s"',
+                        $command->getSupplierId()->getValue()
+                    )
+                );
+            }
+
+        } catch (PrestaShopException $exception) {
+            throw new SupplierException(
+                sprintf(
+                    'An error occurred when toggling status for supplier object with id "%s"',
+                    $command->getSupplierId()->getValue()
+                ),
+                0,
+                $exception
+            );
+        }
+    }
+}

--- a/src/Adapter/Supplier/SupplierAddressProvider.php
+++ b/src/Adapter/Supplier/SupplierAddressProvider.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Supplier;
+
+use Address;
+
+/**
+ * Class SupplierAddressProvider is responsible for supplier address data retrieval.
+ */
+class SupplierAddressProvider
+{
+    /**
+     * Gets address id by supplier
+     *
+     * @param int $supplierId
+     *
+     * @return int
+     */
+    public function getIdBySupplier($supplierId)
+    {
+        return Address::getAddressIdBySupplierId($supplierId);
+    }
+}

--- a/src/Adapter/Supplier/SupplierLogoThumbnailProvider.php
+++ b/src/Adapter/Supplier/SupplierLogoThumbnailProvider.php
@@ -48,7 +48,7 @@ final class SupplierLogoThumbnailProvider implements ImageProviderInterface
 
     /**
      * @param ImageTagSourceParserInterface $imageTagSourceParser
-     * @param $contextShopId
+     * @param int $contextShopId
      */
     public function __construct(
         ImageTagSourceParserInterface $imageTagSourceParser,

--- a/src/Adapter/Supplier/SupplierLogoThumbnailProvider.php
+++ b/src/Adapter/Supplier/SupplierLogoThumbnailProvider.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Adapter\Language;
+namespace PrestaShop\PrestaShop\Adapter\Supplier;
 
 use HelperList;
 use ImageManager;
@@ -32,9 +32,9 @@ use PrestaShop\PrestaShop\Core\Image\ImageProviderInterface;
 use PrestaShop\PrestaShop\Core\Image\Parser\ImageTagSourceParserInterface;
 
 /**
- * Class LanguageThumbnailProvider provides path to language's flag thumbnail.
+ * Class SupplierLogoThumbnailProvider is responsible for providing thumbnail path for supplier logo image.
  */
-final class LanguageFlagThumbnailProvider implements ImageProviderInterface
+final class SupplierLogoThumbnailProvider implements ImageProviderInterface
 {
     /**
      * @var ImageTagSourceParserInterface
@@ -61,15 +61,14 @@ final class LanguageFlagThumbnailProvider implements ImageProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getPath($languageId)
+    public function getPath($supplierId)
     {
-        $pathToImage = _PS_IMG_DIR_ . 'l' . DIRECTORY_SEPARATOR . $languageId . '.jpg';
+        $pathToImage = _PS_IMG_DIR_ . 'su' . DIRECTORY_SEPARATOR . $supplierId . '.jpg';
 
         $imageTag = ImageManager::thumbnail(
             $pathToImage,
-            'lang_mini_' . $languageId . '_' . $this->contextShopId . '.jpg',
-            HelperList::LIST_THUMBNAIL_SIZE,
-            'jpg'
+            'lang_mini_' . $supplierId . '_' . $this->contextShopId . '.jpg',
+            HelperList::LIST_THUMBNAIL_SIZE
         );
 
         return $this->imageTagSourceParser->parse($imageTag);

--- a/src/Adapter/Supplier/SupplierLogoThumbnailProvider.php
+++ b/src/Adapter/Supplier/SupplierLogoThumbnailProvider.php
@@ -67,7 +67,7 @@ final class SupplierLogoThumbnailProvider implements ImageProviderInterface
 
         $imageTag = ImageManager::thumbnail(
             $pathToImage,
-            'lang_mini_' . $supplierId . '_' . $this->contextShopId . '.jpg',
+            'supplier_mini_' . $supplierId . '_' . $this->contextShopId . '.jpg',
             HelperList::LIST_THUMBNAIL_SIZE
         );
 

--- a/src/Adapter/Supplier/SupplierOrderValidator.php
+++ b/src/Adapter/Supplier/SupplierOrderValidator.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Supplier;
+
+use SupplyOrder;
+
+/**
+ * Class SupplierOrderValidator is responsible for handling supplier and its corresponding order validity.
+ */
+class SupplierOrderValidator
+{
+    /**
+     * Checks if the given supplier has pending orders.
+     *
+     * @param int $supplierId
+     *
+     * @return bool
+     */
+    public function hasPendingOrders($supplierId)
+    {
+        return SupplyOrder::supplierHasPendingOrders($supplierId);
+    }
+}

--- a/src/Core/Domain/Supplier/Command/AbstractBulkSupplierCommand.php
+++ b/src/Core/Domain/Supplier/Command/AbstractBulkSupplierCommand.php
@@ -24,12 +24,21 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Command;
 
 /**
- * Class SupplierConstraintException
+ * Class AbstractBulkSupplierCommand is responsible for providing shared logic between all bulk actions
+ * in brands and suppliers listing.
  */
-class SupplierConstraintException extends SupplierException
+abstract class AbstractBulkSupplierCommand
 {
-    const INVALID_BULK_DATA = 1;
+    /**
+     * @param array $ids
+     *
+     * @return bool
+     */
+    protected function assertIsEmptyOrContainsNonIntegerValues(array $ids)
+    {
+        return empty($ids) || $ids !== array_filter($ids, 'is_int');
+    }
 }

--- a/src/Core/Domain/Supplier/Command/BulkDeleteSupplierCommand.php
+++ b/src/Core/Domain/Supplier/Command/BulkDeleteSupplierCommand.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
+
+/**
+ * Class BulkDeleteSupplierCommand is responsible for deleting multiple suppliers.
+ */
+class BulkDeleteSupplierCommand
+{
+    /**
+     * @var SupplierId[]
+     */
+    private $supplierIds;
+
+    /**
+     * @param int[] $supplierIds
+     *
+     * @throws SupplierException
+     * @throws SupplierConstraintException
+     */
+    public function __construct(array $supplierIds)
+    {
+        if (empty($supplierIds)) {
+            throw new SupplierConstraintException(
+                'Missing supplier data for bulk deleting',
+                SupplierConstraintException::MISSING_BULK_DATA
+            );
+        }
+
+        $this->setSupplierIds($supplierIds);
+    }
+
+    /**
+     * @return SupplierId[]
+     */
+    public function getSupplierIds()
+    {
+        return $this->supplierIds;
+    }
+
+    /**
+     * @param array $supplierIds
+     *
+     * @throws SupplierException
+     */
+    private function setSupplierIds(array $supplierIds)
+    {
+        foreach ($supplierIds as $id) {
+            $this->supplierIds[] = new SupplierId($id);
+        }
+    }
+}

--- a/src/Core/Domain/Supplier/Command/BulkDeleteSupplierCommand.php
+++ b/src/Core/Domain/Supplier/Command/BulkDeleteSupplierCommand.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 /**
  * Class BulkDeleteSupplierCommand is responsible for deleting multiple suppliers.
  */
-class BulkDeleteSupplierCommand
+class BulkDeleteSupplierCommand extends AbstractBulkSupplierCommand
 {
     /**
      * @var SupplierId[]
@@ -48,10 +48,13 @@ class BulkDeleteSupplierCommand
      */
     public function __construct(array $supplierIds)
     {
-        if (empty($supplierIds)) {
+        if ($this->assertIsEmptyOrContainsNonIntegerValues($supplierIds)) {
             throw new SupplierConstraintException(
-                'Missing supplier data for bulk deleting',
-                SupplierConstraintException::MISSING_BULK_DATA
+                sprintf(
+                    'Missing supplier data or array %s contains non integer values for bulk deleting',
+                    var_export($supplierIds, true)
+                ),
+                SupplierConstraintException::INVALID_BULK_DATA
             );
         }
 

--- a/src/Core/Domain/Supplier/Command/BulkDisableSupplierCommand.php
+++ b/src/Core/Domain/Supplier/Command/BulkDisableSupplierCommand.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
+
+/**
+ * Class BulkDisableSupplierCommand is responsible for disabling multiple suppliers.
+ */
+class BulkDisableSupplierCommand
+{
+    /**
+     * @var SupplierId[]
+     */
+    private $supplierIds;
+
+    /**
+     * @param int[] $supplierIds
+     *
+     * @throws SupplierException
+     * @throws SupplierConstraintException
+     */
+    public function __construct(array $supplierIds)
+    {
+        if (empty($supplierIds)) {
+            throw new SupplierConstraintException(
+                'Missing supplier data for bulk deleting',
+                SupplierConstraintException::MISSING_BULK_DATA
+            );
+        }
+
+        $this->setSupplierIds($supplierIds);
+    }
+
+    /**
+     * @return SupplierId[]
+     */
+    public function getSupplierIds()
+    {
+        return $this->supplierIds;
+    }
+
+    /**
+     * @param array $supplierIds
+     *
+     * @throws SupplierException
+     */
+    private function setSupplierIds(array $supplierIds)
+    {
+        foreach ($supplierIds as $id) {
+            $this->supplierIds[] = new SupplierId($id);
+        }
+    }
+}

--- a/src/Core/Domain/Supplier/Command/BulkDisableSupplierCommand.php
+++ b/src/Core/Domain/Supplier/Command/BulkDisableSupplierCommand.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 /**
  * Class BulkDisableSupplierCommand is responsible for disabling multiple suppliers.
  */
-class BulkDisableSupplierCommand
+class BulkDisableSupplierCommand extends AbstractBulkSupplierCommand
 {
     /**
      * @var SupplierId[]
@@ -48,10 +48,13 @@ class BulkDisableSupplierCommand
      */
     public function __construct(array $supplierIds)
     {
-        if (empty($supplierIds)) {
+        if ($this->assertIsEmptyOrContainsNonIntegerValues($supplierIds)) {
             throw new SupplierConstraintException(
-                'Missing supplier data for bulk deleting',
-                SupplierConstraintException::MISSING_BULK_DATA
+                sprintf(
+                    'Missing supplier data or array %s contains non integer values for bulk disable',
+                    var_export($supplierIds, true)
+                ),
+                SupplierConstraintException::INVALID_BULK_DATA
             );
         }
 

--- a/src/Core/Domain/Supplier/Command/BulkEnableSupplierCommand.php
+++ b/src/Core/Domain/Supplier/Command/BulkEnableSupplierCommand.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 /**
  * Class BulkEnableSupplierCommand is responsible for enabling multiple suppliers.
  */
-class BulkEnableSupplierCommand
+class BulkEnableSupplierCommand extends AbstractBulkSupplierCommand
 {
     /**
      * @var SupplierId[]
@@ -48,10 +48,13 @@ class BulkEnableSupplierCommand
      */
     public function __construct(array $supplierIds)
     {
-        if (empty($supplierIds)) {
+        if ($this->assertIsEmptyOrContainsNonIntegerValues($supplierIds)) {
             throw new SupplierConstraintException(
-                'Missing supplier data for bulk enabling',
-                SupplierConstraintException::MISSING_BULK_DATA
+                sprintf(
+                    'Missing supplier data or array %s contains non integer values for bulk enable',
+                    var_export($supplierIds, true)
+                ),
+                SupplierConstraintException::INVALID_BULK_DATA
             );
         }
 

--- a/src/Core/Domain/Supplier/Command/BulkEnableSupplierCommand.php
+++ b/src/Core/Domain/Supplier/Command/BulkEnableSupplierCommand.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
+
+/**
+ * Class BulkEnableSupplierCommand is responsible for enabling multiple suppliers.
+ */
+class BulkEnableSupplierCommand
+{
+    /**
+     * @var SupplierId[]
+     */
+    private $supplierIds;
+
+    /**
+     * @param int[] $supplierIds
+     *
+     * @throws SupplierException
+     * @throws SupplierConstraintException
+     */
+    public function __construct(array $supplierIds)
+    {
+        if (empty($supplierIds)) {
+            throw new SupplierConstraintException(
+                'Missing supplier data for bulk enabling',
+                SupplierConstraintException::MISSING_BULK_DATA
+            );
+        }
+
+        $this->setSupplierIds($supplierIds);
+    }
+
+    /**
+     * @return SupplierId[]
+     */
+    public function getSupplierIds()
+    {
+        return $this->supplierIds;
+    }
+
+    /**
+     * @param array $supplierIds
+     *
+     * @throws SupplierException
+     */
+    private function setSupplierIds(array $supplierIds)
+    {
+        foreach ($supplierIds as $id) {
+            $this->supplierIds[] = new SupplierId($id);
+        }
+    }
+}

--- a/src/Core/Domain/Supplier/Command/DeleteSupplierCommand.php
+++ b/src/Core/Domain/Supplier/Command/DeleteSupplierCommand.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Command;
 
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 
 /**
@@ -39,11 +40,13 @@ class DeleteSupplierCommand
     private $supplierId;
 
     /**
-     * @param SupplierId $supplierId
+     * @param int $supplierId
+     *
+     * @throws SupplierException
      */
-    public function __construct(SupplierId $supplierId)
+    public function __construct($supplierId)
     {
-        $this->supplierId = $supplierId;
+        $this->supplierId = new SupplierId($supplierId);
     }
 
     /**

--- a/src/Core/Domain/Supplier/Command/DeleteSupplierCommand.php
+++ b/src/Core/Domain/Supplier/Command/DeleteSupplierCommand.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
+
+/**
+ * Class DeleteSupplierCommand is responsible for deleting the supplier.
+ */
+class DeleteSupplierCommand
+{
+    /**
+     * @var SupplierId
+     */
+    private $supplierId;
+
+    /**
+     * @param SupplierId $supplierId
+     */
+    public function __construct(SupplierId $supplierId)
+    {
+        $this->supplierId = $supplierId;
+    }
+
+    /**
+     * @return SupplierId
+     */
+    public function getSupplierId()
+    {
+        return $this->supplierId;
+    }
+}

--- a/src/Core/Domain/Supplier/Command/ToggleSupplierStatusCommand.php
+++ b/src/Core/Domain/Supplier/Command/ToggleSupplierStatusCommand.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Command;
 
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 
 /**
@@ -39,11 +40,13 @@ class ToggleSupplierStatusCommand
     private $supplierId;
 
     /**
-     * @param SupplierId $supplierId
+     * @param int $supplierId
+     *
+     * @throws SupplierException
      */
-    public function __construct(SupplierId $supplierId)
+    public function __construct($supplierId)
     {
-        $this->supplierId = $supplierId;
+        $this->supplierId = new SupplierId($supplierId);
     }
 
     /**

--- a/src/Core/Domain/Supplier/Command/ToggleSupplierStatusCommand.php
+++ b/src/Core/Domain/Supplier/Command/ToggleSupplierStatusCommand.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
+
+/**
+ * Class ToggleSupplierStatusCommand is responsible for toggling supplier status.
+ */
+class ToggleSupplierStatusCommand
+{
+    /**
+     * @var SupplierId
+     */
+    private $supplierId;
+
+    /**
+     * @param SupplierId $supplierId
+     */
+    public function __construct(SupplierId $supplierId)
+    {
+        $this->supplierId = $supplierId;
+    }
+
+    /**
+     * @return SupplierId
+     */
+    public function getSupplierId()
+    {
+        return $this->supplierId;
+    }
+}

--- a/src/Core/Domain/Supplier/CommandHandler/BulkDeleteSupplierHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/BulkDeleteSupplierHandlerInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDeleteSupplierCommand;
+
+/**
+ * Interface BulkDeleteSupplierHandlerInterface defines contract for BulkDeleteSupplierHandler.
+ */
+interface BulkDeleteSupplierHandlerInterface
+{
+    /**
+     * @param BulkDeleteSupplierCommand $command
+     *
+     * @return void
+     */
+    public function handle(BulkDeleteSupplierCommand $command);
+}

--- a/src/Core/Domain/Supplier/CommandHandler/BulkDeleteSupplierHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/BulkDeleteSupplierHandlerInterface.php
@@ -35,8 +35,6 @@ interface BulkDeleteSupplierHandlerInterface
 {
     /**
      * @param BulkDeleteSupplierCommand $command
-     *
-     * @return void
      */
     public function handle(BulkDeleteSupplierCommand $command);
 }

--- a/src/Core/Domain/Supplier/CommandHandler/BulkDisableSupplierHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/BulkDisableSupplierHandlerInterface.php
@@ -35,8 +35,6 @@ interface BulkDisableSupplierHandlerInterface
 {
     /**
      * @param BulkDisableSupplierCommand $command
-     *
-     * @return void
      */
     public function handle(BulkDisableSupplierCommand $command);
 }

--- a/src/Core/Domain/Supplier/CommandHandler/BulkDisableSupplierHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/BulkDisableSupplierHandlerInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand;
+
+/**
+ * Interface BulkDisableSupplierHandlerInterface defines contract for BulkDisableSupplierHandler.
+ */
+interface BulkDisableSupplierHandlerInterface
+{
+    /**
+     * @param BulkDisableSupplierCommand $command
+     *
+     * @return void
+     */
+    public function handle(BulkDisableSupplierCommand $command);
+}

--- a/src/Core/Domain/Supplier/CommandHandler/BulkEnableSupplierHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/BulkEnableSupplierHandlerInterface.php
@@ -35,8 +35,6 @@ interface BulkEnableSupplierHandlerInterface
 {
     /**
      * @param BulkEnableSupplierCommand $command
-     *
-     * @return void
      */
     public function handle(BulkEnableSupplierCommand $command);
 }

--- a/src/Core/Domain/Supplier/CommandHandler/BulkEnableSupplierHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/BulkEnableSupplierHandlerInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkEnableSupplierCommand;
+
+/**
+ * Interface BulkEnableSupplierHandlerInterface defines contract for BulkEnableSupplierHandler.
+ */
+interface BulkEnableSupplierHandlerInterface
+{
+    /**
+     * @param BulkEnableSupplierCommand $command
+     *
+     * @return void
+     */
+    public function handle(BulkEnableSupplierCommand $command);
+}

--- a/src/Core/Domain/Supplier/CommandHandler/DeleteSupplierHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/DeleteSupplierHandlerInterface.php
@@ -35,8 +35,6 @@ interface DeleteSupplierHandlerInterface
 {
     /**
      * @param DeleteSupplierCommand $command
-     *
-     * @return void
      */
     public function handle(DeleteSupplierCommand $command);
 }

--- a/src/Core/Domain/Supplier/CommandHandler/DeleteSupplierHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/DeleteSupplierHandlerInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
+
+/**
+ * Interface DeleteSupplierHandlerInterface defines contract for DeleteSupplierHandler.
+ */
+interface DeleteSupplierHandlerInterface
+{
+    /**
+     * @param DeleteSupplierCommand $command
+     *
+     * @return void
+     */
+    public function handle(DeleteSupplierCommand $command);
+}

--- a/src/Core/Domain/Supplier/CommandHandler/ToggleSupplierStatusHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/ToggleSupplierStatusHandlerInterface.php
@@ -35,8 +35,6 @@ interface ToggleSupplierStatusHandlerInterface
 {
     /**
      * @param ToggleSupplierStatusCommand $command
-     *
-     * @return void
      */
     public function handle(ToggleSupplierStatusCommand $command);
 }

--- a/src/Core/Domain/Supplier/CommandHandler/ToggleSupplierStatusHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/ToggleSupplierStatusHandlerInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\ToggleSupplierStatusCommand;
+
+/**
+ * Interface ToggleSupplierStatusHandlerInterface defines contract for ToggleSupplierStatusHandler.
+ */
+interface ToggleSupplierStatusHandlerInterface
+{
+    /**
+     * @param ToggleSupplierStatusCommand $command
+     *
+     * @return void
+     */
+    public function handle(ToggleSupplierStatusCommand $command);
+}

--- a/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierAddressException.php
+++ b/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierAddressException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
+
+/**
+ * Class CannotDeleteSupplierAddressException
+ */
+class CannotDeleteSupplierAddressException extends SupplierException
+{
+}

--- a/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierException.php
+++ b/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierException.php
@@ -33,6 +33,8 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
  */
 class CannotDeleteSupplierException extends SupplierException
 {
+    const HAS_PENDING_ORDERS = 1;
+
     /**
      * @var SupplierId
      */

--- a/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierException.php
+++ b/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierException.php
@@ -48,7 +48,7 @@ class CannotDeleteSupplierException extends SupplierException
      */
     public function __construct(
         SupplierId $supplierId,
-        $message = "",
+        $message = '',
         $code = 0,
         $previous = null
     ) {

--- a/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierException.php
+++ b/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierException.php
@@ -36,18 +36,18 @@ class CannotDeleteSupplierException extends SupplierException
     const HAS_PENDING_ORDERS = 1;
 
     /**
-     * @var SupplierId
+     * @var int
      */
     private $supplierId;
 
     /**
-     * @param SupplierId $supplierId
+     * @param int $supplierId
      * @param string $message
      * @param int $code
      * @param $previous
      */
     public function __construct(
-        SupplierId $supplierId,
+        $supplierId,
         $message = '',
         $code = 0,
         $previous = null
@@ -57,7 +57,7 @@ class CannotDeleteSupplierException extends SupplierException
     }
 
     /**
-     * @return SupplierId
+     * @return int
      */
     public function getSupplierId()
     {

--- a/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierException.php
+++ b/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierException.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
+
+/**
+ * Class CannotDeleteSupplierException
+ */
+class CannotDeleteSupplierException extends SupplierException
+{
+    /**
+     * @var SupplierId
+     */
+    private $supplierId;
+
+    /**
+     * @param SupplierId $supplierId
+     * @param string $message
+     * @param int $code
+     * @param $previous
+     */
+    public function __construct(
+        SupplierId $supplierId,
+        $message = "",
+        $code = 0,
+        $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->supplierId = $supplierId;
+    }
+
+    /**
+     * @return SupplierId
+     */
+    public function getSupplierId()
+    {
+        return $this->supplierId;
+    }
+}

--- a/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierProductRelationException.php
+++ b/src/Core/Domain/Supplier/Exception/CannotDeleteSupplierProductRelationException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
+
+/**
+ * Class CannotDeleteSupplierProductRelationException
+ */
+class CannotDeleteSupplierProductRelationException extends SupplierException
+{
+}

--- a/src/Core/Domain/Supplier/Exception/CannotDisableSupplierException.php
+++ b/src/Core/Domain/Supplier/Exception/CannotDisableSupplierException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
+
+/**
+ * Class CannotDisableSupplierException
+ */
+class CannotDisableSupplierException extends SupplierException
+{
+}

--- a/src/Core/Domain/Supplier/Exception/CannotToggleSupplierStatusException.php
+++ b/src/Core/Domain/Supplier/Exception/CannotToggleSupplierStatusException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
+
+/**
+ * Class CannotToggleSupplierStatusException
+ */
+class CannotToggleSupplierStatusException extends SupplierException
+{
+}

--- a/src/Core/Domain/Supplier/Exception/CannotUpdateSupplierStatusException.php
+++ b/src/Core/Domain/Supplier/Exception/CannotUpdateSupplierStatusException.php
@@ -27,8 +27,8 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
 
 /**
- * Class CannotDisableSupplierException
+ * Class CannotUpdateSupplierStatusException
  */
-class CannotDisableSupplierException extends SupplierException
+class CannotUpdateSupplierStatusException extends SupplierException
 {
 }

--- a/src/Core/Domain/Supplier/Exception/SupplierConstraintException.php
+++ b/src/Core/Domain/Supplier/Exception/SupplierConstraintException.php
@@ -26,8 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
 
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
-
 /**
  * Class SupplierConstraintException
  */

--- a/src/Core/Domain/Supplier/Exception/SupplierConstraintException.php
+++ b/src/Core/Domain/Supplier/Exception/SupplierConstraintException.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
+
+use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+
+/**
+ * Class SupplierConstraintException
+ */
+class SupplierConstraintException extends DomainException
+{
+    const MISSING_BULK_DATA = 1;
+}

--- a/src/Core/Domain/Supplier/Exception/SupplierConstraintException.php
+++ b/src/Core/Domain/Supplier/Exception/SupplierConstraintException.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 /**
  * Class SupplierConstraintException
  */
-class SupplierConstraintException extends DomainException
+class SupplierConstraintException extends SupplierException
 {
     const MISSING_BULK_DATA = 1;
 }

--- a/src/Core/Domain/Supplier/Exception/SupplierException.php
+++ b/src/Core/Domain/Supplier/Exception/SupplierException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
+
+use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+
+/**
+ * Class SupplierException
+ */
+class SupplierException extends DomainException
+{
+}

--- a/src/Core/Domain/Supplier/Exception/SupplierNotFoundException.php
+++ b/src/Core/Domain/Supplier/Exception/SupplierNotFoundException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Exception;
+
+/**
+ * Class SupplierNotFoundException
+ */
+class SupplierNotFoundException extends SupplierException
+{
+}

--- a/src/Core/Domain/Supplier/ValueObject/SupplierId.php
+++ b/src/Core/Domain/Supplier/ValueObject/SupplierId.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
+
+/**
+ * Class SupplierId
+ */
+class SupplierId
+{
+    /**
+     * @var int
+     */
+    private $value;
+
+    /**
+     * @param int $supplierId
+     *
+     * @throws SupplierException
+     */
+    public function __construct($supplierId)
+    {
+        if (!is_numeric($supplierId) || $supplierId <= 0) {
+            throw new SupplierException(
+                sprintf('Invalid Supplier id: %s', var_export($supplierId, true))
+            );
+        }
+
+        $this->value = (int) $supplierId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Core/Domain/Supplier/ValueObject/SupplierId.php
+++ b/src/Core/Domain/Supplier/ValueObject/SupplierId.php
@@ -45,13 +45,8 @@ class SupplierId
      */
     public function __construct($supplierId)
     {
-        if (!is_numeric($supplierId) || $supplierId <= 0) {
-            throw new SupplierException(
-                sprintf('Invalid Supplier id: %s', var_export($supplierId, true))
-            );
-        }
-
-        $this->value = (int) $supplierId;
+        $this->assertIsNotIntegerOrLessThanZero($supplierId);
+        $this->value = $supplierId;
     }
 
     /**
@@ -60,5 +55,19 @@ class SupplierId
     public function getValue()
     {
         return $this->value;
+    }
+
+    /**
+     * @param int $supplierId
+     *
+     * @throws SupplierException
+     */
+    private function assertIsNotIntegerOrLessThanZero($supplierId)
+    {
+        if (!is_int($supplierId) || 0 >= $supplierId) {
+            throw new SupplierException(
+                sprintf('Invalid Supplier id: %s', var_export($supplierId, true))
+            );
+        }
     }
 }

--- a/src/Core/Grid/Data/Factory/SupplierGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/SupplierGridDataFactory.php
@@ -48,6 +48,7 @@ final class SupplierGridDataFactory implements GridDataFactoryInterface
 
     /**
      * @param GridDataFactoryInterface $supplierDataFactory
+     * @param ImageProviderInterface $supplierLogoImageProvider
      */
     public function __construct(
         GridDataFactoryInterface $supplierDataFactory,

--- a/src/Core/Grid/Data/Factory/SupplierGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/SupplierGridDataFactory.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Class SupplierGridDataFactory gets data for supplier grid.
+ */
+final class SupplierGridDataFactory implements GridDataFactoryInterface
+{
+    /**
+     * @var GridDataFactoryInterface
+     */
+    private $supplierDataFactory;
+
+    /**
+     * @param GridDataFactoryInterface $supplierDataFactory
+     */
+    public function __construct(GridDataFactoryInterface $supplierDataFactory)
+    {
+        $this->supplierDataFactory = $supplierDataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria)
+    {
+        $supplierData = $this->supplierDataFactory->getData($searchCriteria);
+
+        $modifiedRecords = $this->applyModification(
+            $supplierData->getRecords()->all()
+        );
+
+        return new GridData(
+            new RecordCollection($modifiedRecords),
+            $supplierData->getRecordsTotal(),
+            $supplierData->getQuery()
+        );
+    }
+
+    /**
+     * @param array $suppliers
+     *
+     * @return array
+     */
+    private function applyModification(array $suppliers)
+    {
+        foreach ($suppliers as $i => $supplier) {
+            $suppliers[$i]['logo'] = '';
+        }
+
+        return $suppliers;
+    }
+}

--- a/src/Core/Grid/Data/Factory/SupplierGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/SupplierGridDataFactory.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Image\ImageProviderInterface;
 
 /**
  * Class SupplierGridDataFactory gets data for supplier grid.
@@ -41,11 +42,19 @@ final class SupplierGridDataFactory implements GridDataFactoryInterface
     private $supplierDataFactory;
 
     /**
+     * @var ImageProviderInterface
+     */
+    private $supplierLogoImageProvider;
+
+    /**
      * @param GridDataFactoryInterface $supplierDataFactory
      */
-    public function __construct(GridDataFactoryInterface $supplierDataFactory)
-    {
+    public function __construct(
+        GridDataFactoryInterface $supplierDataFactory,
+        ImageProviderInterface $supplierLogoImageProvider
+    ) {
         $this->supplierDataFactory = $supplierDataFactory;
+        $this->supplierLogoImageProvider = $supplierLogoImageProvider;
     }
 
     /**
@@ -74,7 +83,7 @@ final class SupplierGridDataFactory implements GridDataFactoryInterface
     private function applyModification(array $suppliers)
     {
         foreach ($suppliers as $i => $supplier) {
-            $suppliers[$i]['logo'] = '';
+            $suppliers[$i]['logo'] = $this->supplierLogoImageProvider->getPath($supplier['id_supplier']);
         }
 
         return $suppliers;

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -35,12 +35,37 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
+use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
+use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * Class SupplierGridDefinitionFactory
  */
 final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    /**
+     * @var string
+     */
+    private $resetActionUrl;
+
+    /**
+     * @var string
+     */
+    private $redirectActionUrl;
+
+    /**
+     * @param string $resetActionUrl
+     * @param string $redirectActionUrl
+     */
+    public function __construct($resetActionUrl, $redirectActionUrl)
+    {
+        $this->resetActionUrl = $resetActionUrl;
+        $this->redirectActionUrl = $redirectActionUrl;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -83,10 +108,10 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'route_param_field' => 'id_supplier',
                 ])
             )
-            ->add((new DataColumn('product_count'))
+            ->add((new DataColumn('products_count'))
                 ->setName($this->trans('Number of products', [], 'Admin.Catalog.Feature'))
                 ->setOptions([
-                    'field' => 'product_count',
+                    'field' => 'products_count',
                 ])
             )
             ->add((new ToggleColumn('active'))
@@ -135,6 +160,45 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                                 ),
                             ])
                         ),
+                ])
+            )
+        ;
+    }
+
+    protected function getFilters()
+    {
+        return (new FilterCollection())
+            ->add((new Filter('id_supplier', TextType::class))
+                ->setAssociatedColumn('id_supplier')
+                ->setTypeOptions([
+                    'required' => false,
+                ])
+            )
+            ->add((new Filter('name', TextType::class))
+                ->setAssociatedColumn('name')
+                ->setTypeOptions([
+                    'required' => false,
+                ])
+            )
+            ->add((new Filter('products_count', TextType::class))
+                ->setAssociatedColumn('products_count')
+                ->setTypeOptions([
+                    'required' => false,
+                ])
+            )
+            ->add((new Filter('active', YesAndNoChoiceType::class))
+                ->setAssociatedColumn('active')
+                ->setTypeOptions([
+                    'required' => false,
+                ])
+            )
+            ->add((new Filter('actions', SearchAndResetType::class))
+                ->setAssociatedColumn('actions')
+                ->setTypeOptions([
+                    'attr' => [
+                        'data-url' => $this->resetActionUrl,
+                        'data-redirect' => $this->redirectActionUrl,
+                    ],
                 ])
             )
         ;

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -26,7 +26,11 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
@@ -88,6 +92,36 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'primary_field' => 'id_supplier',
                     'route' => 'admin_suppliers_toggle_status',
                     'route_param_name' => 'supplierId',
+                ])
+            )
+            ->add((new ActionColumn('actions'))
+                ->setName($this->trans('Actions', [], 'Admin.Global'))
+                ->setOptions([
+                    'actions' => (new RowActionCollection())
+                        ->add((new LinkRowAction('edit'))
+                            ->setName($this->trans('Edit', [], 'Admin.Actions'))
+                            ->setIcon('edit')
+                            ->setOptions([
+                                'route' => 'admin_suppliers_edit',
+                                'route_param_name' => 'supplierId',
+                                'route_param_field' => 'id_supplier',
+                            ])
+                        )
+                        ->add((new SubmitRowAction('delete'))
+                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
+                            ->setIcon('delete')
+                            ->setOptions([
+                                'method' => 'DELETE',
+                                'route' => 'admin_suppliers_delete',
+                                'route_param_name' => 'supplierId',
+                                'route_param_field' => 'id_supplier',
+                                'confirm_message' => $this->trans(
+                                    'Delete selected item?',
+                                    [],
+                                    'Admin.Notifications.Warning'
+                                ),
+                            ])
+                        ),
                 ])
             )
         ;

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
@@ -165,6 +167,9 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
         ;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getFilters()
     {
         return (new FilterCollection())
@@ -199,6 +204,22 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'data-url' => $this->resetActionUrl,
                         'data-redirect' => $this->redirectActionUrl,
                     ],
+                ])
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getBulkActions()
+    {
+        return (new BulkActionCollection())
+            ->add((new SubmitBulkAction('delete_supplier'))
+                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
+                ->setOptions([
+                    'submit_route' => 'admin_suppliers_bulk_delete',
+                    'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
                 ])
             )
         ;

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ImageColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
@@ -102,6 +103,12 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setName($this->trans('ID', [], 'Admin.Global'))
                 ->setOptions([
                     'field' => 'id_supplier',
+                ])
+            )
+            ->add((new ImageColumn('logo'))
+                ->setName($this->trans('Logo', [], 'Admin.Global'))
+                ->setOptions([
+                    'src_field' => 'logo',
                 ])
             )
             ->add((new LinkColumn('name'))

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+
+/**
+ * Class SupplierGridDefinitionFactory
+ */
+final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId()
+    {
+        return 'Supplier';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName()
+    {
+        return $this->trans('Suppliers', [], 'Admin.Navigation.Menu');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns()
+    {
+        return (new ColumnCollection())
+            ->add((new BulkActionColumn('bulk'))
+                ->setOptions([
+                    'bulk_field' => 'id_supplier',
+                ])
+            )
+            ->add((new DataColumn('id_contact'))
+                ->setName($this->trans('ID', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'id_supplier',
+                ])
+            )
+        ;
+    }
+}

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -48,7 +48,7 @@ use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
- * Class SupplierGridDefinitionFactory
+ * Class SupplierGridDefinitionFactory creates definition for supplier grid.
  */
 final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
 {

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -98,6 +98,15 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setName($this->trans('Actions', [], 'Admin.Global'))
                 ->setOptions([
                     'actions' => (new RowActionCollection())
+                        ->add((new LinkRowAction('view'))
+                            ->setName($this->trans('View', [], 'Admin.Actions'))
+                            ->setIcon('zoom_in')
+                            ->setOptions([
+                                'route' => 'admin_suppliers_view',
+                                'route_param_name' => 'supplierId',
+                                'route_param_field' => 'id_supplier',
+                            ])
+                        )
                         ->add((new LinkRowAction('edit'))
                             ->setName($this->trans('Edit', [], 'Admin.Actions'))
                             ->setIcon('edit')

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -75,6 +75,12 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'field' => 'name',
                 ])
             )
+            ->add((new DataColumn('product_count'))
+                ->setName($this->trans('Number of products', [], 'Admin.Catalog.Feature'))
+                ->setOptions([
+                    'field' => 'product_count',
+                ])
+            )
             ->add((new ToggleColumn('active'))
                 ->setName($this->trans('Enabled', [], 'Admin.Global'))
                 ->setOptions([

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 
 /**
@@ -62,10 +63,25 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'bulk_field' => 'id_supplier',
                 ])
             )
-            ->add((new DataColumn('id_contact'))
+            ->add((new DataColumn('id_supplier'))
                 ->setName($this->trans('ID', [], 'Admin.Global'))
                 ->setOptions([
                     'field' => 'id_supplier',
+                ])
+            )
+            ->add((new DataColumn('name'))
+                ->setName($this->trans('Name', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'name',
+                ])
+            )
+            ->add((new ToggleColumn('active'))
+                ->setName($this->trans('Enabled', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'active',
+                    'primary_field' => 'id_supplier',
+                    'route' => 'admin_suppliers_toggle_status',
+                    'route_param_name' => 'supplierId',
                 ])
             )
         ;

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -215,7 +215,19 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
     protected function getBulkActions()
     {
         return (new BulkActionCollection())
-            ->add((new SubmitBulkAction('delete_supplier'))
+            ->add((new SubmitBulkAction('suppliers_enable_selection'))
+                ->setName($this->trans('Enable selection', [], 'Admin.Actions'))
+                ->setOptions([
+                    'submit_route' => 'admin_suppliers_bulk_enable',
+                ])
+            )
+            ->add((new SubmitBulkAction('suppliers_disable_selection'))
+                ->setName($this->trans('Disable selection', [], 'Admin.Actions'))
+                ->setOptions([
+                    'submit_route' => 'admin_suppliers_bulk_disable',
+                ])
+            )
+            ->add((new SubmitBulkAction('suppliers_delete'))
                 ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
                 ->setOptions([
                     'submit_route' => 'admin_suppliers_bulk_delete',

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -53,26 +53,6 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     /**
-     * @var string
-     */
-    private $resetActionUrl;
-
-    /**
-     * @var string
-     */
-    private $redirectActionUrl;
-
-    /**
-     * @param string $resetActionUrl
-     * @param string $redirectActionUrl
-     */
-    public function __construct($resetActionUrl, $redirectActionUrl)
-    {
-        $this->resetActionUrl = $resetActionUrl;
-        $this->redirectActionUrl = $redirectActionUrl;
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function getId()

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -166,18 +166,27 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
             ->add((new Filter('id_supplier', TextType::class))
                 ->setAssociatedColumn('id_supplier')
                 ->setTypeOptions([
+                    'attr' => [
+                        'placeholder' => $this->trans('ID', [], 'Admin.Global'),
+                    ],
                     'required' => false,
                 ])
             )
             ->add((new Filter('name', TextType::class))
                 ->setAssociatedColumn('name')
                 ->setTypeOptions([
+                    'attr' => [
+                        'placeholder' => $this->trans('Name', [], 'Admin.Global'),
+                    ],
                     'required' => false,
                 ])
             )
             ->add((new Filter('products_count', TextType::class))
                 ->setAssociatedColumn('products_count')
                 ->setTypeOptions([
+                    'attr' => [
+                        'placeholder' => $this->trans('Number of products', [], 'Admin.Catalog.Feature'),
+                    ],
                     'required' => false,
                 ])
             )

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -210,10 +210,12 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
             ->add((new Filter('actions', SearchAndResetType::class))
                 ->setAssociatedColumn('actions')
                 ->setTypeOptions([
-                    'attr' => [
-                        'data-url' => $this->resetActionUrl,
-                        'data-redirect' => $this->redirectActionUrl,
+                    'reset_route' => 'admin_common_reset_search',
+                    'reset_route_params' => [
+                        'controller' => 'supplier',
+                        'action' => 'index',
                     ],
+                    'redirect_route' => 'admin_suppliers_index',
                 ])
             )
         ;

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -76,7 +76,7 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getId()
     {
-        return 'Suppliers';
+        return 'suppliers';
     }
 
     /**

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -28,9 +28,12 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Type\LinkGridAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
@@ -233,6 +236,44 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'submit_route' => 'admin_suppliers_bulk_delete',
                     'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
                 ])
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGridActions()
+    {
+        return (new GridActionCollection())
+            ->add((new LinkGridAction('import'))
+                ->setName($this->trans('Import', [], 'Admin.Actions'))
+                ->setIcon('cloud_upload')
+                ->setOptions([
+                    'route' => 'admin_import',
+                    'route_params' => [
+                        'import_type' => 'suppliers',
+                    ],
+                ])
+            )
+            ->add((new LinkGridAction('export'))
+                ->setName($this->trans('Export', [], 'Admin.Actions'))
+                ->setIcon('cloud_download')
+                ->setOptions([
+                    'route' => 'admin_suppliers_export',
+                ])
+            )
+            ->add((new SimpleGridAction('common_refresh_list'))
+                ->setName($this->trans('Refresh list', [], 'Admin.Advparameters.Feature'))
+                ->setIcon('refresh')
+            )
+            ->add((new SimpleGridAction('common_show_query'))
+                ->setName($this->trans('Show SQL query', [], 'Admin.Actions'))
+                ->setIcon('code')
+            )
+            ->add((new SimpleGridAction('common_export_sql_manager'))
+                ->setName($this->trans('Export to SQL Manager', [], 'Admin.Actions'))
+                ->setIcon('storage')
             )
         ;
     }

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 
@@ -73,10 +74,13 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'field' => 'id_supplier',
                 ])
             )
-            ->add((new DataColumn('name'))
+            ->add((new LinkColumn('name'))
                 ->setName($this->trans('Name', [], 'Admin.Global'))
                 ->setOptions([
                     'field' => 'name',
+                    'route' => 'admin_suppliers_edit',
+                    'route_param_name' => 'supplierId',
+                    'route_param_field' => 'id_supplier',
                 ])
             )
             ->add((new DataColumn('product_count'))

--- a/src/Core/Grid/Query/SupplierQueryBuilder.php
+++ b/src/Core/Grid/Query/SupplierQueryBuilder.php
@@ -46,20 +46,29 @@ final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
     private $contextShopIds;
 
     /**
+     * @var DoctrineSearchCriteriaApplicatorInterface
+     */
+    private $searchCriteriaApplicator;
+
+    /**
      * @param Connection $connection
      * @param string $dbPrefix
+     * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
      * @param int $contextLangId
      * @param array $contextShopIds
      */
     public function __construct(
         Connection $connection,
         $dbPrefix,
+        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
         $contextLangId,
         array $contextShopIds
     ) {
         parent::__construct($connection, $dbPrefix);
+
         $this->contextLangId = $contextLangId;
         $this->contextShopIds = $contextShopIds;
+        $this->searchCriteriaApplicator = $searchCriteriaApplicator;
     }
 
     /**
@@ -73,6 +82,11 @@ final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
             ->select('s.`id_supplier`, s.`name`, s.`active`')
             ->addSelect('COUNT(DISTINCT ps.`id_product`) AS `product_count`')
             ->groupBy('s.`id_supplier`')
+        ;
+
+        $this->searchCriteriaApplicator
+            ->applySorting($searchCriteria, $qb)
+            ->applyPagination($searchCriteria, $qb)
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/SupplierQueryBuilder.php
+++ b/src/Core/Grid/Query/SupplierQueryBuilder.php
@@ -71,6 +71,7 @@ final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $qb
             ->select('s.`id_supplier`, s.`name`, s.`active`')
+            ->addSelect('COUNT(DISTINCT ps.`id_product`) AS `product_count`')
             ->groupBy('s.`id_supplier`')
         ;
 
@@ -112,6 +113,12 @@ final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->dbPrefix . 'supplier_shop',
                 'ss',
                 'ss.`id_supplier` = s.`id_supplier`'
+            )
+            ->leftJoin(
+                's',
+                $this->dbPrefix . 'product_supplier',
+                'ps',
+                'ps.`id_supplier` = s.`id_supplier`'
             )
             ->andWhere('sl.`id_lang` = :contextLangId')
             ->andWhere('ss.`id_shop` IN (:contextShopIds)')

--- a/src/Core/Grid/Query/SupplierQueryBuilder.php
+++ b/src/Core/Grid/Query/SupplierQueryBuilder.php
@@ -24,50 +24,28 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
-use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
- * Class SupplierGridDefinitionFactory
+ * Class SupplierQueryBuilder
  */
-final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
+final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
 {
     /**
      * {@inheritdoc}
      */
-    protected function getId()
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        return 'Suppliers';
+        // TODO: Implement getSearchQueryBuilder() method.
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getName()
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        return $this->trans('Suppliers', [], 'Admin.Navigation.Menu');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getColumns()
-    {
-        return (new ColumnCollection())
-            ->add((new BulkActionColumn('bulk'))
-                ->setOptions([
-                    'bulk_field' => 'id_supplier',
-                ])
-            )
-            ->add((new DataColumn('id_contact'))
-                ->setName($this->trans('ID', [], 'Admin.Global'))
-                ->setOptions([
-                    'field' => 'id_supplier',
-                ])
-            )
-        ;
+        // TODO: Implement getCountQueryBuilder() method.
     }
 }

--- a/src/Core/Grid/Query/SupplierQueryBuilder.php
+++ b/src/Core/Grid/Query/SupplierQueryBuilder.php
@@ -233,7 +233,7 @@ final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
             }
 
             if (in_array($filterName, ['id_supplier', 'active'], true)) {
-                $qb->andWhere($alias . '.`' . $filterName .'` = :' . $filterName);
+                $qb->andWhere($alias . '.`' . $filterName . '` = :' . $filterName);
                 $qb->setParameter($filterName, $value);
 
                 continue;

--- a/src/Core/Grid/Query/SupplierQueryBuilder.php
+++ b/src/Core/Grid/Query/SupplierQueryBuilder.php
@@ -70,7 +70,7 @@ final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
 
         $qb
-            ->select('s.`id_supplier`')
+            ->select('s.`id_supplier`, s.`name`, s.`active`')
             ->groupBy('s.`id_supplier`')
         ;
 

--- a/src/Core/Grid/Query/SupplierQueryBuilder.php
+++ b/src/Core/Grid/Query/SupplierQueryBuilder.php
@@ -80,7 +80,7 @@ final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $qb
             ->select('s.`id_supplier`, s.`name`, s.`active`')
-            ->addSelect('COUNT(DISTINCT ps.`id_product`) AS `product_count`')
+            ->addSelect('COUNT(DISTINCT ps.`id_product`) AS `products_count`')
             ->groupBy('s.`id_supplier`')
         ;
 

--- a/src/Core/Search/Filters/SupplierFilters.php
+++ b/src/Core/Search/Filters/SupplierFilters.php
@@ -24,28 +24,26 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
 
-use PrestaShop\PrestaShop\Core\Search\Filters\SupplierFilters;
-use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use PrestaShop\PrestaShop\Core\Search\Filters;
 
 /**
- * Class SupplierController is responsible for "Sell > Catalog > Brands & Suppliers > Suppliers" page.
+ * Class SupplierFilters  defines default filters for Suppliers grid.
  */
-class SupplierController extends FrameworkBundleAdminController
+final class SupplierFilters extends Filters
 {
     /**
-     * Show suppliers listing.
-     *
-     * @Template("@PrestaShop/Admin/Sell/Catalog/Suppliers/index.html.twig")
-     *
-     * @param SupplierFilters $filters
-     *
-     * @return array
+     * {@inheritdoc}
      */
-    public function indexAction(SupplierFilters $filters)
+    public static function getDefaults()
     {
-        return [];
+        return [
+            'limit' => 50,
+            'offset' => 0,
+            'orderBy' => 'name',
+            'sortOrder' => 'asc',
+            'filters' => [],
+        ];
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -172,7 +172,7 @@ class SupplierController extends FrameworkBundleAdminController
         $suppliersToDelete = $request->request->get('suppliers_bulk');
 
         try {
-            $suppliersToDelete = array_map(function ($item){ return (int) $item; }, $suppliersToDelete);
+            $suppliersToDelete = array_map(function ($item) { return (int) $item; }, $suppliersToDelete);
             $this->getCommandBus()->handle(new BulkDeleteSupplierCommand($suppliersToDelete));
 
             $this->addFlash(
@@ -207,7 +207,7 @@ class SupplierController extends FrameworkBundleAdminController
         $suppliersToDisable = $request->request->get('suppliers_bulk');
 
         try {
-            $suppliersToDisable = array_map(function ($item){ return (int) $item; }, $suppliersToDisable);
+            $suppliersToDisable = array_map(function ($item) { return (int) $item; }, $suppliersToDisable);
             $this->getCommandBus()->handle(new BulkDisableSupplierCommand($suppliersToDisable));
             $this->addFlash(
                 'success',
@@ -241,7 +241,7 @@ class SupplierController extends FrameworkBundleAdminController
         $suppliersToEnable = $request->request->get('suppliers_bulk');
 
         try {
-            $suppliersToEnable = array_map(function ($item){ return (int) $item; }, $suppliersToEnable);
+            $suppliersToEnable = array_map(function ($item) { return (int) $item; }, $suppliersToEnable);
             $this->getCommandBus()->handle(new BulkEnableSupplierCommand($suppliersToEnable));
             $this->addFlash(
                 'success',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -113,7 +113,7 @@ class SupplierController extends FrameworkBundleAdminController
 
     public function bulkDeleteAction(Request $request)
     {
-        $suppliersToDelete = $request->request->get('supplier_bulk');
+        $suppliersToDelete = $request->request->get('suppliers_bulk');
 
         try {
             $this->getCommandBus()->handle(new BulkDeleteSupplierCommand($suppliersToDelete));

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -203,6 +203,10 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirect($legacyLink);
     }
 
+    public function exportAction()
+    {
+    }
+
     /**
      * Gets error by exception type.
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -156,9 +156,14 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index');
     }
 
-    public function viewAction()
+    public function viewAction($supplierId)
     {
-        //todo: implement
+        $legacyLink = $this->getAdminLink('AdminSuppliers', [
+            'id_supplier' => $supplierId,
+            'viewsupplier' => 1,
+        ]);
+
+        return $this->redirect($legacyLink);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -333,6 +333,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Exports to csv visible suppliers list data.
      *
      * @param SupplierFilters $filters
+     *
      * @return CsvResponse
      */
     public function exportAction(SupplierFilters $filters)

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDeleteSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkEnableSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\ToggleSupplierStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierException;
@@ -148,8 +149,21 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index');
     }
 
-    public function bulkEnableAction()
+    public function bulkEnableAction(Request $request)
     {
+        $suppliersToDisable = $request->request->get('suppliers_bulk');
+
+        try {
+            $this->getCommandBus()->handle(new BulkEnableSupplierCommand($suppliersToDisable));
+            $this->addFlash(
+                'success',
+                $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
+            );
+        } catch (SupplierException $exception) {
+            $this->addFlash('error', $this->handleException($exception));
+        }
+
+        return $this->redirectToRoute('admin_suppliers_index');
     }
 
     public function editAction($supplierId)

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -78,17 +78,35 @@ class SupplierController extends FrameworkBundleAdminController
 
     public function createAction()
     {
+        $legacyLink = $this->getAdminLink('AdminSuppliers', [
+            'addsupplier' => 1,
+        ]);
+
+        return $this->redirect($legacyLink);
     }
 
     public function deleteAction()
     {
+        //todo: implement
     }
 
-    public function editAction()
+    public function editAction($supplierId)
     {
+        $legacyLink = $this->getAdminLink('AdminSuppliers', [
+            'id_supplier' => $supplierId,
+            'updatesupplier' => 1,
+        ]);
+
+        return $this->redirect($legacyLink);
     }
 
     public function toggleStatusAction($supplierId)
     {
+        //todo: implement
+    }
+
+    public function viewAction()
+    {
+        //todo: implement
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -178,4 +178,8 @@ class SupplierController extends FrameworkBundleAdminController
 
         return $this->trans('Unexpected error occurred.', 'Admin.Notifications.Error');
     }
+
+    public function bulkDeleteAction()
+    {
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -46,6 +46,14 @@ class SupplierController extends FrameworkBundleAdminController
      */
     public function indexAction(SupplierFilters $filters)
     {
-        return [];
+        $supplierGridFactory = $this->get('prestashop.core.grid.factory.supplier');
+
+        $supplierGrid = $supplierGridFactory->getGrid($filters);
+
+        $gridPresenter = $this->get('prestashop.core.grid.presenter.grid_presenter');
+
+        return [
+            'supplierGrid' => $gridPresenter->present($supplierGrid),
+        ];
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -43,9 +43,9 @@ use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class SupplierController is responsible for "Sell > Catalog > Brands & Suppliers > Suppliers" page.
@@ -55,13 +55,11 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * Show suppliers listing.
      *
-     * @Template("@PrestaShop/Admin/Sell/Catalog/Suppliers/index.html.twig")
-     *
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param SupplierFilters $filters
      *
-     * @return array
+     * @return Response
      */
     public function indexAction(SupplierFilters $filters)
     {
@@ -71,9 +69,9 @@ class SupplierController extends FrameworkBundleAdminController
 
         $gridPresenter = $this->get('prestashop.core.grid.presenter.grid_presenter');
 
-        return [
+        return $this->render('@PrestaShop/Admin/Sell/Catalog/Suppliers/index.html.twig', [
             'supplierGrid' => $gridPresenter->present($supplierGrid),
-        ];
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -56,4 +56,8 @@ class SupplierController extends FrameworkBundleAdminController
             'supplierGrid' => $gridPresenter->present($supplierGrid),
         ];
     }
+
+    public function toggleStatusAction($supplierId)
+    {
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 use PrestaShop\PrestaShop\Core\Search\Filters\SupplierFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class SupplierController is responsible for "Sell > Catalog > Brands & Suppliers > Suppliers" page.
@@ -55,6 +56,24 @@ class SupplierController extends FrameworkBundleAdminController
         return [
             'supplierGrid' => $gridPresenter->present($supplierGrid),
         ];
+    }
+
+    public function searchAction(Request $request)
+    {
+        $definitionFactory = $this->get('prestashop.core.grid.definition.factory.supplier');
+        $supplierDefinition = $definitionFactory->getDefinition();
+
+        $gridFilterFormFactory = $this->get('prestashop.core.grid.filter.form_factory');
+        $searchParametersForm = $gridFilterFormFactory->create($supplierDefinition);
+
+        $searchParametersForm->handleRequest($request);
+        $filters = [];
+
+        if ($searchParametersForm->isSubmitted()) {
+            $filters = $searchParametersForm->getData();
+        }
+
+        return $this->redirectToRoute('admin_suppliers_index', ['filters' => $filters]);
     }
 
     public function toggleStatusAction($supplierId)

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -439,6 +439,12 @@ class SupplierController extends FrameworkBundleAdminController
                     'Admin.Notifications.Error'
                 ),
             ],
+            CannotDeleteSupplierException::class => [
+                CannotDeleteSupplierException::HAS_PENDING_ORDERS => $this->trans(
+                    'It is not possible to delete a supplier if there are pending supplier orders.',
+                    'Admin.Catalog.Notification'
+                ),
+            ],
         ];
 
         $exceptionType = get_class($exception);

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -41,7 +41,10 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 use PrestaShop\PrestaShop\Core\Search\Filters\SupplierFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -53,6 +56,8 @@ class SupplierController extends FrameworkBundleAdminController
      * Show suppliers listing.
      *
      * @Template("@PrestaShop/Admin/Sell/Catalog/Suppliers/index.html.twig")
+     *
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param SupplierFilters $filters
      *
@@ -71,6 +76,13 @@ class SupplierController extends FrameworkBundleAdminController
         ];
     }
 
+    /**
+     * Filters list results.
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
     public function searchAction(Request $request)
     {
         $definitionFactory = $this->get('prestashop.core.grid.definition.factory.supplier');
@@ -89,6 +101,17 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index', ['filters' => $filters]);
     }
 
+    /**
+     * Displays supplier creation form and handles form submit which creates new supplier.
+     *
+     * @AdminSecurity(
+     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_suppliers_index",
+     *     message="You do not have permission to add this."
+     * )
+     *
+     * @return RedirectResponse
+     */
     public function createAction()
     {
         $legacyLink = $this->getAdminLink('AdminSuppliers', [
@@ -98,6 +121,22 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirect($legacyLink);
     }
 
+    /**
+     * Deletes supplier.
+     *
+     * @AdminSecurity(
+     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_suppliers_index",
+     *     message="You do not have permission to delete this."
+     * )
+     * @DemoRestricted(
+     *     redirectRoute="admin_suppliers_index"
+     * )
+     *
+     * @param int $supplierId
+     *
+     * @return RedirectResponse
+     */
     public function deleteAction($supplierId)
     {
         try {
@@ -115,6 +154,22 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index');
     }
 
+    /**
+     * Bulk deletion of suppliers.
+     *
+     * @AdminSecurity(
+     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_suppliers_index",
+     *     message="You do not have permission to delete this."
+     * )
+     * @DemoRestricted(
+     *     redirectRoute="admin_suppliers_index"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
     public function bulkDeleteAction(Request $request)
     {
         $suppliersToDelete = $request->request->get('suppliers_bulk');
@@ -133,6 +188,22 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index');
     }
 
+    /**
+     * Bulk disables supplier statuses.
+     *
+     * @AdminSecurity(
+     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_suppliers_index",
+     *     message="You do not have permission to edit this."
+     * )
+     * @DemoRestricted(
+     *     redirectRoute="admin_suppliers_index"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
     public function bulkDisableAction(Request $request)
     {
         $suppliersToDisable = $request->request->get('suppliers_bulk');
@@ -150,6 +221,22 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index');
     }
 
+    /**
+     * Bulk enables supplier statuses.
+     *
+     * @AdminSecurity(
+     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_suppliers_index",
+     *     message="You do not have permission to edit this."
+     * )
+     * @DemoRestricted(
+     *     redirectRoute="admin_suppliers_index"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
     public function bulkEnableAction(Request $request)
     {
         $suppliersToDisable = $request->request->get('suppliers_bulk');
@@ -167,6 +254,19 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index');
     }
 
+    /**
+     * Displays edit supplier form and submits form.
+     *
+     * @AdminSecurity(
+     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_suppliers_index",
+     *     message="You do not have permission to edit this."
+     * )
+     *
+     * @param int $supplierId
+     *
+     * @return RedirectResponse
+     */
     public function editAction($supplierId)
     {
         $legacyLink = $this->getAdminLink('AdminSuppliers', [
@@ -177,6 +277,22 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirect($legacyLink);
     }
 
+    /**
+     * Toggles supplier active status.
+     *
+     * @AdminSecurity(
+     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_suppliers_index",
+     *     message="You do not have permission to edit this."
+     * )
+     * @DemoRestricted(
+     *     redirectRoute="admin_suppliers_index"
+     * )
+     *
+     * @param int $supplierId
+     *
+     * @return RedirectResponse
+     */
     public function toggleStatusAction($supplierId)
     {
         try {
@@ -194,6 +310,15 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index');
     }
 
+    /**
+     * Views supplier products information.
+     *
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     *
+     * @param int $supplierId
+     *
+     * @return RedirectResponse
+     */
     public function viewAction($supplierId)
     {
         $legacyLink = $this->getAdminLink('AdminSuppliers', [
@@ -204,6 +329,12 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirect($legacyLink);
     }
 
+    /**
+     * Exports to csv visible suppliers list data.
+     *
+     * @param SupplierFilters $filters
+     * @return CsvResponse
+     */
     public function exportAction(SupplierFilters $filters)
     {
         $supplierGridFactory = $this->get('prestashop.core.grid.factory.supplier');

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -104,7 +104,7 @@ class SupplierController extends FrameworkBundleAdminController
 
         return $this->redirect($legacyLink);
     }
-    
+
     public function toggleStatusAction($supplierId)
     {
         try {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -27,10 +27,12 @@
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDeleteSupplierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\ToggleSupplierStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotToggleSupplierStatusException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotUpdateSupplierStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
@@ -129,6 +131,27 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index');
     }
 
+    public function bulkDisableAction(Request $request)
+    {
+        $suppliersToDisable = $request->request->get('suppliers_bulk');
+
+        try {
+            $this->getCommandBus()->handle(new BulkDisableSupplierCommand($suppliersToDisable));
+            $this->addFlash(
+                'success',
+                $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
+            );
+        } catch (SupplierException $exception) {
+            $this->addFlash('error', $this->handleException($exception));
+        }
+
+        return $this->redirectToRoute('admin_suppliers_index');
+    }
+
+    public function bulkEnableAction()
+    {
+    }
+
     public function editAction($supplierId)
     {
         $legacyLink = $this->getAdminLink('AdminSuppliers', [
@@ -198,6 +221,10 @@ class SupplierController extends FrameworkBundleAdminController
             ),
             CannotToggleSupplierStatusException::class => $this->trans(
                 'An error occurred while updating the status.',
+                'Admin.Notifications.Error'
+            ),
+            CannotUpdateSupplierStatusException::class => $this->trans(
+                'An error occurred while updating the status for an object.',
                 'Admin.Notifications.Error'
             ),
         ];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -138,8 +138,7 @@ class SupplierController extends FrameworkBundleAdminController
     public function deleteAction($supplierId)
     {
         try {
-            $supplierId = new SupplierId($supplierId);
-            $this->getCommandBus()->handle(new DeleteSupplierCommand($supplierId));
+            $this->getCommandBus()->handle(new DeleteSupplierCommand((int) $supplierId));
 
             $this->addFlash(
                 'success',
@@ -173,6 +172,7 @@ class SupplierController extends FrameworkBundleAdminController
         $suppliersToDelete = $request->request->get('suppliers_bulk');
 
         try {
+            $suppliersToDelete = array_map(function ($item){ return (int) $item; }, $suppliersToDelete);
             $this->getCommandBus()->handle(new BulkDeleteSupplierCommand($suppliersToDelete));
 
             $this->addFlash(
@@ -207,6 +207,7 @@ class SupplierController extends FrameworkBundleAdminController
         $suppliersToDisable = $request->request->get('suppliers_bulk');
 
         try {
+            $suppliersToDisable = array_map(function ($item){ return (int) $item; }, $suppliersToDisable);
             $this->getCommandBus()->handle(new BulkDisableSupplierCommand($suppliersToDisable));
             $this->addFlash(
                 'success',
@@ -237,10 +238,11 @@ class SupplierController extends FrameworkBundleAdminController
      */
     public function bulkEnableAction(Request $request)
     {
-        $suppliersToDisable = $request->request->get('suppliers_bulk');
+        $suppliersToEnable = $request->request->get('suppliers_bulk');
 
         try {
-            $this->getCommandBus()->handle(new BulkEnableSupplierCommand($suppliersToDisable));
+            $suppliersToEnable = array_map(function ($item){ return (int) $item; }, $suppliersToEnable);
+            $this->getCommandBus()->handle(new BulkEnableSupplierCommand($suppliersToEnable));
             $this->addFlash(
                 'success',
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
@@ -294,8 +296,7 @@ class SupplierController extends FrameworkBundleAdminController
     public function toggleStatusAction($supplierId)
     {
         try {
-            $supplierId = new SupplierId($supplierId);
-            $this->getCommandBus()->handle(new ToggleSupplierStatusCommand($supplierId));
+            $this->getCommandBus()->handle(new ToggleSupplierStatusCommand((int) $supplierId));
 
             $this->addFlash(
                 'success',
@@ -409,7 +410,7 @@ class SupplierController extends FrameworkBundleAdminController
                 'Can\'t delete #%id%',
                 'Admin.Notifications.Error',
                 [
-                    '%id%' => $exception->getSupplierId()->getValue(),
+                    '%id%' => $exception->getSupplierId(),
                 ]
             );
         }
@@ -433,7 +434,7 @@ class SupplierController extends FrameworkBundleAdminController
     {
         $exceptionConstraintDictionary = [
             SupplierConstraintException::class => [
-                SupplierConstraintException::MISSING_BULK_DATA => $this->trans(
+                SupplierConstraintException::INVALID_BULK_DATA => $this->trans(
                     'You must select at least one element to delete.',
                     'Admin.Notifications.Error'
                 ),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -76,6 +76,18 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_suppliers_index', ['filters' => $filters]);
     }
 
+    public function createAction()
+    {
+    }
+
+    public function deleteAction()
+    {
+    }
+
+    public function editAction()
+    {
+    }
+
     public function toggleStatusAction($supplierId)
     {
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
+
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+/**
+ * Class SupplierController is responsible for "Sell > Catalog > Brands & Suppliers > Suppliers" page.
+ */
+class SupplierController extends FrameworkBundleAdminController
+{
+    /**
+     * Show suppliers listing.
+     *
+     * @Template("@PrestaShop/Admin/Sell/Catalog/Suppliers/index.html.twig")
+     *
+     * @return array
+     */
+    public function indexAction()
+    {
+        return [];
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/_catalog.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/_catalog.yml
@@ -5,3 +5,7 @@ _products:
 _categories:
     resource: "categories.yml"
     prefix: /categories/
+
+_suppliers:
+    resource: "suppliers.yml"
+    prefix: /suppliers/

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -70,7 +70,7 @@ admin_suppliers_toggle_status:
 
 admin_suppliers_export:
   path: /export
-  methods: POST
+  methods: GET
   defaults:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:export'
     _legacy_controller: AdminSuppliers

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -67,3 +67,10 @@ admin_suppliers_toggle_status:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:toggleStatus'
     _legacy_controller: AdminSuppliers
+
+admin_suppliers_export:
+  path: /export
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:export'
+    _legacy_controller: AdminSuppliers

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -1,6 +1,13 @@
 admin_suppliers_index:
-    path: /
-    methods: GET
-    defaults:
-        _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:index'
-        _legacy_controller: AdminCategories
+  path: /
+  methods: GET
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:index'
+    _legacy_controller: AdminCategories
+
+admin_suppliers_toggle_status:
+  path: /{supplierId}/toggle-status
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:toggleStatus'
+    _legacy_controller: AdminCategories

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -40,6 +40,13 @@ admin_suppliers_delete:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:delete'
     _legacy_controller: AdminSuppliers
 
+admin_suppliers_bulk_delete:
+  path: /bulk-delete
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:bulkDelete'
+    _legacy_controller: AdminSuppliers
+
 admin_suppliers_toggle_status:
   path: /{supplierId}/toggle-status
   methods: POST

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -20,7 +20,7 @@ admin_suppliers_view:
     _legacy_controller: AdminSuppliers
 
 admin_suppliers_create:
-  path: /add
+  path: /new
   methods: [GET,POST]
   defaults:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:create'

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -47,6 +47,20 @@ admin_suppliers_bulk_delete:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:bulkDelete'
     _legacy_controller: AdminSuppliers
 
+admin_suppliers_bulk_enable:
+  path: /bulk-enable
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:bulkEnable'
+    _legacy_controller: AdminSuppliers
+
+admin_suppliers_bulk_disable:
+  path: /bulk-disable
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:bulkDisable'
+    _legacy_controller: AdminSuppliers
+
 admin_suppliers_toggle_status:
   path: /{supplierId}/toggle-status
   methods: POST

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -1,0 +1,6 @@
+admin_suppliers_index:
+    path: /
+    methods: GET
+    defaults:
+        _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:index'
+        _legacy_controller: AdminCategories

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -3,18 +3,39 @@ admin_suppliers_index:
   methods: GET
   defaults:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:index'
-    _legacy_controller: AdminCategories
+    _legacy_controller: AdminSuppliers
 
 admin_suppliers_search:
   path: /
   methods: POST
   defaults:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:search'
-    _legacy_controller: AdminCategories
+    _legacy_controller: AdminSuppliers
+
+admin_suppliers_create:
+  path: /add
+  methods: [GET,POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:create'
+    _legacy_controller: AdminSuppliers
+
+admin_suppliers_edit:
+  path: /{supplierId}/edit
+  methods: [GET,POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:edit'
+    _legacy_controller: AdminSuppliers
+
+admin_suppliers_delete:
+  path: /{supplierId}/delete
+  methods: DELETE
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:delete'
+    _legacy_controller: AdminSuppliers
 
 admin_suppliers_toggle_status:
   path: /{supplierId}/toggle-status
   methods: POST
   defaults:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:toggleStatus'
-    _legacy_controller: AdminCategories
+    _legacy_controller: AdminSuppliers

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -12,6 +12,13 @@ admin_suppliers_search:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:search'
     _legacy_controller: AdminSuppliers
 
+admin_suppliers_view:
+  path: /{supplierId}/products
+  methods: GET
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:view'
+    _legacy_controller: AdminSuppliers
+
 admin_suppliers_create:
   path: /add
   methods: [GET,POST]

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -5,6 +5,13 @@ admin_suppliers_index:
     _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:index'
     _legacy_controller: AdminCategories
 
+admin_suppliers_search:
+  path: /
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:search'
+    _legacy_controller: AdminCategories
+
 admin_suppliers_toggle_status:
   path: /{supplierId}/toggle-status
   methods: POST

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -22,3 +22,9 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDeleteSupplierCommand
 
+  prestashop.adapter.supplier.command_handler.bulk_disable_supplier_handler:
+    class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\BulkDisableSupplierHandler
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand
+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -28,3 +28,9 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand
 
+  prestashop.adapter.supplier.command_handler.bulk_enable_supplier_handler:
+    class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\BulkEnableSupplierHandler
+    tags:
+    - name: tactician.handler
+      command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkEnableSupplierCommand
+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -10,3 +10,9 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\ToggleSupplierStatusCommand
 
+  prestashop.adapter.supplier.command_handler.delete_supplier_handler:
+    class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\DeleteSupplierHandler
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand
+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -16,3 +16,9 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand
 
+  prestashop.adapter.supplier.command_handler.bulk_delete_supplier_handler:
+    class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\BulkDeleteSupplierHandler
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDeleteSupplierCommand
+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -8,6 +8,9 @@ services:
       - '@prestashop.core.image.parser.image_tag_source_parser'
       - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
 
+  prestashop.adapter.supplier.supplier_order_validator:
+    class: 'PrestaShop\PrestaShop\Adapter\Supplier\SupplierOrderValidator'
+
 # Command handlers
 
   prestashop.adapter.supplier.command_handler.toggle_supplier_status_handler:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -8,6 +8,9 @@ services:
       - '@prestashop.core.image.parser.image_tag_source_parser'
       - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
 
+  prestashop.adapter.supplier.provider.supplier_address:
+    class: 'PrestaShop\PrestaShop\Adapter\Supplier\SupplierAddressProvider'
+
   prestashop.adapter.supplier.supplier_order_validator:
     class: 'PrestaShop\PrestaShop\Adapter\Supplier\SupplierOrderValidator'
 
@@ -23,6 +26,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\DeleteSupplierHandler
     arguments:
       - '@prestashop.adapter.supplier.supplier_order_validator'
+      - '@prestashop.adapter.supplier.provider.supplier_address'
       - '%database_prefix%'
     tags:
       - name: tactician.handler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -1,0 +1,12 @@
+services:
+  _defaults:
+    public: true
+
+# Command handlers
+
+  prestashop.adapter.supplier.command_handler.toggle_supplier_status_handler:
+    class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\ToggleSupplierStatusHandler
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\ToggleSupplierStatusCommand
+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -21,6 +21,8 @@ services:
 
   prestashop.adapter.supplier.command_handler.delete_supplier_handler:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\DeleteSupplierHandler
+    arguments:
+      - '@prestashop.adapter.supplier.supplier_order_validator'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -22,6 +22,7 @@ services:
       - '@prestashop.adapter.supplier.supplier_order_validator'
       - '@prestashop.adapter.supplier.provider.supplier_address'
       - '%database_prefix%'
+    public: false
 
   prestashop.adapter.supplier.command_handler.toggle_supplier_status_handler:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\ToggleSupplierStatusHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -39,9 +39,11 @@ services:
 
   prestashop.adapter.supplier.command_handler.bulk_delete_supplier_handler:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\BulkDeleteSupplierHandler
+    parent: prestashop.adapter.supplier.command_handler.abstract_delete_supplier_handler
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDeleteSupplierCommand
+    public: true
 
   prestashop.adapter.supplier.command_handler.bulk_disable_supplier_handler:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\BulkDisableSupplierHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -23,6 +23,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\DeleteSupplierHandler
     arguments:
       - '@prestashop.adapter.supplier.supplier_order_validator'
+      - '%database_prefix%'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -16,6 +16,13 @@ services:
 
 # Command handlers
 
+  prestashop.adapter.supplier.command_handler.abstract_delete_supplier_handler:
+    class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\AbstractDeleteSupplierHandler
+    arguments:
+      - '@prestashop.adapter.supplier.supplier_order_validator'
+      - '@prestashop.adapter.supplier.provider.supplier_address'
+      - '%database_prefix%'
+
   prestashop.adapter.supplier.command_handler.toggle_supplier_status_handler:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\ToggleSupplierStatusHandler
     tags:
@@ -24,13 +31,11 @@ services:
 
   prestashop.adapter.supplier.command_handler.delete_supplier_handler:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\DeleteSupplierHandler
-    arguments:
-      - '@prestashop.adapter.supplier.supplier_order_validator'
-      - '@prestashop.adapter.supplier.provider.supplier_address'
-      - '%database_prefix%'
+    parent: prestashop.adapter.supplier.command_handler.abstract_delete_supplier_handler
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand
+    public: true
 
   prestashop.adapter.supplier.command_handler.bulk_delete_supplier_handler:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\BulkDeleteSupplierHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -2,6 +2,12 @@ services:
   _defaults:
     public: true
 
+  prestashop.adapter.supplier.provider.supplier_logo:
+    class: 'PrestaShop\PrestaShop\Adapter\Supplier\SupplierLogoThumbnailProvider'
+    arguments:
+      - '@prestashop.core.image.parser.image_tag_source_parser'
+      - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
+
 # Command handlers
 
   prestashop.adapter.supplier.command_handler.toggle_supplier_status_handler:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -82,3 +82,12 @@ services:
         - '@prestashop.core.query.doctrine_search_criteria_applicator'
         - '@=service("prestashop.adapter.shop.context").getContextListShopID()'
       public: true
+
+    prestashop.core.grid.query_builder.supplier:
+      class: 'PrestaShop\PrestaShop\Core\Grid\Query\SupplierQueryBuilder'
+      parent: 'prestashop.core.grid.abstract_query_builder'
+      arguments:
+        - '@prestashop.core.query.doctrine_search_criteria_applicator'
+        - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+        - "@=service('prestashop.adapter.shop.context').getContextListShopID()"
+      public: true

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -107,3 +107,17 @@ services:
             - '@prestashop.core.hook.dispatcher'
             - '@prestashop.core.grid.query.doctrine_query_parser'
             - 'currency'
+
+    prestashop.core.grid.data_provider.supplier:
+      class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+      arguments:
+        - '@prestashop.core.grid.query_builder.supplier'
+        - '@prestashop.core.hook.dispatcher'
+        - '@prestashop.core.grid.query.doctrine_query_parser'
+        - 'suppliers'
+
+    prestashop.core.grid.factory.supplier_decorator:
+      class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\SupplierGridDataFactory'
+      arguments:
+        - '@prestashop.core.grid.data_provider.supplier'
+        - '@prestashop.adapter.supplier.provider.supplier_logo'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -103,3 +103,8 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CurrencyGridDefinitionFactory'
         parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
         public: true
+
+    prestashop.core.grid.definition.factory.supplier:
+        class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SupplierGridDefinitionFactory'
+        parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+        public: true

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -97,3 +97,11 @@ services:
         - '@prestashop.core.currency.grid_data_factory'
         - '@prestashop.core.grid.filter.form_factory'
         - '@prestashop.core.hook.dispatcher'
+
+    prestashop.core.grid.factory.supplier:
+      class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+      arguments:
+        - '@prestashop.core.grid.definition.factory.supplier'
+        - '@prestashop.core.grid.factory.supplier_decorator'
+        - '@prestashop.core.grid.filter.form_factory'
+        - '@prestashop.core.hook.dispatcher'

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig
@@ -40,7 +40,7 @@
       <a class="page-link" {% if last_url is defined and last_url != false %}href="{{ last_url }}"{% else %}nohref{% endif %}>{{ page_count }}</a>
     </li>
   </ul>
-  <div class="mx-3">
+  <div class="mx-3 col-form-label">
     {{ "Viewing %from%-%to% on %total% (page %current_page% / %page_count%)"|trans({
       '%from%': from+1,
       '%to%': min(to+1, total),

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -26,7 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  
+
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -25,6 +25,15 @@
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
+{% set layoutHeaderToolbarBtn = {
+  add: {
+    href: path('admin_suppliers_create'),
+    desc: 'Add new supplier'|trans({}, 'Admin.Catalog.Feature'),
+    icon: 'add_circle_outline',
+  }
+}
+%}
+
 {% block content %}
   {% block supplier_grid %}
     <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -1,0 +1,36 @@
+{#**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  
+{% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+
+  <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -38,5 +38,6 @@
 {% block javascripts %}
   {{ parent() }}
 
+  <script src="{{ asset('themes/new-theme/public/supplier.bundle.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -26,7 +26,13 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-
+  {% block supplier_grid %}
+    <div class="row">
+      <div class="col">
+        {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': supplierGrid} %}
+      </div>
+    </div>
+  {% endblock %}
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | supplier list can be reached via **admin-dev/index.php/sell/catalog/suppliers/**
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/10545
| How to test?  | The list should work exactly the same just that the "Add", "View" and "Edit" links will point to legacy suppliers form page. Needs assets to be rebuilt.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11153)
<!-- Reviewable:end -->
