### PR TITLE
Handles usecase where carrier tax rate is not provided because of bad address

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -1284,12 +1284,16 @@ class CarrierCore extends ObjectModel
      *
      * @since 1.5
      *
-     * @param Address $address Address
+     * @param Address $address Address optional
      *
      * @return float Total Tax rate for this Carrier
      */
-    public function getTaxesRate(Address $address)
+    public function getTaxesRate(Address $address = null)
     {
+        if (!$address || !$address->id_country) {
+            $address = Address::initialize();
+        }
+
         $tax_calculator = $this->getTaxCalculator($address);
 
         return $tax_calculator->getTotalRate();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Handles usecase where carrier tax rate is not provided because of bad address
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11180
| How to test?  | See issue description

PR has been done on 1.7.5.x as it is a bug fix, however I can change to develop if it is more relevant

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11185)
<!-- Reviewable:end -->
