### PR TITLE
Fix default values on import page

### DIFF
--- a/src/Core/Form/ImportPageFormHandler.php
+++ b/src/Core/Form/ImportPageFormHandler.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form;
+
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Dedicated FormHandler
+ * Temporary fix, it will be replaced by global FormHandler soon.
+ */
+class ImportPageFormHandler extends FormHandler
+{
+    /**
+     * @param FormBuilderInterface $formBuilder
+     * @param HookDispatcherInterface $hookDispatcher
+     * @param FormDataProviderInterface $formDataProvider
+     * @param array $formTypes
+     * @param string $hookName
+     * @param string $formName
+     */
+    public function __construct(
+        FormBuilderInterface $formBuilder,
+        HookDispatcherInterface $hookDispatcher,
+        FormDataProviderInterface $formDataProvider,
+        array $formTypes,
+        $hookName,
+        $formName = 'form'
+    ) {
+        $this->formName = $formName;
+        $this->formBuilder = $formBuilder;
+        $this->hookDispatcher = $hookDispatcher;
+        $this->formDataProvider = $formDataProvider;
+        $this->formTypes = $formTypes;
+        $this->hookName = $hookName;
+    }
+}

--- a/src/Core/Import/ImportSettings.php
+++ b/src/Core/Import/ImportSettings.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Import;
+
+/**
+ * Class ImportSettings provides import constants to be used in import pages.
+ */
+final class ImportSettings
+{
+    /**
+     * Default value separator.
+     */
+    const DEFAULT_SEPARATOR = ';';
+
+    /**
+     * Default multiple value separator.
+     */
+    const DEFAULT_MULTIVALUE_SEPARATOR = ',';
+
+    /**
+     * Maximum number of columns that are visible in the import matches configuration page.
+     */
+    const MAX_VISIBLE_COLUMNS = 6;
+
+    /**
+     * Maximum number of rows that are visible in the import matces configuration page.
+     */
+    const MAX_VISIBLE_ROWS = 10;
+
+    /**
+     * This class cannot be instantiated.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -86,14 +86,6 @@ class ImportController extends FrameworkBundleAdminController
         $finder = $this->get('prestashop.core.import.file_finder');
         $iniConfiguration = $this->get('prestashop.core.configuration.ini_configuration');
 
-        /* NO_PROD
-        // add support for preselected entity when import type is available in query
-        $formData = $request->query->has('import_type') ?
-            ['entity' => $request->query->get('import_type')] :
-            []
-        ;
-        $form = $this->get('form.factory')->createNamed('', ImportType::class, $formData);
-        **/
         $form = $formHandler->getForm();
         $form->handleRequest($request);
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -86,13 +86,15 @@ class ImportController extends FrameworkBundleAdminController
         $finder = $this->get('prestashop.core.import.file_finder');
         $iniConfiguration = $this->get('prestashop.core.configuration.ini_configuration');
 
+        /* NO_PROD
         // add support for preselected entity when import type is available in query
         $formData = $request->query->has('import_type') ?
             ['entity' => $request->query->get('import_type')] :
             []
         ;
-
         $form = $this->get('form.factory')->createNamed('', ImportType::class, $formData);
+        **/
+        $form = $formHandler->getForm();
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -28,7 +28,6 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Exception\FileUploadException;
-use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import\ImportType;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportDataConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportDataConfigurationType.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+/**
+ * Class ImportDataConfigurationType is responsible for displaying the configuration of the
+ * Advanced Parameters -> Import -> second step list.
+ */
+class ImportDataConfigurationType extends TranslatorAwareType
+{
+    /**
+     * @var array choices for data matches
+     */
+    private $dataMatchChoices;
+    /**
+     * @var array choices for entity fields
+     */
+    private $entityFieldChoices;
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param array $dataMatchChoices
+     * @param array $entityFieldChoices
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        array $dataMatchChoices,
+        array $entityFieldChoices
+    ) {
+        parent::__construct($translator, $locales);
+        $this->dataMatchChoices = $dataMatchChoices;
+        $this->entityFieldChoices = $entityFieldChoices;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('matches', ChoiceType::class, [
+                'choices' => $this->dataMatchChoices,
+                'choice_translation_domain' => false,
+            ])
+            ->add('match_name', TextType::class, [
+                'required' => false,
+            ])
+            ->add('skip', IntegerType::class, [
+                'data' => 1,
+            ])
+            ->add('type_value', CollectionType::class, [
+                'entry_type' => ChoiceType::class,
+                'entry_options' => [
+                    'choices' => [
+                            $this->trans('Ignore this column', 'Admin.Advparameters.Feature') => 'no',
+                        ] +
+                        $this->entityFieldChoices,
+                    'choice_translation_domain' => false,
+                    'label' => false,
+                ],
+                'label' => false,
+            ])
+            ->add('entity', HiddenType::class)
+            ->add('csv', HiddenType::class)
+            ->add('iso_lang', HiddenType::class)
+            ->add('truncate', HiddenType::class)
+            ->add('match_ref', HiddenType::class)
+            ->add('regenerate', HiddenType::class)
+            ->add('forceIDs', HiddenType::class)
+            ->add('sendemail', HiddenType::class)
+            ->add('separator', HiddenType::class)
+            ->add('multiple_value_separator', HiddenType::class)
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportDataConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportDataConfigurationType.php
@@ -23,7 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import;
+
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -32,6 +34,7 @@ use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+
 /**
  * Class ImportDataConfigurationType is responsible for displaying the configuration of the
  * Advanced Parameters -> Import -> second step list.
@@ -46,6 +49,7 @@ class ImportDataConfigurationType extends TranslatorAwareType
      * @var array choices for entity fields
      */
     private $entityFieldChoices;
+
     /**
      * @param TranslatorInterface $translator
      * @param array $locales
@@ -62,6 +66,7 @@ class ImportDataConfigurationType extends TranslatorAwareType
         $this->dataMatchChoices = $dataMatchChoices;
         $this->entityFieldChoices = $entityFieldChoices;
     }
+
     /**
      * {@inheritdoc}
      */

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormDataProvider.php
@@ -28,6 +28,8 @@ namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import;
 
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Import\File\FileFinder;
+use PrestaShop\PrestaShop\Core\Import\ImportSettings;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -45,10 +47,16 @@ final class ImportFormDataProvider implements FormDataProviderInterface
      */
     private $importFileFinder;
 
-    public function __construct(SessionInterface $session, FileFinder $importFileFinder)
+    /**
+     * @var null|RequestStack current request
+     */
+    private $request;
+
+    public function __construct(SessionInterface $session, FileFinder $importFileFinder, RequestStack $requestStack)
     {
         $this->session = $session;
         $this->importFileFinder = $importFileFinder;
+        $this->request = $requestStack->getCurrentRequest();
     }
 
     /**
@@ -56,12 +64,28 @@ final class ImportFormDataProvider implements FormDataProviderInterface
      */
     public function getData()
     {
+        // If import entity is available in the query - grab it and preselect in the form,
+        // otherwise - take it from the session.
+        if (null !== $this->request && $this->request->query->has('import_type')) {
+            $entity = $this->request->query->get('import_type');
+        } else {
+            $entity = $this->session->get('entity');
+        }
+
         return [
             'csv' => $this->getSelectedFile(),
-            'entity' => $this->session->get('entity'),
+            'entity' => $entity,
             'iso_lang' => $this->session->get('iso_lang'),
-            'separator' => $this->session->get('separator', ImportType::DEFAULT_SEPARATOR),
-            'multiple_value_separator' => $this->session->get('multiple_value_separator', ImportType::DEFAULT_MULTIVALUE_SEPARATOR),
+            'separator' => $this->session->get('separator', ImportSettings::DEFAULT_SEPARATOR),
+            'multiple_value_separator' => $this->session->get(
+                'multiple_value_separator',
+                ImportSettings::DEFAULT_MULTIVALUE_SEPARATOR
+            ),
+            'truncate' => $this->session->get('truncate', false),
+            'regenerate' => $this->session->get('regenerate', false),
+            'match_ref' => $this->session->get('match_ref', false),
+            'forceIDs' => $this->session->get('forceIDs', false),
+            'sendemail' => $this->session->get('sendemail', true),
         ];
     }
 
@@ -90,6 +114,11 @@ final class ImportFormDataProvider implements FormDataProviderInterface
         $this->session->set('iso_lang', $data['iso_lang']);
         $this->session->set('separator', $data['separator']);
         $this->session->set('multiple_value_separator', $data['multiple_value_separator']);
+        $this->session->set('truncate', $data['truncate']);
+        $this->session->set('match_ref', $data['match_ref']);
+        $this->session->set('regenerate', $data['regenerate']);
+        $this->session->set('forceIDs', $data['forceIDs']);
+        $this->session->set('sendemail', $data['sendemail']);
 
         return $errors;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -42,8 +42,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ImportType extends TranslatorAwareType
 {
-    const DEFAULT_SEPARATOR = ';';
-    const DEFAULT_MULTIVALUE_SEPARATOR = ',';
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -70,21 +68,11 @@ class ImportType extends TranslatorAwareType
             ])
             ->add('separator', TextType::class)
             ->add('multiple_value_separator', TextType::class)
-            ->add('truncate', SwitchType::class, [
-                'data' => false,
-            ])
-            ->add('match_ref', SwitchType::class, [
-                'data' => false,
-            ])
-            ->add('regenerate', SwitchType::class, [
-                'data' => false,
-            ])
-            ->add('forceIDs', SwitchType::class, [
-                'data' => false,
-            ])
-            ->add('sendemail', SwitchType::class, [
-                'data' => true,
-            ])
+            ->add('truncate', SwitchType::class)
+            ->add('match_ref', SwitchType::class)
+            ->add('regenerate', SwitchType::class)
+            ->add('forceIDs', SwitchType::class)
+            ->add('sendemail', SwitchType::class)
         ;
 
         $builder->get('entity')

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -42,7 +42,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ImportType extends TranslatorAwareType
 {
-
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -83,6 +83,7 @@ services:
         arguments:
             - '@session'
             - '@prestashop.core.import.file_finder'
+            - '@request_stack'
 
     prestashop.adapter.order.delivery.slip.options.form_provider:
         class: 'PrestaShopBundle\Form\Admin\Sell\Order\Delivery\SlipOptionsFormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -148,7 +148,7 @@ services:
             - 'LogsPage'
 
     prestashop.admin.import.form_handler:
-        class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'
+        class: 'PrestaShop\PrestaShop\Core\Form\ImportPageFormHandler'
         arguments:
             - '@prestashop.admin.import.form_builder'
             - '@prestashop.core.hook.dispatcher'


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Fix empty default values on import page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10430
| How to test?  | In BO > advanced parameters > import : default values for both separators should not be blank

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11339)
<!-- Reviewable:end -->
