### PR TITLE
The deletion of themes must depends on Employee permissions

### DIFF
--- a/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
@@ -43,17 +43,19 @@
 													<i class="icon-check"></i> {l s='Use this theme'}
 												</a>
 
-												<button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-													<i class="icon-caret-down"></i>&nbsp;
-												</button>
-												<ul class="dropdown-menu">
-													<li>
-														<a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;action=deleteTheme&amp;theme_name={$theme->getName()|urlencode}" title="{l s='Delete this theme'}" class="delete">
-															<i class="icon-trash"></i> {l s='Delete this theme'}
-														</a>
-													</li>
-												</ul>
+												{if $field['can_delete_themes']}
+                          <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                            <i class="icon-caret-down"></i>&nbsp;
+                          </button>
 
+                          <ul class="dropdown-menu">
+                            <li>
+                              <a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;action=deleteTheme&amp;theme_name={$theme->getName()|urlencode}" title="{l s='Delete this theme'}" class="delete">
+                                <i class="icon-trash"></i> {l s='Delete this theme'}
+                              </a>
+                            </li>
+                          </ul>
+												{/if}
 											</div>
 										</div>
 									</div>

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -183,6 +183,7 @@ class AdminThemesControllerCore extends AdminController
         if ($this->display == 'list') {
             $this->display = '';
         }
+
         if (isset($this->display) && method_exists($this, 'render' . $this->display)) {
             $this->content .= $this->initPageHeaderToolbar();
 
@@ -511,6 +512,7 @@ class AdminThemesControllerCore extends AdminController
                         'type' => 'theme',
                         'themes' => $other_themes,
                         'can_display_themes' => $this->can_display_themes,
+                        'can_delete_themes' => $this->isDeleteGranted(),
                         'no_multishop_checkbox' => true,
                     ),
                 ),


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | As an employee with no rights to delete a theme, I can still see the "Delete Theme" option in Design > Themes.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create an employee and set his permissions: disallow the deletion of themes. You shouldn't be able to see the option

### Before

![test2](https://user-images.githubusercontent.com/1247388/47683794-f7179b00-dbd0-11e8-9c7a-8c8ce5994536.png)

### After

![test](https://user-images.githubusercontent.com/1247388/47683726-c7689300-dbd0-11e8-92f2-4552af27a1cc.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11182)
<!-- Reviewable:end -->
