### PR TITLE
Allow product ordering on explicit request

### DIFF
--- a/src/Adapter/Product/ListParametersUpdater.php
+++ b/src/Adapter/Product/ListParametersUpdater.php
@@ -32,7 +32,7 @@ use PrestaShop\PrestaShop\Core\Exception\ProductException;
  * Can manage filter parameters from request in Product Catalogue Page.
  * For internal use only.
  */
-final class FilterParametersUpdater
+final class ListParametersUpdater
 {
     /**
      * In case of position ordering all the filters should be reset.
@@ -65,7 +65,7 @@ final class FilterParametersUpdater
      *
      * @throws ProductException
      */
-    public function buildFilters(
+    public function buildListParameters(
         array $queryFilterParameters,
         array $persistedFilterParameters,
         array $defaultFilterParameters

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -334,7 +334,7 @@ class ProductController extends FrameworkBundleAdminController
             $lastSql = $productProvider->getLastCompiledSql();
         }
 
-        $hasColumnFilter = $productProvider->isColumnFiltered();
+        $hasCategoryFilter = $productProvider->isCategoryFiltered();
 
         // Adds controller info (URLs, etc...) to product list
         foreach ($products as &$product) {

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -3,13 +3,13 @@ services:
         public: true
 
     prestashop.adapter.admin.data_provider.product:
-            class: PrestaShop\PrestaShop\Adapter\Product\AdminProductDataProvider
-            decorates: prestashop.core.admin.data_provider.product_interface
-            arguments:
-                - "@doctrine.orm.entity_manager"
-                - "@prestashop.adapter.image_manager"
-                - "@prestashop.static_cache.adapter"
-            public: false
+        class: PrestaShop\PrestaShop\Adapter\Product\AdminProductDataProvider
+        decorates: prestashop.core.admin.data_provider.product_interface
+        arguments:
+            - "@doctrine.orm.entity_manager"
+            - "@prestashop.adapter.image_manager"
+            - "@prestashop.static_cache.adapter"
+        public: false
 
     prestashop.adapter.admin.data_updater.product:
         class: PrestaShop\PrestaShop\Adapter\Product\AdminProductDataUpdater
@@ -29,5 +29,5 @@ services:
     prestashop.adapter.product.filter_categories_request_purifier:
         class: 'PrestaShop\PrestaShop\Adapter\Product\FilterCategoriesRequestPurifier'
 
-    prestashop.adapter.product.filter_parameters_updater:
-        class: 'PrestaShop\PrestaShop\Adapter\Product\FilterParametersUpdater'
+    prestashop.adapter.product.list_parameters_updater:
+        class: 'PrestaShop\PrestaShop\Adapter\Product\ListParametersUpdater'

--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_inputs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_inputs.html.twig
@@ -118,6 +118,6 @@
 </script>
 <div id="{{ input_name }}_div">
     <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="" sql="{{ value }}" />
-    <input class="form-control form-min-max" type="text" id="{{ input_name }}_min" value="" placeholder="{{ minLabel|default('Min') }}" />
-    <input class="form-control form-min-max" type="text" id="{{ input_name }}_max" value="" placeholder="{{ maxLabel|default('Max') }}" />
+    <input class="form-control form-min-max" type="text" id="{{ input_name }}_min" value="" placeholder="{{ minLabel|default('Min') }}" {% if disabled|default(false) %}disabled{% endif %} />
+    <input class="form-control form-min-max" type="text" id="{{ input_name }}_max" value="" placeholder="{{ maxLabel|default('Max') }}" {% if disabled|default(false) %}disabled{% endif %} />
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
@@ -35,7 +35,7 @@
                   aria-expanded="false"
           >
               {{ 'Filter by categories'|trans({}, 'Admin.Actions') }}
-              {% if selected_category is defined %}
+              {% if selected_category is defined and selected_category is not null %}
                   ({{ selected_category.getName() }})
               {% endif %}
           </button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
@@ -35,6 +35,9 @@
                   aria-expanded="false"
           >
               {{ 'Filter by categories'|trans({}, 'Admin.Actions') }}
+              {% if selected_column.name is defined %}
+                  ({{ selected_column.name }})
+              {% endif %}
           </button>
           <div id="tree-categories" class="dropdown-menu">
             <div class="categories-tree-actions">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
@@ -35,8 +35,8 @@
                   aria-expanded="false"
           >
               {{ 'Filter by categories'|trans({}, 'Admin.Actions') }}
-              {% if selected_column.name is defined %}
-                  ({{ selected_column.name }})
+              {% if selected_category is defined %}
+                  ({{ selected_category.getName() }})
               {% endif %}
           </button>
           <div id="tree-categories" class="dropdown-menu">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 <tbody
-    {% if activate_drag_and_drop and has_category_filter %}class="sortable"{% endif %}
+    {% if activate_drag_and_drop %}class="sortable"{% endif %}
     last_sql="{{ last_sql_query|escape('html_attr') }}"
 >
     {% for product in products %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -70,7 +70,7 @@
           </th>
           {% if has_category_filter == true %}
             <th scope="col">
-              {{ ps.sortable_column_header("Position"|trans({}, 'Admin.Global'), 'position') }}
+              {{ ps.sortable_column_header("Position"|trans({}, 'Admin.Global'), 'position', orderBy, sortOrder) }}
             </th>
           {% endif %}
           <th scope="col" class="text-right" style="width: 3rem; padding-right: 2rem">
@@ -80,6 +80,7 @@
       {% endblock %}
 
       {% block product_catalog_form_table_filters %}
+        {% set filters_disabled = activate_drag_and_drop %}
         <tr class="column-filters">
           <th colspan="2">
             {% include '@PrestaShop/Admin/Helpers/range_inputs.html.twig' with {
@@ -89,6 +90,7 @@
               'minLabel': "Min"|trans({}, 'Admin.Global'),
               'maxLabel': "Max"|trans({}, 'Admin.Global'),
               'value': filter_column_id_product,
+              'disabled': filters_disabled,
             } %}
           </th>
           <th>&nbsp;</th>
@@ -99,6 +101,7 @@
               placeholder="{{ "Search name"|trans({}, 'Admin.Catalog.Help') }}"
               name="filter_column_name"
               value="{{ filter_column_name }}"
+              {% if filters_disabled %}disabled{% endif %}
             />
           </th>
           <th>
@@ -108,6 +111,7 @@
               placeholder="{{ "Search ref."|trans({}, 'Admin.Catalog.Help') }}"
               name="filter_column_reference"
               value="{{ filter_column_reference }}"
+              {% if filters_disabled %}disabled{% endif %}
             />
           </th>
           <th>
@@ -117,6 +121,7 @@
               placeholder="{{ "Search category"|trans({}, 'Admin.Catalog.Help') }}"
               name="filter_column_name_category"
               value="{{ filter_column_name_category }}"
+              {% if filters_disabled %}disabled{% endif %}
             />
           </th>
           <th class="text-center">
@@ -127,6 +132,7 @@
               'minLabel': "Min"|trans({}, 'Admin.Global'),
               'maxLabel': "Max"|trans({}, 'Admin.Global'),
               'value': filter_column_price,
+              'disabled': filters_disabled,
             } %}
           </th>
 
@@ -139,6 +145,7 @@
               'minLabel': "Min"|trans({}, 'Admin.Global'),
               'maxLabel': "Max"|trans({}, 'Admin.Global'),
               'value': filter_column_sav_quantity,
+              'disabled': filters_disabled,
             } %}
           </th>
           {% else %}
