### PR TITLE
Ignore irrelevant SF warning aout composer at install

### DIFF
--- a/src/PrestaShopBundle/Install/System.php
+++ b/src/PrestaShopBundle/Install/System.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Install;
 
 use ConfigurationTest;
+use Requirement;
 use SymfonyRequirements;
 
 require_once __DIR__ . '/../../../var/SymfonyRequirements.php';
@@ -57,7 +58,16 @@ class System extends AbstractInstall
     {
         $symfonyRequirements = new SymfonyRequirements();
 
-        return $symfonyRequirements->getFailedRecommendations();
+        $failedRecommendations = $symfonyRequirements->getFailedRecommendations();
+
+        return array_filter($failedRecommendations, function (Requirement $requirement) {
+            if ($requirement->getTestMessage() === 'Requirements file should be up-to-date') {
+                // this warning is not relevant
+                return false;
+            }
+
+            return true;
+        });
     }
 
     public function checkTests($list, $type)


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Installer: Ignore irrelevant Symfony warning about bad composer install
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11110
| How to test?  | See issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11209)
<!-- Reviewable:end -->
