### PR TITLE
Fix a bug where PrestaShop cookie is set on every page when a cookie value is NULL

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -28,7 +28,7 @@ use Defuse\Crypto\Key;
 class CookieCore
 {
     /** @var array Contain cookie content in a key => value format */
-    protected $_content;
+    protected $_content = array();
 
     /** @var array Crypted cookie name for setcookie() */
     protected $_name;
@@ -188,7 +188,7 @@ class CookieCore
     }
 
     /**
-     * Magic method wich delete data into _content array.
+     * Magic method which delete data into _content array.
      *
      * @param string $key key wanted
      */

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -181,7 +181,7 @@ class CookieCore
         if (preg_match('/¤|\|/', $key . $value)) {
             throw new Exception('Forbidden chars in cookie');
         }
-        if (!$this->_modified && (!isset($this->_content[$key]) || (isset($this->_content[$key]) && $this->_content[$key] != $value))) {
+        if (!$this->_modified && (!array_key_exists($key, $this->_content) || $this->_content[$key] != $value)) {
             $this->_modified = true;
         }
         $this->_content[$key] = $value;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | fix a bug where PrestaShop cookie is set on every page when a cookie content value associated with a key is NULL
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Difficult to test. A new prestashop Cookie entry need to be set with a NULL value. At the first load, the PrestaShop cookie will be set (since it wasn't existing at all). At the second load, the cookie should NOT be set since the NULL has not changed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11202)
<!-- Reviewable:end -->