@@ -147,7 +154,7 @@
 
           <th id="product_filter_column_active" class="text-center">
             <div class="form-select">
-              <select class="custom-select"  name="filter_column_active">
+              <select class="custom-select"  name="filter_column_active" {% if filters_disabled %}disabled{% endif %}>
                 <option value=""></option>
                 <option value="1" {% if (filter_column_active is defined) and filter_column_active == '1' %}selected="selected"{% endif %}>Active</option>
                 <option value="0" {% if (filter_column_active is defined) and filter_column_active == '0' %}selected="selected"{% endif %}>Inactive</option>
@@ -160,8 +167,7 @@
                 <input type="button" class="btn btn-outline-secondary" name="products_filter_position_asc" value="{{ "Reorder"|trans({}, 'Admin.Actions') }}" onclick="productOrderPrioritiesTable();" />
                 {% else %}
                 <input type="button" id="bulk_edition_save_keep" class="btn" onclick="bulkProductAction(this, 'edition');" value="{{ "Save & refresh"|trans({}, 'Admin.Actions')|raw }}" />
-            {% endif %}
-
+              {% endif %}
             </th>
           {% endif %}
           <th class="text-right" style="width: 5rem">


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | The ordering of products was enabled when sort by position, which made the UX confusing. Now ordering is enabled only when the user clicked on the REORDER button, and this mode all filters input are disabled (in consistency with the fact that they are ignored). For more clarity the selected Category name is displayed in the filter select tree.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/10345
| How to test?  | Go to the Product catalog in BO, perform searches and sorting in normal mode. Select a category, the selected category is now displayed. Click on REORDER button, the filters are disabled and you can frag and drop the items. Order products by position, the drag and drop is disabled, and you can perform some research.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11279)
<!-- Reviewable:end -->
