### PR TITLE
Do not install Addons modules for Test BDD creation

### DIFF
--- a/tests/PrestaShopBundle/Utils/DatabaseCreator.php
+++ b/tests/PrestaShopBundle/Utils/DatabaseCreator.php
@@ -68,7 +68,6 @@ class DatabaseCreator
         $language = new \Language(1);
         \Context::getContext()->language = $language;
         $install->installModules();
-        $install->installModulesAddons();
 
         DatabaseDump::create();
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Composer command `composer create-test-db` actually does more than creating a BDD test, it also install modules from Addons which make test environment unstable
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Automatic Travis tests should be green

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11239)
<!-- Reviewable:end -->
