### PR TITLE
Addresses changes not impacted when creating an order from another order

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1241,15 +1241,19 @@ class AdminOrdersControllerCore extends AdminController
         } elseif ((Tools::isSubmit('submitAddressShipping') || Tools::isSubmit('submitAddressInvoice')) && isset($order)) {
             if ($this->access('edit')) {
                 $address = new Address(Tools::getValue('id_address'));
+                $cart = Cart::getCartByOrderId($order->id);
                 if (Validate::isLoadedObject($address)) {
-                    // Update the address on order
+                    // Update the address on order and cart
                     if (Tools::isSubmit('submitAddressShipping')) {
                         $order->id_address_delivery = $address->id;
+                        $cart->id_address_delivery = $address->id;
                     } elseif (Tools::isSubmit('submitAddressInvoice')) {
                         $order->id_address_invoice = $address->id;
+                        $cart->id_address_invoice = $address->id;
                     }
                     $order->update();
                     $order->refreshShippingCost();
+                    $cart->update();
 
                     Tools::redirectAdmin(self::$currentIndex . '&id_order=' . $order->id . '&vieworder&conf=4&token=' . $this->token);
                 } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In back office, on order X, When you change delivery or invoice address, if you create an order Y from order X, the addresses modification are not impacted. The cart of the X order has to be changed too. The cart addresses has to be changed too.
| Type?         | bug fix 
| Category?     |  BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11199
| How to test?  | cf #11199

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11201)
<!-- Reviewable:end -->
