### PR TITLE
Loosing user's groups access when updating category by webservice

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -231,7 +231,11 @@ class CategoryCore extends ObjectModel
         }
 
         // Update group selection
-        $this->updateGroup($this->groupBox);
+        global $webservice_call;
+        if (!$webservice_call) {
+            // It couldn't be updated by webservice cause it doesn't have access to group associations
+            $this->updateGroup($this->groupBox);
+        }
 
         if ($this->level_depth != $this->calcLevelDepth()) {
             $this->level_depth = $this->calcLevelDepth();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | When updating by web service a category with several groups selected previously by the user, the category **reset to the configured** Visitor, Guest and Customer groups, loosing user's. <br/> As the Web Service doesn't give access to the category's groups associations, it is necessary not to override it in the update.
| Type?         | bug fix 
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11289 
| How to test?  | Steps to reproduce the behavior:<br/> - In the back office create a new client group<br/> - In the back office update an existing category giving access to that group<br/> - Update the category using web service (Just GET and POST the same data via PostMan, for example)<br/> - Go back to the back office and refresh the category. With that change, the category hasn't gone back to the standard groups of Visitor, Guest, and Customer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11291)
<!-- Reviewable:end -->
