### PR TITLE
Prevent unnecessary Order objects from being created in Admin Orders

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -186,9 +186,7 @@ class AdminOrdersControllerCore extends AdminController
 
     public static function setOrderCurrency($echo, $tr)
     {
-        $order = new Order($tr['id_order']);
-
-        return Tools::displayPrice($echo, (int) $order->id_currency);
+        return Tools::displayPrice($echo, (int) $tr['id_currency']);
     }
 
     public function initPageHeaderToolbar()

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -186,7 +186,14 @@ class AdminOrdersControllerCore extends AdminController
 
     public static function setOrderCurrency($echo, $tr)
     {
-        return Tools::displayPrice($echo, (int) $tr['id_currency']);
+        if (!empty($tr['id_currency'])) {
+            $idCurrency = (int) $tr['id_currency'];
+        } else {
+            $order = new Order($tr['id_order']);
+            $idCurrency = (int) $order->id_currency;
+        }
+
+        return Tools::displayPrice($echo, $idCurrency);
     }
 
     public function initPageHeaderToolbar()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Every order loaded into the backend's order list creates a new `Order` object to retrieve its' `id_currency`. This results in n+1 queries being executed (with 50 orders that's 50 extra queries). This PR aims to remove that behavior, by using `$tr`'s `id_currency` value instead.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Open the orders list in backend office.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11235)
<!-- Reviewable:end -->
