### PR TITLE
Fixed inconsistent locale in Front Office

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -628,8 +628,10 @@ class ToolsCore
 
         // Only switch if new ID is different from old ID
         $newLanguageId = (int) Tools::getValue('id_lang');
+
         if (
             Validate::isUnsignedId($newLanguageId) &&
+            $newLanguageId !== 0 &&
             $context->cookie->id_lang !== $newLanguageId
         ) {
             $context->cookie->id_lang = $newLanguageId;
@@ -638,6 +640,8 @@ class ToolsCore
                 $context->language = $language;
             }
         }
+
+        Tools::setCookieLanguage($context->cookie);
     }
 
     public static function getCountry($address = null)

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -296,10 +296,6 @@ class FrontControllerCore extends Controller
 
         ob_start();
 
-        // Init cookie language
-        // @TODO This method must be moved into switchLanguage
-        Tools::setCookieLanguage($this->context->cookie);
-
         $protocol_link = (Configuration::get('PS_SSL_ENABLED') || Tools::usingSecureMode()) ? 'https://' : 'http://';
         $useSSL = ((isset($this->ssl) && $this->ssl && Configuration::get('PS_SSL_ENABLED')) || Tools::usingSecureMode()) ? true : false;
         $protocol_content = ($useSSL) ? 'https://' : 'http://';


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Even when we chose a locale using the Language Selector in Front Office, in some pages the default locale was used
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11141 
| How to test?  | You'd better read the related issue ;)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11261)
<!-- Reviewable:end -->
