### PR TITLE
[BO] Fix Bad translation of 'Reorder'

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -157,7 +157,7 @@
           {% if has_category_filter == true %}
             <th>
               {% if not(activate_drag_and_drop) %}
-                <input type="button" class="btn btn-outline-secondary" name="products_filter_position_asc" value="{{ "Reorder"|trans({}, 'Admin.Actions') }}" onclick="productOrderPrioritiesTable();" />
+                <input type="button" class="btn btn-outline-secondary" name="products_filter_position_asc" value="{{ "Save & refresh"|trans({}, 'Admin.Actions')|raw }}" onclick="productOrderPrioritiesTable();" />
                 {% else %}
                 <input type="button" id="bulk_edition_save_keep" class="btn" onclick="bulkProductAction(this, 'edition');" value="{{ "Save & refresh"|trans({}, 'Admin.Actions')|raw }}" />
             {% endif %}


### PR DESCRIPTION
In english it's the same word but not in other languages
Issue: #11298

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x 
| Description?  | 
| Type?         | bug fix 
| Category?     |  BO 
| BC breaks?    | no
| Deprecations? | 
| Fixed ticket? | #11298
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11328)
<!-- Reviewable:end -->
