### PR TITLE
Fix error on tab unregistration when handled by the module

### DIFF
--- a/src/Adapter/Module/Tab/ModuleTabUnregister.php
+++ b/src/Adapter/Module/Tab/ModuleTabUnregister.php
@@ -116,7 +116,9 @@ class ModuleTabUnregister
     private function removeDuplicatedParent(Tab $tab)
     {
         $remainingChildren = $this->tabRepository->findByParentId($tab->getIdParent());
-        if (count($remainingChildren) > 1) {
+        // Or more than one children, the parent tab is still used.
+        // If there is no children, the deletion is likely to be done manually by the module.
+        if (count($remainingChildren) !== 1) {
             return;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | When a module handle its tabs by itself, reseting it will throw an exception in some case.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Manage your tabs manually with a module (new parent with 2 children), then reset it. You will get the following error until you apply this PR.

![exception_on_reset](https://user-images.githubusercontent.com/6768917/48129696-2b025880-e282-11e8-9649-b32905652ffa.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11300)
<!-- Reviewable:end -->
