### PR TITLE
Installer: always clean test assets even if filesystem tests fail, an…

### DIFF
--- a/tools/build/Library/InstallUnpacker/classes/ConfigurationValidator.php
+++ b/tools/build/Library/InstallUnpacker/classes/ConfigurationValidator.php
@@ -94,19 +94,23 @@ class ConfigurationValidator
 
         list($fileCreationTestPath, $createFileResult) = $this->createFileTest($dirPath);
         if (false === $createFileResult) {
+            $this->deleteDirectoryTest($dirPath);
             return ['Cannot write files'];
         }
 
         if (false === $this->downloadFileTest($dirPath)) {
+            $this->deleteDirectoryTest($dirPath);
             return ['Cannot download files from network'];
         }
 
         list($fileMoveTestPath, $moveResult) = $this->moveFileTest($fileCreationTestPath);
         if (false === $moveResult) {
+            $this->deleteDirectoryTest($dirPath);
             return ['Cannot move files into prestashop root directory'];
         }
 
         if (false === $this->deleteFileTest($fileMoveTestPath)) {
+            $this->deleteDirectoryTest($dirPath);
             return ['Cannot delete files in prestashop root directory'];
         }
 
@@ -161,8 +165,7 @@ class ConfigurationValidator
     private function downloadFileTest($dirPath)
     {
         $downloadTestPath = $dirPath . DIRECTORY_SEPARATOR . 'test-download.txt';
-        // @todo: use another file from the network ?
-        $target = 'https://raw.githubusercontent.com/PrestaShop/PrestaShop/develop/robots.txt';
+        $target = 'https://www.google.com/robots.txt';
 
         return (bool) @file_put_contents($downloadTestPath, Download::fileGetContents($target));
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Installer: always clean test assets even if filesystem tests fail, andd use google as a test file provider instead of github
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11107
| How to test?  | See issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11206)
<!-- Reviewable:end -->
