### PR TITLE
Allow BO hooks to use the method $this->render()

### DIFF
--- a/classes/Smarty/SmartyResourceModule.php
+++ b/classes/Smarty/SmartyResourceModule.php
@@ -46,13 +46,6 @@ class SmartyResourceModuleCore extends Smarty_Resource_Custom
      */
     protected function fetch($name, &$source, &$mtime)
     {
-        if ($this->isAdmin) {
-            $source = '';
-            $mtime = time();
-
-            return;
-        }
-
         foreach ($this->paths as $path) {
             if (Tools::file_exists_cache($file = $path . $name)) {
                 if (_PS_MODE_DEV_) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow BO hooks to use the method `$this->render()`
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #11230
| How to test?  | Add ps_homeslider on the hook `displayAdminAfterHeader`. Its content should be displayed on each BO page, although this is front-office content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11266)
<!-- Reviewable:end -->
