### PR TITLE
For beta builds, modify install warning about latest build to download

### DIFF
--- a/tools/build/CreateRelease.php
+++ b/tools/build/CreateRelease.php
@@ -45,6 +45,10 @@ $releaseOptions = [
         'description' => 'Desired release version of PrestaShop',
         'longopt' => 'version:',
     ],
+    'type' => [
+        'description' => 'Desired release type',
+        'longopt' => 'type:',
+    ],
     'no-zip' => [
         'description' => 'Do not zip the release directory. Default: false.',
         'longopt' => 'no-zip',
@@ -109,6 +113,12 @@ if (isset($userOptions['version'])) {
     $version = null;
 }
 
+if (isset($userOptions['type'])) {
+    $type = $userOptions['type'];
+} else {
+    $type = null;
+}
+
 if (isset($userOptions['no-zip'])) {
     $useZip = false;
 }
@@ -122,7 +132,7 @@ if (isset($userOptions['no-installer'])) {
 }
 
 try {
-    $releaseCreator = new ReleaseCreator($version, $useInstaller, $useZip, $destinationDir);
+    $releaseCreator = new ReleaseCreator($version, $type, $useInstaller, $useZip, $destinationDir);
     $releaseCreator->createRelease();
 } catch (Exception $e) {
     $consoleWrite->displayText(

--- a/tools/build/Library/InstallUnpacker/compile.php
+++ b/tools/build/Library/InstallUnpacker/compile.php
@@ -33,8 +33,8 @@
  */
 function validateInput($argv)
 {
-    if (count($argv) !== 2) {
-        echo 'php compile.php <PS_VERSION>' . PHP_EOL;
+    if (count($argv) !== 3) {
+        echo 'php compile.php <PS_VERSION> <RELEASE_TYPE>' . PHP_EOL;
         die(1);
     }
 }
@@ -42,6 +42,7 @@ function validateInput($argv)
 validateInput($argv);
 
 $psVersion = $argv[1];
+$releaseType = $argv[2];
 
 $template = file_get_contents(__DIR__ . '/index_template.php');
 
@@ -69,8 +70,9 @@ if ($handle = opendir(__DIR__ . '/content')) {
     }
 }
 
-// insert Prestashop version
+// replace placeholders
 $template = str_replace('%ps-version-placeholder%', $psVersion, $template);
+$template = str_replace('%ps-release-type-placeholder%', $releaseType, $template);
 
 // compute inline php classes
 // @todo: remove duplicate license headers

--- a/tools/build/Library/InstallUnpacker/content/js-runner.js
+++ b/tools/build/Library/InstallUnpacker/content/js-runner.js
@@ -88,8 +88,9 @@ function checkWhetherThereIsAMoreRecentVersion() {
     if (msg.error) {
       fallbackToExtraction();
     } else {
-      if (msg.thereIsAMoreRecentPSVersionAndItCanBeInstalled == true) {
-        showFormToDownloadLatestPSVersion();
+      if ((msg.thereIsAMoreRecentPSVersionAndItCanBeInstalled == true)
+          && (msg.currentReleaseType)) {
+        showFormToDownloadLatestPSVersion(msg.currentReleaseType);
       } else {
         fallbackToExtraction();
       }
@@ -101,9 +102,20 @@ function checkWhetherThereIsAMoreRecentVersion() {
   });
 }
 
-function showFormToDownloadLatestPSVersion() {
+/**
+ * @param string releaseType
+ */
+function showFormToDownloadLatestPSVersion(releaseType) {
   $('#content-install-in-progress').hide();
   $('#content-install-form').show();
+
+  if (releaseType == 'stable') {
+    $('#header-not-stable').hide();
+    $('#question-not-stable').hide();
+  } else {
+    $('#header').hide();
+    $('#question').hide();
+  }
 }
 
 function skipFormToDownloadLatestPSVersion() {

--- a/tools/build/Library/InstallUnpacker/index_template.php
+++ b/tools/build/Library/InstallUnpacker/index_template.php
@@ -28,6 +28,7 @@ set_time_limit(0);
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 50600);
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '5.6');
 define('_PS_VERSION_', '%ps-version-placeholder%');
+define('_PS_RELEASE_TYPE_', '%ps-release-type-placeholder%');
 
 define('ZIP_NAME', 'prestashop.zip');
 define('TARGET_FOLDER', __DIR__ . '/');
@@ -99,6 +100,7 @@ if (isset($_GET['run']) && ($_GET['run'] === 'check-version')) {
 
         die(json_encode([
             'thereIsAMoreRecentPSVersionAndItCanBeInstalled' => true,
+            'currentReleaseType' => _PS_RELEASE_TYPE_,
         ]));
     } catch (\Exception $e) {
         die(json_encode([
@@ -269,6 +271,13 @@ if (isset($_GET['element'])) {
         </div>
         <div id="question">
           Do you want to install the latest version instead? (recommended)
+        </div>
+        <div id="header-not-stable">
+          The version you are about to install is a BETA BUILD version of PrestaShop,
+          only for testing purpose, and should not be used in production.
+        </div>
+        <div id="question-not-stable">
+          Do you want to install the latest stable version instead?
         </div>
         <div id="form-panel">
           <div id="form">

--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -20,11 +20,12 @@ This tool needs these system commands:
 To create a release:
 
 ```
-php tools/build/CreateRelease.php --version="1.7.2.4"
+php tools/build/CreateRelease.php --version="1.7.2.4" --type="stable"
 ```
 
 Available options:
 * --version: Desired release version of PrestaShop. Required.
+* --type: Desired release type: alpha, beta or stable. Required.
 * --no-installer: Do not put the installer in the release. Default: false.
 * --no-zip: Do not zip the release directory. Default: false.
 * --destination-dir: Path where the release will be stored. Default: tools/build/releases/prestashop_{version}.


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Modify warning message at install step to prevent beta testers to use the last stable version instead of the beta version. This requires to modify build process in order to allow the Build Developer to select a release type: stable, alpha (not used yet, but could be useful) or beta.
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11335
| How to test?  | Once the code has been approved, please ping me and I will build 2 test releases: one "beta" and one "stable". Stable build should behave like before, but Beta build message should be different.

**Also:** once this PR is merged, I need to update the Build documentation with the new option required by `CreateRelease.php`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11338)
<!-- Reviewable:end -->
