### PR TITLE
Fix sorting issue in the webservice page

### DIFF
--- a/controllers/admin/AdminWebserviceController.php
+++ b/controllers/admin/AdminWebserviceController.php
@@ -57,6 +57,7 @@ class AdminWebserviceControllerCore extends AdminController
             'key' => array(
                 'title' => $this->trans('Key', array(), 'Admin.Advparameters.Feature'),
                 'class' => 'fixed-width-md',
+                'filter_key' => 'a!key',
             ),
             'description' => array(
                 'title' => $this->trans('Key description', array(), 'Admin.Advparameters.Feature'),


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It is impossible to sort by Key in the webservice page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11178
| How to test?  | Go to BO => Advanced Parameters => Webservice page => Create at least 2 webservice key => After that, try to apply a sort on the Key with icon

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11179)
<!-- Reviewable:end -->
