### PR TITLE
Fix declaration of method arguments

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1653,8 +1653,8 @@ class CartCore extends ObjectModel
      */
     public function deleteProduct(
         $id_product,
-        $id_product_attribute = null,
-        $id_customization = null,
+        $id_product_attribute = 0,
+        $id_customization = 0,
         $id_address_delivery = 0
     ) {
         if (isset(self::$_nbProducts[$this->id])) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the database structure, these fields are declared as follows: `id_product_attribute` int(10) unsigned NOT NULL DEFAULT '0', `id_customization` int(10) unsigned NOT NULL DEFAULT '0'.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | If you call a method without these arguments, the index is " $id_product.'- ' .$id_product_attribute" of the array "$preservedGifts" at line 1653 will not be correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11249)
<!-- Reviewable:end -->
