### PR TITLE
Duplicate content on canonical redirects from a module

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -820,7 +820,7 @@ class FrontControllerCore extends Controller
                     $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
                 }
             }
-            $excluded_key = array('isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms');
+            $excluded_key = array('isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms', 'module');
             foreach ($_GET as $key => $value) {
                 if (!in_array($key, $excluded_key) && Validate::isUrl($key) && Validate::isUrl($value)) {
                     $params[Tools::safeOutput($key)] = Tools::safeOutput($value);


### PR DESCRIPTION
Hello,

There is a concern about canonical redirects, which creates duplicate content (SEO).
Example, the module corrects the "slug", and gives this redirection:

```
[Debug] This page has moved
Please use the following URL instead: http://www.test.local/fr/blog/category/4_journal.html?module=smartblog
```

The `?module=smartblog` parameter should not appear.

I propose to remove this parameter redirects.

Thank you for studying this request

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | 1.6.22, Module SmartBlog and all other, Theme default
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Yes

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11275)
<!-- Reviewable:end -->
