### PR TITLE
Add LegacyContext::getLegacyAdminLink

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -808,6 +808,26 @@ class LinkCore
     }
 
     /**
+     * Used when you explicitly want to create a LEGACY admin link, this should be deprecated
+     * in 1.8.0.
+     *
+     * @param $controller
+     * @param bool $withToken
+     * @param array $params
+     * @return string
+     */
+    public function getLegacyAdminLink($controller, $withToken = true, $params = array())
+    {
+        $idLang = Context::getContext()->language->id;
+
+        if ($withToken && !TokenInUrls::isDisabled()) {
+            $params['token'] = Tools::getAdminTokenLite($controller);
+        }
+
+        return $this->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . Dispatcher::getInstance()->createUrl($controller, $idLang, $params);
+    }
+
+    /**
      * @param int|null $idShop
      * @param bool|null $ssl
      * @param bool $relativeProtocol

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -814,6 +814,7 @@ class LinkCore
      * @param $controller
      * @param bool $withToken
      * @param array $params
+     *
      * @return string
      */
     public function getLegacyAdminLink($controller, $withToken = true, $params = array())

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -30,11 +30,14 @@ use Employee;
 use RuntimeException;
 use Smarty;
 use Symfony\Component\Process\Exception\LogicException;
+use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use Context;
 use Language;
 use AdminController;
 use Link;
 use Tab;
+use Tools;
+use Dispatcher;
 use AdminLegacyLayoutControllerCore;
 
 /**
@@ -104,9 +107,31 @@ class LegacyContext
     }
 
     /**
+     * Returns the controller link in its legacy form, without trying to convert it in symfony url.
+     *
+     * @param string $controller
+     * @param bool $withToken
+     * @param array $extraParams
+     *
+     * @return string
+     */
+    public function getLegacyAdminLink($controller, $withToken = true, $extraParams = array())
+    {
+        $idLang = $this->getContext()->language->id;
+
+        if ($withToken && !TokenInUrls::isDisabled()) {
+            $extraParams['token'] = Tools::getAdminTokenLite($controller);
+        }
+
+        return $this->getContext()->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . Dispatcher::getInstance()->createUrl($controller, $idLang, $extraParams);
+    }
+
+    /**
      * Adapter to get Front controller HTTP link.
      *
      * @param string $controller the controller name
+     *
+     * @return string
      */
     public function getFrontUrl($controller)
     {

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -30,14 +30,10 @@ use Employee;
 use RuntimeException;
 use Smarty;
 use Symfony\Component\Process\Exception\LogicException;
-use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use Context;
 use Language;
 use AdminController;
-use Link;
 use Tab;
-use Tools;
-use Dispatcher;
 use AdminLegacyLayoutControllerCore;
 
 /**

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -117,13 +117,7 @@ class LegacyContext
      */
     public function getLegacyAdminLink($controller, $withToken = true, $extraParams = array())
     {
-        $idLang = $this->getContext()->language->id;
-
-        if ($withToken && !TokenInUrls::isDisabled()) {
-            $extraParams['token'] = Tools::getAdminTokenLite($controller);
-        }
-
-        return $this->getContext()->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . Dispatcher::getInstance()->createUrl($controller, $idLang, $extraParams);
+        return $this->getContext()->link->getLegacyAdminLink($controller, $withToken, $extraParams);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -125,7 +125,8 @@ class ImportController extends FrameworkBundleAdminController
             }
 
             $formData = $form->getData();
-            if (!$errors = $formHandler->save($formData)) {
+            $errors = $formHandler->save($formData);
+            if (empty($errors)) {
                 return $this->fowardRequestToLegacyResponse($request);
             }
 
@@ -293,7 +294,7 @@ class ImportController extends FrameworkBundleAdminController
         $legacyController = $request->attributes->get('_legacy_controller');
         $legacyContext = $this->get('prestashop.adapter.legacy.context');
 
-        $legacyImportUrl = $legacyContext->getAdminLink($legacyController);
+        $legacyImportUrl = $legacyContext->getLegacyAdminLink($legacyController);
 
         return $this->redirect($legacyImportUrl, Response::HTTP_TEMPORARY_REDIRECT);
     }


### PR DESCRIPTION

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | The import feature looped indefinitely because it tried to redirect to the legacy controller, but because of the _legacy_link feature it was redirected to itself. So a new method is added in LegacyContext to be able to build a legacy link.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10838
| How to test?  | See #10838

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11309)
<!-- Reviewable:end -->
