### PR TITLE
Be able to disable Help Link on Back Office pages

### DIFF
--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -61,7 +61,8 @@
                 {$toolbar_btn['modules-list'].desc}
               </a>
             {/if}
-            {if isset($help_link)}
+
+            {if isset($help_link) and $help_link != false}
 
               {if $enableSidebar}
                 <a class="btn btn-outline-secondary btn-help btn-sidebar" href="#"

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -93,7 +93,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
             'page_header_toolbar_btn' => $this->page_header_toolbar_btn,
         );
 
-        if (!empty($this->helpLink)) {
+        if ($this->helpLink === false || !empty($this->helpLink)) {
             $vars['help_link'] = $this->helpLink;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | On Back Office pages, we were able to disable Help link. This is not possible right now.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Install masterclass module and access Exemple page from Master class menu.


[masterclass.zip](https://github.com/PrestaShop/PrestaShop/files/2558309/masterclass.zip)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11311)
<!-- Reviewable:end -->
