### PR TITLE
Fix address changes not impacted when creating an order from another order

### DIFF
--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -421,10 +421,10 @@ class AdminAddressesControllerCore extends AdminController
                 
                 // update cart
                 $cart = Cart::getCartByOrderId($id_order);
-                if ($address_type=='invoice') {
-                    $cart->id_address_invoice = (int)$this->object->id;
+                if ($address_type == 'invoice') {
+                    $cart->id_address_invoice = (int) $this->object->id;
                 } else {
-                    $cart->id_address_delivery = (int)$this->object->id;
+                    $cart->id_address_delivery = (int) $this->object->id;
                 }
                 $cart->update();
                 // redirect

--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -418,6 +418,16 @@ class AdminAddressesControllerCore extends AdminController
                 //update order shipping cost
                 $order = new Order($id_order);
                 $order->refreshShippingCost();
+                
+                // update cart
+                $cart = Cart::getCartByOrderId($id_order);
+                if ($address_type=='invoice') {
+                    $cart->id_address_invoice = (int)$this->object->id;
+                } else {
+                    $cart->id_address_delivery = (int)$this->object->id;
+                }
+                $cart->update();
+                // redirect
                 Tools::redirectAdmin(urldecode(Tools::getValue('back')) . '&conf=4');
             }
         }

--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -418,15 +418,17 @@ class AdminAddressesControllerCore extends AdminController
                 //update order shipping cost
                 $order = new Order($id_order);
                 $order->refreshShippingCost();
-                
+
                 // update cart
                 $cart = Cart::getCartByOrderId($id_order);
-                if ($address_type == 'invoice') {
-                    $cart->id_address_invoice = (int) $this->object->id;
-                } else {
-                    $cart->id_address_delivery = (int) $this->object->id;
+                if (Validate::isLoadedObject($cart)) {
+                    if ($address_type == 'invoice') {
+                        $cart->id_address_invoice = (int) $this->object->id;
+                    } else {
+                        $cart->id_address_delivery = (int) $this->object->id;
+                    }
+                    $cart->update();
                 }
-                $cart->update();
                 // redirect
                 Tools::redirectAdmin(urldecode(Tools::getValue('back')) . '&conf=4');
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In backoffice, on order X, When you change delivery or invoice address, if you create an order Y from order X, the addresses modification are not impacted. The cart associated with the order has to be changed.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? /no
| Fixed ticket? | Fixes #11199 cf https://github.com/PrestaShop/PrestaShop/issues/11199
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11200)
<!-- Reviewable:end -->
