### PR TITLE
Only call ntree regeneration at this end of a WS call and optimize regenerateEntireNtree

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -513,7 +513,6 @@ class CategoryCore extends ObjectModel
      * @param array $categories
      * @param int $idCategory
      * @param int $n
-     * @param array $queries
      *
      * @return array ntree infos
      */

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -484,7 +484,16 @@ class CategoryCore extends ObjectModel
         $n = 1;
 
         if (isset($categoriesArray[0]) && $categoriesArray[0]['subcategories']) {
-            Category::subTree($categoriesArray, $categoriesArray[0]['subcategories'][0], $n);
+            $queries = Category::computeNTreeInfos($categoriesArray, $categoriesArray[0]['subcategories'][0], $n);
+
+            // update by batch of 5000 categories
+            $chunks = array_chunk($queries, 5000);
+            foreach($chunks as $chunk) {
+                $sqlChunk = array_map(function($value) { return '('.rtrim(implode(',', $value)).')'; }, $chunk);
+                Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'category` (id_category, nleft, nright) 
+                VALUES '.rtrim(implode(',', $sqlChunk), ',').' 
+                ON DUPLICATE KEY UPDATE nleft=VALUES(nleft), nright=VALUES(nright)');
+            }
         }
     }
 
@@ -501,11 +510,37 @@ class CategoryCore extends ObjectModel
     }
 
     /**
+     * @param array $categories
+     * @param int $idCategory
+     * @param int $n
+     * @param array $queries
+     *
+     * @return array ntree infos
+     */
+    protected static function computeNTreeInfos(&$categories, $idCategory, &$n)
+    {
+        $queries = array();
+        $left = $n++;
+        if (isset($categories[(int) $idCategory]['subcategories'])) {
+            foreach ($categories[(int) $idCategory]['subcategories'] as $idSubcategory) {
+                $queries = array_merge($queries, Category::computeNTreeInfos($categories, (int) $idSubcategory, $n));
+            }
+        }
+        $right = (int) $n++;
+
+        $queries[] = array($idCategory, $left, $right);
+
+        return $queries;
+    }
+
+    /**
      * @param $categories
      * @param $idCategory
      * @param $n
      *
      * @return bool Indicates whether the sub tree of categories has been successfully updated
+     *
+     * @deprecated 1.7.6.0 use getNTreeInfos + sql query instead
      */
     protected static function subTree(&$categories, $idCategory, &$n)
     {

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -488,10 +488,10 @@ class CategoryCore extends ObjectModel
 
             // update by batch of 5000 categories
             $chunks = array_chunk($queries, 5000);
-            foreach($chunks as $chunk) {
-                $sqlChunk = array_map(function($value) { return '('.rtrim(implode(',', $value)).')'; }, $chunk);
+            foreach ($chunks as $chunk) {
+                $sqlChunk = array_map(function ($value) { return '(' . rtrim(implode(',', $value)) . ')'; }, $chunk);
                 Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'category` (id_category, nleft, nright) 
-                VALUES '.rtrim(implode(',', $sqlChunk), ',').' 
+                VALUES ' . rtrim(implode(',', $sqlChunk), ',') . ' 
                 ON DUPLICATE KEY UPDATE nleft=VALUES(nleft), nright=VALUES(nright)');
             }
         }

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -539,7 +539,7 @@ class CategoryCore extends ObjectModel
      *
      * @return bool Indicates whether the sub tree of categories has been successfully updated
      *
-     * @deprecated 1.7.6.0 use getNTreeInfos + sql query instead
+     * @deprecated 1.7.6.0 use computeNTreeInfos + sql query instead
      */
     protected static function subTree(&$categories, $idCategory, &$n)
     {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a WS is used in batch mode on category, there's no need to recompute the whole NTree for each entries. Only compute it at this end. Execute sql queries from regenerateEntireNtree by batch of 5000 categories instead of 1 by category
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | inefficient protected function subTree has been replaced by computeNTreeInfos
| Fixed ticket? | Fixes #11303
| How to test?  | Run a category import / delete through WS + very nleft / nright columns are properly computed in the category table after an install

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11313)
<!-- Reviewable:end -->
