### PR TITLE
Allow product default supplier reference to be updated, if the product supplier is already attached to the product

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2521,28 +2521,29 @@ class AdminProductsControllerCore extends AdminController
 
                         if (!$product_supplier_id) {
                             $product->addSupplierReference($supplier->id_supplier, (int) $attribute['id_product_attribute'], $reference, (float) $price, (int) $id_currency);
-                            if ($product->id_supplier == $supplier->id_supplier) {
-                                if ((int) $attribute['id_product_attribute'] > 0) {
-                                    $data = array(
-                                        'supplier_reference' => pSQL($reference),
-                                        'wholesale_price' => (float) Tools::convertPrice($price, $id_currency),
-                                    );
-                                    $where = '
-										a.id_product = ' . (int) $product->id . '
-										AND a.id_product_attribute = ' . (int) $attribute['id_product_attribute'];
-                                    ObjectModel::updateMultishopTable('Combination', $data, $where);
-                                } else {
-                                    $product->wholesale_price = (float) Tools::convertPrice($price, $id_currency); //converted in the default currency
-                                    $product->supplier_reference = pSQL($reference);
-                                    $product->update();
-                                }
-                            }
                         } else {
                             $product_supplier = new ProductSupplier($product_supplier_id);
                             $product_supplier->id_currency = (int) $id_currency;
                             $product_supplier->product_supplier_price_te = (float) $price;
                             $product_supplier->product_supplier_reference = pSQL($reference);
                             $product_supplier->update();
+                        }
+
+                        if ($product->id_supplier == $supplier->id_supplier) {
+                            if ((int) $attribute['id_product_attribute'] > 0) {
+                                $data = array(
+                                    'supplier_reference' => pSQL($reference),
+                                    'wholesale_price' => (float) Tools::convertPrice($price, $id_currency),
+                                );
+                                $where = '
+                                    a.id_product = ' . (int) $product->id . '
+                                    AND a.id_product_attribute = ' . (int) $attribute['id_product_attribute'];
+                                ObjectModel::updateMultishopTable('Combination', $data, $where);
+                            } else {
+                                $product->wholesale_price = (float) Tools::convertPrice($price, $id_currency); //converted in the default currency
+                                $product->supplier_reference = pSQL($reference);
+                                $product->update();
+                            }
                         }
                     } elseif (Tools::isSubmit('supplier_reference_' . $product->id . '_' . $attribute['id_product_attribute'] . '_' . $supplier->id_supplier)) {
                         //int attribute with default values if possible


### PR DESCRIPTION
This PR allows product default supplier reference to be updated, if the product supplier is already attached to the product.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update product supplier reference whatever product supplier is new or not.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create a product, add a product supplier with reference, edit supplier reference

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11175)
<!-- Reviewable:end -->
