### PR TITLE
Avoid warning in WebServiceRequest

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -183,7 +183,7 @@ class WebserviceRequestCore
     public static $ws_current_classname;
 
 
-    public static $shopIDs;
+    public static $shopIDs = array();
 
 
     public function getOutputEnabled()


### PR DESCRIPTION
line 800 assumes that self::$shopIDs is an array that can be counted.
But self::$shopIDs is null and the following error appears:
[PHP Warning #2] count(): Parameter must be an array or an object that implements Countable (/home/jojo/public_html/mydomain.com/presta2/classes/webservice/WebserviceRequest.php, line 800)

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.x
| Description?  | This issue affects any one running PS on PHP 7.2.x with with display_error=on.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11227
| How to test?  | Enable WS and visit /api

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11228)
<!-- Reviewable:end -->
